### PR TITLE
Revert "#19555: remove MatmulMultiCoreProgramConfig (#22181)"

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -533,10 +533,12 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/full_like/device/full_like_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/loss/loss.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/matmul.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp

--- a/ttnn/core/graph/graph_argument_serializer.cpp
+++ b/ttnn/core/graph/graph_argument_serializer.cpp
@@ -44,6 +44,7 @@ std::ostream& operator<<(std::ostream& os, const std::variant<T, U>& variant) {
 std::ostream& operator<<(
     std::ostream& os,
     const std::variant<
+        ttnn::operations::matmul::MatmulMultiCoreProgramConfig,
         ttnn::operations::matmul::MatmulMultiCoreReuseProgramConfig,
         ttnn::operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig,
         ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig,
@@ -195,6 +196,7 @@ void GraphArgumentSerializer::initialize() {
     GraphArgumentSerializer::register_type<
         std::variant<ttnn::GrayskullComputeKernelConfig, ttnn::WormholeComputeKernelConfig>>();
     GraphArgumentSerializer::register_type<std::variant<
+        ttnn::operations::matmul::MatmulMultiCoreProgramConfig,
         ttnn::operations::matmul::MatmulMultiCoreReuseProgramConfig,
         ttnn::operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig,
         ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/matmul.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+using std::uint32_t;
+
+// matmul C=A*B using dims MK*KN = MN (row major order)
+//
+namespace NAMESPACE {
+void MAIN {
+    constexpr int onetile = 1;
+
+    int dst_tile_index = 0;
+    int in0_block_tile_index = 0;
+
+    uint32_t batch = get_compile_time_arg_val(0);
+    uint32_t Mt = get_compile_time_arg_val(1);
+    uint32_t Kt = get_compile_time_arg_val(2);
+    uint32_t Nt = get_compile_time_arg_val(3);
+
+    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+
+    // the simplest possible version of outer product blocked matmul
+    // the reader is expected to read the A's and B's tile rows and tile columns for each output tile
+    for (uint32_t nb = 0; nb < batch; nb++) {
+        for (uint32_t mt_C = 0; mt_C < Mt; ++mt_C) {    // output tile of C
+            for (uint32_t nt_C = 0; nt_C < Nt; ++nt_C)  // output tile index of C
+            {
+                acquire_dst();
+                for (uint32_t kt = 0; kt < Kt; kt++) {
+                    cb_wait_front(tt::CBIndex::c_0, onetile);
+                    cb_wait_front(tt::CBIndex::c_1, onetile);
+
+                    matmul_tiles(tt::CBIndex::c_0, tt::CBIndex::c_1, 0, 0, 0, false);
+
+                    cb_pop_front(tt::CBIndex::c_0, onetile);
+                    cb_pop_front(tt::CBIndex::c_1, onetile);
+                }
+
+                cb_reserve_back(tt::CBIndex::c_16, onetile);
+                pack_tile(0, tt::CBIndex::c_16);
+                cb_push_back(tt::CBIndex::c_16, onetile);
+
+                release_dst();
+            }
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/matmul.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t in0_block_w = get_compile_time_arg_val(0);              // inner block size in tiles
+    uint32_t in0_num_subblocks = get_compile_time_arg_val(1);        // outer row block size (in inner row blocks)
+    uint32_t in0_block_num_tiles = get_compile_time_arg_val(2);      // out_subblock_h*in0_block_w*in0_num_subblocks;
+    uint32_t in0_subblock_num_tiles = get_compile_time_arg_val(3);   // out_subblock_h*in0_block_w
+    uint32_t in1_num_subblocks = get_compile_time_arg_val(4);        // outer column block size (in inner column blocks)
+    uint32_t in1_block_num_tiles = get_compile_time_arg_val(5);      // out_subblock_w*in0_block_w* in1_num_subblocks;
+    uint32_t in1_per_core_w = get_compile_time_arg_val(6);           // out_subblock_w*in1_num_subblocks
+    uint32_t num_blocks = get_compile_time_arg_val(7);               // outer inner dim (in inner dim blocks)
+    uint32_t out_subblock_h = get_compile_time_arg_val(8);           // inner row block size in tiles
+    uint32_t out_subblock_w = get_compile_time_arg_val(9);           // inner column block size in tiles
+    uint32_t out_subblock_num_tiles = get_compile_time_arg_val(10);  // out_subblock_h * out_subblock_w;
+    uint32_t batch = get_compile_time_arg_val(11);                   // batch dim
+
+    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_24);
+
+    for (uint32_t b = 0; b < batch; b++) {
+        bool spill = num_blocks > 1;
+        bool enable_reload = false;
+        uint32_t out_num_tiles_to_wait = out_subblock_num_tiles;
+
+        for (uint32_t block = 0; block < num_blocks; block++) {
+            bool last_out = block == (num_blocks - 1);
+
+            cb_wait_front(tt::CBIndex::c_0, in0_block_num_tiles);
+            cb_wait_front(tt::CBIndex::c_1, in1_block_num_tiles);
+            int in0_index_subblock_offset = 0;
+            for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
+                int in1_index_subblock_offset = 0;
+                for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
+                    acquire_dst();
+
+                    if (enable_reload) {
+                        copy_tile_to_dst_init_short_with_dt(tt::CBIndex::c_1, tt::CBIndex::c_24);
+                        cb_wait_front(tt::CBIndex::c_24, out_subblock_num_tiles);
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                            copy_tile(tt::CBIndex::c_24, i, i);
+                        }
+                        cb_pop_front(tt::CBIndex::c_24, out_subblock_num_tiles);
+                        mm_init_short_with_dt(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_24);
+                    }
+
+                    // Compute output sub-block from in0_subblock x in1_subblock
+                    int dst_index = 0;
+                    int in0_index_h_offset = 0;
+                    for (uint32_t h = 0; h < out_subblock_h; h++) {
+                        for (uint32_t w = 0; w < out_subblock_w; w++) {
+                            int in1_index_inner_dim_offset = 0;
+                            for (uint32_t inner_dim = 0; inner_dim < in0_block_w; inner_dim++) {
+                                int in0_index = in0_index_subblock_offset + in0_index_h_offset + inner_dim;
+                                int in1_index = in1_index_subblock_offset + in1_index_inner_dim_offset + w;
+                                matmul_tiles(
+                                    tt::CBIndex::c_0,
+                                    tt::CBIndex::c_1,
+                                    in0_index,
+                                    in1_index,
+                                    dst_index,
+                                    false /* transpose */);
+                                in1_index_inner_dim_offset += in1_per_core_w;
+                            }
+                            dst_index++;
+                        }
+                        in0_index_h_offset += in0_block_w;
+                    }
+
+                    if (last_out) {
+                        // Pack out to output buffer
+                        cb_reserve_back(tt::CBIndex::c_16, out_subblock_num_tiles);
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                            pack_tile(i, tt::CBIndex::c_16);
+                        }
+                        cb_push_back(tt::CBIndex::c_16, out_subblock_num_tiles);
+                    } else {
+                        // Wait for tiles in output buffer to be written out since interm and output share memory
+                        if (block == 0) {
+                            cb_reserve_back(tt::CBIndex::c_16, out_num_tiles_to_wait);
+                            out_num_tiles_to_wait += out_subblock_num_tiles;
+                        }
+                        // Move partial result to interm buffer
+                        cb_reserve_back(tt::CBIndex::c_24, out_subblock_num_tiles);
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                            pack_tile(i, tt::CBIndex::c_24);
+                        }
+                        cb_push_back(tt::CBIndex::c_24, out_subblock_num_tiles);
+                    }
+
+                    release_dst();
+                    in1_index_subblock_offset += out_subblock_w;
+                }
+                in0_index_subblock_offset += in0_subblock_num_tiles;
+            }
+
+            if (spill) {
+                enable_reload = true;
+            }
+
+            cb_pop_front(tt::CBIndex::c_0, in0_block_num_tiles);
+            cb_pop_front(tt::CBIndex::c_1, in1_block_num_tiles);
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    // same arg indices as in reader_binary_diff_lenghts for compat
+    uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    uint32_t src1_addr = get_arg_val<uint32_t>(1);
+    uint32_t Mt = get_arg_val<uint32_t>(2);
+    uint32_t Kt = get_arg_val<uint32_t>(3);
+    uint32_t Nt = get_arg_val<uint32_t>(4);
+    uint32_t MtKt = get_arg_val<uint32_t>(5);  // if 0
+    uint32_t KtNt = get_arg_val<uint32_t>(6);
+    uint32_t batch = get_arg_val<uint32_t>(7);
+    uint32_t bcast_B = get_arg_val<uint32_t>(8);  // if 1 we broadcast B to batch
+    uint32_t output_tile_start_id = get_arg_val<uint32_t>(9);
+    uint32_t num_output_tiles = get_arg_val<uint32_t>(10);
+    uint32_t MtNt = get_arg_val<uint32_t>(11);
+
+    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
+
+    // DPRINT << "Mt=" << Mt << " Kt=" << Kt << " Nt=" << Nt << " MtKt=" << MtKt << "KtNt=" << KtNt << ENDL();
+    // DPRINT << "src0=" << src0_addr << " src1=" << src1_addr << ENDL();
+    // DPRINT << "batch=" << batch << ENDL();
+
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_in1 = 1;
+
+    constexpr uint32_t onetile = 1;
+    const uint32_t in0_tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat in0_data_format = get_dataformat(cb_id_in0);
+    const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
+    const DataFormat in1_data_format = get_dataformat(cb_id_in1);
+
+    uint32_t itileA = output_tile_start_id / Nt * Kt;  // input0 row = output row * input0 width
+
+    // Keep track of end of output row and end of output batch
+    uint32_t outbatch = output_tile_start_id % MtNt;
+    uint32_t itileB_batch = output_tile_start_id % Nt;
+    uint32_t itileB = itileB_batch;  // input1 col = output col if we are bcasting
+    if (bcast_B == 0) {
+        itileB += output_tile_start_id / MtNt * KtNt;  // offset into correct batch if not bcasting
+    }
+
+    const InterleavedAddrGenFast<src0_is_dram> s0 = {
+        .bank_base_address = src0_addr, .page_size = in0_tile_bytes, .data_format = in0_data_format};
+
+    const InterleavedAddrGenFast<src1_is_dram> s1 = {
+        .bank_base_address = src1_addr, .page_size = in1_tile_bytes, .data_format = in1_data_format};
+
+    for (uint32_t n = 0; n < num_output_tiles; n++) {
+        for (uint32_t kt = 0; kt < Kt; kt++) {
+            {  // Read A's tile at (mt, kt)
+                cb_reserve_back(cb_id_in0, onetile);
+                uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+                noc_async_read_tile(itileA, s0, l1_write_addr_in0);
+                noc_async_read_barrier();
+                cb_push_back(cb_id_in0, onetile);
+            }
+
+            {  // Read B's tile at (kt, nt)
+                cb_reserve_back(cb_id_in1, onetile);
+                uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+                noc_async_read_tile(itileB, s1, l1_write_addr_in1);
+                noc_async_read_barrier();
+                cb_push_back(cb_id_in1, onetile);
+            }
+            // DPRINT << "Pushed itileA=" << itileA << " itileB=" << itileB << ENDL();
+
+            itileA += 1;   // A is MK
+            itileB += Nt;  // B is KN, so to get k++ we stride by Nt
+        }  // Kt loop
+        outbatch += 1;
+        itileB_batch += 1;
+        itileB -= KtNt;  // revert B to previous state before the K loop (to avoid multiplies)
+        itileB += 1;     // Move to next B col
+
+        if (itileB_batch == Nt) {
+            itileB_batch = 0;
+            itileB -= Nt;  // Go back to first column in batch
+            if (outbatch == MtNt) {
+                if (bcast_B == 0) {
+                    itileB += KtNt;  // Move B to start of next batch
+                }
+                outbatch = 0;
+            }
+        } else {
+            itileA -= Kt;  // resets tileA to kt=0, keep the same mt
+        }
+    }  // batch loop
+}

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    bool one_time_profile = true;
+
+    // in0 tensor args
+    uint32_t in0_tensor_addr = get_arg_val<uint32_t>(0);
+    uint32_t in0_tensor_start_tile_id = get_arg_val<uint32_t>(1);
+    uint32_t in0_tensor_stride_w = get_arg_val<uint32_t>(2);
+    uint32_t in0_tensor_stride_h = get_arg_val<uint32_t>(3);
+    uint32_t in0_tensor_next_block_stride = get_arg_val<uint32_t>(4);
+
+    // in0 block args
+    uint32_t in0_block_w = get_arg_val<uint32_t>(5);
+    uint32_t in0_block_h = get_arg_val<uint32_t>(6);
+    uint32_t in0_block_num_tiles = get_arg_val<uint32_t>(7);
+
+    // in1 tensor args
+    uint32_t in1_tensor_addr = get_arg_val<uint32_t>(8);
+    uint32_t in1_tensor_start_tile_id = get_arg_val<uint32_t>(9);
+    uint32_t in1_tensor_stride_w = get_arg_val<uint32_t>(10);
+    uint32_t in1_tensor_stride_h = get_arg_val<uint32_t>(11);
+    uint32_t in1_tensor_next_block_stride = get_arg_val<uint32_t>(12);
+
+    // in1 block args
+    uint32_t in1_block_w = get_arg_val<uint32_t>(13);
+    uint32_t in1_block_h = get_arg_val<uint32_t>(14);
+    uint32_t in1_block_num_tiles = get_arg_val<uint32_t>(15);
+
+    // in0/in1 common args
+    uint32_t num_blocks = get_arg_val<uint32_t>(16);
+
+    // batch args
+    uint32_t MtKt = get_arg_val<uint32_t>(17);  // if 0
+    uint32_t KtNt = get_arg_val<uint32_t>(18);
+    uint32_t batch = get_arg_val<uint32_t>(19);
+    uint32_t bcast_B = get_arg_val<uint32_t>(20);
+
+    constexpr bool in0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool in1_is_dram = get_compile_time_arg_val(1) == 1;
+
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_in1 = 1;
+
+    const uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
+    const DataFormat in0_data_format = get_dataformat(cb_id_in0);
+    const uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
+    const DataFormat in1_data_format = get_dataformat(cb_id_in1);
+
+    uint32_t l1_write_addr_in0;
+    uint32_t l1_write_addr_in1;
+
+    const InterleavedAddrGenFast<in0_is_dram> s0 = {
+        .bank_base_address = in0_tensor_addr, .page_size = in0_single_tile_size_bytes, .data_format = in0_data_format};
+
+    const InterleavedAddrGenFast<in1_is_dram> s1 = {
+        .bank_base_address = in1_tensor_addr, .page_size = in1_single_tile_size_bytes, .data_format = in1_data_format};
+
+    for (uint32_t b = 0; b < batch; b++) {
+        uint32_t in0_tensor_current_block_start_tile_id = in0_tensor_start_tile_id;
+        uint32_t in1_tensor_current_block_start_tile_id = in1_tensor_start_tile_id;
+        for (uint32_t block = 0; block < num_blocks; block++) {
+            cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+            cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+
+            l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+            l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+
+            uint32_t in0_tensor_row_start_tile_id = in0_tensor_current_block_start_tile_id;
+            for (uint32_t h = 0; h < in0_block_h; h++) {
+                uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
+                for (uint32_t w = 0; w < in0_block_w; w++) {
+                    noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_in0);
+                    l1_write_addr_in0 += in0_single_tile_size_bytes;
+                    in0_tensor_tile_id += in0_tensor_stride_w;
+                }
+                in0_tensor_row_start_tile_id += in0_tensor_stride_h;
+            }
+            in0_tensor_current_block_start_tile_id += in0_tensor_next_block_stride;
+
+            uint32_t in1_tensor_row_start_tile_id = in1_tensor_current_block_start_tile_id;
+            for (uint32_t h = 0; h < in1_block_h; h++) {
+                uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
+                for (uint32_t w = 0; w < in1_block_w; w++) {
+                    noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_in1);
+                    l1_write_addr_in1 += in1_single_tile_size_bytes;
+                    in1_tensor_tile_id += in1_tensor_stride_w;
+                }
+                in1_tensor_row_start_tile_id += in1_tensor_stride_h;
+            }
+            in1_tensor_current_block_start_tile_id += in1_tensor_next_block_stride;
+
+            noc_async_read_barrier();
+
+            cb_push_back(cb_id_in0, in0_block_num_tiles);
+            cb_push_back(cb_id_in1, in1_block_num_tiles);
+        }
+        if (bcast_B == 0) {
+            in1_tensor_start_tile_id += KtNt;
+        }
+        in0_tensor_start_tile_id += MtKt;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    // out tensor args
+    uint32_t out_tensor_addr = get_arg_val<uint32_t>(0);
+    uint32_t out_tensor_start_tile_id = get_arg_val<uint32_t>(1);
+    uint32_t out_tensor_stride_w = get_arg_val<uint32_t>(2);
+    uint32_t out_tensor_stride_h = get_arg_val<uint32_t>(3);
+    uint32_t out_tensor_next_subblock_stride_w = get_arg_val<uint32_t>(4);
+    uint32_t out_tensor_next_subblock_stride_h = get_arg_val<uint32_t>(5);
+
+    // out subblock args
+    uint32_t out_subblock_w = get_arg_val<uint32_t>(6);
+    uint32_t out_subblock_h = get_arg_val<uint32_t>(7);
+    uint32_t out_subblock_tile_count = get_arg_val<uint32_t>(8);
+    uint32_t out_num_subblocks_w = get_arg_val<uint32_t>(9);
+    uint32_t out_num_subblocks_h = get_arg_val<uint32_t>(10);
+
+    // batch args
+    uint32_t MtNt = get_arg_val<uint32_t>(11);  // if 0
+    uint32_t batch = get_arg_val<uint32_t>(12);
+
+    constexpr bool out_is_dram = get_compile_time_arg_val(0) == 1;
+
+    constexpr uint32_t cb_id_out0 = 16;
+
+    // single-tile
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_id_out0);
+    const DataFormat data_format = get_dataformat(cb_id_out0);
+
+    const InterleavedAddrGenFast<out_is_dram> s = {
+        .bank_base_address = out_tensor_addr, .page_size = single_tile_size_bytes, .data_format = data_format};
+
+    bool one_time_profile = true;
+    for (uint32_t b = 0; b < batch; b++) {
+        uint32_t out_tensor_sbh_start_tile_id = out_tensor_start_tile_id;
+        for (uint32_t sbh = 0; sbh < out_num_subblocks_h; sbh++) {
+            uint32_t out_tensor_sbw_start_tile_id = out_tensor_sbh_start_tile_id;
+            for (uint32_t sbw = 0; sbw < out_num_subblocks_w; sbw++) {
+                uint32_t out_tensor_sb_row_start_tile_id = out_tensor_sbw_start_tile_id;
+
+                cb_wait_front(cb_id_out0, out_subblock_tile_count);
+                uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+
+                for (uint32_t h = 0; h < out_subblock_h; h++) {
+                    uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
+                    for (uint32_t w = 0; w < out_subblock_w; w++) {
+                        noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                        l1_read_addr += single_tile_size_bytes;
+
+                        out_tensor_tile_id += out_tensor_stride_w;
+                    }
+                    out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
+                }
+
+                noc_async_write_barrier();
+                cb_pop_front(cb_id_out0, out_subblock_tile_count);
+                out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
+            }
+            out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
+        }
+        out_tensor_start_tile_id += MtNt;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -175,7 +175,10 @@ struct MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig {
     std::optional<UnaryWithParam> fused_activation;
 };
 
+struct MatmulMultiCoreProgramConfig {};
+
 using MatmulProgramConfig = std::variant<
+    MatmulMultiCoreProgramConfig,
     MatmulMultiCoreReuseProgramConfig,
     MatmulMultiCoreReuseMultiCastProgramConfig,
     MatmulMultiCoreReuseMultiCast1DProgramConfig,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/util.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/matmul/device/matmul_op.hpp"
+
+using namespace tt;
+using namespace tt::constants;
+
+namespace ttnn {
+
+namespace operations {
+
+namespace matmul {
+
+tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core(
+    const Tensor& a, const Tensor& b, Tensor& output, bool bcast_batch) {
+    tt_metal::Program program{};
+
+    const auto &ashape = a.get_padded_shape(), bshape = b.get_padded_shape();
+
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.get_dtype());
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t in0_single_tile_size = tt_metal::detail::TileSize(in0_data_format);
+    uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
+    uint32_t output_single_tile_size = tt_metal::detail::TileSize(output_data_format);
+    MathFidelity math_fidelity = MathFidelity::HiFi4;
+
+    tt_metal::Buffer* src0_buffer = a.buffer();
+    tt_metal::Buffer* src1_buffer = b.buffer();
+
+    // This should allocate a DRAM buffer on the device
+    tt::tt_metal::IDevice* device = a.device();
+    const auto& cshape = output.get_padded_shape();  // C=A*B, N1MK*11KN->N1MN
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t c_batch_size = get_batch_size(cshape);
+    auto num_output_tiles_total = c_batch_size * cshape[-2] * cshape[-1] / TILE_HW;
+    auto
+        [num_cores,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_output_tiles_per_core_group_1,
+         num_output_tiles_per_core_group_2] =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles_total);
+
+    tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    // C = A*B*...
+    // MN = MK*KN
+    uint32_t B = get_batch_size(ashape);
+    uint32_t Mt = ashape[-2] / TILE_HEIGHT;
+    uint32_t Kt = ashape[-1] / TILE_WIDTH;
+    uint32_t Nt = bshape[-1] / TILE_WIDTH;
+    uint32_t KtNt = Kt * Nt;
+    uint32_t MtKt = Mt * Kt;
+    uint32_t MtNt = Mt * Nt;
+
+    uint32_t src0_addr = src0_buffer->address();
+    uint32_t src1_addr = src1_buffer->address();
+    uint32_t dst_addr = dst_buffer->address();
+
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_tiles = 2;
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(num_input_tiles * in0_single_tile_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_single_tile_size);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+
+    uint32_t src1_cb_index = 1;
+    tt_metal::CircularBufferConfig src1_cb_config =
+        tt_metal::CircularBufferConfig(num_input_tiles * in1_single_tile_size, {{src1_cb_index, in1_data_format}})
+            .set_page_size(src1_cb_index, in1_single_tile_size);
+    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+
+    uint32_t output_cb_index = tt::CBIndex::c_16;
+    uint32_t num_output_tiles = 2;
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(
+            num_output_tiles * output_single_tile_size, {{output_cb_index, output_data_format}})
+            .set_page_size(output_cb_index, output_single_tile_size);
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+
+    bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    bool src1_is_dram = src1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_is_dram, (uint32_t)src1_is_dram};
+
+    bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
+
+    auto reader_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp",
+        all_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    auto writer_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+        all_cores,
+        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    std::vector<uint32_t> compute_args_group_1 = {
+        1,                                 // B
+        1,                                 // Mt
+        Kt,                                // Kt
+        num_output_tiles_per_core_group_1  // Nt
+    };  // bmm compute kernel the B, Mt, Nt are just 3 for loops that technically act as 1 large loop, so only set Nt
+        // for simplicity
+
+    auto eltwise_binary_kernel_group_1_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp",
+        core_group_1,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity, .dst_full_sync_en = true, .compile_args = compute_args_group_1});
+
+    if (!core_group_2.ranges().empty()) {
+        std::vector<uint32_t> compute_args_group_2 = {
+            1,                                 // B
+            1,                                 // Mt
+            Kt,                                // Kt
+            num_output_tiles_per_core_group_2  // Nt
+        };  // bmm compute kernel the B, Mt, Nt are just 3 for loops that technically act as 1 large loop, so only set
+            // Nt for simplicity
+
+        auto eltwise_binary_kernel_group_2_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp",
+            core_group_2,
+            tt_metal::ComputeConfig{
+                .math_fidelity = math_fidelity, .dst_full_sync_en = true, .compile_args = compute_args_group_2});
+    }
+
+    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_output_tiles_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_output_tiles_per_core = num_output_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_output_tiles_per_core = num_output_tiles_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges");
+        }
+        tt_metal::SetRuntimeArgs(
+            program,
+            reader_id,
+            core,
+            {src0_addr,
+             src1_addr,
+             Mt,
+             Kt,
+             Nt,
+             MtKt,
+             KtNt,
+             B,
+             uint32_t(bcast_batch),
+             num_tiles_written,
+             num_output_tiles_per_core,
+             MtNt});
+        tt_metal::SetRuntimeArgs(program, writer_id, core, {dst_addr, num_output_tiles_per_core, num_tiles_written});
+        num_tiles_written += num_output_tiles_per_core;
+    }
+
+    auto override_runtime_args_callback =
+        [reader_kernel_id = reader_id, writer_kernel_id = writer_id, num_cores, num_cores_y](
+            const void* operation,
+            const Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>&,
+            const std::vector<Tensor>& output_tensors) {
+            auto src_dram_buffer_a = input_tensors.at(0).buffer();
+            auto src_dram_buffer_b = input_tensors.at(1).buffer();
+
+            auto dst_dram_buffer = output_tensors.at(0).buffer();
+
+            for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
+                CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+                {
+                    auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    runtime_args[0] = src_dram_buffer_a->address();
+                    runtime_args[1] = src_dram_buffer_b->address();
+                }
+
+                {
+                    auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    runtime_args[0] = dst_dram_buffer->address();
+                }
+            }
+        };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+}
+
+}  // namespace matmul
+
+}  // namespace operations
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
@@ -1,0 +1,324 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/util.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/operation.hpp"
+#include "ttnn/operations/matmul/device/matmul_op.hpp"
+
+using namespace tt::constants;
+using namespace tt;
+using tt_metal::Buffer;
+
+tt_metal::operation::ProgramWithCallbacks create_program(
+    tt_metal::IDevice* device,
+    tt::DataFormat in0_cb_data_format,
+    tt::DataFormat in1_cb_data_format,
+    tt::DataFormat out_cb_data_format,
+    MathFidelity math_fidelity,
+    uint32_t num_cores_x,
+    uint32_t B,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
+    bool bcast_batch,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    tt_metal::Buffer* in0_buffer,
+    tt_metal::Buffer* in1_buffer,
+    tt_metal::Buffer* out_buffer) {
+    tt_metal::Program program{};
+
+    uint32_t in0_single_tile_size = tt_metal::detail::TileSize(in0_cb_data_format);
+    uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_cb_data_format);
+    uint32_t out_single_tile_size = tt_metal::detail::TileSize(out_cb_data_format);
+
+    uint32_t in0_block_tiles = per_core_M * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles * 2;  // double buffer
+    uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
+    uint32_t in1_block_tiles = per_core_N * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles * 2;  // double buffer
+    uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
+    uint32_t out_block_tiles = per_core_M * per_core_N;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t out_CB_size = out_CB_tiles * out_single_tile_size;
+
+    // Compute kernel compile time args
+    uint32_t num_blocks = (K / in0_block_w);
+
+    uint32_t in0_num_subblocks = (per_core_M / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (per_core_N / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
+
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
+
+        num_blocks,  // num_blocks
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        B                        // batch
+    };
+
+    uint32_t num_blocks_read = 0;
+    uint32_t num_blocks_y = M / per_core_M;
+    uint32_t num_blocks_x = N / per_core_N;
+
+    CoreRangeSet all_cores(tt::tt_metal::num_cores_to_corerangeset(
+        num_blocks_x * num_blocks_y, device->compute_with_storage_grid_size(), true));
+
+    // Create circular buffers
+    uint32_t src0_cb_index = 0;
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_cb_data_format}})
+            .set_page_size(src0_cb_index, in0_single_tile_size);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+
+    uint32_t src1_cb_index = 1;
+    tt_metal::CircularBufferConfig src1_cb_config =
+        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_cb_data_format}})
+            .set_page_size(src1_cb_index, in1_single_tile_size);
+    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+
+    uint32_t output_cb_index = tt::CBIndex::c_16;
+    uint32_t interm0_cb_index = 24;
+    std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+        {output_cb_index, out_cb_data_format}, {interm0_cb_index, out_cb_data_format}};
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+            .set_page_size(output_cb_index, out_single_tile_size)
+            .set_page_size(interm0_cb_index, out_single_tile_size);
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+
+    bool in0_is_dram = in0_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    bool in1_is_dram = in1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)in0_is_dram, (uint32_t)in1_is_dram};
+
+    bool out_is_dram = out_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    std::vector<uint32_t> writer_compile_time_args = {(uint32_t)out_is_dram};
+
+    // Create reader and writer kernels per core
+    auto mm_reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout.cpp",
+        all_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    auto unary_writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp",
+        all_cores,
+        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    // Create compute kernel
+    auto mm_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm.cpp",
+        all_cores,
+        tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .compile_args = compute_kernel_args});
+
+    for (int output_idx_y = 0; output_idx_y < num_blocks_y; output_idx_y++) {
+        for (int output_idx_x = 0; output_idx_x < num_blocks_x; output_idx_x++) {
+            int core_idx_x = num_blocks_read % num_cores_x;
+            int core_idx_y = num_blocks_read / num_cores_x;
+            CoreCoord core = {(std::size_t)core_idx_x, (std::size_t)core_idx_y};
+
+            // Write runtime args to device
+            std::vector<uint32_t> mm_reader_args = {
+                (std::uint32_t)in0_buffer->address(),          // in0_tensor_addr
+                (std::uint32_t)K * per_core_M * output_idx_y,  // in0_tensor_start_tile_id
+                (std::uint32_t)1,                              // in0_tensor_stride_w
+                (std::uint32_t)K,                              // in0_tensor_stride_h
+                (std::uint32_t)in0_block_w,                    // in0_tensor_next_block_stride
+
+                (std::uint32_t)in0_block_w,               // in0_block_w
+                (std::uint32_t)per_core_M,                // in0_block_h
+                (std::uint32_t)in0_block_w * per_core_M,  // in0_block_num_tiles
+
+                (std::uint32_t)in1_buffer->address(),      // in1_tensor_addr
+                (std::uint32_t)per_core_N * output_idx_x,  // in1_tensor_start_tile_id
+                (std::uint32_t)1,                          // in1_tensor_stride_w
+                (std::uint32_t)N,                          // in1_tensor_stride_h
+                (std::uint32_t)in0_block_w * N,            // in1_tensor_next_block_stride
+
+                (std::uint32_t)per_core_N,                // in1_block_w
+                (std::uint32_t)in0_block_w,               // in1_block_h
+                (std::uint32_t)per_core_N * in0_block_w,  // in1_block_num_tiles
+
+                (std::uint32_t)K / in0_block_w,  // num_blocks
+
+                (std::uint32_t)M * K,       // MtKt
+                (std::uint32_t)K * N,       // KtNt
+                (std::uint32_t)B,           // batch
+                (std::uint32_t)bcast_batch  // bcast_B
+            };
+
+            std::vector<uint32_t> writer_args = {
+                (std::uint32_t)out_buffer->address(),                                      // out_tensor_addr
+                (std::uint32_t)output_idx_x * per_core_N + output_idx_y * per_core_M * N,  // out_tensor_start_tile_id
+                (std::uint32_t)1,                                                          // out_tensor_stride_w
+                (std::uint32_t)N,                                                          // out_tensor_stride_h
+                (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+                (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+
+                (std::uint32_t)out_subblock_w,                     // out_subblock_w
+                (std::uint32_t)out_subblock_h,                     // out_subblock_h
+                (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+                (std::uint32_t)(per_core_N / out_subblock_w),      // out_num_subblocks_w
+                (std::uint32_t)(per_core_M / out_subblock_h),      // out_num_subblocks_h
+
+                (std::uint32_t)M * N,  // MtNt
+                (std::uint32_t)B       // batch
+            };
+
+            tt_metal::SetRuntimeArgs(program, mm_reader_kernel_id, core, mm_reader_args);
+            tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_args);
+
+            num_blocks_read++;
+        }
+    }
+
+    auto override_runtime_args_callback = [reader_kernel_id = mm_reader_kernel_id,
+                                           writer_kernel_id = unary_writer_kernel_id,
+                                           num_cores_x,
+                                           num_blocks_y,
+                                           num_blocks_x](
+                                              const void* operation,
+                                              const tt::tt_metal::Program& program,
+                                              const std::vector<ttnn::Tensor>& input_tensors,
+                                              const std::vector<std::optional<const ttnn::Tensor>>&,
+                                              const std::vector<ttnn::Tensor>& output_tensors) {
+        auto src_dram_buffer_a = input_tensors.at(0).buffer();
+        auto src_dram_buffer_b = input_tensors.at(1).buffer();
+
+        auto dst_dram_buffer = output_tensors.at(0).buffer();
+
+        uint32_t num_blocks_read = 0;
+        for (int output_idx_y = 0; output_idx_y < num_blocks_y; output_idx_y++) {
+            for (int output_idx_x = 0; output_idx_x < num_blocks_x; output_idx_x++) {
+                int core_idx_x = num_blocks_read % num_cores_x;
+                int core_idx_y = num_blocks_read / num_cores_x;
+                CoreCoord core = {(std::size_t)core_idx_x, (std::size_t)core_idx_y};
+
+                {
+                    auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    runtime_args[0] = src_dram_buffer_a->address();
+                    runtime_args[8] = src_dram_buffer_b->address();
+                }
+
+                {
+                    auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    runtime_args[0] = dst_dram_buffer->address();
+                }
+                num_blocks_read++;
+            }
+        }
+    };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
+namespace ttnn {
+
+namespace operations {
+
+namespace matmul {
+
+tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse(
+    const Tensor& a, const Tensor& b, Tensor& output, bool bcast_batch) {
+    const auto &ashape = a.get_padded_shape(), bshape = b.get_padded_shape();
+
+    tt::DataFormat in0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    tt::DataFormat in1_cb_data_format = tt_metal::datatype_to_dataformat_converter(b.get_dtype());
+    tt::DataFormat out_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    MathFidelity math_fidelity = MathFidelity::HiFi4;
+
+    tt_metal::Buffer* in0_buffer = a.buffer();
+    tt_metal::Buffer* in1_buffer = b.buffer();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Matmul Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    // NOTE: Only supports matmuls where output is blocks of 16 x 16 tiles (ie. multiples of 16*32 x 16*32)
+    // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
+    uint32_t B = get_batch_size(ashape);
+    uint32_t Mt = ashape[-2] / TILE_HEIGHT;
+    uint32_t Kt = ashape[-1] / TILE_WIDTH;
+    uint32_t Nt = bshape[-1] / TILE_WIDTH;
+    uint32_t in0_block_w = 2;
+    uint32_t out_subblock_h = 4;
+    uint32_t out_subblock_w = 2;
+    uint32_t per_core_M = 16;
+    uint32_t per_core_N = 16;
+
+    TT_FATAL(Mt % per_core_M == 0, "Error");
+    TT_FATAL(Nt % per_core_N == 0, "Error");
+    TT_FATAL(Kt % in0_block_w == 0, "Error");
+
+    // This should allocate a DRAM buffer on the device
+    tt_metal::IDevice* device = a.device();
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    uint32_t num_blocks_total = (Mt / per_core_M) * (Nt / per_core_N);
+    TT_FATAL(num_blocks_total <= num_cores_x * num_cores_y, "Error");
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Grayskull Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto cshape = output.get_padded_shape();  // C=A*B, N1MK*11KN->N1MN
+    tt_metal::Buffer* out_buffer = output.buffer();
+    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+
+    return create_program(
+        device,
+        in0_cb_data_format,
+        in1_cb_data_format,
+        out_cb_data_format,
+        math_fidelity,
+        num_cores_x,
+        B,
+        Mt,
+        Nt,
+        Kt,
+        bcast_batch,
+        in0_block_w,
+        out_subblock_h,
+        out_subblock_w,
+        per_core_M,
+        per_core_N,
+        in0_buffer,
+        in1_buffer,
+        out_buffer);
+}
+
+}  // namespace matmul
+
+}  // namespace operations
+
+}  // namespace ttnn


### PR DESCRIPTION
This reverts commit ab1f1dc8eb3e13b6b94a6b0858cdd40c1c280aa3.

### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-metal/issues/22426

### Problem description
There's a failure occurring in (Single-card) Frequent model and ttnn tests pipeline due to a runtime error

> Statically allocated circular buffers on core range [(x=0,y=0) - (x=0,y=7)] grow to 2358240 B which is beyond max L1 size of 1499136 B 

https://github.com/tenstorrent/tt-metal/actions/runs/15166988869/job/42652127572#step:8:2084

### What's changed
Reverting the commit as discussed in this Slack thread: https://tenstorrent.slack.com/archives/C05GRJC4J4A/p1747861919046479

### Checklist
- [Y] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15175524460) CI passes