### PR TITLE
[skip ci] Do not attempt to load tt-fabric tests.  Presumed static object badness inside.

### DIFF
--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -6,7 +6,6 @@ set(UNIT_TESTS_FABRIC_SRC
 )
 
 add_executable(fabric_unit_tests ${UNIT_TESTS_FABRIC_SRC})
-gtest_discover_tests(fabric_unit_tests)
 
 target_link_libraries(
     fabric_unit_tests
@@ -44,7 +43,6 @@ target_link_libraries(
         test_common_libs
 )
 add_executable(test_system_health)
-gtest_discover_tests(test_system_health)
 
 target_include_directories(
     test_system_health_smoke


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Sometimes the binary hangs when attempting to merely list the tests inside.  eg: https://github.com/tenstorrent/tt-metal/actions/runs/15175175128/job/42674836336#step:10:1148
Presumably there is some static object that is causing grief, otherwise that should never happen.  Unfortunately it doesn't always happen, so difficult to root cause.

### What's changed
Do not probe for the individual tests inside the binary.  I'd be surprised if anybody is using that feature anyway.