### PR TITLE
#21299: Fix slice_write channels%16!=0

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -293,9 +293,13 @@ def run_conv(
 
     torch.set_printoptions(precision=3, sci_mode=False)
     if fast_compare:
-        passing, pcc_msg = check_with_fast_pcc_without_tensor_printout(out, ref, pcc=pcc)
-        logger.info(f"PCC = {pcc_msg}. Threshold = {pcc}")
-        assert passing, pcc_msg
+        if fp32_accum:
+            threshold = 3e-1 + 5e-3 * math.log(input_channels * filter_height * filter_width, 2)
+        else:
+            threshold = 3e-1 + 1e-1 * math.log(input_channels * filter_height * filter_width, 2)
+        logger.info(f"Threshold: {threshold}")
+        diff = torch.abs(ref - out) / ref.abs().mean()
+        assert torch.all(diff < threshold), f"Max diff: {diff.max()}, Threshold: {threshold} "
     else:
         passing, pcc_msg = check_with_pcc_without_tensor_printout(out, ref, pcc=pcc)
         logger.info(f"PCC = {pcc_msg}. Threshold = {pcc}")
@@ -3221,7 +3225,7 @@ def test_conv2d_sdxl(
         (1, 512, 512, 512, 512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, 1, 1, ttnn.Conv2dSliceWidth, 8),
 
         # output_channels 3
-        # (1, 128, 3, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, 1, 1, ttnn.Conv2dSliceWidth, 16), #  pcc: 0.0
+        (1, 128, 3, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, 1, 1, ttnn.Conv2dSliceWidth, 16), #  pcc: 0.0
 
         # input_channels 4
         (1, 4, 512, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, 1, 1, None, 1),

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3225,7 +3225,7 @@ def test_conv2d_sdxl(
         (1, 512, 512, 512, 512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, 1, 1, ttnn.Conv2dSliceWidth, 8),
 
         # output_channels 3
-        (1, 128, 3, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, 1, 1, ttnn.Conv2dSliceWidth, 16), #  pcc: 0.0
+        (1, 128, 3, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, 1, 1, ttnn.Conv2dSliceWidth, 16),
 
         # input_channels 4
         (1, 4, 512, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, 1, 1, None, 1),

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -188,6 +188,9 @@ Result conv2d_DRAM(
 
     ttnn::Tensor weight_tensor_on_device;
     std::optional<ttnn::Tensor> bias_tensor_on_device;
+    TT_FATAL(!memory_config_.has_value(), "Setting Memory config for Conv2D with DRAM Slicing is not supported.");
+    TT_FATAL(
+        !conv_config.deallocate_activation, "Deallocate activation is not supported for Conv2D with DRAM Slicing.");
     TT_FATAL(input_tensor_on_device.memory_config().is_dram(), "Conv DRAM expects the input tensor to be in DRAM.");
     TT_FATAL(conv_config.dtype != tt::tt_metal::DataType::BFLOAT8_B, "Conv DRAM currently doesn't support BFLOAT8_B");
     TT_FATAL(
@@ -352,6 +355,7 @@ Result conv2d_DRAM(
             sliced_output_tensor = ttnn::to_memory_config(
                 sliced_output_tensor, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
         }
+        sliced_output_tensor = ttnn::reshape(sliced_output_tensor, sliced_output_tensor.get_padded_shape());
         if (sliced_output_tensor.layout() != Layout::ROW_MAJOR) {
             sliced_output_tensor =
                 ttnn::to_layout(sliced_output_tensor, Layout::ROW_MAJOR, std::nullopt, std::nullopt, device);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -355,7 +355,11 @@ Result conv2d_DRAM(
             sliced_output_tensor = ttnn::to_memory_config(
                 sliced_output_tensor, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
         }
+        // Error in UntilizeWithUnpad.
+        // Reshape to padded_shape makes to_layout call just untilize.
+        // https://github.com/tenstorrent/tt-metal/issues/22580
         sliced_output_tensor = ttnn::reshape(sliced_output_tensor, sliced_output_tensor.get_padded_shape());
+
         if (sliced_output_tensor.layout() != Layout::ROW_MAJOR) {
             sliced_output_tensor =
                 ttnn::to_layout(sliced_output_tensor, Layout::ROW_MAJOR, std::nullopt, std::nullopt, device);

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
@@ -7,8 +7,8 @@
 
 void kernel_main() {
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    const uint32_t padded_stick_size = get_arg_val<uint32_t>(1);
-    const uint32_t unpadded_stick_size = get_arg_val<uint32_t>(2);
+    const uint32_t output_stick_size = get_arg_val<uint32_t>(1);
+    const uint32_t input_stick_size = get_arg_val<uint32_t>(2);
     const uint32_t stick_size_offset = get_arg_val<uint32_t>(3);
     const uint32_t num_dims = get_arg_val<uint32_t>(4);
     const uint32_t start_id = get_arg_val<uint32_t>(5);
@@ -18,8 +18,8 @@ void kernel_main() {
 
 #ifdef DEBUG
     DPRINT << "dst_addr: " << dst_addr << ENDL();
-    DPRINT << "padded_stick_size: " << padded_stick_size << ENDL();
-    DPRINT << "unpadded_stick_size: " << unpadded_stick_size << ENDL();
+    DPRINT << "output_stick_size: " << output_stick_size << ENDL();
+    DPRINT << "input_stick_size: " << input_stick_size << ENDL();
     DPRINT << "stick_size_offset: " << stick_size_offset << ENDL();
     DPRINT << "num_dims: " << num_dims << ENDL();
     DPRINT << "start_id: " << start_id << ENDL();
@@ -31,17 +31,10 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-#ifdef DEBUG
-    DPRINT << "num_unpadded_sticks: " << num_unpadded_sticks[0] << " " << num_unpadded_sticks[1] << " "
-           << num_unpadded_sticks[2] << " " << num_unpadded_sticks[3] << " " << ENDL();
-    DPRINT << "num_padded_sticks: " << num_padded_sticks[0] << " " << num_padded_sticks[1] << " "
-           << num_padded_sticks[2] << " " << num_padded_sticks[3] << " " << ENDL();
-    DPRINT << "Out CB Page size: " << get_local_cb_interface(cb_id_out0).fifo_page_size << ENDL();
-#endif
     constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
 
-    const InterleavedAddrGen<dst0_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = padded_stick_size};
-    const uint32_t noc_write_size = min(padded_stick_size, unpadded_stick_size);
+    const InterleavedAddrGen<dst0_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = output_stick_size};
+    const uint32_t noc_write_size = min(output_stick_size, input_stick_size);
     uint32_t dst_stick_id = start_id;
     uint32_t sticks_read = 0;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -41,7 +41,7 @@ void kernel_main() {
     constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
 
     const InterleavedAddrGen<dst0_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = padded_stick_size};
-
+    const uint32_t noc_write_size = min(padded_stick_size, unpadded_stick_size);
     uint32_t dst_stick_id = start_id;
     uint32_t sticks_read = 0;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
@@ -51,7 +51,7 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
             uint64_t dst_noc_addr = get_noc_addr(dst_stick_id, s0);
-            noc_async_write(src_buffer_l1_addr, dst_noc_addr, unpadded_stick_size);
+            noc_async_write(src_buffer_l1_addr, dst_noc_addr, noc_write_size);
             src_buffer_l1_addr += stick_size_offset;
             dst_stick_id++;
             for (uint32_t j = 0; j < num_dims; j++) {

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_op.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_op.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
### Ticket
#21299

### Problem description
- fast_compare in run_conv always passes, causing failing tests to appear as passing.
- Conv_Dram fails when out_channels%16!=0. When out_channels is not a multiple of 16, the conv op pads the out_channels dimension to make it a multiple. However, the final DRAM output has the actual out_channels dimension, not the padded one. Untilize With Unpad is used to remove this padding. However the output of Untilize with Unpad is incorrect.

### What's changed

- Change fast_compare function to an element-wise comparison which actually works
- Fixed slice write for out_channels%16!=0. Untilize is explicitly used to avoid untilize_with_unpad which fails. 
- Slice write does unpad on the channels dimension when it writes the output to DRAM Interleaved. 


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15302705128)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15302720490)
- [ ] Blackhole Nightly [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15302716059)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15304818647)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15304824615)
- [x] Nightly L2 [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15302712227) 
- [x] New/Existing tests provide coverage for changes