### PR TITLE
#22271: Check that there is sufficient dram banks to run experimental dram matmul test

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/test_experimental.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2043 TenstorrentAI ULC
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/test_experimental.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2043 TenstorrentAI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/test_experimental.py
@@ -13,7 +13,6 @@ from models.utility_functions import (
     is_wormhole_b0,
     is_grayskull,
     is_blackhole,
-    skip_for_blackhole,
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -149,13 +148,15 @@ def test_ttnn_linear(
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9996)
 
 
-@skip_for_blackhole("Does not work on BH P100a. Issue #22271")
 @pytest.mark.parametrize("m_size", [32])
 @pytest.mark.parametrize("k_size", [8192])
 @pytest.mark.parametrize("n_size", [1024])
 def test_ttnn_matmul_dram_sharded(device, m_size, k_size, n_size):
     torch.manual_seed(0)
 
+    dram_grid_size = device.dram_grid_size().x
+    if dram_grid_size < 8:
+        pytest.skip(f"Minimum dram grid size needs to be 8 and is {dram_grid_size}.")
     grid_size = ttnn.CoreGrid(y=1, x=8)
 
     torch_input_tensor_in0 = torch.randn((1, 1, m_size, k_size), dtype=torch.bfloat16)


### PR DESCRIPTION
### Ticket
Link to Github Issue #22271

### Problem description
- test requires a minimum number of dram banks

### What's changed
- check and skip if dram banks is not enough
- there is sufficient coverage in regular matmul unit tests for this functionality

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15196589899
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/15196591741
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). N/A
- [x] New/Existing tests provide coverage for changes

Nightly P150 and P100 passes https://github.com/tenstorrent/tt-metal/actions/runs/15196597563