### PR TITLE
Support running the Fabric Mux on idle eth cores

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -236,6 +236,9 @@ void create_kernel(
     const std::vector<uint32_t>& ct_args,
     const std::vector<uint32_t>& rt_args,
     const std::vector<std::pair<size_t, size_t>>& addresses_to_clear) {
+    // Default to TENSIX for now
+    const auto programmable_core_type = tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
+        tt::tt_metal::HalProgrammableCoreType::TENSIX);
     auto kernel_handle = tt::tt_metal::CreateKernel(
         program_handle,
         kernel_src,
@@ -244,6 +247,7 @@ void create_kernel(
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt::tt_metal::NOC::RISCV_0_default,
             .compile_args = ct_args,
+            .defines = {{"MY_CORE_TYPE", std::to_string(programmable_core_type)}},
             .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
     tt::tt_metal::SetRuntimeArgs(program_handle, kernel_handle, logical_core, rt_args);
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -236,9 +236,6 @@ void create_kernel(
     const std::vector<uint32_t>& ct_args,
     const std::vector<uint32_t>& rt_args,
     const std::vector<std::pair<size_t, size_t>>& addresses_to_clear) {
-    // Default to TENSIX for now
-    const auto programmable_core_type = tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
-        tt::tt_metal::HalProgrammableCoreType::TENSIX);
     auto kernel_handle = tt::tt_metal::CreateKernel(
         program_handle,
         kernel_src,
@@ -247,7 +244,6 @@ void create_kernel(
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt::tt_metal::NOC::RISCV_0_default,
             .compile_args = ct_args,
-            .defines = {{"MY_CORE_TYPE", std::to_string(programmable_core_type)}},
             .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
     tt::tt_metal::SetRuntimeArgs(program_handle, kernel_handle, logical_core, rt_args);
 
@@ -447,6 +443,10 @@ void run_mux_test_variant(FabricMuxFixture* fixture, TestConfig test_config) {
         sizeof(tt::tt_fabric::PacketHeader) + test_config.packet_payload_size_bytes;
     size_t buffer_size_bytes_header_only_channel = sizeof(tt::tt_fabric::PacketHeader);
 
+    // Default to TENSIX for now
+    const auto programmable_core_type = tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
+        tt::tt_metal::HalProgrammableCoreType::TENSIX);
+
     for (auto i = 0; i < devices.size(); i++) {
         program_handles[i] = tt_metal::CreateProgram();
         // use logical core (0,0) for the mux kernel
@@ -462,7 +462,8 @@ void run_mux_test_variant(FabricMuxFixture* fixture, TestConfig test_config) {
             test_config.num_buffers_full_size_channel,
             test_config.num_buffers_header_only_channel,
             buffer_size_bytes_full_size_channel,
-            mux_base_l1_address);
+            mux_base_l1_address,
+            programmable_core_type);
         if (test_config.num_full_size_channel_iters > 1) {
             mux_kernel_config.set_num_full_size_channel_iters(test_config.num_full_size_channel_iters);
         }

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -443,10 +443,6 @@ void run_mux_test_variant(FabricMuxFixture* fixture, TestConfig test_config) {
         sizeof(tt::tt_fabric::PacketHeader) + test_config.packet_payload_size_bytes;
     size_t buffer_size_bytes_header_only_channel = sizeof(tt::tt_fabric::PacketHeader);
 
-    // Default to TENSIX for now
-    const auto programmable_core_type = tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
-        tt::tt_metal::HalProgrammableCoreType::TENSIX);
-
     for (auto i = 0; i < devices.size(); i++) {
         program_handles[i] = tt_metal::CreateProgram();
         // use logical core (0,0) for the mux kernel
@@ -462,8 +458,7 @@ void run_mux_test_variant(FabricMuxFixture* fixture, TestConfig test_config) {
             test_config.num_buffers_full_size_channel,
             test_config.num_buffers_header_only_channel,
             buffer_size_bytes_full_size_channel,
-            mux_base_l1_address,
-            programmable_core_type);
+            mux_base_l1_address);
         if (test_config.num_full_size_channel_iters > 1) {
             mux_kernel_config.set_num_full_size_channel_iters(test_config.num_full_size_channel_iters);
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -110,6 +110,9 @@ void create_kernel(
     const std::vector<uint32_t>& ct_args,
     const std::vector<uint32_t>& rt_args,
     const std::vector<std::pair<size_t, size_t>>& addresses_to_clear) {
+    // Default to TENSIX for now
+    const auto programmable_core_type = tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
+        tt::tt_metal::HalProgrammableCoreType::TENSIX);
     auto kernel_handle = tt::tt_metal::CreateKernel(
         program_handle,
         kernel_src,
@@ -118,6 +121,7 @@ void create_kernel(
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt::tt_metal::NOC::RISCV_0_default,
             .compile_args = ct_args,
+            .defines = {{"MY_CORE_TYPE", std::to_string(programmable_core_type)}},
             .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
     tt::tt_metal::SetRuntimeArgs(program_handle, kernel_handle, logical_core, rt_args);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
@@ -110,9 +110,6 @@ void create_kernel(
     const std::vector<uint32_t>& ct_args,
     const std::vector<uint32_t>& rt_args,
     const std::vector<std::pair<size_t, size_t>>& addresses_to_clear) {
-    // Default to TENSIX for now
-    const auto programmable_core_type = tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
-        tt::tt_metal::HalProgrammableCoreType::TENSIX);
     auto kernel_handle = tt::tt_metal::CreateKernel(
         program_handle,
         kernel_src,
@@ -121,7 +118,6 @@ void create_kernel(
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt::tt_metal::NOC::RISCV_0_default,
             .compile_args = ct_args,
-            .defines = {{"MY_CORE_TYPE", std::to_string(programmable_core_type)}},
             .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
     tt::tt_metal::SetRuntimeArgs(program_handle, kernel_handle, logical_core, rt_args);
 
@@ -370,13 +366,18 @@ int main(int argc, char** argv) {
     const uint32_t l1_unreserved_base_address =
         device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
 
+    // Default to TENSIX for now
+    const auto programmable_core_type = tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
+        tt::tt_metal::HalProgrammableCoreType::TENSIX);
+
     auto mux_kernel_config = tt::tt_fabric::FabricMuxConfig(
         test_params.num_full_size_channels,
         test_params.num_header_only_channels,
         test_params.num_buffers_full_size_channel,
         test_params.num_buffers_header_only_channel,
         test_params.buffer_size_bytes_full_size_channel,
-        l1_unreserved_base_address);
+        l1_unreserved_base_address,
+        programmable_core_type);
     MuxTestConfig mux_test_config = {
         .mux_kernel_config = &mux_kernel_config,
         .mux_logical_core = mux_logical_core,
@@ -389,7 +390,8 @@ int main(int argc, char** argv) {
         16,                                         /* num_buffers_full_size_channel */
         8,                                          /* num_buffers_header_only_channel */
         sizeof(tt::tt_fabric::PacketHeader) + 4096, /* buffer_size_bytes_full_size_channel (4K packet) */
-        l1_unreserved_base_address);
+        l1_unreserved_base_address,
+        programmable_core_type);
     DrainerTestConfig drainer_test_config = {
         .drainer_kernel_config = &drainer_kernel_config,
         .drainer_logical_core = drainer_logical_core,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
@@ -366,18 +366,13 @@ int main(int argc, char** argv) {
     const uint32_t l1_unreserved_base_address =
         device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
 
-    // Default to TENSIX for now
-    const auto programmable_core_type = tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
-        tt::tt_metal::HalProgrammableCoreType::TENSIX);
-
     auto mux_kernel_config = tt::tt_fabric::FabricMuxConfig(
         test_params.num_full_size_channels,
         test_params.num_header_only_channels,
         test_params.num_buffers_full_size_channel,
         test_params.num_buffers_header_only_channel,
         test_params.buffer_size_bytes_full_size_channel,
-        l1_unreserved_base_address,
-        programmable_core_type);
+        l1_unreserved_base_address);
     MuxTestConfig mux_test_config = {
         .mux_kernel_config = &mux_kernel_config,
         .mux_logical_core = mux_logical_core,
@@ -390,8 +385,7 @@ int main(int argc, char** argv) {
         16,                                         /* num_buffers_full_size_channel */
         8,                                          /* num_buffers_header_only_channel */
         sizeof(tt::tt_fabric::PacketHeader) + 4096, /* buffer_size_bytes_full_size_channel (4K packet) */
-        l1_unreserved_base_address,
-        programmable_core_type);
+        l1_unreserved_base_address);
     DrainerTestConfig drainer_test_config = {
         .drainer_kernel_config = &drainer_kernel_config,
         .drainer_logical_core = drainer_logical_core,

--- a/tt_metal/fabric/fabric_mux_config.hpp
+++ b/tt_metal/fabric/fabric_mux_config.hpp
@@ -55,7 +55,7 @@ enum class FabricMuxChannelType : uint8_t { FULL_SIZE_CHANNEL = 0, HEADER_ONLY_C
     -> Buffer size in bytes for a full size channel (for a header only channel its equal to the pre-determined packet
         header size)
     -> Base address where the channels start in the mux's L1
-    -> Core Type of the mux. Supports Worker and Ethernet (idle)
+    -> Core Type of the mux. Supports Worker and Idle Ethernet
 
     Advanced configuration parameters:
     -> Number of full size channel iters
@@ -143,7 +143,7 @@ struct FabricMuxConfig {
         const auto& hal = tt_metal::MetalContext::instance().hal();
         if (core_type == CoreType::WORKER) {
             core_type_index = hal.get_programmable_core_type_index(tt_metal::HalProgrammableCoreType::TENSIX);
-        } else if (core_type == CoreType::ETH) {
+        } else if (core_type == CoreType::IDLE_ETH) {
             core_type_index = hal.get_programmable_core_type_index(tt_metal::HalProgrammableCoreType::IDLE_ETH);
         } else {
             TT_THROW("Fabric Mux does not support core type {}", magic_enum::enum_name(core_type));

--- a/tt_metal/fabric/fabric_mux_config.hpp
+++ b/tt_metal/fabric/fabric_mux_config.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <tt-metalium/fabric.hpp>
 #include <tt-metalium/erisc_datamover_builder.hpp>
+#include <tt-metalium/control_plane.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
 
@@ -81,6 +82,7 @@ struct FabricMuxConfig {
     uint8_t num_buffers_full_size_channel = 0;
     uint8_t num_buffers_header_only_channel = 0;
     size_t buffer_size_bytes_full_size_channel = 0;
+    uint8_t core_type_index = 0;
 
     FabricMuxConfig(
         uint8_t num_full_size_channels,
@@ -88,7 +90,8 @@ struct FabricMuxConfig {
         uint8_t num_buffers_full_size_channel,
         uint8_t num_buffers_header_only_channel,
         size_t buffer_size_bytes_full_size_channel,
-        size_t base_l1_address) :
+        size_t base_l1_address,
+        uint8_t core_type_index) :
         num_full_size_channels(num_full_size_channels),
         num_header_only_channels(num_header_only_channels),
         // set to default number of buffers only for compilation purposes, no functional impact
@@ -96,7 +99,8 @@ struct FabricMuxConfig {
             num_buffers_full_size_channel == 0 ? default_num_buffers : num_buffers_full_size_channel),
         num_buffers_header_only_channel(
             num_buffers_header_only_channel == 0 ? default_num_buffers : num_buffers_header_only_channel),
-        buffer_size_bytes_full_size_channel(buffer_size_bytes_full_size_channel) {
+        buffer_size_bytes_full_size_channel(buffer_size_bytes_full_size_channel),
+        core_type_index(core_type_index) {
         size_t max_buffer_size_bytes_full_size_channel = get_max_buffer_size_bytes_full_size_channel();
         if (buffer_size_bytes_full_size_channel > max_buffer_size_bytes_full_size_channel) {
             TT_THROW(
@@ -170,7 +174,8 @@ struct FabricMuxConfig {
             fabric_router_config.edm_status_address,
             fabric_router_config.sender_channels_num_buffers[0],
             this->num_full_size_channel_iters,
-            this->num_iters_between_teardown_checks};
+            this->num_iters_between_teardown_checks,
+            this->core_type_index};
     }
 
     size_t get_status_address() const { return this->status_address; }

--- a/tt_metal/fabric/fabric_mux_config.hpp
+++ b/tt_metal/fabric/fabric_mux_config.hpp
@@ -55,6 +55,7 @@ enum class FabricMuxChannelType : uint8_t { FULL_SIZE_CHANNEL = 0, HEADER_ONLY_C
     -> Buffer size in bytes for a full size channel (for a header only channel its equal to the pre-determined packet
         header size)
     -> Base address where the channels start in the mux's L1
+    -> Core Type of the mux. Supports Worker and Ethernet (idle)
 
     Advanced configuration parameters:
     -> Number of full size channel iters

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -109,6 +109,7 @@ struct WorkerToFabricEdmSenderImpl {
             write_at_cmd_buf);
     }
 
+    template <ProgrammableCoreType my_core_type = ProgrammableCoreType::ACTIVE_ETH>
     FORCE_INLINE void init(
         bool connected_to_persistent_fabric,
         uint8_t direction,
@@ -145,11 +146,11 @@ struct WorkerToFabricEdmSenderImpl {
         this->edm_connection_handshake_l1_addr =
             connected_to_persistent_fabric
                 ? edm_connection_handshake_l1_id
-                : get_semaphore<ProgrammableCoreType::ACTIVE_ETH>(edm_connection_handshake_l1_id);
+                : get_semaphore<my_core_type>(edm_connection_handshake_l1_id);
         this->edm_worker_location_info_addr = edm_worker_location_info_addr;
         this->edm_copy_of_wr_counter_addr = connected_to_persistent_fabric
                                                 ? edm_buffer_index_id
-                                                : get_semaphore<ProgrammableCoreType::ACTIVE_ETH>(edm_buffer_index_id);
+                                                : get_semaphore<my_core_type>(edm_buffer_index_id);
         this->from_remote_buffer_free_slots_ptr = from_remote_buffer_free_slots_ptr;
         this->worker_teardown_addr = worker_teardown_addr;
         this->edm_buffer_base_addr = edm_buffer_base_addr;
@@ -172,6 +173,7 @@ struct WorkerToFabricEdmSenderImpl {
         }
     }
 
+    template <ProgrammableCoreType my_core_type = ProgrammableCoreType::ACTIVE_ETH>
     WorkerToFabricEdmSenderImpl(
         bool connected_to_persistent_fabric,
         uint8_t direction,
@@ -191,7 +193,7 @@ struct WorkerToFabricEdmSenderImpl {
         StreamId worker_credits_stream_id,
         uint8_t data_noc_cmd_buf = write_reg_cmd_buf,
         uint8_t sync_noc_cmd_buf = write_at_cmd_buf) {
-        this->init(
+        this->init<my_core_type>(
             connected_to_persistent_fabric,
             direction,
             edm_worker_x,

--- a/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
@@ -11,7 +11,6 @@
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp"
 
 #include <cstddef>
-#include <array>
 // clang-format on
 
 constexpr size_t NUM_FULL_SIZE_CHANNELS = get_compile_time_arg_val(0);
@@ -33,6 +32,8 @@ constexpr size_t fabric_router_status_address = get_compile_time_arg_val(12);
 constexpr uint8_t NUM_EDM_BUFFERS = get_compile_time_arg_val(13);
 constexpr size_t NUM_FULL_SIZE_CHANNELS_ITERS = get_compile_time_arg_val(14);
 constexpr size_t NUM_ITERS_BETWEEN_TEARDOWN_CHECKS = get_compile_time_arg_val(15);
+
+constexpr ProgrammableCoreType CORE_TYPE = static_cast<ProgrammableCoreType>(get_compile_time_arg_val(16));
 
 constexpr size_t NOC_ALIGN_PADDING_BYTES = 12;
 
@@ -121,8 +122,7 @@ void kernel_main() {
     status_ptr[0] = tt::tt_fabric::FabricMuxStatus::STARTED;
 
     size_t rt_args_idx = 0;
-    constexpr ProgrammableCoreType programmable_core_type = static_cast<ProgrammableCoreType>(MY_CORE_TYPE);
-    auto fabric_connection = tt::tt_fabric::FabricMuxToEdmSender::build_from_args<programmable_core_type>(rt_args_idx);
+    auto fabric_connection = tt::tt_fabric::FabricMuxToEdmSender::build_from_args<CORE_TYPE>(rt_args_idx);
 
     std::array<tt::tt_fabric::FabricMuxChannelBuffer<NUM_BUFFERS_FULL_SIZE_CHANNEL>, NUM_FULL_SIZE_CHANNELS>
         full_size_channels;

--- a/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
@@ -11,6 +11,7 @@
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp"
 
 #include <cstddef>
+#include <array>
 // clang-format on
 
 constexpr size_t NUM_FULL_SIZE_CHANNELS = get_compile_time_arg_val(0);


### PR DESCRIPTION
### Ticket
#18726

### Problem description
- Fabric MUX has semaphores hardcoded to TENSIX
- Need to run the Fabric MUX on Idle Ethernet cores when using Eth Dispatch
- Risk of hanging on subsequent runs if the mux doesn't exit properly

### What's changed
- Parameterize ProgrammableCoreType in the kernel
- Post eth heartbeat to avoid link training hangs if the mux doesn't exit properly
- Update FabricConfig struct to include the core type

### Checklist
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/15328487155
T3K Fast
https://github.com/tenstorrent/tt-metal/actions/runs/15328494369
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15398016410
BH
https://github.com/tenstorrent/tt-metal/actions/runs/15398024634
TG
https://github.com/tenstorrent/tt-metal/actions/runs/15328490881
