### PR TITLE
Register termination info in topology

### DIFF
--- a/tt_metal/impl/dispatch/kernel_config/demux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.hpp
@@ -1,6 +1,7 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 #include <stdint.h>
 #include <array>
@@ -8,6 +9,9 @@
 
 #include "dispatch/kernels/packet_queue_ctrl.hpp"
 #include "fd_kernel.hpp"
+
+namespace tt {
+namespace tt_metal {
 
 struct demux_static_config_t {
     std::optional<uint32_t> endpoint_id_start_index;
@@ -64,3 +68,6 @@ private:
     demux_dependent_config_t dependent_config_;
     int placement_cq_id_;  // TODO: remove channel hard-coding for dispatch core manager
 };
+
+}  // namespace tt_metal
+}  // namespace tt

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,6 +14,9 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include <umd/device/tt_xy_pair.h>
+
+namespace tt {
+namespace tt_metal {
 
 struct dispatch_static_config_t {
     std::optional<uint32_t> dispatch_cb_base;  // 0
@@ -136,3 +139,6 @@ private:
     dispatch_static_config_t static_config_;
     dispatch_dependent_config_t dependent_config_;
 };
+
+}  // namespace tt_metal
+}  // namespace tt

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
@@ -8,6 +8,9 @@
 #include "fd_kernel.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_xy_pair.h>
+
+namespace tt {
+namespace tt_metal {
 
 struct dispatch_s_static_config_t {
     std::optional<uint32_t> cb_base;
@@ -51,3 +54,6 @@ private:
     dispatch_s_static_config_t static_config_;
     dispatch_s_dependent_config_t dependent_config_;
 };
+
+}  // namespace tt_metal
+}  // namespace tt

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
@@ -8,6 +8,9 @@
 
 #include "dispatch/kernels/packet_queue_ctrl.hpp"
 #include "fd_kernel.hpp"
+
+namespace tt {
+namespace tt_metal {
 
 struct eth_router_static_config_t {
     std::optional<uint32_t> vc_count;                   // Set from arch level
@@ -77,3 +80,6 @@ private:
     int placement_cq_id_;  // TODO: remove channel hard-coding for dispatch core manager
     bool as_mux_;
 };
+
+}  // namespace tt_metal
+}  // namespace tt

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
@@ -9,6 +9,9 @@
 #include "dispatch/kernels/packet_queue_ctrl.hpp"
 #include "fd_kernel.hpp"
 #include <umd/device/tt_core_coordinates.h>
+
+namespace tt {
+namespace tt_metal {
 
 struct eth_tunneler_static_config_t {
     std::optional<uint32_t> endpoint_id_start_index;
@@ -70,3 +73,6 @@ private:
     eth_tunneler_dependent_config_t dependent_config_;
     bool is_remote_;
 };
+
+}  // namespace tt_metal
+}  // namespace tt

--- a/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
@@ -19,14 +19,14 @@
 #include "utils.hpp"
 
 enum class CoreType;
+
 namespace tt {
 namespace tt_metal {
+
 class IDevice;
 class Program;
 enum DispatchWorkerType : uint32_t;
 enum NOC : uint8_t;
-}  // namespace tt_metal
-}  // namespace tt
 
 #define UNUSED_LOGICAL_CORE tt_cxy_pair(device_->id(), 0, 0)
 #define UNUSED_SEM_ID 0
@@ -42,6 +42,13 @@ enum class FDKernelType : uint32_t {
     VIRTUAL,   // Not a real kernel
     DISPATCH,  // Dispatch kernels
     ROUTING,   // Routing/Tunneling kernels
+};
+
+struct TerminationInfo {
+    CoreCoord logical_core;  // Logical core coordination
+    CoreType core_type;      // Core Type
+    uint32_t address;        // Termination signal address in L1
+    uint32_t val;            // Termination signal value
 };
 
 static std::vector<string> dispatch_kernel_file_names = {
@@ -127,6 +134,7 @@ public:
             logical_core_, GetCoreType());
     }
     chip_id_t GetDeviceId() { return device_id_; }  // Since this->device may not exist yet
+    virtual std::optional<tt::tt_metal::TerminationInfo> GetTerminationInfo() const { return std::nullopt; }
 
     // Get the port index for which a given kernel is upstream/downstream of this one
     int GetUpstreamPort(FDKernel* other) { return GetPort(other, this->upstream_kernels_); }
@@ -171,3 +179,6 @@ protected:
     std::vector<FDKernel*> upstream_kernels_;
     std::vector<FDKernel*> downstream_kernels_;
 };
+
+}  // namespace tt_metal
+}  // namespace tt

--- a/tt_metal/impl/dispatch/kernel_config/mux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
@@ -8,6 +8,9 @@
 
 #include "dispatch/kernels/packet_queue_ctrl.hpp"
 #include "fd_kernel.hpp"
+
+namespace tt {
+namespace tt_metal {
 
 struct mux_static_config_t {
     std::optional<uint32_t> reserved;
@@ -57,3 +60,6 @@ private:
     mux_static_config_t static_config_;
     mux_dependent_config_t dependent_config_;
 };
+
+}  // namespace tt_metal
+}  // namespace tt

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,6 +13,9 @@
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.h>
+
+namespace tt {
+namespace tt_metal {
 
 struct prefetch_static_config_t {
     std::optional<uint32_t> my_downstream_cb_sem_id;
@@ -120,3 +123,6 @@ private:
     prefetch_static_config_t static_config_;
     prefetch_dependent_config_t dependent_config_;
 };
+
+}  // namespace tt_metal
+}  // namespace tt

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
@@ -13,14 +13,10 @@
 #include "tt-metalium/program.hpp"
 #include "tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp"
 
-namespace tt {
-namespace tt_metal {
+namespace tt::tt_metal {
+
 class IDevice;
 enum DispatchWorkerType : uint32_t;
-}  // namespace tt_metal
-}  // namespace tt
-
-namespace tt::tt_metal {
 
 // NOC ID used by dispatch kernels to communicate with downstream cores. This parameter
 // is required when setting up Command Queue objects on host.
@@ -66,5 +62,8 @@ const std::unordered_set<CoreCoord>& get_virtual_dispatch_cores(chip_id_t dev_id
 
 // Return the virtual cores used for dispatch routing/tunneling on a given device
 const std::unordered_set<CoreCoord>& get_virtual_dispatch_routing_cores(chip_id_t dev_id);
+
+// Return the list of termination targets that were registered for this device
+const std::vector<tt::tt_metal::TerminationInfo>& get_registered_termination_cores(chip_id_t dev_id);
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
[#18726](https://github.com/tenstorrent/tt-metal/issues/18726)

### Problem description
- When running Dispatch on Fabric we need to terminate Dispatch -> Fabric Mux -> Fabric
- If we get the dispatch kernel to send the termination signal, it could terminate the MUX before other dispatch clients are done.
- Another option is to assign a main dispatch kernel which will terminate the MUX on that device, but that would need to sync with all other dispatch cores to be done on the device which is more complicated than syncing on the host

### What's changed
- Kernels created in topology to register their termination information using `GetTerminationInfo`. DevicePool::close_devices will send termination info to each core that was registered
- Minor cleanup: Put FDKernels into tt::tt_metal namespace

```cpp
struct TerminationInfo {
    CoreCoord logical_core;  // Logical core coordination
    CoreType core_type;      // Core Type
    uint32_t address;        // Termination signal address in L1
    uint32_t val;            // Termination signal value
};
```

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15198863601