### PR TITLE
#22456: Refactor binary max min to use DataType instruction template

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,54 +12,40 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool IS_MAX_OP = true, int ITERATIONS = 8>
+template <InstrModLoadStore INSTRUCTION_MODE, bool IS_MAX_OP = true, int ITERATIONS = 8>
 inline void calculate_binary_max_min(const uint dst_offset) {
+    constexpr auto INSTR_MOD_CAST = InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP;
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
 
-        TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);                          // a
-        TT_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, dst_offset * dst_tile_size);  // b
-
-        // Swap and store maximum in lreg1, minimum in lreg0
-        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-
-        if constexpr (IS_MAX_OP) {
-            TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
-        } else {
-            TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
-        }
-        dst_reg++;
-    }
-}
-
-template <bool IS_MAX_OP = true, int ITERATIONS = 8>
-inline void calculate_binary_max_min_int32(const uint dst_offset) {
-#pragma GCC unroll 0
-    for (int d = 0; d < ITERATIONS; d++) {
-        constexpr uint dst_tile_size = 64;
-
-        constexpr auto INSTR_MOD_CAST = InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP;
-
-        TTI_SFPLOAD(p_sfpu::LREG0, 12, ADDR_MOD_7, 0);                          // a
-        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG2, INSTR_MOD_CAST);
-        TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG0, 0);
-
-        TT_SFPLOAD(p_sfpu::LREG1, 12, ADDR_MOD_7, dst_offset * dst_tile_size);  // b
-        TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, INSTR_MOD_CAST);
-        TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
-
-        // Swap and store maximum in lreg1, minimum in lreg0
-        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-
-        if constexpr (IS_MAX_OP) {
-            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, INSTR_MOD_CAST);
-            TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
-            TTI_SFPSTORE(p_sfpu::LREG1, 12, ADDR_MOD_7, 0);
-        } else {
+        TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, 0);  // a
+        if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
             TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG2, INSTR_MOD_CAST);
             TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG0, 0);
-            TTI_SFPSTORE(p_sfpu::LREG0, 12, ADDR_MOD_7, 0);
+        }
+
+        TT_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, dst_offset * dst_tile_size);  // b
+        if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
+            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, INSTR_MOD_CAST);
+            TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+        }
+
+        // Swap and store maximum in lreg1, minimum in lreg0
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+
+        if constexpr (IS_MAX_OP) {
+            if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
+                TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, INSTR_MOD_CAST);
+                TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+            }
+            TTI_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, 0);
+        } else {
+            if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
+                TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG2, INSTR_MOD_CAST);
+                TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG0, 0);
+            }
+            TTI_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, 0);
         }
         dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,18 +18,11 @@ inline void llk_math_eltwise_binary_sfpu_binary_max_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE>
 inline void llk_math_eltwise_binary_sfpu_binary_max(
     uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max_min<true>, dst_index0, dst_index1, vector_mode);
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_binary_max_int32(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
-    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max_min_int32<true>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_binary_max_min<INSTRUCTION_MODE, true>, dst_index0, dst_index1, vector_mode);
 }
 
 // Binary minimum
@@ -38,18 +31,11 @@ inline void llk_math_eltwise_binary_sfpu_binary_min_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE>
 inline void llk_math_eltwise_binary_sfpu_binary_min(
     uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max_min<false>, dst_index0, dst_index1, vector_mode);
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_binary_min_int32(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
-    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max_min_int32<false>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_binary_max_min<INSTRUCTION_MODE, false>, dst_index0, dst_index1, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,43 +12,22 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool IS_MAX_OP = true, int ITERATIONS = 8>
+template <InstrModLoadStore INSTRUCTION_MODE, bool IS_MAX_OP = true, int ITERATIONS = 8>
 inline void calculate_binary_max_min(const uint dst_offset) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
 
-        TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);                          // a
-        TT_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, dst_offset * dst_tile_size);  // b
+        TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, 0);                          // a
+        TT_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, dst_offset * dst_tile_size);  // b
 
         // Swap and store maximum in lreg1, minimum in lreg0
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
 
         if constexpr (IS_MAX_OP) {
-            TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 0);
+            TTI_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, 0);
         } else {
-            TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
-        }
-        dst_reg++;
-    }
-}
-
-template <bool IS_MAX_OP = true, int ITERATIONS = 8>
-inline void calculate_binary_max_min_int32(const uint dst_offset) {
-#pragma GCC unroll 0
-    for (int d = 0; d < ITERATIONS; d++) {
-        constexpr uint dst_tile_size = 64;
-
-        TTI_SFPLOAD(p_sfpu::LREG0, 12, ADDR_MOD_3, 0);                          // a
-        TT_SFPLOAD(p_sfpu::LREG1, 12, ADDR_MOD_3, dst_offset * dst_tile_size);  // b
-
-        // Swap and store maximum in lreg1, minimum in lreg0
-        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-
-        if constexpr (IS_MAX_OP) {
-            TTI_SFPSTORE(p_sfpu::LREG1, 12, ADDR_MOD_3, 0);
-        } else {
-            TTI_SFPSTORE(p_sfpu::LREG0, 12, ADDR_MOD_3, 0);
+            TTI_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, 0);
         }
         dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,18 +18,11 @@ inline void llk_math_eltwise_binary_sfpu_binary_max_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE>
 inline void llk_math_eltwise_binary_sfpu_binary_max(
     uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max_min<true>, dst_index0, dst_index1, vector_mode);
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_binary_max_int32(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
-    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max_min_int32<true>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_binary_max_min<INSTRUCTION_MODE, true>, dst_index0, dst_index1, vector_mode);
 }
 
 // Binary minimum
@@ -38,18 +31,11 @@ inline void llk_math_eltwise_binary_sfpu_binary_min_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE>
 inline void llk_math_eltwise_binary_sfpu_binary_min(
     uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max_min<false>, dst_index0, dst_index1, vector_mode);
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_binary_sfpu_binary_min_int32(
-    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
-    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max_min_int32<false>, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_binary_max_min<INSTRUCTION_MODE, false>, dst_index0, dst_index1, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/binary_max_min.h
+++ b/tt_metal/include/compute_kernel_api/binary_max_min.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -34,7 +34,7 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void binary_max_int32_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_binary_max_int32<APPROX>(idst0, idst1)));
+    MATH((llk_math_eltwise_binary_sfpu_binary_max<APPROX, InstrModLoadStore::INT32_2S_COMP>(idst0, idst1)));
 }
 
 // clang-format off
@@ -56,7 +56,7 @@ ALWI void binary_max_int32_tile(uint32_t idst0, uint32_t idst1) {
  */
 // clang-format on
 ALWI void binary_max_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_binary_max<APPROX>(idst0, idst1)));
+    MATH((llk_math_eltwise_binary_sfpu_binary_max<APPROX, InstrModLoadStore::DEFAULT>(idst0, idst1)));
 }
 
 /**
@@ -83,7 +83,7 @@ ALWI void binary_max_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_max
  */
 // clang-format on
 ALWI void binary_min_int32_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_binary_min_int32<APPROX>(idst0, idst1)));
+    MATH((llk_math_eltwise_binary_sfpu_binary_min<APPROX, InstrModLoadStore::INT32_2S_COMP>(idst0, idst1)));
 }
 
 // clang-format off
@@ -105,7 +105,7 @@ ALWI void binary_min_int32_tile(uint32_t idst0, uint32_t idst1) {
  */
 // clang-format on
 ALWI void binary_min_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_binary_min<APPROX>(idst0, idst1)));
+    MATH((llk_math_eltwise_binary_sfpu_binary_min<APPROX, InstrModLoadStore::DEFAULT>(idst0, idst1)));
 }
 
 /**


### PR DESCRIPTION
### Ticket
#22456

### Problem description
Clean up binary min max

### What's changed
Expose the dtype param as a template parameter

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15209338610) 
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15209322970) 
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/15209324818) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15209326857) 
- [x] [C++ tests](https://github.com/tenstorrent/tt-metal/actions/runs/15209342297)
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15209331133)
- [ ] New/Existing tests provide coverage for changes