### PR TITLE
Fix conv2d missing compute kernel config

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
@@ -145,6 +145,8 @@ def test_unet_2d_condition_model_512x512(device, batch_size, in_channels, input_
     first_iter = time.time() - first_iter
     print(f"First iteration took {first_iter} seconds")
 
+    ttnn.DumpDeviceProfiler(device)
+
     second_iter = time.time()
     ttnn_output = model(
         input,

--- a/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -144,8 +144,6 @@ def test_unet_2d_condition_model_512x512(device, batch_size, in_channels, input_
         signpost(header="stop")
     first_iter = time.time() - first_iter
     print(f"First iteration took {first_iter} seconds")
-
-    ttnn.DumpDeviceProfiler(device)
 
     second_iter = time.time()
     ttnn_output = model(

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder.py
@@ -111,4 +111,4 @@ def test_decoder(
     ttnn_output = ttnn.to_torch(ttnn_output)
 
     # TODO: Improve PCC (issue #21131)
-    assert_with_pcc(torch_output, ttnn_output, 0.9589)
+    assert_with_pcc(torch_output, ttnn_output, 0.9588)

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
@@ -771,7 +771,6 @@ class resnetBlock2D:
             compute_config = ttnn.init_device_compute_kernel_config(
                 self.device.arch(),
                 math_fidelity=ttnn.MathFidelity.LoFi,
-                math_approx_mode=False,
                 fp32_dest_acc_en=False,
                 packer_l1_acc=True,
             )

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
@@ -771,9 +771,9 @@ class resnetBlock2D:
             compute_config = ttnn.init_device_compute_kernel_config(
                 self.device.arch(),
                 math_fidelity=ttnn.MathFidelity.LoFi,
-                math_approx_mode=True,
-                fp32_dest_acc_en=True,
-                packer_l1_acc=False,
+                math_approx_mode=False,
+                fp32_dest_acc_en=False,
+                packer_l1_acc=True,
             )
 
             conv_kwargs_4 = {

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
@@ -771,6 +771,7 @@ class resnetBlock2D:
             compute_config = ttnn.init_device_compute_kernel_config(
                 self.device.arch(),
                 math_fidelity=ttnn.MathFidelity.LoFi,
+                math_approx_mode=True,
                 fp32_dest_acc_en=False,
                 packer_l1_acc=True,
             )

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
@@ -251,7 +251,9 @@ class transformer_2d_model:
         compute_config = ttnn.init_device_compute_kernel_config(
             self.device.arch(),
             math_fidelity=ttnn.MathFidelity.LoFi,
-            fp32_dest_acc_en=self.compute_kernel_config.fp32_dest_acc_en,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
         )
 
         conv_kwargs = {
@@ -328,7 +330,13 @@ class transformer_2d_model:
                     shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
                     transpose_shards=False,
                 )
-
+                compute_config = ttnn.init_device_compute_kernel_config(
+                    self.device.arch(),
+                    math_fidelity=ttnn.MathFidelity.LoFi,
+                    math_approx_mode=False,
+                    fp32_dest_acc_en=False,
+                    packer_l1_acc=True,
+                )
                 conv_kwargs_1 = {
                     "in_channels": self.proj_out_in_channels,
                     "out_channels": self.proj_out_out_channels,
@@ -371,6 +379,7 @@ class transformer_2d_model:
                     **conv_kwargs_1,
                     weight_tensor=self.proj_out_conv_weights,
                     bias_tensor=self.proj_out_conv_bias,
+                    compute_config=compute_config,
                     return_output_dim=True,
                     return_weights_and_bias=True,
                 )

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
@@ -251,7 +251,6 @@ class transformer_2d_model:
         compute_config = ttnn.init_device_compute_kernel_config(
             self.device.arch(),
             math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=False,
             fp32_dest_acc_en=False,
             packer_l1_acc=True,
         )
@@ -333,7 +332,6 @@ class transformer_2d_model:
                 compute_config = ttnn.init_device_compute_kernel_config(
                     self.device.arch(),
                     math_fidelity=ttnn.MathFidelity.LoFi,
-                    math_approx_mode=False,
                     fp32_dest_acc_en=False,
                     packer_l1_acc=True,
                 )

--- a/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
@@ -66,7 +66,6 @@ def prepare_conv_params(
     act_block_h_override=0,
     fp32_dest_acc_en=False,
     math_fidelity=ttnn.MathFidelity.HiFi4,
-    math_approx_mode=False,
     packer_l1_acc=False,
 ):
     compute_config = ttnn.init_device_compute_kernel_config(
@@ -74,7 +73,6 @@ def prepare_conv_params(
         math_fidelity=math_fidelity,
         fp32_dest_acc_en=fp32_dest_acc_en,
         packer_l1_acc=packer_l1_acc,
-        math_approx_mode=math_approx_mode,
     )
 
     conv_config = ttnn.Conv2dConfig(

--- a/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
@@ -66,12 +66,15 @@ def prepare_conv_params(
     act_block_h_override=0,
     fp32_dest_acc_en=False,
     math_fidelity=ttnn.MathFidelity.HiFi4,
+    math_approx_mode=False,
+    packer_l1_acc=False,
 ):
     compute_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
         math_fidelity=math_fidelity,
         fp32_dest_acc_en=fp32_dest_acc_en,
-        packer_l1_acc=False,
+        packer_l1_acc=packer_l1_acc,
+        math_approx_mode=math_approx_mode,
     )
 
     conv_config = ttnn.Conv2dConfig(

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -126,6 +126,7 @@ class TtResnetBlock2D(nn.Module):
                 fp32_dest_acc_en=False,
                 math_fidelity=ttnn.MathFidelity.HiFi2,
                 math_approx_mode=False,
+                packer_l1_acc=True,
             )
         else:
             self.tt_conv3_weights = self.tt_conv3_bias = None

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -111,8 +111,21 @@ class TtResnetBlock2D(nn.Module):
             device, conv_weights_2, conv_bias_2, conv_weights_dtype, act_block_h_override=32
         )
         if conv_shortcut:
-            _, _, self.tt_conv3_weights, self.tt_conv3_bias, self.conv3_params = prepare_conv_params(
-                device, conv_weights_3, conv_bias_3, conv_weights_dtype, act_block_h_override=32
+            (
+                self.compute_config_conv_linear,
+                _,
+                self.tt_conv3_weights,
+                self.tt_conv3_bias,
+                self.conv3_params,
+            ) = prepare_conv_params(
+                device,
+                conv_weights_3,
+                conv_bias_3,
+                conv_weights_dtype,
+                act_block_h_override=32,
+                fp32_dest_acc_en=False,
+                math_fidelity=ttnn.MathFidelity.HiFi2,
+                math_approx_mode=False,
             )
         else:
             self.tt_conv3_weights = self.tt_conv3_bias = None
@@ -303,7 +316,7 @@ class TtResnetBlock2D(nn.Module):
                 input_height=input_shape[2],
                 input_width=input_shape[3],
                 conv_config=self.conv_config,
-                compute_config=self.compute_config,
+                compute_config=self.compute_config_conv_linear,
                 groups=self.groups,
                 memory_config=None,
                 return_output_dim=True,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -125,7 +125,6 @@ class TtResnetBlock2D(nn.Module):
                 act_block_h_override=32,
                 fp32_dest_acc_en=False,
                 math_fidelity=ttnn.MathFidelity.HiFi2,
-                math_approx_mode=False,
                 packer_l1_acc=True,
             )
         else:

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
@@ -99,14 +99,21 @@ class TtResnetBlock2D(nn.Module):
         self.conv2_slice_config = get_DRAM_conv_config(module_path, 2)
 
         if conv_shortcut:
-            _, _, self.tt_conv3_weights, self.tt_conv3_bias, self.conv3_params = prepare_conv_params(
+            (
+                self.compute_config_conv_linear,
+                _,
+                self.tt_conv3_weights,
+                self.tt_conv3_bias,
+                self.conv3_params,
+            ) = prepare_conv_params(
                 device,
                 conv_weights_3,
                 conv_bias_3,
                 ttnn.bfloat16,
                 act_block_h_override=32,
-                fp32_dest_acc_en=True,
-                math_fidelity=ttnn.MathFidelity.LoFi,
+                fp32_dest_acc_en=False,
+                math_fidelity=ttnn.MathFidelity.HiFi2,
+                math_approx_mode=False,
             )
         else:
             self.tt_conv3_weights = self.tt_conv3_bias = None
@@ -289,7 +296,7 @@ class TtResnetBlock2D(nn.Module):
                 input_height=input_shape[2],
                 input_width=input_shape[3],
                 conv_config=self.conv_config,
-                compute_config=self.compute_config,
+                compute_config=self.compute_config_conv_linear,
                 groups=self.groups,
                 memory_config=None,
                 return_output_dim=True,

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
@@ -113,7 +113,6 @@ class TtResnetBlock2D(nn.Module):
                 act_block_h_override=32,
                 fp32_dest_acc_en=False,
                 math_fidelity=ttnn.MathFidelity.HiFi2,
-                math_approx_mode=False,
             )
         else:
             self.tt_conv3_weights = self.tt_conv3_bias = None

--- a/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
+++ b/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
@@ -40,6 +40,7 @@ class TtConv:
         enable_split_reader=False,
         reshard_if_not_optimal=True,
         batch_size=1,
+        alternate_conv_compute_config=False,
     ):
         self.device = device
         self.parameters = parameters
@@ -62,6 +63,7 @@ class TtConv:
         self.reshard_if_not_optimal = reshard_if_not_optimal
         self.batch_size = batch_size
         self.reshape_tensor = reshape_tensor
+        self.alternate_conv_compute_config = alternate_conv_compute_config
 
         self.conv_config = self._initialize_conv_config()
         self.conv_1x1_config = self.default_1x1_conv_config()
@@ -121,7 +123,21 @@ class TtConv:
         )
 
     def default_1x1_conv_config(self):
-        return None
+        if self.alternate_conv_compute_config:
+            return ttnn.init_device_compute_kernel_config(
+                self.device.arch(),
+                math_fidelity=ttnn.MathFidelity.HiFi2,
+                math_approx_mode=False,
+                fp32_dest_acc_en=False,
+                packer_l1_acc=True,
+            )
+        return ttnn.init_device_compute_kernel_config(
+            self.device.arch(),
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        )
 
     def is_1x1_conv(self, kernel_size, stride, padding, dilation, conv_config):
         return (
@@ -143,6 +159,7 @@ class TtConv:
             input_height = int(math.sqrt(x.shape[2]) // self.batch_size)
             input_width = int(math.sqrt(x.shape[2]) // self.batch_size)
 
+        # print("kernel_size", str(self.input_params[0])+" ,"+ str(self.input_params[0]))
         [x, [out_height, out_width], [self.weights, self.bias]] = ttnn.conv2d(
             input_tensor=x,
             weight_tensor=self.weights,
@@ -185,6 +202,7 @@ class TtConv:
         return x, out_height, out_width
 
 
+# 2 convs
 class TtBottleneck:
     def __init__(
         self,
@@ -228,6 +246,7 @@ class TtBottleneck:
         return ttnn.add(x, cv2, memory_config=x.memory_config()) if self.shortcut else cv2
 
 
+# 2 + n convs
 class TtC2f:
     def __init__(
         self,
@@ -327,6 +346,7 @@ class TtC2f:
         return x, out_h, out_w
 
 
+# 2 convs
 class TtSPPF:
     def __init__(self, device, parameters, input_params, batch_size):
         self.device = device
@@ -335,7 +355,12 @@ class TtSPPF:
         self.batch_size = batch_size
         self.cv1 = TtConv(device, parameters["cv1"], input_params=input_params[0], deallocate_activation=True)
         self.cv2 = TtConv(
-            device, parameters["cv2"], input_params=input_params[1], change_shard=True, deallocate_activation=True
+            device,
+            parameters["cv2"],
+            input_params=input_params[1],
+            change_shard=True,
+            deallocate_activation=True,
+            alternate_conv_compute_config=True,
         )
 
     def __call__(self, x):
@@ -374,6 +399,7 @@ class TtSPPF:
         return x, out_h, out_w
 
 
+# 2 convs
 class TtMaxSigmoidAttnBlock:
     """Max Sigmoid attention block."""
 
@@ -473,6 +499,7 @@ class TtMaxSigmoidAttnBlock:
         return ttnn.reshape(x, (1, 1, x.shape[1] * x.shape[2], x.shape[3])), h, w
 
 
+# 1 + n*2 + 2 + 1 = 4 + n*2
 class TtC2fAttn:
     """C2f module with an additional attn module."""
 
@@ -491,6 +518,8 @@ class TtC2fAttn:
         gc=512,
         g=1,
         e=0.5,
+        alternate_conv_compute_config_cv1=False,
+        alternate_conv_compute_config_cv2=False,
     ):
         """Initializes C2f module with attention mechanism for enhanced feature extraction and processing."""
         super().__init__()
@@ -506,6 +535,7 @@ class TtC2fAttn:
             self.parameters["cv1"],
             input_params=input_params[0],
             deallocate_activation=self.deallocate_activation,
+            alternate_conv_compute_config=alternate_conv_compute_config_cv1,
         )
         self.cv2 = TtConv(
             self.device,
@@ -513,6 +543,7 @@ class TtC2fAttn:
             input_params=input_params[1],
             change_shard=True,
             deallocate_activation=self.deallocate_activation,
+            alternate_conv_compute_config=alternate_conv_compute_config_cv2,
         )
         self.m = [
             TtBottleneck(
@@ -566,6 +597,7 @@ class TtC2fAttn:
         return x, out_h, out_w
 
 
+# len(ch) convs
 class TtImagePoolingAttn:
     """ImagePoolingAttn: Enhance the text embeddings with image-aware information."""
 
@@ -740,6 +772,7 @@ class TtImagePoolingAttn:
         return x
 
 
+# 1 conv
 class TtDFL:
     def __init__(self, device, parameters, input_params):
         self.device = device
@@ -762,6 +795,7 @@ class TtDFL:
         return x
 
 
+# 0 conv
 class TtContrastiveHead:
     """Implements contrastive learning head for region-text similarity in vision-language models."""
 
@@ -1012,6 +1046,7 @@ class TtWorldModel:
                 input_params=[3, 2, 1, 64, 32],
                 deallocate_activation=True,
             ),
+            # 2
             TtC2f(
                 device, parameters["model"][2], n=1, shortcut=True, input_params=c2f_configs["model.2"]["input_params"]
             ),
@@ -1021,6 +1056,7 @@ class TtWorldModel:
                 input_params=[3, 2, 1, 128, 64],
                 deallocate_activation=True,
             ),
+            # 2+2 =4
             TtC2f(
                 device, parameters["model"][4], n=2, shortcut=True, input_params=c2f_configs["model.4"]["input_params"]
             ),
@@ -1030,6 +1066,7 @@ class TtWorldModel:
                 input_params=[3, 2, 1, 256, 128],
                 # deallocate_activation=True,
             ),
+            # 4 + 2 = 6
             TtC2f(
                 device, parameters["model"][6], n=2, shortcut=True, input_params=c2f_configs["model.6"]["input_params"]
             ),
@@ -1039,12 +1076,15 @@ class TtWorldModel:
                 input_params=[3, 2, 1, 512, 256],
                 # deallocate_activation=True,
             ),
+            # 6 + 2 = 8
             TtC2f(
                 device, parameters["model"][8], n=1, shortcut=True, input_params=c2f_configs["model.8"]["input_params"]
             ),
+            # 8 + 2 = 10
             TtSPPF(device, parameters["model"][9], input_params=sppf_configs["input_params"], batch_size=1),
             ttnn.upsample,
             ttnn.concat,
+            # 10 + 2 = 12
             TtC2fAttn(
                 device,
                 parameters["model"][12],
@@ -1054,9 +1094,11 @@ class TtWorldModel:
                 n=1,
                 ec=128,
                 nh=4,
+                alternate_conv_compute_config_cv2=True,
             ),
             ttnn.upsample,
             ttnn.concat,
+            # 12 + 2 = 14
             TtC2fAttn(
                 device,
                 parameters["model"][15],
@@ -1066,7 +1108,9 @@ class TtWorldModel:
                 n=1,
                 ec=64,
                 nh=2,
+                alternate_conv_compute_config_cv2=True,
             ),
+            # 14 + 3 = 17
             TtImagePoolingAttn(
                 device,
                 parameters["model"][16],
@@ -1081,6 +1125,7 @@ class TtWorldModel:
                 # deallocate_activation=True,
             ),
             ttnn.concat,
+            # 17 + 2 = 19
             TtC2fAttn(
                 device,
                 parameters["model"][19],
@@ -1090,6 +1135,7 @@ class TtWorldModel:
                 n=1,
                 ec=128,
                 nh=4,
+                alternate_conv_compute_config_cv2=True,
             ),
             TtConv(
                 device,
@@ -1098,6 +1144,7 @@ class TtWorldModel:
                 # deallocate_activation=True,
             ),
             ttnn.concat,
+            # 19 + 2 = 21
             TtC2fAttn(
                 device,
                 parameters["model"][22],
@@ -1107,7 +1154,9 @@ class TtWorldModel:
                 n=1,
                 ec=256,
                 nh=8,
+                alternate_conv_compute_config_cv2=True,
             ),
+            # 21 + 6 + 1 = 28
             TtWorldDetect(
                 device,
                 parameters["model"][23],

--- a/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
+++ b/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
@@ -121,14 +121,7 @@ class TtConv:
         )
 
     def default_1x1_conv_config(self):
-        return ttnn.init_device_compute_kernel_config(
-            self.device.arch(),
-            # math_fidelity=ttnn.MathFidelity.LoFi,
-            math_fidelity=ttnn.MathFidelity.HiFi2,
-            math_approx_mode=False,
-            fp32_dest_acc_en=True,
-            packer_l1_acc=True,
-        )
+        return None
 
     def is_1x1_conv(self, kernel_size, stride, padding, dilation, conv_config):
         return (
@@ -176,6 +169,7 @@ class TtConv:
                 )
                 else self.compute_config
             ),
+            # compute_config=self.compute_config,
             groups=self.groups,
             memory_config=ttnn.L1_MEMORY_CONFIG if self.change_shard == True else None,
             return_weights_and_bias=True,

--- a/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
+++ b/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
@@ -177,7 +177,6 @@ class TtConv:
                 )
                 else self.compute_config
             ),
-            # compute_config=self.compute_config,
             groups=self.groups,
             memory_config=ttnn.L1_MEMORY_CONFIG if self.change_shard == True else None,
             return_weights_and_bias=True,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -664,7 +664,8 @@ Result conv2d_L1(
             mm_output_memory_config,
             conv_config.dtype,
             program_config,
-            activation);
+            activation,
+            compute_config);
 
         if (memory_config.has_value() && memory_config.value() != matmul_output.memory_config()) {
             matmul_output = ttnn::to_memory_config(matmul_output, memory_config.value(), std::nullopt);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22328

### Problem description
Compute config not being passed into `ttnn.linear` from `ttnn.conv2d`
1x1 Convs in models don't respect passed compute kernel config

### What's changed
- Started passing compute kernel config into `ttnn.linear`
- Fixed `yolov8s` , `stable_diffusion_xl`,`stable_diffusion`  models (perf and pcc)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15208551167)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15208564405)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15256795180)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15256798898)
- [x] [(Single-card) Frequent model and ttnn tests pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15256801981)