### PR TITLE
Error message that only batch 1 or 32 is supported

### DIFF
--- a/models/demos/llama3_subdevices/tt/generator.py
+++ b/models/demos/llama3_subdevices/tt/generator.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -88,6 +88,10 @@ class Generator:
             assert isinstance(
                 page_table, torch.Tensor
             ), "page_table must be a torch.Tensor when passing into prefill_forward"
+            assert batch in [1, 32] and batch == page_table.shape[0], (
+                f"We support only batch=1 or batch=32. The page table's 0th dimension must match the batch size. "
+                f"Provided: batch={batch}, page_table.shape[0]={page_table.shape[0]}"
+            )
 
         for user_id in range(batch):
             logger.info(f"Prefilling User {user_id + 1}")


### PR DESCRIPTION
### Ticket
n/a

### Problem description
While testing vLLM with batch=8 I was failing in a place that's not descriptive enough to understand that we support only batch=1 or batch=32. I was getting a runtime error here: [llama_model.py#L205](https://github.com/tenstorrent/tt-metal/blob/main/models/demos/llama3_subdevices/tt/llama_model.py#L205)

### What's changed
Added an early check and a descriptive message if a batch other than 1 or 32 is tried.

### Checklist
- [ ✅ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15211992929)
- [ ❌ ] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/15212182298) failing the same as on [main](https://github.com/tenstorrent/tt-metal/actions/runs/15203437206)