### PR TITLE
Fix clang-19 build

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -246,7 +246,7 @@ install_sfpi() {
     rm -rf $TEMP_DIR
 }
 
-install_mpi_uflm(){
+install_mpi_ulfm(){
     DEB_URL="https://github.com/dmakoviichuk-tt/mpi-ulfm/releases/download/v5.0.7-ulfm/openmpi-ulfm_5.0.7-1_amd64.deb"
     DEB_FILE="$(basename "$DEB_URL")"
 
@@ -287,13 +287,13 @@ install() {
             runtime)
                 prep_ubuntu_runtime
                 install_sfpi
-                install_mpi_uflm
+                install_mpi_ulfm
                 ;;
             build)
                 prep_ubuntu_build
                 install_llvm
                 install_gcc
-                install_mpi_uflm
+                install_mpi_ulfm
                 ;;
             baremetal)
                 prep_ubuntu_runtime
@@ -302,7 +302,7 @@ install() {
                 install_llvm
                 install_gcc
                 configure_hugepages
-                install_mpi_uflm
+                install_mpi_ulfm
                 ;;
         esac
 

--- a/tt_metal/api/tt-metalium/allocator_types.hpp
+++ b/tt_metal/api/tt-metalium/allocator_types.hpp
@@ -20,7 +20,7 @@ address: bytes
 size: bytes
 */
 using MemoryBlockTable = std::vector<std::unordered_map<std::string, std::string>>;
-struct Allocator;
+class Allocator;
 class BankManager;
 
 // Setup what each core-type is

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -91,8 +91,8 @@ struct ShardSpec {
             shard_shape_[1]);
     }
 
-    const uint32_t num_cores() const { return this->grid.num_cores(); }
-    const uint32_t numel() const { return this->shape[0] * this->shape[1]; }
+    uint32_t num_cores() const { return this->grid.num_cores(); }
+    uint32_t numel() const { return this->shape[0] * this->shape[1]; }
 
     bool operator==(const ShardSpec& other) const;
     bool operator!=(const ShardSpec& other) const;

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -33,7 +33,7 @@ struct to_json_t;
 
 using CoreCoord = tt_xy_pair;
 
-struct CoreRangeSet;
+class CoreRangeSet;
 
 template <>
 struct fmt::formatter<CoreCoord> {
@@ -59,7 +59,8 @@ constexpr inline bool operator!=(const RelativeCoreCoord& a, const RelativeCoreC
 
 CoreCoord get_core_coord_from_relative(const RelativeCoreCoord& in, const CoreCoord& grid_size);
 
-struct CoreRange {
+class CoreRange {
+public:
     CoreCoord start_coord;
     CoreCoord end_coord;
     CoreRange(const CoreCoord& point);

--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -54,7 +54,7 @@ public:
     DispatchCoreConfig(DispatchCoreType type, DispatchCoreAxis axis) : type_(type), axis_(axis) {}
 
     static constexpr auto attribute_names = std::forward_as_tuple("type", "axis");
-    const auto attribute_values() const { return std::forward_as_tuple(this->type_, this->axis_); }
+    auto attribute_values() const { return std::forward_as_tuple(this->type_, this->axis_); }
 
     CoreType get_core_type() const {
         switch (type_) {

--- a/tt_metal/api/tt-metalium/tile.hpp
+++ b/tt_metal/api/tt-metalium/tile.hpp
@@ -54,17 +54,17 @@ struct Tile {
         bool transpose_tile = false);
 
     // Getter methods
-    const uint32_t get_height() const { return tile_shape[0]; }
-    const uint32_t get_width() const { return tile_shape[1]; }
-    const uint32_t get_num_faces() const { return num_faces; }
-    const uint32_t get_tile_hw() const { return tile_hw; }
-    const uint32_t get_face_hw() const { return face_hw; }
-    const uint32_t get_partial_face() const { return partial_face; }
-    const uint32_t get_narrow_tile() const { return narrow_tile; }
-    const std::array<uint32_t, 2> get_tile_shape() const { return tile_shape; }
-    const std::array<uint32_t, 2> get_face_shape() const { return face_shape; }
-    const bool get_transpose_within_face() const { return transpose_within_face; }
-    const bool get_transpose_of_faces() const { return transpose_of_faces; }
+    uint32_t get_height() const { return tile_shape[0]; }
+    uint32_t get_width() const { return tile_shape[1]; }
+    uint32_t get_num_faces() const { return num_faces; }
+    uint32_t get_tile_hw() const { return tile_hw; }
+    uint32_t get_face_hw() const { return face_hw; }
+    uint32_t get_partial_face() const { return partial_face; }
+    uint32_t get_narrow_tile() const { return narrow_tile; }
+    std::array<uint32_t, 2> get_tile_shape() const { return tile_shape; }
+    std::array<uint32_t, 2> get_face_shape() const { return face_shape; }
+    bool get_transpose_within_face() const { return transpose_within_face; }
+    bool get_transpose_of_faces() const { return transpose_of_faces; }
 
     uint32_t get_tile_size(const DataFormat& format) const;
 
@@ -72,7 +72,7 @@ struct Tile {
     bool operator==(const Tile& other) const;
 
     static constexpr auto attribute_names = std::forward_as_tuple("tile_shape", "face_shape", "num_faces");
-    const auto attribute_values() const { return std::forward_as_tuple(tile_shape, face_shape, num_faces); }
+    auto attribute_values() const { return std::forward_as_tuple(tile_shape, face_shape, num_faces); }
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
@@ -83,7 +83,7 @@ void EthRouterKernel::GenerateStaticConfigs() {
             static_config_.output_depacketize_local_sem[idx] =
                 tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
             // Forwward VCs are the ones that don't connect to a prefetch
-            if (nullptr != dynamic_cast<PrefetchKernel*>(downstream_kernels_[idx])) {
+            if (dynamic_cast<PrefetchKernel*>(downstream_kernels_[idx]) != nullptr) {
                 static_config_.fwd_vc_count = this->static_config_.fwd_vc_count.value() - 1;
             }
         }

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
@@ -83,7 +83,7 @@ void EthRouterKernel::GenerateStaticConfigs() {
             static_config_.output_depacketize_local_sem[idx] =
                 tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
             // Forwward VCs are the ones that don't connect to a prefetch
-            if (auto pk = dynamic_cast<PrefetchKernel*>(downstream_kernels_[idx])) {
+            if (nullptr != dynamic_cast<PrefetchKernel*>(downstream_kernels_[idx])) {
                 static_config_.fwd_vc_count = this->static_config_.fwd_vc_count.value() - 1;
             }
         }

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
@@ -368,7 +368,7 @@ uint32_t EthTunnelerKernel::GetRouterId(FDKernel* k, bool upstream) {
     std::vector<FDKernel*>& search = (upstream) ? upstream_kernels_ : downstream_kernels_;
     uint32_t router_id = 0;
     for (auto kernel : search) {
-        if (auto router_kernel = dynamic_cast<EthRouterKernel*>(kernel)) {
+        if (nullptr != dynamic_cast<EthRouterKernel*>(kernel)) {
             if (k == kernel) {
                 return router_id;
             }

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
@@ -368,7 +368,7 @@ uint32_t EthTunnelerKernel::GetRouterId(FDKernel* k, bool upstream) {
     std::vector<FDKernel*>& search = (upstream) ? upstream_kernels_ : downstream_kernels_;
     uint32_t router_id = 0;
     for (auto kernel : search) {
-        if (nullptr != dynamic_cast<EthRouterKernel*>(kernel)) {
+        if (dynamic_cast<EthRouterKernel*>(kernel) != nullptr) {
             if (k == kernel) {
                 return router_id;
             }

--- a/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
@@ -70,13 +70,13 @@ void FabricRouterVC::GenerateDependentConfigs() {
                 ds_kernel->GetDeviceId(), *router_chans_rev.begin());
 
         bool valid_path{false};
-        if (nullptr != dynamic_cast<PrefetchKernel*>(us_kernel) &&
-            nullptr != dynamic_cast<PrefetchKernel*>(ds_kernel)) {
+        if (dynamic_cast<PrefetchKernel*>(us_kernel) != nullptr &&
+            dynamic_cast<PrefetchKernel*>(ds_kernel) != nullptr) {
             valid_path = true;
         }
 
-        if (nullptr != dynamic_cast<DispatchKernel*>(us_kernel) &&
-            nullptr != dynamic_cast<DispatchKernel*>(ds_kernel)) {
+        if (dynamic_cast<DispatchKernel*>(us_kernel) != nullptr &&
+            dynamic_cast<DispatchKernel*>(ds_kernel) != nullptr) {
             valid_path = true;
         }
 

--- a/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
@@ -70,13 +70,13 @@ void FabricRouterVC::GenerateDependentConfigs() {
                 ds_kernel->GetDeviceId(), *router_chans_rev.begin());
 
         bool valid_path{false};
-        if (auto prefetch_us = dynamic_cast<PrefetchKernel*>(us_kernel);
-            auto prefetch_ds = dynamic_cast<PrefetchKernel*>(ds_kernel)) {
+        if (nullptr != dynamic_cast<PrefetchKernel*>(us_kernel) &&
+            nullptr != dynamic_cast<PrefetchKernel*>(ds_kernel)) {
             valid_path = true;
         }
 
-        if (auto dispatch_us = dynamic_cast<DispatchKernel*>(us_kernel);
-            auto dispatch_ds = dynamic_cast<DispatchKernel*>(ds_kernel)) {
+        if (nullptr != dynamic_cast<DispatchKernel*>(us_kernel) &&
+            nullptr != dynamic_cast<DispatchKernel*>(ds_kernel)) {
             valid_path = true;
         }
 

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -143,7 +143,7 @@ struct Attribute final {
     using storage_t = std::array<std::byte, 1312>;
 
     const std::string to_string() const { return this->implementations.to_string_impl_(this->type_erased_storage); }
-    const std::size_t to_hash() const { return this->implementations.to_hash_impl_(this->type_erased_storage); }
+    std::size_t to_hash() const { return this->implementations.to_hash_impl_(this->type_erased_storage); }
     const nlohmann::json to_json() const { return this->implementations.to_json_impl_(this->type_erased_storage); }
 
     template <typename Type, typename BaseType = std::decay_t<Type>>
@@ -174,7 +174,7 @@ struct Attribute final {
                     return fmt::format("{}", object);
                 }
             },
-            .to_hash_impl_ = [](const storage_t& storage) -> const std::size_t {
+            .to_hash_impl_ = [](const storage_t& storage) -> std::size_t {
                 const auto& object = *reinterpret_cast<const BaseType*>(&storage);
                 return hash::detail::hash_object(object);
             },
@@ -249,7 +249,7 @@ private:
 
     struct implementations_t {
         const std::string (*to_string_impl_)(const storage_t&) = nullptr;
-        const std::size_t (*to_hash_impl_)(const storage_t&) = nullptr;
+        std::size_t (*to_hash_impl_)(const storage_t&) = nullptr;
         const nlohmann::json (*to_json_impl_)(const storage_t&) = nullptr;
     };
 
@@ -1304,7 +1304,6 @@ template <typename T, std::size_t N>
 struct to_json_t<std::array<T, N>> {
     nlohmann::json operator()(const std::array<T, N>& array) noexcept {
         nlohmann::json json_array = nlohmann::json::array();
-        std::size_t hash = 0;
         [&array, &json_array]<size_t... Ns>(std::index_sequence<Ns...>) {
             (
                 [&array, &json_array] {

--- a/tt_stl/tt_stl/type_name.hpp
+++ b/tt_stl/tt_stl/type_name.hpp
@@ -38,7 +38,6 @@ constexpr std::size_t suffix_type_name_size = long_double_raw_string.size() - en
 template <typename T>
 constexpr std::string_view long_name() {
     std::string_view raw_name = type_to_string_raw<T>();
-    auto size = raw_name.size();
     raw_name.remove_prefix(begin_type_name);
     raw_name.remove_suffix(suffix_type_name_size);
     std::string_view struct_name("struct ");

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -650,7 +650,7 @@ void memcpy(
 
 void memcpy(Tensor& dst, const void* src, const std::optional<BufferRegion>& region) {
     if (auto mesh_device = dst.mesh_device()) {
-        memcpy(dst.mesh_device()->mesh_command_queue(), dst, src, region);
+        memcpy(mesh_device->mesh_command_queue(), dst, src, region);
     } else {
         memcpy(dst.device()->command_queue(), dst, src, region);
     }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
When building with clang 19 or above, there're several warnings

### What's changed
- Fix inconsistent class/struct declarations scattered across the code base
- Remove `const` qualifiers that has no effect
- Remove unused variables (including the ones from the`dynamic_cast` checks)
- Also fix one typo `uflm -> ulfm`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15240406414