### PR TITLE
Add missing perf report integration.

### DIFF
--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -133,7 +133,7 @@ jobs:
           run_args: |
             ${{ matrix.test-group.cmd }}
       - name: Save environment data
-        if: ${{ (matrix.test-group.name == 'Llama Galaxy Perf Unit Tests' || matrix.test-group.name == 'Galaxy Llama 70B model perf tests'  || matrix.test-group.name == 'Galaxy Llama 70B model dispatch perf tests' || matrix.test-group.name == 'Galaxy Llama 70B prefill perf tests') && !cancelled() }}
+        if: ${{ (matrix.test-group.name == 'Llama Galaxy Perf Unit Tests' || matrix.test-group.name == 'Galaxy Llama 70B model perf tests' || matrix.test-group.name == 'Galaxy Llama 70B model dispatch perf tests' || matrix.test-group.name == 'Galaxy Llama 70B prefill perf tests [128]' || matrix.test-group.name == 'Galaxy Llama 70B prefill perf tests [4096]') && !cancelled() }}
         uses: ./.github/actions/docker-run
         with:
           docker_image: ${{ inputs.docker-image }}
@@ -145,7 +145,7 @@ jobs:
           install_wheel: true
           run_args: python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
       - name: Upload benchmark data
-        if: ${{ (matrix.test-group.name == 'Llama Galaxy Perf Unit Tests' || matrix.test-group.name == 'Galaxy Llama 70B model perf tests' || matrix.test-group.name == 'Galaxy Llama 70B model dispatch perf tests' || matrix.test-group.name == 'Galaxy Llama 70B prefill perf tests') && !cancelled() }}
+        if: ${{ (matrix.test-group.name == 'Llama Galaxy Perf Unit Tests' || matrix.test-group.name == 'Galaxy Llama 70B model perf tests' || matrix.test-group.name == 'Galaxy Llama 70B model dispatch perf tests' || matrix.test-group.name == 'Galaxy Llama 70B prefill perf tests [128]' || matrix.test-group.name == 'Galaxy Llama 70B prefill perf tests [4096]') && !cancelled() }}
         uses: ./.github/actions/upload-data-via-sftp
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
@@ -154,7 +154,7 @@ jobs:
           hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
       - name: Check perf report exists
         id: check-perf-report
-        if: ${{ !(matrix.test-group.name == 'Llama Galaxy Perf Unit Tests'|| matrix.test-group.name == 'Galaxy Llama 70B model perf tests' || matrix.test-group.name == 'Galaxy Llama 70B model dispatch perf tests' || matrix.test-group.name == 'Galaxy Llama 70B prefill perf tests') && !cancelled() }}
+        if: ${{ !(matrix.test-group.name == 'Llama Galaxy Perf Unit Tests'|| matrix.test-group.name == 'Galaxy Llama 70B model perf tests' || matrix.test-group.name == 'Galaxy Llama 70B model dispatch perf tests' || matrix.test-group.name == 'Galaxy Llama 70B prefill perf tests [128]' || matrix.test-group.name == 'Galaxy Llama 70B prefill perf tests [4096]') && !cancelled() }}
         run: |
           TODAY=$(date +%Y_%m_%d)
           PERF_REPORT_FILENAME_MODELS="Models_Perf_${TODAY}.csv"


### PR DESCRIPTION
### Ticket
Failures such as [this](https://github.com/tenstorrent/tt-metal/actions/runs/15212773095/job/42791532670).

### Problem description
Missing integration to the perf report for the newly added prefill perf tests.

### What's changed
- Make sure to run the post processing for the prefill pipelines as well

### Checklist
- [x] [TG Model Perf](https://github.com/tenstorrent/tt-metal/actions/runs/15215193524) passes (only running the changed tests)