### PR TITLE
#0: remove path reserve arg from all mcast api

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -84,13 +84,12 @@ void kernel_main() {
         if (mcast) {
             // write mcast
             noc_async_write_multicast_one_packet(
-                l1_read_addr, mcast_addr_self_noc, page_size, num_dests - 1, false, true, noc);
-            noc_async_write_multicast(l1_read_addr, mcast_addr_self_noc, page_size, num_dests - 1, false, true, noc);
-            noc_async_write_multicast_loopback_src(
-                l1_read_addr, mcast_addr_self_noc, page_size, num_dests, false, true, noc);
+                l1_read_addr, mcast_addr_self_noc, page_size, num_dests - 1, false, noc);
+            noc_async_write_multicast(l1_read_addr, mcast_addr_self_noc, page_size, num_dests - 1, false, noc);
+            noc_async_write_multicast_loopback_src(l1_read_addr, mcast_addr_self_noc, page_size, num_dests, false, noc);
             // semaphore mcast
-            noc_semaphore_set_multicast(l1_read_addr, mcast_addr_self_noc, num_dests - 1, false, true, noc);
-            noc_semaphore_set_multicast_loopback_src(l1_read_addr, mcast_addr_self_noc, num_dests, false, true, noc);
+            noc_semaphore_set_multicast(l1_read_addr, mcast_addr_self_noc, num_dests - 1, false, noc);
+            noc_semaphore_set_multicast_loopback_src(l1_read_addr, mcast_addr_self_noc, num_dests, false, noc);
         }
 
 // dw_write skip BH since there's HW issue

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -101,7 +101,6 @@ void kernel_main() {
                 page_size,
                 num_dests - 1,
                 false,
-                true,
                 noc);
             noc_async_write_multicast(
                 l1_read_addr,
@@ -109,7 +108,6 @@ void kernel_main() {
                 page_size,
                 num_dests - 1,
                 false,
-                true,
                 noc);
             noc_async_write_multicast_loopback_src(
                 l1_read_addr,
@@ -117,23 +115,12 @@ void kernel_main() {
                 page_size,
                 num_dests,
                 false,
-                true,
                 noc);
             // semaphore mcast
             noc_semaphore_set_multicast(
-                l1_read_addr,
-                noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc,
-                num_dests - 1,
-                false,
-                true,
-                noc);
+                l1_read_addr, noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc, num_dests - 1, false, noc);
             noc_semaphore_set_multicast_loopback_src(
-                l1_read_addr,
-                noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc,
-                num_dests,
-                false,
-                true,
-                noc);
+                l1_read_addr, noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc, num_dests, false, noc);
         }
 
 // dw_write skip BH since there's HW issue

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -772,8 +772,8 @@ void noc_async_write_multicast_one_packet(
     std::uint32_t size,
     std::uint32_t num_dests,
     bool linked = false,
-    bool multicast_path_reserve = true,
     uint8_t noc = noc_index) {
+    constexpr bool multicast_path_reserve = true;
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_MULTICAST,dst_noc_addr_multicast,size, NOC_MULTICAST_WRITE_VC);
 
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
@@ -1016,11 +1016,10 @@ inline void noc_async_write_multicast(
     std::uint32_t size,
     std::uint32_t num_dests,
     bool linked = false,
-    bool multicast_path_reserve = true,
     uint8_t noc = noc_index) {
+    constexpr bool multicast_path_reserve = true;
     if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
-        noc_async_write_multicast_one_packet(
-            src_local_l1_addr, dst_noc_addr_multicast, size, num_dests, linked, multicast_path_reserve);
+        noc_async_write_multicast_one_packet(src_local_l1_addr, dst_noc_addr_multicast, size, num_dests, linked);
     } else {
         WAYPOINT("NMWW");
         DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size);
@@ -1071,8 +1070,8 @@ inline void noc_semaphore_set_multicast(
     std::uint64_t dst_noc_addr_multicast,
     std::uint32_t num_dests,
     bool linked = false,
-    bool multicast_path_reserve = true,
     uint8_t noc = noc_index) {
+    constexpr bool multicast_path_reserve = true;
     WAYPOINT("NSNW");
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, 4);
     ncrisc_noc_fast_write_any_len<noc_mode>(
@@ -1119,8 +1118,8 @@ inline void noc_semaphore_set_multicast_loopback_src(
     std::uint64_t dst_noc_addr_multicast,
     std::uint32_t num_dests,
     bool linked = false,
-    bool multicast_path_reserve = true,
     uint8_t noc = noc_index) {
+    constexpr bool multicast_path_reserve = true;
     WAYPOINT("NSLW");
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, 4);
     ncrisc_noc_fast_write_any_len_loopback_src<noc_mode>(
@@ -1143,8 +1142,8 @@ inline void noc_async_write_multicast_loopback_src(
     std::uint32_t size,
     std::uint32_t num_dests,
     bool linked = false,
-    bool multicast_path_reserve = true,
     uint8_t noc = noc_index) {
+    constexpr bool multicast_path_reserve = true;
     WAYPOINT("NMLW");
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size);
     ncrisc_noc_fast_write_any_len_loopback_src<noc_mode>(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -212,7 +212,6 @@ void kernel_main() {
                         act_multicast_data_addr,
                         act_mcast_sender_size_bytes,
                         num_reader_cores,
-                        false,
                         false);
 
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id and same
@@ -229,7 +228,6 @@ void kernel_main() {
                         act_mcast_sender_semaphore_valid_addr,
                         act_mcast_receiver_semaphore_noc_addr,
                         num_reader_cores,
-                        false,
                         false);
 
                     noc_semaphore_wait(act_mcast_receiver_semaphore_addr_ptr, VALID);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -226,7 +226,6 @@ void kernel_main() {
                     act_multicast_data_addr,
                     act_mcast_sender_size_bytes,
                     act_mcast_num_cores + 1,
-                    true,
                     true);
 
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -232,7 +232,6 @@ void kernel_main() {
                             weights_multicast_data_addr,
                             weights_block_size_bytes,
                             weights_mcast_num_cores,
-                            false,
                             false);
 
                         // Note: no need for write barrier, since these two multicasts are done on the same noc id and
@@ -250,7 +249,6 @@ void kernel_main() {
                             weights_mcast_receiver_semaphore_addr,
                             weights_mcast_receiver_semaphore_noc_addr,
                             weights_mcast_num_cores,
-                            false,
                             false);
 #endif
 
@@ -298,7 +296,6 @@ void kernel_main() {
                     bias_multicast_data_addr,
                     bias_block_size_bytes,
                     weights_mcast_num_cores,
-                    false,
                     false);
 
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc
@@ -316,7 +313,6 @@ void kernel_main() {
                     weights_mcast_receiver_semaphore_addr,
                     weights_mcast_receiver_semaphore_noc_addr,
                     weights_mcast_num_cores,
-                    false,
                     false);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -155,7 +155,6 @@ void kernel_main() {
                     weights_multicast_data_addr,
                     weights_block_size_bytes,
                     weights_mcast_num_cores,
-                    true,
                     true);
 
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc
@@ -208,12 +207,7 @@ void kernel_main() {
                     bias_start_address);
                 // num_dests must not include source, since we are NOT really doing a local copy!
                 noc_async_write_multicast(
-                    bias_start_address,
-                    bias_multicast_data_addr,
-                    bias_block_size_bytes,
-                    weights_mcast_num_cores,
-                    true,
-                    true);
+                    bias_start_address, bias_multicast_data_addr, bias_block_size_bytes, weights_mcast_num_cores, true);
 
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc
                 // even though cmd bufs are different Also, this only works because we are setting VCs statically (using

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
@@ -203,8 +203,7 @@ void kernel_main() {
                 concat_semaphore_send_addr,
                 concat_sem_rcv_addr,
                 mcast_dest_num,
-                false,  // linked = false
-                true);  // multicast_path_reserve = true
+                false);  // linked = false
 
             const uint64_t concat_sem_rcv_addr2 = get_noc_multicast_addr(
                 mcast_dest_noc_start_x[i],
@@ -217,8 +216,7 @@ void kernel_main() {
                 concat_semaphore_send_addr2,
                 concat_sem_rcv_addr2,
                 mcast_dest_num,
-                false,  // linked = false
-                true);  // multicast_path_reserve = true
+                false);  // linked = false
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
@@ -200,8 +200,7 @@ void kernel_main() {
             reduction_semaphore_send_addr,
             reduction_semaphore_recv_noc_addr,
             i == 0 ? num_mcast_cores : 0,
-            false,  // linked = false
-            true);  // multicast_path_reserve = true
+            false);  // linked = false
     }
 
     // 4. global semaphore reset

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_sender_reader.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -131,7 +131,7 @@ void kernel_main() {
         *post_reduce_sender_semaphore_addr_ptr = VALID;
 
         noc_semaphore_set_multicast_loopback_src(
-            post_reduce_sender_semaphore_addr, post_reduce_sender_semaphore_noc_addr, num_blocks, false, false);
+            post_reduce_sender_semaphore_addr, post_reduce_sender_semaphore_noc_addr, num_blocks, false);
         noc_async_write_barrier();
     };
 
@@ -144,7 +144,6 @@ void kernel_main() {
                                                         multicast_data_noc | l1_read_addr_ex_global,
                                                         single_tile_size_bytes,
                                                         num_blocks,
-                                                        false,
                                                         false);
                                                     noc_async_write_barrier();
                                                 };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -177,7 +177,7 @@ void kernel_main() {
 
         noc_semaphore_set(stats_set_semaphore_addr_ptr, VALID);
         noc_semaphore_set_multicast_loopback_src(
-            stats_set_semaphore_addr, stats_set_semaphore_noc_addr, num_blocks, false, false);
+            stats_set_semaphore_addr, stats_set_semaphore_noc_addr, num_blocks, false);
         noc_async_write_barrier();
         fabric_connection.close_finish();  // Includes a noc async write barrier
     } else {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/worker_writer.cpp
@@ -178,8 +178,7 @@ void kernel_main() {
             reduction_semaphore_send_addr,
             reduction_semaphore_recv_noc_addr,
             i == 0 ? num_mcast_cores : 0,
-            false,  // linked = false
-            true);  // multicast_path_reserve = true
+            false);  // linked = false
     }
 
     // 4. global semaphore reset

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -94,7 +94,7 @@ void kernel_main() {
 #ifndef SKIP_MCAST
             // num_dests must not include source, since we are NOT really doing a local copy!
             noc_async_write_multicast(
-                local_read_addr, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores - 1, true, true);
+                local_read_addr, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores - 1, true);
 #endif
 
             noc_semaphore_set_multicast(
@@ -123,7 +123,7 @@ void kernel_main() {
                 uint64_t in0_multicast_data_addr = in0_multicast_data_noc | in0_start_address;
 #ifndef SKIP_MCAST
                 noc_async_write_multicast_loopback_src(
-                    local_read_addr, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, true, true);
+                    local_read_addr, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, true);
 #endif
                 noc_semaphore_set_multicast_loopback_src(
                     in0_mcast_sender_valid_semaphore, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -194,12 +194,7 @@ void kernel_main() {
 
                     // num_dests must not include source, since we are NOT really doing a local copy!
                     noc_async_write_multicast(
-                        in0_start_address,
-                        in0_multicast_data_addr,
-                        in0_block_size_bytes,
-                        in0_mcast_num_cores,
-                        true,
-                        true);
+                        in0_start_address, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, true);
 
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc,
                     // same cmd_buf Also, this only works because we are setting VCs statically (using

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -198,7 +198,6 @@ void kernel_main() {
                                         in0_multicast_data_addr,
                                         in0_block_size_bytes,
                                         in0_mcast_num_cores - 1,
-                                        true,
                                         true);
                                 }
                             }
@@ -215,7 +214,6 @@ void kernel_main() {
                                         in0_multicast_data_addr,
                                         in0_block_size_bytes,
                                         in0_mcast_num_cores,
-                                        true,
                                         true);
                                 }
                             }
@@ -240,7 +238,6 @@ void kernel_main() {
                                 in0_multicast_data_addr,
                                 in0_block_size_bytes,
                                 in0_mcast_num_cores,
-                                true,
                                 true);
 
                             // We should also multicast the flag to destinations

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -294,12 +294,7 @@ void kernel_main() {
 
                     // num_dests must not include source, since we are NOT really doing a local copy!
                     noc_async_write_multicast(
-                        in1_start_address,
-                        in1_multicast_data_addr,
-                        in1_block_size_bytes,
-                        in1_mcast_num_cores,
-                        true,
-                        true);
+                        in1_start_address, in1_multicast_data_addr, in1_block_size_bytes, in1_mcast_num_cores, true);
 
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id and same
                     // vc even though cmd bufs are different Also, this only works because we are setting VCs statically
@@ -392,12 +387,7 @@ void kernel_main() {
 
                     // num_dests must not include source, since we are NOT really doing a local copy!
                     noc_async_write_multicast(
-                        in3_start_address,
-                        in3_multicast_data_addr,
-                        in3_block_size_bytes,
-                        in1_mcast_num_cores,
-                        true,
-                        true);
+                        in3_start_address, in3_multicast_data_addr, in3_block_size_bytes, in1_mcast_num_cores, true);
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc,
                     // same cmd_buf Also, this only works because we are setting VCs statically (using
                     // NOC_CMD_STATIC_VC).

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -192,7 +192,6 @@ void kernel_main() {
                     multicast_data_noc | l1_read_addr_ex_global,
                     num_tiles_bytes,
                     num_blocks - 1,
-                    true,
                     true);
                 noc_semaphore_set_multicast(
                     reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_blocks - 1);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -39,7 +39,7 @@ void kernel_main() {
         *reduce_sender_semaphore_addr_ptr = VALID;
 
         noc_semaphore_set_multicast_loopback_src(
-            reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_blocks, false, false);
+            reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_blocks, false);
     };
 
     const auto& global_reduce_sender = [&](const uint32_t cb_ex, const uint32_t cb_ex_global)
@@ -51,7 +51,6 @@ void kernel_main() {
             multicast_data_noc | l1_read_addr_ex_global,
             stats_tiles * num_tiles_per_worker_bytes,
             num_blocks,
-            false,
             false);
         noc_async_write_barrier();
     };


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-metal/issues/22515

Path reserve exposed is dangerous, when disabled and have both unicast and multicast at the same time, it might lead to hang. we should remove that from API.

Changes: 
remove the exposure of the Path reservation arg from dataflow_api.h, and always set it to true

### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/15215301825
- [x] [Blackhole Post commit] https://github.com/tenstorrent/tt-metal/actions/runs/15216062057
- [x] TG https://github.com/tenstorrent/tt-metal/actions/runs/15216386355
- [x] T3K https://github.com/tenstorrent/tt-metal/actions/runs/15216394006
