### PR TITLE
added overlapping post processing

### DIFF
--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -35,9 +35,9 @@ TSU_PERF_DROP_LIMIT_PERCENT = 10
 
 # Constants for TSU thresholds based on the number of layers
 TSU_THRESHOLDS = {
-    "4U": {1: {"min": 340, "max": 380}, 10: {"min": 230, "max": 253}, 80: {"min": 49.5, "max": 54}},
+    "4U": {1: {"min": 390, "max": 448}, 10: {"min": 230, "max": 253}, 80: {"min": 49.5, "max": 54}},
     # TODO: Update thresholds for 6U 10L and 80L based on actual perf when 6U are available and added into CI
-    "6U": {1: {"min": 450, "max": 490}, 10: {"min": 230, "max": 250}, 80: {"min": 49, "max": 53}},
+    "6U": {1: {"min": 480, "max": 550}, 10: {"min": 230, "max": 250}, 80: {"min": 49, "max": 53}},
 }
 
 
@@ -490,13 +490,15 @@ def run_llama3_demo(
 
                 tokens_per_second_per_user = 1 / iteration_time
 
+                all_tokens_per_second_per_user.append(tokens_per_second_per_user)
+
                 if not is_ci_env or current_iteration < 200 or current_iteration % 1000 == 0:
                     logger.info(
                         f"Iteration : {current_iteration}, Decode Iteration : {current_decode_iteration}, tok/s/user : {tokens_per_second_per_user:.2f}, Throughput : {batch_size/iteration_time:.2f} tok/s, Iteration Time : {1000*iteration_time:.2f} ms"
                     )
                 profiler.end(f"log_printing_iter_{current_iteration}", iteration=current_iteration)
 
-                if is_ci_env and current_iteration == 127:
+                if current_iteration == 127:
                     tokens_per_second_per_user_token127 = tokens_per_second_per_user
 
                 if not stress_test:

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -419,27 +419,23 @@ def run_llama3_demo(
     tsu_failures = 0
     all_tokens_per_second_per_user = []
 
+    read_events = []
+    tt_out_toks_cpu = []
+    iteration_time_start = time()
+    prefill = True
+    block_host = True
+    decode_iteration = 0
     while users_decoding:
-        if iteration == 0:  # First iteration also accounts for compile time
-            profiler.start(f"compile_decode", iteration=iteration)
-        iteration_time_start = time()
-
         # Execute trace
-        ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
-        tt_out_tok_device0 = ttnn.get_device_tensors(tt_out_tok)[0]
-        tt_out_tok_cpu = tt_out_tok_device0.cpu(blocking=True, cq_id=0)
-        iteration_time = time() - iteration_time_start
-
-        # Update current pos and mat idxs on host and send to device
-        # TODO This is required for now since we cannot ttnn.plus_one(rot_mat_idxs) while it being uint32.
-        # If this tensor is int32, it won't be supported by ttnn.embedding
-        if not stress_test:
-            current_pos += 1
-        tt_output_torch = ttnn.to_torch(
-            tt_out_tok_cpu,
-        )[0, 0, 0, :batch_size]
-        # Append the generated token to the list of outputs
         if iteration in range(len(encoded_prompts[0])):
+            block_host = True
+            prefill = True
+        else:
+            block_host = False
+            prefill = False
+        ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=block_host)
+
+        if prefill:
             all_outputs.append(encoded_prompts[0][iteration])  # Update list of TT outputs
             tt_out_tok_reset = ttnn.from_torch(
                 encoded_prompts_tensor_whole_sequence[:, iteration].reshape(1, 1, 1, batch_size),
@@ -448,57 +444,43 @@ def run_llama3_demo(
                 mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, None), mesh_shape=model_args.cluster_shape),
             )
             ttnn.copy_host_to_device_tensor(tt_out_tok_reset, tt_out_tok)
-        else:
-            all_outputs.append(tt_output_torch.tolist()[0])  # Update generated token to list of TT outputs
-            if all_outputs[-1] in [128001, 128009] and not stress_test:  # EoT tokens
-                users_decoding = False
-
-        # Ignore the first iteration for average speed calculation
-        if iteration > 0:
-            total_decoding_time += iteration_time
-            total_tokens_generated += 1
-
-        tokens_per_second_per_user = 1 / iteration_time
-
-        profiler.start(f"log_printing_iter_{iteration}", iteration=iteration)
-        # Print out generated outputs for each user at the end of every iteration
-        if not is_ci_env:
-            # if len(user_input) == 1:
+            # Print out generated outputs for each user at the end of every iteration
             logger.info("[User 0] {}".format("".join(tokenizer.decode(all_outputs))))
-            # else:
-            #     for user in range(batch_size):
-            #         text = "".join(tokenizer.decode(all_outputs[user]))
-            #         if len(text) > 100:
-            #             text = "..." + text[-97:]
-            #         text = text.replace("\n", " ")
-            #         logger.info("[User {}] {}".format(user, text))
-
-        if not is_ci_env or iteration < 200 or iteration % 1000 == 0:
-            # Always print perf at every iteration if not in CI
+            iteration_time_ends = time()
+            iteration_time = iteration_time_ends - iteration_time_start
             logger.info(
-                f"Iteration {iteration}: {1000*iteration_time:.0f}ms @ {tokens_per_second_per_user:.1f} tok/s/user ({batch_size*tokens_per_second_per_user:.1f} tok/s throughput)"
+                f"Iteration : {iteration}, Prefill Iteration : {iteration}, time taken : {iteration_time:.2f} seconds, t/s/u : {1/iteration_time:.2f}"
             )
+            iteration_time_start = time()
+        else:
+            tt_out_toks_cpu += [tt_out_tok.cpu(blocking=block_host, cq_id=0)]
+            read_events += [ttnn.record_event(mesh_device, 0)]
 
-        all_tokens_per_second_per_user.append(tokens_per_second_per_user)
-
-        if iteration == 127:
-            tokens_per_second_per_user_token127 = tokens_per_second_per_user
-
-        if not stress_test:
-            # Increment failure count if throughput is too low
-            if tokens_per_second_per_user < tsu_thresholds["min"] or tokens_per_second_per_user > tsu_thresholds["max"]:
-                tsu_failures += 1
-
-        profiler.end(f"log_printing_iter_{iteration}", iteration=iteration)
-
-        if iteration == 0:  # First iteration also accounts for compile time
-            profiler.end(f"compile_decode", iteration=iteration)
+            if decode_iteration >= 1:
+                # Write to host
+                ttnn.event_synchronize(read_events[decode_iteration - 1])
+                tt_output_torch = ttnn.to_torch(
+                    tt_out_toks_cpu[decode_iteration - 1],
+                    mesh_composer=ttnn.ConcatMesh2dToTensor(
+                        mesh_device,
+                        dims=(3, 1),
+                        mesh_shape=model_args.cluster_shape,
+                    ),
+                )[0, 0, 0, :batch_size]
+                all_outputs.append(tt_output_torch.tolist()[0])  # Update generated token to list of TT outputs
+                # Print out generated outputs for each user at the end of every iteration
+                logger.info("[User 0] {}".format("".join(tokenizer.decode(all_outputs))))
+                iteration_time_ends = time()
+                iteration_time = iteration_time_ends - iteration_time_start
+                logger.info(
+                    f"Iteration : {iteration-1}, Decode Iteration : {decode_iteration-1}, time taken : {iteration_time:.2f} seconds, t/s/u : {1/iteration_time:.2f}"
+                )
+                iteration_time_start = time()
+                if iteration + 1 > max_generated_tokens:  # EoT tokens
+                    users_decoding = False
+            decode_iteration += 1
 
         iteration += 1
-
-        # Upper limit of generated tokens for each user (to avoid infinite generation in case eos is not seen)
-        if iteration >= max_generated_tokens:
-            users_decoding = False
 
     # Release trace
     ttnn.release_trace(mesh_device, trace_id)

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -449,7 +449,7 @@ def run_llama3_demo(
             iteration_time_ends = time()
             iteration_time = iteration_time_ends - iteration_time_start
             logger.info(
-                f"Iteration : {iteration}, Prefill Iteration : {iteration}, time taken : {iteration_time:.2f} seconds, t/s/u : {1/iteration_time:.2f}"
+                f"Iteration : {iteration}, Prefill Iteration : {iteration}, Iteration Time : {1000*iteration_time:.2f} ms, tok/s/user : {1/iteration_time:.2f}, Throughput : {batch_size/iteration_time:.2f} tok/s"
             )
             iteration_time_start = time()
         else:
@@ -473,7 +473,7 @@ def run_llama3_demo(
                 iteration_time_ends = time()
                 iteration_time = iteration_time_ends - iteration_time_start
                 logger.info(
-                    f"Iteration : {iteration-1}, Decode Iteration : {decode_iteration-1}, time taken : {iteration_time:.2f} seconds, t/s/u : {1/iteration_time:.2f}"
+                    f"Iteration : {iteration-1}, Decode Iteration : {decode_iteration-1}, Iteration Time : {1000*iteration_time:.2f} ms, tok/s/user : {1/iteration_time:.2f}, Throughput : {batch_size/iteration_time:.2f} tok/s"
                 )
                 iteration_time_start = time()
                 if iteration + 1 > max_generated_tokens:  # EoT tokens

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -35,9 +35,9 @@ TSU_PERF_DROP_LIMIT_PERCENT = 10
 
 # Constants for TSU thresholds based on the number of layers
 TSU_THRESHOLDS = {
-    "4U": {1: {"min": 290, "max": 320}, 10: {"min": 230, "max": 253}, 80: {"min": 49.5, "max": 54}},
+    "4U": {1: {"min": 340, "max": 380}, 10: {"min": 230, "max": 253}, 80: {"min": 49.5, "max": 54}},
     # TODO: Update thresholds for 6U 10L and 80L based on actual perf when 6U are available and added into CI
-    "6U": {1: {"min": 350, "max": 400}, 10: {"min": 230, "max": 250}, 80: {"min": 49, "max": 53}},
+    "6U": {1: {"min": 450, "max": 490}, 10: {"min": 230, "max": 250}, 80: {"min": 49, "max": 53}},
 }
 
 
@@ -475,14 +475,9 @@ def run_llama3_demo(
                 current_decode_iteration = decode_iteration - trace_exec_offset
                 # Write to host
                 ttnn.event_synchronize(read_events[current_decode_iteration])
-                tt_output_torch = ttnn.to_torch(
-                    tt_out_toks_cpu[current_decode_iteration],
-                    mesh_composer=ttnn.ConcatMesh2dToTensor(
-                        mesh_device,
-                        dims=(3, 1),
-                        mesh_shape=model_args.cluster_shape,
-                    ),
-                )[0, 0, 0, :batch_size]
+                tt_output_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_out_toks_cpu[current_decode_iteration])[0])[
+                    0, 0, 0, :batch_size
+                ]
                 all_outputs.append(tt_output_torch.tolist()[0])  # Update generated token to list of TT outputs
 
                 profiler.start(f"log_printing_iter_{current_iteration}", iteration=current_iteration)

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -35,9 +35,9 @@ TSU_PERF_DROP_LIMIT_PERCENT = 10
 
 # Constants for TSU thresholds based on the number of layers
 TSU_THRESHOLDS = {
-    "4U": {1: {"min": 620, "max": 800}, 10: {"min": 230, "max": 253}, 80: {"min": 49.5, "max": 54}},
+    "4U": {1: {"min": 290, "max": 320}, 10: {"min": 230, "max": 253}, 80: {"min": 49.5, "max": 54}},
     # TODO: Update thresholds for 6U 10L and 80L based on actual perf when 6U are available and added into CI
-    "6U": {1: {"min": 720, "max": 900}, 10: {"min": 230, "max": 250}, 80: {"min": 49, "max": 53}},
+    "6U": {1: {"min": 350, "max": 400}, 10: {"min": 230, "max": 250}, 80: {"min": 49, "max": 53}},
 }
 
 
@@ -433,7 +433,7 @@ def run_llama3_demo(
             block_host = True
             prefill = True
         else:
-            block_host = False
+            block_host = False if layers == 80 else True
             prefill = False
 
         if iteration == 0:  # First iteration also accounts for compile time


### PR DESCRIPTION
### Problem description
This PR overlaps to_torch and output logging with trace execution
### What's changed
We were not accounting time for to_torch and output logging in our t/s/u reporting. This PR hides that by buffering future execute_trace and overlaps the output torch conversion of previous iteration.
https://github.com/tenstorrent/tt-metal/actions/runs/15483434534
https://github.com/tenstorrent/tt-metal/actions/runs/15483448532 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes