### PR TITLE
#22524: Workaround for 1d fabric routing due to routing tables not correctly setting up wraparound links

### DIFF
--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -61,6 +61,12 @@ public:
     // reserved along the way for tunneling etc.
     std::vector<chan_id_t> get_forwarding_eth_chans_to_chip(
         mesh_id_t src_mesh_id, chip_id_t src_chip_id, mesh_id_t dst_mesh_id, chip_id_t dst_chip_id) const;
+    std::vector<chan_id_t> get_forwarding_eth_chans_to_chip(
+        mesh_id_t src_mesh_id,
+        chip_id_t src_chip_id,
+        mesh_id_t dst_mesh_id,
+        chip_id_t dst_chip_id,
+        RoutingDirection forwarding_direction) const;
 
     stl::Span<const chip_id_t> get_intra_chip_neighbors(
         mesh_id_t src_mesh_id, chip_id_t src_chip_id, RoutingDirection routing_direction) const;

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -950,9 +950,19 @@ std::vector<chan_id_t> ControlPlane::get_forwarding_eth_chans_to_chip(
         return {};
     }
 
+    return this->get_forwarding_eth_chans_to_chip(
+        src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id, *forwarding_direction);
+}
+
+std::vector<chan_id_t> ControlPlane::get_forwarding_eth_chans_to_chip(
+    mesh_id_t src_mesh_id,
+    chip_id_t src_chip_id,
+    mesh_id_t dst_mesh_id,
+    chip_id_t dst_chip_id,
+    RoutingDirection forwarding_direction) const {
     std::vector<chan_id_t> forwarding_channels;
     const auto& active_channels =
-        this->get_active_fabric_eth_channels_in_direction(src_mesh_id, src_chip_id, forwarding_direction.value());
+        this->get_active_fabric_eth_channels_in_direction(src_mesh_id, src_chip_id, forwarding_direction);
     for (const auto& src_chan_id : active_channels) {
         // check for end-to-end route before accepting this channel
         if (get_fabric_route(src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id, src_chan_id).empty()) {

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -498,11 +498,6 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
 std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const {
     const bool is_handshake_master = this->my_chip_id < this->peer_chip_id;
     TT_ASSERT(this->my_chip_id != this->peer_chip_id);
-    TT_ASSERT(
-        std::unordered_set<size_t>(
-            sender_channels_num_buffers.begin(), sender_channels_num_buffers.begin() + config.num_used_sender_channels)
-                .size() == 1,
-        "Implementation expects sender_channels_num_buffers to all be the same for now");
 
     for (uint32_t i = 0; i < FabricEriscDatamoverConfig::num_sender_channels; i++) {
         log_trace(tt::LogTest, "Sender {} num buffers: {}", i, this->sender_channels_num_buffers[i]);

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -66,7 +66,7 @@ std::vector<uint32_t> get_forwarding_link_indices_in_direction(
 
     // the subset of routers that support forwarding b/w those chips
     const std::vector<chan_id_t>& forwarding_channels = control_plane->get_forwarding_eth_chans_to_chip(
-        src_mesh_id, src_logical_chip_id, dst_mesh_id, dst_logical_chip_id);
+        src_mesh_id, src_logical_chip_id, dst_mesh_id, dst_logical_chip_id, direction);
 
     const std::vector<chan_id_t>& fabric_channels =
         control_plane->get_active_fabric_eth_channels_in_direction(src_mesh_id, src_logical_chip_id, direction);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
6u using 1d ring is broken due to the router lookup using the routing tables, which doesn't have the torus links. This causes it to route in the opposite direction (long path) instead of going over the torus link.

### What's changed
Workaround for now to revert to the old method of direction lookup while we work on proper fix through routing table.
Also delete an assert that is triggered by some recent buffering changes. It should now be supported.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15217998721
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes