### PR TITLE
Having per risc fabric config

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -1211,19 +1211,14 @@ void setup_test_with_persistent_fabric(
         devices, fabric_program_ptrs, enable_persistent_fabric, num_links.value_or(1), false, topology, is_galaxy);
     line_fabric->set_firmware_context_switch_interval(switch_interval);
     if (loopback_on_last_device) {
-        for (auto& edm_builders_per_conn : line_fabric->edm_builders_backward_direction.at(devices.back()->id())) {
+        for (auto& edm_builder : line_fabric->edm_builders_backward_direction.at(devices.back()->id())) {
             log_trace(
                 tt::LogTest,
                 "Implementing loopback on device {} by connecting 1D fabric endpoint to itself at x={}, y={}",
                 devices.back()->id(),
-                edm_builders_per_conn.begin()->my_noc_x,
-                edm_builders_per_conn.begin()->my_noc_y);
-            // TODO: update from vector<vector> to specified struct/class
-            //       Conceptually this method (connect_to_downstream_edm) call
-            //       is for each connection. not for each risc.
-            for (auto& edm_per_risc : edm_builders_per_conn) {
-                edm_per_risc.connect_to_downstream_edm(edm_per_risc);
-            }
+                edm_builder.my_noc_x,
+                edm_builder.my_noc_y);
+            edm_builder.connect_to_downstream_edm(edm_builder);
         }
     }
 

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -23,6 +23,8 @@
 
 namespace tt::tt_fabric {
 
+class FabricRiscConfig;
+
 struct FabricEriscDatamoverConfig {
     static constexpr uint32_t WR_CMD_BUF = 0;      // for large writes
     static constexpr uint32_t RD_CMD_BUF = 1;      // for all reads
@@ -83,6 +85,7 @@ struct FabricEriscDatamoverConfig {
     std::array<std::size_t, num_receiver_channels> receivers_completed_packet_header_cb_address;
     std::array<std::size_t, num_sender_channels> senders_completed_packet_header_cb_address;
 
+    std::vector<FabricRiscConfig> risc_configs;
     // ----------- Sender Channels
     std::vector<std::array<bool, num_sender_channels>> is_sender_channel_serviced;
 
@@ -158,6 +161,17 @@ struct FabricEriscDatamoverConfig {
 
 private:
     FabricEriscDatamoverConfig(Topology topology = Topology::Linear);
+};
+
+class FabricRiscConfig {
+public:
+    FabricRiscConfig();
+    bool enable_handshake;
+    bool enable_context_switch;
+    bool enable_interrupts;
+    size_t iterations_between_ctx_switch_and_teardown_checks;
+    std::array<bool, FabricEriscDatamoverConfig::num_sender_channels> is_sender_channel_serviced;
+    std::array<bool, FabricEriscDatamoverConfig::num_receiver_channels> is_receiver_channel_serviced;
 };
 
 struct SenderWorkerAdapterSpec {
@@ -239,7 +253,7 @@ public:
     [[nodiscard]] SenderWorkerAdapterSpec build_connection_to_worker_channel() const;
     [[nodiscard]] SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t vc);
 
-    [[nodiscard]] std::vector<uint32_t> get_compile_time_args() const;
+    [[nodiscard]] std::vector<uint32_t> get_compile_time_args(uint32_t risc_id) const;
 
     [[nodiscard]] std::vector<uint32_t> get_runtime_args() const;
 
@@ -285,10 +299,6 @@ public:
 
     std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> is_sender_channel_serviced;
     std::array<size_t, FabricEriscDatamoverConfig::num_receiver_channels> is_receiver_channel_serviced;
-    bool enable_handshake = false;
-    bool enable_context_switch = false;
-    bool enable_interrupts = false;
-    size_t iterations_between_ctx_switch_and_teardown_checks;
 
     size_t termination_signal_ptr = 0;
     size_t edm_local_sync_ptr = 0;

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -327,7 +327,7 @@ tt::tt_metal::KernelHandle generate_edm_kernel_impl(
 
     std::vector<uint32_t> const edm_kernel_rt_args = edm_builder.get_runtime_args();
     // Ethernet Kernels
-    std::vector<uint32_t> const eth_sender_ct_args = edm_builder.get_compile_time_args();
+    const std::vector<uint32_t> eth_sender_ct_args = edm_builder.get_compile_time_args((uint32_t)risc_id);
     log_trace(tt::LogOp, "EDM core (x={},y={}):", eth_core.x, eth_core.y);
     log_trace(tt::LogOp, "CT ARGS:");
     for (auto const& s : eth_sender_ct_args) {

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
@@ -250,7 +250,8 @@ public:
     }
 
     [[nodiscard]]
-    std::vector<uint32_t> get_compile_time_args() const {
+    std::vector<uint32_t> get_compile_time_args(uint32_t risc_id) const {
+        // TODO: use risc_id accordingly
         return std::vector<uint32_t>{
             static_cast<uint32_t>(this->enable_sender ? 1 : 0),
             static_cast<uint32_t>(this->enable_receiver ? 1 : 0),

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.hpp
@@ -107,10 +107,8 @@ public:
     void set_firmware_context_switch_interval(size_t interval);
 
     // Device ID -> EDM Builders for each eth core for each Risc core
-    std::unordered_map<size_t, std::vector<std::vector<tt::tt_fabric::FabricEriscDatamoverBuilder>>>
-        edm_builders_forward_direction;
-    std::unordered_map<size_t, std::vector<std::vector<tt::tt_fabric::FabricEriscDatamoverBuilder>>>
-        edm_builders_backward_direction;
+    std::unordered_map<size_t, std::vector<tt::tt_fabric::FabricEriscDatamoverBuilder>> edm_builders_forward_direction;
+    std::unordered_map<size_t, std::vector<tt::tt_fabric::FabricEriscDatamoverBuilder>> edm_builders_backward_direction;
 
 private:
     // Device ID -> link index


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21235

### Problem description
FabricEriscDatamoverConfig have per risc parameters by vector.

### What's changed
Replace the vectors by vector of FabricRiscConfig which hold all the params

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes