### PR TITLE
#21074: Update memory load type for bh active eth riscs to use contiguous and put load types into HAL

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
@@ -101,10 +101,6 @@ void RunTest(
 }
 
 TEST_F(DPrintFixture, ActiveEthTestPrint) {
-    if (this->arch_ == ARCH::BLACKHOLE) {  // TODO: Re-enable when this is supported on BH
-        log_info(tt::LogTest, "DPrint on BH active eth not yet supported");
-        GTEST_SKIP();
-    }
     for (IDevice* device : this->devices_) {
         // Skip if no ethernet cores on this device
         if (device->get_active_ethernet_cores(true).size() == 0) {

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
@@ -111,10 +111,6 @@ TEST_F(DPrintFixture, TensixTestPrintPrependDeviceCoreRisc) {
 }
 
 TEST_F(DPrintFixture, TensixActiveEthTestPrintPrependDeviceCoreRisc) {
-    if (this->arch_ == ARCH::BLACKHOLE) {  // TODO: Re-enable when this is supported on BH
-        log_info(tt::LogTest, "DPrint on BH active eth not yet supported");
-        GTEST_SKIP();
-    }
     tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
         tt::llrt::RunTimeDebugFeatureDprint, true);
     for (IDevice* device : this->devices_) {

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -92,11 +92,17 @@ inline uint64_t GetDprintBufAddr(chip_id_t device_id, const CoreCoord& virtual_c
 #define DPRINT_NRISCVS 5
 #define DPRINT_NRISCVS_ETH 1
 
-inline int GetNumRiscs(const CoreDescriptor& core) {
+inline int GetNumRiscs(chip_id_t device_id, const CoreDescriptor& core) {
     if (core.type == CoreType::ETH) {
-        return (tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE)
-                   ? DPRINT_NRISCVS_ETH + 1
-                   : DPRINT_NRISCVS_ETH;
+        if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE) {
+            // TODO: Update this to be `DPRINT_NRISCVS_ETH + 1` when active erisc0 is running Metal FW
+            auto logical_active_eths =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id);
+            CoreCoord logical_eth(core.coord.x, core.coord.y);
+            return (logical_active_eths.find(logical_eth) != logical_active_eths.end()) ? DPRINT_NRISCVS_ETH
+                                                                                        : DPRINT_NRISCVS_ETH + 1;
+        }
+        return DPRINT_NRISCVS_ETH;
     } else {
         return DPRINT_NRISCVS;
     }

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -613,7 +613,7 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
         CoreCoord virtual_core =
             tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
                 device_id, logical_core.coord, logical_core.type);
-        for (int risc_index = 0; risc_index < tt::tt_metal::GetNumRiscs(logical_core); risc_index++) {
+        for (int risc_index = 0; risc_index < tt::tt_metal::GetNumRiscs(device_id, logical_core); risc_index++) {
             WriteInitMagic(device_id, virtual_core, risc_index, false);
         }
     }
@@ -720,7 +720,7 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
         CoreCoord virtual_core =
             tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
                 device_id, logical_core.coord, logical_core.type);
-        for (int risc_index = 0; risc_index < tt::tt_metal::GetNumRiscs(logical_core); risc_index++) {
+        for (int risc_index = 0; risc_index < tt::tt_metal::GetNumRiscs(device_id, logical_core); risc_index++) {
             if (RiscEnabled(logical_core, risc_index)) {
                 WriteInitMagic(device_id, virtual_core, risc_index, true);
             }
@@ -770,7 +770,7 @@ void DebugPrintServerContext::DetachDevice(chip_id_t device_id) {
             CoreCoord virtual_core =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
                     device_id, logical_core.coord, logical_core.type);
-            for (int risc_id = 0; risc_id < tt::tt_metal::GetNumRiscs(logical_core); risc_id++) {
+            for (int risc_id = 0; risc_id < tt::tt_metal::GetNumRiscs(device_id, logical_core); risc_id++) {
                 if (RiscEnabled(logical_core, risc_id)) {
                     // No need to check if risc is not dprint-enabled.
                     if (!CheckInitMagicCleared(device_id, virtual_core, risc_id)) {
@@ -834,7 +834,7 @@ void DebugPrintServerContext::DetachDevice(chip_id_t device_id) {
         CoreCoord virtual_core =
             tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
                 device_id, logical_core.coord, logical_core.type);
-        for (int risc_index = 0; risc_index < tt::tt_metal::GetNumRiscs(logical_core); risc_index++) {
+        for (int risc_index = 0; risc_index < tt::tt_metal::GetNumRiscs(device_id, logical_core); risc_index++) {
             WriteInitMagic(device_id, virtual_core, risc_index, false);
         }
     }
@@ -1202,7 +1202,7 @@ void DebugPrintServerContext::PollPrintData() {
             }
             device_intermediate_streams_force_flush_lock_.unlock();
             for (auto& logical_core : device_and_cores.second) {
-                int risc_count = tt::tt_metal::GetNumRiscs(logical_core);
+                int risc_count = tt::tt_metal::GetNumRiscs(device_id, logical_core);
                 for (int risc_index = 0; risc_index < risc_count; risc_index++) {
                     if (RiscEnabled(logical_core, risc_index)) {
                         try {

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -51,7 +51,7 @@ void DumpCoreNocData(chip_id_t device_id, const CoreDescriptor& logical_core, no
     CoreCoord virtual_core =
         tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
             device_id, logical_core.coord, logical_core.type);
-    for (int risc_id = 0; risc_id < GetNumRiscs(logical_core); risc_id++) {
+    for (int risc_id = 0; risc_id < GetNumRiscs(device_id, logical_core); risc_id++) {
         // Read out the DPRINT buffer, we stored our data in the "data field"
         uint64_t addr = GetDprintBufAddr(device_id, virtual_core, risc_id);
         auto from_dev = tt::llrt::read_hex_vec_from_core(device_id, virtual_core, addr, DPRINT_BUFFER_SIZE);
@@ -113,7 +113,7 @@ void ClearNocData(chip_id_t device_id) {
         CoreCoord virtual_core =
             tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
                 device_id, logical_core.coord, logical_core.type);
-        for (int risc_id = 0; risc_id < GetNumRiscs(logical_core); risc_id++) {
+        for (int risc_id = 0; risc_id < GetNumRiscs(device_id, logical_core); risc_id++) {
             uint64_t addr = GetDprintBufAddr(device_id, virtual_core, risc_id);
             std::vector<uint32_t> initbuf = std::vector<uint32_t>(DPRINT_BUFFER_SIZE / sizeof(uint32_t), 0);
             tt::llrt::write_hex_vec_to_core(device_id, virtual_core, initbuf, addr);

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -86,6 +86,7 @@ HalCoreInfoType create_active_eth_mem_map() {
             .local_init_addr = MEM_AERISC_INIT_LOCAL_L1_BASE_SCRATCH,
             .fw_launch_addr = SUBORDINATE_IERISC_RESET_PC,
             .fw_launch_addr_value = MEM_AERISC_FIRMWARE_BASE,
+            .memory_load = ll_api::memory::Loading::CONTIGUOUS,
         };
         processor_classes[processor_class_idx] = processor_types;
     }

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -71,6 +71,7 @@ HalCoreInfoType create_idle_eth_mem_map() {
     for (std::uint8_t processor_class_idx = 0; processor_class_idx < NumEthDispatchClasses; processor_class_idx++) {
         DeviceAddr fw_base, local_init, fw_launch;
         uint32_t fw_launch_value;
+        ll_api::memory::Loading memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP;
         switch (static_cast<EthProcessorTypes>(processor_class_idx)) {
             case EthProcessorTypes::DM0: {
                 fw_base = MEM_IERISC_FIRMWARE_BASE;
@@ -91,7 +92,8 @@ HalCoreInfoType create_idle_eth_mem_map() {
             .fw_base_addr = fw_base,
             .local_init_addr = local_init,
             .fw_launch_addr = fw_launch,
-            .fw_launch_addr_value = fw_launch_value
+            .fw_launch_addr_value = fw_launch_value,
+            .memory_load = memory_load,
         };
         processor_classes[processor_class_idx] = processor_types;
     }

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -72,6 +72,7 @@ HalCoreInfoType create_tensix_mem_map() {
         for (size_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
             DeviceAddr fw_base{}, local_init{}, fw_launch{};
             uint32_t fw_launch_value{};
+            ll_api::memory::Loading memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP;
             switch (processor_class_idx) {
                 case 0: {
                     fw_base = MEM_BRISC_FIRMWARE_BASE;
@@ -119,7 +120,8 @@ HalCoreInfoType create_tensix_mem_map() {
                 .fw_base_addr = fw_base,
                 .local_init_addr = local_init,
                 .fw_launch_addr = fw_launch,
-                .fw_launch_addr_value = fw_launch_value
+                .fw_launch_addr_value = fw_launch_value,
+                .memory_load = memory_load,
             };
         }
         processor_classes[processor_class_idx] = processor_types;

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/assert.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/utils.hpp>
+#include <tt_memory.h>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -38,6 +39,7 @@ struct HalJitBuildConfig {
     DeviceAddr local_init_addr;
     DeviceAddr fw_launch_addr;
     uint32_t fw_launch_addr_value;
+    ll_api::memory::Loading memory_load;
 };
 
 class Hal;

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -92,6 +92,7 @@ HalCoreInfoType create_active_eth_mem_map(bool is_base_routing_fw_enabled) {
             .local_init_addr = eth_l1_mem::address_map::FIRMWARE_BASE,
             .fw_launch_addr = eth_l1_mem::address_map::LAUNCH_ERISC_APP_FLAG,
             .fw_launch_addr_value = 0x1,
+            .memory_load = ll_api::memory::Loading::DISCRETE,
         };
         processor_classes[processor_class_idx] = processor_types;
     }

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -74,6 +74,7 @@ HalCoreInfoType create_idle_eth_mem_map() {
             .local_init_addr = MEM_IERISC_INIT_LOCAL_L1_BASE_SCRATCH,
             .fw_launch_addr = 0x0,
             .fw_launch_addr_value = generate_risc_startup_addr(MEM_IERISC_FIRMWARE_BASE),
+            .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP,
         };
         processor_classes[processor_class_idx] = processor_types;
     }

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -69,6 +69,7 @@ HalCoreInfoType create_tensix_mem_map() {
         for (std::size_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
             DeviceAddr fw_base{}, local_init{}, fw_launch{};
             uint32_t fw_launch_value{};
+            ll_api::memory::Loading memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP;
             switch (processor_class_idx) {
                 case 0: {
                     fw_base = MEM_BRISC_FIRMWARE_BASE;
@@ -82,6 +83,7 @@ HalCoreInfoType create_tensix_mem_map() {
                     local_init = MEM_NCRISC_INIT_LOCAL_L1_BASE_SCRATCH;
                     fw_launch = 0;//fix me;
                     fw_launch_value = fw_base;
+                    memory_load = ll_api::memory::Loading::CONTIGUOUS;
                 }
                 break;
                 case 2: {
@@ -116,8 +118,8 @@ HalCoreInfoType create_tensix_mem_map() {
                 .fw_base_addr = fw_base,
                 .local_init_addr = local_init,
                 .fw_launch_addr = fw_launch,
-                .fw_launch_addr_value = fw_launch_value
-            };
+                .fw_launch_addr_value = fw_launch_value,
+                .memory_load = memory_load};
         }
         processor_classes[processor_class_idx] = processor_types;
     }


### PR DESCRIPTION
### Ticket
#21074 

### Problem description
Active eth kernels were using discrete mem load type (specific to active eth on WH) but should be using contiguous to properly init globals in active eriscs. 

### What's changed
Also added memory load type to hal jit build config

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15261185201) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15261193822) CI with demo tests passes (if applicable)