### PR TITLE
Fix missing dependency

### DIFF
--- a/tt_stl/CMakeLists.txt
+++ b/tt_stl/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(
         Reflect::Reflect
         magic_enum::magic_enum
         nlohmann_json::nlohmann_json
+        span
 )
 
 target_precompile_headers(

--- a/tt_stl/tests/CMakeLists.txt
+++ b/tt_stl/tests/CMakeLists.txt
@@ -12,13 +12,13 @@ target_sources(
         test_span.cpp
         test_strong_type.cpp
 )
-target_include_directories(unit_tests_stl_smoke PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(
     unit_tests_stl_smoke
     PRIVATE
         gmock
         gtest
         gtest_main
+        TT::STL
 )
 
 add_executable(unit_tests_stl)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
TT-STL is missing a dependency on span.  It only accidentally works if Boost is installed on the system and is a sufficient version to include span.
TT-STL's test is missing a dependency on UUT.  It only accidentally works because include dirs were being assumed.  And even then only if Boost is installed on the system and is a sufficient version to include span.

### What's changed
Fixed the dependency logic so that it works even if deps come in via CPM.