### PR TITLE
Use mask to avoid processing unused CBs in firmware

### DIFF
--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -115,6 +115,7 @@ target_sources(
             test_kernels/dataflow/unit_tests/command_queue/random_program.cpp
             test_kernels/misc/add_two_ints.cpp
             test_kernels/misc/brisc_print.cpp
+            test_kernels/misc/circular_buffer/cb_init.cpp
             test_kernels/misc/circular_buffer/cb_non_blocking_master_test_kernel.cpp
             test_kernels/misc/circular_buffer/cb_non_blocking_subordinate_test_kernel.cpp
             test_kernels/misc/dprint_raise_wait_brisc.cpp

--- a/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_init.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_init.cpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "circular_buffer_init.h"
+
+#include "debug/assert.h"
+#include "debug/dprint.h"
+
+void check_cb_values(bool read, bool write, bool init_wr_tile_ptr, uint32_t initial_value, uint32_t mask) {
+    for (uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
+        if (!(mask & (1 << i))) {
+            continue;  // Skip circular buffers that are not set up
+        }
+        uint32_t fifo_addr = initial_value + i * 4;
+        uint32_t fifo_size = initial_value + i * 4 + 1;
+        uint32_t fifo_num_pages = initial_value + i * 4 + 2;
+        uint32_t fifo_page_size = initial_value + i * 4 + 3;
+        LocalCBInterface& local_interface = get_local_cb_interface(i);
+        DPRINT << "CB " << i << " local_interface.fifo_limit: " << local_interface.fifo_limit
+               << ", fifo_wr_ptr: " << local_interface.fifo_wr_ptr << ", fifo_rd_ptr: " << local_interface.fifo_rd_ptr
+               << ", fifo_size: " << local_interface.fifo_size << ", fifo_num_pages: " << local_interface.fifo_num_pages
+               << ", fifo_page_size: " << local_interface.fifo_page_size << ENDL();
+        if (local_interface.fifo_limit != fifo_addr + fifo_size) {
+            DPRINT << "FIFO limit mismatch for CB " << i << ": expected " << (fifo_addr + fifo_size) << ", got "
+                   << local_interface.fifo_limit << ENDL();
+            while (true);  // Purposefully hang the kernel if FIFO limit did not arrive correctly
+        }
+        if (write) {
+            if (local_interface.fifo_wr_ptr != fifo_addr) {
+                DPRINT << "FIFO write pointer mismatch for CB " << i << ": expected " << fifo_addr << ", got "
+                       << local_interface.fifo_wr_ptr << ENDL();
+                while (true);  // Purposefully hang the kernel if FIFO write pointer did not arrive correctly
+            }
+        }
+        if (read) {
+            if (local_interface.fifo_rd_ptr != fifo_addr) {
+                DPRINT << "FIFO read pointer mismatch for CB " << i << ": expected " << fifo_addr << ", got "
+                       << local_interface.fifo_rd_ptr << ENDL();
+                while (true);  // Purposefully hang the kernel if FIFO read pointer did not arrive correctly
+            }
+        }
+        if (local_interface.fifo_size != fifo_size) {
+            DPRINT << "FIFO size mismatch for CB " << i << ": expected " << fifo_size << ", got "
+                   << local_interface.fifo_size << ENDL();
+            while (true);  // Purposefully hang the kernel if FIFO size did not arrive correctly
+        }
+        if (write) {
+            if (local_interface.fifo_num_pages != fifo_num_pages) {
+                DPRINT << "FIFO num pages mismatch for CB " << i << ": expected " << fifo_num_pages << ", got "
+                       << local_interface.fifo_num_pages << ENDL();
+                while (true);  // Purposefully hang the kernel if FIFO num pages did not arrive correctly
+            }
+        }
+        if (local_interface.fifo_page_size != fifo_page_size) {
+            DPRINT << "FIFO page size mismatch for CB " << i << ": expected " << fifo_page_size << ", got "
+                   << local_interface.fifo_page_size << ENDL();
+            while (true);  // Purposefully hang the kernel if FIFO page size did not arrive correctly
+        }
+        if (local_interface.tiles_acked_received_init != 0) {
+            DPRINT << "Tiles acked received init mismatch for CB " << i << ": expected 0, got "
+                   << local_interface.tiles_acked_received_init << ENDL();
+            while (true);  // Purposefully hang the kernel if tiles acked received init did not arrive correctly
+        }
+        if (init_wr_tile_ptr) {
+            if (local_interface.fifo_wr_tile_ptr != 0) {
+                DPRINT << "FIFO write tile pointer mismatch for CB " << i << ": expected 0, got "
+                       << local_interface.fifo_wr_tile_ptr << ENDL();
+                while (true);  // Purposefully hang the kernel if FIFO write tile pointer did not arrive correctly
+            }
+        }
+    }
+}
+
+uint32_t get_clock_lo() {
+    volatile uint tt_reg_ptr* clock_lo = reinterpret_cast<volatile uint tt_reg_ptr*>(RISCV_DEBUG_REG_WALL_CLOCK_L);
+    return *clock_lo;
+}
+
+template <bool read, bool write, bool init_wr_tile_ptr>
+void perform_test(uint32_t initial_value) {
+    uint32_t mask = get_arg_val<uint32_t>(0);
+    DPRINT << "Performing test with read: " << static_cast<uint32_t>(read)
+           << ", write: " << static_cast<uint32_t>(write)
+           << ", init_wr_tile_ptr: " << static_cast<uint32_t>(init_wr_tile_ptr) << ", mask: " << mask << ENDL();
+
+    uint32_t tt_l1_ptr* cb_l1_base = get_arg_val<uint32_t tt_l1_ptr*>(1);
+
+    for (uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS * 4; i++) {
+        ((volatile uint32_t*)cb_l1_base)[i] = initial_value + i;
+    }
+    uint8_t* out_data = reinterpret_cast<uint8_t*>(cb_interface);
+    for (uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS * sizeof(CBInterface); i++) {
+        out_data[i] = 0xff;
+    }
+
+    uint32_t start_time = get_clock_lo();
+    setup_local_cb_read_write_interfaces<read, write, init_wr_tile_ptr>(cb_l1_base, 0, mask);
+    uint32_t end_time = get_clock_lo();
+    DPRINT << "Time taken for setup: " << (end_time - start_time) << " cycles" << ENDL();
+
+    check_cb_values(read, write, init_wr_tile_ptr, initial_value, mask);
+}
+
+void kernel_main() {
+    perform_test<true, true, false>(0);
+    perform_test<true, false, true>(1000);
+    perform_test<false, true, true>(2000);
+    perform_test<false, false, true>(3000);
+}

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -446,7 +446,7 @@ int main() {
             WAYPOINT("R");
             if (enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM0) {
                 uint32_t local_cb_mask = launch_msg_address->kernel_config.local_cb_mask;
-                setup_local_cb_read_write_interfaces(cb_l1_base, 0, local_cb_mask, true, true, false);
+                setup_local_cb_read_write_interfaces<true, true, false>(cb_l1_base, 0, local_cb_mask);
                 cb_l1_base =
                     (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg_address->kernel_config.remote_cb_offset);
                 uint32_t end_cb_index = launch_msg_address->kernel_config.min_remote_cb_start_index;

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -445,11 +445,11 @@ int main() {
             // Run the BRISC kernel
             WAYPOINT("R");
             if (enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM0) {
-                uint32_t end_cb_index = launch_msg_address->kernel_config.max_local_cb_end_index;
-                setup_local_cb_read_write_interfaces(cb_l1_base, 0, end_cb_index, true, true, false);
+                uint32_t local_cb_mask = launch_msg_address->kernel_config.local_cb_mask;
+                setup_local_cb_read_write_interfaces(cb_l1_base, 0, local_cb_mask, true, true, false);
                 cb_l1_base =
                     (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg_address->kernel_config.remote_cb_offset);
-                end_cb_index = launch_msg_address->kernel_config.min_remote_cb_start_index;
+                uint32_t end_cb_index = launch_msg_address->kernel_config.min_remote_cb_start_index;
                 experimental::setup_remote_cb_interfaces<true>(
                     cb_l1_base, end_cb_index, noc_index, noc_mode, true, cmd_buf);
                 barrier_remote_cb_interface_setup(noc_index, end_cb_index);

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -131,7 +131,7 @@ int main(int argc, char *argv[]) {
         uint32_t tt_l1_ptr* cb_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.local_cb_offset);
         uint32_t local_cb_mask = launch_msg->kernel_config.local_cb_mask;
-        setup_local_cb_read_write_interfaces(cb_l1_base, 0, local_cb_mask, true, true, false);
+        setup_local_cb_read_write_interfaces<true, true, false>(cb_l1_base, 0, local_cb_mask);
 
 #if defined(ARCH_WORMHOLE)
         l1_to_ncrisc_iram_copy_wait();

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -130,15 +130,15 @@ int main(int argc, char *argv[]) {
 #endif
         uint32_t tt_l1_ptr* cb_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.local_cb_offset);
-        uint32_t end_cb_index = launch_msg->kernel_config.max_local_cb_end_index;
-        setup_local_cb_read_write_interfaces(cb_l1_base, 0, end_cb_index, true, true, false);
+        uint32_t local_cb_mask = launch_msg->kernel_config.local_cb_mask;
+        setup_local_cb_read_write_interfaces(cb_l1_base, 0, local_cb_mask, true, true, false);
 
 #if defined(ARCH_WORMHOLE)
         l1_to_ncrisc_iram_copy_wait();
 #endif
 
         cb_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.remote_cb_offset);
-        end_cb_index = launch_msg->kernel_config.min_remote_cb_start_index;
+        uint32_t end_cb_index = launch_msg->kernel_config.min_remote_cb_start_index;
         // NOC argument is unused
         experimental::setup_remote_cb_interfaces<false>(cb_l1_base, end_cb_index, 0, 0, 0, 0);
         my_relative_x_ = my_logical_x_ - launch_msg->kernel_config.sub_device_origin_x;

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -136,11 +136,11 @@ int main(int argc, char *argv[]) {
 #if !defined(UCK_CHLKC_MATH)
         uint32_t tt_l1_ptr* cb_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.local_cb_offset);
-        uint32_t end_cb_index = launch_msg->kernel_config.max_local_cb_end_index;
-        setup_local_cb_read_write_interfaces(cb_l1_base, 0, end_cb_index, cb_init_read, cb_init_write, cb_init_write);
+        uint32_t local_cb_mask = launch_msg->kernel_config.local_cb_mask;
+        setup_local_cb_read_write_interfaces(cb_l1_base, 0, local_cb_mask, cb_init_read, cb_init_write, cb_init_write);
 
         cb_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.remote_cb_offset);
-        end_cb_index = launch_msg->kernel_config.min_remote_cb_start_index;
+        uint32_t end_cb_index = launch_msg->kernel_config.min_remote_cb_start_index;
         // NOC argument is unused
         experimental::setup_remote_cb_interfaces<false>(cb_l1_base, end_cb_index, 0, 0, 0, 0);
 #endif

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -137,7 +137,7 @@ int main(int argc, char *argv[]) {
         uint32_t tt_l1_ptr* cb_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.local_cb_offset);
         uint32_t local_cb_mask = launch_msg->kernel_config.local_cb_mask;
-        setup_local_cb_read_write_interfaces(cb_l1_base, 0, local_cb_mask, cb_init_read, cb_init_write, cb_init_write);
+        setup_local_cb_read_write_interfaces<cb_init_read, cb_init_write, cb_init_write>(cb_l1_base, 0, local_cb_mask);
 
         cb_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.remote_cb_offset);
         uint32_t end_cb_index = launch_msg->kernel_config.min_remote_cb_start_index;

--- a/tt_metal/hw/inc/circular_buffer_init.h
+++ b/tt_metal/hw/inc/circular_buffer_init.h
@@ -13,30 +13,38 @@
 
 // NCRISC and BRISC setup read and write
 // TRISC sets up read or write
+template <bool read, bool write, bool init_wr_tile_ptr>
 FORCE_INLINE void setup_local_cb_read_write_interfaces(
-    uint32_t tt_l1_ptr* cb_l1_base,
-    uint32_t start_cb_index,
-    uint32_t local_cb_mask,
-    bool read,
-    bool write,
-    bool init_wr_tile_ptr) {
+    uint32_t tt_l1_ptr* cb_l1_base, uint32_t start_cb_index, uint32_t local_cb_mask) {
     volatile tt_l1_ptr uint32_t* circular_buffer_config_addr =
         cb_l1_base + start_cb_index * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG;
 
     local_cb_mask >>= start_cb_index;
     uint32_t cb_id = start_cb_index;
+    LocalCBInterface* local_interface_ptr = &get_local_cb_interface(cb_id);
+
+// The following code is a C++ version of the assembly loop. It performs the same operations as the assembly, but
+// the compiler doesn't optimize it as well as the assembly version (roughly 770 vs 595 cycles for 32 CBs on wormhole).
+// This code is only to demonstrate the logic of the loop and is not used in production builds.
+#if DISABLE_CB_ASSEMBLY
+
+    bool next_cb_exists = local_cb_mask & 1;
     while (local_cb_mask) {
         // We could attempt to find the next set bit instead of iterating through all bits, but the circular buffers are
         // often pretty tightly packed and computing the next set bit is somewhat expensive without specialized
         // instructions.
         // TODO: Blackhole supports zbb, so use __builtin_ctz there.
-        if (local_cb_mask & 1) {
+        if (next_cb_exists) {
             // NOTE: fifo_addr, fifo_size and fifo_limit in 16B words!
-            uint32_t fifo_addr = circular_buffer_config_addr[0] >> cb_addr_shift;
             uint32_t fifo_size = circular_buffer_config_addr[1] >> cb_addr_shift;
-            uint32_t fifo_num_pages = circular_buffer_config_addr[2];
+            uint32_t fifo_addr = circular_buffer_config_addr[0] >> cb_addr_shift;
+            uint32_t fifo_num_pages = write ? circular_buffer_config_addr[2] : 0;
             uint32_t fifo_page_size = circular_buffer_config_addr[3] >> cb_addr_shift;
             uint32_t fifo_limit = fifo_addr + fifo_size;
+            local_cb_mask >>= 1;
+            next_cb_exists = local_cb_mask & 1;
+
+            circular_buffer_config_addr += UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG;
 
             LocalCBInterface& local_interface = get_local_cb_interface(cb_id);
             local_interface.fifo_limit = fifo_limit;  // to check if we need to wrap
@@ -52,16 +60,107 @@ FORCE_INLINE void setup_local_cb_read_write_interfaces(
                 local_interface.fifo_num_pages = fifo_num_pages;
             }
             local_interface.fifo_page_size = fifo_page_size;
-
             if (init_wr_tile_ptr) {
                 local_interface.fifo_wr_tile_ptr = 0;
             }
-        }
-        local_cb_mask >>= 1;
-        cb_id++;
+            cb_id++;
+        } else {
+            circular_buffer_config_addr += UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG;
+            cb_id++;
 
-        circular_buffer_config_addr += UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG;
+            local_cb_mask >>= 1;
+            next_cb_exists = local_cb_mask & 1;
+        }
     }
+
+#else
+
+    asm volatile(
+        "    j .LOOP_ENTRY%=\n\t"
+
+        // Process a single CB.
+        ".LOOP%=:\n\t"
+        "    lw a3, 4(%[cbconfig])\n\t"  // fifo_size = *(circular_buffer_config_addr + 1)
+        "    lw a2, 0(%[cbconfig])\n\t"  // fifo_addr = *(circular_buffer_config_addr + 0)
+        ".if %[write]\n\t"
+        "    lw a6, 8(%[cbconfig])\n\t"  // fifo_num_pages = *(circular_buffer_config_addr + 2)
+        ".endif\n\t"
+        "    lw a7, 12(%[cbconfig])\n\t"  // fifo_page_size = *(circular_buffer_config_addr + 3)
+
+        // Fill the load latency (8 cycles) with useful work.
+        "    srli %[local_cb_mask], %[local_cb_mask], 1\n\t"  // local_cb_mask >>= 1
+        "    andi t0, %[local_cb_mask], 1\n\t"                // next_cb_exists = local_cb_mask & 1
+
+        "    sw zero, %[off_tiles_acked](%[liptr])\n\t"  // local_interface.tiles_acked_received_init = 0;
+        ".if %[init_wr_tile_ptr]\n\t"
+        "    sw zero, %[off_fifo_tile_wr_ptr](%[liptr])\n\t"  // local_interface.fifo_wr_tile_ptr = 0;
+        ".endif\n\t"
+
+        // Advance to next cb config.
+        "    addi %[cbconfig], %[cbconfig], %[circular_buffer_byte_size]\n\t"
+
+        // 8 cycles have passed, so we can now use the loaded values.
+
+        ".if %[cb_addr_shift] != 0\n\t"
+        "    srli a3, a3, %[cb_addr_shift]\n\t"  // fifo_size >>= cb_addr_shift
+        "    srli a2, a2, %[cb_addr_shift]\n\t"  // fifo_addr >>= cb_addr_shift
+        "    srli a7, a7, %[cb_addr_shift]\n\t"  // fifo_page_size >>= cb_addr_shift
+        ".endif\n\t"
+
+        "    sw a3, %[off_fifo_size](%[liptr])\n\t"
+        "    add a3, a2, a3\n\t"  // fifo_limit = fifo_addr + fifo_size
+        "    sw a3, %[off_fifo_limit](%[liptr])\n\t"
+
+        ".if %[write]\n\t"
+        "    sw a2, %[off_fifo_wr_ptr](%[liptr])\n\t"
+        "    sw a6, %[off_fifo_num_pages](%[liptr])\n\t"
+        ".endif\n\t"
+
+        ".if %[read]\n\t"
+        "    sw a2, %[off_fifo_rd_ptr](%[liptr])\n\t"
+        ".endif\n\t"
+
+        "    sw a7, %[off_fifo_page_size](%[liptr])\n\t"
+
+        "    addi %[liptr], %[liptr], %[local_cb_interface_size]\n\t"  // local_interface_ptr++;
+
+        "    bnez t0, .LOOP%=\n\t"                     // if (next_cb_exists) goto LOOP
+        "    beqz %[local_cb_mask], .LOOP_EXIT%=\n\t"  // if (local_cb_mask == 0) goto LOOP_EXIT
+
+        // Skip over the current cb since it's not in the mask.
+        ".NO_CB%=:\n\t"
+        // Advance cb config address and local interface pointer
+        "    addi %[cbconfig], %[cbconfig], %[circular_buffer_byte_size]\n\t"
+        "    addi %[liptr], %[liptr], %[local_cb_interface_size]\n\t"
+
+        "    srli %[local_cb_mask], %[local_cb_mask], 1\n\t"  // local_cb_mask >>= 1
+
+        ".LOOP_ENTRY%=:\n\t"
+        "    andi t0, %[local_cb_mask], 1\n\t"     // next_cb_exists = local_cb_mask & 1
+        "    bnez t0, .LOOP%=\n\t"                 // if (next_cb_exists) goto LOOP
+        "    bnez %[local_cb_mask], .NO_CB%=\n\t"  // if (local_cb_mask != 0) goto NO_CB
+
+        ".LOOP_EXIT%=:\n\t"
+
+        : [cbconfig] "+r"(circular_buffer_config_addr),
+          [local_cb_mask] "+r"(local_cb_mask),
+          [liptr] "+r"(local_interface_ptr)
+        : [off_fifo_size] "i"(offsetof(LocalCBInterface, fifo_size)),
+          [off_fifo_limit] "i"(offsetof(LocalCBInterface, fifo_limit)),
+          [off_fifo_page_size] "i"(offsetof(LocalCBInterface, fifo_page_size)),
+          [off_fifo_num_pages] "i"(offsetof(LocalCBInterface, fifo_num_pages)),
+          [off_fifo_rd_ptr] "i"(offsetof(LocalCBInterface, fifo_rd_ptr)),
+          [off_fifo_wr_ptr] "i"(offsetof(LocalCBInterface, fifo_wr_ptr)),
+          [off_tiles_acked] "i"(offsetof(LocalCBInterface, tiles_acked_received_init)),
+          [off_fifo_tile_wr_ptr] "i"(offsetof(LocalCBInterface, fifo_wr_tile_ptr)),
+          [local_cb_interface_size] "i"(sizeof(CBInterface)),
+          [circular_buffer_byte_size] "i"(UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t)),
+          [read] "i"(read ? 1 : 0),
+          [write] "i"(write ? 1 : 0),
+          [init_wr_tile_ptr] "i"(init_wr_tile_ptr ? 1 : 0),
+          [cb_addr_shift] "i"(cb_addr_shift)
+        : "a2", "a3", "a6", "a7", "t0", "memory");
+#endif
 }
 
 namespace experimental {

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -144,25 +144,23 @@ struct kernel_config_msg_t {
     volatile uint16_t local_cb_offset;
     volatile uint16_t remote_cb_offset;
     rta_offset_t rta_offset[DISPATCH_CLASS_MAX];
-    volatile uint8_t pad1[2];
-    volatile uint32_t kernel_text_offset[NUM_PROCESSORS_PER_CORE_TYPE];
-
     volatile uint8_t mode;  // dispatch mode host/dev
+    volatile uint8_t pad1[1];
+    volatile uint32_t kernel_text_offset[NUM_PROCESSORS_PER_CORE_TYPE];
+    volatile uint32_t local_cb_mask;
+
     volatile uint8_t brisc_noc_id;
     volatile uint8_t brisc_noc_mode;
-    volatile uint8_t max_local_cb_end_index;
     volatile uint8_t min_remote_cb_start_index;
     volatile uint8_t exit_erisc_kernel;
-    volatile uint8_t sub_device_origin_x;  // Logical X coordinate of the sub device origin
-    volatile uint8_t sub_device_origin_y;  // Logical Y coordinate of the sub device origin
     // 32 bit program/launch_msg_id used by the performance profiler
     // [9:0]: physical device id
     // [30:10]: program id
     // [31:31]: 0 (specifies that this id corresponds to a program running on device)
     volatile uint32_t host_assigned_id;
+    volatile uint8_t sub_device_origin_x;  // Logical X coordinate of the sub device origin
+    volatile uint8_t sub_device_origin_y;  // Logical Y coordinate of the sub device origin
     volatile uint8_t enables;
-
-    volatile uint8_t pad2[2];
 
     volatile uint8_t preload;  // Must be at end, so it's only written when all other data is written.
 } __attribute__((packed));
@@ -175,6 +173,7 @@ static_assert(offsetof(kernel_config_msg_t, remote_cb_offset) % sizeof(uint16_t)
 static_assert(offsetof(kernel_config_msg_t, remote_cb_offset) % sizeof(uint16_t) == 0);
 static_assert(offsetof(kernel_config_msg_t, rta_offset) % sizeof(uint16_t) == 0);
 static_assert(offsetof(kernel_config_msg_t, kernel_text_offset) % sizeof(uint32_t) == 0);
+static_assert(offsetof(kernel_config_msg_t, local_cb_mask) % sizeof(uint32_t) == 0);
 static_assert(offsetof(kernel_config_msg_t, host_assigned_id) % sizeof(uint32_t) == 0);
 
 struct go_msg_t {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -261,8 +261,9 @@ uint32_t finalize_cbs(
     uint32_t min_remote_start_index = NUM_CIRCULAR_BUFFERS;
 
     for (auto& kg : kernel_groups) {
-        max_local_end_index =
-            std::max(max_local_end_index, (uint32_t)kg->launch_msg.kernel_config.max_local_cb_end_index);
+        uint32_t local_cb_mask = kg->launch_msg.kernel_config.local_cb_mask;
+        uint32_t current_local_end_index = local_cb_mask == 0 ? 0 : 32 - __builtin_clz(local_cb_mask);
+        max_local_end_index = std::max(max_local_end_index, current_local_end_index);
         min_remote_start_index =
             std::min(min_remote_start_index, (uint32_t)kg->launch_msg.kernel_config.min_remote_cb_start_index);
     }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -371,7 +371,7 @@ KernelGroup::KernelGroup(
     uint32_t programmable_core_type_index,
     kernel_id_array_t kernel_ids,
     bool /*erisc_is_idle*/,
-    uint32_t max_local_cb_end_index,
+    uint32_t local_cb_mask,
     uint32_t min_remote_cb_start_index,
     const CoreRangeSet& new_ranges) :
     core_ranges(CoreRangeSet()) {
@@ -433,7 +433,7 @@ KernelGroup::KernelGroup(
     this->launch_msg.kernel_config.ncrisc_kernel_size16 = 0;
 
     this->launch_msg.kernel_config.exit_erisc_kernel = false;
-    this->launch_msg.kernel_config.max_local_cb_end_index = max_local_cb_end_index;
+    this->launch_msg.kernel_config.local_cb_mask = local_cb_mask;
     this->launch_msg.kernel_config.min_remote_cb_start_index = min_remote_cb_start_index;
     this->go_msg.signal = RUN_MSG_GO;
 }
@@ -553,6 +553,7 @@ void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_i
             // Start inclusive, max exclusive
             uint32_t max_local_cb_end_index = 0;
             uint32_t min_remote_cb_start_index = NUM_CIRCULAR_BUFFERS;
+            uint32_t local_cb_mask = 0;
 
             // Map from core X,Y back to the unique KernelGroup
             for (CoreRange range : kg_to_cores.second) {
@@ -568,6 +569,7 @@ void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_i
                         auto local_val = per_core_local_cb_indices_.find(core);
                         if (local_val != per_core_local_cb_indices_.end() && local_val->second.any()) {
                             uint32_t used_cbs = local_val->second.to_ulong();
+                            local_cb_mask |= used_cbs;
                             max_local_cb_end_index = std::max(
                                 max_local_cb_end_index, NUM_CIRCULAR_BUFFERS - (uint32_t)__builtin_clz(used_cbs));
                             if (!logged_noncontiguous) {
@@ -642,16 +644,14 @@ void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_i
                 programmable_core_type_index,
                 max_local_cb_end_index,
                 min_remote_cb_start_index);
-            kernel_groups_[programmable_core_type_index].push_back(
-                std::make_shared<KernelGroup>(
-                    *this,
-                    programmable_core_type_index,
-                    kg_to_cores.first.kernel_ids,
-                    erisc_is_idle,
-                    max_local_cb_end_index,
-                    min_remote_cb_start_index,
-                    kg_to_cores.second)
-                );
+            kernel_groups_[programmable_core_type_index].push_back(std::make_shared<KernelGroup>(
+                *this,
+                programmable_core_type_index,
+                kg_to_cores.first.kernel_ids,
+                erisc_is_idle,
+                local_cb_mask,
+                min_remote_cb_start_index,
+                kg_to_cores.second));
             index++;
         }
     }

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -77,7 +77,7 @@ struct KernelGroup {
         uint32_t programmable_core_type_index,
         kernel_id_array_t kernel_ids,
         bool erisc_is_idle,
-        uint32_t max_local_cb_end_index,
+        uint32_t local_cb_mask,
         uint32_t min_remote_cb_start_index,
         const CoreRangeSet& new_ranges);
 


### PR DESCRIPTION
### Problem description
Currently the firmware has to initialize all CBs up to max_local_cb_end_index, even if they're not all used. Since initializing each CB takes around 25 cycles (on wormhole), this leads to increased kernel-kernel initialization latency. We've tried to get op writers to make CBs contiguous, but that hasn't always happened.

### What's changed
Instead of storing max_local_cb_end_index, store a mask of used local cbs. Then we can skip most work associated with unused CBs, at the cost of a few (~1) extra instructions.

Also switch to using inline assembly for initializing CBs. The compiler can't fully optimize the existing code and has some stalls waiting for loads and some unnecessary instructions. For 32 CBs, the inline assembly reduces the number of cycles from around 770 to around 595.

Some llama3 benchmark measurements need to be updated. In addition, the calculation of the non-overlapped dispatch time needs to be fixed: it was only considering the op-to-op time but in addition the kernel time for the previous op needs to be included as well. On any single core the kernel time is negligible (since TT_METAL_KERNELS_EARLY_RETURN is set), but across all cores some start the kernel earlier and others start the kernel later, so the total time (measured from first start to last end) is nontrivial. The previous program was ready to dispatch when the first kernel loaded, so the dispatcher is busy loading the next kernel throughout the kernel time and it should be counted towards that next kernel's dispatch time.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes