### PR TITLE
Validate "DEVICE KERNEL FIRST TO LAST START" in llama model perf tests

### DIFF
--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -32,7 +32,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 8380,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.2,
     },
     "RMSAllGather_1": {
@@ -43,7 +43,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 8139.7,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.2,
     },
     "AllGatherConcat_0": {
@@ -54,7 +54,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 12541.7,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.5,
     },
     "AllGatherAsync_0": {
@@ -65,7 +65,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 4351.1,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.2,
     },
     "Matmul_0": {
@@ -76,7 +76,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 5653.2,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.1,
     },
     "Matmul_1": {
@@ -87,7 +87,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 5760.2,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.1,
     },
     "Matmul_2": {
@@ -98,7 +98,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 5380.6,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.1,
     },
     "Matmul_3": {
@@ -109,7 +109,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 7093.7,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.15,
     },
     "Matmul_4": {
@@ -120,7 +120,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 6770.3,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.1,
     },
     "AllReduceCreateQkvHeads_0": {
@@ -131,7 +131,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 7932.2,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.4,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.2,
     },
     "AllReduceAsync_0": {
@@ -142,7 +142,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 8510.2,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.3,
     },
     "AllReduceAsync_1": {
@@ -153,7 +153,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 7252.4,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.2,
     },
     "LlamaReduceScatterDeviceOperation_0": {
@@ -164,7 +164,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 8058.9,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.3,
     },
     "LlamaReduceScatterDeviceOperation_1": {
@@ -175,7 +175,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 7359.9,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.3,
     },
     "RotaryEmbeddingLlamaFusedQK_0": {
@@ -186,7 +186,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 2844.3,
         "kernel_duration_relative_margin": 0.1,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.35,
     },
     "PagedUpdateCacheDeviceOperation_0": {
@@ -197,7 +197,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 5890.0,
         "kernel_duration_relative_margin": 0.2,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.2,
     },
     "ScaledDotProductAttentionDecode_0": {
@@ -208,7 +208,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 9741.5,
         "kernel_duration_relative_margin": 0.07,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.3,
     },
     "BinaryDeviceOperation_0": {
@@ -219,7 +219,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 6111.2,
         "kernel_duration_relative_margin": 0.1,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.2,
     },
     "Untilize_0": {
@@ -230,7 +230,7 @@ perf_targets = {
         "non-overlapped-dispatch-time": 3113.6,
         "kernel_duration_relative_margin": 0.2,
         "op_to_op_duration_relative_margin": 0.2,
-        "first_to_last_start_relative_margin": 0.1,
+        "first_to_last_start_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.5,
     },
 }

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -28,171 +28,209 @@ perf_targets = {
         "op_name": "RMS_0",
         "kernel_duration": 18530.621527777777,
         "op_to_op": 839.6666666666666,
+        "first_to_last_start": 2484.1111111111113,
         "non-overlapped-dispatch-time": 8380,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.2,
     },
     "RMSAllGather_1": {
         "op_name": "RMS_1",
         "kernel_duration": 18100.121527777777,
         "op_to_op": 816.2222222222222,
+        "first_to_last_start": 2509.6666666666665,
         "non-overlapped-dispatch-time": 8139.7,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.2,
     },
     "AllGatherConcat_0": {
         "op_name": "AllGatherConcat",
         "kernel_duration": 12419.194444444445,
         "op_to_op": 796.8888888888889,
+        "first_to_last_start": 1866.0,
         "non-overlapped-dispatch-time": 12541.7,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.5,
     },
     "AllGatherAsync_0": {
         "op_name": "AllGatherAsync_Binary_Mult",
         "kernel_duration": 11328.694444444445,
         "op_to_op": 959.5555,
+        "first_to_last_start": 1565.888888888889,
         "non-overlapped-dispatch-time": 4351.1,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.2,
     },
     "Matmul_0": {
         "op_name": "QKV_MM",
         "kernel_duration": 8556.222222222223,
         "op_to_op": 716.4444444444445,
+        "first_to_last_start": 2106.0,
         "non-overlapped-dispatch-time": 5653.2,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.1,
     },
     "Matmul_1": {
         "op_name": "DO_MM",
         "kernel_duration": 8902,
         "op_to_op": 723.0,
+        "first_to_last_start": 2207.5555555555557,
         "non-overlapped-dispatch-time": 5760.2,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.1,
     },
     "Matmul_2": {
         "op_name": "FF1_MM",
         "kernel_duration": 9483.888888888889,
         "op_to_op": 711.8888888888889,
+        "first_to_last_start": 2120.6666666666665,
         "non-overlapped-dispatch-time": 5380.6,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.1,
     },
     "Matmul_3": {
         "op_name": "FF3_MM",
         "kernel_duration": 9435.333333333334,
         "op_to_op": 688.7777777777778,
+        "first_to_last_start": 2132.3333333333335,
         "non-overlapped-dispatch-time": 7093.7,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.15,
     },
     "Matmul_4": {
         "op_name": "FF2_MM",
         "kernel_duration": 15891.0,
         "op_to_op": 658.7777777777778,
+        "first_to_last_start": 1719.111111111111,
         "non-overlapped-dispatch-time": 6770.3,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.1,
     },
     "AllReduceCreateQkvHeads_0": {
         "op_name": "AllReduce_Fuse_Createheads",
         "kernel_duration": 14541.059027777777,
         "op_to_op": 966.0,
+        "first_to_last_start": 1906.2222222222222,
         "non-overlapped-dispatch-time": 7932.2,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.4,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.2,
     },
     "AllReduceAsync_0": {
         "op_name": "AllReduceAsync_DO",
         "kernel_duration": 21736.76736111111,
         "op_to_op": 626.5555555555555,
+        "first_to_last_start": 1660.7777777777778,
         "non-overlapped-dispatch-time": 8510.2,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.3,
     },
     "AllReduceAsync_1": {
         "op_name": "AllReduceAsync_FF2",
         "kernel_duration": 22341.23263888889,
         "op_to_op": 637.1111111111111,
+        "first_to_last_start": 1785.2222222222222,
         "non-overlapped-dispatch-time": 7252.4,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.2,
     },
     "LlamaReduceScatterDeviceOperation_0": {
         "op_name": "ReduceScatter_FF1",
         "kernel_duration": 9952.402777777777,
         "op_to_op": 708.1111111111111,
+        "first_to_last_start": 1993.7777777777778,
         "non-overlapped-dispatch-time": 8058.9,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.3,
     },
     "LlamaReduceScatterDeviceOperation_1": {
         "op_name": "ReduceScatter_FF3",
         "kernel_duration": 9817.020833333334,
         "op_to_op": 812.1111111111111,
+        "first_to_last_start": 2018.2222222222222,
         "non-overlapped-dispatch-time": 7359.9,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.3,
     },
     "RotaryEmbeddingLlamaFusedQK_0": {
         "op_name": "RotaryEmbeddingLlamaFusedQK",
         "kernel_duration": 4296,
         "op_to_op": 606.1111111111111,
+        "first_to_last_start": 2560.8888888888887,
         "non-overlapped-dispatch-time": 2844.3,
         "kernel_duration_relative_margin": 0.1,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.35,
     },
     "PagedUpdateCacheDeviceOperation_0": {
         "op_name": "PagedUpdateCache",
         "kernel_duration": 5963,
         "op_to_op": 860.2222222222222,
+        "first_to_last_start": 2317.1111111111113,
         "non-overlapped-dispatch-time": 5890.0,
         "kernel_duration_relative_margin": 0.2,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.2,
     },
     "ScaledDotProductAttentionDecode_0": {
         "op_name": "SDPA",
         "kernel_duration": 13338,
         "op_to_op": 652.6666666666666,
+        "first_to_last_start": 2766.222222222222,
         "non-overlapped-dispatch-time": 9741.5,
         "kernel_duration_relative_margin": 0.07,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.3,
     },
     "BinaryDeviceOperation_0": {
         "op_name": "Binary_Mult_Silu",
         "kernel_duration": 2923.5555555555557,
         "op_to_op": 661.0,
+        "first_to_last_start": 1857.5555555555557,
         "non-overlapped-dispatch-time": 6111.2,
         "kernel_duration_relative_margin": 0.1,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.2,
     },
     "Untilize_0": {
         "op_name": "Untilize",
         "kernel_duration": 1517.3333333333335,
         "op_to_op": 800,
+        "first_to_last_start": 2043.3333333333333,
         "non-overlapped-dispatch-time": 3113.6,
         "kernel_duration_relative_margin": 0.2,
         "op_to_op_duration_relative_margin": 0.2,
+        "first_to_last_start_relative_margin": 0.1,
         "dispatch_duration_relative_margin": 0.5,
     },
 }
@@ -488,16 +526,36 @@ def test_llama_TG_perf_device(
     df_mid_layers_trace = df_layers_trace[int(len(df_layers_trace) / num_layers) :]
 
     mid_layers_raw_dict_compilation = df_mid_layers_compilation[
-        ["OP CODE", "DEVICE KERNEL DURATION [ns]", "OP TO OP LATENCY [ns]"]
+        [
+            "OP CODE",
+            "DEVICE KERNEL DURATION [ns]",
+            "OP TO OP LATENCY [ns]",
+            "DEVICE KERNEL FIRST TO LAST START [ns]",
+        ]
     ].to_dict(orient="records")
     mid_layers_raw_dict_trace = df_mid_layers_trace[
-        ["OP CODE", "DEVICE KERNEL DURATION [ns]", "OP TO OP LATENCY [ns]"]
+        [
+            "OP CODE",
+            "DEVICE KERNEL DURATION [ns]",
+            "OP TO OP LATENCY [ns]",
+            "DEVICE KERNEL FIRST TO LAST START [ns]",
+        ]
     ].to_dict(orient="records")
     first_layer_raw_dict_compilation = df_first_layer_compilation[
-        ["OP CODE", "DEVICE KERNEL DURATION [ns]", "OP TO OP LATENCY [ns]"]
+        [
+            "OP CODE",
+            "DEVICE KERNEL DURATION [ns]",
+            "OP TO OP LATENCY [ns]",
+            "DEVICE KERNEL FIRST TO LAST START [ns]",
+        ]
     ].to_dict(orient="records")
     first_layer_raw_dict_trace = df_first_layer_trace[
-        ["OP CODE", "DEVICE KERNEL DURATION [ns]", "OP TO OP LATENCY [ns]"]
+        [
+            "OP CODE",
+            "DEVICE KERNEL DURATION [ns]",
+            "OP TO OP LATENCY [ns]",
+            "DEVICE KERNEL FIRST TO LAST START [ns]",
+        ]
     ].to_dict(orient="records")
 
     # Build dicts of op_code to list of durations
@@ -506,6 +564,7 @@ def test_llama_TG_perf_device(
     )
     kernel_duration_dict_trace = build_duration_dict(mid_layers_raw_dict_trace, "DEVICE KERNEL DURATION [ns]")
     dispatch_duration_dict = build_duration_dict(mid_layers_raw_dict_trace, "OP TO OP LATENCY [ns]")
+    first_to_last_start_dict = build_duration_dict(mid_layers_raw_dict_trace, "DEVICE KERNEL FIRST TO LAST START [ns]")
 
     # first layer
     kernel_duration_dict_compilation_first_layer = build_duration_dict(
@@ -515,6 +574,9 @@ def test_llama_TG_perf_device(
         first_layer_raw_dict_trace, "DEVICE KERNEL DURATION [ns]"
     )
     dispatch_duration_dict_first_layer = build_duration_dict(first_layer_raw_dict_trace, "OP TO OP LATENCY [ns]")
+    first_to_last_start_dict_first_layer = build_duration_dict(
+        first_layer_raw_dict_trace, "DEVICE KERNEL FIRST TO LAST START [ns]"
+    )
 
     # Build dicts of op_code_with_id to list of durations - one list per op instance
     kernel_duration_per_instance_dict_compilation = build_duration_per_instance_dict(
@@ -524,6 +586,7 @@ def test_llama_TG_perf_device(
         kernel_duration_dict_trace, num_layers - 1
     )
     dispatch_duration_per_instance_dict = build_duration_per_instance_dict(dispatch_duration_dict, num_layers - 1)
+    first_to_last_start_per_instance_dict = build_duration_per_instance_dict(first_to_last_start_dict, num_layers - 1)
 
     # first layer
     kernel_duration_per_instance_dict_compilation_first_layer = build_duration_per_instance_dict(
@@ -535,6 +598,9 @@ def test_llama_TG_perf_device(
     dispatch_duration_per_instance_dict_first_layer = build_duration_per_instance_dict(
         dispatch_duration_dict_first_layer, 1
     )
+    first_to_last_start_per_instance_dict_first_layer = build_duration_per_instance_dict(
+        first_to_last_start_dict_first_layer, 1
+    )
 
     # Average over all iterations of each op instance
     kernel_duration_per_instance_averaged_dict_compilation = average_per_instance_dict(
@@ -544,6 +610,18 @@ def test_llama_TG_perf_device(
         kernel_duration_per_instance_dict_trace
     )
     dispatch_duration_per_instance_averaged_dict = average_per_instance_dict(dispatch_duration_per_instance_dict)
+    first_to_last_start_per_instance_averaged_dict = average_per_instance_dict(first_to_last_start_per_instance_dict)
+
+    # first layer
+    kernel_duration_per_instance_averaged_dict_compilation_first_layer = average_per_instance_dict(
+        kernel_duration_per_instance_dict_compilation_first_layer
+    )
+    kernel_duration_per_instance_averaged_dict_trace_first_layer = average_per_instance_dict(
+        kernel_duration_per_instance_dict_trace_first_layer
+    )
+    dispatch_duration_per_instance_averaged_dict_first_layer = average_per_instance_dict(
+        dispatch_duration_per_instance_dict_first_layer
+    )
 
     # Min over all iterations of each op instance
     kernel_duration_per_instance_min_dict_compilation = min_per_instance_dict(
@@ -551,6 +629,7 @@ def test_llama_TG_perf_device(
     )
     kernel_duration_per_instance_min_dict_trace = min_per_instance_dict(kernel_duration_per_instance_dict_trace)
     dispatch_duration_per_instance_min_dict = min_per_instance_dict(dispatch_duration_per_instance_dict)
+    first_to_last_start_per_instance_min_dict = min_per_instance_dict(first_to_last_start_per_instance_dict)
 
     # Max over all iterations of each op instance
     kernel_duration_per_instance_max_dict_compilation = max_per_instance_dict(
@@ -558,6 +637,7 @@ def test_llama_TG_perf_device(
     )
     kernel_duration_per_instance_max_dict_trace = max_per_instance_dict(kernel_duration_per_instance_dict_trace)
     dispatch_duration_per_instance_max_dict = max_per_instance_dict(dispatch_duration_per_instance_dict)
+    first_to_last_start_per_instance_max_dict = max_per_instance_dict(first_to_last_start_per_instance_dict)
 
     if len(kernel_duration_per_instance_averaged_dict_compilation) != len(perf_targets):
         print(f"perf_targets: {perf_targets}")
@@ -567,6 +647,7 @@ def test_llama_TG_perf_device(
     )
     print_dict(kernel_duration_per_instance_averaged_dict_trace, "kernel_duration_per_instance_averaged_dict_trace")
     print_dict(dispatch_duration_per_instance_averaged_dict, "dispatch_duration_per_instance_averaged_dict")
+    print_dict(first_to_last_start_per_instance_averaged_dict, "first_to_last_start_per_instance_averaged_dict")
 
     assert len(kernel_duration_per_instance_averaged_dict_compilation) == len(
         perf_targets
@@ -593,6 +674,13 @@ def test_llama_TG_perf_device(
             benchmark_data.add_measurement(
                 profiler, 0, step_name, op_name + "-model-op_to_op-avg", avg_dispatch_duration
             )
+            benchmark_data.add_measurement(
+                profiler,
+                0,
+                step_name,
+                op_name + "-model-first_to_last-avg",
+                first_to_last_start_per_instance_averaged_dict[op_code_with_id],
+            )
 
             # min
             benchmark_data.add_measurement(
@@ -609,6 +697,13 @@ def test_llama_TG_perf_device(
                 op_name + "-model-op_to_op-min",
                 dispatch_duration_per_instance_min_dict[op_code_with_id],
             )
+            benchmark_data.add_measurement(
+                profiler,
+                0,
+                step_name,
+                op_name + "-model-first_to_last-min",
+                first_to_last_start_per_instance_min_dict[op_code_with_id],
+            )
 
             # max
             benchmark_data.add_measurement(
@@ -624,6 +719,13 @@ def test_llama_TG_perf_device(
                 step_name,
                 op_name + "-model-op_to_op-max",
                 dispatch_duration_per_instance_max_dict[op_code_with_id],
+            )
+            benchmark_data.add_measurement(
+                profiler,
+                0,
+                step_name,
+                op_name + "-model-first_to_last-max",
+                first_to_last_start_per_instance_max_dict[op_code_with_id],
             )
 
             # Verify kernel duration is within tolerance
@@ -687,6 +789,39 @@ def test_llama_TG_perf_device(
                     f"{perf_targets[op_code_with_id]['op_to_op_duration_relative_margin']}, "
                     f"relative margin to pass would be: "
                     f"{abs(perf_targets[op_code_with_id]['op_to_op'] - avg_dispatch_duration) / perf_targets[op_code_with_id]['op_to_op']}"
+                )
+
+            # Verify first_to_last_start is within tolerance
+            avg_first_to_last = first_to_last_start_per_instance_averaged_dict[op_code_with_id]
+            upper_limit = (
+                perf_targets[op_code_with_id]["first_to_last_start"]
+                + perf_targets[op_code_with_id]["first_to_last_start_relative_margin"]
+                * perf_targets[op_code_with_id]["first_to_last_start"]
+            )
+            lower_limit = (
+                perf_targets[op_code_with_id]["first_to_last_start"]
+                - perf_targets[op_code_with_id]["first_to_last_start_relative_margin"]
+                * perf_targets[op_code_with_id]["first_to_last_start"]
+            )
+            if avg_first_to_last > upper_limit:
+                passing = False
+                logger.info(
+                    f"{op_code_with_id} first_to_last_start: {avg_first_to_last} ns is larger than target "
+                    f"({perf_targets[op_code_with_id]['first_to_last_start']}) ns, difference: "
+                    f"{abs(avg_first_to_last - upper_limit)} ns, margin: "
+                    f"{perf_targets[op_code_with_id]['first_to_last_start_relative_margin']}, "
+                    f"relative margin to pass would be: "
+                    f"{abs(perf_targets[op_code_with_id]['first_to_last_start'] - avg_first_to_last) / perf_targets[op_code_with_id]['first_to_last_start']}"
+                )
+            elif avg_first_to_last < lower_limit:
+                passing = False
+                logger.info(
+                    f"{op_code_with_id} first_to_last_start: {avg_first_to_last} ns is smaller than target "
+                    f"({perf_targets[op_code_with_id]['first_to_last_start']}) ns, difference: "
+                    f"{abs(lower_limit - avg_first_to_last)} ns, margin: "
+                    f"{perf_targets[op_code_with_id]['first_to_last_start_relative_margin']}, "
+                    f"relative margin to pass would be: "
+                    f"{abs(perf_targets[op_code_with_id]['first_to_last_start'] - avg_first_to_last) / perf_targets[op_code_with_id]['first_to_last_start']}"
                 )
 
         else:


### PR DESCRIPTION
### Problem description
Currently our performance benchmarks miss some overhead initializing kernels, including profiler overhead, time initializing CBs, and some other firmware activities. This is because the op to op time measures time to from the last kernel to finish to the first kernel to start. If any core is idle before starting a kernel, then it can perform all that overhead work while other cores are running the previous kernel.

### What's changed
Track DEVICE KERNEL FIRST TO LAST START and ensure it doesn't change. In the case one core starts extremely early because it was idle before, this measurement will catch all that firmware overhead.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes