### PR TITLE
Enable AvgPool2d on BH

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avg_pool2d_sweeps.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avg_pool2d_sweeps.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from tests.ttnn.unit_tests.operations.pool.test_avgpool2d import run_avg_pool2d
-from models.utility_functions import skip_for_blackhole
 
 import pytest
 import ttnn
@@ -50,7 +49,6 @@ parameters = {
 }
 
 
-@skip_for_blackhole("Nigthly CI tests failing, ticket #20492")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize("input_spec", parameters["input_specs"])
 def test_ttnn_pytorch_sweep(device, tensor_map, input_spec):

--- a/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
@@ -7,7 +7,6 @@ import ttnn
 import pytest
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import skip_for_blackhole
 
 
 @pytest.fixture(scope="module")
@@ -78,7 +77,6 @@ def run_avg_pool2d(
     assert allclose, " Reference and output tensor are not close"
 
 
-@skip_for_blackhole("Nigthly CI tests failing, ticket #20492")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "input_shape",  # NCHW

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core.cpp
@@ -67,6 +67,7 @@ void MAIN {
     constexpr uint32_t in_cb_id_1 = get_compile_time_arg_val(11);
     constexpr uint32_t in_scalar_cb_id = get_compile_time_arg_val(12);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(13);
+    constexpr uint32_t is_blackhole = (bool)get_compile_time_arg_val(16);
 
     constexpr bool is_partial_tile = in_c < 32;
     static_assert((!is_partial_tile || (in_c == 16)), "Partial tile must have c_dim 16");
@@ -89,7 +90,8 @@ void MAIN {
     // In case #sticks > 16 we need bottom two faces as well, and we need to configure reduce to
     // process all rows per face. In the case we rely on reader kernel to put "clear value"
     // in datums which are not used.
-    constexpr uint32_t face_r_dim = window_size_hw > 16 ? 16 : window_size_hw;
+    constexpr bool avg_pool_blackhole = REDUCE_OP == PoolType::SUM && is_blackhole;
+    constexpr uint32_t face_r_dim = (window_size_hw > 16 || avg_pool_blackhole) ? 16 : window_size_hw;
     tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
         in_cb_id_0, in_scalar_cb_id, max_tiles_per_iter, out_cb_id, num_faces_in_tile, face_r_dim);
     pack_untilize_dst_init_short<max_tiles_per_iter>(out_cb_id, num_out_rows, num_faces_in_tile);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_v2.cpp
@@ -14,6 +14,11 @@
 
 #define ALWI inline __attribute__((always_inline))
 
+enum PoolType {
+    MAX = 0,
+    SUM = 1,
+};
+
 // Fill an L1 buffer with the given val
 // WARNING: Use with caution as there's no memory protection. Make sure size is within limits
 ALWI bool fill_with_val(uint32_t begin_addr, uint32_t n, uint16_t val) {
@@ -75,6 +80,8 @@ void kernel_main() {
     constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(19);
     constexpr uint32_t in_scalar_cb_id = get_compile_time_arg_val(20);
     constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(23);
+    constexpr bool is_blackhole = (bool)get_compile_time_arg_val(24);
+    constexpr uint32_t pool_type = get_compile_time_arg_val(25);
 
     if (reader_id == 0) {
         cb_reserve_back(in_scalar_cb_id, 1);
@@ -89,7 +96,7 @@ void kernel_main() {
     // as number of valid rows in upper two faces will be 16 and in bottom two some different number.
     // In that case not all rows will have valid data, so we need to clear them out.
     constexpr uint32_t window_hw = window_h * window_w;
-    if constexpr (window_hw > 16) {
+    if constexpr (window_hw > 16 || (pool_type == PoolType::SUM && is_blackhole)) {
         fill_with_val(get_read_ptr(clear_value_cb_id), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
         clear_out_tiles<in_cb_id, clear_value_cb_id>();
     }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_wide.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_wide.cpp
@@ -14,6 +14,11 @@
 
 #define ALWI inline __attribute__((always_inline))
 
+enum PoolType {
+    MAX = 0,
+    SUM = 1,
+};
+
 // Fill an L1 buffer with the given val
 // WARNING: Use with caution as there's no memory protection. Make sure size is within limits
 ALWI bool fill_with_val(uint32_t begin_addr, uint32_t n, uint16_t val) {
@@ -92,6 +97,9 @@ void kernel_main() {
     constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(19);
     constexpr uint32_t in_scalar_cb_id = get_compile_time_arg_val(20);
     constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(23);
+    constexpr bool is_blackhole = (bool)get_compile_time_arg_val(24);
+    constexpr uint32_t pool_type = (bool)get_compile_time_arg_val(25);
+
     constexpr uint32_t in_nbytes_leftover = (in_c % (TILE_WIDTH * MAX_TILES_PER_REDUCTION)) * BYTES_PER_DATUM;
 
     if (reader_id == 0) {
@@ -110,7 +118,7 @@ void kernel_main() {
     // In case we need bottom two faces, than we have to configure reduce to process all rows,
     // as number of valid rows in upper two faces will be 16 and in bottom two some different number.
     // In that case not all rows will have valid data, so we need to clear them out.
-    if constexpr (window_hw > 16) {
+    if constexpr (window_hw > 16 || (pool_type == PoolType::SUM && is_blackhole)) {
         fill_with_val(get_read_ptr(clear_value_cb_id), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
         clear_out_tiles<in_cb_id, clear_value_cb_id>();
     }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -7,6 +7,7 @@
 #include "tt-metalium/circular_buffer_config.hpp"
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/pool/pool_utils.hpp"
+#include <tt-metalium/hal.hpp>
 
 namespace ttnn::operations::pool {
 /**
@@ -76,6 +77,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         (!is_partial_tile && !is_large_kernel) ? tt::constants::TILE_HEIGHT : tt::constants::TILE_HEIGHT / 2;
     TT_FATAL(nblocks == 1, "Multiple blocks not yet supported");
 
+    const bool is_blackhole = tt::tt_metal::hal::get_arch() == tt::ARCH::BLACKHOLE;
+
     if (input_shape[3] < tt::constants::TILE_WIDTH) {
         TT_FATAL(input_shape[3] == 16, "Error");
     }
@@ -128,7 +131,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     }
 
     uint32_t clear_value_cb_id = 32;
-    if (max_rows_for_reduction == tt::constants::TILE_HEIGHT) {
+    const bool avg_pool_on_blackhole = is_blackhole && pool_type == Pool2DType::AVG_POOL2D;
+    if (max_rows_for_reduction == tt::constants::TILE_HEIGHT || avg_pool_on_blackhole) {
         // CB storing just "clear value" (-inf for maxpool, 0 for avgpool)
         // is needed only if we use more then 16 sticks per tile for reduction.
         clear_value_cb_id = next_cb_index++;
@@ -305,33 +309,11 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         in_scalar_cb_id,
         max_pool_partials_cb_id,
         in_one_cb_id,
-        clear_value_cb_id};
-
-    std::vector<uint32_t> reader1_ct_args = {
-        out_nhw_per_core,
-        kernel_size_h,
-        kernel_size_w,
-        pad_w,
-        in_nbytes_c,
-        in_w,
-        input_shape[3] / num_shards_c,
-        split_reader,  // enable split reader
-        1,             // split reader id
-        bf16_scalar,
-        bf16_one_u32,
-        bf16_init_value,
-        in_nblocks_c,
-        in_cb_sz,
-        max_rows_for_reduction,
-        ceil_pad_w,
-        in_cb_id_0,
-        in_cb_id_1,
-        raw_in_cb_id,
-        in_reader_indices_cb_id,
-        in_scalar_cb_id,
-        max_pool_partials_cb_id,
-        in_one_cb_id,
-        clear_value_cb_id};
+        clear_value_cb_id,
+        is_blackhole,
+        (uint32_t)pool_type};
+    std::vector<uint32_t> reader1_ct_args = reader0_ct_args;
+    reader1_ct_args[8] = 1;  // split reader id for reader1
 
     std::string reader_kernel_fname;
     if (is_large_kernel) {
@@ -380,7 +362,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         in_scalar_cb_id,
         out_cb_id,
         max_pool_partials_cb_id,
-        in_one_cb_id};
+        in_one_cb_id,
+        is_blackhole};
 
     auto compute_config = tt::tt_metal::ComputeConfig{
         .math_fidelity = MathFidelity::HiFi4,


### PR DESCRIPTION
Workaround LLK failures on BH for average pool
by always using full face (16 rows) for reduction, and making sure that unused that in face are filled with appropriate "clear" value.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/20492)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15239032963) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15239034809) CI with demo tests passes (if applicable)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/15239039574) CI passes (if applicable)
- [x]  [Nightly tt-metal L2 tests BH](https://github.com/tenstorrent/tt-metal/actions/runs/15247170373)

