### PR TITLE
Fix Watcher assert by using correct barrier

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_height_sharded_width_concat_two_tensors_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_height_sharded_width_concat_two_tensors_tiled.cpp
@@ -39,7 +39,7 @@ void kernel_main() {
         noc_async_read_one_packet_with_state<true>(base_l1_read_addr_0, l1_write_addr);
         l1_write_addr += width_len_bytes;
 
-        noc_async_write_barrier();
+        noc_async_read_barrier();
 
         cb_pop_front(output_transpose_cb, input0_num_tiles_width + input1_num_tiles_width);
         cb_push_back(output_cb, input0_num_tiles_width + input1_num_tiles_width);


### PR DESCRIPTION
### Ticket
#22561

### What's Changed
This commit fixes a Watcher assert that was triggered in Shallow UNet in the BH demo pipeline.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml): https://github.com/tenstorrent/tt-metal/actions/runs/15253398620
- [x] Blackhole demo: https://github.com/tenstorrent/tt-metal/actions/runs/15254539184