### PR TITLE
Fix slotmap default operator<=> return type

### DIFF
--- a/tt_stl/tt_stl/slotmap.hpp
+++ b/tt_stl/tt_stl/slotmap.hpp
@@ -65,7 +65,7 @@ public:
     T index() const { return value >> VERSION_BITS; }
     T version() const { return value & VERSION_MASK; }
 
-    bool operator<=>(const Key& other) const = default;
+    friend auto operator<=>(Key, Key) = default;
 };
 
 #define MAKE_SLOTMAP_KEY(NAME, T, N)     \


### PR DESCRIPTION
Default three-way comparison returns std::strong_ordering
(or weak_ordering or partial_ordering), not convertible to bool,
 so bool is a bug here; this declaration will fail on instantiation.

This PR also changes the operator to a non-member friend function
(a 'hidden friend' as it's defined in-class) which allows the
parameters to be passed by-value rather than by-reference -
assuming that T is a trivial type this can give better codegen.

(This is a first test PR, with no ticket, to test the process.)

### Ticket
No ticket

### Problem description
slotmap comparison operators fail to compile with an error;
std::stong_ordering does not convert to bool

### What's changed
Changed return type to auto to deduce the return type correctly.
Changed to a friend function, which some prefer, and which allows -
Change parameter to by-value rather than by-reference for codegen.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml)
- [ ] New/Existing tests provide coverage for changes