### PR TITLE
[skip ci] Update TG nightly tests to use Llama 3.3 weights instead of 3.1

### DIFF
--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -38,7 +38,7 @@ jobs:
           {
             name: "Llama Galaxy Long Stress Test",
             arch: wormhole_b0,
-            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/ FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/demo/demo_decode.py  -k 'stress-test and not mini-stress-test'",
+            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/demo/demo_decode.py  -k 'stress-test and not mini-stress-test'",
             timeout: 240,
             owner_id: U053W15B6JF
           }, # Djordje Ivanovic


### PR DESCRIPTION
Use Llama3.3 weights instead of old Llama3.1 ones.

### Problem description
Accidentally test is set up with Llama3.1 weights. 
### What's changed
Flag for using weights now points to Llama3.3 70b instruct weights as it should have been in the first place!