### PR TITLE
Add required permissions to static checks job on merge gate, because for some reason it's crying NOW and not before

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -27,6 +27,9 @@ jobs:
     # We must have this workflow trigger on PRs in order to allow us to require them in the merge queue.
     # But we don't actually WANT to run it on PRs -- that's the whole point.  GitHub strikes again.
     if: github.event_name != 'pull_request'
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/all-static-checks.yaml
     secrets: inherit
 


### PR DESCRIPTION
…

### Ticket

N/A - hot fix

### Problem description

We're seeing Merge Gate not start up because it's complaining of permissions problems for all static checks. Not sure how this didn't happen before

### What's changed

Add permissions at Merge Gate level

### Checklist
- [ ] Manual merge gate https://github.com/tenstorrent/tt-metal/actions/runs/15255464180
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes