### PR TITLE
Removed assert for wormhole_b0 downsample

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_downsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_downsample.py
@@ -7,12 +7,12 @@ import math
 from loguru import logger
 
 import ttnn
-from models.utility_functions import is_blackhole, _nearest_y
+from models.utility_functions import is_blackhole, _nearest_y, skip_for_blackhole
 import torch
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 
 
-@pytest.mark.skip("Test case failing assert_equal() - see #22482")
+@skip_for_blackhole("Temporary skip until #18643 is not closed")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, stride_h, stride_w, num_cores, grid_size, height_sharded",
@@ -44,8 +44,6 @@ def test_run_downsample(
     height_sharded,
     dtype,
 ):
-    if dtype == ttnn.bfloat8_b and is_blackhole():
-        pytest.skip("Temporary skip until #18643 is not closed")
     if batch_size > 8 and dtype != ttnn.bfloat8_b:
         pytest.skip("Batch > 8 must be run fully bfp8")
     compute_grid_size = device.compute_with_storage_grid_size()


### PR DESCRIPTION
### Ticket
#22482

### Problem description
All downsample tests were disabled because of error discovered with #22450. Wormhole_b0 tests still pass. 

### What's changed
Disabled just blackhole tests which are going to be tracked in #18643, and reenable tests for wormhole_b0.

### Checklist
- [x] [Nightly tt-metal L2 tests Wormhole](https://github.com/tenstorrent/tt-metal/actions/runs/15255837185) 
- [x] [Nightly tt-metal L2 tests Blackhole](https://github.com/tenstorrent/tt-metal/actions/runs/15255864431)