### PR TITLE
#0: Add additional perms to TG quick, PR gate

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -49,6 +49,7 @@ permissions:
   contents: write
   pull-requests: write
   checks: write
+  packages: write
 
 jobs:
   asan-build:

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -45,6 +45,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}-${{ inputs.build-type || 'default' }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  pull-requests: write
+  checks: write
+
 jobs:
   asan-build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft

--- a/.github/workflows/tg-quick-trigger.yaml
+++ b/.github/workflows/tg-quick-trigger.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  packages: write
+  contents: write
+
 jobs:
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Seeing error in workflows:
https://github.com/tenstorrent/tt-metal/actions/runs/15255915787/job/42903436587#step:3:188
```
denied: installation not allowed to Write organization package
```

### What's changed
Add packages: write perms
Also added content: write perms (cursor told me I needed it for artifact upload, it wouldn't lie to me right...)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes