### PR TITLE
Fix set_tunnels_from_mmio_device

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -865,14 +865,14 @@ void Cluster::set_tunnels_from_mmio_device() {
         }
 
         bool tunneled_device_hit;
-        for (auto it = device_ids.begin(); it != device_ids.end();) {
+        while (!device_ids.empty()) {
             tunneled_device_hit = false;
             for (auto &dev_vec : tunnels_from_mmio) {
                 for (const auto &[eth_chan, connected_chip_chan] : all_eth_connections.at(dev_vec.back())) {
                     const auto &other_chip_id = std::get<0>(connected_chip_chan);
                     auto id_iter = device_ids.find(other_chip_id);
                     if (id_iter != device_ids.end()) {
-                        it = device_ids.erase(id_iter);
+                        device_ids.erase(id_iter);
                         dev_vec.push_back(other_chip_id);
                         tunneled_device_hit = true;
                         break;
@@ -880,7 +880,7 @@ void Cluster::set_tunnels_from_mmio_device() {
                 }
             }
             TT_FATAL(
-                tunneled_device_hit || (it == device_ids.end()),
+                tunneled_device_hit || device_ids.empty(),
                 "Detected ethernet connections did not match expected device connectivity, try re-running "
                 "tt-topology.");
         }


### PR DESCRIPTION
### Ticket
Found this issue while working on UMD topology discovery.

### Problem description
Some devices can be left unpicked by this algorithm, since the the intended way of iterating while there is something in the set was not written correctly previously.

### What's changed
Fixed the issue in set_tunnels_from_mmio_device.
I expect to see no changes for current tt_metal code, but it fixed an issue once https://github.com/tenstorrent/tt-umd/pull/902 is consumed 

### Checklist
All runs on brosko/fix_tunnel :
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15258165132
- [x] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15258166536
- [x] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/15258168346
- [x] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/15258170220
- [x] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15258172176
- [x] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/15258174184
- [x] (TG) TG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15258175791
- [x] (TG) TG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/15258177129