### PR TITLE
Prod - Add bfloat8_b to NC Prod Test

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -64,20 +64,21 @@ def test_var(device, batch_size, h, w, dim, keepdim, correction):
 @pytest.mark.parametrize("w", [77])
 @pytest.mark.parametrize("dim", [0, 1, 2, 3])
 @pytest.mark.parametrize("keepdim", [True, False])
-def test_prod(device, batch_size, c, h, w, dim, keepdim):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+def test_prod(device, batch_size, c, h, w, dim, keepdim, dtype):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((batch_size, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.prod(torch_input_tensor, dim=dim, keepdim=keepdim)
 
     input_tensor = ttnn.from_torch(
-        torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+        torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG, dtype=dtype
     )
 
     output_tensor = ttnn.prod(input_tensor, dim=dim, keepdim=keepdim, memory_config=ttnn.L1_MEMORY_CONFIG)
     output_tensor = ttnn.from_device(output_tensor)
 
-    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor, dtype=torch.bfloat16)
     assert len(output_tensor.shape) == len(torch_output_tensor.shape)
     assert output_tensor.shape == torch_output_tensor.shape
     # assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -9,7 +9,7 @@
 #include <tt-metalium/constants.hpp>
 #include <ttnn/operations/functions.hpp>
 #include "tools/profiler/op_profiler.hpp"
-#include <ttnn/operations/core/core.hpp>
+
 #include <umd/device/tt_cluster_descriptor.h>  // tt_ClusterDescriptor
 
 namespace tt {
@@ -23,10 +23,9 @@ void Prod_op::validate(const std::vector<tt::tt_metal::Tensor>& input_tensors) c
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
     TT_FATAL((input_tensor_a.get_layout() == tt::tt_metal::Layout::TILE), "Input Layout must be tilized");
     TT_FATAL(input_tensor_a.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED, "Error");
-    const auto dtype = input_tensor_a.get_dtype();
     TT_FATAL(
-        dtype == tt::tt_metal::DataType::BFLOAT16 || dtype == tt::tt_metal::DataType::BFLOAT8_B,
-        "Error - unsupported data type for prod, expected BFLOAT16 or BFLOAT8 but got {}.",
+        input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16,
+        "Error - unsupported data type for prod, expected BFLOAT16 but got {}.",
         input_tensor_a.get_dtype());
 }
 
@@ -36,9 +35,7 @@ std::vector<tt::tt_metal::TensorSpec> Prod_op::compute_output_specs(
     return {tt::tt_metal::TensorSpec(
         ttnn::Shape({1, 1, 1, TILE_HW}),
         tt::tt_metal::TensorLayout(
-            tt::tt_metal::DataType::BFLOAT16,
-            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
-            output_mem_config))};
+            input_tensor.get_dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), output_mem_config))};
 }
 
 tt::tt_metal::operation::ProgramWithCallbacks Prod_op::create_program(


### PR DESCRIPTION
### Ticket
#14274

### Problem description
Running an NC prod with bfloat8_b yielded a fatal error `Unsupported DataType!`. This is because the data creation functions used only supported bfloat16, but NC prod had no checks or documentation indicating this. 

### What's changed
Since prod was originally written, the data creation functions added support for bfloat8_b. This PR just updates the NC prod test to exercise both float16 and float8_b.

Full prod remains unchanged, with an assertion to only function with bfloat16. This is required for the final reduction from a tile to a scalar. Adding a float16 conversion to support float8_b is not practical, and eventual float8_b support is better obtained if/when the final reduction is performed on the device instead of on the host. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15260161530)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15260162981)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes