### PR TITLE
 #22596: Fix the docs wrapper workflow to run not on just main and release branches

### DIFF
--- a/.github/workflows/docs-latest-public-wrapper.yaml
+++ b/.github/workflows/docs-latest-public-wrapper.yaml
@@ -1,4 +1,4 @@
-name: "[post-commit] Docs build and deploy to GitHub pages on main"
+name: "[post-commit] Docs build and deploy (release and main branches) to GitHub pages on main"
 
 on:
   workflow_dispatch:
@@ -24,7 +24,7 @@ jobs:
             VERSION=${BRANCH_NAME#releases/}
           else
             echo "Error: Branch name must be 'main' or follow pattern 'releases/vX.Y.Z' (e.g., releases/v0.58.0)"
-            exit 1
+            VERSION="not-for-deployment"  # This is to allow the users to build docs but not deploy them.
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
   build-artifact:


### PR DESCRIPTION

### Ticket
#22596 

### Problem description
Developer identifying issues in the workflow can not test the docs flow in CI

### What's changed
Instead of raising an error in the CI workflow, allow the Docs Wrapper workflow to call Docs Workflow with version set to `not-for-deployment`. 

Only the build of the docs will be performed as there is another check for the branch name in the Internal Docs workflow 
https://github.com/tenstorrent/tt-metal/blob/main/.github/workflows/docs-latest-public.yaml#L103


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes