### PR TITLE
#21738: [skip ci] Set the model cache and tt tensor cache stuff to be ro in BH demo tests, because they should be!

### DIFF
--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -78,7 +78,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.test-group.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e HF_TOKEN=${{ secrets.HUGGINGFACE_TOKEN }}
-            -v /localdev/blackhole_demos:/localdev/blackhole_demos
+            -v /localdev/blackhole_demos:/localdev/blackhole_demos:ro
           install_wheel: true
           run_args: |
             if [[ "${{ matrix.test-group.name }}" == *"Llama"* ]]; then


### PR DESCRIPTION
### Ticket

#21738 

### Problem description

We weren't mounting weights and caches as read-only.

We should!

### What's changed

Mount read-only.

### Checklist
- BH demos:  https://github.com/tenstorrent/tt-metal/actions/runs/15260355385
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes