### PR TITLE
#21738: [skip ci] Add llama 8b to BH upstream tests via `LLAMA_DIR` instead

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -188,6 +188,9 @@ jobs:
       - ${{ matrix.bh-card }}
       - in-service
       - cloud-virtual-machine
+      # Targeting cloud machines with pipeline-functional per now per
+      # https://github.com/tenstorrent/tt-metal/issues/21738#issuecomment-2925788342
+      - pipeline-functional
     steps:
       - name: Run image
         timeout-minutes: 30

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -193,7 +193,7 @@ jobs:
         timeout-minutes: 30
         env:
           # For different environments, yyz BH VLAN vs. cloud
-          LLAMA_DIR: ${{ contains(runner.name, 'gh') && '/localdev/blackhole_demos/huggingface_data' || '/mnt/MLPerf/huggingface' }}/meta-llama/Llama-3.1-8B-Instruct
+          LLAMA_DIR: ${{ contains(runner.name, 'gh') && '/localdev/blackhole_demos/huggingface_data' || '/mnt/MLPerf/tt_dnn-models' }}/meta-llama/Llama-3.1-8B-Instruct
         run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -193,7 +193,7 @@ jobs:
         timeout-minutes: 30
         env:
           # For different environments, yyz BH VLAN vs. cloud
-          LLAMA_DIR: ${{ contains(runner.name, 'gh') && '/localdev/blackhole_demos/huggingface_data' || '/mnt/MLPerf/huggingface' }}/hub/models--meta-llama--Llama-3.1-8B-Instruct/snapshots/0e9e39f249a16976918f6564b8830bc894c89659/original
+          LLAMA_DIR: ${{ contains(runner.name, 'gh') && '/localdev/blackhole_demos/huggingface_data' || '/mnt/MLPerf/huggingface' }}/meta-llama/Llama-3.1-8B-Instruct
         run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -197,7 +197,7 @@ jobs:
         env:
           # For different environments, yyz BH VLAN vs. cloud
           LLAMA_DIR: ${{ contains(runner.name, 'gh') && '/localdev/blackhole_demos/huggingface_data' || '/mnt/MLPerf/tt_dnn-models' }}/meta-llama/Llama-3.1-8B-Instruct
-        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-image-tag }}
+        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10
         run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -197,7 +197,7 @@ jobs:
         env:
           # For different environments, yyz BH VLAN vs. cloud
           LLAMA_DIR: ${{ contains(runner.name, 'gh') && '/localdev/blackhole_demos/huggingface_data' || '/mnt/MLPerf/tt_dnn-models' }}/meta-llama/Llama-3.1-8B-Instruct
-        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-image-tag }}
+        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10
         run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -191,7 +191,10 @@ jobs:
     steps:
       - name: Run image
         timeout-minutes: 30
-        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.bh-image-tag }}
+        env:
+          # For different environments, yyz BH VLAN vs. cloud
+          LLAMA_DIR: ${{ contains(runner.name, 'gh') && '/localdev/blackhole_demos/huggingface_data' || '/mnt/MLPerf/huggingface' }}/hub/models--meta-llama--Llama-3.1-8B-Instruct/snapshots/0e9e39f249a16976918f6564b8830bc894c89659/original
+        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10
         run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -27,6 +27,18 @@ test_suite_bh_single_pcie_small_ml_model_tests() {
 }
 
 test_suite_bh_single_pcie_llama_demo_tests() {
+    if [ -z "${LLAMA_DIR}" ]; then
+      echo "Error: LLAMA_DIR environment variable not detected. Please set this environment variable to tell the tests where to find the downloaded Llama weights." >&2
+      exit 1
+    fi
+
+    if [ -d "$LLAMA_DIR" ] && [ "$(ls -A $LLAMA_DIR)" ]; then
+      echo "[upstream-tests] Llama weights exist, continuing"
+    else
+      echo "[upstream-tests] Error: Llama weights do not seem to exist in $LLAMA_DIR, exiting" >&2
+      exit 1
+    fi
+
     echo "[upstream-tests] Running BH upstream Llama demo model tests"
     # TODO: remove me , just testing this out
     pip3 install -r models/tt_transformers/requirements.txt

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -42,7 +42,7 @@ test_suite_bh_single_pcie_llama_demo_tests() {
     echo "[upstream-tests] Running BH upstream Llama demo model tests"
     # TODO: remove me , just testing this out
     pip3 install -r models/tt_transformers/requirements.txt
-    HF_MODEL=meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-batch-1
+    pytest models/tt_transformers/demo/simple_text_demo.py -k performance-batch-1
 }
 
 test_suite_wh_6u_metal_unit_tests() {

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -26,6 +26,13 @@ test_suite_bh_single_pcie_small_ml_model_tests() {
     pytest models/demos/blackhole/resnet50/tests/upstream_pipeline
 }
 
+test_suite_bh_single_pcie_llama_demo_tests() {
+    echo "[upstream-tests] Running BH upstream Llama demo model tests"
+    # TODO: remove me , just testing this out
+    pip3 install -r models/tt_transformers/requirements.txt
+    HF_MODEL=meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-batch-1
+}
+
 test_suite_wh_6u_metal_unit_tests() {
     echo "[upstream-tests] running WH 6U upstream metalium unit tests. Note that skips should be treated as failures"
     ./build/test/tt_metal/tt_fabric/test_system_health
@@ -100,9 +107,19 @@ test_suite_wh_6u_llama_long_stress_tests() {
 # Define test suite mappings for different hardware topologies
 declare -A hw_topology_test_suites
 
-hw_topology_test_suites["blackhole"]="test_suite_bh_single_pcie_python_unit_tests test_suite_bh_single_pcie_metal_unit_tests test_suite_bh_single_pcie_small_ml_model_tests"
-hw_topology_test_suites["blackhole_no_models"]="test_suite_bh_single_pcie_python_unit_tests test_suite_bh_single_pcie_metal_unit_tests"
-hw_topology_test_suites["wh_6u"]="test_suite_wh_6u_model_unit_tests test_suite_wh_6u_llama_demo_tests test_suite_wh_6u_metal_unit_tests test_suite_wh_6u_metal_2d_torus_health_check_tests"
+# Store test suites as newline-separated lists
+hw_topology_test_suites["blackhole"]="test_suite_bh_single_pcie_python_unit_tests
+test_suite_bh_single_pcie_metal_unit_tests
+test_suite_bh_single_pcie_small_ml_model_tests
+test_suite_bh_single_pcie_llama_demo_tests" # NOTE: This test MUST be last because of the requirements install currently in the llama tests
+
+hw_topology_test_suites["blackhole_no_models"]="test_suite_bh_single_pcie_python_unit_tests
+test_suite_bh_single_pcie_metal_unit_tests"
+
+hw_topology_test_suites["wh_6u"]="test_suite_wh_6u_model_unit_tests
+test_suite_wh_6u_llama_demo_tests
+test_suite_wh_6u_metal_unit_tests
+test_suite_wh_6u_metal_2d_torus_health_check_tests"
 
 # Function to display help
 show_help() {
@@ -155,7 +172,6 @@ if [[ -z "$hw_topology" ]]; then
     exit 1
 fi
 
-
 # Check if the test suite is part of the specified hardware topology
 if [[ -z "${hw_topology_test_suites[$hw_topology]:-}" ]]; then
     echo "Error: Unsupported hw/topology: $hw_topology"
@@ -173,15 +189,16 @@ if [[ -n "$test_suite" ]]; then
     fi
 
     # Check if the test suite is in the list of test suites for this topology
-    if ! echo "${hw_topology_test_suites[$hw_topology]}" | grep -q "\b$test_suite\b"; then
+    if ! echo "${hw_topology_test_suites[$hw_topology]}" | grep -q "^$test_suite$"; then
         echo "[upstream-tests] Warning: Test suite '$test_suite' is not part of the '$hw_topology' hw/topology"
-        echo "Available test suites for $hw_topology: ${hw_topology_test_suites[$hw_topology]}"
+        echo "Available test suites for $hw_topology:"
+        echo "${hw_topology_test_suites[$hw_topology]}" | sed 's/^/  - /'
     fi
 
     $test_suite
 else
-    # Run all test suites for the specified hardware topology as opposed to just one
-    for test_func in ${hw_topology_test_suites[$hw_topology]}; do
-        $test_func
-    done
+    # Run all test suites for the specified hardware topology
+    while IFS= read -r test_func; do
+        [[ -n "$test_func" ]] && $test_func
+    done <<< "${hw_topology_test_suites[$hw_topology]}"
 fi


### PR DESCRIPTION
### Ticket

#21738 

### Problem description

We're using `LLAMA_DIR`, as according to https://github.com/tenstorrent/cloud/issues/4467#issuecomment-2885043152 , our directory structure will be more amenable to using it.

`HF_HOME` seems to require continuous write access while using the transformers or related libraries, so unfortunately it's not a good candidate for our cache systems which are read-only, except for when explicit updates need to be made.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes