### PR TITLE
[skip ci] Fix tg unit tests call by taking out the `wormhole_b0` from the binary call because it doesn't exist anymore

### DIFF
--- a/tests/scripts/tg/run_tg_unit_tests.sh
+++ b/tests/scripts/tg/run_tg_unit_tests.sh
@@ -110,7 +110,7 @@ run_tg_tests() {
         read -r TEST_NUMBER TEST_ARGS <<< "$TEST"
         echo "LOG_FABRIC: Test $TEST_NUMBER: $TEST_ARGS"
         # Execute the test command with extracted arguments
-        TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 $TEST_ARGS
+        TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity $TEST_ARGS
     done
 
   elif [[ "$1" == "llama3-70b" ]]; then


### PR DESCRIPTION
### Ticket


### Problem description
minor refactor missing from  https://github.com/tenstorrent/tt-metal/commit/356c1722567bf444c11fd4b20ccd3bb1227a81e0

### What's changed
fix typo

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes