### PR TITLE
Fix DRAM address offset bug in direct core read/write operations

### DIFF
--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -132,6 +132,7 @@ public:
 
     virtual CoreCoord logical_core_from_dram_channel(uint32_t dram_channel) const = 0;
     virtual uint32_t dram_channel_from_logical_core(const CoreCoord& logical_core) const = 0;
+    virtual uint32_t dram_channel_from_virtual_core(const CoreCoord& virtual_core) const = 0;
 
     virtual std::optional<DeviceAddr> lowest_occupied_compute_l1_address() const = 0;
     virtual std::optional<DeviceAddr> lowest_occupied_compute_l1_address(tt::stl::Span<const SubDeviceId> sub_device_ids) const = 0;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -177,6 +177,7 @@ public:
     const std::unique_ptr<Allocator>& allocator(SubDeviceId sub_device_id) const override;
     CoreCoord logical_core_from_dram_channel(uint32_t dram_channel) const override;
     uint32_t dram_channel_from_logical_core(const CoreCoord& logical_core) const override;
+    uint32_t dram_channel_from_virtual_core(const CoreCoord& virtual_core) const override;
     std::optional<DeviceAddr> lowest_occupied_compute_l1_address() const override;
     std::optional<DeviceAddr> lowest_occupied_compute_l1_address(
         tt::stl::Span<const SubDeviceId> sub_device_ids) const override;

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -334,10 +334,7 @@ void FDMeshCommandQueue::enqueue_write_shard_to_core(
     TT_FATAL(!trace_id_.has_value(), "Writes are not supported during trace capture.");
 
     IDevice* device = mesh_device_->get_device(address.device_coord);
-    if (device->get_mem_type_of_core(address.virtual_core_coord) == HalMemType::DRAM) {
-        address.address += device->allocator()->get_bank_offset(
-            BufferType::DRAM, device->dram_channel_from_virtual_core(address.virtual_core_coord));
-    }
+    address.address = device_dispatch::add_bank_offset_to_address(device, address.virtual_core_coord, address.address);
 
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
 
@@ -366,10 +363,7 @@ void FDMeshCommandQueue::enqueue_read_shard_from_core(
     TT_FATAL(!trace_id_.has_value(), "Reads are not supported during trace capture.");
 
     IDevice* device = mesh_device_->get_device(address.device_coord);
-    if (device->get_mem_type_of_core(address.virtual_core_coord) == HalMemType::DRAM) {
-        address.address += device->allocator()->get_bank_offset(
-            BufferType::DRAM, device->dram_channel_from_virtual_core(address.virtual_core_coord));
-    }
+    address.address = device_dispatch::add_bank_offset_to_address(device, address.virtual_core_coord, address.address);
 
     device_dispatch::validate_core_read_write_bounds(device, address.virtual_core_coord, address.address, size_bytes);
 

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -325,7 +325,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
 }
 
 void FDMeshCommandQueue::enqueue_write_shard_to_core(
-    DeviceMemoryAddress& address,
+    DeviceMemoryAddress address,
     const void* src,
     uint32_t size_bytes,
     bool blocking,
@@ -357,7 +357,7 @@ void FDMeshCommandQueue::enqueue_write_shard_to_core(
 }
 
 void FDMeshCommandQueue::enqueue_read_shard_from_core(
-    DeviceMemoryAddress& address,
+    DeviceMemoryAddress address,
     void* dst,
     uint32_t size_bytes,
     bool blocking,
@@ -420,12 +420,11 @@ void FDMeshCommandQueue::write_shard_to_device(
             const auto virtual_core =
                 shard_view->device()->virtual_core_from_logical_core(banks[i], shard_view->core_type());
             for (const auto& chunk_mapping_in_bytes : bank_mapping_in_bytes[i]) {
-                DeviceMemoryAddress address = {
-                    .device_coord = device_coord,
-                    .virtual_core_coord = virtual_core,
-                    .address = shard_view->address() + chunk_mapping_in_bytes.dst};
                 enqueue_write_shard_to_core(
-                    address,
+                    DeviceMemoryAddress{
+                        .device_coord = device_coord,
+                        .virtual_core_coord = virtual_core,
+                        .address = shard_view->address() + chunk_mapping_in_bytes.dst},
                     (char*)src + chunk_mapping_in_bytes.src,
                     chunk_mapping_in_bytes.size,
                     /*blocking=*/false,
@@ -470,12 +469,11 @@ void FDMeshCommandQueue::read_shard_from_device(
             const auto virtual_core =
                 shard_view->device()->virtual_core_from_logical_core(banks[i], shard_view->core_type());
             for (const auto& chunk_mapping_in_bytes : bank_mapping_in_bytes[i]) {
-                DeviceMemoryAddress address = {
-                    .device_coord = device_coord,
-                    .virtual_core_coord = virtual_core,
-                    .address = shard_view->address() + chunk_mapping_in_bytes.dst};
                 enqueue_read_shard_from_core(
-                    address,
+                    DeviceMemoryAddress{
+                        .device_coord = device_coord,
+                        .virtual_core_coord = virtual_core,
+                        .address = shard_view->address() + chunk_mapping_in_bytes.dst},
                     (char*)dst + chunk_mapping_in_bytes.src,
                     chunk_mapping_in_bytes.size,
                     /*blocking=*/false,

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -184,13 +184,13 @@ public:
     // TODO: This will error out for SD mesh command queues
     // - Need to add equivalent APIs for SD and expose via mesh command queue base or mesh command queue
     void enqueue_write_shard_to_core(
-        const DeviceMemoryAddress& address,
+        DeviceMemoryAddress& address,
         const void* src,
         uint32_t size_bytes,
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {});
     void enqueue_read_shard_from_core(
-        const DeviceMemoryAddress& address,
+        DeviceMemoryAddress& address,
         void* dst,
         uint32_t size_bytes,
         bool blocking,

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -184,13 +184,13 @@ public:
     // TODO: This will error out for SD mesh command queues
     // - Need to add equivalent APIs for SD and expose via mesh command queue base or mesh command queue
     void enqueue_write_shard_to_core(
-        DeviceMemoryAddress& address,
+        DeviceMemoryAddress address,
         const void* src,
         uint32_t size_bytes,
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {});
     void enqueue_read_shard_from_core(
-        DeviceMemoryAddress& address,
+        DeviceMemoryAddress address,
         void* dst,
         uint32_t size_bytes,
         bool blocking,

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -664,6 +664,11 @@ uint32_t MeshDevice::dram_channel_from_logical_core(const CoreCoord& logical_cor
         return device->dram_channel_from_logical_core(logical_core);
     });
 }
+uint32_t MeshDevice::dram_channel_from_virtual_core(const CoreCoord& virtual_core) const {
+    return validate_and_get_reference_value(scoped_devices_->root_devices(), [virtual_core](const auto& device) {
+        return device->dram_channel_from_virtual_core(virtual_core);
+    });
+}
 
 // Core management and network operations
 const std::set<CoreCoord>& MeshDevice::ethernet_cores() const {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1294,6 +1294,16 @@ uint32_t Device::dram_channel_from_logical_core(const CoreCoord& logical_core) c
         logical_core);
 }
 
+uint32_t Device::dram_channel_from_virtual_core(const CoreCoord& virtual_core) const {
+    const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id_);
+    for (uint32_t channel = 0; channel < this->num_dram_channels(); ++channel) {
+        if (soc_desc.get_preferred_worker_core_for_dram_view(channel) == virtual_core) {
+            return channel;
+        }
+    }
+    TT_THROW("Virtual core {} is not a DRAM core", virtual_core.str());
+}
+
 std::optional<DeviceAddr> Device::lowest_occupied_compute_l1_address() const {
     return sub_device_manager_tracker_->lowest_occupied_compute_l1_address();
 }

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -103,6 +103,7 @@ public:
 
     CoreCoord logical_core_from_dram_channel(uint32_t dram_channel) const override;
     uint32_t dram_channel_from_logical_core(const CoreCoord& logical_core) const override;
+    uint32_t dram_channel_from_virtual_core(const CoreCoord& virtual_core) const override;
 
     std::optional<DeviceAddr> lowest_occupied_compute_l1_address() const override;
     std::optional<DeviceAddr> lowest_occupied_compute_l1_address(tt::stl::Span<const SubDeviceId> sub_device_ids) const override;

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -28,12 +28,11 @@ void validate_core_read_write_bounds(
     IDevice* device, const CoreCoord& virtual_core, DeviceAddr address, uint32_t size_bytes) {
     const HalMemType mem_type = device->get_mem_type_of_core(virtual_core);
     if (mem_type == HalMemType::L1) {
-        TT_FATAL(
-            address >= device->get_dev_addr(virtual_core, HalL1MemAddrType::BASE), "Region in L1 is out of bounds");
-        TT_FATAL(
-            address + size_bytes <= device->get_dev_addr(virtual_core, HalL1MemAddrType::BASE) +
-                                        device->get_dev_size(virtual_core, HalL1MemAddrType::BASE),
-            "Region in L1 is out of bounds");
+        const DeviceAddr l1_base_address = device->get_dev_addr(virtual_core, HalL1MemAddrType::BASE);
+        const DeviceAddr l1_size = device->get_dev_size(virtual_core, HalL1MemAddrType::BASE);
+
+        TT_FATAL(address >= l1_base_address, "Region in L1 is out of bounds");
+        TT_FATAL(address + size_bytes <= l1_base_address + l1_size, "Region in L1 is out of bounds");
     } else {
         TT_ASSERT(mem_type == HalMemType::DRAM);
 

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -7,7 +7,7 @@
 #include "dispatch/device_command.hpp"
 #include "dispatch/device_command_calculator.hpp"
 #include "dispatch/system_memory_manager.hpp"
-
+#include "allocator.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -34,7 +34,12 @@ void validate_core_read_write_bounds(
             "Region in L1 is out of bounds");
     } else {
         TT_ASSERT(mem_type == HalMemType::DRAM);
-        TT_FATAL(address + size_bytes <= device->dram_size_per_channel(), "Region in DRAM is out of bounds");
+
+        const DeviceAddr dram_channel_size = device->dram_size_per_channel();
+        const DeviceAddr dram_base_address = device->allocator()->get_bank_offset(
+            BufferType::DRAM, device->dram_channel_from_virtual_core(virtual_core));
+
+        TT_FATAL(address + size_bytes <= dram_base_address + dram_channel_size, "Region in DRAM is out of bounds");
     }
 }
 

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -29,6 +29,8 @@ void validate_core_read_write_bounds(
     const HalMemType mem_type = device->get_mem_type_of_core(virtual_core);
     if (mem_type == HalMemType::L1) {
         TT_FATAL(
+            address >= device->get_dev_addr(virtual_core, HalL1MemAddrType::BASE), "Region in L1 is out of bounds");
+        TT_FATAL(
             address + size_bytes <= device->get_dev_addr(virtual_core, HalL1MemAddrType::BASE) +
                                         device->get_dev_size(virtual_core, HalL1MemAddrType::BASE),
             "Region in L1 is out of bounds");
@@ -39,6 +41,7 @@ void validate_core_read_write_bounds(
         const DeviceAddr dram_base_address = device->allocator()->get_bank_offset(
             BufferType::DRAM, device->dram_channel_from_virtual_core(virtual_core));
 
+        TT_FATAL(address >= dram_base_address, "Region in DRAM is out of bounds");
         TT_FATAL(address + size_bytes <= dram_base_address + dram_channel_size, "Region in DRAM is out of bounds");
     }
 }

--- a/tt_metal/impl/device/dispatch.hpp
+++ b/tt_metal/impl/device/dispatch.hpp
@@ -39,6 +39,8 @@ struct CoreReadDispatchParams : public CoreDispatchParams {};
 void validate_core_read_write_bounds(
     IDevice* device, const CoreCoord& virtual_core, DeviceAddr address, uint32_t size_bytes);
 
+DeviceAddr add_bank_offset_to_address(IDevice* device, const CoreCoord& virtual_core, DeviceAddr address);
+
 void write_to_core(
     IDevice* device,
     const CoreCoord& virtual_core,

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -356,10 +356,7 @@ void HWCommandQueue::enqueue_read_from_core(
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScopedN("HWCommandQueue_enqueue_read_from_core");
 
-    if (this->device_->get_mem_type_of_core(virtual_core) == HalMemType::DRAM) {
-        address += this->device_->allocator()->get_bank_offset(
-            BufferType::DRAM, this->device_->dram_channel_from_virtual_core(virtual_core));
-    }
+    address = device_dispatch::add_bank_offset_to_address(this->device_, virtual_core, address);
 
     device_dispatch::validate_core_read_write_bounds(this->device_, virtual_core, address, size_bytes);
 
@@ -396,10 +393,7 @@ void HWCommandQueue::enqueue_write_to_core(
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScopedN("HWCommandQueue_enqueue_write_to_core");
 
-    if (this->device_->get_mem_type_of_core(virtual_core) == HalMemType::DRAM) {
-        address += this->device_->allocator()->get_bank_offset(
-            BufferType::DRAM, this->device_->dram_channel_from_virtual_core(virtual_core));
-    }
+    address = device_dispatch::add_bank_offset_to_address(this->device_, virtual_core, address);
 
     sub_device_ids = buffer_dispatch::select_sub_device_ids(this->device_, sub_device_ids);
 

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -356,6 +356,11 @@ void HWCommandQueue::enqueue_read_from_core(
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScopedN("HWCommandQueue_enqueue_read_from_core");
 
+    if (this->device_->get_mem_type_of_core(virtual_core) == HalMemType::DRAM) {
+        address += this->device_->allocator()->get_bank_offset(
+            BufferType::DRAM, this->device_->dram_channel_from_virtual_core(virtual_core));
+    }
+
     device_dispatch::validate_core_read_write_bounds(this->device_, virtual_core, address, size_bytes);
 
     sub_device_ids = buffer_dispatch::select_sub_device_ids(this->device_, sub_device_ids);
@@ -390,6 +395,11 @@ void HWCommandQueue::enqueue_write_to_core(
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScopedN("HWCommandQueue_enqueue_write_to_core");
+
+    if (this->device_->get_mem_type_of_core(virtual_core) == HalMemType::DRAM) {
+        address += this->device_->allocator()->get_bank_offset(
+            BufferType::DRAM, this->device_->dram_channel_from_virtual_core(virtual_core));
+    }
 
     sub_device_ids = buffer_dispatch::select_sub_device_ids(this->device_, sub_device_ids);
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -79,7 +79,7 @@ std::vector<uint32_t> read_control_buffer_from_core(
                 distributed::FDMeshCommandQueue& mesh_cq =
                     dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
                 const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
-                distributed::DeviceMemoryAddress address = {
+                const distributed::DeviceMemoryAddress address = {
                     device_coord, core, reinterpret_cast<DeviceAddr>(profiler_msg->control_vector)};
                 control_buffer.resize(kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE);
                 mesh_cq.enqueue_read_shard_from_core(
@@ -126,7 +126,7 @@ void write_control_buffer_to_core(
                 distributed::FDMeshCommandQueue& mesh_cq =
                     dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
                 const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
-                distributed::DeviceMemoryAddress address = {
+                const distributed::DeviceMemoryAddress address = {
                     device_coord, core, reinterpret_cast<DeviceAddr>(profiler_msg->control_vector)};
                 mesh_cq.enqueue_write_shard_to_core(
                     address, control_buffer.data(), kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE, true);

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -79,7 +79,7 @@ std::vector<uint32_t> read_control_buffer_from_core(
                 distributed::FDMeshCommandQueue& mesh_cq =
                     dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
                 const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
-                const distributed::DeviceMemoryAddress address = {
+                distributed::DeviceMemoryAddress address = {
                     device_coord, core, reinterpret_cast<DeviceAddr>(profiler_msg->control_vector)};
                 control_buffer.resize(kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE);
                 mesh_cq.enqueue_read_shard_from_core(
@@ -126,7 +126,7 @@ void write_control_buffer_to_core(
                 distributed::FDMeshCommandQueue& mesh_cq =
                     dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
                 const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
-                const distributed::DeviceMemoryAddress address = {
+                distributed::DeviceMemoryAddress address = {
                     device_coord, core, reinterpret_cast<DeviceAddr>(profiler_msg->control_vector)};
                 mesh_cq.enqueue_write_shard_to_core(
                     address, control_buffer.data(), kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE, true);


### PR DESCRIPTION
This PR fixes an issue with direct read/write calls on DRAM cores in which the address to read from/write to wasn't being offset according to the DRAM channel.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15264313111)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/15264316440)
- [x] New/Existing tests provide coverage for changes