### PR TITLE
#13973: Add BFLOAT8_B dtype check for logaddexp2_bw 

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -358,6 +358,16 @@ std::vector<ttnn::Tensor> ExecuteBackwardLogaddexp2::invoke(
     const Tensor& input_a,
     const Tensor& other,
     const std::optional<MemoryConfig>& output_mem_config) {
+    TT_FATAL(
+        !(input_a.dtype() == ttnn::DataType::BFLOAT8_B || grad.dtype() == ttnn::DataType::BFLOAT8_B ||
+          other.dtype() == ttnn::DataType::BFLOAT8_B),
+        "BFLOAT8_B dtypes are not supported !!");
+
+    TT_FATAL(
+        !(input_a.dtype() == ttnn::DataType::BFLOAT4_B || grad.dtype() == ttnn::DataType::BFLOAT4_B ||
+          other.dtype() == ttnn::DataType::BFLOAT4_B),
+        "BFLOAT4_B dtypes are not supported !!");
+
     std::vector<Tensor> grad_tensor;
     auto output_memory_config = output_mem_config.value_or(input_a.memory_config());
     Tensor oppow = ttnn::add(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -45,6 +45,10 @@ void preallocated_tensors_check(
     }
 }
 
+bool is_block_format_dtype(const Tensor& tensor) {
+    return (tensor.dtype() == ttnn::DataType::BFLOAT8_B || tensor.dtype() == ttnn::DataType::BFLOAT4_B);
+}
+
 std::vector<ttnn::Tensor> ExecuteBackwardAtan2::invoke(
     const Tensor& grad,
     const Tensor& input,
@@ -359,14 +363,8 @@ std::vector<ttnn::Tensor> ExecuteBackwardLogaddexp2::invoke(
     const Tensor& other,
     const std::optional<MemoryConfig>& output_mem_config) {
     TT_FATAL(
-        !(input_a.dtype() == ttnn::DataType::BFLOAT8_B || grad.dtype() == ttnn::DataType::BFLOAT8_B ||
-          other.dtype() == ttnn::DataType::BFLOAT8_B),
-        "BFLOAT8_B dtypes are not supported !!");
-
-    TT_FATAL(
-        !(input_a.dtype() == ttnn::DataType::BFLOAT4_B || grad.dtype() == ttnn::DataType::BFLOAT4_B ||
-          other.dtype() == ttnn::DataType::BFLOAT4_B),
-        "BFLOAT4_B dtypes are not supported !!");
+        !(is_block_format_dtype(input_a) || is_block_format_dtype(grad) || is_block_format_dtype(other)),
+        "BFLOAT8_B/BFLOAT4_B dtypes are not supported !!");
 
     std::vector<Tensor> grad_tensor;
     auto output_memory_config = output_mem_config.value_or(input_a.memory_config());


### PR DESCRIPTION
### Ticket
[13973](https://github.com/tenstorrent/tt-metal/issues/13973)

### Problem description
Low pcc due to unsupported BFLOAT8_B dtype for exp and recip in logaddexp2_bw.

### What's changed
Updated implementation to check for BFLOAT8_B dtype in logaddexp2_bw in binary_backward.cpp.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15292675123)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15292683009)