### PR TITLE
#21054: Fix Conv2D when input dtype != output dtype

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -189,7 +189,7 @@ def run_conv(
         input_dtype,
         mesh_mapper=input_mesh_mapper,
         layout=input_layout,
-        device=device if activations_dtype == ttnn.bfloat8_b else None,
+        device=device if input_dtype == ttnn.bfloat8_b else None,
     )
 
     conv_config = ttnn.Conv2dConfig(

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -82,6 +82,7 @@ def run_conv(
     fp32_accum=False,
     packer_l1_acc=False,
     input_layout=ttnn.ROW_MAJOR_LAYOUT,
+    input_dtype=None,
     output_layout=ttnn.TILE_LAYOUT,
     deallocate_activation=False,
     groups=1,
@@ -139,6 +140,8 @@ def run_conv(
         pad_left = padding
         pad_right = padding
 
+    if input_dtype is None:
+        input_dtype = activations_dtype
     torch.manual_seed(0)
     conv_input_shape = (total_batch_size, input_channels, input_height, input_width)
     conv_weight_shape = (output_channels, input_channels // groups, filter_height, filter_width)
@@ -183,7 +186,7 @@ def run_conv(
 
     tt_input_tensor = ttnn.from_torch(
         torch_input_tensor,
-        activations_dtype,
+        input_dtype,
         mesh_mapper=input_mesh_mapper,
         layout=input_layout,
         device=device if activations_dtype == ttnn.bfloat8_b else None,

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -63,7 +63,7 @@ def run_conv(
     device,
     torch_tensor_map,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -116,9 +116,9 @@ def run_conv(
     else:
         total_batch_size = batch_size
 
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and activations_dtype == ttnn.bfloat8_b:
+    if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat8_b:
         pytest.skip("Row major layout not compatible with bfloat8_b")
-    if slice_config and activations_dtype != ttnn.bfloat16:
+    if slice_config and output_dtype != ttnn.bfloat16:
         pytest.xfail("Conv2d with DRAM Slicing only supports BFloat16 for activation dtype")
 
     if hasattr(padding, "__len__"):
@@ -141,7 +141,7 @@ def run_conv(
         pad_right = padding
 
     if input_dtype is None:
-        input_dtype = activations_dtype
+        input_dtype = output_dtype
     torch.manual_seed(0)
     conv_input_shape = (total_batch_size, input_channels, input_height, input_width)
     conv_weight_shape = (output_channels, input_channels // groups, filter_height, filter_width)
@@ -193,7 +193,7 @@ def run_conv(
     )
 
     conv_config = ttnn.Conv2dConfig(
-        dtype=activations_dtype,
+        dtype=output_dtype,
         weights_dtype=weights_dtype,
         shard_layout=shard_layout if not auto_shard else None,
         deallocate_activation=deallocate_activation,
@@ -284,7 +284,7 @@ def run_conv(
         pcc = 0.985
         if input_channels * filter_height * filter_width > 10000:
             pcc = 0.97
-    elif math_fidelity == ttnn.MathFidelity.LoFi and activations_dtype == ttnn.bfloat8_b:
+    elif math_fidelity == ttnn.MathFidelity.LoFi and output_dtype == ttnn.bfloat8_b:
         pcc = 0.996
     else:
         pcc = 0.997
@@ -318,7 +318,7 @@ def run_conv_with_split(
     device,
     torch_tensor_map,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -403,7 +403,7 @@ def run_conv_with_split(
         split_weight_tensors[i] = torch.split(split_weight_tensors[i], split_input_channels, 1)
 
     conv_config = ttnn.Conv2dConfig(
-        dtype=activations_dtype,
+        dtype=output_dtype,
         weights_dtype=weights_dtype,
         shard_layout=shard_layout if not auto_shard else None,
     )
@@ -430,9 +430,9 @@ def run_conv_with_split(
             torch_input_tensor = torch.permute(split_input_tensors[i], (0, 2, 3, 1))
             tt_input_tensor = ttnn.from_torch(
                 torch_input_tensor,
-                activations_dtype,
+                output_dtype,
                 layout=input_layout,
-                device=device if activations_dtype == ttnn.bfloat8_b else None,
+                device=device if output_dtype == ttnn.bfloat8_b else None,
             )
             [tt_output_tensor_on_device, [out_height, out_width]] = ttnn.conv2d(
                 input_tensor=tt_input_tensor,
@@ -492,7 +492,7 @@ def run_conv_with_split(
     [ttnn.bfloat8_b, ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat8_b, ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
@@ -508,7 +508,7 @@ def test_conv_features_multi_device(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -523,17 +523,17 @@ def test_conv_features_multi_device(
     output_layout,
     groups,
 ):
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and activations_dtype == ttnn.bfloat8_b:
+    if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat8_b:
         pytest.skip("Row major layout not compatible with bfloat8_b")
 
-    if activations_dtype == ttnn.bfloat8_b and shard_layout == WS:
+    if output_dtype == ttnn.bfloat8_b and shard_layout == WS:
         pytest.skip("Skipping until Issue: #21209 is fixed")
 
     run_conv(
         mesh_device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -553,7 +553,7 @@ def test_conv_features_multi_device(
         weight_mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         output_mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0),
         groups=groups,
-        input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
     )
 
 
@@ -573,7 +573,7 @@ def test_conv_features_multi_device(
     [ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
-    "activations_dtype, output_layout",
+    "output_dtype, output_layout",
     [
         [ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT],
         [ttnn.bfloat8_b, ttnn.TILE_LAYOUT],
@@ -600,7 +600,7 @@ def test_conv_activation(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -617,10 +617,10 @@ def test_conv_activation(
     has_bias,
     activation,
 ):
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and activations_dtype == ttnn.bfloat8_b:
+    if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat8_b:
         pytest.skip("Row major layout not compatible with bfloat8_b")
 
-    if activations_dtype == ttnn.bfloat8_b and shard_layout == HS and activation == "sqrt":
+    if output_dtype == ttnn.bfloat8_b and shard_layout == HS and activation == "sqrt":
         pytest.skip(
             "Skipping sqrt activation for bfloat8_b and height sharded due to PCC error that occurs due to how sqrt over negative numbers is handled in bfloat8_b vs bfloat16"
         )
@@ -629,7 +629,7 @@ def test_conv_activation(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -648,7 +648,7 @@ def test_conv_activation(
         fp32_accum=fp32_accum,
         packer_l1_acc=False,
         activation=activation,
-        input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
     )
 
 
@@ -658,7 +658,7 @@ SliceWidth = ttnn.Conv2dSliceWidth
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize(
-    "input_channels, output_channels, input_height, input_width, slice_type, num_slices, weights_dtype, activations_dtype, kernel, stride, padding, dilation, act_block_h_override,  math_fidelity",
+    "input_channels, output_channels, input_height, input_width, slice_type, num_slices, weights_dtype, output_dtype, kernel, stride, padding, dilation, act_block_h_override,  math_fidelity",
     # fmt: off
     (
         (10,    64,  4096,   512,  SliceHeight,   4,  ttnn.bfloat8_b, ttnn.bfloat16, (4, 4), (2, 2), (1, 1), (1, 1),  32 * 8, ttnn.MathFidelity.LoFi  ),
@@ -696,7 +696,7 @@ def test_conv_dram(
     input_width,
     has_bias,
     weights_dtype,
-    activations_dtype,
+    output_dtype,
     slice_type,
     num_slices,
     kernel,
@@ -719,7 +719,7 @@ def test_conv_dram(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -776,7 +776,7 @@ def test_conv_dram(
     [ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat16, ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize("auto_shard", [True, False], ids=["auto_shard", "no_auto_shard"])
@@ -798,7 +798,7 @@ def test_conv_ws(
     stride,
     has_bias,
     weights_dtype,
-    activations_dtype,
+    output_dtype,
     auto_shard,
     tilized_input,
 ):
@@ -853,7 +853,7 @@ def test_conv_ws(
             pytest.skip("Test is not supported on n300 (8,7) grid due to #13541")
 
     conv_config = ttnn.Conv2dConfig(
-        dtype=activations_dtype,
+        dtype=output_dtype,
         weights_dtype=weights_dtype,
         shard_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED if not auto_shard else None,
         deallocate_activation=deallocate_activation,
@@ -939,7 +939,7 @@ def test_conv_ws(
     [ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat16],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
@@ -950,7 +950,7 @@ def test_conv_for_segformer_512x512(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -973,7 +973,7 @@ def test_conv_for_segformer_512x512(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -1050,7 +1050,7 @@ def test_conv_for_segformer_512x512(
     [ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat16, ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
@@ -1062,7 +1062,7 @@ def test_resnet50_conv_wh(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -1088,7 +1088,7 @@ def test_resnet50_conv_wh(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -1106,7 +1106,7 @@ def test_resnet50_conv_wh(
         has_bias=has_bias,
         auto_shard=auto_shard,
         shard_layout=shard_layout,
-        input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
     )
 
 
@@ -1209,7 +1209,7 @@ def test_conv_mem_config_wh(
     [ttnn.float32, ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.float32, ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
@@ -1228,7 +1228,7 @@ def test_resnet50_conv_wh_fp32(
     use_program_cache,
     math_fidelity,
     fp32_accum,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -1246,11 +1246,11 @@ def test_resnet50_conv_wh_fp32(
     packer_l1_acc,
     auto_shard,
 ):
-    if batch_size > 8 and (activations_dtype != ttnn.bfloat8_b or weights_dtype != ttnn.bfloat8_b):
+    if batch_size > 8 and (output_dtype != ttnn.bfloat8_b or weights_dtype != ttnn.bfloat8_b):
         pytest.skip("Batch > 8 must be run fully bfp8")
 
     if (
-        activations_dtype == ttnn.bfloat16
+        output_dtype == ttnn.bfloat16
         and batch_size == 20
         and (
             output_channels == 64
@@ -1266,7 +1266,7 @@ def test_resnet50_conv_wh_fp32(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -1344,7 +1344,7 @@ def test_resnet50_conv_wh_fp32(
     [ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
@@ -1356,7 +1356,7 @@ def test_sd_conv(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -1381,7 +1381,7 @@ def test_sd_conv(
             device,
             torch_tensor_map,
             math_fidelity,
-            activations_dtype,
+            output_dtype,
             weights_dtype,
             batch_size,
             output_channels,
@@ -1396,14 +1396,14 @@ def test_sd_conv(
             config_override,
             shard_layout=shard_layout,
             split_input_channels_factor=3 if input_channels == 1920 else 2,
-            input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+            input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
         )
     else:
         run_conv(
             device,
             torch_tensor_map,
             math_fidelity,
-            activations_dtype,
+            output_dtype,
             weights_dtype,
             batch_size,
             output_channels,
@@ -1418,7 +1418,7 @@ def test_sd_conv(
             config_override,
             shard_layout=shard_layout,
             auto_shard=auto_shard,
-            input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+            input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
         )
 
 
@@ -1480,7 +1480,7 @@ def test_sd_conv(
     [ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize(
-    "activations_dtype, output_layout",
+    "output_dtype, output_layout",
     [(ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT), (ttnn.bfloat8_b, ttnn.TILE_LAYOUT)],
 )
 @pytest.mark.parametrize(
@@ -1495,7 +1495,7 @@ def test_sd_conv_wh(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     fp32_accum,
     batch_size,
@@ -1518,12 +1518,12 @@ def test_sd_conv_wh(
 
     # Skip test cases raising OOM, but do not affect the SD e2e test
     if (
-        (input_channels == 320 and config_override == None and activations_dtype == ttnn.bfloat16)
+        (input_channels == 320 and config_override == None and output_dtype == ttnn.bfloat16)
         or (input_channels == 960 and config_override == None and fp32_accum == True)
         or (
             output_channels == 1280
             and input_height == 32
-            and activations_dtype == ttnn.bfloat16
+            and output_dtype == ttnn.bfloat16
             and weights_dtype == ttnn.bfloat16
         )
     ):
@@ -1534,7 +1534,7 @@ def test_sd_conv_wh(
             device,
             torch_tensor_map,
             math_fidelity,
-            activations_dtype,
+            output_dtype,
             weights_dtype,
             batch_size,
             output_channels,
@@ -1551,14 +1551,14 @@ def test_sd_conv_wh(
             split_input_channels_factor=3 if input_channels == 1920 else 2,
             fp32_accum=fp32_accum,
             packer_l1_acc=True,
-            input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+            input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
         )
     else:
         run_conv(
             device,
             torch_tensor_map,
             math_fidelity,
-            activations_dtype,
+            output_dtype,
             weights_dtype,
             batch_size,
             output_channels,
@@ -1575,7 +1575,7 @@ def test_sd_conv_wh(
             fp32_accum=fp32_accum,
             packer_l1_acc=True,
             output_layout=output_layout,
-            input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+            input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
         )
 
 
@@ -1642,7 +1642,7 @@ def test_sd14_vae_conv(
             device=device,
             torch_tensor_map=torch_tensor_map,
             math_fidelity=ttnn.MathFidelity.LoFi,
-            activations_dtype=dtype,
+            output_dtype=dtype,
             weights_dtype=dtype,
             batch_size=batch,
             output_channels=output_channels,
@@ -1692,7 +1692,7 @@ def test_sd14_vae_conv(
     [ttnn.bfloat8_b, ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
-    "activations_dtype, output_layout",
+    "output_dtype, output_layout",
     [(ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT), (ttnn.bfloat8_b, ttnn.TILE_LAYOUT)],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
@@ -1702,7 +1702,7 @@ def test_unet_conv_wh(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -1722,7 +1722,7 @@ def test_unet_conv_wh(
 ):
     if (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y) == (8, 7):
         pytest.skip("Test is not supported on n300 (8,7) grid")
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and activations_dtype == ttnn.bfloat8_b:
+    if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat8_b:
         pytest.skip("Row major layout not compatible with bfloat8_b")
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and input_height >= 1056:
         pytest.skip("OOM")
@@ -1730,7 +1730,7 @@ def test_unet_conv_wh(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -1746,7 +1746,7 @@ def test_unet_conv_wh(
         shard_layout=shard_layout,
         output_layout=output_layout,
         auto_shard=auto_shard,
-        input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
     )
 
 
@@ -1785,7 +1785,7 @@ def test_unet_conv_wh(
     [ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat16],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
@@ -1796,7 +1796,7 @@ def test_unet_conv_groups_2_wh(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -1817,7 +1817,7 @@ def test_unet_conv_groups_2_wh(
 ):
     if (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y) == (8, 7):
         pytest.skip("Test is not supported on n300 (8,7) grid")
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and activations_dtype == ttnn.bfloat8_b:
+    if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat8_b:
         pytest.skip("Row major layout not compatible with bfloat8_b")
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and input_height >= 1056:
         pytest.skip("OOM")
@@ -1825,7 +1825,7 @@ def test_unet_conv_groups_2_wh(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         groups * output_channels,
@@ -1842,7 +1842,7 @@ def test_unet_conv_groups_2_wh(
         output_layout=output_layout,
         auto_shard=auto_shard,
         groups=groups,
-        input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
     )
 
 
@@ -1882,7 +1882,7 @@ def test_unet_conv_groups_2_wh(
     [ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
@@ -1892,7 +1892,7 @@ def test_unet_conv_groups_4_6_wh(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -1913,7 +1913,7 @@ def test_unet_conv_groups_4_6_wh(
 ):
     if (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y) == (8, 7):
         pytest.skip("Test is not supported on n300 (8,7) grid")
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and activations_dtype == ttnn.bfloat8_b:
+    if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat8_b:
         pytest.skip("Row major layout not compatible with bfloat8_b")
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and input_height >= 1056:
         pytest.skip("OOM")
@@ -1923,7 +1923,7 @@ def test_unet_conv_groups_4_6_wh(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         groups * output_channels,
@@ -1937,7 +1937,7 @@ def test_unet_conv_groups_4_6_wh(
         (pad_h, pad_w),
         config_override,
         shard_layout=shard_layout,
-        input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else ttnn.ROW_MAJOR_LAYOUT,
+        input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else ttnn.ROW_MAJOR_LAYOUT,
         output_layout=output_layout,
         groups=groups,
         in_place=in_place,
@@ -1979,7 +1979,7 @@ def test_unet_conv_groups_4_6_wh(
     [ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
@@ -1990,7 +1990,7 @@ def test_unet_conv_groups_8_wh(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -2011,7 +2011,7 @@ def test_unet_conv_groups_8_wh(
 ):
     if (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y) == (8, 7):
         pytest.skip("Test is not supported on n300 (8,7) grid")
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and activations_dtype == ttnn.bfloat8_b:
+    if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat8_b:
         pytest.skip("Row major layout not compatible with bfloat8_b")
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and input_height >= 1056:
         pytest.skip("OOM")
@@ -2019,7 +2019,7 @@ def test_unet_conv_groups_8_wh(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         groups * output_channels,
@@ -2036,7 +2036,7 @@ def test_unet_conv_groups_8_wh(
         output_layout=output_layout,
         auto_shard=auto_shard,
         groups=groups,
-        input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
     )
 
 
@@ -2075,14 +2075,14 @@ def test_halo_reshard_conv(
     auto_shard,
 ):
     math_fidelity = ttnn.MathFidelity.HiFi4
-    activations_dtype = ttnn.bfloat16
+    output_dtype = ttnn.bfloat16
     weights_dtype = ttnn.bfloat8_b
 
     run_conv(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -2138,14 +2138,14 @@ def test_conv_core_nondivis(
         pytest.xfail()
 
     math_fidelity = ttnn.MathFidelity.HiFi4
-    activations_dtype = ttnn.bfloat16
+    output_dtype = ttnn.bfloat16
     weights_dtype = ttnn.bfloat8_b
 
     run_conv(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -2190,7 +2190,7 @@ def test_conv_core_nondivis(
     [ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat16],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
@@ -2211,7 +2211,7 @@ def test_conv_dilation(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -2233,7 +2233,7 @@ def test_conv_dilation(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -2253,7 +2253,7 @@ def test_conv_dilation(
         has_bias=False,
         auto_shard=auto_shard,
         enable_split_reader=split_reader,
-        input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
     )
 
 
@@ -2295,7 +2295,7 @@ def test_conv_dilation(
     [ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat8_b, ttnn.bfloat16],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
@@ -2306,7 +2306,7 @@ def test_conv_groups(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -2329,7 +2329,7 @@ def test_conv_groups(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -2346,7 +2346,7 @@ def test_conv_groups(
         groups=groups,
         output_layout=output_layout,
         auto_shard=auto_shard,
-        input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
     )
 
 
@@ -2409,7 +2409,7 @@ def test_conv_groups(
     [ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
@@ -2420,7 +2420,7 @@ def test_yolov4_conv_groups_larger_than_one(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -2439,7 +2439,7 @@ def test_yolov4_conv_groups_larger_than_one(
     output_layout,
     auto_shard,
 ):
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and activations_dtype == ttnn.bfloat8_b:
+    if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat8_b:
         pytest.skip("Row major layout not compatible with bfloat8_b")
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and input_height >= 1056:
         pytest.skip("OOM")
@@ -2447,7 +2447,7 @@ def test_yolov4_conv_groups_larger_than_one(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -2464,7 +2464,7 @@ def test_yolov4_conv_groups_larger_than_one(
         groups=groups,
         output_layout=output_layout,
         auto_shard=auto_shard,
-        input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
     )
 
 
@@ -2482,7 +2482,7 @@ def test_yolov4_conv_groups_larger_than_one(
     [1, 8],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat8_b, ttnn.bfloat16],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
@@ -2493,7 +2493,7 @@ def test_swin_s_conv(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -2520,7 +2520,7 @@ def test_swin_s_conv(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -2537,7 +2537,7 @@ def test_swin_s_conv(
         groups=groups,
         output_layout=output_layout,
         auto_shard=auto_shard,
-        input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
     )
 
 
@@ -2557,7 +2557,7 @@ def test_swin_s_conv(
     [ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
@@ -2567,7 +2567,7 @@ def test_model_k_256x256(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -2588,7 +2588,7 @@ def test_model_k_256x256(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -2605,7 +2605,7 @@ def test_model_k_256x256(
         dilation_h=dilation,
         dilation_w=dilation,
         auto_shard=auto_shard,
-        input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
     )
 
 
@@ -2636,7 +2636,7 @@ def test_model_k_256x256(
     [ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat16, ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
@@ -2646,7 +2646,7 @@ def test_conv_for_vanilla_unet(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -2669,7 +2669,7 @@ def test_conv_for_vanilla_unet(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -2686,7 +2686,7 @@ def test_conv_for_vanilla_unet(
         groups=1,
         output_layout=output_layout,
         has_bias=False,
-        input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
     )
 
 
@@ -2982,7 +2982,7 @@ def test_block_sharding_relu_act_block_h(
 
 # fmt: off
 @pytest.mark.parametrize(
-    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, activations_dtype, groups, kernel, stride, padding, dilation, auto_shard, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, enable_split_reader",
+    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, stride, padding, dilation, auto_shard, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, enable_split_reader",
     (
         # model strawberry
         (1, 10,   64, 1024, 128, ttnn.bfloat8_b, ttnn.bfloat8_b, 1, (4, 4), (2, 2), (1, 1), (1, 1), True, 0, 1, True, ttnn.MathFidelity.LoFi, False, False, False),
@@ -3013,7 +3013,7 @@ def test_conv2d_model_fruit(
     input_height,
     input_width,
     weights_dtype,
-    activations_dtype,
+    output_dtype,
     groups,
     kernel,
     stride,
@@ -3036,7 +3036,7 @@ def test_conv2d_model_fruit(
         device=device,
         torch_tensor_map=torch_tensor_map,
         math_fidelity=math_fidelity,
-        activations_dtype=activations_dtype,
+        output_dtype=output_dtype,
         weights_dtype=weights_dtype,
         batch_size=batch,
         output_channels=output_channels,
@@ -3064,13 +3064,13 @@ def test_conv2d_model_fruit(
         weight_mesh_mapper=None,
         output_mesh_composer=None,
         enable_split_reader=enable_split_reader,
-        input_layout= ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_layout= ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
     )
 
 
 
 @pytest.mark.parametrize(
-    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, activations_dtype, groups, kernel, stride, padding, dilation, auto_shard, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, enable_split_reader, split_input_channels_factor, split_output_channels_factor",
+    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, stride, padding, dilation, auto_shard, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, enable_split_reader, split_input_channels_factor, split_output_channels_factor",
     (
         # 1024x1024 resolution
 
@@ -3126,7 +3126,7 @@ def test_conv2d_sdxl(
     input_height,
     input_width,
     weights_dtype,
-    activations_dtype,
+    output_dtype,
     groups,
     kernel,
     stride,
@@ -3153,7 +3153,7 @@ def test_conv2d_sdxl(
             device,
             torch_tensor_map,
             math_fidelity,
-            activations_dtype,
+            output_dtype,
             weights_dtype,
             batch,
             output_channels,
@@ -3172,14 +3172,14 @@ def test_conv2d_sdxl(
             fp32_accum=fp32_accum,
             packer_l1_acc=packer_l1_acc,
             auto_shard=auto_shard,
-            input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+            input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
         )
     else:
         run_conv(
             device=device,
             torch_tensor_map=torch_tensor_map,
             math_fidelity=math_fidelity,
-            activations_dtype=activations_dtype,
+            output_dtype=output_dtype,
             weights_dtype=weights_dtype,
             batch_size=batch,
             output_channels=output_channels,
@@ -3207,12 +3207,12 @@ def test_conv2d_sdxl(
             weight_mesh_mapper=None,
             output_mesh_composer=None,
             enable_split_reader=enable_split_reader,
-            input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+            input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
         )
 
 
 @pytest.mark.parametrize(
-    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, activations_dtype, groups, kernel, stride, padding, dilation, auto_shard, deallocate_activation, split_factor_input_channels, split_factor_output_channels, slice_type, num_slices",
+    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, stride, padding, dilation, auto_shard, deallocate_activation, split_factor_input_channels, split_factor_output_channels, slice_type, num_slices",
     (
         # 1024x1024 resolution
 
@@ -3252,7 +3252,7 @@ def test_conv2d_vae_sdxl(
     input_height,
     input_width,
     weights_dtype,
-    activations_dtype,
+    output_dtype,
     groups,
     kernel,
     stride,
@@ -3280,7 +3280,7 @@ def test_conv2d_vae_sdxl(
             device,
             torch_tensor_map,
             ttnn.MathFidelity.LoFi,
-            activations_dtype,
+            output_dtype,
             weights_dtype,
             batch,
             output_channels,
@@ -3298,14 +3298,14 @@ def test_conv2d_vae_sdxl(
             split_output_channels_factor=split_factor_output_channels,
             auto_shard=True,
             pcc=0.97,
-            input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+            input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
         )
     else:
         run_conv(
             device=device,
             torch_tensor_map=torch_tensor_map,
             math_fidelity=ttnn.MathFidelity.LoFi,
-            activations_dtype=activations_dtype,
+            output_dtype=output_dtype,
             weights_dtype=weights_dtype,
             batch_size=batch,
             output_channels=output_channels,
@@ -3334,12 +3334,12 @@ def test_conv2d_vae_sdxl(
             output_mesh_composer=None,
             enable_split_reader=False,
             slice_config=slice_config,
-            input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+            input_layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else None,
         )
 
 
 @pytest.mark.parametrize(
-    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, activations_dtype, groups, kernel, stride, padding, dilation, auto_shard, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, enable_split_reader",
+    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, stride, padding, dilation, auto_shard, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, enable_split_reader",
     (
         (1, (1920, 1280, 1920), 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, 0, 1, False, ttnn.MathFidelity.LoFi, False, False, False),
     ),
@@ -3355,7 +3355,7 @@ def test_conv2d_ws_program_cache(
     input_height,
     input_width,
     weights_dtype,
-    activations_dtype,
+    output_dtype,
     groups,
     kernel,
     stride,
@@ -3381,7 +3381,7 @@ def test_conv2d_ws_program_cache(
             device=device,
             torch_tensor_map=torch_tensor_map,
             math_fidelity=math_fidelity,
-            activations_dtype=activations_dtype,
+            output_dtype=output_dtype,
             weights_dtype=weights_dtype,
             batch_size=batch,
             output_channels=output_channels,
@@ -3584,7 +3584,7 @@ def test_conv2d_with_fold(
         torch_tensor_map=torch_tensor_map,
         math_fidelity=ttnn.MathFidelity.LoFi,
         packer_l1_acc = True,
-        activations_dtype=ttnn.bfloat16,
+        output_dtype=ttnn.bfloat16,
         weights_dtype=ttnn.bfloat16,
         batch_size=batch_size,
         output_channels=output_channels,

--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -24,7 +24,7 @@ import torch
     [None, ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
+    "output_dtype",
     [ttnn.bfloat8_b, ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
@@ -54,7 +54,7 @@ def test_conv_features(
     torch_tensor_map,
     use_program_cache,
     math_fidelity,
-    activations_dtype,
+    output_dtype,
     weights_dtype,
     batch_size,
     output_channels,
@@ -74,17 +74,17 @@ def test_conv_features(
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and shard_layout == WS:
         pytest.skip("Bug in Width Sharded Row Major Tensor Creation when height%32!=0. #19408")
 
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and activations_dtype == ttnn.bfloat8_b:
+    if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat8_b:
         pytest.skip("Row major layout not compatible with bfloat8_b")
 
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and activations_dtype == ttnn.bfloat16 and packer_l1_acc and fp32_accum:
+    if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat16 and packer_l1_acc and fp32_accum:
         pytest.skip("skipping due to pack_untilize_dst issue!")
 
     run_conv(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -115,7 +115,7 @@ SliceWidth = ttnn.Conv2dSliceWidth
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize(
-    "batch_size, input_channels, output_channels, input_height, input_width, slice_type, num_slices, weights_dtype, activations_dtype, kernel, stride, padding, dilation, act_block_h_override,  math_fidelity",
+    "batch_size, input_channels, output_channels, input_height, input_width, slice_type, num_slices, weights_dtype, output_dtype, kernel, stride, padding, dilation, act_block_h_override,  math_fidelity",
     # fmt: off
     (
         (2, 512,  512,  128,   128,   SliceWidth,    4,  ttnn.bfloat8_b, ttnn.bfloat16, (3, 3), (1, 1), (1, 1), (1, 1), 32 * 8,  ttnn.MathFidelity.LoFi  ),
@@ -139,7 +139,7 @@ def test_conv_dram(
     input_width,
     has_bias,
     weights_dtype,
-    activations_dtype,
+    output_dtype,
     slice_type,
     num_slices,
     kernel,
@@ -160,7 +160,7 @@ def test_conv_dram(
         device,
         torch_tensor_map,
         math_fidelity,
-        activations_dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,

--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -28,6 +28,10 @@ import torch
     [ttnn.bfloat8_b, ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
+    "input_dtype",
+    [None, ttnn.float32],
+)
+@pytest.mark.parametrize(
     "fp32_accum",
     [True, False],
 )
@@ -65,6 +69,7 @@ def test_conv_features(
     output_layout,
     fp32_accum,
     packer_l1_acc,
+    input_dtype,
 ):
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and shard_layout == WS:
         pytest.skip("Bug in Width Sharded Row Major Tensor Creation when height%32!=0. #19408")
@@ -100,6 +105,7 @@ def test_conv_features(
         preprocess_weights_on_device=True,
         run_twice=True,
         input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_dtype=input_dtype,
     )
 
 

--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -29,7 +29,7 @@ import torch
 )
 @pytest.mark.parametrize(
     "input_dtype",
-    [None, ttnn.float32],
+    [ttnn.bfloat8_b, ttnn.bfloat16, ttnn.float32],
 )
 @pytest.mark.parametrize(
     "fp32_accum",
@@ -104,7 +104,7 @@ def test_conv_features(
         packer_l1_acc=packer_l1_acc,
         preprocess_weights_on_device=True,
         run_twice=True,
-        input_layout=ttnn.TILE_LAYOUT if activations_dtype == ttnn.bfloat8_b else None,
+        input_layout=ttnn.TILE_LAYOUT if input_dtype == ttnn.bfloat8_b else None,
         input_dtype=input_dtype,
     )
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -299,6 +299,7 @@ Result conv2d_DRAM(
                 input_slice_width,
                 compute_grid_size,
                 input_tensor_on_device.layout(),
+                input_tensor_on_device.dtype(),
                 std::make_optional(input_tensor_on_device.memory_config()),
                 kernel_size,
                 groups,
@@ -457,6 +458,7 @@ Result conv2d_L1(
             input_width,
             compute_grid_size,
             input_tensor.layout(),
+            input_tensor.dtype(),
             tt::tt_metal::is_device_tensor(input_tensor) ? std::make_optional(input_tensor.memory_config())
                                                          : std::nullopt,
             kernel_size,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -981,8 +981,8 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
     bool untilize_out = conv_config.output_layout == Layout::ROW_MAJOR;
 
     // Output of halo op is always ROW_MAJOR, so input for convs is either DataType::FLOAT32 or DataType::BFLOAT16
-    auto conv_input_dtype =
-        (input_datatype == tt::tt_metal::DataType::BFLOAT8_B) ? tt_metal::DataType::BFLOAT16 : input_datatype;
+    auto conv_input_dtype = (input_datatype == tt::tt_metal::DataType::FLOAT32) ? tt_metal::DataType::FLOAT32
+                                                                                : tt_metal::DataType::BFLOAT16;
     uint32_t input_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_input_dtype));
 
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -770,6 +770,7 @@ Conv2dConfig determine_conv_config_for_auto_shard(
     uint32_t input_width,
     const CoreCoord& compute_grid_size,
     Layout input_layout,
+    tt_metal::DataType input_datatype,
     std::optional<const MemoryConfig> input_memory_config,
     const std::array<uint32_t, 2>& kernel_size,
     const uint32_t groups,
@@ -868,6 +869,7 @@ Conv2dConfig determine_conv_config_for_auto_shard(
             weights_shape,
             kernel_size,
             conv_config,
+            input_datatype,
             conv_out_memory_config,
             enable_bias,
             conv_is_1d_deptwise);
@@ -972,14 +974,14 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
     const ttnn::Shape& weights_shape,
     std::array<uint32_t, 2> kernel_size,
     const Conv2dConfig& conv_config,
+    const DataType input_datatype,
     const MemoryConfig& output_memory_config,
     const bool enable_bias,
     bool is_1d_depthwise_conv) {
     bool untilize_out = conv_config.output_layout == Layout::ROW_MAJOR;
 
-    // Output of halo op is always ROW_MAJOR, so input for convs is eighter DataType::FLOAT32 or DataType::BFLOAT16
-    const DataType input_dtype = conv_config.dtype == DataType::FLOAT32 ? DataType::FLOAT32 : DataType::BFLOAT16;
-    uint32_t input_tile_size = tt::tile_size(datatype_to_dataformat_converter(input_dtype));
+    // Output of halo op is always ROW_MAJOR, so input for convs is either DataType::FLOAT32 or DataType::BFLOAT16
+    uint32_t input_tile_size = tt::tile_size(datatype_to_dataformat_converter(input_datatype));
 
     TT_FATAL(
         conv_config.weights_dtype.has_value(),

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -981,7 +981,9 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
     bool untilize_out = conv_config.output_layout == Layout::ROW_MAJOR;
 
     // Output of halo op is always ROW_MAJOR, so input for convs is either DataType::FLOAT32 or DataType::BFLOAT16
-    uint32_t input_tile_size = tt::tile_size(datatype_to_dataformat_converter(input_datatype));
+    auto conv_input_dtype =
+        (input_datatype == tt::tt_metal::DataType::BFLOAT8_B) ? tt_metal::DataType::BFLOAT16 : input_datatype;
+    uint32_t input_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_input_dtype));
 
     TT_FATAL(
         conv_config.weights_dtype.has_value(),

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/tensor/types.hpp"
 
 namespace ttnn {
 
@@ -149,6 +150,7 @@ Conv2dConfig determine_conv_config_for_auto_shard(
     uint32_t input_width,
     const CoreCoord& compute_grid_size,
     Layout input_layout,
+    tt::tt_metal::DataType input_datatype,
     std::optional<const MemoryConfig> input_memory_config,
     const std::array<uint32_t, 2>& kernel_size,
     const uint32_t groups,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -285,6 +285,7 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(
             .enable_weights_double_buffer = enable_weights_double_buffer,
             .enable_split_reader = enable_split_reader,
             .enable_subblock_padding = enable_subblock_padding},
+        input_tensor_a.dtype(),
         this->memory_config,
         has_bias,
         is_1d_deptwise_conv(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -342,6 +342,7 @@ conv_op_l1_usage calculate_L1_usage(
     const ttnn::Shape& weights_shape,
     std::array<uint32_t, 2> kernel_size,
     const Conv2dConfig& conv_config,
+    const tt::tt_metal::DataType input_datatype,
     const tt::tt_metal::MemoryConfig& output_memory_config,
     bool enable_bias,
     bool is_1d_depthwise_conv);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -572,6 +572,7 @@ static OptimizedConvBlockConfig get_opt_block_config(
         input_width,
         compute_grid_size,
         input_layout,
+        conv_config.dtype,
         input_memory_config,
         kernel_size,
         groups,

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -122,6 +122,7 @@ Result conv_transpose2d(
             full_input_width,
             compute_grid_size,
             input_tensor.layout(),
+            input_tensor.dtype(),
             tt::tt_metal::is_device_tensor(input_tensor) ? std::make_optional(input_tensor.memory_config())
                                                          : std::nullopt,
             kernel_size,

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -56,8 +56,9 @@ std::vector<TensorSpec> HaloDeviceOperation::compute_output_specs(const std::vec
     log_debug(tt::LogOp, "num_cores_nhw: {}", config_.num_cores_nhw);
 
     const auto& input_tensor = input_tensors.at(0);
-    DataType output_dtype =
-        input_tensor.get_dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_tensor.get_dtype();
+    DataType output_dtype = (input_tensor.get_dtype() == tt::tt_metal::DataType::FLOAT32)
+                                ? tt::tt_metal::DataType::FLOAT32
+                                : tt::tt_metal::DataType::BFLOAT16;
 
     TT_FATAL(
         input_tensor.memory_config().memory_layout() == output_memory_config_.memory_layout(),


### PR DESCRIPTION
### Ticket
#21054 

### Problem description
Calculate L1 fails when input dtype is not output dtype as this function assumes both are the same.

### What's changed
Separately pass input_dtype to calc L1 function.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15341959587)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15341961592) (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15341979344) (if applicable)
- [x] Frequent Models [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15341966837)
- [x] Nightly L2 [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15341971206)
- [x] New/Existing tests provide coverage for changes