### PR TITLE
Upgrade transformers version 

### DIFF
--- a/models/common/utils.py
+++ b/models/common/utils.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+
+def top_k_top_p_filtering(
+    logits: Tensor,
+    top_k: int = 0,
+    top_p: float = 1.0,
+    filter_value: float = -float("Inf"),
+    min_tokens_to_keep: int = 1,
+) -> Tensor:
+    """Filter a distribution of logits using top-k and/or nucleus (top-p) filtering
+    Args:
+        logits: logits distribution shape (batch size, vocabulary size)
+        if top_k > 0: keep only top k tokens with highest probability (top-k filtering).
+        if top_p < 1.0: keep the top tokens with cumulative probability >= top_p (nucleus filtering).
+            Nucleus filtering is described in Holtzman et al. (http://arxiv.org/abs/1904.09751)
+        Make sure we keep at least min_tokens_to_keep per batch example in the output
+    From: https://gist.github.com/thomwolf/1a5a29f6962089e871b94cbd09daf317
+    """
+    if top_k > 0:
+        top_k = min(max(top_k, min_tokens_to_keep), logits.size(-1))  # Safety check
+        # Remove all tokens with a probability less than the last token of the top-k
+        indices_to_remove = logits < torch.topk(logits, top_k)[0][..., -1, None]
+        logits[indices_to_remove] = filter_value
+
+    if top_p < 1.0:
+        sorted_logits, sorted_indices = torch.sort(logits, descending=True)
+        cumulative_probs = torch.cumsum(F.softmax(sorted_logits, dim=-1), dim=-1)
+
+        # Remove tokens with cumulative probability above the threshold (token with 0 are kept)
+        sorted_indices_to_remove = cumulative_probs > top_p
+        if min_tokens_to_keep > 1:
+            # Keep at least min_tokens_to_keep (set to min_tokens_to_keep-1 because we add the first one below)
+            sorted_indices_to_remove[..., :min_tokens_to_keep] = 0
+        # Shift the indices to the right to keep also the first token above the threshold
+        sorted_indices_to_remove[..., 1:] = sorted_indices_to_remove[..., :-1].clone()
+        sorted_indices_to_remove[..., 0] = 0
+
+        # scatter sorted tensors to original indexing
+        indices_to_remove = sorted_indices_to_remove.scatter(1, sorted_indices, sorted_indices_to_remove)
+        logits[indices_to_remove] = filter_value
+    return logits

--- a/models/demos/falcon7b_common/demo/demo.py
+++ b/models/demos/falcon7b_common/demo/demo.py
@@ -12,9 +12,9 @@ import torch.nn.functional as F
 from loguru import logger
 from tqdm import tqdm
 from transformers import AutoTokenizer
-from transformers.generation.utils import top_k_top_p_filtering
 
 import ttnn
+from models.common.utils import top_k_top_p_filtering
 from models.demos.falcon7b_common.tests.test_utils import get_num_devices, initialize_kv_cache, load_hf_model
 from models.demos.falcon7b_common.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.falcon7b_common.tt.model_config import get_model_config

--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -12,9 +12,9 @@ import torch.nn.functional as F
 from loguru import logger
 from tqdm import tqdm
 from transformers import AutoTokenizer
-from transformers.generation.utils import top_k_top_p_filtering
 
 import ttnn
+from models.common.utils import top_k_top_p_filtering
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconConfig, FalconForCausalLM
 from models.demos.t3000.falcon40b.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.t3000.falcon40b.tt.falcon_common import PytorchFalconCausalLM

--- a/models/demos/t3000/llama2_70b/demo/demo.py
+++ b/models/demos/t3000/llama2_70b/demo/demo.py
@@ -11,8 +11,8 @@ import pytest
 import torch
 import torch.nn.functional as F
 from loguru import logger
-from transformers.generation.utils import top_k_top_p_filtering
 
+from models.common.utils import top_k_top_p_filtering
 from models.demos.t3000.llama2_70b.reference.llama.llama import Llama
 from models.demos.t3000.llama2_70b.reference.llama.llama.tokenizer3 import ChatFormat
 from models.demos.t3000.llama2_70b.tt.llama_common import (

--- a/models/demos/t3000/llama2_70b/demo/demo_continuous_batching.py
+++ b/models/demos/t3000/llama2_70b/demo/demo_continuous_batching.py
@@ -10,8 +10,8 @@ import pytest
 import torch
 import torch.nn.functional as F
 from loguru import logger
-from transformers.generation.utils import top_k_top_p_filtering
 
+from models.common.utils import top_k_top_p_filtering
 from models.demos.t3000.llama2_70b.reference.llama.llama import Llama
 from models.demos.t3000.llama2_70b.reference.llama.llama.tokenizer3 import ChatFormat
 from models.demos.t3000.llama2_70b.tt.llama_common import check_mesh_device, load_llama_state_dict, setup_llama_env

--- a/models/demos/t3000/llama2_70b/demo/demo_continuous_batching_paged_attention.py
+++ b/models/demos/t3000/llama2_70b/demo/demo_continuous_batching_paged_attention.py
@@ -10,9 +10,9 @@ import pytest
 import torch
 import torch.nn.functional as F
 from loguru import logger
-from transformers.generation.utils import top_k_top_p_filtering
 
 import ttnn
+from models.common.utils import top_k_top_p_filtering
 from models.demos.t3000.llama2_70b.reference.llama.llama import Llama
 from models.demos.t3000.llama2_70b.reference.llama.llama.tokenizer3 import ChatFormat
 from models.demos.t3000.llama2_70b.tt.llama_common import check_mesh_device, load_llama_state_dict, setup_llama_env

--- a/models/demos/tg/llama3_70b/demo/demo.py
+++ b/models/demos/tg/llama3_70b/demo/demo.py
@@ -11,8 +11,8 @@ import pytest
 import torch
 import torch.nn.functional as F
 from loguru import logger
-from transformers.generation.utils import top_k_top_p_filtering
 
+from models.common.utils import top_k_top_p_filtering
 from models.demos.t3000.llama2_70b.reference.llama.llama import Llama
 from models.demos.t3000.llama2_70b.reference.llama.llama.tokenizer3 import ChatFormat
 from models.demos.t3000.llama2_70b.tt.llama_common import (

--- a/models/demos/wormhole/mistral7b/tests/test_mistral_torch.py
+++ b/models/demos/wormhole/mistral7b/tests/test_mistral_torch.py
@@ -10,7 +10,7 @@ from models.demos.wormhole.mistral7b.reference.tokenizer import Tokenizer
 from models.demos.wormhole.mistral7b.tt.mistral_common import precompute_freqs
 from models.demos.wormhole.mistral7b.tt.model_config import TtModelArgs
 
-# from transformers.generation.utils import top_k_top_p_filtering
+# from models.common.utils import top_k_top_p_filtering
 
 
 class Emb(torch.nn.Module):

--- a/models/generation_utils.py
+++ b/models/generation_utils.py
@@ -5,13 +5,12 @@
 import torch
 from loguru import logger
 from transformers.generation.configuration_utils import GenerationConfig
-from transformers.generation.logits_process import (
+from transformers.generation.logits_process import (  # ForceTokensLogitsProcessor,
     EncoderNoRepeatNGramLogitsProcessor,
     EncoderRepetitionPenaltyLogitsProcessor,
     ExponentialDecayLengthPenalty,
     ForcedBOSTokenLogitsProcessor,
     ForcedEOSTokenLogitsProcessor,
-    ForceTokensLogitsProcessor,
     HammingDiversityLogitsProcessor,
     InfNanRemoveLogitsProcessor,
     LogitNormalization,
@@ -151,6 +150,9 @@ def _get_logits_processor(
             begin_index += generation_config.forced_decoder_ids[-1][0]
         processors.append(SuppressTokensAtBeginLogitsProcessor(generation_config.begin_suppress_tokens, begin_index))
     if generation_config.forced_decoder_ids is not None:
+        assert (
+            False
+        ), "ForceTokensLogitsProcessor was removed from HuggingFace in 2024, please update your code (https://github.com/huggingface/transformers/pull/29487)"
         processors.append(ForceTokensLogitsProcessor(generation_config.forced_decoder_ids))
     processors = _merge_criteria_processor_list(processors, logits_processor)
     # `LogitNormalization` should always be the last logit processor, when present

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -34,6 +34,10 @@ git+https://github.com/tenstorrent/llama-models.git@tt_metal_tag
 # For Mistral-7B-v0.3 demo tests
 protobuf==3.20.0
 
+# For TT-Transformers Qwen3 support
+transformers == 4.51.3
+huggingface-hub >= 0.30.0
+
 # testing
 pytest==7.2.2
 pytest-timeout==2.2.0
@@ -49,7 +53,6 @@ torchvision==0.17.1+cpu ; platform_machine == 'x86_64'
 torchvision==0.17.1 ; platform_machine == 'aarch64'
 torchmetrics==1.3.1
 torch-fidelity==0.3.0
-transformers==4.38.0
 xlsxwriter==3.0.8
 tiktoken==0.3.3
 tqdm==4.66.3
@@ -76,7 +79,6 @@ docopt==0.6.2
 tabulate==0.9.0
 blobfile==2.1.1 # Required for llama3
 numpy>=1.24.4,<2
-huggingface-hub==0.25.2
 pydantic==2.9.2 # Required for Superset benchmarking
 fiftyone==0.25.2 # Required for Yolo benchmarking
 jiwer==3.0.5 # Required for speech recognition evaluation


### PR DESCRIPTION
### Ticket
[22607](https://github.com/tenstorrent/tt-metal/issues/22607)

### Problem description
Our current HuggingFace transformers version is 18 months old. Many models rely on a more recent version and updating to `transformers == 4.51.3` is a hard requirement for Qwen 3 support.

The `transformers` library has changed significantly since our last update, such that several of our model tests rely on functionality that has been removed or dramatically changed, making updating this a non-trivial task in terms of code changes and retesting required, hence breaking it out into its own issue independent of [#21822](https://github.com/tenstorrent/tt-metal/issues/21822)

Work is ongoing on `yieldthought/upgrade-transformers` but may require input from other teams / test owners.

### What's changed
- Updated the version of `transformers` and `huggingface-hub` in requirements-dev.txt
- Reimplemented top_p_top_k_filtering function
- Removed `ForceTokensLogitsProcessor` and added an assert in case the functionality is actually used (inspection suggests it isn't but playing it safe - @nemanjagrujic can we remove this entirely? It'd be much cleaner)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes