### PR TITLE
Fix L1 OOM for Llama 8B and Mistral 7B on N150

### DIFF
--- a/models/tt_transformers/tests/test_mlp.py
+++ b/models/tt_transformers/tests/test_mlp.py
@@ -34,13 +34,6 @@ from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
     (1,),
 )
 def test_mlp_inference(seq_len, batch_size, mesh_device, use_program_cache, reset_seeds, ensure_gc):
-    # TODO Fix long seqlen for Mistral-7B
-    model_name_env = os.getenv("HF_MODEL")
-    if seq_len >= 1024 and model_name_env and "Mistral-7B" in model_name_env:
-        pytest.skip(
-            "Mistral-7B models do not support seq_len >= 1024, See issue: https://github.com/tenstorrent/tt-metal/issues/19806"
-        )
-
     dtype = ttnn.bfloat8_b
     mode = "decode" if seq_len <= 32 else "prefill"
 

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -589,6 +589,10 @@ class ModelArgs:
             max_prefill_chunk_size_div1024 = int(max_prefill_chunk_size_div1024)
         self.max_prefill_chunk_size = max_prefill_chunk_size_div1024 * 1024
 
+        if self.base_model_name in ["Llama3.1-8B", "Llama3.2-11B", "Mistral-7B"] and self.device_name == "N150":
+            logger.info(f"Reducing prefill_len_cutoff to 512 for {self.model_name} on {self.device_name}")
+            self.prefill_len_cutoff = 512
+
         if callable(optimizations):
             self.optimizations = optimizations(self)
         else:


### PR DESCRIPTION
### Ticket
#19806

### Problem description
Models with large MLPs were running out of L1 when trying to prefill a seqlen of 1024 rows.

### What's changed
Specifically for the problem models the prefill seqlen block size is reduced from 1024 rows to 512 rows. This affects Llama-3.1-8B and Mistral-7B-v0.3

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes