### PR TITLE
Bump UMD, remove CEM

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -227,13 +227,6 @@ void Cluster::generate_cluster_descriptor() {
             this->cluster_desc_->get_all_chips().size(),
             total_num_hugepages);
     }
-
-    if (this->arch_ == tt::ARCH::WORMHOLE_B0 and not this->is_galaxy_cluster()) {
-        // Give UMD Limited access to eth cores 8 and 9 for Non-Galaxy Wormhole Clusters
-        for (const auto& mmio_device_id : driver_->get_target_mmio_device_ids()) {
-            driver_->configure_active_ethernet_cores_for_mmio_device(mmio_device_id, {});
-        }
-    }
 }
 
 void Cluster::validate_harvesting_masks() const {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-umd/issues/856

### Problem description
Main motivation for this bump is removing luwen's create-ethernet-map.

### What's changed
- Remove configure_active_ethernet_cores_for_mmio_device call, since it is both unnecessary and wrong now, we do want to have cores 8 and 9 configured.
Changes in UMD since the last bump:
- New version of yaml-cpp and cxxopts
- By default use only connected (active) eth cores for remote communication.
- Added harvesting tool which prints all cores
- Removed CEM and switched to UMD's topology discovery

### Checklist
All runs on brosko/remove_cem :
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15273539721
- [x] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15273542340
- [x] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/15273545022
- [x] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/15273547542
- [x] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15273549946
- [ ] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/15273552684
- [x] (TG) TG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15273555116
- [x] (TG) TG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/15273557613