### PR TITLE
Remove SLOW_MATMULS from stable_diffusion

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -147,7 +147,7 @@ jobs:
       matrix:
         test-config:
           - model: "stable_diffusion"
-            cmd: SLOW_MATMULS=1 pytest --timeout 1000 -n auto tests/nightly/single_card/stable_diffusion
+            cmd: pytest --timeout 1000 -n auto tests/nightly/single_card/stable_diffusion
               # Skipping due to issue #15932
               # - model: "mamba 1"
               # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 1

--- a/models/demos/wormhole/stable_diffusion/demo/demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/demo.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import os
 import time
 
 import numpy as np
@@ -84,8 +83,6 @@ def run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inferen
     device.enable_program_cache()
     profiler.clear()
 
-    # Until di/dt issues are resolved
-    os.environ["SLOW_MATMULS"] = "1"
     assert (
         num_inference_steps >= 4
     ), f"PNDMScheduler only supports num_inference_steps >= 4. Found num_inference_steps={num_inference_steps}"
@@ -262,8 +259,6 @@ def run_interactive_demo_inference(device, num_inference_steps, image_size=(256,
     enable_persistent_kernel_cache()
     device.enable_program_cache()
 
-    # Until di/dt issues are resolved
-    os.environ["SLOW_MATMULS"] = "1"
     assert (
         num_inference_steps >= 4
     ), f"PNDMScheduler only supports num_inference_steps >= 4. Found num_inference_steps={num_inference_steps}"
@@ -428,9 +423,6 @@ def run_demo_inference_diffusiondb(
 ):
     enable_persistent_kernel_cache()
     device.enable_program_cache()
-
-    # Until di/dt issues are resolved
-    os.environ["SLOW_MATMULS"] = "1"
 
     assert (
         num_inference_steps >= 4

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
@@ -56,8 +56,6 @@ def create_model_pipeline(device, num_inference_steps, image_size=(256, 256)):
     disable_persistent_kernel_cache()
     device.enable_program_cache()
 
-    # Until di/dt issues are resolved
-    os.environ["SLOW_MATMULS"] = "1"
     assert (
         num_inference_steps >= 4
     ), f"PNDMScheduler only supports num_inference_steps >= 4. Found num_inference_steps={num_inference_steps}"

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -330,7 +330,6 @@ def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
         if "WH_ARCH_YAML" in os.environ:
             wh_arch_yaml_backup = os.environ["WH_ARCH_YAML"]
         os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-        os.environ["SLOW_MATMULS"] = "1"
 
     post_processed_results = run_device_perf(command, subdir, iterations, cols, batch, has_signposts=True)
     expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols, assert_on_fail=True)

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -311,7 +311,7 @@ def test_stable_diffusion_perf(
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_second",
-    ((9.8),),
+    ((10.5),),
 )
 def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
     subdir = "ttnn_stable_diffusion"

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_cross_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_cross_attention.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
-import os
 
 import torch
 
@@ -288,10 +287,6 @@ class cross_attention:
 
             out_subblock_h = 1
             out_subblock_w = 8
-            self.slow_mm = os.environ.get("SLOW_MATMULS", "0") == "1"
-            if self.slow_mm:
-                out_subblock_h = 1
-                out_subblock_w = 1
             self.program_configs["tsa_qkt"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=self.tsa_grid_size,
                 in0_block_w=self.key_len // 32,
@@ -312,9 +307,6 @@ class cross_attention:
             )
             out_subblock_h = tiles_per_shard
             out_subblock_w = self.key_len // 32
-            if self.slow_mm:
-                out_subblock_h = 1
-                out_subblock_w = 1
             self.program_configs["tsa_v"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=self.tsa_grid_size,
                 in0_block_w=seq_len // 32,
@@ -588,10 +580,6 @@ class cross_attention:
 
             out_subblock_h = 1 if hs else self.out_subblock_hs[size]
             out_subblock_w = 2 if hs else 1
-
-            if self.slow_mm:
-                out_subblock_h = 1
-                out_subblock_w = 1
 
             program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=grid_size,

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_feedforward.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_feedforward.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import math
-import os
 
 import torch
 
@@ -51,8 +50,6 @@ class feedforward:
         self.grid_sizes = {8192: (5, 8), 2048: (5, 8), 512: (8, 8), 128: (8, 4)}
         self.out_subblock_hs = {8192: 8, 2048: 8, 512: 2, 128: 1}
 
-        self.slow_mm = os.environ.get("SLOW_MATMULS", "0") == "1"
-
     def __call__(self, config, hidden_states):
         hidden_states = self.geglu(config, hidden_states)
 
@@ -65,8 +62,7 @@ class feedforward:
         out_block_h = math.ceil(M / grid_size[1] / 32)
         out_block_w = math.ceil(N / grid_size[0] / 32)
         out_subblock_h, out_subblock_w = determine_largest_subblock_size(out_block_h, out_block_w)
-        # TODO: https://github.com/tenstorrent/tt-metal/issues/7560
-        if size == 512 or self.slow_mm:
+        if size == 512:
             out_subblock_h = 1
             out_subblock_w = 1
         program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_utility_functions.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_utility_functions.py
@@ -198,13 +198,7 @@ def determine_blocking(M, K, N, grid_size, transpose_mcast=False):
     out_block_h = math.ceil(M / logical_grid_size[1] / 32)
     out_block_w = math.ceil(N / logical_grid_size[0] / 32)
     out_subblock_h, out_subblock_w = determine_largest_subblock_size(out_block_h, out_block_w)
-    # TODO: https://github.com/tenstorrent/tt-metal/issues/7560
-    # There's a bug that causes an ND hang, until it's solved reduce subblock sizes to 1, if we're not
-    import os
 
-    if os.environ.get("SLOW_MATMULS", "0") == "1":
-        out_subblock_h = 1
-        out_subblock_w = 1
     return in0_block_h, in0_block_w, out_subblock_h, out_subblock_w, out_block_h, out_block_w
 
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11449

### Problem description
Currently slow matmuls are enabled because di/dt issues were present: https://github.com/tenstorrent/tt-metal/issues/7560

### What's changed
- removed `SLOW_MATMULS` flag from stable_diffusion
- increased expected samples per second for perf testing

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15271468485)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15271475637)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15271431175)
- [x] [(Single-card) Frequent model and ttnn tests pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15271461345)