### PR TITLE
Improved how we provide the << operator for Layout

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_morehdot.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_morehdot.cpp
@@ -113,7 +113,7 @@ TEST_F(TestGraphCaptureArgumentsMorehDot, MorehDot) {
     EXPECT_EQ(operation3.arguments.size(), 5);
     EXPECT_EQ(operation3.arguments[0], "Shape([1, 1, 1, 1])");
     EXPECT_EQ(operation3.arguments[1], "DataType::BFLOAT16");
-    EXPECT_EQ(operation3.arguments[2], "Tile");
+    EXPECT_EQ(operation3.arguments[2], "Layout::TILE");
     EXPECT_EQ(operation3.arguments[3], "[ unsupported type , std::reference_wrapper<tt::tt_metal::IDevice*>]");
     EXPECT_EQ(
         operation3.arguments[4],

--- a/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_transpose.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_transpose.cpp
@@ -93,7 +93,7 @@ TEST_F(TestGraphCaptureArgumentsTranspose, Transpose) {
     EXPECT_EQ(operation3.arguments.size(), 5);
     EXPECT_EQ(operation3.arguments[0], "Shape([1, 2048, 1, 512])");
     EXPECT_EQ(operation3.arguments[1], "DataType::BFLOAT16");
-    EXPECT_EQ(operation3.arguments[2], "Row Major");
+    EXPECT_EQ(operation3.arguments[2], "Layout::ROW_MAJOR");
     EXPECT_EQ(operation3.arguments[3], "[ unsupported type , std::reference_wrapper<tt::tt_metal::IDevice*>]");
     EXPECT_EQ(
         operation3.arguments[4],

--- a/tests/ttnn/unit_tests/test_graph_capture.py
+++ b/tests/ttnn/unit_tests/test_graph_capture.py
@@ -94,7 +94,7 @@ def test_graph_capture_with_all_parameters(device):
     node7 = captured_graph[7]["arguments"]
     assert node7[0] == "Shape([1, 4, 2048, 128])"
     assert node7[1] == "DataType::BFLOAT16"
-    assert node7[2] == "Row Major"
+    assert node7[2] == "Layout::ROW_MAJOR"
     assert node7[3] == "[ unsupported type , std::reference_wrapper<tt::tt_metal::IDevice*>]"
     assert (
         node7[4]
@@ -171,7 +171,7 @@ def test_graph_capture_without_memory_config(device):
     node10 = captured_graph[10]["arguments"]
     assert node10[0] == "Shape([1, 1, 1, 1])"
     assert node10[1] == "DataType::BFLOAT16"
-    assert node10[2] == "Tile"
+    assert node10[2] == "Layout::TILE"
     assert node10[3] == "[ unsupported type , std::reference_wrapper<tt::tt_metal::IDevice*>]"
     assert (
         node10[4]
@@ -223,7 +223,7 @@ def test_graph_capture_without_dtype(device):
     node7 = captured_graph[7]["arguments"]
     assert node7[0] == "Shape([32, 32])"
     assert node7[1] == "DataType::INT32"
-    assert node7[2] == "Tile"
+    assert node7[2] == "Layout::TILE"
     assert node7[3] == "[ unsupported type , std::reference_wrapper<tt::tt_metal::IDevice*>]"
     assert (
         node7[4]
@@ -330,7 +330,7 @@ def test_graph_capture_with_all_parameters_json_output(device):
     arg0_item3 = item3["arguments"][0]["arg0"]
     assert arg0_item3["Shape"] == [1, 4, 2048, 128]
     assert item3["arguments"][1]["arg1"] == "DataType::BFLOAT16"
-    assert item3["arguments"][2]["arg2"] == "Row Major"
+    assert item3["arguments"][2]["arg2"] == "Layout::ROW_MAJOR"
     assert item3["arguments"][3]["arg3"] == "[ unsupported type , std::reference_wrapper<tt::tt_metal::IDevice*>]"
 
     arg4_item3 = item3["arguments"][4]["arg4"]
@@ -501,7 +501,7 @@ def test_graph_capture_without_memory_config_json_output(device):
     arg0_item3 = item3["arguments"][0]["arg0"]
     assert arg0_item3["Shape"] == [1, 1, 1, 1]
     assert item3["arguments"][1]["arg1"] == "DataType::BFLOAT16"
-    assert item3["arguments"][2]["arg2"] == "Tile"
+    assert item3["arguments"][2]["arg2"] == "Layout::TILE"
     assert item3["arguments"][3]["arg3"] == "[ unsupported type , std::reference_wrapper<tt::tt_metal::IDevice*>]"
 
     arg4_item3 = item3["arguments"][4]["arg4"]
@@ -623,7 +623,7 @@ def test_graph_capture_without_dtype_json_output(device):
     # arg1
     assert item3["arguments"][1]["arg1"] == "DataType::INT32"
     # arg2
-    assert item3["arguments"][2]["arg2"] == "Tile"
+    assert item3["arguments"][2]["arg2"] == "Layout::TILE"
     # arg3
     assert item3["arguments"][3]["arg3"] == "[ unsupported type , std::reference_wrapper<tt::tt_metal::IDevice*>]"
 

--- a/ttnn/api/ttnn/tensor/types.hpp
+++ b/ttnn/api/ttnn/tensor/types.hpp
@@ -158,6 +158,8 @@ std::ostream& operator<<(std::ostream& os, const MemoryConfig& config);
 bool operator==(const MemoryConfig& config_a, const MemoryConfig& config_b);
 bool operator!=(const MemoryConfig& config_a, const MemoryConfig& config_b);
 
+std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Layout& layout);
+
 }  // namespace tt_metal
 }  // namespace tt
 

--- a/ttnn/core/graph/graph_argument_serializer.cpp
+++ b/ttnn/core/graph/graph_argument_serializer.cpp
@@ -9,14 +9,6 @@
 #include <boost/algorithm/string/replace.hpp>
 
 namespace ttnn::graph {
-std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Layout& layout) {
-    switch (layout) {
-        case Layout::ROW_MAJOR: return os << "Row Major";
-        case Layout::TILE: return os << "Tile";
-        case Layout::INVALID: return os << "Invalid";
-        default: return os << "Unknown layout";
-    }
-}
 
 std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Tile& config) {
     tt::stl::reflection::operator<<(os, config);

--- a/ttnn/core/tensor/types.cpp
+++ b/ttnn/core/tensor/types.cpp
@@ -111,6 +111,15 @@ std::ostream& operator<<(std::ostream& os, const MemoryConfig& config) {
     return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Layout& layout) {
+    switch (layout) {
+        case Layout::ROW_MAJOR: return os << "Layout::ROW_MAJOR";
+        case Layout::TILE: return os << "Layout::TILE";
+        case Layout::INVALID: return os << "Layout::INVALID";
+        default: return os << "Layout::UNKNOWN";
+    }
+}
+
 }  // namespace tt::tt_metal
 
 nlohmann::json tt::stl::json::to_json_t<tt::tt_metal::MemoryConfig>::operator()(


### PR DESCRIPTION
Improved how we provide the << operator for Layout
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/19459)

### Problem description
Originally we provided a way to overload the operator << just for the graph tracing tool, but other products could benefit from that logic.

### What's changed
Now the << operator in Layout is accessible from any api consumer and not just the graph tool. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes