### PR TITLE
Sequence length is an integer, not a tensor

### DIFF
--- a/models/demos/llama3_subdevices/tt/generator.py
+++ b/models/demos/llama3_subdevices/tt/generator.py
@@ -27,7 +27,7 @@ from models.tt_transformers.tt.common import (
 from models.tt_transformers.tt.generator import SamplingParams
 
 
-def get_padded_prefill_len(seq_len):
+def get_padded_prefill_len(seq_len: int) -> int:
     """
     Get the padded prefill length for a given sequence length.
     This is used to pad the sequence length to the nearest power of 2.
@@ -91,7 +91,7 @@ class Generator:
 
         for user_id in range(batch):
             logger.info(f"Prefilling User {user_id + 1}")
-            seq_len = prompt_lens[user_id]
+            seq_len = int(prompt_lens[user_id])
             last_token_idx = seq_len - 1
 
             prefill_seq_len = get_padded_prefill_len(seq_len)

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -409,7 +409,7 @@ def sample_host(tt_input, temperature=0.6, top_p=0.08, on_host=True):
     return None, pt_out
 
 
-def get_padded_prefill_len(seq_len):
+def get_padded_prefill_len(seq_len: int) -> int:
     """
     If seq_len is less than 128, pad to 128
     If seq_len is more than 128, pad to whichever is smaller: a power of 2 or a multiple of 2048

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -104,7 +104,7 @@ class Generator:
             group_user_id = idx // self.data_parallel
             user_id = group_user_id + model_id * batch_per_device
 
-            seq_len = prompt_lens[user_id]
+            seq_len = int(prompt_lens[user_id])
             last_token_idx = seq_len - 1
 
             # Since we give unpadded_seq_len, only the tile containing the last token is returned
@@ -504,7 +504,7 @@ class Generator:
                 user_id = group_user_id + model_id * batch_per_device
 
                 logger.info(f"Prefilling User {user_id + 1}")
-                seq_len = prompt_lens[user_id]
+                seq_len = int(prompt_lens[user_id])
                 user_page_table = page_table[model_id] if page_table is not None else None
                 user_kv_cache = kv_cache[model_id] if kv_cache is not None else None
                 user_cross_page_table = cross_page_table[model_id] if kv_cache is not None else None

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -76,7 +76,7 @@ class Generator:
                 user_id = group_user_id + model_id * batch_per_device
 
                 logger.info(f"Prefilling User {user_id + 1}")
-                seq_len = prompt_lens[user_id]
+                seq_len = int(prompt_lens[user_id])
                 last_token_idx = seq_len - 1
 
                 prefill_seq_len = get_padded_prefill_len(seq_len)


### PR DESCRIPTION
### Ticket
n/a

### Problem description
llama3_subdevices crash for sequence lengths over 1024

### What's changed
Make sure that sequence length is an integer

### Checklist
- [ ✅ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15274420179)
- [ ✅ ] [(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/15274427545)