### PR TITLE
llama3_subdevices require transformers 4.43.0

### DIFF
--- a/models/demos/llama3_subdevices/requirements.txt
+++ b/models/demos/llama3_subdevices/requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/tenstorrent/llama-models.git@tt_metal_tag
+transformers >= 4.43.0


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21913

### Problem description
In order to load HuggingFace weights and configure rope properly, we need transformers at least at 4.43.0 (commit 2e11342)

### What's changed
Update requirements.txt in llama3_subdevices

### Checklist
- [ ✅ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15274866228)
- [ ✅ ] [(TG) TG demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/15274881506)