### PR TITLE
Philei/fix big buffer overflow

### DIFF
--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -236,11 +236,13 @@ public:
 
     // Returns address of buffer in the first bank
     uint32_t address() const;
+    uint64_t address_u64() const;
 
     DeviceAddr page_size() const;
     void set_page_size(DeviceAddr page_size);
 
     uint32_t num_pages() const;
+    uint64_t num_pages_u64() const;
     uint32_t num_dev_pages() const;
 
     BufferType buffer_type() const { return buffer_type_; }
@@ -258,9 +260,9 @@ public:
 
     bool bottom_up() const { return bottom_up_; }
 
-    DeviceAddr page_address(uint32_t bank_id, uint32_t page_index) const;
+    DeviceAddr page_address(uint64_t bank_id, uint64_t page_index) const;
 
-    DeviceAddr bank_local_page_address(uint32_t bank_id, uint32_t page_index) const;
+    DeviceAddr bank_local_page_address(uint64_t bank_id, uint64_t page_index) const;
     uint32_t alignment() const;
     DeviceAddr aligned_page_size() const;
     DeviceAddr aligned_size() const;

--- a/tt_metal/api/tt-metalium/math.hpp
+++ b/tt_metal/api/tt-metalium/math.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,6 +6,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <type_traits>
 
 namespace tt {
 
@@ -20,9 +21,11 @@ namespace tt {
  *
  * @note If b is zero, this results in undefined behavior.
  */
-constexpr uint32_t div_up(uint32_t a, uint32_t b) {
+template <typename A, typename B>
+constexpr auto div_up(A a, B b) noexcept -> std::common_type_t<A, B> {
+    using T = std::common_type_t<A, B>;
     assert(b != 0 && "Divide by zero error in div_up");
-    return static_cast<uint32_t>((a + b - 1) / b);
+    return static_cast<T>((static_cast<T>(a) + static_cast<T>(b) - 1) / static_cast<T>(b));
 }
 
 /**
@@ -36,8 +39,11 @@ constexpr uint32_t div_up(uint32_t a, uint32_t b) {
  *
  * @note Internally uses div_up. If b is zero, this results in undefined behavior.
  */
-constexpr uint32_t round_up(uint32_t a, uint32_t b) { return b * div_up(a, b); }
-
+template <typename A, typename B>
+constexpr auto round_up(A a, B b) {
+    using T = std::common_type_t<A, B>;
+    return static_cast<T>(b) * div_up(static_cast<T>(a), static_cast<T>(b));
+}
 /**
  * @brief Rounds down a to the nearest multiple of b.
  *
@@ -49,6 +55,10 @@ constexpr uint32_t round_up(uint32_t a, uint32_t b) { return b * div_up(a, b); }
  *
  * @note If b is zero, this results in undefined behavior.
  */
-constexpr uint32_t round_down(uint32_t a, uint32_t b) { return a / b * b; }
+template <typename A, typename B>
+constexpr auto round_down(A a, B b) {
+    using T = std::common_type_t<A, B>;
+    return static_cast<T>(b) * (static_cast<T>(a) / static_cast<T>(b));
+}
 
 }  // namespace tt

--- a/tt_metal/api/tt-metalium/tt_align.hpp
+++ b/tt_metal/api/tt-metalium/tt_align.hpp
@@ -1,13 +1,28 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 
 namespace tt {
 
-inline constexpr uint32_t align(uint32_t addr, uint32_t alignment) { return ((addr - 1) | (alignment - 1)) + 1; }
+template <typename A, typename B>
+inline constexpr auto align(A addr, B alignment) {
+    if constexpr (std::is_pointer_v<A>) {
+        using P = A;  // Preserve pointer type
+        using T = std::common_type_t<std::uintptr_t, B>;
+
+        std::uintptr_t addr_int = reinterpret_cast<std::uintptr_t>(addr);
+        T result = ((static_cast<T>(addr_int) - 1) | (static_cast<T>(alignment) - 1)) + 1;
+
+        return reinterpret_cast<P>(static_cast<std::uintptr_t>(result));
+    } else {
+        using T = std::common_type_t<A, B>;
+        return ((static_cast<T>(addr) - 1) | (static_cast<T>(alignment) - 1)) + 1;
+    }
+}
 
 }  // namespace tt

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -315,7 +315,7 @@ uint32_t EncodePerDeviceProgramID(uint32_t base_program_id, uint32_t device_id, 
  * | [DRAM_UNRESERVED_BASE, dram_size)         | Yes      | | host_buffer  | Buffer on host to copy data from |
  * std::vector<uint32_t> | Host buffer must be fully fit DRAM buffer | Yes      |
  */
-bool WriteToDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t address, std::vector<uint32_t>& host_buffer);
+bool WriteToDeviceDRAMChannel(IDevice* device, int dram_channel, uint64_t address, std::vector<uint32_t>& host_buffer);
 
 /**
  * Copy data from a device DRAM channel to a host buffer
@@ -333,7 +333,7 @@ bool WriteToDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t addres
  * | Buffer on host to copy data into                             | std::vector<uint32_t> | | Yes      |
  */
 bool ReadFromDeviceDRAMChannel(
-    IDevice* device, int dram_channel, uint32_t address, uint32_t size, std::vector<uint32_t>& host_buffer);
+    IDevice* device, int dram_channel, uint64_t address, uint32_t size, std::vector<uint32_t>& host_buffer);
 
 /**
  * Copy data from a host buffer into an L1 buffer. (Note: Current Can not be a CircularBuffer.)

--- a/tt_metal/api/tt-metalium/util.hpp
+++ b/tt_metal/api/tt-metalium/util.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -34,7 +34,7 @@ inline DeviceAddr SizeBytesPerBank(
         size_bytes);
     DeviceAddr num_pages = page_size_bytes == 0 ? 0 : size_bytes / page_size_bytes;
     DeviceAddr num_equally_distributed_pages = num_pages == 0 ? 0 : 1 + ((num_pages - 1) / num_banks);
-    return num_equally_distributed_pages * round_up(page_size_bytes, alignment_bytes);
+    return num_equally_distributed_pages * round_up(page_size_bytes, static_cast<uint64_t>(alignment_bytes));
 }
 
 inline NOC GetPreferredNOCForDRAMRead(ARCH arch) {

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -412,7 +412,7 @@ void FDMeshCommandQueue::write_shard_to_device(
                     DeviceMemoryAddress{
                         .device_coord = device_coord,
                         .virtual_core_coord = virtual_core,
-                        .address = shard_view->address() + chunk_mapping_in_bytes.dst},
+                        .address = shard_view->address_u64() + chunk_mapping_in_bytes.dst},
                     (char*)src + chunk_mapping_in_bytes.src,
                     chunk_mapping_in_bytes.size,
                     /*blocking=*/false,

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -484,6 +484,13 @@ uint32_t Buffer::address() const {
     return address_;
 }
 
+uint64_t Buffer::address_u64() const {
+    TT_FATAL(
+        allocation_status_ != AllocationStatus::ALLOCATION_REQUESTED,
+        "Can only query the address of a buffer that has been allocated");
+    return address_;
+}
+
 DeviceAddr Buffer::page_size() const { return page_size_; }
 
 void Buffer::set_page_size(DeviceAddr page_size) {
@@ -495,6 +502,7 @@ void Buffer::set_page_size(DeviceAddr page_size) {
 }
 
 uint32_t Buffer::num_pages() const { return page_size() == 0 ? 0 : size() / page_size(); }
+uint64_t Buffer::num_pages_u64() const { return page_size() == 0 ? 0 : size() / page_size(); }
 
 uint32_t Buffer::num_dev_pages() const {
     if (!is_sharded(this->buffer_layout_)) {
@@ -536,29 +544,29 @@ bool Buffer::is_valid_partial_region(const BufferRegion& region) const {
     return this->is_valid_region(region) && (region.offset > 0 || region.size != this->size());
 }
 
-DeviceAddr Buffer::page_address(uint32_t bank_id, uint32_t page_index) const {
-    uint32_t num_banks = allocator_->get_num_banks(buffer_type_);
+DeviceAddr Buffer::page_address(uint64_t bank_id, uint64_t page_index) const {
+    uint64_t num_banks = static_cast<uint64_t>(allocator_->get_num_banks(buffer_type_));
     TT_FATAL(bank_id < num_banks, "Invalid Bank ID: {} exceeds total numbers of banks ({})!", bank_id, num_banks);
-    int pages_offset_within_bank = (int)page_index / num_banks;
-    auto offset = (round_up(this->page_size(), this->alignment()) * pages_offset_within_bank);
+    uint64_t pages_offset_within_bank = page_index / num_banks;
+    auto offset = (round_up(this->page_size(), static_cast<uint64_t>(this->alignment())) * pages_offset_within_bank);
     return translate_page_address(offset, bank_id);
 }
 
-DeviceAddr Buffer::bank_local_page_address(uint32_t bank_id, uint32_t page_index) const {
-    uint32_t num_banks = allocator_->get_num_banks(buffer_type_);
+DeviceAddr Buffer::bank_local_page_address(uint64_t bank_id, uint64_t page_index) const {
+    uint64_t num_banks = static_cast<uint64_t>(allocator_->get_num_banks(buffer_type_));
     TT_FATAL(bank_id < num_banks, "Invalid Bank ID: {} exceeds total numbers of banks ({})!", bank_id, num_banks);
-    uint32_t offset;
+    DeviceAddr offset;
     if (is_sharded(this->buffer_layout())) {
         // TODO: Revist for ND sharding
         auto shard_spec = this->shard_spec();
         // TODO: This logic assumes only one shard per core
-        uint32_t pages_offset_within_bank = page_index % shard_spec.num_pages();
-        offset = (round_up(this->page_size(), this->alignment()) * pages_offset_within_bank);
+        DeviceAddr pages_offset_within_bank = page_index % shard_spec.num_pages();
+        offset = (round_up(this->page_size(), static_cast<uint64_t>(this->alignment())) * pages_offset_within_bank);
     } else {
-        uint32_t pages_offset_within_bank = page_index / num_banks;
-        offset = (round_up(this->page_size(), this->alignment()) * pages_offset_within_bank);
+        DeviceAddr pages_offset_within_bank = page_index / num_banks;
+        offset = (round_up(this->page_size(), static_cast<uint64_t>(this->alignment())) * pages_offset_within_bank);
     }
-    return this->address() + offset;
+    return this->address_u64() + offset;
 }
 
 uint32_t Buffer::alignment() const { return allocator_->get_alignment(this->buffer_type()); }
@@ -671,7 +679,7 @@ std::array<uint32_t, 2> ShardSpecBuffer::shape_in_pages() const {
 
 DeviceAddr ShardSpecBuffer::num_pages() const {
     auto shape_in_pages_ = this->shape_in_pages();
-    return shape_in_pages_[0] * shape_in_pages_[1];
+    return static_cast<DeviceAddr>(shape_in_pages_[0]) * static_cast<DeviceAddr>(shape_in_pages_[1]);
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -71,19 +71,19 @@ struct BufferReadDispatchParams {
     tt::stl::Span<const uint32_t> expected_num_workers_completed;
     uint32_t cq_id = 0;
     IDevice* device = nullptr;
-    uint32_t padded_page_size = 0;
-    uint32_t src_page_index = 0;
-    uint32_t unpadded_dst_offset = 0;
-    uint32_t pages_per_txn = 0;
-    uint32_t address = 0;
-    uint32_t total_pages_to_read = 0;
-    uint32_t total_pages_read = 0;
-    uint32_t num_banks = 0;
+    size_t padded_page_size = 0;
+    size_t src_page_index = 0;
+    size_t unpadded_dst_offset = 0;
+    size_t pages_per_txn = 0;
+    size_t address = 0;
+    size_t total_pages_to_read = 0;
+    size_t total_pages_read = 0;
+    size_t num_banks = 0;
 
     virtual ~BufferReadDispatchParams() = default;
 
     virtual void update_params_to_be_within_bounds(const Buffer& buffer) {
-        const uint32_t num_pages_per_bank = this->src_page_index / this->num_banks;
+        const size_t num_pages_per_bank = this->src_page_index / this->num_banks;
         this->address += num_pages_per_bank * this->padded_page_size;
         this->src_page_index = this->src_page_index % this->num_banks;
     }
@@ -98,8 +98,8 @@ struct BufferReadDispatchParams {
 };
 
 struct PartialPageSpec {
-    uint32_t partial_page_size = 0;
-    uint32_t num_partial_pages_per_full_page = 0;
+    size_t partial_page_size = 0;
+    size_t num_partial_pages_per_full_page = 0;
 };
 
 struct BufferReadLargePageDispatchParams : BufferReadDispatchParams {
@@ -110,11 +110,11 @@ using BufferReadDispatchParamsVariant = std::variant<BufferReadDispatchParams, B
 
 struct ShardedBufferReadDispatchParams : BufferReadDispatchParams {
     bool width_split = false;
-    uint32_t initial_pages_skipped = 0;
-    uint32_t starting_src_host_page_index = 0;
+    size_t initial_pages_skipped = 0;
+    size_t starting_src_host_page_index = 0;
     std::shared_ptr<const BufferPageMapping> buffer_page_mapping = nullptr;
-    uint32_t total_pages_read = 0;
-    uint32_t max_pages_per_shard = 0;
+    size_t total_pages_read = 0;
+    size_t max_pages_per_shard = 0;
     CoreCoord core;
 };
 

--- a/tt_metal/impl/data_format/tilize_utils.cpp
+++ b/tt_metal/impl/data_format/tilize_utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -54,23 +54,23 @@ std::vector<T> convert_layout_row_major_to_tile_swizzled(
         return tilized_result;
     }
 
-    auto tile_H = tile_shape.has_value() ? tile_shape.value()[0] : tt::constants::TILE_HEIGHT;
-    auto tile_W = tile_shape.has_value() ? tile_shape.value()[1] : tt::constants::TILE_WIDTH;
+    size_t tile_H = tile_shape.has_value() ? tile_shape.value()[0] : tt::constants::TILE_HEIGHT;
+    size_t tile_W = tile_shape.has_value() ? tile_shape.value()[1] : tt::constants::TILE_WIDTH;
 
-    uint32_t H = shape[0];
-    uint32_t W = shape[1];
-    uint32_t B = in_row_major.size() / (H * W);
+    size_t H = shape[0];
+    size_t W = shape[1];
+    size_t B = in_row_major.size() / (H * W);
 
     TT_FATAL(in_row_major.size() > 0 and H > 0 and W > 0, "None of the input size, H, nor W can be 0");
     TT_FATAL((in_row_major.size() % (H * W)) == 0, "Input size must be divisible by H and W");
     TT_FATAL((H % tile_H == 0) and (W % tile_W == 0), "H and W must be divisible by {} and {}", tile_H, tile_W);
 
     tilized_result.resize(in_row_major.size());
-    uint64_t out_index = 0;
-    for (auto b = 0; b < B; b++) {
-        for (auto hs = 0; hs < H; hs += tile_H) {
-            for (auto ws = 0; ws < W; ws += tile_W) {
-                for (auto ht = 0; ht < tile_H; ht++) {
+    size_t out_index = 0;
+    for (size_t b = 0; b < B; b++) {
+        for (size_t hs = 0; hs < H; hs += tile_H) {
+            for (size_t ws = 0; ws < W; ws += tile_W) {
+                for (size_t ht = 0; ht < tile_H; ht++) {
                     size_t src_idx = b * H * W + (hs + ht) * W + ws;
                     size_t dst_idx = b * H * W + hs * W + (ws * tile_H) + (ht * tile_W);
                     std::memcpy(&tilized_result[dst_idx], &in_row_major[src_idx], tile_W * sizeof(T));
@@ -92,24 +92,24 @@ std::vector<T> convert_layout_tile_swizzled_to_row_major(
         return result;
     }
 
-    auto tile_H = tile_shape.has_value() ? tile_shape.value()[0] : tt::constants::TILE_HEIGHT;
-    auto tile_W = tile_shape.has_value() ? tile_shape.value()[1] : tt::constants::TILE_WIDTH;
+    size_t tile_H = tile_shape.has_value() ? tile_shape.value()[0] : tt::constants::TILE_HEIGHT;
+    size_t tile_W = tile_shape.has_value() ? tile_shape.value()[1] : tt::constants::TILE_WIDTH;
 
     // Untilize into row major
-    uint32_t H = shape[0];
-    uint32_t W = shape[1];
-    uint32_t B = in_tile_swizzled.size() / (H * W);
+    size_t H = shape[0];
+    size_t W = shape[1];
+    size_t B = in_tile_swizzled.size() / (H * W);
 
     TT_FATAL(in_tile_swizzled.size() > 0 and H > 0 and W > 0, "None of the input size, H, nor W can be 0");
     TT_FATAL((in_tile_swizzled.size() % (H * W)) == 0, "Input size must be divisible by H and W");
     TT_FATAL((H % tile_H == 0) and (W % tile_W == 0), "H and W must be divisible by {} and {}", tile_H, tile_W);
 
     result.resize(in_tile_swizzled.size());
-    uint64_t linear = 0;
-    for (auto b = 0; b < B; b++) {
-        for (auto hs = 0; hs < H; hs += tile_H) {
-            for (auto ws = 0; ws < W; ws += tile_W) {
-                for (auto ht = 0; ht < tile_H; ht++) {
+    size_t linear = 0;
+    for (size_t b = 0; b < B; b++) {
+        for (size_t hs = 0; hs < H; hs += tile_H) {
+            for (size_t ws = 0; ws < W; ws += tile_W) {
+                for (size_t ht = 0; ht < tile_H; ht++) {
                     // Note: the only difference with tilize_row_major - switched src and dst indices
                     size_t src_idx = b * H * W + hs * W + (ws * tile_H) + (ht * tile_W);
                     size_t dst_idx = b * H * W + (hs + ht) * W + ws;
@@ -134,34 +134,34 @@ std::vector<T> convert_layout_tile_swizzled_to_tile_nfaces(
         return result;
     }
 
-    auto tile_H = tile_shape.has_value() ? tile_shape.value()[0] : tt::constants::TILE_HEIGHT;
-    auto tile_W = tile_shape.has_value() ? tile_shape.value()[1] : tt::constants::TILE_WIDTH;
-    auto face_H = face_shape.has_value() ? face_shape.value()[0] : tt::constants::FACE_HEIGHT;
-    auto face_W = face_shape.has_value() ? face_shape.value()[1] : tt::constants::FACE_WIDTH;
-    auto tile_HW = tile_H * tile_W;
-    auto face_HW = face_H * face_W;
-    uint32_t row_faces = tile_H / face_H;
-    uint32_t col_faces = tile_W / face_W;
+    size_t tile_H = tile_shape.has_value() ? tile_shape.value()[0] : tt::constants::TILE_HEIGHT;
+    size_t tile_W = tile_shape.has_value() ? tile_shape.value()[1] : tt::constants::TILE_WIDTH;
+    size_t face_H = face_shape.has_value() ? face_shape.value()[0] : tt::constants::FACE_HEIGHT;
+    size_t face_W = face_shape.has_value() ? face_shape.value()[1] : tt::constants::FACE_WIDTH;
+    size_t tile_HW = tile_H * tile_W;
+    size_t face_HW = face_H * face_W;
+    size_t row_faces = tile_H / face_H;
+    size_t col_faces = tile_W / face_W;
 
     // We don't transpose face order if we have only one face in the row or column
     transpose_face_order = transpose_face_order && row_faces > 1 && col_faces > 1;
 
     TT_FATAL(in_tile_swizzled.size() % tile_HW == 0, "Input size must be divisible by tile size");
     result.resize(in_tile_swizzled.size());
-    int num_tiles = in_tile_swizzled.size() / tile_HW;
-    auto num_faces_col = tile_W / face_W;
-    auto num_faces_row = tile_H / face_H;
+    size_t num_tiles = in_tile_swizzled.size() / tile_HW;
+    size_t num_faces_col = tile_W / face_W;
+    size_t num_faces_row = tile_H / face_H;
 
-    for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
-        int tile_offset = tile_idx * tile_HW;
-        for (int face_y = 0; face_y < num_faces_row; face_y++) {
-            for (int face_x = 0; face_x < num_faces_col; face_x++) {
+    for (size_t tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
+        size_t tile_offset = tile_idx * tile_HW;
+        for (size_t face_y = 0; face_y < num_faces_row; face_y++) {
+            for (size_t face_x = 0; face_x < num_faces_col; face_x++) {
                 size_t face_y_dst = transpose_face_order ? face_x : face_y;
                 size_t face_x_dst = transpose_face_order ? face_y : face_x;
 
                 if (transpose_face) {
-                    for (int row = 0; row < face_W; row++) {
-                        for (int col = 0; col < face_H; col++) {
+                    for (size_t row = 0; row < face_W; row++) {
+                        for (size_t col = 0; col < face_H; col++) {
                             size_t src_index =
                                 tile_offset + face_y * (face_H * tile_W) + face_x * face_W + row * tile_W + col;
                             size_t dst_index = tile_offset + face_y_dst * (face_H * tile_W) + face_x_dst * face_HW +
@@ -170,7 +170,7 @@ std::vector<T> convert_layout_tile_swizzled_to_tile_nfaces(
                         }
                     }
                 } else {
-                    for (int row = 0; row < face_H; row++) {
+                    for (size_t row = 0; row < face_H; row++) {
                         size_t src_index = tile_offset + face_y * (face_H * tile_W) + face_x * face_W + row * tile_W;
                         size_t dst_index =
                             tile_offset + face_y_dst * (face_H * tile_W) + face_x_dst * face_HW + row * face_W;
@@ -196,35 +196,35 @@ std::vector<T> convert_layout_tile_nfaces_to_tile_swizzled(
     if (in_tile_nfaces.size() == 0) {
         return result;
     }
-    auto tile_H = tile_shape.has_value() ? tile_shape.value()[0] : tt::constants::TILE_HEIGHT;
-    auto tile_W = tile_shape.has_value() ? tile_shape.value()[1] : tt::constants::TILE_WIDTH;
-    auto face_H = face_shape.has_value() ? face_shape.value()[0] : tt::constants::FACE_HEIGHT;
-    auto face_W = face_shape.has_value() ? face_shape.value()[1] : tt::constants::FACE_WIDTH;
-    auto tile_HW = tile_H * tile_W;
-    auto face_HW = face_H * face_W;
+    size_t tile_H = tile_shape.has_value() ? tile_shape.value()[0] : tt::constants::TILE_HEIGHT;
+    size_t tile_W = tile_shape.has_value() ? tile_shape.value()[1] : tt::constants::TILE_WIDTH;
+    size_t face_H = face_shape.has_value() ? face_shape.value()[0] : tt::constants::FACE_HEIGHT;
+    size_t face_W = face_shape.has_value() ? face_shape.value()[1] : tt::constants::FACE_WIDTH;
+    size_t tile_HW = tile_H * tile_W;
+    size_t face_HW = face_H * face_W;
 
-    uint32_t row_faces = tile_H / face_H;
-    uint32_t col_faces = tile_W / face_W;
-    auto num_faces_col = tile_W / face_W;
-    auto num_faces_row = tile_H / face_H;
+    size_t row_faces = tile_H / face_H;
+    size_t col_faces = tile_W / face_W;
+    size_t num_faces_col = tile_W / face_W;
+    size_t num_faces_row = tile_H / face_H;
 
     // We don't transpose face order if we have only one face in the row or column
     transpose_face_order = transpose_face_order && row_faces > 1 && col_faces > 1;
 
     TT_FATAL(in_tile_nfaces.size() % tile_HW == 0, "Input size must be divisible by tile size");
-    int num_tiles = in_tile_nfaces.size() / tile_HW;
+    size_t num_tiles = in_tile_nfaces.size() / tile_HW;
     size_t dest_idx = 0;
-    for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
-        int tile_start = tile_idx * tile_HW;
+    for (size_t tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
+        size_t tile_start = tile_idx * tile_HW;
 
         if (transpose_face) {
-            for (int face_y = 0; face_y < num_faces_row; face_y++) {
-                for (int face_x = 0; face_x < num_faces_col; face_x++) {
+            for (size_t face_y = 0; face_y < num_faces_row; face_y++) {
+                for (size_t face_x = 0; face_x < num_faces_col; face_x++) {
                     size_t face_y_src = transpose_face_order ? face_x : face_y;
                     size_t face_x_src = transpose_face_order ? face_y : face_x;
                     // Note: coalescted reads, strided writes
-                    for (int row = 0; row < face_H; row++) {
-                        for (int col = 0; col < face_W; col++) {
+                    for (size_t row = 0; row < face_H; row++) {
+                        for (size_t col = 0; col < face_W; col++) {
                             size_t src_idx =
                                 tile_start + face_y_src * (face_H * tile_W) + face_x_src * face_HW + row * face_W + col;
                             size_t dst_idx =
@@ -236,15 +236,15 @@ std::vector<T> convert_layout_tile_nfaces_to_tile_swizzled(
             }
         } else {
             size_t src_face_start = 0;
-            for (int face_y = 0; face_y < num_faces_row; face_y++) {
-                for (int face_x = 0; face_x < num_faces_col; face_x++) {
+            for (size_t face_y = 0; face_y < num_faces_row; face_y++) {
+                for (size_t face_x = 0; face_x < num_faces_col; face_x++) {
                     if (!transpose_face_order) {
                         src_face_start = tile_start + face_y * (face_H * tile_W) + face_x * face_HW;
                     } else {
                         src_face_start = tile_start + face_x * (face_H * tile_W) + face_y * face_HW;
                     }
                     size_t dst_face_start = tile_start + face_y * (face_H * tile_W) + face_x * face_W;
-                    for (int row = 0; row < face_H; row++) {
+                    for (size_t row = 0; row < face_H; row++) {
                         size_t src_idx = src_face_start + row * face_W;
                         size_t dst_idx = dst_face_start + row * tile_W;
                         std::memcpy(&result[dst_idx], &in_tile_nfaces[src_idx], face_W * sizeof(T));
@@ -267,64 +267,64 @@ std::vector<T> convert_layout_row_major_to_tile_nfaces(
     const bool transpose_face_order) {
     ZoneScoped;
 
-    uint32_t H = shape[0];
-    uint32_t W = shape[1];
-    uint32_t batch_size = H * W;
-    uint32_t B = in_row_major.size() / batch_size;  // Number of batches
+    size_t H = shape[0];
+    size_t W = shape[1];
+    size_t batch_size = H * W;
+    size_t B = in_row_major.size() / batch_size;  // Number of batches
 
     std::vector<T> tilized_input;
     tilized_input.reserve(in_row_major.size());
 
-    auto tile_H = tile_shape.has_value() ? tile_shape.value()[0] : tt::constants::TILE_HEIGHT;
-    auto tile_W = tile_shape.has_value() ? tile_shape.value()[1] : tt::constants::TILE_WIDTH;
-    auto face_H = face_shape.has_value() ? face_shape.value()[0] : tt::constants::FACE_HEIGHT;
-    auto face_W = face_shape.has_value() ? face_shape.value()[1] : tt::constants::FACE_WIDTH;
+    size_t tile_H = tile_shape.has_value() ? tile_shape.value()[0] : tt::constants::TILE_HEIGHT;
+    size_t tile_W = tile_shape.has_value() ? tile_shape.value()[1] : tt::constants::TILE_WIDTH;
+    size_t face_H = face_shape.has_value() ? face_shape.value()[0] : tt::constants::FACE_HEIGHT;
+    size_t face_W = face_shape.has_value() ? face_shape.value()[1] : tt::constants::FACE_WIDTH;
 
-    uint32_t row_tiles = H / tile_H;
-    uint32_t col_tiles = W / tile_W;
-    uint32_t row_of_tiles_num_elements = tile_H * W;
+    size_t row_tiles = H / tile_H;
+    size_t col_tiles = W / tile_W;
+    size_t row_of_tiles_num_elements = tile_H * W;
 
     TT_FATAL(in_row_major.size() > 0 and H > 0 and W > 0, "None of the input size, H, nor W can be 0");
     TT_FATAL((in_row_major.size() % (H * W)) == 0, "Input size must be divisible by H and W");
     TT_FATAL((H % tile_H == 0) and (W % tile_W == 0), "H and W must be divisible by {} and {}", tile_H, tile_W);
 
-    auto write_face = [&](uint32_t face_idx, uint32_t face_height, uint32_t face_width, uint32_t stride) {
+    auto write_face = [&](size_t face_idx, size_t face_height, size_t face_width, size_t stride) {
         size_t offset = tilized_input.size();
         tilized_input.resize(offset + face_height * face_width);
         T* dst = tilized_input.data() + offset;
         const T* src = in_row_major.data() + face_idx;
         if (!transpose_face) {
-            for (uint32_t row = 0; row < face_height; row++) {
+            for (size_t row = 0; row < face_height; row++) {
                 std::memcpy(dst, src, face_width * sizeof(T));
                 dst += face_width;
                 src += stride;
             }
         } else {
-            for (uint32_t row = 0; row < face_height; row++) {
-                for (uint32_t col = 0; col < face_width; col++) {
+            for (size_t row = 0; row < face_height; row++) {
+                for (size_t col = 0; col < face_width; col++) {
                     dst[col * face_height + row] = src[row * stride + col];
                 }
             }
         }
     };
 
-    uint32_t batch_start = 0;
+    size_t batch_start = 0;
     for (size_t b = 0; b < B; b++) {
-        uint32_t tile_start = batch_start;
-        for (uint32_t row_tile = 0; row_tile < row_tiles; row_tile++) {
-            uint32_t row_tile_start = tile_start;
-            for (uint32_t col_tile = 0; col_tile < col_tiles; col_tile++) {
+        size_t tile_start = batch_start;
+        for (size_t row_tile = 0; row_tile < row_tiles; row_tile++) {
+            size_t row_tile_start = tile_start;
+            for (size_t col_tile = 0; col_tile < col_tiles; col_tile++) {
                 if (!transpose_face_order) {
-                    for (int face_h_index = 0; face_h_index < static_cast<int>(tile_H / face_H); face_h_index++) {
-                        for (int face_w_index = 0; face_w_index < static_cast<int>(tile_W / face_W); face_w_index++) {
-                            uint32_t src_idx = row_tile_start + face_w_index * face_W + face_h_index * face_H * W;
+                    for (size_t face_h_index = 0; face_h_index < tile_H / face_H; face_h_index++) {
+                        for (size_t face_w_index = 0; face_w_index < tile_W / face_W; face_w_index++) {
+                            size_t src_idx = row_tile_start + face_w_index * face_W + face_h_index * face_H * W;
                             write_face(src_idx, face_H, face_W, W);
                         }
                     }
                 } else {
-                    for (int face_w_index = 0; face_w_index < static_cast<int>(tile_W / face_W); face_w_index++) {
-                        for (int face_h_index = 0; face_h_index < static_cast<int>(tile_H / face_H); face_h_index++) {
-                            uint32_t src_idx = row_tile_start + face_w_index * face_W + face_h_index * face_H * W;
+                    for (size_t face_w_index = 0; face_w_index < tile_W / face_W; face_w_index++) {
+                        for (size_t face_h_index = 0; face_h_index < tile_H / face_H; face_h_index++) {
+                            size_t src_idx = row_tile_start + face_w_index * face_W + face_h_index * face_H * W;
                             write_face(src_idx, face_H, face_W, W);
                         }
                     }
@@ -377,7 +377,7 @@ std::vector<T> convert_layout_tile_nfaces_to_row_major(
     auto write_face =
         [&](std::vector<T>& out_data, tt::stl::Span<const T> in_data, size_t in_face_start, size_t out_face_start) {
             if (!transpose_face) {
-                for (uint32_t row = 0; row < face_H; row++) {
+                for (size_t row = 0; row < face_H; row++) {
                     size_t src_idx = in_face_start + row * face_W;
                     size_t dst_idx = out_face_start + row * tile_W * tile_cols;
                     if (dst_idx + face_W > out_data.size()) {
@@ -389,8 +389,8 @@ std::vector<T> convert_layout_tile_nfaces_to_row_major(
                     std::memcpy(&out_data[dst_idx], &in_data[src_idx], face_W * sizeof(T));
                 }
             } else {
-                for (uint32_t row = 0; row < face_H; row++) {
-                    for (uint32_t col = 0; col < face_W; col++) {
+                for (size_t row = 0; row < face_H; row++) {
+                    for (size_t col = 0; col < face_W; col++) {
                         size_t src_idx = in_face_start + row * face_W + col;
                         size_t dst_idx = out_face_start + col * face_H * col_faces * tile_cols + row;
 
@@ -495,9 +495,9 @@ std::vector<T> convert_layout(
     const bool transpose_of_faces) {
     ZoneScoped;
     TT_ASSERT(shape.size() >= 2, "Shape size {} must be at least rank 2!", shape.size());
-    uint32_t H = shape[shape.size() - 2];
-    uint32_t W = shape[shape.size() - 1];
-    for (int i = 0; i < shape.size() - 2; i++) {
+    size_t H = shape[shape.size() - 2];
+    size_t W = shape[shape.size() - 1];
+    for (size_t i = 0; i < shape.size() - 2; i++) {
         H *= shape[i];
     }
     return convert_layout(

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,17 +11,17 @@ enum class CoreType;
 
 namespace tt::tt_metal {
 
-uint32_t get_relative_cq_offset(uint8_t cq_id, uint32_t cq_size) { return cq_id * cq_size; }
+size_t get_relative_cq_offset(uint8_t cq_id, size_t cq_size) { return cq_id * cq_size; }
 
 uint16_t get_umd_channel(uint16_t channel) { return channel & 0x3; }
 
-uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_size) {
+size_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, size_t cq_size) {
     return (DispatchSettings::MAX_HUGEPAGE_SIZE * get_umd_channel(channel)) +
            ((channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE) + get_relative_cq_offset(cq_id, cq_size);
 }
 
 template <bool addr_16B>
-uint32_t get_cq_issue_rd_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size) {
+size_t get_cq_issue_rd_ptr(chip_id_t chip_id, uint8_t cq_id, size_t cq_size) {
     uint32_t recv;
     chip_id_t mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
     uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
@@ -40,11 +40,11 @@ uint32_t get_cq_issue_rd_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size)
     return recv;
 }
 
-template uint32_t get_cq_issue_rd_ptr<true>(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
-template uint32_t get_cq_issue_rd_ptr<false>(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
+template size_t get_cq_issue_rd_ptr<true>(chip_id_t chip_id, uint8_t cq_id, size_t cq_size);
+template size_t get_cq_issue_rd_ptr<false>(chip_id_t chip_id, uint8_t cq_id, size_t cq_size);
 
 template <bool addr_16B>
-uint32_t get_cq_issue_wr_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size) {
+size_t get_cq_issue_wr_ptr(chip_id_t chip_id, uint8_t cq_id, size_t cq_size) {
     uint32_t recv;
     chip_id_t mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
     uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
@@ -58,11 +58,11 @@ uint32_t get_cq_issue_wr_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size)
     return recv;
 }
 
-template uint32_t get_cq_issue_wr_ptr<true>(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
-template uint32_t get_cq_issue_wr_ptr<false>(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
+template size_t get_cq_issue_wr_ptr<true>(chip_id_t chip_id, uint8_t cq_id, size_t cq_size);
+template size_t get_cq_issue_wr_ptr<false>(chip_id_t chip_id, uint8_t cq_id, size_t cq_size);
 
 template <bool addr_16B>
-uint32_t get_cq_completion_wr_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size) {
+size_t get_cq_completion_wr_ptr(chip_id_t chip_id, uint8_t cq_id, size_t cq_size) {
     uint32_t recv;
     chip_id_t mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
     uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
@@ -81,11 +81,11 @@ uint32_t get_cq_completion_wr_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_
     return recv;
 }
 
-template uint32_t get_cq_completion_wr_ptr<true>(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
-template uint32_t get_cq_completion_wr_ptr<false>(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
+template size_t get_cq_completion_wr_ptr<true>(chip_id_t chip_id, uint8_t cq_id, size_t cq_size);
+template size_t get_cq_completion_wr_ptr<false>(chip_id_t chip_id, uint8_t cq_id, size_t cq_size);
 
 template <bool addr_16B>
-inline uint32_t get_cq_completion_rd_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size) {
+inline size_t get_cq_completion_rd_ptr(chip_id_t chip_id, uint8_t cq_id, size_t cq_size) {
     uint32_t recv;
     chip_id_t mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
     uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
@@ -99,7 +99,7 @@ inline uint32_t get_cq_completion_rd_ptr(chip_id_t chip_id, uint8_t cq_id, uint3
     return recv;
 }
 
-template uint32_t get_cq_completion_rd_ptr<true>(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
-template uint32_t get_cq_completion_rd_ptr<false>(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
+template size_t get_cq_completion_rd_ptr<true>(chip_id_t chip_id, uint8_t cq_id, size_t cq_size);
+template size_t get_cq_completion_rd_ptr<false>(chip_id_t chip_id, uint8_t cq_id, size_t cq_size);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/command_queue_common.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -40,7 +40,7 @@ enum class CommandQueueHostAddrType : uint8_t {
 /// @param cq_id uint8_t ID the command queue
 /// @param cq_size uint32_t size of the command queue
 /// @return uint32_t relative offset
-uint32_t get_relative_cq_offset(uint8_t cq_id, uint32_t cq_size);
+size_t get_relative_cq_offset(uint8_t cq_id, size_t cq_size);
 
 // used in system_memory_manager and device
 uint16_t get_umd_channel(uint16_t channel);
@@ -52,20 +52,20 @@ uint16_t get_umd_channel(uint16_t channel);
 /// @param cq_id uint8_t ID the command queue
 /// @param cq_size uint32_t size of the command queue
 /// @return uint32_t absolute offset
-uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_size);
+size_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, size_t cq_size);
 
 // mostly used in debug_tools
 template <bool addr_16B>
-uint32_t get_cq_issue_rd_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
+size_t get_cq_issue_rd_ptr(chip_id_t chip_id, uint8_t cq_id, size_t cq_size);
 
 template <bool addr_16B>
-uint32_t get_cq_issue_wr_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
+size_t get_cq_issue_wr_ptr(chip_id_t chip_id, uint8_t cq_id, size_t cq_size);
 
 // has usage in system_memory_manager.cpp
 template <bool addr_16B>
-uint32_t get_cq_completion_wr_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
+size_t get_cq_completion_wr_ptr(chip_id_t chip_id, uint8_t cq_id, size_t cq_size);
 
 template <bool addr_16B>
-uint32_t get_cq_completion_rd_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
+size_t get_cq_completion_rd_ptr(chip_id_t chip_id, uint8_t cq_id, size_t cq_size);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -52,26 +52,25 @@ public:
 
     vector_aligned<uint32_t> cmd_vector() const;
 
-    void add_dispatch_wait(
-        uint32_t flags, uint32_t address, uint32_t stream, uint32_t count, uint8_t dispatcher_type = 0);
+    void add_dispatch_wait(uint32_t flags, size_t address, uint32_t stream, size_t count, uint8_t dispatcher_type = 0);
 
-    void add_dispatch_wait_with_prefetch_stall(uint32_t flags, uint32_t address, uint32_t stream, uint32_t count);
+    void add_dispatch_wait_with_prefetch_stall(uint32_t flags, size_t address, uint32_t stream, size_t count);
 
     void add_prefetch_relay_linear(uint32_t noc_xy_addr, uint32_t lengthB, uint32_t addr);
 
     void add_prefetch_relay_paged(
         uint8_t is_dram,
         uint8_t start_page,
-        uint32_t base_addr,
-        uint32_t page_size,
-        uint32_t pages,
+        size_t base_addr,
+        size_t page_size,
+        size_t pages,
         uint16_t length_adjust = 0);
 
     void add_prefetch_relay_paged_packed(
-        uint32_t length,
+        size_t length,
         const std::vector<CQPrefetchRelayPagedPackedSubCmd>& sub_cmds,
         uint16_t num_sub_cmds,
-        uint32_t offset_idx = 0);
+        size_t offset_idx = 0);
 
     template <bool flush_prefetch = true, bool inline_data = false>
     void add_dispatch_write_linear(
@@ -104,7 +103,7 @@ public:
         const void* data = nullptr);
 
     template <bool inline_data = false>
-    void add_dispatch_write_host(bool flush_prefetch, uint32_t data_sizeB, bool is_event, const void* data = nullptr);
+    void add_dispatch_write_host(bool flush_prefetch, size_t data_sizeB, bool is_event, const void* data = nullptr);
 
     void add_prefetch_exec_buf(uint32_t base_addr, uint32_t log_page_size, uint32_t pages);
 
@@ -123,7 +122,7 @@ public:
 
     void update_cmd_sequence(uint32_t cmd_offsetB, const void* new_data, uint32_t data_sizeB);
 
-    void add_data(const void* data, uint32_t data_size_to_copyB, uint32_t cmd_write_offset_incrementB)
+    void add_data(const void* data, size_t data_size_to_copyB, size_t cmd_write_offset_incrementB)
         __attribute((nonnull(2)));
 
     template <typename PackedSubCmd>
@@ -178,7 +177,7 @@ public:
         uint32_t write_offset_index = 0);
 
     template <typename CommandPtr, bool data = false>
-    CommandPtr reserve_space(uint32_t size_to_writeB) {
+    CommandPtr reserve_space(size_t size_to_writeB) {
         this->validate_cmd_write(size_to_writeB);
         CommandPtr cmd = (CommandPtr)((char*)this->cmd_region + this->cmd_write_offsetB);
         // Only zero out cmds
@@ -195,7 +194,7 @@ private:
     static bool zero_init_enable;
 
     void add_prefetch_relay_inline(
-        bool flush, uint32_t lengthB, DispatcherSelect dispatcher_type = DispatcherSelect::DISPATCH_MASTER);
+        bool flush, size_t lengthB, DispatcherSelect dispatcher_type = DispatcherSelect::DISPATCH_MASTER);
 
     // Write packed large cmd and subcmds, but not data.
     void add_dispatch_write_packed_large_internal(
@@ -208,7 +207,7 @@ private:
         const uint32_t offset_idx,
         uint32_t write_offset_index);
 
-    void validate_cmd_write(uint32_t data_sizeB) const;
+    void validate_cmd_write(size_t data_sizeB) const;
 
     void deepcopy(const DeviceCommand& other);
 
@@ -224,11 +223,10 @@ private:
         }
     }
 
-    uint32_t cmd_sequence_sizeB = 0;
+    size_t cmd_sequence_sizeB = 0;
     void* cmd_region = nullptr;
-    uint32_t cmd_write_offsetB = 0;
-    uint32_t pcie_alignment =
-        tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
+    size_t cmd_write_offsetB = 0;
+    size_t pcie_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
     uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
 
     vector_aligned<uint32_t> cmd_region_vector;

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,7 +16,7 @@
 namespace tt::tt_metal {
 class DeviceCommandCalculator {
 public:
-    uint32_t write_offset_bytes() const { return this->cmd_write_offsetB; }
+    size_t write_offset_bytes() const { return this->cmd_write_offsetB; }
 
     void add_dispatch_wait() {
         this->add_prefetch_relay_inline();
@@ -39,10 +39,10 @@ public:
         this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
     }
 
-    void add_data(uint32_t cmd_write_offset_incrementB) { this->cmd_write_offsetB += cmd_write_offset_incrementB; }
+    void add_data(size_t cmd_write_offset_incrementB) { this->cmd_write_offsetB += cmd_write_offset_incrementB; }
 
     template <bool flush_prefetch = true, bool inline_data = false>
-    void add_dispatch_write_linear(uint32_t data_sizeB) {
+    void add_dispatch_write_linear(size_t data_sizeB) {
         this->add_prefetch_relay_inline();
         this->cmd_write_offsetB += sizeof(CQDispatchCmd);
 
@@ -59,7 +59,7 @@ public:
         }
     }
 
-    void add_dispatch_write_linear_host_event(uint32_t data_sizeB) {
+    void add_dispatch_write_linear_host_event(size_t data_sizeB) {
         this->add_prefetch_relay_inline();
         this->cmd_write_offsetB += sizeof(CQDispatchCmd) + data_sizeB;
         this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
@@ -89,7 +89,7 @@ public:
         this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
     }
 
-    void add_dispatch_set_go_signal_noc_data(uint32_t num_words) {
+    void add_dispatch_set_go_signal_noc_data(size_t num_words) {
         this->add_prefetch_relay_inline();
         this->cmd_write_offsetB += sizeof(CQDispatchCmd) + num_words * sizeof(uint32_t);
         this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
@@ -108,8 +108,8 @@ public:
     }
 
     template <bool inline_data = false>
-    void add_dispatch_write_paged(uint32_t page_size, uint32_t pages) {
-        uint32_t data_sizeB = page_size * pages;
+    void add_dispatch_write_paged(size_t page_size, size_t pages) {
+        size_t data_sizeB = page_size * pages;
         this->add_prefetch_relay_inline();
         this->cmd_write_offsetB += sizeof(CQDispatchCmd);
         if constexpr (inline_data) {
@@ -220,9 +220,8 @@ public:
 
 private:
     void add_prefetch_relay_inline() { this->cmd_write_offsetB += sizeof(CQPrefetchCmd); }
-    uint32_t cmd_write_offsetB = 0;
-    uint32_t pcie_alignment =
-        tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
-    uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
+    size_t cmd_write_offsetB = 0;
+    size_t pcie_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
+    size_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
 };
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_mem_map.hpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -92,7 +92,7 @@ private:
     uint32_t dispatch_buffer_base_ = 0;
 
     uint32_t dispatch_buffer_block_size_pages_ = 0;
-    std::vector<uint32_t> device_cq_addrs_;
+    std::vector<size_t> device_cq_addrs_;
 
     DispatchSettings settings;
 

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -99,16 +99,19 @@ constexpr uint32_t CQ_PREFETCH_RELAY_PAGED_LENGTH_ADJUST_MASK = 0x7fff;
 struct CQPrefetchRelayPagedCmd {
     uint8_t start_page;
     uint16_t is_dram_and_length_adjust;  // is_dram flag and bytes subtracted from size (multiple of 32)
-    uint32_t base_addr;
-    uint32_t page_size;
-    uint32_t pages;
+    uint64_t base_addr;
+    uint64_t page_size;
+    uint64_t pages;
+    uint32_t pad;
 } __attribute__((packed));
 
 struct CQPrefetchRelayPagedPackedCmd {
     uint8_t pad1;
     uint16_t count;
-    uint32_t total_length;  // aggregate length of all sub-read-cmds
-    uint32_t stride;        // stride to start of next cmd
+    uint64_t total_length;  // aggregate length of all sub-read-cmds
+    uint64_t stride;        // stride to start of next cmd
+    uint64_t pad2;
+    uint32_t pad3;
 } __attribute__((packed));
 
 struct CQPrefetchRelayPagedPackedSubCmd {
@@ -124,16 +127,19 @@ constexpr uint32_t CQ_PREFETCH_CMD_RELAY_PAGED_PACKED_MAX_SUB_CMDS = 35;
 struct CQPrefetchRelayInlineCmd {
     uint8_t dispatcher_type;
     uint16_t pad;
-    uint32_t length;
-    uint32_t stride;  // explicit stride saves a few insns on device
+    uint64_t length;
+    uint64_t stride;  // explicit stride saves a few insns on device
+    uint64_t pad2;
+    uint32_t pad3;
 } __attribute__((packed));
 
 struct CQPrefetchExecBufCmd {
     uint8_t pad1;
-    uint16_t pad2;
-    uint32_t base_addr;
-    uint32_t log_page_size;
-    uint32_t pages;
+    uint64_t base_addr;
+    uint64_t log_page_size;
+    uint64_t pages;
+    uint32_t pad2;
+    uint16_t pad3;
 } __attribute__((packed));
 
 // Reset the write pointer to the start of the ring buffer. If this isn't set,
@@ -201,8 +207,7 @@ struct CQDispatchWriteHostCmd {
     uint8_t is_event;  // one flag, false=read buffer
     uint16_t pad1;
     uint32_t pad2;
-    uint32_t pad3;
-    uint32_t length;
+    uint64_t length;
 } __attribute__((packed));
 
 constexpr uint16_t CQ_DISPATCH_CMD_PAGED_WRITE_MAX_PAGE_INDEX = 0xFFFF;
@@ -299,8 +304,10 @@ constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM = 0x10;
 struct CQDispatchWaitCmd {
     uint8_t flags;    // see above
     uint16_t stream;  // stream to read/write
-    uint32_t addr;   // address to read
-    uint32_t count;  // wait while address is < count
+    uint64_t addr;    // address to read
+    uint64_t count;   // wait while address is < count
+    uint64_t pad;
+    uint32_t pad2;  // padding to align to 16 bytes
 } __attribute__((packed));
 
 struct CQDispatchDelayCmd {

--- a/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
+++ b/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +11,8 @@
 
 namespace tt::tt_metal {
 
-SystemMemoryCQInterface::SystemMemoryCQInterface(uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start) :
+SystemMemoryCQInterface::SystemMemoryCQInterface(
+    uint16_t channel, uint8_t cq_id, std::size_t cq_size, std::size_t cq_start) :
     cq_start(cq_start),
     command_completion_region_size(
         (((cq_size - cq_start) / DispatchSettings::TRANSFER_PAGE_SIZE) / 4) * DispatchSettings::TRANSFER_PAGE_SIZE),

--- a/tt_metal/impl/dispatch/system_memory_cq_interface.hpp
+++ b/tt_metal/impl/dispatch/system_memory_cq_interface.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,26 +14,26 @@ struct SystemMemoryCQInterface {
     // Device signals completion and writes data for D2H transfers in the completion region, host reads from the
     // completion region Equation for issue fifo size is | issue_fifo_wr_ptr + command size B - issue_fifo_rd_ptr |
     // Space available would just be issue_fifo_limit - issue_fifo_size
-    SystemMemoryCQInterface(uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start);
+    SystemMemoryCQInterface(uint16_t channel, uint8_t cq_id, std::size_t cq_size, std::size_t cq_start);
 
     // Percentage of the command queue that is dedicated for issuing commands. Issue queue size is rounded to be 32B
     // aligned and remaining space is dedicated for completion queue Smaller issue queues can lead to more stalls for
     // applications that send more work to device than readback data.
     static constexpr float default_issue_queue_split = 0.75;
-    const uint32_t cq_start = 0;
-    const uint32_t command_completion_region_size = 0;
-    const uint32_t command_issue_region_size = 0;
+    const std::size_t cq_start = 0;
+    const std::size_t command_completion_region_size = 0;
+    const std::size_t command_issue_region_size = 0;
     const uint8_t id = 0;
 
-    uint32_t issue_fifo_size = 0;
-    uint32_t issue_fifo_limit = 0;  // Last possible FIFO address
-    const uint32_t offset;
-    uint32_t issue_fifo_wr_ptr = 0;
+    std::size_t issue_fifo_size = 0;
+    std::size_t issue_fifo_limit = 0;  // Last possible FIFO address
+    const std::size_t offset;
+    std::size_t issue_fifo_wr_ptr = 0;
     bool issue_fifo_wr_toggle = false;
 
-    uint32_t completion_fifo_size = 0;
-    uint32_t completion_fifo_limit = 0;  // Last possible FIFO address
-    uint32_t completion_fifo_rd_ptr = 0;
+    std::size_t completion_fifo_size = 0;
+    std::size_t completion_fifo_limit = 0;  // Last possible FIFO address
+    std::size_t completion_fifo_rd_ptr = 0;
     bool completion_fifo_rd_toggle = false;
 
     // TODO add the host addresses from dispatch constants in here

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -51,7 +51,7 @@ public:
 
     uint32_t get_completion_queue_limit(uint8_t cq_id) const;
 
-    uint32_t get_issue_queue_write_ptr(uint8_t cq_id) const;
+    size_t get_issue_queue_write_ptr(uint8_t cq_id) const;
 
     uint32_t get_completion_queue_read_ptr(uint8_t cq_id) const;
 
@@ -63,12 +63,12 @@ public:
 
     std::vector<SystemMemoryCQInterface>& get_cq_interfaces();
 
-    void* issue_queue_reserve(uint32_t cmd_size_B, uint8_t cq_id);
+    void* issue_queue_reserve(size_t cmd_size_B, uint8_t cq_id);
 
     void cq_write(const void* data, uint32_t size_in_bytes, uint32_t write_ptr);
 
     // TODO: RENAME issue_queue_stride ?
-    void issue_queue_push_back(uint32_t push_size_B, uint8_t cq_id);
+    void issue_queue_push_back(size_t push_size_B, uint8_t cq_id);
 
     uint32_t completion_queue_wait_front(uint8_t cq_id, std::atomic<bool>& exit_condition) const;
 
@@ -103,7 +103,7 @@ private:
 
     bool bypass_enable = false;
     std::vector<uint32_t> bypass_buffer;
-    uint32_t bypass_buffer_write_offset = 0;
+    size_t bypass_buffer_write_offset = 0;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -313,7 +313,7 @@ inline void SetRuntimeArgsImpl(
 
 namespace detail {
 
-bool WriteToDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t address, std::vector<uint32_t>& host_buffer) {
+bool WriteToDeviceDRAMChannel(IDevice* device, int dram_channel, uint64_t address, std::vector<uint32_t>& host_buffer) {
     bool pass = true;
     TT_FATAL(
         address >= device->allocator()->get_base_allocator_addr(HalMemType::DRAM),
@@ -325,7 +325,7 @@ bool WriteToDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t addres
 }
 
 bool ReadFromDeviceDRAMChannel(
-    IDevice* device, int dram_channel, uint32_t address, uint32_t size, std::vector<uint32_t>& host_buffer) {
+    IDevice* device, int dram_channel, uint64_t address, uint32_t size, std::vector<uint32_t>& host_buffer) {
     bool pass = true;
     tt::tt_metal::MetalContext::instance().get_cluster().dram_barrier(device->id());
     tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
@@ -483,7 +483,7 @@ void WriteToDeviceSharded(Buffer& buffer, tt::stl::Span<const uint8_t> host_buff
     }
 }
 
-DeviceAddr CalculateAddressDeviceInterleavedContiguous(const Buffer& buffer, uint32_t bank_index, uint32_t page_index) {
+DeviceAddr CalculateAddressDeviceInterleavedContiguous(const Buffer& buffer, uint64_t bank_index, uint64_t page_index) {
     DeviceAddr addr = 0;
     if (buffer.is_dram()) {
         addr = buffer.bank_local_page_address(bank_index, page_index);
@@ -496,23 +496,23 @@ DeviceAddr CalculateAddressDeviceInterleavedContiguous(const Buffer& buffer, uin
 }
 
 void WriteToDeviceInterleavedContiguous(const Buffer& buffer, tt::stl::Span<const uint8_t> host_buffer) {
-    uint32_t host_buffer_size_bytes = host_buffer.size();
+    size_t host_buffer_size_bytes = host_buffer.size();
     TT_FATAL(
         host_buffer_size_bytes <= buffer.size(),
         "Bounds-Error -- Attempting to write {} bytes to a {} byte buffer",
         host_buffer_size_bytes,
         buffer.size());
 
-    uint32_t page_size = buffer.page_size();
-    uint32_t num_pages = buffer.num_pages();
+    size_t page_size = buffer.page_size();
+    size_t num_pages = buffer.num_pages();
 
     auto device = buffer.device();
-    auto num_banks = device->allocator()->get_num_banks(buffer.buffer_type());
-    uint32_t bank_index = 0;
-    int data_index = 0;
+    size_t num_banks = device->allocator()->get_num_banks(buffer.buffer_type());
+    size_t bank_index = 0;
+    size_t data_index = 0;
     std::vector<uint32_t> page;
     page.resize(page_size / sizeof(uint32_t));
-    for (int page_index = 0; page_index < num_pages; page_index++) {
+    for (size_t page_index = 0; page_index < num_pages; page_index++) {
         const DeviceAddr address = CalculateAddressDeviceInterleavedContiguous(buffer, bank_index, page_index);
         std::memcpy(page.data(), host_buffer.data() + data_index, page_size);
         switch (buffer.buffer_type()) {
@@ -571,17 +571,17 @@ void WriteToBuffer(Buffer& buffer, tt::stl::Span<const uint8_t> host_buffer) {
 }
 
 void ReadFromDeviceInterleavedContiguous(const Buffer& buffer, uint8_t* host_buffer) {
-    uint32_t page_size = buffer.page_size();
-    uint32_t num_pages = buffer.num_pages();
+    size_t page_size = buffer.page_size();
+    size_t num_pages = buffer.num_pages();
 
     auto device = buffer.device();
-    auto num_banks = device->allocator()->get_num_banks(buffer.buffer_type());
+    size_t num_banks = device->allocator()->get_num_banks(buffer.buffer_type());
 
     size_t host_idx = 0;
-    uint32_t bank_index = 0;
+    size_t bank_index = 0;
     std::vector<uint32_t> page;
     page.resize(page_size / sizeof(uint32_t));
-    for (int page_index = 0; page_index < num_pages; page_index++) {
+    for (size_t page_index = 0; page_index < num_pages; page_index++) {
         const DeviceAddr address = CalculateAddressDeviceInterleavedContiguous(buffer, bank_index, page_index);
         page.clear();
         switch (buffer.buffer_type()) {

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -1244,7 +1244,7 @@ Tensor pad(
     const auto input_data_type = tensor.get_dtype();
 
     auto pad = [&input_padded_shape, &output_padded_shape, &input_tensor_start, &pad_value_](const auto& input_buffer) {
-        const int rank = input_padded_shape.rank();
+        const size_t rank = input_padded_shape.rank();
 
         auto output_buffer = std::vector<T>(output_padded_shape.volume());
         std::fill(output_buffer.begin(), output_buffer.end(), pad_value_);
@@ -1255,9 +1255,23 @@ Tensor pad(
 
         if (rank == 1) {
             std::memcpy(
-                output_buffer.data() + input_tensor_start[0], input_buffer.begin(), input_padded_shape[0] * sizeof(T));
+                output_buffer.data() + input_tensor_start[0],
+                input_buffer.begin(),
+                static_cast<size_t>(input_padded_shape[0]) * sizeof(T));
             return output_buffer;
         }
+
+        // Note: compute_strides from shape.hpp can overflow
+        auto compute_strides = [](const tt::tt_metal::Shape& shape) -> tt::stl::SmallVector<size_t> {
+            size_t num_elements = shape.volume();
+
+            ttnn::SmallVector<size_t> strides;
+            for (size_t index = 0; index < shape.rank(); index++) {
+                num_elements /= static_cast<size_t>(shape[index]);
+                strides.push_back(num_elements);
+            }
+            return strides;
+        };
 
         // Calculate strides
         auto input_strides = compute_strides(input_padded_shape);
@@ -1274,17 +1288,17 @@ Tensor pad(
 
             for (int i = 0; i < rank - 1; ++i) {
                 input_idx += coords[i] * input_strides[i];
-                output_idx += (coords[i] + input_tensor_start[i]) * output_strides[i];
+                output_idx += (coords[i] + static_cast<size_t>(input_tensor_start[i])) * output_strides[i];
             }
 
             // Add offset (left padding) for the innermost dimension
-            output_idx += input_tensor_start[rank - 1] * output_strides[rank - 1];
+            output_idx += static_cast<size_t>(input_tensor_start[rank - 1]) * output_strides[rank - 1];
 
             // Copy entire input row with memcpy
             std::memcpy(
                 output_buffer.data() + output_idx,
                 input_buffer.begin() + input_idx,
-                input_padded_shape[rank - 1] * sizeof(T));
+                static_cast<size_t>(input_padded_shape[rank - 1]) * sizeof(T));
 
             // Increment coordinates (from right to left), ignore last dimension
             processed_all_coords = true;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22336)

### Problem description
Allocating buffers with volume > 2**31 is not working. Probably integer overflow.

### What's changed
Changed integer types throughout the code to size_t/uint64_t where overflow happens. 

- [x] TTNN padding/tilizing
- [x] Slow dispatch read/write
- [ ] Fast dispatch read/write [WIP}

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes