### PR TITLE
Reimplement stack usage api

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_stack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_stack.cpp
@@ -6,34 +6,7 @@
 
 #include "compile_time_args.h"
 #include <dev_mem_map.h>
-
-static uint32_t get_stack_base() {
-#if defined(COMPILE_FOR_BRISC)
-    return MEM_BRISC_STACK_TOP - MEM_BRISC_STACK_SIZE;
-#elif defined(COMPILE_FOR_NCRISC)
-    return MEM_NCRISC_STACK_TOP - MEM_NCRISC_STACK_SIZE;
-#elif defined(COMPILE_FOR_IDLE_ERISC)
-#if COMPILE_FOR_IDLE_ERISC == 0
-    return MEM_IERISC_STACK_TOP - MEM_IERISC_STACK_SIZE;
-#elif COMPILE_FOR_IDLE_ERISC == 1
-    return MEM_SLAVE_IERISC_STACK_TOP - MEM_SLAVE_IERISC_STACK_SIZE;
-#else
-#error "idle erisc get_stack_base unknown"
-#endif
-#elif defined(COMPILE_FOR_TRISC)
-#if COMPILE_FOR_TRISC == 0
-    return MEM_TRISC0_STACK_TOP - MEM_TRISC0_STACK_SIZE;
-#elif COMPILE_FOR_TRISC == 1
-    return MEM_TRISC1_STACK_TOP - MEM_TRISC1_STACK_SIZE;
-#elif COMPILE_FOR_TRISC == 2
-    return MEM_TRISC2_STACK_TOP - MEM_TRISC2_STACK_SIZE;
-#else
-#error "trisc get_stack_base unknown"
-#endif
-#else
-#error "get_stack_base unknown"
-#endif
-}
+#include "stack_usage.h"
 
 #if defined(COMPILE_FOR_TRISC)
 #include "compute_kernel_api/common.h"

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_stack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_stack.cpp
@@ -6,7 +6,7 @@
 
 #include "compile_time_args.h"
 #include <dev_mem_map.h>
-#include "stack_usage.h"
+#include "debug/stack_usage.h"
 
 #if defined(COMPILE_FOR_TRISC)
 #include "compute_kernel_api/common.h"

--- a/tt_metal/hw/firmware/src/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/active_erisc.cc
@@ -67,7 +67,6 @@ uint32_t sumIDs[SUM_COUNT] __attribute__((used));
 
 int main() {
     configure_csr();
-    DIRTY_STACK_MEMORY();
     WAYPOINT("I");
     do_crt1((uint32_t*)MEM_AERISC_INIT_LOCAL_L1_BASE_SCRATCH);
 
@@ -143,11 +142,10 @@ int main() {
                 // TODO: This currently runs on second risc on active eth cores but with newer drop of syseng FW
                 //  this will run on risc0
                 int index = static_cast<std::underlying_type<EthProcessorTypes>::type>(EthProcessorTypes::DM0);
-                void (*kernel_address)(uint32_t) = (void (*)(uint32_t))(
+                uint32_t (*kernel_address)(uint32_t) = (uint32_t (*)(uint32_t))(
                     mailboxes->launch[mailboxes->launch_msg_rd_ptr].kernel_config.kernel_text_offset[index]);
-                (*kernel_address)((uint32_t)kernel_address);
-
-                RECORD_STACK_USAGE();
+                auto stack_free = (*kernel_address)((uint32_t)kernel_address);
+                record_stack_usage(stack_free);
                 WAYPOINT("D");
             }
 

--- a/tt_metal/hw/firmware/src/active_erisck.cc
+++ b/tt_metal/hw/firmware/src/active_erisck.cc
@@ -17,12 +17,14 @@
 #include "stream_io_map.h"
 #include "tdma_xmov.h"
 #include "debug/dprint.h"
+#include "debug/stack_usage.h"
 #include "dataflow_api.h"
 #include "tools/profiler/kernel_profiler.hpp"
 #include <kernel_includes.hpp>
 #include <stdint.h>
 
-void kernel_launch(uint32_t kernel_base_addr) {
+uint32_t kernel_launch(uint32_t kernel_base_addr) {
+    mark_stack_usage();
     extern uint32_t __kernel_init_local_l1_base[];
     extern uint32_t __fw_export_text_end[];
     do_crt1((uint32_t tt_l1_ptr*)(kernel_base_addr + (uint32_t)__kernel_init_local_l1_base -
@@ -51,4 +53,5 @@ void kernel_launch(uint32_t kernel_base_addr) {
             ASSERT(erisc_info->channels[i].bytes_sent == 0);
         }
     }
+    return measure_stack_usage();
 }

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -325,7 +325,6 @@ inline void barrier_remote_cb_interface_setup(uint8_t noc_index, uint32_t end_cb
 
 int main() {
     configure_csr();
-    DIRTY_STACK_MEMORY();
     WAYPOINT("I");
 
     do_crt1((uint32_t*)MEM_BRISC_INIT_LOCAL_L1_BASE_SCRATCH);
@@ -451,10 +450,10 @@ int main() {
                 barrier_remote_cb_interface_setup(noc_index, end_cb_index);
                 start_ncrisc_kernel_run(enables);
                 int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::DM0);
-                void (*kernel_address)(uint32_t) = (void (*)(uint32_t))
+                uint32_t (*kernel_address)(uint32_t) = (uint32_t (*)(uint32_t))
                     (kernel_config_base + launch_msg_address->kernel_config.kernel_text_offset[index]);
-                (*kernel_address)((uint32_t)kernel_address);
-                RECORD_STACK_USAGE();
+                auto stack_free = (*kernel_address)((uint32_t)kernel_address);
+                record_stack_usage(stack_free);
             } else {
 #if defined(PROFILE_KERNEL)
                 // This was not initialized in the kernel

--- a/tt_metal/hw/firmware/src/brisck.cc
+++ b/tt_metal/hw/firmware/src/brisck.cc
@@ -17,12 +17,14 @@
 #include "firmware_common.h"
 #include "dataflow_api.h"
 #include "tools/profiler/kernel_profiler.hpp"
+#include "debug/stack_usage.h"
 #include <kernel_includes.hpp>
 #if defined ALIGN_LOCAL_CBS_TO_REMOTE_CBS
 #include "remote_circular_buffer_api.h"
 #endif
 
-void kernel_launch(uint32_t kernel_base_addr) {
+uint32_t kernel_launch(uint32_t kernel_base_addr) {
+    mark_stack_usage();
 #if defined(DEBUG_NULL_KERNELS) && !defined(DISPATCH_KERNEL)
     wait_for_go_message();
 #ifdef KERNEL_RUN_TIME
@@ -60,5 +62,7 @@ void kernel_launch(uint32_t kernel_base_addr) {
             WAYPOINT("NKFD");
         }
     }
+    EARLY_RETURN_FOR_DEBUG_EXIT;
 #endif
+    return measure_stack_usage();
 }

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -106,7 +106,6 @@ inline void wait_subordinate_eriscs(uint32_t &heartbeat) {
 
 int main() {
     configure_csr();
-    DIRTY_STACK_MEMORY();
     WAYPOINT("I");
     do_crt1((uint32_t *)MEM_IERISC_INIT_LOCAL_L1_BASE_SCRATCH);
     uint32_t heartbeat = 0;
@@ -167,10 +166,10 @@ int main() {
             if (enables & DISPATCH_CLASS_MASK_ETH_DM0) {
                 WAYPOINT("R");
                 int index = static_cast<std::underlying_type<EthProcessorTypes>::type>(EthProcessorTypes::DM0);
-                void (*kernel_address)(uint32_t) = (void (*)(uint32_t))(
+                uint32_t (*kernel_address)(uint32_t) = (uint32_t (*)(uint32_t))(
                     kernel_config_base + launch_msg_address->kernel_config.kernel_text_offset[index]);
-                (*kernel_address)((uint32_t)kernel_address);
-                RECORD_STACK_USAGE();
+                auto stack_free = (*kernel_address)((uint32_t)kernel_address);
+                record_stack_usage(stack_free);
                 WAYPOINT("D");
             }
 

--- a/tt_metal/hw/firmware/src/idle_erisck.cc
+++ b/tt_metal/hw/firmware/src/idle_erisck.cc
@@ -18,10 +18,12 @@
 #include "firmware_common.h"
 #include "tools/profiler/kernel_profiler.hpp"
 #include "dataflow_api.h"
+#include "debug/stack_usage.h"
 
 #include <kernel_includes.hpp>
 
-void kernel_launch(uint32_t kernel_base_addr) {
+uint32_t kernel_launch(uint32_t kernel_base_addr) {
+    mark_stack_usage();
     extern uint32_t __kernel_init_local_l1_base[];
     extern uint32_t __fw_export_text_end[];
     do_crt1((uint32_t tt_l1_ptr
@@ -45,4 +47,5 @@ void kernel_launch(uint32_t kernel_base_addr) {
             WAYPOINT("NKFD");
         }
     }
+    return measure_stack_usage();
 }

--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -23,6 +23,7 @@
 #if defined ALIGN_LOCAL_CBS_TO_REMOTE_CBS
 #include "remote_circular_buffer_api.h"
 #endif
+#include "debug/stack_usage.h"
 
 uint32_t noc_reads_num_issued[NUM_NOCS];
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS];
@@ -30,7 +31,8 @@ uint32_t noc_nonposted_writes_acked[NUM_NOCS];
 uint32_t noc_nonposted_atomics_acked[NUM_NOCS];
 uint32_t noc_posted_writes_num_issued[NUM_NOCS];
 
-void kernel_launch(uint32_t kernel_base_addr) {
+uint32_t kernel_launch(uint32_t kernel_base_addr) {
+    mark_stack_usage();
 #if defined(DEBUG_NULL_KERNELS) && !defined(DISPATCH_KERNEL)
     wait_for_go_message();
     DeviceZoneScopedMainChildN("NCRISC-KERNEL");
@@ -70,5 +72,7 @@ void kernel_launch(uint32_t kernel_base_addr) {
         WAYPOINT("NKFD");
     }
 #endif
+    EARLY_RETURN_FOR_DEBUG_EXIT;
 #endif
+    return measure_stack_usage();
 }

--- a/tt_metal/hw/firmware/src/subordinate_idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/subordinate_idle_erisc.cc
@@ -65,7 +65,6 @@ inline __attribute__((always_inline)) void signal_subordinate_idle_erisc_complet
 
 int main(int argc, char *argv[]) {
     configure_csr();
-    DIRTY_STACK_MEMORY();
     WAYPOINT("I");
     do_crt1((uint32_t *)MEM_SUBORDINATE_IERISC_INIT_LOCAL_L1_BASE_SCRATCH);
 
@@ -94,10 +93,10 @@ int main(int argc, char *argv[]) {
 
         WAYPOINT("R");
         int index = static_cast<std::underlying_type<EthProcessorTypes>::type>(EthProcessorTypes::DM1);
-        void (*kernel_address)(uint32_t) = (void (*)(uint32_t))
+        uint32_t (*kernel_address)(uint32_t) = (uint32_t (*)(uint32_t))
             (kernel_config_base + mailboxes->launch[mailboxes->launch_msg_rd_ptr].kernel_config.kernel_text_offset[index]);
-        (*kernel_address)((uint32_t)kernel_address);
-        RECORD_STACK_USAGE();
+        auto stack_free = (*kernel_address)((uint32_t)kernel_address);
+        record_stack_usage(stack_free);
         WAYPOINT("D");
 
         signal_subordinate_idle_erisc_completion();

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -94,7 +94,6 @@ void init_sync_registers() {
 
 int main(int argc, char *argv[]) {
     configure_csr();
-    DIRTY_STACK_MEMORY();
     WAYPOINT("I");
 
     do_crt1((uint32_t tt_l1_ptr *)PREPROCESSOR_EXPAND(MEM_TRISC, COMPILE_FOR_TRISC, _INIT_LOCAL_L1_BASE_SCRATCH));
@@ -155,10 +154,10 @@ int main(int argc, char *argv[]) {
 
         WAYPOINT("R");
         int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::MATH0) + thread_id;
-        void (*kernel_address)(uint32_t) = (void (*)(uint32_t))
+        uint32_t (*kernel_address)(uint32_t) = (uint32_t (*)(uint32_t))
             (kernel_config_base + launch_msg->kernel_config.kernel_text_offset[index]);
-        (*kernel_address)((uint32_t)kernel_address);
-        RECORD_STACK_USAGE();
+        auto stack_free = (*kernel_address)((uint32_t)kernel_address);
+        record_stack_usage(stack_free);
         WAYPOINT("D");
 
         // Signal completion

--- a/tt_metal/hw/firmware/src/trisck.cc
+++ b/tt_metal/hw/firmware/src/trisck.cc
@@ -18,6 +18,7 @@
 #if defined ALIGN_LOCAL_CBS_TO_REMOTE_CBS
 #include "remote_circular_buffer_api.h"
 #endif
+#include "debug/stack_usage.h"
 
 // Global vars
 uint32_t unp_cfg_context = 0;
@@ -37,7 +38,8 @@ volatile tt_reg_ptr uint * mailbox_base[4] = {
 };
 }
 
-void kernel_launch(uint32_t kernel_base_addr) {
+uint32_t kernel_launch(uint32_t kernel_base_addr) {
+    mark_stack_usage();
 #if defined(DEBUG_NULL_KERNELS) && !defined(DISPATCH_KERNEL)
     wait_for_go_message();
     DeviceZoneScopedMainChildN("TRISC-KERNEL");
@@ -63,5 +65,7 @@ void kernel_launch(uint32_t kernel_base_addr) {
     WAYPOINT("K");
     run_kernel();
     WAYPOINT("KD");
+    EARLY_RETURN_FOR_DEBUG_EXIT;
 #endif
+    return measure_stack_usage();
 }

--- a/tt_metal/hw/inc/debug/stack_usage.h
+++ b/tt_metal/hw/inc/debug/stack_usage.h
@@ -43,7 +43,7 @@ static inline uint32_t get_stack_base() {
 constexpr uint32_t stack_usage_pattern = 0xBABABABA;
 
 static inline void mark_stack_usage() {
-    uint32_t tt_l1_pt *base = (uint32_t tt_l1_ptr *)get_stack_base();
+    uint32_t tt_l1_ptr *base = (uint32_t tt_l1_ptr *)get_stack_base();
     uint32_t tt_l1_ptr *ptr;
     asm ("mv %0,sp" : "=r"(ptr));
 
@@ -53,7 +53,7 @@ static inline void mark_stack_usage() {
 
 // Returns unused stack + 1. (0 means unknown.)
 static inline int measure_stack_usage() {
-    uint32_t tt_l1_pt *base = (uint32_t tt_l1_ptr *)get_stack_base();
+    uint32_t tt_l1_ptr *base = (uint32_t tt_l1_ptr *)get_stack_base();
     uint32_t tt_l1_ptr* stack_ptr = base;
 
     // We don't need to check size here, as we know we'll hit a

--- a/tt_metal/hw/inc/debug/stack_usage.h
+++ b/tt_metal/hw/inc/debug/stack_usage.h
@@ -90,7 +90,7 @@ static inline void record_stack_usage(uint32_t stack_free) {
     unsigned idx = debug_get_which_riscv();
     debug_stack_usage_t::usage_t tt_l1_ptr* usage = &GET_MAILBOX_ADDRESS_DEV(watcher.stack_usage)->cpu[idx];
     // min_free is initialized to zero, which we want to compare as
-    // least noteworthy, and an ofset free stack of one as the most
+    // least noteworthy, and an offset free stack of one as the most
     // noteworthy. Decrement the former, so zero wraps around before
     // checking. (The cast to uint32_t isn't necessary, but conveys
     // meaning.)

--- a/tt_metal/hw/inc/debug/stack_usage.h
+++ b/tt_metal/hw/inc/debug/stack_usage.h
@@ -43,7 +43,7 @@ static inline uint32_t get_stack_base() {
 constexpr uint32_t stack_usage_pattern = 0xBABABABA;
 
 static inline void mark_stack_usage() {
-    uint32_t *base = (uint32_t tt_l1_ptr *)get_stack_base();
+    uint32_t tt_l1_pt *base = (uint32_t tt_l1_ptr *)get_stack_base();
     uint32_t tt_l1_ptr *ptr;
     asm ("mv %0,sp" : "=r"(ptr));
 
@@ -53,9 +53,9 @@ static inline void mark_stack_usage() {
 
 // Returns unused stack + 1. (0 means unknown.)
 static inline int measure_stack_usage() {
-    uint32_t *base = (uint32_t tt_l1_ptr *)get_stack_base();
-
+    uint32_t tt_l1_pt *base = (uint32_t tt_l1_ptr *)get_stack_base();
     uint32_t tt_l1_ptr* stack_ptr = base;
+
     // We don't need to check size here, as we know we'll hit a
     // non-dirty value at some point (a set of return addresses).
     while (*stack_ptr == stack_usage_pattern)

--- a/tt_metal/hw/inc/debug/stack_usage.h
+++ b/tt_metal/hw/inc/debug/stack_usage.h
@@ -41,6 +41,7 @@ static inline uint32_t get_stack_base() {
 }
 
 constexpr uint32_t stack_usage_pattern = 0xBABABABA;
+
 static inline void mark_stack_usage() {
     uint32_t *base = (uint32_t tt_l1_ptr *)get_stack_base();
     uint32_t tt_l1_ptr *ptr;
@@ -50,6 +51,7 @@ static inline void mark_stack_usage() {
         *--ptr = stack_usage_pattern;
 }
 
+// Returns unused stack + 1. (0 means unknown.)
 static inline int measure_stack_usage() {
     uint32_t *base = (uint32_t tt_l1_ptr *)get_stack_base();
 

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -26,7 +26,6 @@ extern uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS];
 extern int32_t bank_to_l1_offset[NUM_L1_BANKS];
 
 extern void kernel_init(uint32_t kernel_init);
-extern void kernel_launch(uint32_t kernel_base_addr);
 void l1_to_local_mem_copy(uint32_t* dst, uint32_t tt_l1_ptr* src, int32_t len);
 
 inline void do_crt1(uint32_t tt_l1_ptr* data_image) {
@@ -124,11 +123,11 @@ bool is_message_go() {
 }
 
 #define EARLY_RETURN_FOR_DEBUG \
-    if (is_message_go()) {     \
-        return;                \
-    }
+    if (is_message_go()) { goto early_debug_exit; }
+#define EARLY_RETURN_FOR_DEBUG_EXIT early_debug_exit:
 #else
 #define EARLY_RETURN_FOR_DEBUG
+#define EARLY_RETURN_FOR_DEBUG_EXIT
 #endif
 
 inline __attribute__((always_inline)) void configure_gathering() {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19983

### Problem description
Only kernels know how much global data they have, thus dynamically-sized stack usage has to be determined there, not in firmware. (while firmware will know the amount of initialized data, the uninitialized data is not known there).

### What's changed
Move stack checking into kernels.  Kernel startup colors the stack with a canary value, and kernel exit looks for the presence of that canary to determine the stack usage.  This patch doesn't make the stack usage dynamic, so we're still using the same stack boundaries. Three other changes are:
1) don't use macros for the stack usage routines, just rely on inlining to evaporate the non-checking case.
2) kernels return the stack usage (offset by 1), so that firmware can record it in an unchanged manner.
3) because each kernel colors its own stack at startup, there's a slow down in the checking case -- the firmware only colored the stack once.

The next patch will make the stack size dynamic.

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes