### PR TITLE
#18200:Add missing template arguments to unpack_tilizeA_B_block and correct number of input rows to tilize reduce

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_upsample.py
@@ -327,7 +327,6 @@ def test_upsample_multicore_corerange(
     assert isequal
 
 
-@skip_for_blackhole("Temporary skip until #18200 is not closed")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, num_channels, height, width, scale_h, scale_w",

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -209,7 +209,7 @@ inline void llk_unpack_tilizeA_B_init(
     llk_unpack_tilizeA_B_mop_config<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(narrow_tile, num_faces);
 }
 
-template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false>
+template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
 inline void llk_unpack_tilizeA_B(
     std::uint32_t operandA,
     std::uint32_t operandB,
@@ -261,6 +261,8 @@ inline void llk_unpack_tilizeA_B(
 
         if constexpr (neginf_srcA) {
             TTI_UNPACR_NOP(SrcA,0,0,0,0,0,0,p_unpacr::UNP_CLRSRC_NEGINF, p_unpacr::UNP_CLRSRC);
+        } else if constexpr (zero_srcA_reduce) {
+            TTI_UNPACR_NOP(SrcA,0,0,0,0,0,0,p_unpacr::UNP_CLRSRC_ZERO, p_unpacr::UNP_CLRSRC);
         }
 
         // Get tile address
@@ -303,7 +305,7 @@ inline void llk_unpack_tilizeA_B(
     WAYPOINT("UPTD");
 }
 
-template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false>
+template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
 inline void llk_unpack_tilizeA_B_block(
     std::uint32_t operandA,
     std::uint32_t operandB,
@@ -312,6 +314,6 @@ inline void llk_unpack_tilizeA_B_block(
     std::uint32_t num_faces = 4,
     std::uint32_t unpA_face_r_dim = FACE_R_DIM) {
     for (std::uint32_t tile_idx_a = 0; tile_idx_a < block_c_tiles_a; tile_idx_a++) {
-        llk_unpack_tilizeA_B<neginf_srcA, reload_srcB, zero_srcA>(operandA, operandB, tile_idx_a, tile_idx_b, block_c_tiles_a, num_faces, unpA_face_r_dim);
+        llk_unpack_tilizeA_B<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(operandA, operandB, tile_idx_a, tile_idx_b, block_c_tiles_a, num_faces, unpA_face_r_dim);
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -209,7 +209,7 @@ inline void llk_unpack_tilizeA_B(
     WAYPOINT("UPTD");
 }
 
-template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false>
+template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
 inline void llk_unpack_tilizeA_B_block(
     std::uint32_t operandA,
     std::uint32_t operandB,

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -158,6 +158,7 @@ ALWI void tilize_block(uint32_t icb, uint32_t block, uint32_t ocb) {
 
 ALWI void unpack_tilize_block(uint32_t icb, uint32_t block) { UNPACK((llk_unpack_tilize_block(icb, block))); }
 
+template <bool neginf_srcA = true, std::uint32_t reload_srcB = true, bool zero_srcA = false, bool zero_srcA_reduce = false>
 ALWI void unpack_tilizeA_B_block(
     uint32_t icb0,
     uint32_t icb1,
@@ -165,7 +166,8 @@ ALWI void unpack_tilizeA_B_block(
     uint32_t tile_idx_b,
     uint32_t num_faces = 4,
     uint32_t srca_face_r_dim = 16) {
-    UNPACK((llk_unpack_tilizeA_B_block<true, true>(icb0, icb1, block, tile_idx_b, num_faces, srca_face_r_dim)));
+    UNPACK((llk_unpack_tilizeA_B_block<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(
+        icb0, icb1, block, tile_idx_b, num_faces, srca_face_r_dim)));
 }
 
 // clang-format off

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
@@ -13,7 +13,7 @@ inline void reduce_h_fused(const uint32_t in_cb_id, const uint32_t in_scalar_cb_
     cb_reserve_back(out_cb_id, tiles_per_reduction);
     tile_regs_acquire();
     cb_wait_front(in_cb_id, 4);
-    unpack_tilizeA_B_block(
+    unpack_tilizeA_B_block<false, true, false, true>(
         in_cb_id,
         in_scalar_cb_id,
         tiles_per_reduction,

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -267,7 +267,7 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
         out_cb_id,
         in_ntiles_c,
         1 * in_ntiles_c,
-        scale_factor_h * scale_factor_w,
+        4,  // Number of input rows required for tilize reduction is 4 as we are processing single output row at a time.
         (uint32_t)std::ceil((float)output_shape[3] / constants::TILE_WIDTH),
         output_nsticks_per_core,  // loop count with blocks
         num_input_width_blocks,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18200

### Problem description

The upsampling tests failed with PCC errors due to two issues which are fixed in this PR. 

### What's changed

unpack_tilizeA_B_block was missing some template arguments which needed to be passed and it used hardcoded values. These values are needed for blackhole since blackhole does not delegate all the tasks to the mop like wormhole and uses them in the function. In wormhole the mop does the work and these arguments are used in the init function to configure the mop. 

The number of input rows has also been modified by Nilay.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes