### PR TITLE
[DM]: Enhancements for Core Locations test

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -28,7 +28,8 @@ TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --g
 ```
 
 ### Pytest
-For performance checks and more extensive testing, our Python test can be run as follows:
+Before running any tests, build the repo with profiler and tests: ```./build_metal.sh --enable-profiler --build-tests```
+Then, for performance checks and more extensive testing, our Python test can be run as follows:
 ```
 pytest tests/tt_metal/tt_metal/data_movement <options>
 ```

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -24,7 +24,7 @@ TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement
 
 To run a single test, add a gtest filter with the name of the test. Example:
 ```
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement gtest_filter="*TensixDataMovementDRAMInterleavedPacketSizes*"
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*TensixDataMovementDRAMInterleavedPacketSizes*"
 ```
 
 ### Pytest

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -183,8 +183,8 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPacketSizes) {
 
 /* ========== Test case for varying core locations; Test id = 1 ========== */
 TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedCoreLocations) {
-    uint32_t num_of_transactions = 1;     // Bound for testing different number of transactions
-    uint32_t transaction_size_pages = 1;  // Bound for testing different transaction sizes
+    uint32_t num_of_transactions = 128;     // Bound for testing different number of transactions
+    uint32_t transaction_size_pages = 128;  // Bound for testing different transaction sizes
     uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
 
     for (unsigned int id = 0; id < num_devices_; id++) {

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -101,8 +101,8 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 300, "upper": 25000}, "bandwidth": 0.07},
         },
         1: {
-            "riscv_1": {"latency": {"lower": 400, "upper": 700}, "bandwidth": 0.19},
-            "riscv_0": {"latency": {"lower": 300, "upper": 500}, "bandwidth": 0.29},
+            "riscv_1": {"latency": {"lower": 23000, "upper": 24000}, "bandwidth": 21},
+            "riscv_0": {"latency": {"lower": 24000, "upper": 25000}, "bandwidth": 21},
         },
         2: {
             "riscv_1": {"latency": {"lower": 500, "upper": 600}, "bandwidth": 0.24},

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -158,8 +158,8 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 300, "upper": 16000}, "bandwidth": 0.15},
         },
         1: {
-            "riscv_1": {"latency": {"lower": 300, "upper": 700}, "bandwidth": 0.17},
-            "riscv_0": {"latency": {"lower": 200, "upper": 500}, "bandwidth": 0.23},
+            "riscv_1": {"latency": {"lower": 30000, "upper": 33000}, "bandwidth": 32},
+            "riscv_0": {"latency": {"lower": 30000, "upper": 31000}, "bandwidth": 33},
         },
         2: {
             "riscv_1": {"latency": {"lower": 400, "upper": 600}, "bandwidth": 0.13},


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22507)

### Problem description
Performance numbers and the plot for the `1: "DRAM Interleaved Core Locations"` test are off. The bandwidth graph shows much less BW than the actual DRAM BW due to very small number of transactions and transaction sizes used in this test (1 transaction which is 1 page large - 32B in WH and 64B in BH).

### What's changed
Increased the transaction count and the transaction size (in pages) to 128. Plots and performance results are more meaningful.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15283168674) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15283170460) CI with demo tests passes (if applicable)