### PR TITLE
Improve Buffer/Tensor APIs related to ND sharding

### DIFF
--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> create_replicated_mesh_bu
         .page_size = page_size,
         .buffer_type = inputs.buffer_type,
         .buffer_layout = tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED,
-        .buffer_distribution_spec = buffer_distribution_spec,
+        .shard_parameters = buffer_distribution_spec,
     };
 
     // Mirrors allocate_mesh_buffer_on_device in ttnn

--- a/tests/ttnn/unit_tests/gtests/accessor/test_sharded_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_sharded_accessor_on_device.cpp
@@ -54,7 +54,7 @@ create_replicated_input_and_output_mesh_buffers_from_inputs(
         .page_size = page_size,
         .buffer_type = inputs.input_shard_spec.buffer_type,
         .buffer_layout = tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED,
-        .buffer_distribution_spec = input_buffer_distribution_spec,
+        .shard_parameters = input_buffer_distribution_spec,
     };
     const auto input_mesh_buffer =
         tt::tt_metal::distributed::MeshBuffer::create(mesh_buffer_config, input_device_local_config, mesh_device);
@@ -70,7 +70,7 @@ create_replicated_input_and_output_mesh_buffers_from_inputs(
         .page_size = page_size,
         .buffer_type = inputs.output_shard_spec.buffer_type,
         .buffer_layout = tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED,
-        .buffer_distribution_spec = output_buffer_distribution_spec,
+        .shard_parameters = output_buffer_distribution_spec,
     };
     const auto output_mesh_buffer =
         tt::tt_metal::distributed::MeshBuffer::create(mesh_buffer_config, output_device_local_config, mesh_device);
@@ -169,7 +169,7 @@ TEST_P(ShardedAccessorTestsOnDevice, SingleCoreReshard) {
 
         // Set up compile-time args for reader kernel
         const auto& input_buffer_distribution_spec =
-            input_mesh_buffer->device_local_config().buffer_distribution_spec.value();
+            std::get<BufferDistributionSpec>(input_mesh_buffer->device_local_config().shard_parameters.value());
         const auto input_sharded_accessor_args = tt::tt_metal::sharded_accessor_utils::get_sharded_accessor_args(
             *mesh_device_, input_buffer_distribution_spec, input_shard_view->core_type());
         std::vector<uint32_t> input_compile_time_args = {
@@ -183,7 +183,7 @@ TEST_P(ShardedAccessorTestsOnDevice, SingleCoreReshard) {
 
         // Set up compile-time args for writer  kernel
         const auto& output_buffer_distribution_spec =
-            output_mesh_buffer->device_local_config().buffer_distribution_spec.value();
+            std::get<BufferDistributionSpec>(output_mesh_buffer->device_local_config().shard_parameters.value());
         const auto output_sharded_accessor_args = tt::tt_metal::sharded_accessor_utils::get_sharded_accessor_args(
             *mesh_device_, output_buffer_distribution_spec, output_shard_view->core_type());
         std::vector<uint32_t> output_compile_time_args = {

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -207,7 +207,7 @@ public:
         DeviceAddr page_size,
         BufferType buffer_type,
         TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
-        const std::optional<ShardSpecBuffer>& shard_parameter = std::nullopt,
+        const std::optional<std::variant<ShardSpecBuffer, BufferDistributionSpec>>& shard_parameter = std::nullopt,
         std::optional<bool> bottom_up = std::nullopt,
         std::optional<SubDeviceId> sub_device_id = std::nullopt);
     static std::shared_ptr<Buffer> create(
@@ -217,24 +217,7 @@ public:
         DeviceAddr page_size,
         BufferType buffer_type,
         TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
-        const std::optional<ShardSpecBuffer>& shard_parameter = std::nullopt,
-        std::optional<bool> bottom_up = std::nullopt,
-        std::optional<SubDeviceId> sub_device_id = std::nullopt);
-    static std::shared_ptr<Buffer> create(
-        IDevice* device,
-        DeviceAddr size,
-        DeviceAddr page_size,
-        BufferType buffer_type,
-        const BufferDistributionSpec& shard_parameter,
-        std::optional<bool> bottom_up = std::nullopt,
-        std::optional<SubDeviceId> sub_device_id = std::nullopt);
-    static std::shared_ptr<Buffer> create(
-        IDevice* device,
-        DeviceAddr address,
-        DeviceAddr size,
-        DeviceAddr page_size,
-        BufferType buffer_type,
-        const BufferDistributionSpec& shard_parameter,
+        const std::optional<std::variant<ShardSpecBuffer, BufferDistributionSpec>>& shard_parameter = std::nullopt,
         std::optional<bool> bottom_up = std::nullopt,
         std::optional<SubDeviceId> sub_device_id = std::nullopt);
 
@@ -328,8 +311,7 @@ public:
         DeviceAddr page_size,
         BufferType buffer_type,
         TensorMemoryLayout buffer_layout,
-        const std::optional<ShardSpecBuffer>& shard_parameter,
-        const std::optional<BufferDistributionSpec>& buffer_distribution_spec,
+        const std::optional<std::variant<ShardSpecBuffer, BufferDistributionSpec>>& shard_parameter,
         std::optional<bool> bottom_up,
         std::optional<SubDeviceId> sub_device_id,
         bool owns_data,

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -209,8 +209,7 @@ public:
         TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
         const std::optional<ShardSpecBuffer>& shard_parameter = std::nullopt,
         std::optional<bool> bottom_up = std::nullopt,
-        std::optional<SubDeviceId> sub_device_id = std::nullopt,
-        const std::optional<BufferDistributionSpec>& buffer_distribution_spec = std::nullopt);
+        std::optional<SubDeviceId> sub_device_id = std::nullopt);
     static std::shared_ptr<Buffer> create(
         IDevice* device,
         DeviceAddr address,
@@ -220,8 +219,24 @@ public:
         TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
         const std::optional<ShardSpecBuffer>& shard_parameter = std::nullopt,
         std::optional<bool> bottom_up = std::nullopt,
-        std::optional<SubDeviceId> sub_device_id = std::nullopt,
-        const std::optional<BufferDistributionSpec>& buffer_distribution_spec = std::nullopt);
+        std::optional<SubDeviceId> sub_device_id = std::nullopt);
+    static std::shared_ptr<Buffer> create(
+        IDevice* device,
+        DeviceAddr size,
+        DeviceAddr page_size,
+        BufferType buffer_type,
+        const BufferDistributionSpec& shard_parameter,
+        std::optional<bool> bottom_up = std::nullopt,
+        std::optional<SubDeviceId> sub_device_id = std::nullopt);
+    static std::shared_ptr<Buffer> create(
+        IDevice* device,
+        DeviceAddr address,
+        DeviceAddr size,
+        DeviceAddr page_size,
+        BufferType buffer_type,
+        const BufferDistributionSpec& shard_parameter,
+        std::optional<bool> bottom_up = std::nullopt,
+        std::optional<SubDeviceId> sub_device_id = std::nullopt);
 
     Buffer(const Buffer& other) = delete;
     Buffer& operator=(const Buffer& other) = delete;

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -31,9 +31,7 @@ struct DeviceLocalBufferConfig {
     TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED;
 
     // Must be set for sharded buffer layouts.
-    std::optional<ShardSpecBuffer> shard_parameters;
-
-    std::optional<BufferDistributionSpec> buffer_distribution_spec;
+    std::optional<std::variant<ShardSpecBuffer, BufferDistributionSpec>> shard_parameters;
 
     // The direction in which memory for this buffer is allocated.
     std::optional<bool> bottom_up;

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -93,27 +93,15 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
     if (!address.has_value()) {
         // Rely on the MeshDevice allocator to provide the address for the entire mesh buffer.
         // The address provided to the backing buffer is used as the address for the MeshBuffer object.
-        std::shared_ptr<Buffer> backing_buffer;
-        if (device_local_config.buffer_distribution_spec && !device_local_config.shard_parameters) {
-            backing_buffer = Buffer::create(
-                mesh_device,
-                device_local_size,
-                device_local_config.page_size,
-                device_local_config.buffer_type,
-                *device_local_config.buffer_distribution_spec,
-                device_local_config.bottom_up,
-                device_local_config.sub_device_id);
-        } else {
-            backing_buffer = Buffer::create(
-                mesh_device,
-                device_local_size,
-                device_local_config.page_size,
-                device_local_config.buffer_type,
-                device_local_config.buffer_layout,
-                device_local_config.shard_parameters,
-                device_local_config.bottom_up,
-                device_local_config.sub_device_id);
-        }
+        std::shared_ptr<Buffer> backing_buffer = Buffer::create(
+            mesh_device,
+            device_local_size,
+            device_local_config.page_size,
+            device_local_config.buffer_type,
+            device_local_config.buffer_layout,
+            device_local_config.shard_parameters,
+            device_local_config.bottom_up,
+            device_local_config.sub_device_id);
 
         mesh_buffer = std::shared_ptr<MeshBuffer>(new MeshBuffer(
             mesh_buffer_config, device_local_config, device_local_size, mesh_device, std::move(backing_buffer)));
@@ -129,29 +117,16 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
 
 void MeshBuffer::initialize_device_buffers() {
     auto init_device_buffer_at_address = [this](const MeshCoordinate& coord) {
-        std::shared_ptr<Buffer> buffer;
-        if (device_local_config_.buffer_distribution_spec && !device_local_config_.shard_parameters) {
-            buffer = Buffer::create(
-                device()->get_device(coord),
-                address_,
-                device_local_size_,
-                device_local_config_.page_size,
-                device_local_config_.buffer_type,
-                *device_local_config_.buffer_distribution_spec,
-                device_local_config_.bottom_up,
-                /*sub_device_id=*/std::nullopt);  // TODO: sub_device_id is unsupported
-        } else {
-            buffer = Buffer::create(
-                device()->get_device(coord),
-                address_,
-                device_local_size_,
-                device_local_config_.page_size,
-                device_local_config_.buffer_type,
-                device_local_config_.buffer_layout,
-                device_local_config_.shard_parameters,
-                device_local_config_.bottom_up,
-                /*sub_device_id=*/std::nullopt);  // TODO: sub_device_id is unsupported
-        }
+        std::shared_ptr<Buffer> buffer = Buffer::create(
+            device()->get_device(coord),
+            address_,
+            device_local_size_,
+            device_local_config_.page_size,
+            device_local_config_.buffer_type,
+            device_local_config_.buffer_layout,
+            device_local_config_.shard_parameters,
+            device_local_config_.bottom_up,
+            /*sub_device_id=*/std::nullopt);  // TODO: sub_device_id is unsupported
         return buffer;
     };
 

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -93,16 +93,27 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
     if (!address.has_value()) {
         // Rely on the MeshDevice allocator to provide the address for the entire mesh buffer.
         // The address provided to the backing buffer is used as the address for the MeshBuffer object.
-        std::shared_ptr<Buffer> backing_buffer = Buffer::create(
-            mesh_device,
-            device_local_size,
-            device_local_config.page_size,
-            device_local_config.buffer_type,
-            device_local_config.buffer_layout,
-            device_local_config.shard_parameters,
-            device_local_config.bottom_up,
-            device_local_config.sub_device_id,
-            device_local_config.buffer_distribution_spec);
+        std::shared_ptr<Buffer> backing_buffer;
+        if (device_local_config.buffer_distribution_spec && !device_local_config.shard_parameters) {
+            backing_buffer = Buffer::create(
+                mesh_device,
+                device_local_size,
+                device_local_config.page_size,
+                device_local_config.buffer_type,
+                *device_local_config.buffer_distribution_spec,
+                device_local_config.bottom_up,
+                device_local_config.sub_device_id);
+        } else {
+            backing_buffer = Buffer::create(
+                mesh_device,
+                device_local_size,
+                device_local_config.page_size,
+                device_local_config.buffer_type,
+                device_local_config.buffer_layout,
+                device_local_config.shard_parameters,
+                device_local_config.bottom_up,
+                device_local_config.sub_device_id);
+        }
 
         mesh_buffer = std::shared_ptr<MeshBuffer>(new MeshBuffer(
             mesh_buffer_config, device_local_config, device_local_size, mesh_device, std::move(backing_buffer)));
@@ -118,17 +129,29 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
 
 void MeshBuffer::initialize_device_buffers() {
     auto init_device_buffer_at_address = [this](const MeshCoordinate& coord) {
-        std::shared_ptr<Buffer> buffer = Buffer::create(
-            device()->get_device(coord),
-            address_,
-            device_local_size_,
-            device_local_config_.page_size,
-            device_local_config_.buffer_type,
-            device_local_config_.buffer_layout,
-            device_local_config_.shard_parameters,
-            device_local_config_.bottom_up,
-            /*sub_device_id=*/std::nullopt,  // TODO: sub_device_id is unsupported
-            device_local_config_.buffer_distribution_spec);
+        std::shared_ptr<Buffer> buffer;
+        if (device_local_config_.buffer_distribution_spec && !device_local_config_.shard_parameters) {
+            buffer = Buffer::create(
+                device()->get_device(coord),
+                address_,
+                device_local_size_,
+                device_local_config_.page_size,
+                device_local_config_.buffer_type,
+                *device_local_config_.buffer_distribution_spec,
+                device_local_config_.bottom_up,
+                /*sub_device_id=*/std::nullopt);  // TODO: sub_device_id is unsupported
+        } else {
+            buffer = Buffer::create(
+                device()->get_device(coord),
+                address_,
+                device_local_size_,
+                device_local_config_.page_size,
+                device_local_config_.buffer_type,
+                device_local_config_.buffer_layout,
+                device_local_config_.shard_parameters,
+                device_local_config_.bottom_up,
+                /*sub_device_id=*/std::nullopt);  // TODO: sub_device_id is unsupported
+        }
         return buffer;
     };
 

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -12,6 +12,7 @@
 #include <math.hpp>
 #include <nlohmann/json.hpp>
 #include <tt_stl/reflection.hpp>
+#include <tt_stl/overloaded.hpp>
 #include <algorithm>
 #include <atomic>
 #include <map>
@@ -281,8 +282,7 @@ Buffer::Buffer(
     DeviceAddr page_size,
     const BufferType buffer_type,
     const TensorMemoryLayout buffer_layout,
-    const std::optional<ShardSpecBuffer>& shard_parameters,
-    const std::optional<BufferDistributionSpec>& buffer_distribution_spec,
+    const std::optional<std::variant<ShardSpecBuffer, BufferDistributionSpec>>& shard_parameters,
     const std::optional<bool> bottom_up,
     const std::optional<SubDeviceId> sub_device_id,
     const bool owns_data,
@@ -292,21 +292,29 @@ Buffer::Buffer(
     page_size_(page_size),
     buffer_type_(buffer_type),
     buffer_layout_(buffer_layout),
-    shard_parameters_(shard_parameters),
-    buffer_distribution_spec_(buffer_distribution_spec),
     bottom_up_(bottom_up.value_or(this->is_dram())),
     sub_device_id_(sub_device_id),
     owns_data_(owns_data),
     buffer_page_mapping_(nullptr) {
+    if (shard_parameters) {
+        std::visit(
+            tt::stl::overloaded{
+                [this](const ShardSpecBuffer& shard_spec_buffer) { this->shard_parameters_ = shard_spec_buffer; },
+                [this](const BufferDistributionSpec& buffer_distribution_spec) {
+                    this->buffer_distribution_spec_ = buffer_distribution_spec;
+                }},
+            shard_parameters.value());
+    }
     TT_FATAL(this->device_ != nullptr, "Device needs to not be null.");
     if (this->sub_device_id_.has_value()) {
-        validate_sub_device_id(this->sub_device_id_, this->device_, buffer_type, shard_parameters);
+        validate_sub_device_id(this->sub_device_id_, this->device_, buffer_type, shard_parameters_);
         this->sub_device_manager_id_ = this->device_->get_active_sub_device_manager_id();
         this->allocator_ = device->allocator(*this->sub_device_id_).get();
     } else {
         this->allocator_ = device->allocator().get();
     }
-    validate_buffer_parameters(size, page_size, buffer_type, buffer_layout, shard_parameters, buffer_distribution_spec);
+    validate_buffer_parameters(
+        size, page_size, buffer_type, buffer_layout, shard_parameters_, buffer_distribution_spec_);
     unique_id_ = next_unique_id.fetch_add(1);
 }
 
@@ -316,7 +324,7 @@ std::shared_ptr<Buffer> Buffer::create(
     DeviceAddr page_size,
     const BufferType buffer_type,
     const TensorMemoryLayout buffer_layout,
-    const std::optional<ShardSpecBuffer>& shard_parameters,
+    const std::optional<std::variant<ShardSpecBuffer, BufferDistributionSpec>>& shard_parameters,
     const std::optional<bool> bottom_up,
     const std::optional<SubDeviceId> sub_device_id) {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
@@ -328,7 +336,6 @@ std::shared_ptr<Buffer> Buffer::create(
         buffer_type,
         buffer_layout,
         shard_parameters,
-        std::nullopt,
         bottom_up,
         sub_device_id,
         true /* owns data */,
@@ -352,8 +359,7 @@ std::shared_ptr<Buffer> Buffer::create(
         buffer_layout,
         shard_parameters,
         bottom_up,
-        sub_device_id,
-        std::nullopt);
+        sub_device_id);
 
     return buffer;
 }
@@ -365,7 +371,7 @@ std::shared_ptr<Buffer> Buffer::create(
     DeviceAddr page_size,
     const BufferType buffer_type,
     const TensorMemoryLayout buffer_layout,
-    const std::optional<ShardSpecBuffer>& shard_parameters,
+    const std::optional<std::variant<ShardSpecBuffer, BufferDistributionSpec>>& shard_parameters,
     const std::optional<bool> bottom_up,
     const std::optional<SubDeviceId> sub_device_id) {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
@@ -376,7 +382,6 @@ std::shared_ptr<Buffer> Buffer::create(
         buffer_type,
         buffer_layout,
         shard_parameters,
-        std::nullopt,
         bottom_up,
         sub_device_id,
         false /* owns data */,
@@ -396,98 +401,7 @@ std::shared_ptr<Buffer> Buffer::create(
         buffer_layout,
         shard_parameters,
         bottom_up,
-        sub_device_id,
-        std::nullopt);
-
-    return buffer;
-}
-
-std::shared_ptr<Buffer> Buffer::create(
-    IDevice* device,
-    DeviceAddr size,
-    DeviceAddr page_size,
-    const BufferType buffer_type,
-    const BufferDistributionSpec& shard_parameters,
-    const std::optional<bool> bottom_up,
-    const std::optional<SubDeviceId> sub_device_id) {
-    LIGHT_METAL_TRACE_FUNCTION_ENTRY();
-
-    auto buffer = std::make_shared<Buffer>(
-        device,
-        size,
-        page_size,
-        buffer_type,
-        TensorMemoryLayout::BLOCK_SHARDED,
-        std::nullopt,
-        shard_parameters,
-        bottom_up,
-        sub_device_id,
-        true /* owns data */,
-        Private());
-
-    if (buffer->size_ == 0) {
-        buffer->allocation_status_ = AllocationStatus::ALLOCATED;
-        return buffer;
-    }
-
-    buffer->allocate_impl();
-
-    LIGHT_METAL_TRACE_FUNCTION_CALL(
-        CaptureBufferCreate,
-        buffer,
-        device,
-        std::nullopt,
-        size,
-        page_size,
-        buffer_type,
-        TensorMemoryLayout::BLOCK_SHARDED,
-        std::nullopt,
-        bottom_up,
-        sub_device_id,
-        shard_parameters);
-
-    return buffer;
-}
-
-std::shared_ptr<Buffer> Buffer::create(
-    IDevice* device,
-    DeviceAddr address,
-    DeviceAddr size,
-    DeviceAddr page_size,
-    const BufferType buffer_type,
-    const BufferDistributionSpec& shard_parameters,
-    const std::optional<bool> bottom_up,
-    const std::optional<SubDeviceId> sub_device_id) {
-    LIGHT_METAL_TRACE_FUNCTION_ENTRY();
-    auto buffer = std::make_shared<Buffer>(
-        device,
-        size,
-        page_size,
-        buffer_type,
-        TensorMemoryLayout::BLOCK_SHARDED,
-        std::nullopt,
-        shard_parameters,
-        bottom_up,
-        sub_device_id,
-        false /* owns data */,
-        Private());
-
-    buffer->address_ = address;
-    buffer->allocation_status_ = AllocationStatus::ALLOCATED;
-
-    LIGHT_METAL_TRACE_FUNCTION_CALL(
-        CaptureBufferCreate,
-        buffer,
-        device,
-        address,
-        size,
-        page_size,
-        buffer_type,
-        TensorMemoryLayout::BLOCK_SHARDED,
-        std::nullopt,
-        bottom_up,
-        sub_device_id,
-        shard_parameters);
+        sub_device_id);
 
     return buffer;
 }

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
@@ -85,10 +85,9 @@ void CaptureBufferCreate(
     DeviceAddr page_size,
     const BufferType buffer_type,
     const TensorMemoryLayout buffer_layout,
-    const std::optional<ShardSpecBuffer>& shard_parameters,
+    const std::optional<std::variant<ShardSpecBuffer, BufferDistributionSpec>>& shard_parameters,
     const std::optional<bool> bottom_up,
-    const std::optional<SubDeviceId> sub_device_id,
-    const std::optional<BufferDistributionSpec>& buffer_distribution_spec);
+    const std::optional<SubDeviceId> sub_device_id);
 
 void CaptureBufferDeallocate(const Buffer& buffer);
 void CaptureBufferDelete(const Buffer& buffer);

--- a/ttnn/api/ttnn/tensor/layout/tensor_layout.hpp
+++ b/ttnn/api/ttnn/tensor/layout/tensor_layout.hpp
@@ -42,8 +42,8 @@ public:
 
     Strides compute_strides(const ttnn::Shape& shape) const;
 
-    using BufferDistributionSpecVariant = std::variant<std::monostate, ShardSpecBuffer, BufferDistributionSpec>;
-    BufferDistributionSpecVariant compute_distribution_spec(const ttnn::Shape& shape) const;
+    std::optional<std::variant<ShardSpecBuffer, BufferDistributionSpec>> compute_distribution_spec(
+        const ttnn::Shape& shape) const;
 
     size_t compute_packed_buffer_size_bytes(const ttnn::Shape& shape) const;
     size_t compute_page_size_bytes(const ttnn::Shape& shape) const;

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -210,6 +210,7 @@ public:
     const DistributedTensorConfig& distributed_tensor_config() const;
     const MemoryConfig& memory_config() const;
     const std::optional<ShardSpec>& shard_spec() const;
+    const std::optional<NdShardSpec>& nd_shard_spec() const;
 
     // ======================================================================================
     //                                      Extra Helper Functions

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -209,6 +209,8 @@ public:
     uint64_t padded_volume() const;
     const DistributedTensorConfig& distributed_tensor_config() const;
     const MemoryConfig& memory_config() const;
+
+    // For sharded tensors, at least one of ShardSpec or NdShardSpec will be provided.
     const std::optional<ShardSpec>& shard_spec() const;
     const std::optional<NdShardSpec>& nd_shard_spec() const;
 

--- a/ttnn/api/ttnn/tensor/tensor_spec.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_spec.hpp
@@ -32,7 +32,7 @@ public:
     Tile tile() const { return tensor_layout_.get_tile(); }
 
     Strides compute_strides() const { return tensor_layout_.compute_strides(logical_shape_); }
-    TensorLayout::BufferDistributionSpecVariant compute_distribution_spec() const {
+    std::optional<std::variant<ShardSpecBuffer, BufferDistributionSpec>> compute_distribution_spec() const {
         return tensor_layout_.compute_distribution_spec(logical_shape_);
     }
     size_t compute_packed_buffer_size_bytes() const {

--- a/ttnn/core/tensor/layout/tensor_layout.cpp
+++ b/ttnn/core/tensor/layout/tensor_layout.cpp
@@ -170,9 +170,10 @@ void TensorLayout::initialize_alignment() {
     alignment_ = Alignment(std::move(result));
 }
 
-TensorLayout::BufferDistributionSpecVariant TensorLayout::compute_distribution_spec(const ttnn::Shape& shape) const {
+std::optional<std::variant<ShardSpecBuffer, BufferDistributionSpec>> TensorLayout::compute_distribution_spec(
+    const ttnn::Shape& shape) const {
     if (!memory_config_.is_sharded()) {
-        return std::monostate{};
+        return std::nullopt;
     }
 
     TT_FATAL(

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -835,6 +835,8 @@ const MemoryConfig& Tensor::memory_config() const { return get_tensor_spec().ten
 
 const std::optional<ShardSpec>& Tensor::shard_spec() const { return this->memory_config().shard_spec(); }
 
+const std::optional<NdShardSpec>& Tensor::nd_shard_spec() const { return this->memory_config().nd_shard_spec(); }
+
 const DistributedTensorConfig& Tensor::distributed_tensor_config() const {
     return this->tensor_attributes->get_distributed_tensor_config();
 }

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -65,57 +65,27 @@ uint32_t element_size_bytes(DataType dtype) {
 std::shared_ptr<Buffer> allocate_buffer_on_device(IDevice* device, const TensorSpec& tensor_spec) {
     auto buffer_size_bytes = tensor_spec.compute_packed_buffer_size_bytes();
     auto page_size_bytes = tensor_spec.compute_page_size_bytes();
-    auto shard_spec_buffer = tensor_spec.compute_distribution_spec();
     auto memory_config = tensor_spec.tensor_layout().get_memory_config();
 
-    return std::visit(
-        tt::stl::overloaded{
-            [&](const std::monostate&) {
-                return Buffer::create(
-                    device,
-                    buffer_size_bytes,
-                    page_size_bytes,
-                    memory_config.buffer_type(),
-                    memory_config.memory_layout());
-            },
-            [&](const ShardSpecBuffer& shard_spec_buffer) {
-                return Buffer::create(
-                    device,
-                    buffer_size_bytes,
-                    page_size_bytes,
-                    memory_config.buffer_type(),
-                    memory_config.memory_layout(),
-                    shard_spec_buffer);
-            },
-            [&](const BufferDistributionSpec& buffer_distribution_spec) {
-                return Buffer::create(
-                    device, buffer_size_bytes, page_size_bytes, memory_config.buffer_type(), buffer_distribution_spec);
-            }},
-        shard_spec_buffer);
+    return Buffer::create(
+        device,
+        buffer_size_bytes,
+        page_size_bytes,
+        memory_config.buffer_type(),
+        memory_config.memory_layout(),
+        tensor_spec.compute_distribution_spec());
 }
 
 std::shared_ptr<distributed::MeshBuffer> allocate_mesh_buffer_on_device(
     distributed::MeshDevice* mesh_device, const TensorSpec& tensor_spec) {
     const auto& memory_config = tensor_spec.tensor_layout().get_memory_config();
-    auto shard_spec_buffer_variant = tensor_spec.compute_distribution_spec();
 
     distributed::DeviceLocalBufferConfig device_local_buffer_config{
         .page_size = tensor_spec.compute_page_size_bytes(),
         .buffer_type = memory_config.buffer_type(),
         .buffer_layout = memory_config.memory_layout(),
+        .shard_parameters = tensor_spec.compute_distribution_spec(),
     };
-
-    std::visit(
-        tt::stl::overloaded{
-            [&](const std::monostate&) {},
-            [&](const ShardSpecBuffer& shard_spec_buffer) {
-                device_local_buffer_config.shard_parameters = shard_spec_buffer;
-            },
-            [&](const BufferDistributionSpec& buffer_distribution_spec) {
-                device_local_buffer_config.buffer_distribution_spec = buffer_distribution_spec;
-            },
-        },
-        shard_spec_buffer_variant);
 
     // Use replicated buffer, which supports both working with individual shards and replicating data across all shards.
     // This is required for the time being, as TTNN has rich multi-device sharding implementation.

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -89,15 +89,7 @@ std::shared_ptr<Buffer> allocate_buffer_on_device(IDevice* device, const TensorS
             },
             [&](const BufferDistributionSpec& buffer_distribution_spec) {
                 return Buffer::create(
-                    device,
-                    buffer_size_bytes,
-                    page_size_bytes,
-                    memory_config.buffer_type(),
-                    TensorMemoryLayout::BLOCK_SHARDED,
-                    std::nullopt,
-                    std::nullopt,
-                    std::nullopt,
-                    buffer_distribution_spec);
+                    device, buffer_size_bytes, page_size_bytes, memory_config.buffer_type(), buffer_distribution_spec);
             }},
         shard_spec_buffer);
 }


### PR DESCRIPTION
### Ticket

### Problem description
Minor API improvements for Buffer/Tensor related to ND sharding

### What's changed
Made Buffer constructor to take a variant of ShardSpecBuffer and BufferDistributionSpec instead of two separate parameters
Updated DeviceLocalBufferConfig to have a variant of ShardSpecBuffer and BufferDistributionSpec instead of two separate fields
Added nd_shard_spec() getter to Tensor for convinience

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/15284830645)
- [x] New/Existing tests provide coverage for changes