### PR TITLE
#21734: [skip ci] Add falcon7b and some variant tests to the WH 6U upstream test suite

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -164,7 +164,18 @@ jobs:
         env:
           SOURCE_LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct
           LLAMA_DIR: /model_weights/llama/Llama3.3-70B-Instruct
-        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $SOURCE_LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
+          SOURCE_FALCON_HF_DIR: /mnt/MLPerf/tt_dnn-models/Falcon
+          SOURCE_FALCON_TT_CACHE_DIR: /mnt/MLPerf/tt_dnn-models/tt/Falcon
+        # We need to mount both the HF weights and the tensor cache
+        run: |
+          docker run \
+          -v /dev/hugepages-1G:/dev/hugepages-1G \
+          -v $SOURCE_LLAMA_DIR:$LLAMA_DIR:ro \
+          -v $SOURCE_FALCON_HF_DIR:$SOURCE_FALCON_HF_DIR:ro \
+          -v $SOURCE_FALCON_TT_CACHE_DIR:$SOURCE_FALCON_TT_CACHE_DIR:ro \
+          --device /dev/tenstorrent \
+          -e LLAMA_DIR \
+          ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10
         run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -160,7 +160,7 @@ jobs:
         timeout-minutes: 10
         run: docker pull ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
       - name: Run image
-        timeout-minutes: 15
+        timeout-minutes: 30
         env:
           SOURCE_LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct
           LLAMA_DIR: /model_weights/llama/Llama3.3-70B-Instruct

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -84,6 +84,8 @@ def test_demo_multichip(
         }
         expected_perf_metrics = expected_perf_dict[galaxy_type][max_seq_len]
         expected_perf_metrics["decode_t/s"] = global_batch_size * expected_perf_metrics["decode_t/s/u"]
+    else:
+        expected_perf_metrics = None
 
     if perf_mode:
         json_perf_targets = {

--- a/tests/scripts/wh_6u/run_wh_6u_upstream_tests.sh
+++ b/tests/scripts/wh_6u/run_wh_6u_upstream_tests.sh
@@ -2,7 +2,20 @@
 set -euo pipefail
 
 echo "[upstream-tests] Running falcon7b model unit tests"
-pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/tg/falcon7b/input_data_tg.json' models/demos/tg/falcon7b/demo_tg.py --timeout=300 -k "default_mode_1024_stochastic"
+declare -a FALCON_TESTS=(
+    "perf_mode_128_stochastic and not verify"
+    "perf_mode_1024_stochastic and not verify"
+    "perf_mode_2048_stochastic and not verify"
+    "default_mode_1024_stochastic"
+)
+for falcon_test_filter in "${FALCON_TESTS[@]}"; do
+    pytest --disable-warnings -q -s \
+        --input-method=json \
+        --input-path='models/demos/tg/falcon7b/input_data_tg.json' \
+        models/demos/tg/falcon7b/demo_tg.py \
+        --timeout=300 \
+        -k "$falcon_test_filter"
+done
 
 echo "[upstream-tests] Running minimal model unit tests"
 pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py

--- a/tests/scripts/wh_6u/run_wh_6u_upstream_tests.sh
+++ b/tests/scripts/wh_6u/run_wh_6u_upstream_tests.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "[upstream-tests] running metalium section. Note that skips should be treated as failures"
-./build/test/tt_metal/tt_fabric/test_system_health
-TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardFixture.*"
-TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardProgramFixture.*"
-TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites"
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+echo "[upstream-tests] Running falcon7b model unit tests"
+pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/tg/falcon7b/input_data_tg.json' models/demos/tg/falcon7b/demo_tg.py --timeout=300 -k "default_mode_1024_stochastic"
 
 echo "[upstream-tests] Running minimal model unit tests"
 pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
@@ -33,3 +29,10 @@ pytest models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.
 
 echo "[upstream-tests] Unsetting LLAMA_DIR to ensure later tests can't use it"
 unset LLAMA_DIR
+
+echo "[upstream-tests] running metalium section. Note that skips should be treated as failures"
+./build/test/tt_metal/tt_fabric/test_system_health
+TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardFixture.*"
+TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardProgramFixture.*"
+TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites"
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"


### PR DESCRIPTION
### Ticket

#21734

### Problem description

Add falcon7b and their variants to 6U tests.

### What's changed

Add them with stuff mounted.

Note that a full run on an empty 6U will likely take 2hr.

### Checklist
- [ ] https://github.com/tenstorrent/tt-metal/actions/runs/15260013065
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes