### PR TITLE
Use `ttnn.convert_to_hwc` to do the Shallow UNet input preprocessing

### DIFF
--- a/models/experimental/functional_unet/README.md
+++ b/models/experimental/functional_unet/README.md
@@ -10,7 +10,7 @@ When running this model on N300 or T3000, make sure to place dispatch on etherne
 To run UNet Shallow for multiple iterations on single-chip at the best performance:
 
 ```sh
-pytest --disable-warnings models/experimental/functional_unet/tests/test_unet_trace.py::test_unet_trace_2cq_same_io
+pytest --disable-warnings models/experimental/functional_unet/tests/test_unet_trace.py::test_unet_trace_2cq
 ```
 
 To run UNet Shallow for multiple iterations on N300 and T3000 at the best performance:

--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -31,14 +31,22 @@ def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
     ):
         pytest.skip(f"Shallow UNet only support 110 cores on BH (was {device.compute_with_storage_grid_size()})")
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, channel_order="first", pad=False, fold=False)
+    torch_input, ttnn_input = create_unet_input_tensors(
+        batch,
+        groups,
+        channel_order="first",
+        pad=False,
+        fold=True,
+        device=device,
+        memory_config=unet_shallow_ttnn.UNet.input_sharded_memory_config,
+    )
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
 
     torch_output_tensor = model(torch_input)
-    output_tensor = ttnn_model(ttnn_input)
+    output_tensor = ttnn_model(ttnn_input, move_input_tensor_to_device=False)
 
     B, C, H, W = torch_output_tensor.shape
     ttnn_output_tensor = ttnn.to_torch(output_tensor).reshape(B, C, H, W)

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -21,7 +21,7 @@ from models.experimental.functional_unet.tests.common import UNET_TRACE_REGION_S
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1385.0),),
+    ((1, 4, 1407.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"
@@ -35,7 +35,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
     )
     expected_perf_cols = {inference_time_key: expected_device_perf_fps}
     expected_results = check_device_perf(
-        post_processed_results, margin=0.02, expected_perf_cols=expected_perf_cols, assert_on_fail=True
+        post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
     )
     prep_device_perf_report(
         model_name=f"unet-shallow_batch-{batch}_groups-{groups}",
@@ -61,7 +61,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput",
-    ((1, 4, 256, 30.0, 1235.0),),
+    ((1, 4, 256, 30.0, 1254.0),),
 )
 def test_unet_trace_perf(
     batch: int,
@@ -80,11 +80,11 @@ def test_unet_trace_perf(
         pytest.skip(f"shallow unet only support 110 cores on bh (was {device.compute_with_storage_grid_size()})")
 
     from models.experimental.functional_unet.tests.test_unet_trace import (
-        test_unet_trace_2cq_same_io,
+        test_unet_trace_2cq,
     )
 
     logger.info(f"Invoking underlying model test for {iterations} iterations...")
-    result = test_unet_trace_2cq_same_io(batch, groups, iterations, device, use_program_cache, reset_seeds)
+    result = test_unet_trace_2cq(batch, groups, iterations, device, use_program_cache, reset_seeds)
 
     total_num_samples = result.batch * result.groups * result.num_devices
     expected_inference_time = total_num_samples / expected_throughput
@@ -116,7 +116,7 @@ def test_unet_trace_perf(
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2455.0),)
+    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2500.0),)
 )
 def test_unet_trace_perf_multi_device(
     batch: int,
@@ -129,15 +129,13 @@ def test_unet_trace_perf_multi_device(
     reset_seeds,
 ):
     from models.experimental.functional_unet.tests.test_unet_trace import (
-        test_unet_trace_2cq_same_io_multi_device,
+        test_unet_trace_2cq_multi_device,
     )
 
     model_name = "unet_shallow-trace_2cq_same_io-multi_device"
 
     logger.info(f"Invoking underlying model test for {iterations} iterations...")
-    result = test_unet_trace_2cq_same_io_multi_device(
-        batch, groups, iterations, mesh_device, use_program_cache, reset_seeds
-    )
+    result = test_unet_trace_2cq_multi_device(batch, groups, iterations, mesh_device, use_program_cache, reset_seeds)
 
     total_num_samples = result.batch * result.groups * result.num_devices
     expected_inference_time = total_num_samples / expected_throughput

--- a/models/experimental/functional_unet/tests/test_unet_trace.py
+++ b/models/experimental/functional_unet/tests/test_unet_trace.py
@@ -27,15 +27,29 @@ from models.experimental.functional_unet.tests.common import (
     UNetPerformanceStatistics,
 )
 
-from models.utility_functions import skip_for_grayskull, divup, nearest_32
+from models.utility_functions import skip_for_grayskull
 
 
-def get_dram_sharded_memory_config_for_output_tensor(output_tensor, dram_grid_size):
+def determine_num_cores_for_even_sharding(shard_dim: int, max_cores: int):
+    number_of_cores = max_cores
+    while shard_dim % number_of_cores != 0:
+        assert number_of_cores > 0, "Unable to find core grid"
+        number_of_cores = number_of_cores - 1
+    return number_of_cores
+
+
+def get_dram_sharded_memory_config_for_tensor(output_tensor, dram_grid_size):
+    # Force even shards because uneven width-sharding is not supported properly transferring from host (#22396)
+    total_number_of_dram_cores = dram_grid_size.x
+    dram_cores_for_even_sharding = determine_num_cores_for_even_sharding(
+        output_tensor.shape[-1], total_number_of_dram_cores
+    )
+    assert (
+        output_tensor.shape[-1] % dram_cores_for_even_sharding == 0
+    ), "Number of DRAM cores must evenly divide sharded tensor"
     output_dram_shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
-        ),
-        [output_tensor.shape[-2], nearest_32(divup(output_tensor.shape[-1], dram_grid_size.x))],
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_cores_for_even_sharding - 1, 0))}),
+        [output_tensor.shape[-2], output_tensor.shape[-1] // dram_cores_for_even_sharding],
         ttnn.ShardOrientation.ROW_MAJOR,
     )
     return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, output_dram_shard_spec)
@@ -55,7 +69,7 @@ def get_dram_sharded_memory_config_for_output_tensor(output_tensor, dram_grid_si
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations",
-    ((1, 4, 32),),
+    ((1, 4, 256),),
 )
 def test_unet_trace_2cq(
     batch: int,
@@ -65,7 +79,7 @@ def test_unet_trace_2cq(
     use_program_cache,
     reset_seeds,
 ):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, channel_order="first", pad=False, fold=False)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, channel_order="first", pad=False, fold=True)
 
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
     torch_output_tensor = model(torch_input)
@@ -74,265 +88,7 @@ def test_unet_trace_2cq(
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
 
     dram_grid_size = device.dram_grid_size()
-    dram_shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
-        ),
-        [
-            divup(ttnn_input.volume() // ttnn_input.shape[-1], dram_grid_size.x),
-            ttnn_input.shape[-1],
-        ],
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    dram_memory_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, dram_shard_spec
-    )
-
-    input_tensor = ttnn.allocate_tensor_on_device(
-        ttnn_input.shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, device, dram_memory_config
-    )
-    op_event = ttnn.record_event(device, 0)
-
-    logger.info(f"Compiling model with warmup run")
-    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-
-    write_event = ttnn.record_event(device, 1)
-    ttnn.wait_for_event(0, write_event)
-
-    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
-    op_event = ttnn.record_event(device, 0)
-    output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
-    logger.info(f"Done compile run")
-
-    logger.info(f"Capturing trace")
-    ttnn.wait_for_event(1, op_event)
-    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-    write_event = ttnn.record_event(device, 1)
-    ttnn.wait_for_event(0, write_event)
-    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
-    op_event = ttnn.record_event(device, 0)
-
-    input_trace_addr = l1_input_tensor.buffer_address()
-    spec = l1_input_tensor.spec
-    output_tensor.deallocate(force=True)
-
-    tid = ttnn.begin_trace_capture(device, cq_id=0)
-    output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
-
-    # Try allocating our persistent input tensor here and verifying it matches the address that trace captured
-    l1_input_tensor = ttnn.allocate_tensor_on_device(spec, device)
-    assert input_trace_addr == l1_input_tensor.buffer_address()
-    ttnn.end_trace_capture(device, tid, cq_id=0)
-
-    ttnn.synchronize_device(device)
-
-    outputs = []
-    start = time.time()
-    for _ in range(iterations):
-        ttnn.wait_for_event(1, op_event)
-        ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-        write_event = ttnn.record_event(device, 1)
-        ttnn.wait_for_event(0, write_event)
-
-        l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
-        op_event = ttnn.record_event(device, 0)
-
-        ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
-        outputs.append(output_tensor.cpu(blocking=False))
-    ttnn.synchronize_device(device)
-    end = time.time()
-    logger.info(f"Average model time={1000.0 * (end-start) / iterations : .2f} ms")
-    logger.info(f"Average model performance={iterations * batch / (end-start) : .2f} fps")
-
-    logger.info(f"Running sanity check against reference model output")
-    B, C, H, W = torch_output_tensor.shape
-    ttnn_output_tensor = ttnn.to_torch(outputs[-1]).reshape(B, C, H, W)
-    verify_with_pcc(
-        torch_output_tensor,
-        ttnn_output_tensor,
-        UNET_FULL_MODEL_PCC if is_wormhole_b0(device) else UNET_FULL_MODEL_PCC_BH,
-    )
-
-    ttnn.release_trace(device, tid)
-
-
-@skip_for_grayskull("UNet not currently supported on GS")
-@pytest.mark.parametrize(
-    "device_params",
-    [
-        {
-            "l1_small_size": UNET_L1_SMALL_REGION_SIZE,
-            "trace_region_size": UNET_TRACE_REGION_SIZE,
-            "num_command_queues": 2,
-        }
-    ],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "batch, groups, iterations",
-    ((1, 4, 128),),
-)
-def test_unet_trace_2cq_multi_device(
-    batch: int, groups: int, iterations: int, mesh_device, use_program_cache, reset_seeds
-):
-    if not is_n300_with_eth_dispatch_cores(mesh_device) and not is_t3k_with_eth_dispatch_cores(mesh_device):
-        pytest.skip("Test is only valid for N300 or T3000")
-
-    inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
-    weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
-    output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
-
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
-
-    model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
-
-    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
-    ttnn_model = unet_shallow_ttnn.UNet(parameters, mesh_device)
-
-    num_devices = len(mesh_device.get_device_ids())
-    logger.info(f"Using {num_devices} devices for this test")
-
-    total_batch = num_devices * batch
-    torch_input, ttnn_input = create_unet_input_tensors(
-        total_batch, groups, channel_order="first", pad=False, fold=False, mesh_mapper=inputs_mesh_mapper
-    )
-    logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
-    logger.info(
-        f"Created multi-device input tensors: shape={list(ttnn_input.shape)} on devices={mesh_device.get_device_ids()}"
-    )
-
-    torch_output_tensor = model(torch_input)
-
-    dram_grid_size = mesh_device.dram_grid_size()
-    dram_shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
-        ),
-        [
-            divup(ttnn_input.volume() // ttnn_input.shape[-1], dram_grid_size.x),
-            ttnn_input.shape[-1],
-        ],
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    dram_memory_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, dram_shard_spec
-    )
-
-    input_tensor = ttnn.allocate_tensor_on_device(
-        ttnn_input.shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, mesh_device, dram_memory_config
-    )
-    op_event = ttnn.record_event(mesh_device, 0)
-
-    logger.info(f"Compiling model with warmup run")
-    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-
-    write_event = ttnn.record_event(mesh_device, 1)
-    ttnn.wait_for_event(0, write_event)
-
-    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
-    op_event = ttnn.record_event(mesh_device, 0)
-    output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
-    logger.info(f"Done compile run")
-
-    logger.info(f"Capturing trace")
-    ttnn.wait_for_event(1, op_event)
-    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-    write_event = ttnn.record_event(mesh_device, 1)
-    ttnn.wait_for_event(0, write_event)
-    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
-    op_event = ttnn.record_event(mesh_device, 0)
-
-    input_trace_addr = l1_input_tensor.buffer_address()
-    spec = l1_input_tensor.spec
-    output_tensor.deallocate(force=True)
-
-    tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-    output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
-
-    # Try allocating our persistent input tensor here and verifying it matches the address that trace captured
-    l1_input_tensor = ttnn.allocate_tensor_on_device(spec, mesh_device)
-    assert input_trace_addr == l1_input_tensor.buffer_address()
-    ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
-
-    ttnn.synchronize_device(mesh_device)
-
-    outputs = []
-    start = time.time()
-    for _ in range(iterations):
-        ttnn.wait_for_event(1, op_event)
-        ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-        write_event = ttnn.record_event(mesh_device, 1)
-        ttnn.wait_for_event(0, write_event)
-
-        l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
-        op_event = ttnn.record_event(mesh_device, 0)
-
-        ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
-        outputs.append(output_tensor.cpu(blocking=False))
-    ttnn.synchronize_device(mesh_device)
-    end = time.time()
-    logger.info(f"Average model time={1000.0 * (end-start) / iterations : .2f} ms")
-    logger.info(f"Average model performance={iterations * total_batch / (end-start) : .2f} fps")
-
-    logger.info(f"Running sanity check against reference model output")
-    B, C, H, W = torch_output_tensor.shape
-    ttnn_output_tensor = ttnn.to_torch(outputs[-1], mesh_composer=output_mesh_composer).reshape(B, C, H, W)
-    verify_with_pcc(
-        torch_output_tensor,
-        ttnn_output_tensor,
-        UNET_FULL_MODEL_PCC if is_wormhole_b0(mesh_device) else UNET_FULL_MODEL_PCC_BH,
-    )
-
-    ttnn.release_trace(mesh_device, tid)
-
-
-@skip_for_grayskull("UNet not currently supported on GS")
-@pytest.mark.parametrize(
-    "device_params",
-    [
-        {
-            "l1_small_size": UNET_L1_SMALL_REGION_SIZE,
-            "trace_region_size": UNET_TRACE_REGION_SIZE,
-            "num_command_queues": 2,
-        }
-    ],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "batch, groups, iterations",
-    ((1, 4, 256),),
-)
-def test_unet_trace_2cq_same_io(
-    batch: int,
-    groups: int,
-    iterations: int,
-    device,
-    use_program_cache,
-    reset_seeds,
-):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, channel_order="first", pad=False, fold=False)
-
-    model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
-    torch_output_tensor = model(torch_input)
-
-    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
-    ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
-
-    dram_grid_size = device.dram_grid_size()
-    dram_shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
-        ),
-        [
-            divup(ttnn_input.volume() // ttnn_input.shape[-1], dram_grid_size.x),
-            ttnn_input.shape[-1],
-        ],
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    input_dram_memory_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, dram_shard_spec
-    )
-
+    input_dram_memory_config = get_dram_sharded_memory_config_for_tensor(ttnn_input, dram_grid_size)
     input_tensor = ttnn.allocate_tensor_on_device(
         ttnn_input.shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, device, input_dram_memory_config
     )
@@ -346,11 +102,9 @@ def test_unet_trace_2cq_same_io(
     write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
 
-    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
     op_event = ttnn.record_event(device, 0)
-    output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
-
-    output_dram_memory_config = get_dram_sharded_memory_config_for_output_tensor(output_tensor, dram_grid_size)
+    output_tensor = ttnn_model(input_tensor, move_input_tensor_to_device=False, deallocate_input_activation=False)
+    output_dram_memory_config = get_dram_sharded_memory_config_for_tensor(output_tensor, dram_grid_size)
     dram_output_tensor = ttnn.reshard(output_tensor, output_dram_memory_config)
     inference_and_compile_time = time.time() - start
     logger.info(f"Done compile run")
@@ -360,19 +114,11 @@ def test_unet_trace_2cq_same_io(
     ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
     write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
-    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
     op_event = ttnn.record_event(device, 0)
-
-    input_trace_addr = l1_input_tensor.buffer_address()
-    spec = l1_input_tensor.spec
     output_tensor.deallocate(force=True)
 
     tid = ttnn.begin_trace_capture(device, cq_id=0)
-    output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
-
-    # Try allocating our persistent input tensor here and verifying it matches the address that trace captured
-    l1_input_tensor = ttnn.allocate_tensor_on_device(spec, device)
-    assert input_trace_addr == l1_input_tensor.buffer_address()
+    output_tensor = ttnn_model(input_tensor, move_input_tensor_to_device=False, deallocate_input_activation=False)
     ttnn.end_trace_capture(device, tid, cq_id=0)
     dram_output_tensor = ttnn.reshard(output_tensor, output_dram_memory_config, dram_output_tensor)
     ttnn.synchronize_device(device)
@@ -384,7 +130,6 @@ def test_unet_trace_2cq_same_io(
     write_event = ttnn.record_event(device, 1)
     for _ in range(iterations - 1):
         ttnn.wait_for_event(0, write_event)
-        l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
         op_event = ttnn.record_event(device, 0)
         ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
         ttnn.wait_for_event(0, read_event)
@@ -397,7 +142,6 @@ def test_unet_trace_2cq_same_io(
         outputs.append(dram_output_tensor.cpu(blocking=False, cq_id=1))
         read_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
-    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
     op_event = ttnn.record_event(device, 0)
     ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
     ttnn.wait_for_event(0, read_event)
@@ -439,7 +183,7 @@ def test_unet_trace_2cq_same_io(
     "batch, groups, iterations",
     ((1, 4, 256),),
 )
-def test_unet_trace_2cq_same_io_multi_device(
+def test_unet_trace_2cq_multi_device(
     batch: int,
     groups: int,
     iterations: int,
@@ -466,7 +210,7 @@ def test_unet_trace_2cq_same_io_multi_device(
 
     total_batch = num_devices * batch
     torch_input, ttnn_input = create_unet_input_tensors(
-        total_batch, groups, channel_order="first", pad=False, fold=False, mesh_mapper=inputs_mesh_mapper
+        total_batch, groups, channel_order="first", pad=False, fold=True, mesh_mapper=inputs_mesh_mapper
     )
     logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
     logger.info(
@@ -476,20 +220,7 @@ def test_unet_trace_2cq_same_io_multi_device(
     torch_output_tensor = model(torch_input)
 
     dram_grid_size = mesh_device.dram_grid_size()
-    dram_shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
-        ),
-        [
-            divup(ttnn_input.volume() // ttnn_input.shape[-1], dram_grid_size.x),
-            ttnn_input.shape[-1],
-        ],
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    input_dram_memory_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, dram_shard_spec
-    )
-
+    input_dram_memory_config = get_dram_sharded_memory_config_for_tensor(ttnn_input, dram_grid_size)
     input_tensor = ttnn.allocate_tensor_on_device(
         ttnn_input.shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, mesh_device, input_dram_memory_config
     )
@@ -503,11 +234,9 @@ def test_unet_trace_2cq_same_io_multi_device(
     write_event = ttnn.record_event(mesh_device, 1)
     ttnn.wait_for_event(0, write_event)
 
-    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
     op_event = ttnn.record_event(mesh_device, 0)
-    output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
-
-    output_dram_memory_config = get_dram_sharded_memory_config_for_output_tensor(output_tensor, dram_grid_size)
+    output_tensor = ttnn_model(input_tensor, move_input_tensor_to_device=False, deallocate_input_activation=False)
+    output_dram_memory_config = get_dram_sharded_memory_config_for_tensor(output_tensor, dram_grid_size)
     dram_output_tensor = ttnn.reshard(output_tensor, output_dram_memory_config)
     inference_and_compile_time = time.time() - start
     logger.info(f"Done compile run")
@@ -517,23 +246,13 @@ def test_unet_trace_2cq_same_io_multi_device(
     ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
     write_event = ttnn.record_event(mesh_device, 1)
     ttnn.wait_for_event(0, write_event)
-    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
     op_event = ttnn.record_event(mesh_device, 0)
 
-    input_trace_addr = l1_input_tensor.buffer_address()
-    shape = l1_input_tensor.shape
-    dtype = l1_input_tensor.dtype
-    layout = l1_input_tensor.layout
     output_tensor.deallocate(force=True)
 
     tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-    output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
+    output_tensor = ttnn_model(input_tensor, move_input_tensor_to_device=False, deallocate_input_activation=False)
 
-    # Try allocating our persistent input tensor here and verifying it matches the address that trace captured
-    l1_input_tensor = ttnn.allocate_tensor_on_device(
-        shape, dtype, layout, mesh_device, ttnn_model.input_sharded_memory_config
-    )
-    assert input_trace_addr == l1_input_tensor.buffer_address()
     ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
     dram_output_tensor = ttnn.reshard(output_tensor, output_dram_memory_config, dram_output_tensor)
     ttnn.synchronize_device(mesh_device)
@@ -545,7 +264,6 @@ def test_unet_trace_2cq_same_io_multi_device(
     write_event = ttnn.record_event(mesh_device, 1)
     for _ in range(iterations - 1):
         ttnn.wait_for_event(0, write_event)
-        l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
         op_event = ttnn.record_event(mesh_device, 0)
         ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
         ttnn.wait_for_event(0, read_event)
@@ -558,7 +276,6 @@ def test_unet_trace_2cq_same_io_multi_device(
         outputs.append(dram_output_tensor.cpu(blocking=False, cq_id=1))
         read_event = ttnn.record_event(mesh_device, 1)
     ttnn.wait_for_event(0, write_event)
-    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
     op_event = ttnn.record_event(mesh_device, 0)
     ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
     ttnn.wait_for_event(0, read_event)


### PR DESCRIPTION
### Summary
- Use `ttnn.experimental.convert_to_hwc` to do the Shallow UNet input preprocessing. This requires us to modify the model to take width-sharded inputs. 
- This improves end-to-end performance on N300 to 2500 fps.
- Remove some old test cases.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/15284320970
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/15299534404
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/15284364903
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/15299507937
- [x] Frequent models: https://github.com/tenstorrent/tt-metal/actions/runs/15284327373
- [x] Blackhole demo: https://github.com/tenstorrent/tt-metal/actions/runs/15299511951