### PR TITLE
Fix incorrect tile size calculation for bfloat8_b

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -1225,3 +1225,23 @@ def test_resnet50_fold(device, n, c, h, w, dim0, dim1):
     tt_output = ttnn.to_torch(tt_output.cpu())
 
     assert_with_pcc(torch_output, tt_output, 0.9999)
+
+
+def test_transpose_21803(device):
+    torch.manual_seed(2005)
+    # Test parameters
+    dim1, dim2, dim3, dim4, dim5 = 1, 1, 8, 64, 256
+    dtype = ttnn.bfloat8_b
+
+    for i in range(100):
+        torch_input = torch.randn(dim1, dim2, dim3, dim4, dim5, dtype=torch.bfloat16)
+        ttnn_input = ttnn.from_torch(torch_input, dtype, layout=ttnn.Layout.TILE, device=device)
+        ttnn_output = ttnn.permute(ttnn_input, [0, 1, 2, 4, 3])
+
+        torch_output = ttnn.to_torch(ttnn_output, dtype=torch.bfloat16)
+
+        if torch.any(torch.isnan(torch_input)) or torch.any(torch.isinf(torch_input)):
+            continue
+
+        if torch.any(torch.isinf(torch_output)) or (torch.any(torch.isnan(torch_output))):
+            assert False, f"Found infinity values at iteration {i} in ttnn but not in pytorch"

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -21,7 +21,10 @@ uint32_t num_tiles(const ttnn::Tensor& input_tensor) {
     return shape.volume() / tile_vol;
 }
 
-uint32_t tile_size(const ttnn::Tensor& input_tensor) { return tile_volume(input_tensor) * input_tensor.element_size(); }
+uint32_t tile_size(const ttnn::Tensor& input_tensor) {
+    auto dataformat = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    return tt::tt_metal::detail::TileSize(dataformat);
+}
 
 ttnn::Shape get_tiled_shape(const ttnn::Tensor& input_tensor) {
     const auto& tile_shape = input_tensor.get_tensor_spec().tile().get_tile_shape();


### PR DESCRIPTION
### Ticket
#21803

### Problem description
bfloat8_b tile size did not include header size.

### What's changed
Correct the calculation

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15286552949
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes