### PR TITLE
#21652: Enforce specs to be uniform across multi-device sharded tensor

### DIFF
--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -55,9 +55,7 @@ struct DeviceStorage {
 
 class MultiDeviceHostStorage {
 public:
-    MultiDeviceHostStorage() = default;
-    MultiDeviceHostStorage(std::vector<HostBuffer> buffers, std::vector<TensorSpec> specs) :
-        buffers_(std::move(buffers)), specs_(std::move(specs)) {}
+    MultiDeviceHostStorage(std::vector<HostBuffer> buffers, std::vector<TensorSpec> specs);
 
     static constexpr auto attribute_names = std::forward_as_tuple();
     auto attribute_values() const { return std::forward_as_tuple(); }


### PR DESCRIPTION
### Ticket
#21652

### Problem description
TTNN doesn't properly support uneven tensor specs. This PR adds a check to ensure this is not misused.

### What's changed
Adding checks in `DeviceStorage` and `MultiDeviceHostStorage`.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15282573314)
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15282941423)
- [X] [TG tests](https://github.com/tenstorrent/tt-metal/actions/runs/15288307400)
- [X] [Single card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/15301378160)
- [X] New/Existing tests provide coverage for changes