### PR TITLE
Raw ethernet ubench. Add information on summary row

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_common.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_common.py
@@ -158,6 +158,7 @@ def write_results_to_csv(file_name, test_latency):
     if test_latency == 1:
         header = [
             "Benchmark ID",
+            "Summary Statistics",
             "Sender Device ID",
             "Sender Eth Channel",
             "Receiver Device ID",
@@ -190,6 +191,7 @@ def write_results_to_csv(file_name, test_latency):
     else:
         header = [
             "Benchmark ID",
+            "Summary Statistics",
             "Sender Device ID",
             "Sender Eth Channel",
             "Receiver Device ID",
@@ -235,6 +237,7 @@ def write_results_to_csv(file_name, test_latency):
                 file_name,
                 [
                     benchmark_type,
+                    0,
                     sender_info[0],
                     sender_info[1],
                     receiver_info[0],
@@ -250,6 +253,14 @@ def write_results_to_csv(file_name, test_latency):
         mean = np.mean(measurements)
         std_dev = np.std(measurements)
         summary_stats = [""] * len(header)
+        summary_stats[0] = benchmark_type
+        summary_stats[1] = 1
+        summary_stats[2] = sender_info[0]
+        summary_stats[3] = sender_info[1]
+        summary_stats[4] = receiver_info[0]
+        summary_stats[5] = receiver_info[1]
+        summary_stats[6] = num_packets
+        summary_stats[7] = packet_size
         summary_stats[-1] = std_dev
         summary_stats[-2] = mean
         summary_stats[-3] = max_val


### PR DESCRIPTION
### Ticket
N/A

### Problem description
It is really annoying to query summary line without information.

### What's changed
Add more information in summary line

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes