### PR TITLE
#22660: Update MeshTrace region size when traces are released

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -109,41 +109,43 @@ TEST_F(MeshTraceTestSuite, Sanity) {
     uint32_t num_workloads_per_trace = 5;
     uint32_t num_traces = 4;
     uint32_t num_iters = 10;
+    uint32_t num_trace_setup_teardown_loops = 10;
 
     MeshCoordinateRange all_devices(mesh_device_->shape());
-
-    std::vector<std::shared_ptr<MeshWorkload>> mesh_workloads = {};
-    for (int i = 0; i < num_workloads_per_trace * num_traces; i++) {
-        auto workload = std::make_shared<MeshWorkload>();
-        auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
-            1, mesh_device_->compute_with_storage_grid_size(), seed);
-        AddProgramToMeshWorkload(*workload, std::move(*programs[0]), all_devices);
-        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
-        mesh_workloads.push_back(workload);
-    }
-
-    std::vector<MeshTraceId> trace_ids = {};
-    for (int trace_idx = 0; trace_idx < num_traces; trace_idx++) {
-        auto trace_id = BeginTraceCapture(mesh_device_.get(), 0);
-        for (int workload_idx = 0; workload_idx < num_workloads_per_trace; workload_idx++) {
-            EnqueueMeshWorkload(
-                mesh_device_->mesh_command_queue(),
-                *mesh_workloads[trace_idx * num_workloads_per_trace + workload_idx],
-                false);
+    for (int outer_loop = 0; outer_loop < num_trace_setup_teardown_loops; outer_loop++) {
+        std::vector<std::shared_ptr<MeshWorkload>> mesh_workloads = {};
+        for (int i = 0; i < num_workloads_per_trace * num_traces; i++) {
+            auto workload = std::make_shared<MeshWorkload>();
+            auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+                1, mesh_device_->compute_with_storage_grid_size(), seed);
+            AddProgramToMeshWorkload(*workload, std::move(*programs[0]), all_devices);
+            EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
+            mesh_workloads.push_back(workload);
         }
-        EndTraceCapture(mesh_device_.get(), 0, trace_id);
-        trace_ids.push_back(trace_id);
-    }
 
-    for (int i = 0; i < num_iters; i++) {
+        std::vector<MeshTraceId> trace_ids = {};
+        for (int trace_idx = 0; trace_idx < num_traces; trace_idx++) {
+            auto trace_id = BeginTraceCapture(mesh_device_.get(), 0);
+            for (int workload_idx = 0; workload_idx < num_workloads_per_trace; workload_idx++) {
+                EnqueueMeshWorkload(
+                    mesh_device_->mesh_command_queue(),
+                    *mesh_workloads[trace_idx * num_workloads_per_trace + workload_idx],
+                    false);
+            }
+            EndTraceCapture(mesh_device_.get(), 0, trace_id);
+            trace_ids.push_back(trace_id);
+        }
+
+        for (int i = 0; i < num_iters; i++) {
+            for (auto trace_id : trace_ids) {
+                ReplayTrace(mesh_device_.get(), 0, trace_id, false);
+            }
+        }
+        Finish(mesh_device_->mesh_command_queue());
+
         for (auto trace_id : trace_ids) {
-            ReplayTrace(mesh_device_.get(), 0, trace_id, false);
+            ReleaseTrace(mesh_device_.get(), trace_id);
         }
-    }
-    Finish(mesh_device_->mesh_command_queue());
-
-    for (auto trace_id : trace_ids) {
-        ReleaseTrace(mesh_device_.get(), trace_id);
     }
 }
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -725,6 +725,14 @@ std::shared_ptr<MeshTraceBuffer>& MeshDevice::create_mesh_trace(const MeshTraceI
 
 void MeshDevice::release_mesh_trace(const MeshTraceId& trace_id) {
     TracyTTMetalReleaseMeshTrace(this->get_device_ids(), *trace_id);
+    const auto& trace_mesh_buffer = trace_buffer_pool_.at(trace_id)->mesh_buffer;
+    TT_FATAL(
+        trace_mesh_buffer and trace_mesh_buffer->is_allocated(),
+        "Trace buffer for {} is not allocated when calling {}",
+        *trace_id,
+        __FUNCTION__);
+    auto current_trace_buffers_size = this->get_trace_buffers_size();
+    this->set_trace_buffers_size(current_trace_buffers_size - trace_mesh_buffer->size());
     trace_buffer_pool_.erase(trace_id);
 }
 

--- a/tt_metal/distributed/mesh_trace.hpp
+++ b/tt_metal/distributed/mesh_trace.hpp
@@ -61,10 +61,10 @@ public:
 // Ties a MeshTraceDescriptor (host side state) to a MeshBuffer (device side state)
 struct MeshTraceBuffer {
     // The trace descriptor associated with a MeshTrace
-    std::shared_ptr<MeshTraceDescriptor> desc;
+    std::shared_ptr<MeshTraceDescriptor> desc = nullptr;
     // The MeshBuffer this trace will be serialized to, before being run on a
     // MeshDevice
-    std::shared_ptr<MeshBuffer> mesh_buffer;
+    std::shared_ptr<MeshBuffer> mesh_buffer = nullptr;
 };
 
 // Top level class - Manages MeshTrace


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22660

### Problem description
- `MeshTrace` sizes are tracked by `MeshDevice` for more descriptive error reporting (we need the ability to inform the user when they exceeded the trace region size, and what the delta was).
- The tracked size was not getting decremented when traces were released.
- This shows up as a bug in sweeps, which capture and release multiple traces in the same test.

### What's changed
- Add `MeshTraceBuffer` destructor to update `MeshDevice` trace region size, based on the padded size of the `MeshBuffer` it stores.
- Updated `MeshTrace` runtime sanity test to catch similar issues with `MeshTrace::release`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes