### PR TITLE
Fix conv2d nightly

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3576,6 +3576,7 @@ def test_conv2d_with_fold(
         device=device,
         torch_tensor_map=torch_tensor_map,
         math_fidelity=ttnn.MathFidelity.LoFi,
+        packer_l1_acc = True,
         activations_dtype=ttnn.bfloat16,
         weights_dtype=ttnn.bfloat16,
         batch_size=batch_size,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22665

### Problem description
nightly conv fails in `test_conv2d_with_fold`

### What's changed
setting `packer_l1_acc = True`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15298008760)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15298015297) (if applicable)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) [WH passes](https://github.com/tenstorrent/tt-metal/actions/runs/15296775219) [BH passes](https://github.com/tenstorrent/tt-metal/actions/runs/15296780035)
- [x] [(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15296822810)