### PR TITLE
Remove device-host profiler sync requirement for DRAM buffers 

### DIFF
--- a/tt_metal/api/tt-metalium/profiler_types.hpp
+++ b/tt_metal/api/tt-metalium/profiler_types.hpp
@@ -8,5 +8,6 @@ namespace tt::tt_metal {
 
 enum class ProfilerDumpState { NORMAL, CLOSE_DEVICE_SYNC, LAST_CLOSE_DEVICE, FORCE_UMD_READ };
 enum class ProfilerSyncState { INIT, CLOSE_DEVICE };
+enum class ProfilerDataBufferSource { L1, DRAM };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -34,6 +34,7 @@
 #include "sub_device_types.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "util.hpp"
+#include "tracy/Tracy.hpp"
 
 enum class CoreType;
 namespace tt {
@@ -61,6 +62,7 @@ std::optional<MeshCoordinateRange> find_intersection(
 }  // namespace
 
 MeshWorkloadImpl::MeshWorkloadImpl() {
+    ZoneScoped;
     // A MeshWorkload tracks maintains its own handles to kernels across all
     // encapsulated programs
     kernel_groups_.resize(MetalContext::instance().hal().get_programmable_core_type_count());
@@ -68,6 +70,7 @@ MeshWorkloadImpl::MeshWorkloadImpl() {
 }
 
 void MeshWorkloadImpl::add_program(const MeshCoordinateRange& device_range, Program&& program) {
+    ZoneScoped;
     auto potential_intersection = find_intersection(programs_, device_range);
     TT_FATAL(
         !potential_intersection,
@@ -78,6 +81,7 @@ void MeshWorkloadImpl::add_program(const MeshCoordinateRange& device_range, Prog
 }
 
 void MeshWorkloadImpl::compile_program(const MeshCoordinateRange& device_range, MeshDevice* mesh_device) {
+    ZoneScoped;
     auto& program = programs_.at(device_range);
     program.compile(mesh_device);
     program.allocate_circular_buffers(mesh_device);
@@ -85,6 +89,7 @@ void MeshWorkloadImpl::compile_program(const MeshCoordinateRange& device_range, 
 }
 
 void MeshWorkloadImpl::compile(MeshDevice* mesh_device) {
+    ZoneScoped;
     // Multi-Step Compile:
     // 1. Compile Kernel Binaries
     // 2. Allocate and Validate CBs
@@ -104,6 +109,7 @@ void MeshWorkloadImpl::compile(MeshDevice* mesh_device) {
 }
 
 void MeshWorkloadImpl::load_binaries(MeshCommandQueue& mesh_cq) {
+    ZoneScoped;
     // Load binaries for all programs to their respective devices in
     // the Mesh. Only done when the MeshWorkload is enqueued for the first
     // time.
@@ -173,6 +179,7 @@ void MeshWorkloadImpl::load_binaries(MeshCommandQueue& mesh_cq) {
 }
 
 ProgramBinaryStatus MeshWorkloadImpl::get_program_binary_status(std::size_t mesh_id) const {
+    ZoneScoped;
     if (program_binary_status_.find(mesh_id) != program_binary_status_.end()) {
         return program_binary_status_.at(mesh_id);
     }
@@ -180,10 +187,12 @@ ProgramBinaryStatus MeshWorkloadImpl::get_program_binary_status(std::size_t mesh
 }
 
 void MeshWorkloadImpl::set_program_binary_status(std::size_t mesh_id, ProgramBinaryStatus status) {
+    ZoneScoped;
     program_binary_status_[mesh_id] = status;
 }
 
 void MeshWorkloadImpl::generate_dispatch_commands(MeshCommandQueue& mesh_cq) {
+    ZoneScoped;
     // Generate Dispatch Commands for each Program in the MeshWorkload.
     // These commands will be updated based on MeshDevice state when the
     // workload is enqueued.
@@ -194,6 +203,7 @@ void MeshWorkloadImpl::generate_dispatch_commands(MeshCommandQueue& mesh_cq) {
 }
 
 bool MeshWorkloadImpl::runs_on_noc_multicast_only_cores() {
+    ZoneScoped;
     // Return true if any program in the MeshWorkload runs on cores
     // that can be multicasted to
     bool ret = false;
@@ -204,6 +214,7 @@ bool MeshWorkloadImpl::runs_on_noc_multicast_only_cores() {
 }
 
 bool MeshWorkloadImpl::runs_on_noc_unicast_only_cores() {
+    ZoneScoped;
     // Return true if any program in the MeshWorkload runs on cores
     // that can only be unicasted to
     bool ret = false;
@@ -214,6 +225,7 @@ bool MeshWorkloadImpl::runs_on_noc_unicast_only_cores() {
 }
 
 bool MeshWorkloadImpl::kernel_binary_always_stored_in_ringbuffer() {
+    ZoneScoped;
     // Return true if kernel binaries cannot be placed in a ring buffer for
     // any program in the MeshWorkload
     bool stored_in_ring_buf = true;
@@ -225,6 +237,7 @@ bool MeshWorkloadImpl::kernel_binary_always_stored_in_ringbuffer() {
 
 std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& MeshWorkloadImpl::get_kernels(
     uint32_t programmable_core_type_index) {
+    ZoneScoped;
     // Get all kernels across all programs in the MeshWorkload
     if (kernels_.at(programmable_core_type_index).empty()) {
         uint32_t device_range_idx = 0;
@@ -240,6 +253,7 @@ std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& MeshWorkloadImpl::get
 }
 
 std::vector<std::shared_ptr<KernelGroup>>& MeshWorkloadImpl::get_kernel_groups(uint32_t programmable_core_type_index) {
+    ZoneScoped;
     // Get all kernel groups across all programs in the MeshWorkload
     if (kernel_groups_.at(programmable_core_type_index).empty()) {
         uint32_t device_range_idx = 0;
@@ -259,6 +273,7 @@ std::vector<std::shared_ptr<KernelGroup>>& MeshWorkloadImpl::get_kernel_groups(u
 }
 
 std::vector<Semaphore>& MeshWorkloadImpl::semaphores() {
+    ZoneScoped;
     // Get all semaphores across all programs in the MeshWorkload
     if (not semaphores_.size()) {
         for (auto& [device_range, program] : programs_) {
@@ -269,6 +284,7 @@ std::vector<Semaphore>& MeshWorkloadImpl::semaphores() {
 }
 
 std::vector<uint32_t> MeshWorkloadImpl::get_program_config_sizes() {
+    ZoneScoped;
     // Get the config sizes for all L1 Program Data Structures
     std::vector<uint32_t> global_program_config_sizes;
     for (auto& program_on_grid : programs_) {
@@ -286,6 +302,7 @@ std::vector<uint32_t> MeshWorkloadImpl::get_program_config_sizes() {
 }
 
 std::unordered_set<SubDeviceId> MeshWorkloadImpl::determine_sub_device_ids(MeshDevice* mesh_device) {
+    ZoneScoped;
     // Get the sub device ids for all program across all devices in the Workload
     std::unordered_set<SubDeviceId> sub_devices_;
     for (auto& [device_range, program] : programs_) {
@@ -299,18 +316,21 @@ std::unordered_set<SubDeviceId> MeshWorkloadImpl::determine_sub_device_ids(MeshD
 }
 
 ProgramCommandSequence& MeshWorkloadImpl::get_dispatch_cmds_for_program(Program& program, uint64_t command_hash) {
+    ZoneScoped;
     // Get the dispatch commands associated with this program
     return program.get_cached_program_command_sequences().at(command_hash);
 }
 
 // The functions below are for testing purposes only
 void MeshWorkloadImpl::set_last_used_command_queue_for_testing(MeshCommandQueue* mesh_cq) {
+    ZoneScoped;
     last_used_command_queue_ = mesh_cq;
 }
 
 MeshCommandQueue* MeshWorkloadImpl::get_last_used_command_queue() const { return last_used_command_queue_; }
 
 ProgramConfig& MeshWorkloadImpl::get_program_config(uint32_t index) {
+    ZoneScoped;
     TT_FATAL(
         programs_.size() and is_finalized(),
         "Program Configs can only be queried if a MeshWorkload is populated and finalized.");
@@ -319,6 +339,7 @@ ProgramConfig& MeshWorkloadImpl::get_program_config(uint32_t index) {
 
 uint32_t MeshWorkloadImpl::get_sem_base_addr(
     std::shared_ptr<MeshDevice>& mesh_device, CoreCoord /*logical_core*/, CoreType core_type) {
+    ZoneScoped;
     HalProgrammableCoreType programmable_core_type =
         ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, mesh_device.get(), programmable_core_type);
@@ -329,6 +350,7 @@ uint32_t MeshWorkloadImpl::get_sem_base_addr(
 
 uint32_t MeshWorkloadImpl::get_sem_size(
     std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
+    ZoneScoped;
     uint32_t sem_size = 0;
     uint32_t program_idx = 0;
     for (auto& [device_range, program] : programs_) {
@@ -344,6 +366,7 @@ uint32_t MeshWorkloadImpl::get_sem_size(
 
 uint32_t MeshWorkloadImpl::get_cb_base_addr(
     std::shared_ptr<MeshDevice>& mesh_device, CoreCoord /*logical_core*/, CoreType core_type) {
+    ZoneScoped;
     HalProgrammableCoreType programmable_core_type =
         ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, mesh_device.get(), programmable_core_type);
@@ -354,6 +377,7 @@ uint32_t MeshWorkloadImpl::get_cb_base_addr(
 
 uint32_t MeshWorkloadImpl::get_cb_size(
     std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
+    ZoneScoped;
     uint32_t cb_size = 0;
     uint32_t program_idx = 0;
     for (auto& [device_range, program] : programs_) {
@@ -368,6 +392,7 @@ uint32_t MeshWorkloadImpl::get_cb_size(
 }
 
 void MeshWorkloadImpl::finalize_offsets(MeshDevice* mesh_device) {
+    ZoneScoped;
     if (is_finalized()) {
         return;
     }

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -369,17 +369,21 @@ int main() {
             invalidate_l1_cache();
             // While the go signal for kernel execution is not sent, check if the worker was signalled
             // to reset its launch message read pointer.
-            if (go_message_signal == RUN_MSG_RESET_READ_PTR) {
+            if ((go_message_signal == RUN_MSG_RESET_READ_PTR) ||
+                (go_message_signal == RUN_MSG_RESET_READ_PTR_FROM_HOST)) {
                 // Set the rd_ptr on workers to specified value
                 mailboxes->launch_msg_rd_ptr = 0;
-                // Querying the noc_index is safe here, since the RUN_MSG_RESET_READ_PTR go signal is currently guaranteed
-                // to only be seen after a RUN_MSG_GO signal, which will set the noc_index to a valid value.
-                // For future proofing, the noc_index value is initialized to 0, to ensure an invalid NOC txn is not issued.
-                uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_message);
-                mailboxes->go_message.signal = RUN_MSG_DONE;
-                // Notify dispatcher that this has been done
-                DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
-                notify_dispatch_core_done(dispatch_addr, noc_index);
+                if (go_message_signal == RUN_MSG_RESET_READ_PTR) {
+                    // Querying the noc_index is safe here, since the RUN_MSG_RESET_READ_PTR go signal is currently
+                    // guaranteed to only be seen after a RUN_MSG_GO signal, which will set the noc_index to a valid
+                    // value. For future proofing, the noc_index value is initialized to 0, to ensure an invalid NOC txn
+                    // is not issued.
+                    uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_message);
+                    mailboxes->go_message.signal = RUN_MSG_DONE;
+                    // Notify dispatcher that this has been done
+                    DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
+                    notify_dispatch_core_done(dispatch_addr, noc_index);
+                }
             }
         }
 

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -52,6 +52,7 @@ static constexpr uint32_t PROFILER_RISC_COUNT = 5;
 constexpr uint32_t RUN_MSG_INIT = 0x40;
 constexpr uint32_t RUN_MSG_GO = 0x80;
 constexpr uint32_t RUN_MSG_RESET_READ_PTR = 0xc0;
+constexpr uint32_t RUN_MSG_RESET_READ_PTR_FROM_HOST = 0xe0;
 constexpr uint32_t RUN_MSG_DONE = 0;
 
 // 0x80808000 is a micro-optimization, calculated with 1 riscv insn

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -51,7 +51,7 @@ std::vector<uint32_t> read_control_buffer_from_core(
     std::vector<uint32_t> control_buffer;
     profiler_msg_t* profiler_msg =
         MetalContext::instance().hal().get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
-    if (tt::DevicePool::instance().is_dispatch_firmware_active()) {
+    if (state != ProfilerDumpState::FORCE_UMD_READ && tt::DevicePool::instance().is_dispatch_firmware_active()) {
         if (auto mesh_device = device->get_mesh_device()) {
             if (core_type == HalProgrammableCoreType::TENSIX) {
                 distributed::FDMeshCommandQueue& mesh_cq =
@@ -98,7 +98,7 @@ void write_control_buffer_to_core(
     const std::vector<uint32_t>& control_buffer) {
     profiler_msg_t* profiler_msg =
         MetalContext::instance().hal().get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
-    if (tt::DevicePool::instance().is_dispatch_firmware_active()) {
+    if (state != ProfilerDumpState::FORCE_UMD_READ && tt::DevicePool::instance().is_dispatch_firmware_active()) {
         if (auto mesh_device = device->get_mesh_device()) {
             if (core_type == HalProgrammableCoreType::TENSIX) {
                 distributed::FDMeshCommandQueue& mesh_cq =
@@ -125,28 +125,6 @@ void write_control_buffer_to_core(
         tt::llrt::write_hex_vec_to_core(
             device->id(), core, control_buffer, reinterpret_cast<uint64_t>(profiler_msg->control_vector));
     }
-}
-
-HalProgrammableCoreType get_core_type(chip_id_t device_id, const CoreCoord& core) {
-    ZoneScoped;
-
-    HalProgrammableCoreType CoreType;
-
-    if (tt::tt_metal::MetalContext::instance().get_cluster().is_worker_core(core, device_id)) {
-        CoreType = HalProgrammableCoreType::TENSIX;
-    } else {
-        auto active_eth_cores =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id);
-        bool is_active_eth_core =
-            active_eth_cores.find(
-                tt::tt_metal::MetalContext::instance().get_cluster().get_logical_ethernet_core_from_virtual(
-                    device_id, core)) != active_eth_cores.end();
-
-        CoreType = is_active_eth_core ? tt_metal::HalProgrammableCoreType::ACTIVE_ETH
-                                      : tt_metal::HalProgrammableCoreType::IDLE_ETH;
-    }
-
-    return CoreType;
 }
 
 void DeviceProfiler::issueFastDispatchReadFromProfilerBuffer(IDevice* device) {
@@ -203,7 +181,7 @@ void DeviceProfiler::readControlBuffers(IDevice* device, const CoreCoord& worker
     ZoneScoped;
     chip_id_t device_id = device->id();
 
-    HalProgrammableCoreType CoreType = get_core_type(device_id, worker_core);
+    HalProgrammableCoreType CoreType = tt::llrt::get_core_type(device_id, worker_core);
 
     std::vector<uint32_t> control_buffer = read_control_buffer_from_core(device, worker_core, CoreType, state);
     core_control_buffers[worker_core] = control_buffer;
@@ -213,7 +191,7 @@ void DeviceProfiler::resetControlBuffers(IDevice* device, const CoreCoord& worke
     ZoneScoped;
 
     chip_id_t device_id = device->id();
-    HalProgrammableCoreType CoreType = get_core_type(device_id, worker_core);
+    HalProgrammableCoreType CoreType = tt::llrt::get_core_type(device_id, worker_core);
 
     std::vector<uint32_t> control_buffer = core_control_buffers.at(worker_core);
     std::vector<uint32_t> control_buffer_reset(kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE, 0);
@@ -230,18 +208,12 @@ void DeviceProfiler::readRiscProfilerResults(
     IDevice* device,
     const CoreCoord& worker_core,
     const ProfilerDumpState state,
+    const std::vector<uint32_t>& data_buffer,
+    const ProfilerDataBufferSource data_source,
     const std::optional<ProfilerOptionalMetadata>& metadata,
     std::ofstream& log_file_ofs,
     nlohmann::ordered_json& noc_trace_json_log) {
     ZoneScoped;
-    chip_id_t device_id = device->id();
-
-    HalProgrammableCoreType CoreType = get_core_type(device_id, worker_core);
-    int riscCount = 1;
-
-    if (CoreType == HalProgrammableCoreType::TENSIX) {
-        riscCount = 5;
-    }
 
     std::vector<uint32_t> control_buffer = core_control_buffers.at(worker_core);
 
@@ -250,22 +222,34 @@ void DeviceProfiler::readRiscProfilerResults(
         return;
     }
 
+    chip_id_t device_id = device->id();
+
     const uint32_t coreFlatID =
         tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_routing_to_profiler_flat_id(device_id).at(
             worker_core);
     const uint32_t startIndex = coreFlatID * MAX_RISCV_PER_CORE * PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC;
+
+    // translate worker core virtual coord to phys coordinates
+    auto phys_coord = getPhysicalAddressFromVirtual(device_id, worker_core);
 
     // helper function to lookup opname from runtime id if metadata is available
     auto getOpNameIfAvailable = [&metadata](auto device_id, auto runtime_id) {
         return (metadata.has_value()) ? metadata->get_op_name(device_id, runtime_id) : "";
     };
 
-    // translate worker core virtual coord to phys coordinates
-    auto phys_coord = getPhysicalAddressFromVirtual(device_id, worker_core);
+    HalProgrammableCoreType CoreType = tt::llrt::get_core_type(device_id, worker_core);
+    int riscCount = 1;
 
-    int riscNum = 0;
+    if (CoreType == HalProgrammableCoreType::TENSIX) {
+        riscCount = 5;
+    }
+
     for (int riscEndIndex = 0; riscEndIndex < riscCount; riscEndIndex++) {
         uint32_t bufferEndIndex = control_buffer[riscEndIndex];
+        if (data_source == ProfilerDataBufferSource::L1) {
+            // Just grab the device end index
+            bufferEndIndex = control_buffer[riscEndIndex + kernel_profiler::DEVICE_BUFFER_END_INDEX_BR_ER];
+        }
         uint32_t riscType;
         if (CoreType == HalProgrammableCoreType::TENSIX) {
             riscType = riscEndIndex;
@@ -273,7 +257,11 @@ void DeviceProfiler::readRiscProfilerResults(
             riscType = 5;
         }
         if (bufferEndIndex > 0) {
-            uint32_t bufferRiscShift = riscNum * PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC + startIndex;
+            uint32_t bufferRiscShift = riscEndIndex * PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC + startIndex;
+            if (data_source == ProfilerDataBufferSource::L1) {
+                // Shift by L1 buffer size only
+                bufferRiscShift = riscEndIndex * kernel_profiler::PROFILER_L1_VECTOR_SIZE;
+            }
             if ((control_buffer[kernel_profiler::DROPPED_ZONES] >> riscEndIndex) & 1) {
                 std::string warningMsg = fmt::format(
                     "Profiler DRAM buffers were full, markers were dropped! device {}, worker core {}, {}, Risc "
@@ -300,7 +288,7 @@ void DeviceProfiler::readRiscProfilerResults(
             std::string opname;
             for (int index = bufferRiscShift; index < (bufferRiscShift + bufferEndIndex);
                  index += kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE) {
-                if (!newRunStart && profile_buffer.at(index) == 0 && profile_buffer.at(index + 1) == 0) {
+                if (!newRunStart && data_buffer.at(index) == 0 && data_buffer.at(index + 1) == 0) {
                     newRunStart = true;
                     opTime_H = 0;
                     opTime_L = 0;
@@ -308,22 +296,22 @@ void DeviceProfiler::readRiscProfilerResults(
                     newRunStart = false;
 
                     // TODO(MO): Cleanup magic numbers
-                    riscNumRead = profile_buffer.at(index) & 0x7;
-                    coreFlatIDRead = (profile_buffer.at(index) >> 3) & 0xFF;
-                    runHostCounterRead = profile_buffer.at(index + 1);
+                    riscNumRead = data_buffer.at(index) & 0x7;
+                    coreFlatIDRead = (data_buffer.at(index) >> 3) & 0xFF;
+                    runHostCounterRead = data_buffer.at(index + 1);
 
                     opname = getOpNameIfAvailable(device_id, runHostCounterRead);
 
                 } else {
-                    uint32_t timer_id = (profile_buffer.at(index) >> 12) & 0x7FFFF;
+                    uint32_t timer_id = (data_buffer.at(index) >> 12) & 0x7FFFF;
                     kernel_profiler::PacketTypes packet_type = get_packet_type(timer_id);
 
                     switch (packet_type) {
                         case kernel_profiler::ZONE_START:
                         case kernel_profiler::ZONE_END: {
-                            uint32_t time_H = profile_buffer.at(index) & 0xFFF;
+                            uint32_t time_H = data_buffer.at(index) & 0xFFF;
                             if (timer_id || time_H) {
-                                uint32_t time_L = profile_buffer.at(index + 1);
+                                uint32_t time_L = data_buffer.at(index + 1);
 
                                 if (opTime_H == 0) {
                                     opTime_H = time_H;
@@ -333,9 +321,9 @@ void DeviceProfiler::readRiscProfilerResults(
                                 }
 
                                 TT_ASSERT(
-                                    riscNumRead == riscNum,
+                                    riscNumRead == riscEndIndex,
                                     "Unexpected risc id, expected {}, read {}. In core {},{} {} at run {}, index {}",
-                                    riscNum,
+                                    riscEndIndex,
                                     riscNumRead,
                                     worker_core.x,
                                     worker_core.y,
@@ -368,7 +356,7 @@ void DeviceProfiler::readRiscProfilerResults(
                             }
                         } break;
                         case kernel_profiler::ZONE_TOTAL: {
-                            uint32_t sum = profile_buffer.at(index + 1);
+                            uint32_t sum = data_buffer.at(index + 1);
 
                             uint32_t time_H = opTime_H;
                             uint32_t time_L = opTime_L;
@@ -388,11 +376,11 @@ void DeviceProfiler::readRiscProfilerResults(
                             break;
                         }
                         case kernel_profiler::TS_DATA: {
-                            uint32_t time_H = profile_buffer.at(index) & 0xFFF;
-                            uint32_t time_L = profile_buffer.at(index + 1);
+                            uint32_t time_H = data_buffer.at(index) & 0xFFF;
+                            uint32_t time_L = data_buffer.at(index + 1);
                             index += kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE;
-                            uint32_t data_H = profile_buffer.at(index);
-                            uint32_t data_L = profile_buffer.at(index + 1);
+                            uint32_t data_H = data_buffer.at(index);
+                            uint32_t data_L = data_buffer.at(index + 1);
                             logPacketData(
                                 log_file_ofs,
                                 noc_trace_json_log,
@@ -408,8 +396,8 @@ void DeviceProfiler::readRiscProfilerResults(
                             continue;
                         }
                         case kernel_profiler::TS_EVENT: {
-                            uint32_t time_H = profile_buffer.at(index) & 0xFFF;
-                            uint32_t time_L = profile_buffer.at(index + 1);
+                            uint32_t time_H = data_buffer.at(index) & 0xFFF;
+                            uint32_t time_L = data_buffer.at(index + 1);
                             logPacketData(
                                 log_file_ofs,
                                 noc_trace_json_log,
@@ -427,7 +415,6 @@ void DeviceProfiler::readRiscProfilerResults(
                 }
             }
         }
-        riscNum++;
     }
 }
 
@@ -460,6 +447,7 @@ void DeviceProfiler::logPacketData(
     uint64_t data,
     uint32_t timer_id,
     uint64_t timestamp) {
+    ZoneScoped;
     kernel_profiler::PacketTypes packet_type = get_packet_type(timer_id);
     uint32_t t_id = timer_id & 0xFFFF;
     nlohmann::json metaData;
@@ -903,7 +891,8 @@ void DeviceProfiler::generateZoneSourceLocationsHashes() {
 void DeviceProfiler::dumpResults(
     IDevice* device,
     const std::vector<CoreCoord>& worker_cores,
-    ProfilerDumpState state,
+    const ProfilerDumpState state,
+    const ProfilerDataBufferSource data_source,
     const std::optional<ProfilerOptionalMetadata>& metadata) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
@@ -914,28 +903,33 @@ void DeviceProfiler::dumpResults(
 
     generateZoneSourceLocationsHashes();
 
-    for (const auto& worker_core : worker_cores) {
-        readControlBuffers(device, worker_core, state);
-    }
+    bool do_L1_data_buffer = data_source == ProfilerDataBufferSource::L1;
 
-    const auto USE_FAST_DISPATCH = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr;
-    if (USE_FAST_DISPATCH) {
-        if (state == ProfilerDumpState::LAST_CLOSE_DEVICE || state == ProfilerDumpState::FORCE_UMD_READ) {
-            if (rtoptions.get_profiler_do_dispatch_cores() || state == ProfilerDumpState::FORCE_UMD_READ) {
-                issueSlowDispatchReadFromProfilerBuffer(device);
+    if (!do_L1_data_buffer) {
+        for (const auto& worker_core : worker_cores) {
+            readControlBuffers(device, worker_core, state);
+        }
+        const auto USE_FAST_DISPATCH = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr;
+        if (USE_FAST_DISPATCH) {
+            if (state == ProfilerDumpState::LAST_CLOSE_DEVICE || state == ProfilerDumpState::FORCE_UMD_READ) {
+                if (rtoptions.get_profiler_do_dispatch_cores() || state == ProfilerDumpState::FORCE_UMD_READ) {
+                    issueSlowDispatchReadFromProfilerBuffer(device);
+                }
+            } else {
+                issueFastDispatchReadFromProfilerBuffer(device);
             }
         } else {
-            issueFastDispatchReadFromProfilerBuffer(device);
+            if (state != ProfilerDumpState::LAST_CLOSE_DEVICE) {
+                issueSlowDispatchReadFromProfilerBuffer(device);
+            }
         }
-    } else {
-        if (state != ProfilerDumpState::LAST_CLOSE_DEVICE) {
-            issueSlowDispatchReadFromProfilerBuffer(device);
+        for (const auto& worker_core : worker_cores) {
+            resetControlBuffers(device, worker_core, state);
         }
     }
 
-    for (const auto& worker_core : worker_cores) {
-        resetControlBuffers(device, worker_core, state);
-    }
+    std::string zone_name = fmt::format("{}-{}-{}", device_id, magic_enum::enum_name(state), magic_enum::enum_name(data_source));
+    ZoneName(zone_name.c_str(), zone_name.size());
 
     if (rtoptions.get_profiler_noc_events_enabled()) {
         log_warning("Profiler NoC events are enabled; this can add 1-15% cycle overhead to typical operations!");
@@ -960,10 +954,42 @@ void DeviceProfiler::dumpResults(
         log_error("Could not open kernel profiler dump file '{}'", log_path);
     } else {
         for (const auto& worker_core : worker_cores) {
-            readRiscProfilerResults(device, worker_core, state, metadata, log_file_ofs, noc_trace_json_log);
+            if (do_L1_data_buffer) {
+                ZoneScopedN("Reading L1 profiler Data buffer");
+                readControlBuffers(device, worker_core, state);
+                resetControlBuffers(device, worker_core, state);
+                HalProgrammableCoreType core_type = tt::llrt::get_core_type(device_id, worker_core);
+
+                profiler_msg_t* profiler_msg =
+                    MetalContext::instance().hal().get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
+                std::vector<uint32_t> L1_data_buffer = tt::llrt::read_hex_vec_from_core(
+                    device_id,
+                    worker_core,
+                    reinterpret_cast<uint64_t>(profiler_msg->buffer),
+                    kernel_profiler::PROFILER_L1_VECTOR_SIZE * PROFILER_RISC_COUNT);
+                readRiscProfilerResults(
+                    device,
+                    worker_core,
+                    state,
+                    L1_data_buffer,
+                    ProfilerDataBufferSource::L1,
+                    metadata,
+                    log_file_ofs,
+                    noc_trace_json_log);
+            } else {
+                readRiscProfilerResults(
+                    device,
+                    worker_core,
+                    state,
+                    profile_buffer,
+                    ProfilerDataBufferSource::DRAM,
+                    metadata,
+                    log_file_ofs,
+                    noc_trace_json_log);
+            }
         }
 
-        // if defined, use profiler_noc_events_report_path to write json log. otherwise use output_dir
+        // if defined, used profiler_noc_events_report_path to write json log. otherwise use output_dir
         auto rpt_path = rtoptions.get_profiler_noc_events_report_path();
         if (rpt_path.empty()) {
             rpt_path = output_dir;

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -201,6 +201,8 @@ private:
         IDevice* device,
         const CoreCoord& worker_core,
         const ProfilerDumpState state,
+        const std::vector<uint32_t>& data_buffer,
+        const ProfilerDataBufferSource data_source,
         const std::optional<ProfilerOptionalMetadata>& metadata,
         std::ofstream& log_file_ofs,
         nlohmann::ordered_json& noc_trace_json_log);
@@ -258,7 +260,8 @@ public:
     void dumpResults(
         IDevice* device,
         const std::vector<CoreCoord>& worker_cores,
-        ProfilerDumpState state = ProfilerDumpState::NORMAL,
+        const ProfilerDumpState state = ProfilerDumpState::NORMAL,
+        const ProfilerDataBufferSource data_source = ProfilerDataBufferSource::DRAM,
         const std::optional<ProfilerOptionalMetadata>& metadata = {});
 
     // Push device results to tracy
@@ -280,8 +283,6 @@ void write_control_buffer_to_core(
     const HalProgrammableCoreType core_type,
     const ProfilerDumpState state,
     const std::vector<uint32_t>& control_buffer);
-
-HalProgrammableCoreType get_core_type(chip_id_t device_id, const CoreCoord& core);
 
 }  // namespace tt_metal
 

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -120,7 +120,7 @@ void setControlBuffer(IDevice* device, std::vector<uint32_t>& control_buffer) {
     for (auto core :
          tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_routing_to_profiler_flat_id(device_id)) {
         const CoreCoord curr_core = core.first;
-        const HalProgrammableCoreType core_type = get_core_type(device_id, curr_core);
+        const HalProgrammableCoreType core_type = tt::llrt::get_core_type(device_id, curr_core);
 
         profiler_msg_t* profiler_msg = hal.get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
 
@@ -164,19 +164,8 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
             .defines = kernel_defines});
 
     // Using MeshDevice APIs if the current device is managed by MeshDevice
-    if (tt::DevicePool::instance().is_dispatch_firmware_active()) {
-        if (auto mesh_device = device->get_mesh_device()) {
-            auto device_coord = mesh_device->get_view().find_device(device_id);
-            distributed::MeshWorkload workload;
-            workload.add_program(distributed::MeshCoordinateRange(device_coord, device_coord), std::move(sync_program));
-            distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
-        } else {
-            EnqueueProgram(device->command_queue(), sync_program, false);
-        }
-    } else {
-        tt_metal::detail::LaunchProgram(
-            device, sync_program, false /* wait_until_cores_done */, /* force_slow_dispatch */ true);
-    }
+    tt_metal::detail::LaunchProgram(
+        device, sync_program, false /* wait_until_cores_done */, /* force_slow_dispatch */ true);
 
     std::filesystem::path output_dir = std::filesystem::path(get_profiler_logs_dir());
     std::filesystem::path log_path = output_dir / "sync_device_info.csv";
@@ -203,15 +192,10 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
             &sinceStart, tt_cxy_pair(device_id, core), control_addr);
         writeTimes[i] = (TracyGetCpuTime() - writeStart);
     }
-    if (tt::DevicePool::instance().is_dispatch_firmware_active()) {
-        if (auto mesh_device = device->get_mesh_device()) {
-            mesh_device->mesh_command_queue().finish();
-        } else {
-            Finish(device->command_queue());
-        }
-    } else {
-        tt_metal::detail::WaitProgramDone(device, sync_program, false);
-    }
+    tt_metal::detail::WaitProgramDone(device, sync_program, false);
+    std::vector<CoreCoord> cores = {core};
+    tt_metal_device_profiler_map.at(device_id).dumpResults(
+        device, cores, ProfilerDumpState::FORCE_UMD_READ, ProfilerDataBufferSource::L1);
 
     log_info("SYNC PROGRAM FINISH IS DONE ON {}", device_id);
     if ((smallestHostime[device_id] == 0) || (smallestHostime[device_id] > hostStartTime)) {
@@ -359,7 +343,8 @@ void peekDeviceData(IDevice* device, std::vector<CoreCoord>& worker_cores) {
     ZoneName(zoneName.c_str(), zoneName.size());
     if (tt_metal_device_profiler_map.find(device_id) != tt_metal_device_profiler_map.end()) {
         tt_metal_device_profiler_map.at(device_id).device_sync_new_events.clear();
-        tt_metal_device_profiler_map.at(device_id).dumpResults(device, worker_cores, ProfilerDumpState::FORCE_UMD_READ);
+        tt_metal_device_profiler_map.at(device_id).dumpResults(
+            device, worker_cores, ProfilerDumpState::FORCE_UMD_READ, ProfilerDataBufferSource::L1);
         for (auto& event : tt_metal_device_profiler_map.at(device_id).device_events) {
             if (event.zone_name.find("SYNC-ZONE") != std::string::npos) {
                 ZoneScopedN("Adding_device_sync_event");
@@ -392,12 +377,6 @@ void syncDeviceDevice(chip_id_t device_id_sender, chip_id_t device_id_receiver) 
     }
 
     if (device_sender != nullptr and device_receiver != nullptr) {
-        FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
-        TT_FATAL(
-            fabric_config != FabricConfig::DISABLED,
-            "Cannot support device to device synchronization when TT-Fabric is disabled.");
-        log_info("Calling {} when TT-Fabric is enabled. This may take a while", __FUNCTION__);
-
         constexpr std::uint16_t sample_count = 240;
         constexpr std::uint16_t sample_size = 16;
         constexpr std::uint16_t channel_count = 1;
@@ -656,7 +635,11 @@ void ProfilerSync(ProfilerSyncState state) {
 
     if (state == ProfilerSyncState::CLOSE_DEVICE and do_sync_on_close) {
         do_sync_on_close = false;
-        // If at least one sender reciever pair has been found
+        for (const auto& synced_with_host_device : deviceHostTimePair) {
+            auto deviceToSync = tt::DevicePool::instance().get_active_device(synced_with_host_device.first);
+            syncDeviceHost(deviceToSync, SYNC_CORE, false);
+        }
+        //  If at least one sender reciever pair has been found
         if (first_connected_device_id != -1) {
             syncAllDevices(first_connected_device_id);
         }
@@ -785,7 +768,7 @@ void DumpDeviceProfileResults(
                     bool coreDone = false;
 
                     auto curr_core = device->virtual_core_from_logical_core(dispatchCores[0], dispatch_core_type);
-                    HalProgrammableCoreType CoreType = get_core_type(device_id, curr_core);
+                    HalProgrammableCoreType CoreType = tt::llrt::get_core_type(device_id, curr_core);
 
                     profiler_msg_t* profiler_msg =
                         hal.get_dev_addr<profiler_msg_t*>(CoreType, HalL1MemAddrType::PROFILER);
@@ -818,13 +801,9 @@ void DumpDeviceProfileResults(
         auto device_id = device->id();
 
         if (tt_metal_device_profiler_map.find(device_id) != tt_metal_device_profiler_map.end()) {
-            if (state != ProfilerDumpState::LAST_CLOSE_DEVICE) {
-                if (deviceHostTimePair.find(device_id) != deviceHostTimePair.end()) {
-                    syncDeviceHost(device, SYNC_CORE, false);
-                }
-            }
             tt_metal_device_profiler_map.at(device_id).setDeviceArchitecture(device->arch());
-            tt_metal_device_profiler_map.at(device_id).dumpResults(device, worker_cores, state, metadata);
+            tt_metal_device_profiler_map.at(device_id).dumpResults(
+                device, worker_cores, state, ProfilerDataBufferSource::DRAM, metadata);
             if (state == ProfilerDumpState::LAST_CLOSE_DEVICE) {
                 // Process is ending, no more device dumps are coming, reset your ref on the buffer so deallocate is the
                 // last owner. Sync program also contains a buffer so it is safter to release it here

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -81,6 +81,10 @@ std::vector<std::uint32_t> read_hex_vec_from_core(chip_id_t chip, const CoreCoor
 
 CoreCoord logical_core_from_ethernet_core(chip_id_t chip_id, CoreCoord& ethernet_core);
 
+tt_metal::HalProgrammableCoreType get_core_type(chip_id_t chip_id, const CoreCoord& virtual_core);
+
+void send_reset_go_signal(chip_id_t chip, const CoreCoord& virtual_core);
+
 void write_launch_msg_to_core(
     chip_id_t chip, CoreCoord core, launch_msg_t* msg, go_msg_t* go_msg, uint64_t addr, bool send_go = true);
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -773,7 +773,10 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
         // Must be set by the user only when its safe to mix slow dispatch with fast dispatch (advanced feature).
         if (!force_slow_dispatch) {
             detail::DispatchStateCheck(false);
+        } else {
+            TT_ASSERT(!tt::DevicePool::instance().is_dispatch_firmware_active());
         }
+
         detail::CompileProgram(device, program);
         if (!program.is_finalized()) {
             program.finalize_offsets(device);
@@ -805,6 +808,10 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
 
                 auto physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
                 not_done_cores.insert(physical_core);
+                if (force_slow_dispatch) {
+                    tt::llrt::send_reset_go_signal(device->id(), physical_core);
+                }
+
                 tt::llrt::write_launch_msg_to_core(
                     device->id(),
                     physical_core,


### PR DESCRIPTION
### Ticket
#21514 

### Problem description
Profiler sync requirement on profiler DRAM buffer is complicating the init process for mesh_device.

### What's changed
Remove that requirement by reading directly from L1 in profiler sync calls

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15398606847)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15398616261)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15398624041)
- [x] [uBenchmark](https://github.com/tenstorrent/tt-metal/actions/runs/15398621241) BW diffs wee source of the fail, no profiler issue
- [x] [T3K Profiler](https://github.com/tenstorrent/tt-metal/actions/runs/15398610399)