### PR TITLE
#21732: [skip ci] Add prefill + decode llama demo to WH 6U upstream tests

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -160,10 +160,10 @@ jobs:
         timeout-minutes: 10
         run: docker pull ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
       - name: Run image
-        timeout-minutes: 15
+        timeout-minutes: 30
         env:
           SOURCE_LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct
-          LLAMA_DIR: /model_weights/llama/Llama3.3-70B-Instruct
+          LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct
         run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $SOURCE_LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10

--- a/tests/scripts/wh_6u/run_wh_6u_upstream_tests.sh
+++ b/tests/scripts/wh_6u/run_wh_6u_upstream_tests.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "[upstream-tests] Running minimal model unit tests"
-pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
-pytest tests/ttnn/unit_tests/operations/test_prefetcher_TG.py
-pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py::test_matmul_1d_ring_llama_perf
-pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
-# pytest tests/ttnn/unit_tests/operations/ccl/test_minimals.py hang???
-
 if [ -z "${LLAMA_DIR}" ]; then
   echo "Error: LLAMA_DIR environment variable not detected. Please set this environment variable to tell the tests where to find the downloaded Llama weights." >&2
   exit 1
@@ -27,6 +20,13 @@ pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "full"
 
 echo "[upstream-tests] Unsetting LLAMA_DIR to ensure later tests can't use it"
 unset LLAMA_DIR
+
+echo "[upstream-tests] Running minimal model unit tests"
+pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
+pytest tests/ttnn/unit_tests/operations/test_prefetcher_TG.py
+pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py::test_matmul_1d_ring_llama_perf
+pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
+# pytest tests/ttnn/unit_tests/operations/ccl/test_minimals.py hang???
 
 echo "[upstream-tests] running metalium section. Note that skips should be treated as failures"
 ./build/test/tt_metal/tt_fabric/test_system_health

--- a/tests/scripts/wh_6u/run_wh_6u_upstream_tests.sh
+++ b/tests/scripts/wh_6u/run_wh_6u_upstream_tests.sh
@@ -16,7 +16,7 @@ fi
 echo "[upstream-tests] Running validation model tests with weights"
 pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick"
 pytest models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
-pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "full"
+pytest models/demos/llama3_subdevices/demo/text_demo.py -k "repeat"
 
 echo "[upstream-tests] Unsetting LLAMA_DIR to ensure later tests can't use it"
 unset LLAMA_DIR

--- a/tests/scripts/wh_6u/run_wh_6u_upstream_tests.sh
+++ b/tests/scripts/wh_6u/run_wh_6u_upstream_tests.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "[upstream-tests] running metalium section. Note that skips should be treated as failures"
-./build/test/tt_metal/tt_fabric/test_system_health
-TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardFixture.*"
-TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardProgramFixture.*"
-TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites"
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-
 echo "[upstream-tests] Running minimal model unit tests"
 pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
 pytest tests/ttnn/unit_tests/operations/test_prefetcher_TG.py
@@ -30,6 +23,14 @@ fi
 echo "[upstream-tests] Running validation model tests with weights"
 pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick"
 pytest models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
+pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "full"
 
 echo "[upstream-tests] Unsetting LLAMA_DIR to ensure later tests can't use it"
 unset LLAMA_DIR
+
+echo "[upstream-tests] running metalium section. Note that skips should be treated as failures"
+./build/test/tt_metal/tt_fabric/test_system_health
+TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardFixture.*"
+TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardProgramFixture.*"
+TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites"
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"


### PR DESCRIPTION
### Ticket

#21732 

### Problem description

We want to add the full prefill + decode demo and the decode mini stress test.

### What's changed

Add these tests, and execute before other tests because some of the lower level tests, including health check, depend on ring topology, which the current machines are very flaky at.

### Checklist
- [ ] https://github.com/tenstorrent/tt-metal/actions/runs/15290866964
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes