### PR TITLE
#22696: Add benchmarking tests for ND ShardedAccessor

### DIFF
--- a/tests/ttnn/benchmark/python/test_accessor_benchmarks.py
+++ b/tests/ttnn/benchmark/python/test_accessor_benchmarks.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import os
+import re
+import subprocess
+import pytest
+from loguru import logger
+from pathlib import Path
+
+from tt_metal.tools.profiler.process_device_log import import_log_run_stats
+import tt_metal.tools.profiler.device_post_proc_config as device_post_proc_config
+
+
+# Helper function to sort strings naturally
+def natural_key_from_path(s):
+    return [int(part) if part.isdigit() else part for part in re.split(r"(\d+)", s.name)]
+
+
+"""
+Runs tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp test and parses output.
+See the C++ test for more details on what is benchmarked and generated.
+"""
+
+
+def test_accessors():
+    ENV = os.environ.copy()
+    ENV["TT_METAL_DEVICE_PROFILER"] = "1"
+    BASE = Path(ENV["TT_METAL_HOME"])
+
+    binary_path = Path(BASE / "build" / "test" / "ttnn" / "unit_tests_ttnn_accessor")
+    subprocess.run([binary_path, "--gtest_filter=AccessorTests/AccessorBenchmarks.*"], env=ENV)
+
+    setup = device_post_proc_config.default_setup()
+    setup.timerAnalysis = {
+        "SHARDED_ACCESSOR_GET_NOC_ADDR": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"risc": "BRISC", "zone_name": "SHARDED_ACCESSOR"},
+            "end": {"risc": "BRISC", "zone_name": "SHARDED_ACCESSOR"},
+        },
+        "INTERLEAVED_ACCESSOR_GET_NOC_ADDR": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"risc": "BRISC", "zone_name": "INTERLEAVED_ACCESSOR"},
+            "end": {"risc": "BRISC", "zone_name": "INTERLEAVED_ACCESSOR"},
+        },
+    }
+
+    results_dir = Path(BASE / "accessor_benchmarks")
+    profile_log_file = Path(".logs/profile_log_device.csv")
+    for test_dir in sorted(results_dir.iterdir(), key=natural_key_from_path):
+        if not test_dir.is_dir():
+            raise IsADirectoryError(f"Expected {test_dir} to be a directory containing {profile_log_file}")
+        profile_log_path = test_dir / "profile_log_device.csv"
+        setup.deviceInputLog = profile_log_path
+
+        stats = import_log_run_stats(setup)
+        core = [key for key in stats["devices"][0]["cores"].keys() if key != "DEVICE"][0]
+        sharded_stats = stats["devices"][0]["cores"][core]["riscs"]["TENSIX"]["analysis"][
+            "SHARDED_ACCESSOR_GET_NOC_ADDR"
+        ]["stats"]
+        interleaved_stats = stats["devices"][0]["cores"][core]["riscs"]["TENSIX"]["analysis"][
+            "INTERLEAVED_ACCESSOR_GET_NOC_ADDR"
+        ]["stats"]
+
+        logger.info(f"Results for {test_dir}:")
+        logger.info(f"Sharded Stats: {sharded_stats}")
+        logger.info(f"Sharded Average: {sharded_stats['Average']} (cycles)")
+        logger.info(f"Interleaved Stats: {interleaved_stats}")
+        logger.info(f"Interleaved Average: {interleaved_stats['Average']} (cycles)")

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TTNN_1D_FABRIC_LATENCY_TEST_SRC ${CMAKE_CURRENT_SOURCE_DIR}/ccl/test_1d_fabr
 set(TTNN_ACCESSOR_UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/accessor/test_sharded_accessor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/accessor/test_sharded_accessor_on_device.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/accessor/test_accessor_benchmarks.cpp
 )
 
 set(TTNN_TENSOR_UNIT_TESTS_SRC

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_benchmark.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_benchmark.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "accessor/sharded_accessor.h"
+
+void kernel_main() {
+    const uint32_t bank_base_address = get_arg_val<uint32_t>(0);
+
+    constexpr DataFormat data_format = static_cast<DataFormat>(get_compile_time_arg_val(0));
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr uint32_t rank = get_compile_time_arg_val(2);
+    constexpr uint32_t num_banks = get_compile_time_arg_val(3);
+    constexpr uint32_t base_idx = 4;
+
+    using input_dspec = distribution_spec_t<base_idx, rank, num_banks>;
+
+    auto sharded_accessor = ShardedAccessor<input_dspec, page_size>{.bank_base_address = bank_base_address};
+
+    auto interleaved_accessor = InterleavedAddrGenFast</*DRAM=*/false>{
+        .bank_base_address = bank_base_address, .page_size = page_size, .data_format = data_format};
+
+    /* Benchmark get_noc_addr for both accessors
+     * - get_noc_addr is a good proxy for page lookup logic
+     * - Use volatile to prevent compiler from optimizing away the calls
+     * - Some notes on tracy profiler:
+     *   - Max number of markers is 250 (?), so we use a hard-coded loop count to make sure tests are consistent for
+     * larger shapes
+     *   - Cycles are fairly consistent across runs without much variation
+     *   - There is a small overhead for tracy (~18 cycles?) for each marker
+     *     * You can verify by inserting a dummy marker or removing the volatile since compiler will optimize out the
+     * calls
+     */
+    constexpr size_t loop_count = 30;
+    for (size_t i = 0; i < loop_count; ++i) {
+        auto page_id = i % input_dspec::tensor_volume;
+        {
+            DeviceZoneScopedN("SHARDED_ACCESSOR");
+            volatile auto _ = sharded_accessor.get_noc_addr(i);
+        }
+        {
+            DeviceZoneScopedN("INTERLEAVED_ACCESSOR");
+            volatile auto _ = interleaved_accessor.get_noc_addr(i);
+        }
+    }
+}

--- a/tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include <fmt/format.h>
+
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
+
+#include <tt-metalium/shape.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/buffer_distribution_spec.hpp>
+
+#include "ttnn/cpp/ttnn/operations/sharding_utilities.hpp"
+
+namespace accessor_benchmarks {
+
+// TODO: Very similar to test_buffer_distribution_spec.cpp; refactor to common header?
+struct InputBufferParams {
+    std::string test_name;  // Used for generating unique files
+    tt::tt_metal::Shape physical_tensor_shape;
+    tt::tt_metal::Shape2D page_shape;
+    float bytes_per_element;
+    tt::DataFormat data_format;  // Used for setting up CBs
+
+    struct DistributionSpecParams {
+        tt::tt_metal::Shape physical_shard_shape;
+        tt::tt_metal::CoreRangeSet grid;
+        tt::tt_metal::ShardOrientation shard_orientation;
+        tt::tt_metal::BufferType buffer_type;
+    };
+    DistributionSpecParams input_shard_spec;
+};
+
+std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> create_replicated_input_mesh_buffer_from_inputs(
+    const InputBufferParams& inputs, tt::tt_metal::distributed::MeshDevice* mesh_device) {
+    // These values would be passed from tensor correctly based on PageConfig
+    const auto host_size_in_bytes = inputs.physical_tensor_shape.volume() * inputs.bytes_per_element;
+    const auto page_size = inputs.page_shape.height() * inputs.page_shape.width() * inputs.bytes_per_element;
+
+    // Mirrors allocate_mesh_buffer_on_device in ttnn
+    const tt::tt_metal::distributed::ReplicatedBufferConfig mesh_buffer_config{.size = host_size_in_bytes};
+
+    // Create input mesh buffer
+    auto input_buffer_distribution_spec = tt::tt_metal::BufferDistributionSpec::from_shard_spec(
+        inputs.physical_tensor_shape,
+        inputs.input_shard_spec.physical_shard_shape,
+        inputs.page_shape,
+        inputs.input_shard_spec.grid,
+        inputs.input_shard_spec.shard_orientation);
+    const tt::tt_metal::distributed::DeviceLocalBufferConfig input_device_local_config{
+        .page_size = page_size,
+        .buffer_type = inputs.input_shard_spec.buffer_type,
+        .buffer_layout = tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED,
+        .shard_parameters = input_buffer_distribution_spec,
+    };
+    const auto input_mesh_buffer =
+        tt::tt_metal::distributed::MeshBuffer::create(mesh_buffer_config, input_device_local_config, mesh_device);
+
+    return input_mesh_buffer;
+}
+
+}  // namespace accessor_benchmarks
+
+using namespace accessor_benchmarks;
+using namespace tt::tt_metal;
+
+class AccessorBenchmarks : public GenericMeshDeviceFixture, public ::testing::WithParamInterface<InputBufferParams> {};
+
+TEST_P(AccessorBenchmarks, Generic) {
+    const auto& params = GetParam();
+
+    // Create input and output replicated mesh buffers across generic mesh device; tests will only use first device
+    const auto input_mesh_buffer = create_replicated_input_mesh_buffer_from_inputs(params, mesh_device_.get());
+
+    // Extract local single-device buffer (ie. shard_view) concepts for testing
+    const tt::tt_metal::distributed::MeshCoordinate mesh_coordinate{0, 0};
+    const auto input_shard_view = input_mesh_buffer->get_device_buffer(mesh_coordinate);
+    const auto local_device = input_shard_view->device();
+
+    const auto input_bank_base_address = input_mesh_buffer->address();
+
+    /* CREATE AND LAUNCH PROGRAM ON DEVICE
+     * - This program uses a single reader kernel to measure get_noc_addr overhead with different accessors
+     * - It does not actually do any reads, so no CBs are needed
+     * - Input buffers are set up with actual ND ShardSpec, but for interleaved we use same buffer
+     *   -  ie. Calculations are definitely wrong/nonsense for interleaved, but it's ok to use for benchmarking
+     *   - TODO: We can properly setup the input buffers and try reading from them as well
+     */
+    tt::tt_metal::detail::SetDeviceProfilerDir("accessor_benchmarks/" + params.test_name);
+    tt::tt_metal::detail::FreshProfilerDeviceLog();
+    {
+        tt::log_info("Creating single-core benchmarking program");
+        auto program = CreateProgram();
+
+        constexpr CoreCoord grid = {0, 0};
+        const auto data_format = params.data_format;
+        const auto aligned_page_size = input_shard_view->aligned_page_size();
+
+        // Set up sharded accessor compile-time args for reader kernel
+        const auto& input_buffer_distribution_spec =
+            std::get<BufferDistributionSpec>(input_mesh_buffer->device_local_config().shard_parameters.value());
+        const auto input_sharded_accessor_args = tt::tt_metal::sharded_accessor_utils::get_sharded_accessor_args(
+            *mesh_device_, input_buffer_distribution_spec, input_shard_view->core_type());
+        std::vector<uint32_t> input_compile_time_args = {
+            (uint32_t)data_format,
+            aligned_page_size,
+            input_sharded_accessor_args.rank,
+            input_sharded_accessor_args.num_banks};
+        input_compile_time_args.insert(
+            input_compile_time_args.end(),
+            input_sharded_accessor_args.shapes_and_bank_coords.cbegin(),
+            input_sharded_accessor_args.shapes_and_bank_coords.cend());
+
+        // Create reader kernel
+        KernelHandle reader_kernel_id = CreateKernel(
+            program,
+            "tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_benchmark.cpp",
+            grid,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = input_compile_time_args});
+
+        // Set up runtime args for reader kernel
+        std::vector<uint32_t> input_runtime_args = {
+            input_bank_base_address,
+        };
+        SetRuntimeArgs(program, reader_kernel_id, grid, input_runtime_args);
+
+        // Launch program
+        auto mesh_work_load = tt::tt_metal::distributed::CreateMeshWorkload();
+        AddProgramToMeshWorkload(
+            mesh_work_load, std::move(program), (tt::tt_metal::distributed::MeshCoordinateRange)mesh_coordinate);
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_work_load, false);
+
+        // Wait for program to finish
+        tt::log_info("Program launched!");
+        Finish(mesh_device_->mesh_command_queue());
+        tt::log_info("Program finished!");
+    }
+    tt::tt_metal::detail::DumpDeviceProfileResults(local_device);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AccessorTests,
+    AccessorBenchmarks,
+    ::testing::Values(
+        // Sweep across shape ranks since ShardedAccessor calculations scale with rank
+        // TODO: Other interesting parameters to try:
+        // - Page size: Possible that compiler optimizes division for power of 2 page sizes
+        // - Shape dim: Possible that compiler optimizes division or modulo for certain values
+        // - Try out other accessors as well, especially legacy ShardedAddrGen
+        InputBufferParams{
+            .test_name = "rank_2",
+            .physical_tensor_shape = tt::tt_metal::Shape{160, 160},
+            .page_shape = tt::tt_metal::Shape2D{32, 32},
+            .bytes_per_element = 2,
+            .data_format = tt::DataFormat::Float16,
+
+            .input_shard_spec =
+                InputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{96, 96},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+        },
+        InputBufferParams{
+            .test_name = "rank_3",
+            .physical_tensor_shape = tt::tt_metal::Shape{5, 160, 160},
+            .page_shape = tt::tt_metal::Shape2D{32, 32},
+            .bytes_per_element = 2,
+            .data_format = tt::DataFormat::Float16,
+
+            .input_shard_spec =
+                InputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{3, 96, 96},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+        },
+        InputBufferParams{
+            .test_name = "rank_5",
+            .physical_tensor_shape = tt::tt_metal::Shape{5, 5, 5, 160, 160},
+            .page_shape = tt::tt_metal::Shape2D{32, 32},
+            .bytes_per_element = 2,
+            .data_format = tt::DataFormat::Float16,
+
+            .input_shard_spec =
+                InputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{3, 3, 3, 96, 96},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+        },
+        InputBufferParams{
+            .test_name = "rank_7",
+            .physical_tensor_shape = tt::tt_metal::Shape{3, 3, 3, 3, 3, 64, 64},
+            .page_shape = tt::tt_metal::Shape2D{32, 32},
+            .bytes_per_element = 2,
+            .data_format = tt::DataFormat::Float16,
+
+            .input_shard_spec =
+                InputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{2, 2, 2, 2, 2, 96, 96},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+        }));

--- a/tests/ttnn/unit_tests/gtests/accessor/test_sharded_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_sharded_accessor_on_device.cpp
@@ -181,7 +181,7 @@ TEST_P(ShardedAccessorTestsOnDevice, SingleCoreReshard) {
         input_compile_time_args.push_back(cb_in0_idx);
         input_compile_time_args.push_back(aligned_page_size);
 
-        // Set up compile-time args for writer  kernel
+        // Set up compile-time args for writer kernel
         const auto& output_buffer_distribution_spec =
             std::get<BufferDistributionSpec>(output_mesh_buffer->device_local_config().shard_parameters.value());
         const auto output_sharded_accessor_args = tt::tt_metal::sharded_accessor_utils::get_sharded_accessor_args(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22696)

### Problem description
ND ShardedAccessor is functional, but we need to investigate the performance for page lookups. Then, we can optimize for common use cases.

### What's changed
- Add C++ test: tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
- Add python test which wraps around C++ test and parses output
- How to run C++ test:
  * ./build_metal.sh --enable-profiler --build-ttnn-tests
  * TT_METAL_DEVICE_PROFILER=1 ./build/test/ttnn/unit_tests_ttnn_accessor --gtest_filter=AccessorTests/AccessorBenchmarks.*
    * Results are in ./accessor_benchmarks/ (each sub-folder corresponds to a test param)
- How to run python test:
  * ./build_metal.sh --enable-profiler --build-ttnn-tests
  * pytest tests/ttnn/benchmark/python/test_accessor_benchmarks.py
    * Results are generated in ./accessor_benchmarks and parsed/printed to terminal


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/15309381723
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/15309379795
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes