### PR TITLE
Add ttnn import test to `ttnn-post-commit.yaml`

### DIFF
--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -98,8 +98,6 @@ jobs:
             fast_runtime_mode_off: true
           - name: ttnn example tests
             cmd: ./tests/scripts/run_ttnn_examples.sh
-          - name: ttnn import test
-            cmd: python3 -c "import ttnn"
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
@@ -152,3 +150,18 @@ jobs:
 
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
+
+  ttnn-import-test:
+    name: ttnn import test ubuntu-22.04
+    runs-on: ubuntu-22.04
+    steps:
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        timeout-minutes: 10
+        with:
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+
+      - name: ttnn import test
+        timeout-minutes: 5
+        run: |
+          python3 -c "import ttnn"

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -99,7 +99,7 @@ jobs:
           - name: ttnn example tests
             cmd: ./tests/scripts/run_ttnn_examples.sh
           - name: ttnn import test
-            cmd: python -c "import ttnn"
+            cmd: python3 -c "import ttnn"
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -98,6 +98,8 @@ jobs:
             fast_runtime_mode_off: true
           - name: ttnn example tests
             cmd: ./tests/scripts/run_ttnn_examples.sh
+          - name: ttnn import test
+            cmd: python -c "import ttnn"
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17057

### Problem description
We can't import ttnn without torch as of today.
This test serves to verify that after installing the wheel, we can import ttnn.
As of today, it will likely pass because we have `torch` as a hard dependency in `pyproject.toml`.
Once that is removed, it can only pass if we have no import time dependency on `torch`.

### What's changed
Added new test

### Checklist
- [ ] [ttnn post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15309680827) CI passes
- [x] New/Existing tests provide coverage for changes
