### PR TITLE
ttnn.concat fix for rank one tensors

### DIFF
--- a/open_mpi.sh
+++ b/open_mpi.sh
@@ -1,0 +1,18 @@
+install_mpi_uflm(){
+    DEB_URL="https://github.com/dmakoviichuk-tt/mpi-ulfm/releases/download/v5.0.7-ulfm/openmpi-ulfm_5.0.7-1_amd64.deb"
+    DEB_FILE="$(basename "$DEB_URL")"
+
+    # 1. Create temp workspace
+    TMP_DIR="$(mktemp -d)"
+    cleanup() { rm -rf "$TMP_DIR"; }
+    trap cleanup EXIT INT TERM
+
+    echo "→ Downloading $DEB_FILE …"
+    wget -q --show-progress -O "$TMP_DIR/$DEB_FILE" "$DEB_URL"
+
+    # 2. Install
+    echo "→ Installing $DEB_FILE …"
+    apt-get update -qq
+    apt-get install -f -y "$TMP_DIR/$DEB_FILE"
+}
+install_mpi_uflm

--- a/test.py
+++ b/test.py
@@ -1,0 +1,98 @@
+import torch
+import ttnn
+
+
+def reproduce_program_cache_concat_issue():
+    # Initialize device
+    device = ttnn.open_device(device_id=0)
+
+    # Enable program cache (this is key!)
+    # ttnn.enable_program_cache(device)
+
+    # Test parameters from the failing test
+    shapes = ((1, 1, 64, 64), (1, 1, 128, 64))
+    dim = -2
+    layout = ttnn.TILE_LAYOUT
+    dtype = ttnn.bfloat16
+
+    input_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
+        buffer_type=ttnn.BufferType.DRAM,
+    )
+    output_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
+        buffer_type=ttnn.BufferType.DRAM,
+    )
+
+    def run_concat_once():
+        print(f"Running concat with shapes: {shapes}, dim: {dim}")
+
+        # Create input tensors
+        inputs = []
+        tt_inputs = []
+        for i, shape in enumerate(shapes):
+            tensor_shape = torch.Size(shape)
+            inputs.append(torch.rand(tensor_shape).to(torch.bfloat16))
+            tt_inputs.append(ttnn.Tensor(inputs[i], dtype).to(layout).to(device, input_mem_config))
+
+        # Expected result
+        expected = torch.concat(inputs, dim)
+
+        # Run ttnn concat
+        result = ttnn.concat(tt_inputs, dim, memory_config=output_mem_config)
+
+        # Convert back and compare
+        actual = result.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+        return torch.allclose(expected, actual, rtol=1e-2, atol=1e-2)
+
+    print("=== First concat run (should populate program cache) ===")
+    success1 = run_concat_once()
+    print(f"First run success: {success1}")
+
+    print("\n=== Creating dummy tensor (like in test) ===")
+    tmp = ttnn.zeros([1, 256, 32, 32], ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
+    print("Dummy tensor created")
+
+    print("\n=== Second concat run (should use cached program) ===")
+    success2 = run_concat_once()  # This should crash and show the traceback
+    print(f"Second run success: {success2}")
+
+    print(f"\nOverall test result: {success1 and success2}")
+
+
+def test_large_tensor_count():
+    """Test with large tensor count to trigger the original error"""
+    device = ttnn.open_device(device_id=0)
+    # ttnn.enable_program_cache(device)
+
+    # Test with 55 tensors to trigger the original 278 argument error
+    num_tensors = 55
+    base_shape = (1, 1, 32, 32)
+    dim = 3  # concat on width
+
+    print(f"=== Testing with {num_tensors} tensors (should trigger argument limit) ===")
+
+    shapes = [base_shape] * num_tensors
+
+    # Create tensors
+    inputs = []
+    tt_inputs = []
+    for i in range(num_tensors):
+        inputs.append(torch.rand(base_shape).to(torch.bfloat16))
+        tt_inputs.append(ttnn.Tensor(inputs[i], ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device))
+
+    print("First run...")
+    result1 = ttnn.concat(tt_inputs, dim)  # Let this crash if it will
+
+    print("Second run...")
+    result2 = ttnn.concat(tt_inputs, dim)  # Let this crash if it will
+
+
+if __name__ == "__main__":
+    print("=== Testing program cache concat issue ===")
+    reproduce_program_cache_concat_issue()
+
+    print("\n" + "=" * 50)
+    print("=== Testing large tensor count ===")
+    test_large_tensor_count()

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_stick_layout_interleaved_start_id.cpp
@@ -10,85 +10,44 @@
 // Expects n provided src_addr, src_noc_x, src_noc_y, and cb_id_in
 void kernel_main() {
     const uint32_t num_pages = get_arg_val<uint32_t>(0);
-    const uint32_t start_tensor = get_arg_val<uint32_t>(1);
-    const uint32_t start_tensor_id = get_arg_val<uint32_t>(2);
+    const uint32_t num_tensor_segments = get_arg_val<uint32_t>(1);
 
     constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
-    constexpr uint32_t num_tensors = get_compile_time_arg_val(1);
-
-    // ublocks size defined in pages
+    constexpr bool rm_layout = get_compile_time_arg_val(1) == 1;
     constexpr uint32_t ublock_size_pages = 1;
 
-    uint8_t l1_src_addr_gens_memblk[sizeof(InterleavedAddrGen<false>) * num_tensors];
-    uint8_t dram_src_addr_gens_memblk[sizeof(InterleavedAddrGen<true>) * num_tensors];
+    // Read tensor metadata for only the tensors this core needs
+    uint32_t arg_idx = 2;
+    for (uint32_t seg_id = 0; seg_id < num_tensor_segments; ++seg_id) {
+        uint32_t src_addr = get_arg_val<uint32_t>(arg_idx++);
+        bool is_dram = get_arg_val<uint32_t>(arg_idx++) == 1;
+        uint32_t start_page = get_arg_val<uint32_t>(arg_idx++);
+        uint32_t num_pages_from_tensor = get_arg_val<uint32_t>(arg_idx++);
+        uint32_t page_size = rm_layout ? get_arg_val<uint32_t>(arg_idx++) : get_tile_size(cb_id_in);
 
-    InterleavedAddrGen<false>* l1_src_addr_gens = reinterpret_cast<InterleavedAddrGen<false>*>(l1_src_addr_gens_memblk);
-    InterleavedAddrGen<true>* dram_src_addr_gens =
-        reinterpret_cast<InterleavedAddrGen<true>*>(dram_src_addr_gens_memblk);
+        // Create address generator for this tensor
+        if (is_dram) {
+            InterleavedAddrGen<true> addr_gen = {.bank_base_address = src_addr, .page_size = page_size};
 
-    bool is_dram[num_tensors];
-    uint32_t num_pages_per_block[num_tensors];
-    uint32_t page_id_per_tensor[num_tensors];
-    constexpr uint32_t src_addr_base_idx = 3;
-    constexpr uint32_t is_dram_base_offset = num_tensors;
-    constexpr uint32_t num_pages_per_block_base_offset = is_dram_base_offset + num_tensors;
-    constexpr uint32_t page_size_per_tensor_offset = num_pages_per_block_base_offset + num_tensors;
-    constexpr uint32_t page_id_per_tensor_offset = page_size_per_tensor_offset + num_tensors;
-    tt_l1_ptr uint32_t* arg_ptr = (tt_l1_ptr uint32_t*)get_arg_addr(src_addr_base_idx);
-    for (uint32_t i = 0; i < num_tensors; ++i) {
-        uint32_t src_addr = arg_ptr[i];
-        is_dram[i] = (bool)arg_ptr[is_dram_base_offset + i];
-        num_pages_per_block[i] = arg_ptr[num_pages_per_block_base_offset + i];
-        page_id_per_tensor[i] = arg_ptr[page_id_per_tensor_offset + i];
-        if (is_dram[i]) {
-            new (&dram_src_addr_gens[i]) InterleavedAddrGen<true>{
-                .bank_base_address = src_addr, .page_size = arg_ptr[page_size_per_tensor_offset + i]};
-        } else {
-            new (&l1_src_addr_gens[i]) InterleavedAddrGen<false>{
-                .bank_base_address = src_addr, .page_size = arg_ptr[page_size_per_tensor_offset + i]};
-        }
-    }
-
-    uint32_t curr_tensor = start_tensor;
-    uint32_t curr_tensor_id = start_tensor_id;
-    // FIX RM CONCAT WIDTH
-    for (uint32_t i = 0; i < num_pages; ++i) {
-        cb_reserve_back(cb_id_in, ublock_size_pages);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in);
-#ifdef WIDTH_CONCAT
-        // For width concat we know we start at curr_tensor=0
-        // num_pages_per_block[curr_tensor] is always one for width concat
-        for (uint32_t j = 0; j < num_tensors; ++j) {
-            if (is_dram[curr_tensor]) {
-                noc_async_read_page(page_id_per_tensor[curr_tensor], dram_src_addr_gens[curr_tensor], l1_write_addr);
-                l1_write_addr += dram_src_addr_gens[curr_tensor].page_size;
-            } else {
-                noc_async_read_page(page_id_per_tensor[curr_tensor], l1_src_addr_gens[curr_tensor], l1_write_addr);
-                l1_write_addr += l1_src_addr_gens[curr_tensor].page_size;
+            // Read pages from this tensor
+            for (uint32_t page_offset = 0; page_offset < num_pages_from_tensor; ++page_offset) {
+                cb_reserve_back(cb_id_in, ublock_size_pages);
+                uint32_t l1_write_addr = get_write_ptr(cb_id_in);
+                noc_async_read_page(start_page + page_offset, addr_gen, l1_write_addr);
+                noc_async_read_barrier();
+                cb_push_back(cb_id_in, ublock_size_pages);
             }
-            page_id_per_tensor[curr_tensor]++;
-            curr_tensor++;
-        }
-        curr_tensor = 0;
-#else
-        if (is_dram[curr_tensor]) {
-            noc_async_read_page(page_id_per_tensor[curr_tensor], dram_src_addr_gens[curr_tensor], l1_write_addr);
         } else {
-            noc_async_read_page(page_id_per_tensor[curr_tensor], l1_src_addr_gens[curr_tensor], l1_write_addr);
-        }
+            InterleavedAddrGen<false> addr_gen = {.bank_base_address = src_addr, .page_size = page_size};
 
-        page_id_per_tensor[curr_tensor]++;
-        curr_tensor_id++;
-
-        if (curr_tensor_id == num_pages_per_block[curr_tensor]) {
-            curr_tensor_id = 0;
-            curr_tensor++;
-            if (curr_tensor == num_tensors) {
-                curr_tensor = 0;
+            // Read pages from this tensor
+            for (uint32_t page_offset = 0; page_offset < num_pages_from_tensor; ++page_offset) {
+                cb_reserve_back(cb_id_in, ublock_size_pages);
+                uint32_t l1_write_addr = get_write_ptr(cb_id_in);
+                noc_async_read_page(start_page + page_offset, addr_gen, l1_write_addr);
+                noc_async_read_barrier();
+                cb_push_back(cb_id_in, ublock_size_pages);
             }
         }
-#endif
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in, ublock_size_pages);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_stick_layout_interleaved_start_id.cpp
@@ -1,53 +1,70 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-//
-// SPDX-License-Identifier: Apache-2.0
-
 #include <stdint.h>
-#include "dataflow_api.h"
 
-// Make n reads defined by num_reads
-// Writes to Specified Circular Buffers in L1
-// Expects n provided src_addr, src_noc_x, src_noc_y, and cb_id_in
 void kernel_main() {
-    const uint32_t num_pages = get_arg_val<uint32_t>(0);
-    const uint32_t num_tensor_segments = get_arg_val<uint32_t>(1);
+    const uint32_t num_pages_per_core = get_arg_val<uint32_t>(0);
+    const uint32_t page_start = get_arg_val<uint32_t>(1);
+    const uint32_t metadata_buffer_addr = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
     constexpr bool rm_layout = get_compile_time_arg_val(1) == 1;
     constexpr uint32_t ublock_size_pages = 1;
 
-    // Read tensor metadata for only the tensors this core needs
-    uint32_t arg_idx = 2;
-    for (uint32_t seg_id = 0; seg_id < num_tensor_segments; ++seg_id) {
-        uint32_t src_addr = get_arg_val<uint32_t>(arg_idx++);
-        bool is_dram = get_arg_val<uint32_t>(arg_idx++) == 1;
-        uint32_t start_page = get_arg_val<uint32_t>(arg_idx++);
-        uint32_t num_pages_from_tensor = get_arg_val<uint32_t>(arg_idx++);
-        uint32_t page_size = rm_layout ? get_arg_val<uint32_t>(arg_idx++) : get_tile_size(cb_id_in);
+    // READ METADATA from buffer address
+    volatile tt_l1_ptr uint32_t* metadata_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_buffer_addr);
 
-        // Create address generator for this tensor
+    // Read header
+    const uint32_t num_tensors = metadata_ptr[0];
+    const uint32_t num_output_pages_per_block = metadata_ptr[1];
+    const uint32_t concat_dim = metadata_ptr[2];
+    const uint32_t is_rm_layout = metadata_ptr[3];
+
+    // Process pages assigned to this core
+    const uint32_t page_end = page_start + num_pages_per_core;
+
+    for (uint32_t page = page_start; page < page_end; ++page) {
+        // Figure out which block and position within block
+        uint32_t block_id = page / num_output_pages_per_block;
+        uint32_t pos_in_block = page % num_output_pages_per_block;
+
+        // Find tensor and page within tensor
+        uint32_t tensor_id = 0;
+        uint32_t pages_before_tensor = 0;
+
+        for (uint32_t t = 0; t < num_tensors; ++t) {
+            // Each tensor metadata starts at index 4 + t*5
+            uint32_t tensor_metadata_start = 4 + t * 5;
+            uint32_t pages_per_block = metadata_ptr[tensor_metadata_start + 3];
+
+            if (pos_in_block < pages_before_tensor + pages_per_block) {
+                tensor_id = t;
+                break;
+            }
+            pages_before_tensor += pages_per_block;
+        }
+
+        // Read tensor metadata
+        uint32_t tensor_metadata_start = 4 + tensor_id * 5;
+        uint32_t src_addr = metadata_ptr[tensor_metadata_start + 0];
+        uint32_t is_dram = metadata_ptr[tensor_metadata_start + 1];
+        uint32_t page_size = metadata_ptr[tensor_metadata_start + 2];
+        uint32_t pages_per_block = metadata_ptr[tensor_metadata_start + 3];
+
+        // Calculate page within tensor
+        uint32_t page_in_tensor = block_id * pages_per_block + (pos_in_block - pages_before_tensor);
+
+        // Read page from the identified tensor
+        cb_reserve_back(cb_id_in, ublock_size_pages);
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in);
+
         if (is_dram) {
             InterleavedAddrGen<true> addr_gen = {.bank_base_address = src_addr, .page_size = page_size};
-
-            // Read pages from this tensor
-            for (uint32_t page_offset = 0; page_offset < num_pages_from_tensor; ++page_offset) {
-                cb_reserve_back(cb_id_in, ublock_size_pages);
-                uint32_t l1_write_addr = get_write_ptr(cb_id_in);
-                noc_async_read_page(start_page + page_offset, addr_gen, l1_write_addr);
-                noc_async_read_barrier();
-                cb_push_back(cb_id_in, ublock_size_pages);
-            }
+            noc_async_read_page(page_in_tensor, addr_gen, l1_write_addr);
         } else {
             InterleavedAddrGen<false> addr_gen = {.bank_base_address = src_addr, .page_size = page_size};
-
-            // Read pages from this tensor
-            for (uint32_t page_offset = 0; page_offset < num_pages_from_tensor; ++page_offset) {
-                cb_reserve_back(cb_id_in, ublock_size_pages);
-                uint32_t l1_write_addr = get_write_ptr(cb_id_in);
-                noc_async_read_page(start_page + page_offset, addr_gen, l1_write_addr);
-                noc_async_read_barrier();
-                cb_push_back(cb_id_in, ublock_size_pages);
-            }
+            noc_async_read_page(page_in_tensor, addr_gen, l1_write_addr);
         }
+
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in, ublock_size_pages);
     }
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22541)

### Problem description
Rank 1 tensors passed to `ttnn.concat` causes errors.  

### What's changed
Added unsqueezing step.

The error being thrown was in the slice op, line 80:
```
TT_FATAL(
        input_tensor_a.get_padded_shape().rank() == this->slice_start.rank() &&
            this->slice_start.rank() == this->slice_end.rank(),
        "Error");
```
The slice op is called inside the `build_untilize_rm_retilize_concat` function, in order to slice away the padding for concatenating the logical parts of the tensor.  The relevant tensors attributes that were triggering the error were the rank of the input tensor not matching the rank of the slice start and/or end.

Unsqueezing was a quick fix to make the ranks always equal, but it could be glossing over a deeper issue in how those values are constructed, in this part of the code (In the .pre_transform of `build_untilize_rm_retilize_concat`):

```auto untilized_tensor = ttnn::untilize(input_tensor);
                    // untilized, so now we have a padded rm tensor. we slice to
                    // remove the padding.
                    const auto& input_shape = input_tensor.get_logical_shape();
                    std::vector<uint32_t> begins_vec(input_shape.rank(), 0);
                    tt::stl::Span<const uint32_t> begins = begins_vec;
                    tt::stl::Span<const uint32_t> ends = input_shape.view();
                    std::vector<uint32_t> steps_vec(input_shape.rank(), 1);
                    tt::stl::Span<const uint32_t> steps = steps_vec;
```

I can't find anything wrong with this, but `begins` and `ends` translate to inconsistent ranks when the input is 1D.  The unsqueezing step seems to fix this, but is there a better solution?

### Second Bug 
There was also a second unrelated error that came up that I added a fix for in this PR, see this GitHub issue: [link](https://github.com/tenstorrent/tt-metal/issues/22845)

This occurred because the original implementation gave every core metadata for all input tensors, resulting in `3 + 5×N `runtime arguments per core for N tensors, which exceeds the hardware limit of 256 arguments when trying to concatenate 51 tensors or more at one time.

To fix this, the logic which distributes core workloads was modified to pre-compute which data each core needs before reading the tensors, as opposed to figuring it out at runtime on each core.  

This should improve memory usage by eliminating redundant tensor meta data being passed to multiple cores.




### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes