### PR TITLE
SDXL: VAE conv fix

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_autoencoder_kl.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_autoencoder_kl.py
@@ -69,6 +69,7 @@ class TtAutoencoderKL(nn.Module):
 
         self.tt_post_quant_conv_weights = d_w
         self.tt_post_quant_conv_bias = d_b
+        self.conv_config.always_preprocess_weights = False
 
         hidden_states = ttnn.sharded_to_interleaved(hidden_states, ttnn.L1_MEMORY_CONFIG)
         hidden_states = self.decoder(hidden_states, [B, C, H, W])

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
@@ -5,7 +5,6 @@
 import ttnn
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_midblock2d import TtUNetMidBlock2D
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_upblock2d import TtUpDecoderBlock2D
 from models.experimental.stable_diffusion_xl_base.vae.tt.vae_utility import get_DRAM_conv_config, get_DRAM_GN_config
@@ -53,8 +52,8 @@ class TtDecoder(nn.Module):
         conv_in_weights = state_dict[f"decoder.conv_in.weight"]
         conv_in_bias = state_dict[f"decoder.conv_in.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
 
-        self.conv_out_weights = state_dict[f"decoder.conv_out.weight"]
-        self.conv_out_bias = state_dict[f"decoder.conv_out.bias"]
+        conv_out_weights = state_dict[f"decoder.conv_out.weight"]
+        conv_out_bias = state_dict[f"decoder.conv_out.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
 
         core_x, core_y, self.norm_blocks = get_DRAM_GN_config(None, 1)
         self.norm_core_grid = ttnn.CoreGrid(y=core_y, x=core_x)
@@ -67,8 +66,8 @@ class TtDecoder(nn.Module):
         )
 
         (
-            self.compute_config,
-            self.conv_config,
+            self.compute_in_config,
+            self.conv_in_config,
             self.tt_conv_in_weights,
             self.tt_conv_in_bias,
             self.conv_in_params,
@@ -82,6 +81,27 @@ class TtDecoder(nn.Module):
             math_fidelity=ttnn.MathFidelity.LoFi,
         )
         self.conv_in_slice_config = get_DRAM_conv_config(None, 1)
+        if self.conv_in_slice_config is not None:
+            self.conv_in_config.deallocate_activation = False
+
+        (
+            self.compute_out_config,
+            self.conv_out_config,
+            self.tt_conv_out_weights,
+            self.tt_conv_out_bias,
+            self.conv_out_params,
+        ) = prepare_conv_params(
+            device,
+            conv_out_weights,
+            conv_out_bias,
+            ttnn.bfloat16,
+            act_block_h_override=32,
+            fp32_dest_acc_en=True,
+            math_fidelity=ttnn.MathFidelity.LoFi,
+        )
+        self.conv_out_slice_config = get_DRAM_conv_config(None, 2)
+        if self.conv_out_slice_config is not None:
+            self.conv_out_config.deallocate_activation = False
 
     def forward(self, sample, input_shape):
         B, C, H, W = input_shape
@@ -104,8 +124,8 @@ class TtDecoder(nn.Module):
             batch_size=B,
             input_height=H,
             input_width=W,
-            conv_config=self.conv_config,
-            compute_config=self.compute_config,
+            conv_config=self.conv_in_config,
+            compute_config=self.compute_in_config,
             groups=self.groups,
             memory_config=None,
             slice_config=self.conv_in_slice_config,
@@ -147,10 +167,42 @@ class TtDecoder(nn.Module):
         hidden_states = ttnn.to_layout(hidden_states, ttnn.TILE_LAYOUT)
         hidden_states = ttnn.silu(hidden_states)
 
-        # HOST FALLBACK: Conv2d
+        if self.conv_out_slice_config is not None:
+            hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
+            hidden_states = ttnn.reshape(hidden_states, (B, H, W, C))
+        [hidden_states, [H, W], [d_w, d_b]] = ttnn.conv2d(
+            input_tensor=hidden_states,
+            weight_tensor=self.tt_conv_out_weights,
+            in_channels=self.conv_out_params["input_channels"],
+            out_channels=self.conv_out_params["output_channels"],
+            device=self.device,
+            bias_tensor=self.tt_conv_out_bias,
+            kernel_size=self.conv_out_params["kernel_size"],
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            batch_size=B,
+            input_height=H,
+            input_width=W,
+            conv_config=self.conv_out_config,
+            compute_config=self.compute_out_config,
+            groups=self.groups,
+            memory_config=None,
+            slice_config=self.conv_out_slice_config,
+            return_output_dim=True,
+            return_weights_and_bias=True,
+        )
+        C = self.conv_out_params["output_channels"]
+
+        self.tt_conv_out_weights = d_w
+        self.tt_conv_out_bias = d_b
+
+        self.conv_in_config.always_preprocess_weights = False
+        self.conv_out_config.always_preprocess_weights = False
+
+        # Convert to torch
         hidden_states = ttnn.to_torch(hidden_states).float()
         hidden_states = hidden_states.reshape(B, H, W, C)
         hidden_states = torch.permute(hidden_states, (0, 3, 1, 2))
 
-        hidden_states = F.conv2d(hidden_states, self.conv_out_weights, bias=self.conv_out_bias, stride=1, padding=1)
         return hidden_states

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
@@ -71,8 +71,8 @@ class TtResnetBlock2D(nn.Module):
             )
 
         (
-            self.compute_config,
-            self.conv_config,
+            self.compute1_config,
+            self.conv1_config,
             self.tt_conv1_weights,
             self.tt_conv1_bias,
             self.conv1_params,
@@ -86,8 +86,16 @@ class TtResnetBlock2D(nn.Module):
             math_fidelity=ttnn.MathFidelity.LoFi,
         )
         self.conv1_slice_config = get_DRAM_conv_config(module_path, 1)
+        if self.conv1_slice_config is not None:
+            self.conv1_config.deallocate_activation = False
 
-        _, _, self.tt_conv2_weights, self.tt_conv2_bias, self.conv2_params = prepare_conv_params(
+        (
+            self.compute2_config,
+            self.conv2_config,
+            self.tt_conv2_weights,
+            self.tt_conv2_bias,
+            self.conv2_params,
+        ) = prepare_conv_params(
             device,
             conv_weights_2,
             conv_bias_2,
@@ -97,11 +105,13 @@ class TtResnetBlock2D(nn.Module):
             math_fidelity=ttnn.MathFidelity.LoFi,
         )
         self.conv2_slice_config = get_DRAM_conv_config(module_path, 2)
+        if self.conv2_slice_config is not None:
+            self.conv2_config.deallocate_activation = False
 
         if conv_shortcut:
             (
                 self.compute_config_conv_linear,
-                _,
+                self.conv3_config,
                 self.tt_conv3_weights,
                 self.tt_conv3_bias,
                 self.conv3_params,
@@ -162,10 +172,10 @@ class TtResnetBlock2D(nn.Module):
 
         hidden_states = ttnn.silu(hidden_states)
 
-        self.conv_config.shard_layout = (
+        self.conv1_config.shard_layout = (
             hidden_states.memory_config().memory_layout if hidden_states.is_sharded() else None
         )
-        self.conv_config.act_block_h_override = 32 if hidden_states.is_sharded() else 0
+        self.conv1_config.act_block_h_override = 32 if hidden_states.is_sharded() else 0
 
         if self.conv1_slice_config is not None:
             hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
@@ -184,8 +194,8 @@ class TtResnetBlock2D(nn.Module):
             batch_size=B,
             input_height=H,
             input_width=W,
-            conv_config=self.conv_config,
-            compute_config=self.compute_config,
+            conv_config=self.conv1_config,
+            compute_config=self.compute1_config,
             groups=self.groups,
             memory_config=None,
             slice_config=self.conv1_slice_config,
@@ -242,7 +252,7 @@ class TtResnetBlock2D(nn.Module):
 
         hidden_states = ttnn.to_layout(hidden_states, ttnn.TILE_LAYOUT)
         hidden_states = ttnn.silu(hidden_states)  # note: silu hangs if not tile
-        self.conv_config.shard_layout = None
+        self.conv2_config.shard_layout = None
         if self.conv2_slice_config is not None:
             hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
             hidden_states = ttnn.reshape(hidden_states, (B, H, W, C))
@@ -260,8 +270,8 @@ class TtResnetBlock2D(nn.Module):
             batch_size=B,
             input_height=H,
             input_width=W,
-            conv_config=self.conv_config,
-            compute_config=self.compute_config,
+            conv_config=self.conv2_config,
+            compute_config=self.compute2_config,
             groups=self.groups,
             memory_config=None,
             slice_config=self.conv2_slice_config,
@@ -278,8 +288,8 @@ class TtResnetBlock2D(nn.Module):
             if input_tensor.shape[3] >= 1920:
                 input_tensor = ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT)
                 input_tensor = ttnn.sharded_to_interleaved(input_tensor, ttnn.L1_MEMORY_CONFIG)
-            self.conv_config.shard_layout = None
-            self.conv_config.act_block_h_override = 0
+            self.conv3_config.shard_layout = None
+            self.conv3_config.act_block_h_override = 0
             [input_tensor, [H, W], [d_w, d_b]] = ttnn.conv2d(
                 input_tensor=input_tensor,
                 weight_tensor=self.tt_conv3_weights,
@@ -294,7 +304,7 @@ class TtResnetBlock2D(nn.Module):
                 batch_size=input_shape[0],
                 input_height=input_shape[2],
                 input_width=input_shape[3],
-                conv_config=self.conv_config,
+                conv_config=self.conv3_config,
                 compute_config=self.compute_config_conv_linear,
                 groups=self.groups,
                 memory_config=None,
@@ -304,6 +314,8 @@ class TtResnetBlock2D(nn.Module):
             C = self.conv3_params["output_channels"]
             self.tt_conv3_weights = d_w
             self.tt_conv3_bias = d_b
+            self.conv3_config.preprocess_weights_on_device = False
+            self.conv3_config.always_preprocess_weights = False
         if input_tensor.is_sharded():
             input_tensor = ttnn.sharded_to_interleaved(input_tensor, ttnn.L1_MEMORY_CONFIG)
         if hidden_states.is_sharded():
@@ -316,6 +328,8 @@ class TtResnetBlock2D(nn.Module):
         ttnn.deallocate(input_tensor)
         hidden_states = ttnn.move(hidden_states)
 
-        self.conv_config.preprocess_weights_on_device = False
-        self.conv_config.always_preprocess_weights = False
+        self.conv1_config.preprocess_weights_on_device = False
+        self.conv1_config.always_preprocess_weights = False
+        self.conv2_config.preprocess_weights_on_device = False
+        self.conv2_config.always_preprocess_weights = False
         return hidden_states, [C, H, W]

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upsample2d.py
@@ -39,6 +39,8 @@ class TtUpsample2D(nn.Module):
             device, weights, bias, ttnn.bfloat16, fp32_dest_acc_en=True, math_fidelity=ttnn.MathFidelity.LoFi
         )
         self.conv_slice_config = get_DRAM_conv_config(module_path, 1)
+        if self.conv_slice_config is not None:
+            self.conv_config.deallocate_activation = False
 
     def interpolate(self, hidden_states):
         hidden_states = ttnn.upsample(hidden_states, (self.scale_factor, self.scale_factor))

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
@@ -42,8 +42,12 @@ def get_DRAM_GN_config(module_path, idx):
 
 def get_DRAM_conv_config(module_path, idx):
     if module_path is None:
-        slice_type = None
-        num_slices = 1
+        if idx == 1:
+            slice_type = None
+            num_slices = 1
+        else:
+            slice_type = ttnn.Conv2dSliceWidth
+            num_slices = 16
     elif "mid_block" in module_path:
         slice_type = None
         num_slices = 1


### PR DESCRIPTION
### What's changed
With [#21299]( https://github.com/tenstorrent/tt-metal/issues/21299) fixed, we can remove host fallback for the last VAE conv. Additionally, fixed regression in VAE CI tests.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15310708607) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15310713228) CI passes