### PR TITLE
[skip ci] Allow usage of system sfpi for firmware build

### DIFF
--- a/cmake/project_options.cmake
+++ b/cmake/project_options.cmake
@@ -20,6 +20,7 @@ option(TT_ENABLE_LIGHT_METAL_TRACE "Enable Light Metal Trace" ON)
 option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
 option(TT_UMD_BUILD_SIMULATION "Force UMD to include its simulation harnessing" ON)
 option(TT_INSTALL "Define installation rules" ON)
+option(TT_USE_SYSTEM_SFPI "Use system path for SFPI. SFPI is used to compile firmware." OFF)
 
 ###########################################################################################
 

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -136,9 +136,6 @@ function(get_alias INPUT_STRING OUTPUT_VAR)
     endif()
 endfunction()
 
-# Option to use system-installed SFPI
-option(TT_USE_SYSTEM_SFPI "Use system-installed SFPI compiler" OFF)
-
 if(TT_USE_SYSTEM_SFPI)
     set(GPP_CMD "/opt/tenstorrent/sfpi/compiler/bin/riscv32-tt-elf-g++")
 else()

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -136,11 +136,20 @@ function(get_alias INPUT_STRING OUTPUT_VAR)
     endif()
 endfunction()
 
-# Define the compiler command
-set(GPP_CMD ${PROJECT_SOURCE_DIR}/runtime/sfpi/compiler/bin/riscv32-tt-elf-g++)
+# Option to use system-installed SFPI
+option(TT_USE_SYSTEM_SFPI "Use system-installed SFPI compiler" OFF)
 
-# May switch to this someday
-# set(GPP_CMD /opt/tenstorrent/sfpi/compiler/bin/riscv32-tt-elf-g++)
+if(TT_USE_SYSTEM_SFPI)
+    set(GPP_CMD "/opt/tenstorrent/sfpi/compiler/bin/riscv32-tt-elf-g++")
+else()
+    set(GPP_CMD "${PROJECT_SOURCE_DIR}/runtime/sfpi/compiler/bin/riscv32-tt-elf-g++")
+endif()
+
+if(NOT EXISTS "${GPP_CMD}")
+    message(FATAL_ERROR "GPP_CMD path '${GPP_CMD}' does not exist. Please check your configuration.")
+endif()
+
+message(STATUS "Using SFPI compiler: ${GPP_CMD}")
 
 set(GPP_DEFINES -DTENSIX_FIRMWARE)
 


### PR DESCRIPTION
### Problem description
Can't build `tt-metal` on `AlmaLinux9`, because the auto-downloaded binaries were built on ubuntu.

### What's changed
Add a CMake option to use a system install of sfpi for building firmware files during tt-metal build.

This way, if the AlmaLinux9 container already has sfpi installed to /opt/tenstorrent/ we can actually build.

### Checklist
- [x] [Build](https://github.com/tenstorrent/tt-metal/actions/runs/15311334560) CI passes
- [x] New/Existing tests provide coverage for changes