### PR TITLE
#22307 binary ng fix for updating sharded tensor cb dynamic address

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -2049,9 +2049,9 @@ height_sharded_memory_config_4 = ttnn.create_sharded_memory_config(
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_decoder(dtype_pt, dtype_tt, device, use_program_cache):
+def test_binary_sharded_decoder_program_cache(dtype_pt, dtype_tt, device, use_program_cache):
     compute_grid_size = device.compute_with_storage_grid_size()
-    if compute_grid_size.x * compute_grid_size.y < 64:
+    if compute_grid_size.x < 8 or compute_grid_size.y < 8:
         pytest.skip("Test is skipped because the device does not have full coregrid 8x8")
 
     torch.manual_seed(0)
@@ -2100,3 +2100,6 @@ def test_binary_sharded_decoder(dtype_pt, dtype_tt, device, use_program_cache):
                 # print(f"Pearson correlation coefficient: {pcc}")
                 print(f"device.num_program_cache_entries(): {device.num_program_cache_entries()}")
                 assert pcc >= 0.99988
+    assert (
+        device.num_program_cache_entries() == 5
+    ), f"device.num_program_cache_entries(): {device.num_program_cache_entries()}"

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -2012,3 +2012,87 @@ def test_bcast(input_shape_a, device, bcast_dim, math_op):
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor], 0.9999)
     assert comp_pass
+
+
+height_sharded_memory_config_1 = ttnn.create_sharded_memory_config(
+    [1024, 256],
+    core_grid=ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (7, 7))}),
+    strategy=ttnn.ShardStrategy.HEIGHT,
+    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    use_height_and_width_as_shard_shape=True,
+)
+
+height_sharded_memory_config_2 = ttnn.create_sharded_memory_config(
+    [1024, 128],
+    core_grid=ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (7, 7))}),
+    strategy=ttnn.ShardStrategy.HEIGHT,
+    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    use_height_and_width_as_shard_shape=True,
+)
+height_sharded_memory_config_3 = ttnn.create_sharded_memory_config(
+    [4096, 64],
+    core_grid=ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (7, 7))}),
+    strategy=ttnn.ShardStrategy.HEIGHT,
+    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    use_height_and_width_as_shard_shape=True,
+)
+height_sharded_memory_config_4 = ttnn.create_sharded_memory_config(
+    [4096, 32],
+    core_grid=ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (7, 7))}),
+    strategy=ttnn.ShardStrategy.HEIGHT,
+    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    use_height_and_width_as_shard_shape=True,
+)
+
+
+@pytest.mark.parametrize(
+    "dtype_pt, dtype_tt",
+    ([torch.bfloat16, ttnn.bfloat16],),
+)
+def test_binary_sharded_decoder(dtype_pt, dtype_tt, device, use_program_cache):
+    torch.manual_seed(0)
+    # device.disable_and_clear_program_cache()
+
+    input_tensors = (
+        (torch.Size([1, 1, 65536, 256]), torch.Size([1, 1, 65536, 256]), height_sharded_memory_config_1),
+        (torch.Size([1, 1, 65536, 128]), torch.Size([1, 1, 65536, 128]), height_sharded_memory_config_2),
+        (torch.Size([1, 1, 262144, 64]), torch.Size([1, 1, 262144, 64]), height_sharded_memory_config_3),
+        (torch.Size([1, 1, 262144, 3]), torch.Size([1, 1, 262144, 3]), height_sharded_memory_config_4),
+    )
+    for _i in range(2):
+        for a_shape, b_shape, sharded_config in input_tensors:
+            input_combinations = (
+                (ttnn.DRAM_MEMORY_CONFIG, sharded_config),
+                (ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
+            )
+            for src_a_config, src_b_config in input_combinations:
+                a_pt = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=dtype_pt), dtype_tt)(
+                    a_shape
+                )
+                b_pt = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=dtype_pt), dtype_tt)(
+                    b_shape
+                )
+
+                a_tt = ttnn.from_torch(
+                    a_pt,
+                    dtype=dtype_tt,
+                    device=device,
+                    layout=ttnn.TILE_LAYOUT,
+                    memory_config=src_a_config,
+                )
+                b_tt = ttnn.from_torch(
+                    b_pt,
+                    dtype=dtype_tt,
+                    device=device,
+                    layout=ttnn.TILE_LAYOUT,
+                    memory_config=src_b_config,
+                )
+
+                out_pt = torch.add(a_pt, b_pt)
+                ttnn.add(a_tt, b_tt, memory_config=ttnn.DRAM_MEMORY_CONFIG, output_tensor=a_tt, use_legacy=False)
+                out_tt_interleaved = ttnn.to_torch(a_tt)
+
+                pcc = ttnn.pearson_correlation_coefficient(out_tt_interleaved, out_pt)
+                # print(f"Pearson correlation coefficient: {pcc}")
+                print(f"device.num_program_cache_entries(): {device.num_program_cache_entries()}")
+                assert pcc >= 0.99988

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -2050,6 +2050,10 @@ height_sharded_memory_config_4 = ttnn.create_sharded_memory_config(
     ([torch.bfloat16, ttnn.bfloat16],),
 )
 def test_binary_sharded_decoder(dtype_pt, dtype_tt, device, use_program_cache):
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if compute_grid_size.x * compute_grid_size.y < 64:
+        pytest.skip("Test is skipped because the device does not have full coregrid 8x8")
+
     torch.manual_seed(0)
     # device.disable_and_clear_program_cache()
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -59,6 +59,9 @@ struct BinaryNgDeviceOperation {
             tt::tt_metal::KernelHandle reader_kernel_id;
             tt::tt_metal::KernelHandle writer_kernel_id;
             tt::tt_metal::KernelHandle compute_kernel_id;
+            tt::tt_metal::CBHandle cb_src_a;
+            tt::tt_metal::CBHandle cb_src_b;
+            tt::tt_metal::CBHandle cb_src_c;
         };
 
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22307)

### Problem description
FAILED tests/nightly/single_card/stable_diffusion/vae/test_vae_decoder.py::test_decoder[4-64-64-3-512-512-512-midblock_resnet_norm_blocks0-midblock_conv_channel_split_factors0-upblock_out_channels0-upblock_out_dimensions0-upblock_resnet_norm_blocks0-upblock_resnet_conv_in_channel_split_factors0-upblock_upsample_conv_channel_split_factors0-device_params0] - AssertionError: 0.5735226952361068

### What's changed
The reason for the problem is that for one binary_ng ttnn.add op with sharded tensor, it produced wrong result. The root cause is that for sharded tensor, when updating runtime args, it did not call UpdateDynamicCircularBufferAddress().

The fix is to add the call. Also added unit test during debugging the problem, although the unit test cannot reproduce the problem.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes