### PR TITLE
#0: Remove single device bindings from core.py, serialization code

### DIFF
--- a/ttnn/api/ttnn/tensor/serialization.hpp
+++ b/ttnn/api/ttnn/tensor/serialization.hpp
@@ -14,7 +14,6 @@ namespace tt::tt_metal {
 void dump_tensor(
     const std::string& file_name, const Tensor& tensor, const std::unordered_map<std::string, std::string>& strategy);
 
-Tensor load_tensor(const std::string& file_name, IDevice* device = nullptr);
 Tensor load_tensor(const std::string& file_name, distributed::MeshDevice* device = nullptr);
 
 void dump_memory_config(FILE* output_file, const MemoryConfig& memory_config);

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -236,13 +236,10 @@ DistributedStorage load_multi_device_host_storage(
     }
 }
 
-template <typename T>
 DistributedStorage load_storage(
-    FILE* input_file, DataType data_type, Layout layout, StorageType storage_type, T device) {
+    FILE* input_file, DataType data_type, Layout layout, StorageType storage_type, MeshDevice* device) {
     if (storage_type == StorageType::MULTI_DEVICE_HOST or storage_type == StorageType::DEVICE) {
-        if constexpr (std::is_same_v<T, MeshDevice*>) {
-            return load_multi_device_host_storage(input_file, data_type, layout, device);
-        }
+        return load_multi_device_host_storage(input_file, data_type, layout, device);
     }
     return DistributedStorage{load_host_storage(input_file, data_type), ReplicateTensor{}};
 }

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -247,8 +247,9 @@ DistributedStorage load_storage(
     return DistributedStorage{load_host_storage(input_file, data_type), ReplicateTensor{}};
 }
 
-template <typename T>
-Tensor load_tensor_helper(const std::string& file_name, T device) {
+}  // namespace
+
+Tensor load_tensor(const std::string& file_name, MeshDevice* device) {
     FILE* input_file = fopen(file_name.c_str(), "rb");
     if (not input_file) {
         TT_THROW("Cannot open \"{}\"", file_name);
@@ -276,8 +277,6 @@ Tensor load_tensor_helper(const std::string& file_name, T device) {
     }
     return tensor;
 }
-
-}  // namespace
 
 void dump_tensor(
     const std::string& file_name, const Tensor& tensor, const std::unordered_map<std::string, std::string>& strategy) {
@@ -315,14 +314,6 @@ void dump_tensor(
             },
         },
         tensor_to_dump.get_storage());
-}
-
-// Explicit instantiations
-Tensor load_tensor(const std::string& file_name, IDevice* device) {
-    return load_tensor_helper<IDevice*>(file_name, device);
-}
-Tensor load_tensor(const std::string& file_name, MeshDevice* device) {
-    return load_tensor_helper<MeshDevice*>(file_name, device);
 }
 
 void dump_memory_config(FILE* output_file, const MemoryConfig& memory_config) {

--- a/ttnn/cpp/ttnn-pybind/tensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/tensor.cpp
@@ -251,12 +251,6 @@ void tensor_mem_config_module(py::module& m_tensor) {
         py::arg("file_name"),
         py::arg("device") = nullptr,
         R"doc(Load tensor to file)doc");
-    m_tensor.def(
-        "load_tensor",
-        py::overload_cast<const std::string&, IDevice*>(&load_tensor),
-        py::arg("file_name"),
-        py::arg("device") = nullptr,
-        R"doc(Load tensor to file)doc");
 }
 
 }  // namespace ttnn::tensor

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -241,7 +241,7 @@ def from_torch(
     tile: Optional[ttnn.Tile] = None,
     pad_value: Optional[float] = None,
     layout: Optional[ttnn.Layout] = ttnn.ROW_MAJOR_LAYOUT,
-    device: Optional[ttnn.Device] = None,
+    device: Optional[ttnn.MeshDevice] = None,
     memory_config: Optional[ttnn.MemoryConfig] = None,
     mesh_mapper: Optional[ttnn.TensorToMesh] = None,
     cq_id: Optional[int] = ttnn.DefaultQueueId,
@@ -260,7 +260,7 @@ def from_torch(
         tile (ttnn.Tile, optional): the desired tiling configuration for the tensor. Defaults to `None`.
         pad_value (float, optional): the desired padding value for tiling. Only used if `layout` is `TILE_LAYOUT`. Defaults to `None`.
         layout (ttnn.Layout, optional): the desired `ttnn` layout. Defaults to `ttnn.ROW_MAJOR_LAYOUT`.
-        device (ttnn.Device, optional): the desired `ttnn` device. Defaults to `None`.
+        device (ttnn.MeshDevice, optional): the desired `ttnn` device. Defaults to `None`.
         memory_config (ttnn.MemoryConfig, optional): The desired `ttnn` memory configuration. Defaults to `None`.
         mesh_mapper (ttnn.TensorToMesh, optional): The desired `ttnn` mesh mapper. Defaults to `None`.
         cq_id (int, optional): The command queue ID to use. Defaults to `0`.
@@ -324,7 +324,7 @@ def to_torch(
     *,
     torch_rank: Optional[int] = None,
     mesh_composer: Optional[ttnn.MeshToTensor] = None,
-    device: Optional[ttnn.Device] = None,
+    device: Optional[ttnn.MeshDevice] = None,
     cq_id: Optional[int] = ttnn.DefaultQueueId,
 ) -> "torch.Tensor":
     """
@@ -339,7 +339,7 @@ def to_torch(
         torch_rank (int, optional): Desired rank of the `torch.Tensor`. Defaults to `None`.
             Will use `torch.squeeze` operation to remove dimensions until the desired rank is reached. If not possible, the operation will raise an error.
         mesh_composer (ttnn.MeshToTensor, optional): The desired `ttnn` mesh composer. Defaults to `None`.
-        device (ttnn.Device, optional): The `ttnn` device of the input tensor. Defaults to `None`.
+        device (ttnn.MeshDevice, optional): The `ttnn` device of the input tensor. Defaults to `None`.
         cq_id (int, optional): The command queue ID to use. Defaults to `0`.
 
     Returns:
@@ -394,7 +394,7 @@ def _golden_function(tensor, *args, **kwargs):
 
 
 doc = """
-Copies the `ttnn.Tensor` :attr:`tensor` to the `tt_lib.device.Device`.
+Copies the `ttnn.Tensor` :attr:`tensor` to the `tt_lib.device.MeshDevice`.
 
 The tensor may be placed in DRAM or L1 memory.
 
@@ -402,7 +402,7 @@ Currently memory_config must be of an Interleaved tensor (not sharded)
 
 Args:
     * :attr:`tensor`: the ttnn.Tensor
-    * :attr:`device`: the ttnn.Device
+    * :attr:`device`: the ttnn.MeshDevice
     * :attr:`memory_config`: the optional MemoryConfig (DRAM_MEMORY_CONFIG or L1_MEMORY_CONFIG). Defaults to DRAM_MEMORY_CONFIG.
 
 Example::
@@ -516,7 +516,7 @@ ttnn.attach_golden_function(ttnn.reallocate, golden_function=_golden_function)
 
 
 @ttnn.register_python_operation(name="ttnn.load_tensor")
-def load_tensor(file_name: Union[str, pathlib.Path], *, device: ttnn.Device = None) -> ttnn.Tensor:
+def load_tensor(file_name: Union[str, pathlib.Path], *, device: ttnn.MeshDevice = None) -> ttnn.Tensor:
     """
     Load tensor from a file.
 
@@ -524,7 +524,7 @@ def load_tensor(file_name: Union[str, pathlib.Path], *, device: ttnn.Device = No
         file_name (str | pathlib.Path): the file name.
 
     Keyword Args:
-        device (ttnn.Device, optional): the device. Defaults to `None`.
+        device (ttnn.MeshDevice, optional): the device. Defaults to `None`.
 
     Returns:
         ttnn.Tensor: the loaded tensor.
@@ -570,7 +570,7 @@ def as_tensor(
     dtype: Optional[ttnn.DataType] = None,
     *,
     layout: Optional[ttnn.Layout] = ttnn.ROW_MAJOR_LAYOUT,
-    device: Optional[ttnn.Device] = None,
+    device: Optional[ttnn.MeshDevice] = None,
     memory_config: Optional[ttnn.MemoryConfig] = None,
     cache_file_name: Optional[Union[str, pathlib.Path]] = None,
     preprocess: Optional[Callable[[ttnn.Tensor], ttnn.Tensor]] = None,
@@ -586,7 +586,7 @@ def as_tensor(
 
     Keyword args:
         layout (ttnn.Layout, optional): The `ttnn` layout. Defaults to `ttnn.ROW_MAJOR_LAYOUT`.
-        device (ttnn.Device, optional): The `ttnn` device. Defaults to `None`.
+        device (ttnn.MeshDevice, optional): The `ttnn` device. Defaults to `None`.
         memory_config (ttnn.MemoryConfig, optional): The `ttnn` memory configuration. Defaults to `None`.
         cache_file_name (str | pathlib.Path, optional): The cache file name. Defaults to `None`.
         preprocess (Callable[[ttnn.Tensor], ttnn.Tensor], optional): The function to preprocess the tensor before serializing/converting to ttnn. Defaults to `None`.
@@ -624,7 +624,7 @@ def as_tensor(
         tensor: torch.Tensor,
         dtype: Optional[ttnn.DataType],
         layout: Optional[ttnn.Layout],
-        device: Optional[ttnn.Device],
+        device: Optional[ttnn.MeshDevice],
         memory_config: Optional[ttnn.MemoryConfig],
         mesh_mapper: Optional[ttnn.TensorToMesh],
     ):


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`IDevice` isn't used by TTNN, and the legacy code needs to be cleaned up.

### What's changed
Remove the use of `IDevice` in core.py and in load/dump tensor code.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15311565374)
- [x] [Single device demos](https://github.com/tenstorrent/tt-metal/actions/runs/15314757772)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15314708464)
- [x] New/Existing tests provide coverage for changes
