### PR TITLE
Modify Llama11B-Vision vLLM Generator and input processor to be compatible with more recent upstream version of vLLM

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -89,7 +89,7 @@ jobs:
 
       - name: 📀 Install vLLM
         run: |
-          pip3 install vllm/ -f https://download.pytorch.org/whl/cpu
+          pip install vllm/ --extra-index-url https://download.pytorch.org/whl/cpu
 
       - name: 📂 Create output directory
         run: |

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -89,7 +89,7 @@ jobs:
 
       - name: 📀 Install vLLM
         run: |
-          pip install vllm/ --extra-index-url https://download.pytorch.org/whl/cpu
+          pip3 install vllm/ --extra-index-url https://download.pytorch.org/whl/cpu
 
       - name: 📂 Create output directory
         run: |

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -89,7 +89,7 @@ jobs:
 
       - name: 📀 Install vLLM
         run: |
-          pip3 install vllm/
+          pip3 install vllm/ -f https://download.pytorch.org/whl/cpu
 
       - name: 📂 Create output directory
         run: |

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -11,7 +11,6 @@ from llama_models.llama3.api.chat_format import create_vision_mask
 from tqdm import tqdm
 from vllm.inputs import INPUT_REGISTRY, DecoderOnlyInputs, EncoderDecoderInputs, InputContext, TokenInputs, token_inputs
 from vllm.model_executor.models.interfaces import SupportsMultiModal
-from vllm.model_executor.models.mllama import MLLAMA_IMAGE_TOKEN, MLLAMA_IMAGE_TOKEN_ID
 
 import ttnn
 from models.tt_transformers.demo.simple_vision_demo import create_multimodal_model
@@ -97,13 +96,14 @@ def initialize_vllm_text_transformer(
     return tt_model, model_args
 
 
+# TODO: Update input processor to inherit from EncDecMultiModalProcessor as is done in vllm.model_executor.models.mllama.py
 def input_processor_for_mllama(
     ctx: InputContext,
     inputs: EncoderDecoderInputs,
 ) -> EncoderDecoderInputs:
     """
-    Based on vllm.model_executor.models.mllama.py::input_processor_for_mllama().
-    Note that vLLM's input_processor_for_mllama performs additional processing to compute num_tiles while here it is fixed.
+    This was based on a previous version of vllm.model_executor.models.mllama.py::input_processor_for_mllama()
+    without the additional processing for computing num_tiles (here it is fixed).
     """
     # Example input to processor:
     # {
@@ -167,6 +167,8 @@ def input_processor_for_mllama(
     #         'multi_modal_data': {'image': <PIL.Image.Image image mode=RGB size=1770x1180 at 0x7FDE2C624880>},  # noqa: E501
     #     },
     # }
+    MLLAMA_IMAGE_TOKEN_ID = 128256
+    MLLAMA_IMAGE_TOKEN = "<|image|>"
     return EncoderDecoderInputs(
         encoder=token_inputs(
             prompt_token_ids=[MLLAMA_IMAGE_TOKEN_ID] * num_vision_tokens,
@@ -232,7 +234,7 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
     def prefill_forward(
         self,
         tokens: torch.Tensor,
-        images: List[PIL.Image.Image],
+        images: Union[List[PIL.Image.Image], List[List[PIL.Image.Image]]],
         page_table: torch.Tensor,
         kv_cache,
         prompt_lens,
@@ -248,6 +250,9 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
         total_lens = []
         for user_id in range(batch):
             image = images[user_id]
+            if isinstance(image, list):
+                assert len(image) == 1, "Only one image is supported for each user in the batch"
+                image = image[0]
             vision_images.append([image] if image else None)
             prompt_tokens = [int(tokens[user_id, i]) for i in range(prompt_lens[user_id])]
             vision_masks.append(create_vision_mask(prompt_tokens, self.MLLAMA_IMAGE_TOKEN_ID) if image else None)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
N/A

### What's changed
- This PR only affects vLLM and is necessary to be able to update our vLLM fork to a more recent upstream version. Once this change is merged, previous versions of our vLLM fork will not be compatible.
- Modified the Llama11B custom vLLM input processor to be compatible with the updated `EncoderDecoderInputs` inputs
- Modified the Llama11B vLLM prefill forward function to accept list of list of images for server mode (with an assert for 1 image per user)
- Removed imports from vllm.model_executor.models.mllama
- Update vLLM pip install in vLLM nightly pipeline to use extra index url since CPU version of Torch is no longer available through PyPI.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes