### PR TITLE
Move all profiling dependencies to install_dependencies.sh

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -160,11 +160,6 @@ source python_env/bin/activate
 ```
 
 - (optional) Software dependencies for profiling use:
-  - Install dependencies:
-  ```sh
-  sudo apt install pandoc libtbb-dev libcapstone-dev pkg-config
-  ```
-
   - Download and install [Doxygen](https://www.doxygen.nl/download.html), (v1.9 or higher, but less than v1.10)
 
 - Continue to [You Are All Set!](#you-are-all-set)

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -210,12 +210,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     file \
     graphviz \
     jq \
-    pandoc \
     sudo \
     uuid-runtime \
     wget \
-    libtbb-dev \
-    libcapstone-dev \
     libgtest-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -113,7 +113,6 @@ ub_buildtime_packages()
      libc++abi-17-dev \
      build-essential \
      xz-utils \
-     libopenmpi-dev \
      pandoc \
      libtbb-dev \
      libcapstone-dev \

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -114,7 +114,10 @@ ub_buildtime_packages()
      build-essential \
      xz-utils \
      libopenmpi-dev \
+     pandoc \
+     libtbb-dev \
      libcapstone-dev \
+     pkg-config \
     )
 
     if [ "$distributed" -eq 1 ]; then

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -113,6 +113,8 @@ ub_buildtime_packages()
      libc++abi-17-dev \
      build-essential \
      xz-utils \
+     libopenmpi-dev \
+     libcapstone-dev \
     )
 
     if [ "$distributed" -eq 1 ]; then


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Yesterday I tried to compile tt-metal with "--enable-profiler" and got the following error: 
```
../../../server/TracyWorker.cpp:24:10: fatal error: capstone.h: No such file or directory
   24 | #include <capstone.h>
```

I managed to fix that with `sudo apt install libcapstone-dev`

I managed to reproduce that on both ubuntu 24.04 and ubuntu 22.04

### What's changed
Add libcapstone-dev to build dependencies of tt-metal in ./install_dependencies.sh

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes -- https://github.com/tenstorrent/tt-metal/actions/runs/15344858236
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes