### PR TITLE
Llama70B - Update tsu range for 6U in Galaxy quick

### DIFF
--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -35,7 +35,7 @@ TSU_PERF_DROP_LIMIT_COUNT = 20
 TSU_THRESHOLDS = {
     "4U": {1: {"min": 520, "max": 545}, 10: {"min": 230, "max": 250}, 80: {"min": 48.5, "max": 53}},
     # TODO: Update thresholds for 6U 10L and 80L based on actual perf when 6U are available and added into CI
-    "6U": {1: {"min": 545, "max": 570}, 10: {"min": 230, "max": 250}, 80: {"min": 49, "max": 53}},
+    "6U": {1: {"min": 600, "max": 635}, 10: {"min": 230, "max": 250}, 80: {"min": 49, "max": 53}},
 }
 
 


### PR DESCRIPTION
tsu range modified to [600 - 635] t/s/u.
### Problem description
Model got improved and started asserting on going out of range for expected tsu performance. 
### What's changed
tsu range is modified [545 - 570] -> [600 - 635]

### Checklist
- [ ] [Last Galaxy Quick tsu numbers](https://github.com/tenstorrent/tt-metal/actions/runs/15320176213/job/43102666001#step:5:1191)