### PR TITLE
Refactor Conv2d Weight Preparation APIs and Add Host-Side Kernel Stride Folding

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3597,6 +3597,7 @@ def test_segformer_channel_padding(device, enable_act_double_buffer, enable_spli
 @pytest.mark.parametrize("kernel_height,kernel_width", [(16, 16), (32, 32)])
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("has_bias", [True, False])
+@pytest.mark.parametrize("preprocess_weights_on_device", [True, False])
 def test_conv2d_with_fold(
     device,
     torch_tensor_map,
@@ -3609,6 +3610,7 @@ def test_conv2d_with_fold(
     kernel_width,
     input_layout,
     has_bias,
+    preprocess_weights_on_device,
 ):
     run_conv(
         device=device,
@@ -3631,4 +3633,5 @@ def test_conv2d_with_fold(
         input_layout=input_layout,
         has_bias=has_bias,
         enable_kernel_stride_folding=True,
+        preprocess_weights_on_device=preprocess_weights_on_device,
     )

--- a/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
@@ -482,14 +482,16 @@ def test_conv_dram(
 
 
 @pytest.mark.parametrize(
-    "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, on_device, is_owned",
+    "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w",
     (
-        (1, 1024, 3, 224, 224, 16, 16, 16, 16, True, True),
-        (1, 1024, 3, 224, 224, 32, 32, 32, 32, True, False),
-        (1, 192, 3, 512, 672, 16, 16, 16, 16, False, True),
-        (1, 192, 3, 512, 672, 32, 32, 32, 32, False, False),
+        (1, 1024, 3, 224, 224, 16, 16, 16, 16),
+        (1, 1024, 3, 224, 224, 32, 32, 32, 32),
+        (1, 192, 3, 512, 672, 16, 16, 16, 16),
+        (1, 192, 3, 512, 672, 32, 32, 32, 32),
+        (1, 768, 3, 384, 512, 32, 32, 32, 32),
     ),
 )
+@pytest.mark.parametrize("on_device", [True, False], ids=["on_device", "on_host"])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 2**15}], indirect=True)
 def test_prepare_conv_weights_with_fold(
     batch_size,
@@ -502,7 +504,6 @@ def test_prepare_conv_weights_with_fold(
     stride_h,
     stride_w,
     on_device,
-    is_owned,
     device,
 ):
     pad_h = 0
@@ -525,6 +526,6 @@ def test_prepare_conv_weights_with_fold(
         on_device,
         device,
         groups,
-        is_owned,
+        is_owned=False,
         enable_kernel_stride_folding=True,
     )

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -428,23 +428,14 @@ Result conv2d_L1(
     auto weight_tensor = weight_tensor_;
     std::optional<ttnn::Tensor> bias_tensor = bias_tensor_;
     bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
+    // Store the original stride size for weight folding
+    auto orig_stride = stride;
     if (conv_config.enable_kernel_stride_folding) {
-        auto folding_result = apply_kernel_stride_folding(
-            input_tensor,
-            weight_tensor,
-            bias_tensor,
-            device,
-            input_height,
-            input_width,
-            in_channels,
-            kernel_size,
-            stride,
-            padding_n4,
-            conv_config);
+        auto folding_result = compute_kernel_stride_folding_params(
+            input_height, input_width, in_channels, kernel_size, stride, padding_n4, conv_config);
+        input_tensor = fold_tensor(input_tensor, device, stride, kernel_size, padding_n4, conv_config.dtype, false);
 
-        input_tensor = folding_result.input_tensor;
-        weight_tensor = folding_result.weight_tensor;
-        bias_tensor = folding_result.bias_tensor;
+        // Update the input tensor parameters to the folding result
         input_height = folding_result.input_height;
         input_width = folding_result.input_width;
         in_channels = folding_result.in_channels;
@@ -524,49 +515,36 @@ Result conv2d_L1(
         kernel_size,
         compute_grid_size);
 
-    bool weight_is_on_device = tt::tt_metal::is_device_tensor(weight_tensor);
     ttnn::Tensor weight_tensor_on_device = weight_tensor;
     std::optional<ttnn::Tensor> bias_tensor_on_device = bias_tensor;
-    // If kernel stride folding is enabled, we don't need to preprocess weights.
-    if (conv_config.enable_kernel_stride_folding) {
-        // Skip weight preprocessing for kernel stride folding
-    } else {
-        if (!weight_is_on_device || conv_config.always_preprocess_weights) {
-            // prepare weights in desired layout and move to device
 
-            // TODO: Implement heuristic to decide if weights should be preprocessed on device.
-            if (!conv_config.preprocess_weights_on_device) {
-                tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_and_move_to_device(
-                    weight_tensor,
-                    bias_tensor,
-                    input_channels_alignment,
-                    conv_config.weights_dtype,
-                    opt_conv_op_block_config.act_block_w_ntiles,
-                    opt_conv_op_block_config.out_subblock_w_ntiles,
-                    parallel_config,
-                    output_parallel_config,
-                    device,
-                    groups,
-                    opt_conv_op_block_config.act_block_h_ntiles,
-                    input_width,
-                    bias_tensor.has_value(),
-                    true);
-            } else {
-                tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_on_device(
-                    weight_tensor,
-                    bias_tensor,
-                    input_channels_alignment,
-                    conv_config.weights_dtype,
-                    opt_conv_op_block_config.act_block_w_ntiles,
-                    opt_conv_op_block_config.out_subblock_w_ntiles,
-                    parallel_config,
-                    output_parallel_config,
-                    device,
-                    groups,
-                    opt_conv_op_block_config.act_block_h_ntiles,
-                    input_width,
-                    bias_tensor.has_value());
-            }
+    Conv2dWeightsBiasPrepConfig params(
+        input_channels_alignment,
+        conv_config.weights_dtype,
+        opt_conv_op_block_config.act_block_w_ntiles,
+        opt_conv_op_block_config.out_subblock_w_ntiles,
+        parallel_config,
+        output_parallel_config,
+        groups,
+        opt_conv_op_block_config.act_block_h_ntiles,
+        input_width,
+        bias_tensor.has_value(),
+        true,  // parameters_on_device
+        conv_config.enable_kernel_stride_folding,
+        kernel_size,
+        orig_stride,
+        padding_n4);
+
+    if (!tt::tt_metal::is_device_tensor(weight_tensor) || conv_config.always_preprocess_weights) {
+        // prepare weights in desired layout and move to device
+
+        // TODO: Implement heuristic to decide if weights should be preprocessed on device.
+        if (!conv_config.preprocess_weights_on_device) {
+            std::tie(weight_tensor_on_device, bias_tensor_on_device) =
+                prepare_conv_weights_biases_and_move_to_device(weight_tensor, bias_tensor, params, device);
+        } else {
+            std::tie(weight_tensor_on_device, bias_tensor_on_device) =
+                prepare_conv_weights_biases_on_device(weight_tensor, bias_tensor, params, device);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1355,7 +1355,7 @@ ttnn::Tensor fold_tensor(
     tensor_on_device = ttnn::fold(tensor_on_device, stride[0], stride[1]);
 
     if (is_weight_tensor) {
-        tensor_on_device = ttnn::permute(tensor_on_device, ttnn::SmallVector<int64_t>({0, 3, 2, 1}));
+        tensor_on_device = ttnn::permute(tensor_on_device, ttnn::SmallVector<int64_t>({0, 3, 1, 2}));
     }
 
     return tensor_on_device;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1355,19 +1355,13 @@ ttnn::Tensor fold_tensor(
     tensor_on_device = ttnn::fold(tensor_on_device, stride[0], stride[1]);
 
     if (is_weight_tensor) {
-        tensor_on_device = ttnn::permute(tensor_on_device, ttnn::SmallVector<int64_t>({1, 2, 3, 0}));
-        tensor_on_device = ttnn::to_layout(tensor_on_device, Layout::TILE, std::nullopt, std::nullopt, device);
+        tensor_on_device = ttnn::permute(tensor_on_device, ttnn::SmallVector<int64_t>({0, 3, 2, 1}));
     }
 
     return tensor_on_device;
 }
 
-template <typename T>
-KernelStrideFoldingResult apply_kernel_stride_folding(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight_tensor,
-    const std::optional<const ttnn::Tensor>& bias_tensor,
-    T* device,
+KernelStrideFoldingResult compute_kernel_stride_folding_params(
     uint32_t input_height,
     uint32_t input_width,
     uint32_t in_channels,
@@ -1378,32 +1372,12 @@ KernelStrideFoldingResult apply_kernel_stride_folding(
     TT_FATAL(input_height % stride[0] == 0, "Input height must be divisible by stride for kernel stride folding.");
     TT_FATAL(input_width % stride[1] == 0, "Input width must be divisible by stride for kernel stride folding.");
 
-    // Fold the input tensor to reduce spatial dimensions by stride factors
-    auto folded_input = fold_tensor(input_tensor, device, stride, kernel_size, padding_n4, conv_config.dtype, false);
-
-    // If the weight is not preprocessed on device, fold it
-    auto folded_weight = weight_tensor;
-    if (!tt::tt_metal::is_device_tensor(weight_tensor) || conv_config.always_preprocess_weights) {
-        folded_weight =
-            fold_tensor(weight_tensor, device, stride, kernel_size, padding_n4, conv_config.weights_dtype, true);
-    }
-
-    // If the bias is not on device, move it to device
-    std::optional<ttnn::Tensor> folded_bias = bias_tensor;
-    if (bias_tensor.has_value()) {
-        folded_bias = ttnn::to_device(bias_tensor.value(), device, ttnn::DRAM_MEMORY_CONFIG);
-        folded_bias = ttnn::to_layout(folded_bias.value(), Layout::TILE, std::nullopt, std::nullopt, device);
-    }
-
     // Update dimensions for folded operation
     input_height = input_height / stride[0];
     input_width = input_width / stride[1];
     in_channels = in_channels * stride[0] * stride[1];
 
     return KernelStrideFoldingResult{
-        .input_tensor = folded_input,
-        .weight_tensor = folded_weight,
-        .bias_tensor = folded_bias,
         .input_height = input_height,
         .input_width = input_width,
         .in_channels = in_channels,
@@ -1500,32 +1474,6 @@ template ttnn::Tensor fold_tensor<MeshDevice>(
     std::array<uint32_t, 4> padding_n4,
     std::optional<DataType> dtype,
     bool is_weight_tensor);
-
-template KernelStrideFoldingResult apply_kernel_stride_folding<IDevice>(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight_tensor,
-    const std::optional<const ttnn::Tensor>& bias_tensor,
-    tt::tt_metal::IDevice* device,
-    uint32_t input_height,
-    uint32_t input_width,
-    uint32_t in_channels,
-    std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 2> stride,
-    std::array<uint32_t, 4> padding_n4,
-    const Conv2dConfig& conv_config);
-
-template KernelStrideFoldingResult apply_kernel_stride_folding<MeshDevice>(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight_tensor,
-    const std::optional<const ttnn::Tensor>& bias_tensor,
-    tt::tt_metal::distributed::MeshDevice* device,
-    uint32_t input_height,
-    uint32_t input_width,
-    uint32_t in_channels,
-    std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 2> stride,
-    std::array<uint32_t, 4> padding_n4,
-    const Conv2dConfig& conv_config);
 
 std::ostream& operator<<(std::ostream& os, const Conv2dConfig& config) {
     tt::stl::reflection::operator<<(os, config);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -195,9 +195,6 @@ ttnn::Tensor fold_tensor(
     bool is_weight_tensor = false);
 
 struct KernelStrideFoldingResult {
-    ttnn::Tensor input_tensor;
-    ttnn::Tensor weight_tensor;
-    std::optional<ttnn::Tensor> bias_tensor;
     uint32_t input_height;
     uint32_t input_width;
     uint32_t in_channels;
@@ -206,12 +203,7 @@ struct KernelStrideFoldingResult {
     bool mm_conv;
 };
 
-template <typename T>
-KernelStrideFoldingResult apply_kernel_stride_folding(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight_tensor,
-    const std::optional<const ttnn::Tensor>& bias_tensor,
-    T* device,
+KernelStrideFoldingResult compute_kernel_stride_folding_params(
     uint32_t input_height,
     uint32_t input_width,
     uint32_t in_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/pad/pad.hpp"
+#include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -495,6 +496,60 @@ Tensor convert_conv_weight_tensor_to_depthwise_layout(
         output_conv_weight_tensor_shape);
 }
 
+static Tensor to_folded_weight_layout(
+    const Tensor& conv_weight_tensor,
+    std::array<uint32_t, 2> stride,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 4> padding) {
+    auto w_shape = conv_weight_tensor.get_padded_shape();
+    uint32_t out_channels = w_shape[0];
+    uint32_t in_channels = w_shape[1];
+    uint32_t kernel_h = w_shape[2];
+    uint32_t kernel_w = w_shape[3];
+
+    // Get input data type
+    auto dtype = conv_weight_tensor.get_dtype();
+
+    ttnn::Shape output_shape = ttnn::Shape({w_shape[0], w_shape[1] * kernel_h * kernel_w, 1, 1});
+    auto storage = std::get<tt::tt_metal::HostStorage>(conv_weight_tensor.get_storage()).buffer;
+
+    auto fold_weights = [&](auto input_buffer) {
+        using T = std::decay_t<decltype(input_buffer[0])>;
+        std::vector<T> output_buffer(output_shape.volume());
+
+        uint32_t patch_size = kernel_h * kernel_w * in_channels;
+        for (auto oc = 0; oc < out_channels; oc++) {
+            uint32_t dst_offset = oc * patch_size;
+            uint32_t dst_idx = 0;
+            for (auto kh = 0; kh < kernel_h; kh++) {
+                for (auto kw = 0; kw < kernel_w; kw++) {
+                    for (auto ic = 0; ic < in_channels; ic++) {
+                        uint32_t src_idx = ((((oc * in_channels + ic) * kernel_h) + kh) * kernel_w) + kw;
+                        output_buffer[dst_offset + dst_idx++] = input_buffer[src_idx];
+                    }
+                }
+            }
+        }
+
+        return Tensor(tt::tt_metal::HostBuffer(std::move(output_buffer)), output_shape, dtype, Layout::ROW_MAJOR);
+    };
+
+    switch (dtype) {
+        case DataType::FLOAT32: return fold_weights(tt::tt_metal::host_buffer::get_as<float>(storage));
+        case DataType::BFLOAT16: return fold_weights(tt::tt_metal::host_buffer::get_as<bfloat16>(storage));
+        case DataType::UINT32: return fold_weights(tt::tt_metal::host_buffer::get_as<uint32_t>(storage));
+        case DataType::INT32: return fold_weights(tt::tt_metal::host_buffer::get_as<int32_t>(storage));
+        case DataType::UINT16: return fold_weights(tt::tt_metal::host_buffer::get_as<uint16_t>(storage));
+        case DataType::BFLOAT8_B: return fold_weights(tt::tt_metal::host_buffer::get_as<float>(storage));
+        case DataType::BFLOAT4_B: return fold_weights(tt::tt_metal::host_buffer::get_as<uint32_t>(storage));
+        default:
+            TT_THROW(
+                "Unsupported input data type for to_folded_weight_layout: {} (type id: {})",
+                dtype,
+                static_cast<int>(dtype));
+    }
+}
+
 void validate_weight_tensor(const ttnn::Tensor& weight_tensor) {
     TT_FATAL(weight_tensor.get_layout() == Layout::ROW_MAJOR, "conv weight layout should be in row_major layout");
     TT_FATAL(weight_tensor.get_logical_shape().rank() == 4, "conv weight should be 4D tensor");
@@ -737,21 +792,12 @@ template <typename T>
 std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_on_device(
     const ttnn::Tensor& weight_tensor,
     const std::optional<const ttnn::Tensor>& bias_tensor,
-    uint32_t input_channels_alignment,
-    std::optional<DataType> weights_bias_dtype,
-    uint32_t weight_block_h_ntiles,
-    uint32_t weight_block_w_ntiles,
-    const sliding_window::ParallelConfig& input_parallel_config,
-    const sliding_window::ParallelConfig& output_parallel_config,
-    T* device,
-    uint32_t groups,
-    uint32_t act_block_h_ntiles,
-    uint32_t input_width,
-    const bool has_bias) {
+    Conv2dWeightsBiasPrepConfig& params,
+    T* device) {
     ttnn::Tensor weight_tensor_ = weight_tensor;  // tensor to return
     Shape weight_shape = weight_tensor.get_logical_shape();
     // In case of 1D convolution and 3D weight tensor, reinterpret it as 4D tensor
-    if (weight_shape.rank() == 3 && input_width == 1) {
+    if (weight_shape.rank() == 3 && params.input_width == 1) {
         weight_tensor_ = ttnn::reshape(weight_tensor_, Shape({weight_shape[0], weight_shape[1], weight_shape[2], 1}));
     }
 
@@ -764,26 +810,51 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
     uint32_t original_weights_window_w = original_weights_shape[3];
 
     ttnn::Tensor bias_tensor_;
-    const bool is_conv1d = is_1d_conv(original_weights_window_w, input_width);
+    const bool is_conv1d = is_1d_conv(original_weights_window_w, params.input_width);
     const bool is_conv_1d_depthwise_conv = is_1d_deptwise_conv(
-        groups,
-        original_weights_in_channels * groups,
+        params.groups,
+        original_weights_in_channels * params.groups,
         original_weights_out_channels,
         original_weights_window_w,
-        input_width,
-        has_bias);
+        params.input_width,
+        params.has_bias);
 
-    if (!is_conv1d and groups > 1) {
+    // Handle kernel stride folding for weights if enabled
+    if (params.enable_kernel_stride_folding &&
+        (params.stride[0] == original_weights_window_h && params.stride[1] == original_weights_window_w)) {
+        // Validate padding is zero for folding
+        TT_FATAL(
+            params.padding_n4[0] == 0 && params.padding_n4[1] == 0 && params.padding_n4[2] == 0 &&
+                params.padding_n4[3] == 0,
+            "Padding must be 0 for folding");
+
+        // Move to device if needed
+        if (!tt::tt_metal::is_device_tensor(weight_tensor_)) {
+            weight_tensor_ = ttnn::to_device(weight_tensor_, device, ttnn::DRAM_MEMORY_CONFIG);
+        }
+
+        // Use the fold_tensor utility from conv2d_utils
+        weight_tensor_ = fold_tensor(
+            weight_tensor_,
+            device,
+            params.stride,
+            {original_weights_window_h, original_weights_window_w},
+            params.padding_n4,
+            params.weights_bias_dtype,
+            true);
+    }
+
+    if (!is_conv1d and params.groups > 1) {
         weight_tensor_ =
-            convert_conv_weight_tensor_to_grouped_layout(weight_tensor_, groups, weight_tensor_.get_dtype());
-    } else if (is_conv1d and groups > 1) {
+            convert_conv_weight_tensor_to_grouped_layout(weight_tensor_, params.groups, weight_tensor_.get_dtype());
+    } else if (is_conv1d and params.groups > 1) {
         if (is_conv_1d_depthwise_conv) {
             weight_tensor_ = convert_conv_weight_tensor_to_depthwise_layout(
-                weight_tensor_, act_block_h_ntiles, weight_tensor_.get_dtype());
-            weight_block_h_ntiles = act_block_h_ntiles;
+                weight_tensor_, params.act_block_h_ntiles, weight_tensor_.get_dtype());
+            params.weight_block_h_ntiles = params.act_block_h_ntiles;
         } else {
             weight_tensor_ =
-                convert_conv_weight_tensor_to_grouped_layout(weight_tensor_, groups, weight_tensor_.get_dtype());
+                convert_conv_weight_tensor_to_grouped_layout(weight_tensor_, params.groups, weight_tensor_.get_dtype());
         }
     }
 
@@ -795,17 +866,17 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
     uint32_t window_h = weights_shape[2];
     uint32_t window_w = weights_shape[3];
 
-    uint32_t input_num_cores_channels = get_num_cores_channels_from_parallel_config(input_parallel_config);
-    uint32_t output_num_cores_channels = get_num_cores_channels_from_parallel_config(output_parallel_config);
+    uint32_t input_num_cores_channels = get_num_cores_channels_from_parallel_config(params.input_parallel_config);
+    uint32_t output_num_cores_channels = get_num_cores_channels_from_parallel_config(params.output_parallel_config);
 
     uint32_t out_channels_padded = tt::round_up(out_channels, output_num_cores_channels * tt::constants::TILE_WIDTH);
-    uint32_t in_channels_padded = tt::round_up(in_channels, input_num_cores_channels * input_channels_alignment);
+    uint32_t in_channels_padded = tt::round_up(in_channels, input_num_cores_channels * params.input_channels_alignment);
     uint32_t out_channel_padding = out_channels_padded - out_channels;
 
     TT_ASSERT(weight_tensor_.get_layout() == Layout::ROW_MAJOR, "Conv Weights should be in row major layout ");
 
     // Block sharding re-orders the weights by dividing the input_channels along number of in_channel_cores.
-    if (input_parallel_config.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
+    if (params.input_parallel_config.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
         weight_tensor_ = ttnn::permute(weight_tensor_, ttnn::SmallVector<int64_t>({2, 3, 1, 0}));
 
         ttnn::Shape weights_channels_padded_shape(
@@ -892,9 +963,9 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
             true,
             std::nullopt);
 
-        auto weight_block_h_datums = weight_block_h_ntiles * constants::TILE_HEIGHT;
+        auto weight_block_h_datums = params.weight_block_h_ntiles * constants::TILE_HEIGHT;
         if ((weight_block_h_datums > (window_w * in_channels_padded)) &&
-            (input_parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED)) {
+            (params.input_parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED)) {
             weight_tensor_ = ttnn::reshape(
                 weight_tensor_, ttnn::Shape({1, window_h, window_w * in_channels_padded, out_channels_padded}));
             weight_tensor_ = ttnn::pad(
@@ -914,12 +985,12 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
     weight_tensor_ = ttnn::tilize(
         weight_tensor_,
         ttnn::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM),
-        weights_bias_dtype,
+        params.weights_bias_dtype,
         true);
 
-    if (weights_bias_dtype.has_value()) {
+    if (params.weights_bias_dtype.has_value()) {
         TT_ASSERT(
-            weight_tensor_.get_dtype() == weights_bias_dtype.value(),
+            weight_tensor_.get_dtype() == params.weights_bias_dtype.value(),
             "Weight tensor should be in the dtype specified by Conv2dConfig");
     }
     uint32_t weight_matrix_height = in_channels * window_h * window_w;
@@ -935,9 +1006,9 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
             bias_tensor.value(),
             weight_tensor_.get_dtype(),
             out_channels,
-            weight_block_w_ntiles,
-            input_parallel_config,
-            output_parallel_config,
+            params.weight_block_w_ntiles,
+            params.input_parallel_config,
+            params.output_parallel_config,
             device);
         TT_ASSERT(
             bias_tensor_.get_dtype() == weight_tensor_.get_dtype(),
@@ -950,22 +1021,12 @@ template <typename T>
 std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device(
     const ttnn::Tensor& weight_tensor,
     const std::optional<const ttnn::Tensor>& bias_tensor,
-    uint32_t input_channels_alignment,
-    std::optional<DataType> weights_bias_dtype,
-    uint32_t weight_block_h_ntiles,
-    uint32_t weight_block_w_ntiles,
-    const ParallelConfig& input_parallel_config,
-    const ParallelConfig& output_parallel_config,
-    T* device,
-    uint32_t groups,
-    uint32_t act_block_h_ntiles,
-    uint32_t input_width,
-    const bool has_bias,
-    const bool parameters_on_device) {
+    Conv2dWeightsBiasPrepConfig& params,
+    T* device) {
     ttnn::Tensor weight_tensor_ = weight_tensor;  // tensor to return
     Shape weight_shape = weight_tensor.get_logical_shape();
     // In case of 1D convolution and 3D weight tensor, reinterpret it as 4D tensor
-    if (weight_shape.rank() == 3 && input_width == 1) {
+    if (weight_shape.rank() == 3 && params.input_width == 1) {
         weight_tensor_ = ttnn::reshape(weight_tensor_, Shape({weight_shape[0], weight_shape[1], weight_shape[2], 1}));
     }
     validate_weight_tensor(weight_tensor_);
@@ -977,43 +1038,46 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
     uint32_t original_weights_window_h = original_weights_shape[2];
     uint32_t original_weights_window_w = original_weights_shape[3];
 
-    const bool is_conv1d = is_1d_conv(original_weights_window_w, input_width);
+    const bool is_conv1d = is_1d_conv(original_weights_window_w, params.input_width);
     const bool is_conv_1d_depthwise_conv = is_1d_deptwise_conv(
-        groups,
-        original_weights_in_channels * groups,
+        params.groups,
+        original_weights_in_channels * params.groups,
         original_weights_out_channels,
         original_weights_window_w,
-        input_width,
-        has_bias);
+        params.input_width,
+        params.has_bias);
     TT_FATAL(
         !is_device_tensor(weight_tensor_),
         "prepare_conv_weights_biases_and_move_to_device is not supported when the weights tensor is on the device");
     // Convert weight tensor to 0 padded shape if groups > 1
-    if (!is_conv1d and groups > 1) {
+    if (!is_conv1d and params.groups > 1) {
         weight_tensor_ =
-            convert_conv_weight_tensor_to_grouped_layout(weight_tensor_, groups, weight_tensor_.get_dtype());
-    } else if (is_conv1d and groups > 1) {
+            convert_conv_weight_tensor_to_grouped_layout(weight_tensor_, params.groups, weight_tensor_.get_dtype());
+    } else if (is_conv1d and params.groups > 1) {
         if (is_conv_1d_depthwise_conv) {
             weight_tensor_ = convert_conv_weight_tensor_to_depthwise_layout(
-                weight_tensor_, act_block_h_ntiles, weight_tensor_.get_dtype());
-            weight_block_h_ntiles = act_block_h_ntiles;
+                weight_tensor_, params.act_block_h_ntiles, weight_tensor_.get_dtype());
+            params.weight_block_h_ntiles = params.act_block_h_ntiles;
         } else {
             weight_tensor_ =
-                convert_conv_weight_tensor_to_grouped_layout(weight_tensor_, groups, weight_tensor_.get_dtype());
+                convert_conv_weight_tensor_to_grouped_layout(weight_tensor_, params.groups, weight_tensor_.get_dtype());
         }
     }
-
+    if (params.enable_kernel_stride_folding) {
+        weight_tensor_ = to_folded_weight_layout(
+            weight_tensor_, params.stride, {original_weights_window_h, original_weights_window_w}, params.padding_n4);
+    }
     const auto& weights_shape = weight_tensor_.get_logical_shape();
     uint32_t out_channels = weights_shape[0];
     uint32_t in_channels = weights_shape[1];
     uint32_t window_h = weights_shape[2];
     uint32_t window_w = weights_shape[3];
 
-    uint32_t input_num_cores_channels = get_num_cores_channels_from_parallel_config(input_parallel_config);
-    uint32_t output_num_cores_channels = get_num_cores_channels_from_parallel_config(output_parallel_config);
+    uint32_t input_num_cores_channels = get_num_cores_channels_from_parallel_config(params.input_parallel_config);
+    uint32_t output_num_cores_channels = get_num_cores_channels_from_parallel_config(params.output_parallel_config);
 
     uint32_t out_channels_padded = tt::round_up(out_channels, output_num_cores_channels * tt::constants::TILE_WIDTH);
-    uint32_t in_channels_padded = tt::round_up(in_channels, input_num_cores_channels * input_channels_alignment);
+    uint32_t in_channels_padded = tt::round_up(in_channels, input_num_cores_channels * params.input_channels_alignment);
     uint32_t out_channel_padding = out_channels_padded - out_channels;
 
     ttnn::Shape weights_channels_padded_shape({out_channels_padded, in_channels_padded, window_h, window_w});
@@ -1021,15 +1085,15 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
     weight_tensor_ =
         ttnn::pad(weight_tensor_, weights_channels_padded_shape.to_array_4D(), tt::tt_metal::Array4D({0, 0, 0, 0}), 0);
     // for conv op, pad the weights to block shape
-    if (input_parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
+    if (params.input_parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
         weight_tensor_ = convert_conv_weight_tensor_to_special_padding_tiled_layout(
-            weight_tensor_, weight_block_h_ntiles, weight_block_w_ntiles, weight_tensor_.get_dtype());
-    } else if (input_parallel_config.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
+            weight_tensor_, params.weight_block_h_ntiles, params.weight_block_w_ntiles, weight_tensor_.get_dtype());
+    } else if (params.input_parallel_config.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
         weight_tensor_ = convert_conv_weight_tensor_to_tiled_layout_block_sharded(
             weight_tensor_, input_num_cores_channels, weight_tensor_.get_dtype());
     } else {
         weight_tensor_ = convert_conv_weight_tensor_to_tiled_layout(
-            weight_tensor_, weight_block_h_ntiles, weight_block_w_ntiles, weight_tensor_.get_dtype());
+            weight_tensor_, params.weight_block_h_ntiles, params.weight_block_w_ntiles, weight_tensor_.get_dtype());
     }
 
     uint32_t weight_matrix_height = in_channels * window_h * window_w;
@@ -1037,11 +1101,11 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
     ttnn::Shape target_shape({1, 1, weight_matrix_height, out_channels});
     ttnn::Shape padded_target_shape({1, 1, weight_tensor_.get_logical_shape()[2], out_channels + out_channel_padding});
     weight_tensor_ = ttnn::reshape(weight_tensor_, target_shape, padded_target_shape);
-    if (weights_bias_dtype.has_value()) {
-        weight_tensor_ = ttnn::to_dtype(weight_tensor_, weights_bias_dtype.value());
+    if (params.weights_bias_dtype.has_value()) {
+        weight_tensor_ = ttnn::to_dtype(weight_tensor_, params.weights_bias_dtype.value());
     }
 
-    if (parameters_on_device) {
+    if (params.parameters_on_device) {
         weight_tensor_ = ttnn::operations::core::to_device(weight_tensor_, device, std::nullopt);
     }
 
@@ -1055,9 +1119,9 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
             bias_tensor_ = conv_bias_layout_convert(
                 bias_tensor_,
                 weight_tensor_.get_dtype(),
-                weight_block_h_ntiles,
-                weight_block_w_ntiles,
-                output_parallel_config,
+                params.weight_block_h_ntiles,
+                params.weight_block_w_ntiles,
+                params.output_parallel_config,
                 device,
                 out_channels_padded);
             bias_tensor_ = ttnn::operations::core::to_device(bias_tensor_, device, std::nullopt);
@@ -1100,11 +1164,18 @@ ttnn::Tensor prepare_conv_weights(
 
     DeviceComputeKernelConfig compute_config = compute_config_.value_or(get_conv_default_compute_kernel_config(device));
     std::array<uint32_t, 4> padding_n4 = sliding_window::get_pair_n4_padding(padding);
-    const bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
-
-    // if folding is enabled, move the weight tensor to device DRAM, fold it and return the folded weight tensor
+    bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
+    auto orig_stride = stride;
     if (conv_config.enable_kernel_stride_folding) {
-        return fold_tensor(weight_tensor, device, stride, kernel_size, padding_n4, conv_config.dtype, true);
+        auto folding_result = compute_kernel_stride_folding_params(
+            input_height, input_width, in_channels, kernel_size, stride, padding_n4, conv_config);
+
+        input_height = folding_result.input_height;
+        input_width = folding_result.input_width;
+        in_channels = folding_result.in_channels;
+        stride = folding_result.stride;
+        kernel_size = folding_result.kernel_size;
+        mm_conv = folding_result.mm_conv;
     }
     auto [output_height, output_width] =
         calculate_output_image_size({input_height, input_width}, kernel_size, stride, padding_n4, dilation);
@@ -1197,6 +1268,22 @@ ttnn::Tensor prepare_conv_weights(
     std::optional<const ttnn::Tensor> bias_tensor = std::nullopt;
     ttnn::Tensor weight_tensor_on_device = weight_tensor;
     std::optional<ttnn::Tensor> bias_tensor_on_device = bias_tensor;
+    Conv2dWeightsBiasPrepConfig params(
+        input_channels_alignment,
+        conv_config.weights_dtype,
+        opt_conv_op_block_config.act_block_w_ntiles,
+        opt_conv_op_block_config.out_subblock_w_ntiles,
+        parallel_config,
+        output_parallel_config,
+        groups,
+        opt_conv_op_block_config.act_block_h_ntiles,
+        input_width,
+        has_bias,
+        true,  // parameters_on_device
+        conv_config.enable_kernel_stride_folding,
+        kernel_size,
+        orig_stride,
+        padding_n4);
     if (is_device_tensor(weight_tensor) || conv_config.preprocess_weights_on_device) {
         if (!conv_config.preprocess_weights_on_device) {
             log_warning(
@@ -1205,36 +1292,11 @@ ttnn::Tensor prepare_conv_weights(
                 "conv_config.preprocess_weights_on_device flag was not set to True. \n This will use the device to "
                 "prepare weights, which is not fully supported.");
         }
-
-        tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_on_device(
-            weight_tensor,
-            bias_tensor,
-            input_channels_alignment,
-            conv_config.weights_dtype,
-            opt_conv_op_block_config.act_block_w_ntiles,
-            opt_conv_op_block_config.out_subblock_w_ntiles,
-            parallel_config,
-            output_parallel_config,
-            device,
-            groups,
-            opt_conv_op_block_config.act_block_h_ntiles,
-            input_width,
-            has_bias);
+        std::tie(weight_tensor_on_device, bias_tensor_on_device) =
+            prepare_conv_weights_biases_on_device(weight_tensor, bias_tensor, params, device);
     } else {
-        tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_and_move_to_device(
-            weight_tensor,
-            bias_tensor,
-            input_channels_alignment,
-            conv_config.weights_dtype,
-            opt_conv_op_block_config.act_block_w_ntiles,
-            opt_conv_op_block_config.out_subblock_w_ntiles,
-            parallel_config,
-            output_parallel_config,
-            device,
-            groups,
-            opt_conv_op_block_config.act_block_h_ntiles,
-            input_width,
-            has_bias);
+        std::tie(weight_tensor_on_device, bias_tensor_on_device) =
+            prepare_conv_weights_biases_and_move_to_device(weight_tensor, bias_tensor, params, device);
     }
 
     return weight_tensor_on_device;
@@ -1263,7 +1325,18 @@ ttnn::Tensor prepare_conv_bias(
     TT_ASSERT(conv_config.weights_dtype.has_value(), "prepare_conv_bias requires conv_config.weights_dtype to be set.");
 
     std::array<uint32_t, 4> padding_n4 = sliding_window::get_pair_n4_padding(padding);
-    const bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
+    bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
+    if (conv_config.enable_kernel_stride_folding) {
+        auto folding_result = compute_kernel_stride_folding_params(
+            input_height, input_width, in_channels, kernel_size, stride, padding_n4, conv_config);
+
+        input_height = folding_result.input_height;
+        input_width = folding_result.input_width;
+        in_channels = folding_result.in_channels;
+        stride = folding_result.stride;
+        kernel_size = folding_result.kernel_size;
+        mm_conv = folding_result.mm_conv;
+    }
     auto [output_height, output_width] =
         calculate_output_image_size({input_height, input_width}, kernel_size, stride, padding_n4, dilation);
 
@@ -1393,65 +1466,27 @@ template ttnn::Tensor prepare_conv_weights<MeshDevice>(
 template std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_on_device<IDevice>(
     const ttnn::Tensor& weight_tensor,
     const std::optional<const ttnn::Tensor>& bias_tensor,
-    uint32_t input_channels_alignment,
-    std::optional<DataType> weights_bias_dtype,
-    uint32_t weight_block_h_ntiles,
-    uint32_t weight_block_w_ntiles,
-    const sliding_window::ParallelConfig& input_parallel_config,
-    const sliding_window::ParallelConfig& output_parallel_config,
-    IDevice* device,
-    uint32_t groups,
-    uint32_t act_block_h_ntiles,
-    uint32_t input_width,
-    const bool has_bias);
+    Conv2dWeightsBiasPrepConfig& params,
+    IDevice* device);
 
 template std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_on_device<MeshDevice>(
     const ttnn::Tensor& weight_tensor,
     const std::optional<const ttnn::Tensor>& bias_tensor,
-    uint32_t input_channels_alignment,
-    std::optional<DataType> weights_bias_dtype,
-    uint32_t weight_block_h_ntiles,
-    uint32_t weight_block_w_ntiles,
-    const sliding_window::ParallelConfig& input_parallel_config,
-    const sliding_window::ParallelConfig& output_parallel_config,
-    MeshDevice* device,
-    uint32_t groups,
-    uint32_t act_block_h_ntiles,
-    uint32_t input_width,
-    const bool has_bias);
+    Conv2dWeightsBiasPrepConfig& params,
+    MeshDevice* device);
 
 template std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device<IDevice>(
     const ttnn::Tensor& weight_tensor,
     const std::optional<const ttnn::Tensor>& bias_tensor,
-    uint32_t input_channels_alignment,
-    std::optional<DataType> weights_bias_dtype,
-    uint32_t weight_block_h_ntiles,
-    uint32_t weight_block_w_ntiles,
-    const ParallelConfig& input_parallel_config,
-    const ParallelConfig& output_parallel_config,
-    IDevice* device,
-    uint32_t groups,
-    uint32_t act_block_h_ntiles,
-    uint32_t input_width,
-    const bool has_bias,
-    const bool parameters_on_device);
+    Conv2dWeightsBiasPrepConfig& params,
+    IDevice* device);
 
 template std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>>
 prepare_conv_weights_biases_and_move_to_device<MeshDevice>(
     const ttnn::Tensor& weight_tensor,
     const std::optional<const ttnn::Tensor>& bias_tensor,
-    uint32_t input_channels_alignment,
-    std::optional<DataType> weights_bias_dtype,
-    uint32_t weight_block_h_ntiles,
-    uint32_t weight_block_w_ntiles,
-    const ParallelConfig& input_parallel_config,
-    const ParallelConfig& output_parallel_config,
-    MeshDevice* device,
-    uint32_t groups,
-    uint32_t act_block_h_ntiles,
-    uint32_t input_width,
-    const bool has_bias,
-    const bool parameters_on_device);
+    Conv2dWeightsBiasPrepConfig& params,
+    MeshDevice* device);
 
 template ttnn::Tensor prepare_conv_bias<IDevice>(
     const ttnn::Tensor& bias_tensor,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
@@ -103,38 +103,74 @@ ttnn::Tensor prepare_conv_bias(
     const std::optional<const Conv2dConfig>& conv_config_,
     const std::optional<const DeviceComputeKernelConfig>& compute_config_);
 
+// Unified parameter struct for conv2d weight and bias preparation
+struct Conv2dWeightsBiasPrepConfig {
+    // Constructor to ensure all required parameters are initialized
+    Conv2dWeightsBiasPrepConfig(
+        uint32_t input_channels_alignment_,
+        std::optional<DataType> weights_bias_dtype_,
+        uint32_t weight_block_h_ntiles_,
+        uint32_t weight_block_w_ntiles_,
+        const sliding_window::ParallelConfig& input_parallel_config_,
+        const sliding_window::ParallelConfig& output_parallel_config_,
+        uint32_t groups_,
+        uint32_t act_block_h_ntiles_,
+        uint32_t input_width_,
+        bool has_bias_ = false,
+        bool parameters_on_device_ = true,
+        bool enable_kernel_stride_folding_ = false,
+        std::array<uint32_t, 2> kernel_size_ = {1, 1},
+        std::array<uint32_t, 2> stride_ = {1, 1},
+        std::array<uint32_t, 4> padding_n4_ = {0, 0, 0, 0}) :
+        input_channels_alignment(input_channels_alignment_),
+        weights_bias_dtype(weights_bias_dtype_),
+        weight_block_h_ntiles(weight_block_h_ntiles_),
+        weight_block_w_ntiles(weight_block_w_ntiles_),
+        input_parallel_config(input_parallel_config_),
+        output_parallel_config(output_parallel_config_),
+        groups(groups_),
+        act_block_h_ntiles(act_block_h_ntiles_),
+        input_width(input_width_),
+        has_bias(has_bias_),
+        parameters_on_device(parameters_on_device_),
+        enable_kernel_stride_folding(enable_kernel_stride_folding_),
+        kernel_size(kernel_size_),
+        stride(stride_),
+        padding_n4(padding_n4_) {}
+
+    // Common parameters
+    const uint32_t input_channels_alignment;
+    const std::optional<DataType> weights_bias_dtype;
+    uint32_t weight_block_h_ntiles;
+    const uint32_t weight_block_w_ntiles;
+    const sliding_window::ParallelConfig& input_parallel_config;
+    const sliding_window::ParallelConfig& output_parallel_config;
+    const uint32_t groups;
+    const uint32_t act_block_h_ntiles;
+    const uint32_t input_width;
+    const bool has_bias;
+    const bool parameters_on_device;
+
+    // Kernel stride folding parameters
+    const bool enable_kernel_stride_folding;
+    const std::array<uint32_t, 2> kernel_size;
+    const std::array<uint32_t, 2> stride;
+    const std::array<uint32_t, 4> padding_n4;
+};
+
 template <typename T>
 std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_on_device(
     const ttnn::Tensor& weight_tensor,
     const std::optional<const ttnn::Tensor>& bias_tensor,
-    uint32_t input_channels_alignment,
-    std::optional<DataType> weights_bias_dtype,
-    uint32_t weight_block_h_ntiles,
-    uint32_t weight_block_w_ntiles,
-    const sliding_window::ParallelConfig& input_parallel_config,
-    const sliding_window::ParallelConfig& output_parallel_config,
-    T* device,
-    uint32_t groups,
-    uint32_t act_block_h_ntiles,
-    uint32_t input_width,
-    const bool has_bias);
+    Conv2dWeightsBiasPrepConfig& params,
+    T* device);
 
 template <typename T>
 std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device(
     const ttnn::Tensor& weight_tensor,
     const std::optional<const ttnn::Tensor>& bias_tensor,
-    uint32_t input_channels_alignment,
-    std::optional<DataType> weights_bias_dtype,
-    uint32_t weight_block_h_ntiles,
-    uint32_t weight_block_w_ntiles,
-    const sliding_window::ParallelConfig& input_parallel_config,
-    const sliding_window::ParallelConfig& output_parallel_config,
-    T* device,
-    uint32_t groups,
-    uint32_t act_block_h_ntiles,
-    uint32_t input_width,
-    const bool has_bias,
-    const bool parameters_on_device = true);
+    Conv2dWeightsBiasPrepConfig& params,
+    T* device);
 
 }  // namespace conv2d
 }  // namespace operations::conv

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -214,20 +214,19 @@ Result conv_transpose2d(
     std::optional<ttnn::Tensor> bias_tensor_on_device = bias_tensor;
     if (!weight_is_on_device) {
         // prepare weights in desired layout and move to device
-        tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_and_move_to_device(
-            transform_weights_for_conv_transpose2d(weight_tensor, mirror_kernel),
-            bias_tensor,
+        Conv2dWeightsBiasPrepConfig params(
             input_channels_alignment,
             conv_config.weights_dtype,
             opt_conv_op_block_config.act_block_w_ntiles,
             opt_conv_op_block_config.out_subblock_w_ntiles,
             parallel_config,
             output_parallel_config,
-            device,
             groups,
             opt_conv_op_block_config.act_block_h_ntiles,
             input_width,
             bias_tensor.has_value());
+        tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_on_device(
+            transform_weights_for_conv_transpose2d(weight_tensor, mirror_kernel), bias_tensor, params, device);
     }
     if (mm_conv) {
         input_tensor_post_tm = ttnn::to_layout(

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -225,7 +225,7 @@ Result conv_transpose2d(
             opt_conv_op_block_config.act_block_h_ntiles,
             input_width,
             bias_tensor.has_value());
-        tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_on_device(
+        tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_and_move_to_device(
             transform_weights_for_conv_transpose2d(weight_tensor, mirror_kernel), bias_tensor, params, device);
     }
     if (mm_conv) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22378

### Problem description
This PR tackles two related issues in our Conv2D implementation:
- Previously, the prepare_conv_weights* functions had long parameter lists (11-13 parameters) making the code difficult to maintain and extend.

- The kernel stride folding was always done on device.

### What's changed
This PR implements a refactoring and feature enhancement:

1. Unified Parameter Structure:
    - Introduced Conv2dWeightsBiasPrepConfig to encapsulate all configuration parameters
    - Reduced function parameter count from 11+ to just 3 parameters plus the config structure
    - Made most parameters const to prevent unintended modifications

2. Host-Side Kernel Stride Folding:
    - Added support for weight tensor folding on the host side
    - Implemented a new to_folded_weight_layout function that performs folding on host tensors.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15483456483)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15459842533)
- [X] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15443059628)
- [X] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15443062154)
- [X] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15443065270)
- [X] Nightly tt-metal L2 tests [WH](https://github.com/tenstorrent/tt-metal/actions/runs/15483447329), [BH](https://github.com/tenstorrent/tt-metal/actions/runs/15483449299)