### PR TITLE
#20712: Report tray and N-id for UBBs and add option to specify minimum number of links to check to system health check

### DIFF
--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -114,14 +114,12 @@ TEST(Cluster, TestMeshFullConnectivity) {
     std::uint32_t num_expected_chips = 0;
     std::uint32_t num_connections_per_side = 0;
     auto cluster_type = cluster.get_cluster_type();
-    std::vector<std::uint16_t> tray_bus_ids;
     if (cluster_type == tt::ClusterType::T3K) {
         num_expected_chips = 8;
         num_connections_per_side = 2;
     } else if (cluster_type == tt::ClusterType::GALAXY) {
         num_expected_chips = 32;
         num_connections_per_side = 4;
-        tray_bus_ids = ubb_bus_ids.at(tt::tt_metal::MetalContext::instance().get_cluster().arch());
     } else {
         GTEST_SKIP() << "Mesh check not supported for system type " << magic_enum::enum_name(cluster_type);
     }

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -155,17 +155,17 @@ TEST(Cluster, TestMeshFullConnectivity) {
     }
 
     std::optional<FabricType> target_system_topology = std::nullopt;
-    std::optional<std::string> target_system_topology_str = std::nullopt;
+    std::string target_system_topology_str = "";
     std::tie(target_system_topology_str, input_args) =
-        test_args::get_command_option_and_remaining_args(input_args, "--system-topology", std::nullopt);
-    if (target_system_topology_str.has_value()) {
+        test_args::get_command_option_and_remaining_args(input_args, "--system-topology", "");
+    if (not target_system_topology_str.empty()) {
         target_system_topology =
-            magic_enum::enum_cast<FabricType>(target_system_topology_str.value(), magic_enum::case_insensitive);
+            magic_enum::enum_cast<FabricType>(target_system_topology_str, magic_enum::case_insensitive);
         if (*target_system_topology != FabricType::TORUS_2D) {
             log_warning(
                 tt::LogTest,
                 "System topology {} not supported for mesh check, skipping topology verification",
-                *target_system_topology_str);
+                target_system_topology_str);
             target_system_topology = std::nullopt;
         }
     }

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -47,17 +47,10 @@ std::unordered_map<chip_id_t, std::vector<CoreCoord>> get_ethernet_cores_grouped
 }
 
 // Get the physical chip ids for a mesh
-// TODO: get this from Cluster, once UMD unique id changes are merged
 std::uint32_t get_ubb_asic_id(chip_id_t physical_chip_id) {
-    std::vector<uint32_t> ubb_asic_loc_vec;
-    const auto& eth_cores = tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(physical_chip_id, false);
-    auto virtual_eth_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-        physical_chip_id, *eth_cores.begin(), CoreType::ETH);
-
-    std::uint32_t addr = 0x1ec0 + 65 * sizeof(uint32_t);
-    tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-        ubb_asic_loc_vec, sizeof(uint32_t), tt_cxy_pair(physical_chip_id, virtual_eth_core), addr);
-    return ((ubb_asic_loc_vec[0] >> 24) & 0xFF);
+    auto unique_chip_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_unique_chip_ids().at(physical_chip_id);
+    return ((unique_chip_id >> 56) & 0xFF);
 }
 
 bool is_external_ubb_cable(chip_id_t physical_chip_id, CoreCoord eth_core) {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -113,7 +113,7 @@ public:
 
     // TODO: UMD will eventually consolidate ethernet coordinates and unique ids, we can remove the ethernet coord
     // getter after that change is in
-    std::unordered_map<chip_id_t, uint64_t> get_unique_chip_ids() const {
+    const std::unordered_map<chip_id_t, uint64_t>& get_unique_chip_ids() const {
         return this->cluster_desc_->get_chip_unique_ids();
     }
     std::unordered_map<chip_id_t, eth_coord_t> get_all_chip_ethernet_coordinates() const;
@@ -135,6 +135,10 @@ public:
 
     uint32_t get_harvesting_mask(chip_id_t chip) const {
         return this->driver_->get_soc_descriptor(chip).harvesting_masks.tensix_harvesting_mask;
+    }
+
+    uint16_t get_bus_id(chip_id_t chip) const {
+        return this->driver_->get_chip(chip)->get_tt_device()->get_pci_device()->get_device_info().pci_bus;
     }
 
     //! device driver and misc apis


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20712

### Problem description
Need to provide user additional details/options when validating a system configuration.

### What's changed
Print the tray and id of a chip if it is a UBB.
Add option to specify topology and number of links to expect, which allows us to either relax tolerances (ex reduce number of links) or increase validation (ex check all 4 sides for torus 2d).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes