### PR TITLE
Use TMP on edm sender and receiver channels

### DIFF
--- a/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
@@ -109,6 +109,18 @@ constexpr size_t worker_info_offset_past_connection_semaphore = 32;
 constexpr size_t channel_buffer_size = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 7);
 
 constexpr size_t SENDER_NUM_BUFFERS = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 8);
+
+template <std::size_t... Is>
+constexpr std::array<unsigned int, NUM_SENDER_CHANNELS> make_buffers_array_impl(std::index_sequence<Is...>) {
+    // the ((void)Is, SENDER_NUM_BUFFERS) is just a trick
+    // to repeat the same value in each slot
+    return {{((void)Is, SENDER_NUM_BUFFERS)...}};
+}
+
+// the constexpr array you can now use everywhere
+static constexpr auto SENDER_NUM_BUFFERS_ARRAY =
+    make_buffers_array_impl(std::make_index_sequence<NUM_SENDER_CHANNELS>{});
+
 constexpr size_t RECEIVER_NUM_BUFFERS = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 9);
 constexpr size_t local_sender_0_channel_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 10);
 constexpr size_t local_sender_channel_0_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 11);

--- a/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
@@ -128,6 +128,9 @@ static constexpr auto SENDER_NUM_BUFFERS_ARRAY = make_buffers_array<SENDER_NUM_B
 
 static constexpr auto RECEIVER_NUM_BUFFERS_ARRAY = make_buffers_array<RECEIVER_NUM_BUFFERS, NUM_RECEIVER_CHANNELS>();
 
+static constexpr auto REMOTE_RECEIVER_NUM_BUFFERS_ARRAY =
+    make_buffers_array<RECEIVER_NUM_BUFFERS, NUM_RECEIVER_CHANNELS>();
+
 constexpr size_t local_sender_0_channel_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 10);
 constexpr size_t local_sender_channel_0_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 11);
 constexpr size_t local_sender_1_channel_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 12);

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_tmp_utils.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_tmp_utils.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <tuple>
+
+namespace tt::tt_fabric {
+
+// a generic tuple‐for_each helper
+template <typename Tuple, typename F, size_t... Is>
+constexpr void tuple_for_each_impl(Tuple&& t, F&& f, std::index_sequence<Is...>) {
+    // expansion: f(std::get<0>(t),0), f(std::get<1>(t),1), …
+    (void)std::initializer_list<int>{(f(std::get<Is>(std::forward<Tuple>(t)), Is), 0)...};
+}
+
+template <typename Tuple, typename F>
+constexpr void tuple_for_each(Tuple&& t, F&& f) {
+    tuple_for_each_impl(
+        std::forward<Tuple>(t),
+        std::forward<F>(f),
+        std::make_index_sequence<std::tuple_size_v<std::remove_reference_t<Tuple>>>{});
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -123,7 +123,8 @@ struct EthChannelBufferTuple {
         const size_t channel_base_address[],
         const size_t buffer_size_bytes,
         const size_t header_size_bytes,
-        const size_t eth_transaction_ack_word_addr) {
+        const size_t eth_transaction_ack_word_addr,
+        const uint8_t channel_base_id) {
         std::apply(
             // <-- note the template<...> here
             [&]<typename... ChanT>(ChanT&... chans) {
@@ -134,7 +135,7 @@ struct EthChannelBufferTuple {
                         buffer_size_bytes,
                         header_size_bytes,
                         eth_transaction_ack_word_addr,
-                        idx),
+                        channel_base_id + idx),
                     ++idx,  // increment *after* the read
                     0       // dummy value
                     )...};

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -881,7 +881,6 @@ template <
     typename WriteTridTracker>
 void run_receiver_channel_step(
     tt::tt_fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS>& local_receiver_channel,
-    std::array<tt::tt_fabric::EthChannelBuffer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS>& remote_sender_channels,
     std::array<tt::tt_fabric::EdmToEdmSender<SENDER_NUM_BUFFERS>, NUM_USED_RECEIVER_CHANNELS>& downstream_edm_interface,
     volatile tt::tt_fabric::EdmFabricReceiverChannelCounters* receiver_channel_counters_ptr,
     ReceiverChannelPointers<RECEIVER_NUM_BUFFERS>& receiver_channel_pointers,
@@ -1081,7 +1080,6 @@ void run_fabric_edm_main_loop(
     EdmChannelWorkerIFs& local_sender_channel_worker_interfaces,
     std::array<tt::tt_fabric::EdmToEdmSender<SENDER_NUM_BUFFERS>, NUM_USED_RECEIVER_CHANNELS>&
         downstream_edm_noc_interfaces,
-    std::array<tt::tt_fabric::EthChannelBuffer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS>& remote_sender_channels,
     std::array<tt::tt_fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS>, NUM_RECEIVER_CHANNELS>& remote_receiver_channels,
     volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr,
     std::array<volatile tt::tt_fabric::EdmFabricReceiverChannelCounters*, MAX_NUM_RECEIVER_CHANNELS>
@@ -1165,7 +1163,6 @@ void run_fabric_edm_main_loop(
                         to_receiver_packets_sent_streams[0],
                         0>(
                         local_receiver_channels[0],
-                        remote_sender_channels,
                         downstream_edm_noc_interfaces,
                         receiver_channel_counters_ptrs[0],
                         receiver_channel_pointers[0],
@@ -1186,7 +1183,6 @@ void run_fabric_edm_main_loop(
                         to_receiver_packets_sent_streams[1],
                         1>(
                         local_receiver_channels[1],
-                        remote_sender_channels,
                         downstream_edm_noc_interfaces,
                         receiver_channel_counters_ptrs[1],
                         receiver_channel_pointers[1],
@@ -1592,7 +1588,6 @@ void kernel_main() {
 
     std::array<tt::tt_fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS>, NUM_RECEIVER_CHANNELS> remote_receiver_channels;
     std::array<tt::tt_fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS>, NUM_RECEIVER_CHANNELS> local_receiver_channels;
-    std::array<tt::tt_fabric::EthChannelBuffer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS> remote_sender_channels;
     std::array<tt::tt_fabric::EthChannelBuffer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS> local_sender_channels;
 
     std::array<size_t, NUM_SENDER_CHANNELS> local_sender_flow_control_semaphores =
@@ -1779,12 +1774,6 @@ void kernel_main() {
             sizeof(PACKET_HEADER_TYPE),
             0,  // For sender channels there is no eth_transaction_ack_word_addr because they don't send acks
             i);
-        new (&remote_sender_channels[i]) tt::tt_fabric::EthChannelBuffer<SENDER_NUM_BUFFERS>(
-            remote_sender_buffer_addresses[i],
-            channel_buffer_size,
-            sizeof(PACKET_HEADER_TYPE),
-            0,  // For sender channels there is no eth_transaction_ack_word_addr because they don't send acks
-            i);
     }
 
     WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS, 0> receiver_channel_0_trid_tracker;
@@ -1906,7 +1895,6 @@ void kernel_main() {
         local_sender_channels,
         local_sender_channel_worker_interfaces,
         downstream_edm_noc_interfaces,
-        remote_sender_channels,
         remote_receiver_channels,
         termination_signal_ptr,
         {receiver_0_channel_counters_ptr, receiver_1_channel_counters_ptr},


### PR DESCRIPTION
Current style assumes the sender, local/remote receiver, downstream channels are using the same number of buffer slots, we need to break this assumption since we can benefit from having different buffer slots on different edms. 

This should unblock the issue here: https://github.com/tenstorrent/tt-metal/issues/22473

In this pr it uses TMP for sender, local/remote receiver channels, not downstream channels atm. The reason is that downstream channels have arbitrary indexing in the table-based routing mode, and cannot convert easily.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes