### PR TITLE
#22739 No circular buffer with id exists in Program

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
@@ -175,7 +175,7 @@ struct BinaryDeviceOperation {
         struct shared_variables_t {
             tt::tt_metal::KernelHandle binary_reader_kernel_id;
             tt::tt_metal::KernelHandle bcast_kernel_id;
-            uint32_t cb_src0;
+            tt::tt_metal::CBHandle cb_src0;
             tt::tt_metal::CBHandle out_cb;
             uint32_t ncores_x;
         };
@@ -198,7 +198,7 @@ struct BinaryDeviceOperation {
         struct shared_variables_t {
             tt::tt_metal::KernelHandle binary_reader_kernel_id;
             tt::tt_metal::KernelHandle bcast_kernel_id;
-            uint32_t cb_src0;
+            tt::tt_metal::CBHandle cb_src0;
             tt::tt_metal::CBHandle out_cb;
             uint32_t ncores_x;
         };


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22739)

### Problem description
This problem is from legacy binary op. Runtime error "No circular buffer with id 2384567136 exists in Program 11"

### What's changed
Should not use uint32_t for cb handle during update sharded tensor dynamic address. It should be 64 bit. Use tt::tt_metal::CBHandle instead.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes
