### PR TITLE
#22258: Remove tracking of per-device tensor spec

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -62,8 +62,7 @@ void run_create_tensor_test(tt::tt_metal::distributed::MeshDevice* device, const
     ASSERT_EQ(input_buf_size_datums * datum_size_bytes, tensor_spec.compute_packed_buffer_size_bytes());
     auto input_buffer = tt::tt_metal::tensor_impl::allocate_mesh_buffer_on_device(device, tensor_spec);
 
-    auto input_storage =
-        tt::tt_metal::DeviceStorage{input_buffer, {{tt::tt_metal::distributed::MeshCoordinate{0, 0}, tensor_spec}}};
+    auto input_storage = tt::tt_metal::DeviceStorage{input_buffer, {tt::tt_metal::distributed::MeshCoordinate{0, 0}}};
 
     Tensor input_tensor = Tensor(input_storage, tensor_spec, ReplicateTensor{});
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -93,10 +93,7 @@ TEST_F(MeshTensorTest, ReplicateOwnedTensor) {
     auto* device_storage = std::get_if<tt::tt_metal::DeviceStorage>(&device_tensor.get_storage());
     ASSERT_NE(device_storage, nullptr);
     EXPECT_NE(device_storage->mesh_buffer, nullptr);
-    EXPECT_THAT(device_storage->specs, SizeIs(mesh_device_->num_devices()));
-    for (const auto& [coord, spec] : device_storage->specs) {
-        EXPECT_THAT(spec.logical_shape(), Eq(ttnn::Shape{1, 1, 32, 32}));
-    }
+    EXPECT_THAT(device_storage->coords, SizeIs(mesh_device_->num_devices()));
 
     // Read the tensor back, and compare it with input data.
     Tensor output_host_tensor = tensor_impl::to_host_mesh_tensor_wrapper(device_tensor);
@@ -124,7 +121,7 @@ TEST_F(MeshTensorTest, GetDeviceTensors) {
     auto* device_storage = std::get_if<tt::tt_metal::DeviceStorage>(&device_tensor.get_storage());
     ASSERT_NE(device_storage, nullptr);
     EXPECT_NE(device_storage->mesh_buffer, nullptr);
-    EXPECT_THAT(device_storage->specs, SizeIs(mesh_device_->num_devices()));
+    EXPECT_THAT(device_storage->coords, SizeIs(mesh_device_->num_devices()));
 
     // Validate each tensor shard.
     std::vector<Tensor> device_tensors = get_device_tensors(device_tensor);
@@ -134,8 +131,8 @@ TEST_F(MeshTensorTest, GetDeviceTensors) {
         auto* shard_storage = std::get_if<tt::tt_metal::DeviceStorage>(&tensor_shard.get_storage());
         ASSERT_NE(shard_storage, nullptr);
         EXPECT_NE(shard_storage->mesh_buffer, nullptr);
-        EXPECT_THAT(shard_storage->specs, SizeIs(1));
-        device_shard_coords.push_back(shard_storage->specs.front().first);
+        EXPECT_THAT(shard_storage->coords, SizeIs(1));
+        device_shard_coords.push_back(shard_storage->coords.front());
         EXPECT_THAT(tensor_shard.to_vector<float>(), Pointwise(FloatEq(), host_data));
     }
 
@@ -194,17 +191,19 @@ TEST_F(MeshTensorTestT3K, AggregateAsTensor) {
     EXPECT_NE(partial_device_storage->mesh_buffer, nullptr);
 
     // Validate the shards are sorted, and are as expected.
-    ASSERT_THAT(partial_device_storage->specs, SizeIs(4));
-    EXPECT_EQ(partial_device_storage->specs[0].first, (distributed::MeshCoordinate{0, 0}));
-    EXPECT_EQ(partial_device_storage->specs[1].first, (distributed::MeshCoordinate{0, 2}));
-    EXPECT_EQ(partial_device_storage->specs[2].first, (distributed::MeshCoordinate{1, 0}));
-    EXPECT_EQ(partial_device_storage->specs[3].first, (distributed::MeshCoordinate{1, 2}));
+    ASSERT_THAT(partial_device_storage->coords, SizeIs(4));
+    EXPECT_EQ(partial_device_storage->coords[0], (distributed::MeshCoordinate{0, 0}));
+    EXPECT_EQ(partial_device_storage->coords[1], (distributed::MeshCoordinate{0, 2}));
+    EXPECT_EQ(partial_device_storage->coords[2], (distributed::MeshCoordinate{1, 0}));
+    EXPECT_EQ(partial_device_storage->coords[3], (distributed::MeshCoordinate{1, 2}));
 }
 
 struct MeshTensorWriteTestParams {
     ttnn::Shape shape;
     bool use_pre_allocated_tensor = false;
-    std::vector<ttnn::Shape> expected_shapes;
+
+    // Shape of the resulting shards.
+    ttnn::Shape sharded_shape;
     std::vector<distributed::MeshCoordinate> expected_coords;
     std::function<std::unique_ptr<ttnn::distributed::TensorToMesh>(MeshDevice*)> get_mapper;
 };
@@ -217,11 +216,7 @@ TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {
     ASSERT_EQ(num_devices, 8);
 
     const ttnn::Shape shape = GetParam().shape;
-
-    std::vector<::testing::Matcher<ttnn::Shape>> shape_matchers;
-    for (const auto& expected_shape : GetParam().expected_shapes) {
-        shape_matchers.push_back(Eq(expected_shape));
-    }
+    const ttnn::Shape sharded_shape = GetParam().sharded_shape;
 
     std::vector<::testing::Matcher<distributed::MeshCoordinate>> coord_matchers;
     for (const auto& expected_coord : GetParam().expected_coords) {
@@ -238,6 +233,7 @@ TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {
     Tensor input_host_tensor_sharded = distribute_tensor(Tensor::from_vector(host_data, tensor_spec), *mapper);
     EXPECT_TRUE(input_host_tensor_sharded.storage_type() == StorageType::MULTI_DEVICE_HOST);
     EXPECT_EQ(input_host_tensor_sharded.get_distributed_tensor_config(), mapper->config());
+    EXPECT_EQ(input_host_tensor_sharded.get_tensor_spec().logical_shape(), sharded_shape);
 
     std::vector<Tensor> input_host_shards = get_device_tensors(input_host_tensor_sharded);
 
@@ -257,28 +253,11 @@ TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {
 
     auto* device_storage = std::get_if<tt::tt_metal::DeviceStorage>(&device_tensor.get_storage());
     ASSERT_NE(device_storage, nullptr);
-
-    std::vector<distributed::MeshCoordinate> device_shard_coords;
-    std::vector<ttnn::Shape> device_shard_shapes;
-    for (const auto& [coord, spec] : device_storage->specs) {
-        device_shard_coords.push_back(coord);
-        device_shard_shapes.push_back(spec.logical_shape());
-    }
-    EXPECT_THAT(device_shard_shapes, ElementsAreArray(shape_matchers));
-    EXPECT_THAT(device_shard_coords, ElementsAreArray(coord_matchers));
+    EXPECT_THAT(device_storage->coords, ElementsAreArray(coord_matchers));
 
     // Read the tensor back, and compare it with input data.
     auto output_host_tensor = tensor_impl::to_host_mesh_tensor_wrapper(device_tensor);
     EXPECT_EQ(output_host_tensor.get_distributed_tensor_config(), mapper->config());
-
-    auto* output_multi_device_host_storage =
-        std::get_if<tt::tt_metal::MultiDeviceHostStorage>(&output_host_tensor.get_storage());
-    ASSERT_NE(output_multi_device_host_storage, nullptr);
-    std::vector<ttnn::Shape> output_host_shapes;
-    for (size_t i = 0; i < output_multi_device_host_storage->num_buffers(); i++) {
-        output_host_shapes.push_back(output_multi_device_host_storage->get_tensor_spec(i).logical_shape());
-    }
-    EXPECT_THAT(output_host_shapes, ElementsAreArray(shape_matchers));
 
     std::vector<Tensor> output_host_shards = get_device_tensors(output_host_tensor);
     ASSERT_EQ(output_host_shards.size(), input_host_shards.size());
@@ -293,15 +272,7 @@ auto get_mesh_tensor_write_test_params() {
     std::vector<MeshTensorWriteTestParams> base_params = {
         MeshTensorWriteTestParams{
             .shape = ttnn::Shape{1, 8, 32, 32},
-            .expected_shapes =
-                {ttnn::Shape{1, 1, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32}},
+            .sharded_shape = ttnn::Shape{1, 1, 32, 32},
             .expected_coords =
                 {distributed::MeshCoordinate{0, 0},
                  distributed::MeshCoordinate{0, 1},
@@ -315,12 +286,7 @@ auto get_mesh_tensor_write_test_params() {
         },
         MeshTensorWriteTestParams{
             .shape = ttnn::Shape{1, 9, 32, 32},
-            .expected_shapes =
-                {ttnn::Shape{1, 2, 32, 32},
-                 ttnn::Shape{1, 2, 32, 32},
-                 ttnn::Shape{1, 2, 32, 32},
-                 ttnn::Shape{1, 2, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32}},
+            .sharded_shape = ttnn::Shape{1, 2, 32, 32},
             .expected_coords =
                 {distributed::MeshCoordinate{0, 0},
                  distributed::MeshCoordinate{0, 1},
@@ -331,15 +297,7 @@ auto get_mesh_tensor_write_test_params() {
         },
         MeshTensorWriteTestParams{
             .shape = ttnn::Shape{1, 1, 32, 32},
-            .expected_shapes =
-                {ttnn::Shape{1, 1, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32},
-                 ttnn::Shape{1, 1, 32, 32}},
+            .sharded_shape = ttnn::Shape{1, 1, 32, 32},
             .expected_coords =
                 {distributed::MeshCoordinate{0, 0},
                  distributed::MeshCoordinate{0, 1},
@@ -353,13 +311,7 @@ auto get_mesh_tensor_write_test_params() {
         },
         MeshTensorWriteTestParams{
             .shape = ttnn::Shape{7, 3, 32, 32},
-            .expected_shapes =
-                {ttnn::Shape{7, 1, 32, 32},
-                 ttnn::Shape{7, 1, 32, 32},
-                 ttnn::Shape{7, 1, 32, 32},
-                 ttnn::Shape{7, 1, 32, 32},
-                 ttnn::Shape{7, 1, 32, 32},
-                 ttnn::Shape{7, 1, 32, 32}},
+            .sharded_shape = ttnn::Shape{7, 1, 32, 32},
             .expected_coords =
                 {distributed::MeshCoordinate{0, 0},
                  distributed::MeshCoordinate{0, 1},

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -285,17 +285,6 @@ auto get_mesh_tensor_write_test_params() {
             .get_mapper = [](MeshDevice* device) { return shard_tensor_to_mesh_mapper(*device, 1); },
         },
         MeshTensorWriteTestParams{
-            .shape = ttnn::Shape{1, 9, 32, 32},
-            .sharded_shape = ttnn::Shape{1, 2, 32, 32},
-            .expected_coords =
-                {distributed::MeshCoordinate{0, 0},
-                 distributed::MeshCoordinate{0, 1},
-                 distributed::MeshCoordinate{0, 2},
-                 distributed::MeshCoordinate{0, 3},
-                 distributed::MeshCoordinate{1, 0}},
-            .get_mapper = [](MeshDevice* device) { return shard_tensor_to_mesh_mapper(*device, 1); },
-        },
-        MeshTensorWriteTestParams{
             .shape = ttnn::Shape{1, 1, 32, 32},
             .sharded_shape = ttnn::Shape{1, 1, 32, 32},
             .expected_coords =

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -176,7 +176,7 @@ TEST_F(LaunchOperationT3000Test, UnevenTensor) {
         ttnn::Shape{1, 1, 32, 32}, tt::tt_metal::TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
     auto uneven_tensor = make_tensor_with_num_shards(tensor_spec, 2, mesh_device_.get());
 
-    EXPECT_THAT(uneven_tensor.device_storage().specs, SizeIs(2));
+    EXPECT_THAT(uneven_tensor.device_storage().coords, SizeIs(2));
 
     EXPECT_FALSE(all_tensors_have_uniform_storage(uneven_tensor));
     EXPECT_THAT(

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
@@ -51,7 +51,7 @@ tt::tt_metal::Tensor scatter(const tt::tt_metal::Tensor& tensor, int dim) {
 
     auto device_grid_shape = current_device->shape();
     const auto& storage = std::get<tt::tt_metal::DeviceStorage>(tensor.storage());
-    const auto num_tensor_buffers = storage.specs.size();
+    const auto num_tensor_buffers = storage.coords.size();
 
     if (num_devices != num_tensor_buffers) {
         throw std::logic_error(fmt::format(

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -25,16 +25,14 @@ struct HostStorage {
 };
 
 struct DeviceStorage {
-    std::vector<std::pair<distributed::MeshCoordinate, TensorSpec>> specs;
-
+    std::vector<distributed::MeshCoordinate> coords;
     std::shared_ptr<Buffer> buffer;
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer;
 
     DeviceStorage() = default;
     DeviceStorage(std::shared_ptr<Buffer> buffer_);
     DeviceStorage(
-        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
-        std::vector<std::pair<distributed::MeshCoordinate, TensorSpec>> specs_);
+        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords_);
 
     MemoryConfig memory_config() const;
     Buffer* get_buffer() const;
@@ -47,15 +45,13 @@ struct DeviceStorage {
 
     IDevice* get_device() const;
 
-    void update_specs(const TensorSpec& new_spec);
-
-    // Returns true if the tensor spans across all devices in a mesh, and all specs are the same.
+    // Returns true if the tensor spans across all devices in a mesh.
     bool is_uniform_storage() const;
 };
 
 class MultiDeviceHostStorage {
 public:
-    MultiDeviceHostStorage(std::vector<HostBuffer> buffers, std::vector<TensorSpec> specs);
+    explicit MultiDeviceHostStorage(std::vector<HostBuffer> buffers);
 
     static constexpr auto attribute_names = std::forward_as_tuple();
     auto attribute_values() const { return std::forward_as_tuple(); }
@@ -63,15 +59,11 @@ public:
     // Returns `HostBuffer` at position `buffer_index`;
     HostBuffer get_buffer(int buffer_index) const;
 
-    // Returns `TensorSpec` at position `spec_index`;
-    TensorSpec get_tensor_spec(int spec_index) const;
-
     // Returns the number of `HostBuffer`s in the storage;
     size_t num_buffers() const;
 
 private:
     std::vector<HostBuffer> buffers_;
-    std::vector<TensorSpec> specs_;
 };
 
 using Storage = std::variant<HostStorage, DeviceStorage, MultiDeviceHostStorage>;

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -243,8 +243,6 @@ public:
     // Throws if the tensor is not allocated on a device.
     IDevice* device() const;
 
-    std::vector<IDevice*> active_physical_devices() const;
-
     bool is_sharded() const;
 
     // Size in bytes of a single element held in tensor

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -125,7 +125,7 @@ Tensor aggregate_as_tensor(
         std::sort(coords.begin(), coords.end());
         auto duplicate =
             std::adjacent_find(coords.begin(), coords.end(), [](const auto& a, const auto& b) { return a == b; });
-        TT_FATAL(duplicate == coords.end(), "Found a tensor shard at duplicate coordiante {0}", *duplicate);
+        TT_FATAL(duplicate == coords.end(), "Found a tensor shard at duplicate coordinate {}", *duplicate);
         return Tensor(
             DeviceStorage(std::move(mesh_buffer), std::move(coords)),
             reference_shard.get_tensor_spec(),

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -202,7 +202,7 @@ Tensor from_flatbuffer(const ttnn::flatbuffer::Tensor* fb_tensor, tt::stl::Span<
                 buffers.push_back(std::move(host_buffer));
             }
 
-            tt::tt_metal::MultiDeviceHostStorage multi_device_storage{std::move(buffers), std::move(specs)};
+            tt::tt_metal::MultiDeviceHostStorage multi_device_storage{std::move(buffers)};
 
             return Tensor(std::move(multi_device_storage), spec, strategy);
         }

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -46,7 +46,7 @@ std::vector<distributed::MeshCoordinate> TensorAttributes::determine_distributio
     const int num_shards = std::visit(
         tt::stl::overloaded{
             [&mesh_shape](const HostStorage&) { return mesh_shape.mesh_size(); },
-            [&mesh_shape](const DeviceStorage& s) { return s.specs.size(); },
+            [&mesh_shape](const DeviceStorage& s) { return s.coords.size(); },
             [&mesh_shape](const MultiDeviceHostStorage& s) { return s.num_buffers(); },
         },
         storage_);

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -109,9 +109,9 @@ Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distri
                     std::vector<Tensor> shards(s.num_buffers());
                     for (std::size_t shard_idx = 0; shard_idx < s.num_buffers(); ++shard_idx) {
                         // Multi-Thread Host tilization of shards.
-                        mesh_device->enqueue_to_thread_pool([shard_idx, &s, &shards, target_layout]() {
+                        mesh_device->enqueue_to_thread_pool([shard_idx, &s, &shards, target_layout, &input_tensor]() {
                             ZoneScopedN("HostTilize");
-                            Tensor shard(s.get_buffer(shard_idx), s.get_tensor_spec(shard_idx));
+                            Tensor shard(s.get_buffer(shard_idx), input_tensor.get_tensor_spec());
                             shards[shard_idx] = tensor_impl::to_layout_wrapper(shard, target_layout);
                         });
                     }

--- a/ttnn/core/tensor/tensor_utils.cpp
+++ b/ttnn/core/tensor/tensor_utils.cpp
@@ -109,14 +109,14 @@ Tensor transform(const Tensor& tensor, const std::function<Tensor(const Tensor&)
     transformed_buffers.reserve(storage.num_buffers());
     transformed_specs.reserve(storage.num_buffers());
     for (size_t i = 0; i < storage.num_buffers(); i++) {
-        Tensor transformed_tensor_shard = transform_func(Tensor(storage.get_buffer(i), storage.get_tensor_spec(i)));
+        Tensor transformed_tensor_shard = transform_func(Tensor(storage.get_buffer(i), tensor.get_tensor_spec()));
         transformed_specs.push_back(transformed_tensor_shard.get_tensor_spec());
         auto* host_storage = std::get_if<HostStorage>(&transformed_tensor_shard.get_storage());
         TT_FATAL(host_storage != nullptr, "transform function must return a host tensor");
         transformed_buffers.push_back(std::move(host_storage->buffer));
     }
     TensorSpec reference_spec = transformed_specs.front();
-    MultiDeviceHostStorage transformed_storage(std::move(transformed_buffers), std::move(transformed_specs));
+    MultiDeviceHostStorage transformed_storage(std::move(transformed_buffers));
     return Tensor(std::move(transformed_storage), reference_spec, tensor.get_distributed_tensor_config());
 }
 
@@ -124,7 +124,7 @@ void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& calla
     TT_FATAL(is_multi_device_host_tensor(tensor), "apply only supports multi-device host tensors");
     const auto& storage = std::get<MultiDeviceHostStorage>(tensor.storage());
     for (size_t i = 0; i < storage.num_buffers(); i++) {
-        callable(Tensor(storage.get_buffer(i), storage.get_tensor_spec(i)));
+        callable(Tensor(storage.get_buffer(i), tensor.get_tensor_spec()));
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
@@ -349,7 +349,7 @@ Tensor all_gather(
         user_defined_num_workers,
         user_defined_num_buffers_per_channel,
         topology,
-        input_tensor.active_physical_devices());
+        ttnn::ccl::get_active_physical_devices(input_tensor));
 }
 
 std::vector<Tensor> all_gather(

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -137,6 +137,16 @@ SenderRecieverConfig get_device_sender_receiver_config_in_ring(
     return config;
 }
 
+std::vector<IDevice*> get_active_physical_devices(const Tensor& tensor) {
+    auto mesh_device = tensor.mesh_device();
+    std::vector<IDevice*> devices = {};
+    devices.reserve(tensor.device_storage().coords.size());
+    for (const auto& coord : tensor.device_storage().coords) {
+        devices.push_back(mesh_device->get_device(coord));
+    }
+    return devices;
+}
+
 std::vector<ttnn::Tensor> unpad_output_tensor(
     const std::vector<ttnn::Tensor>& output_tensor,
     const uint32_t num_devices,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -210,7 +210,7 @@ Tensor reduce_scatter(
         topology,
         user_defined_num_workers,
         user_defined_num_buffers_per_channel,
-        input_tensor.active_physical_devices());
+        ttnn::ccl::get_active_physical_devices(input_tensor));
 }
 
 std::vector<Tensor> reduce_scatter(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -440,11 +440,15 @@ Tensor all_gather_async(
     const ttnn::ccl::Topology topology,
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id) {
     std::vector<IDevice*> devices;
-    for (const auto& spec : input_tensor.device_storage().specs) {
-        devices.push_back(input_tensor.mesh_device()->get_device(spec.first));
-    }
     return all_gather_async_impl(
-        input_tensor, dim, multi_device_global_semaphore, num_links, memory_config, topology, sub_device_id, devices);
+        input_tensor,
+        dim,
+        multi_device_global_semaphore,
+        num_links,
+        memory_config,
+        topology,
+        sub_device_id,
+        ttnn::ccl::get_active_physical_devices(input_tensor));
 }
 
 std::vector<Tensor> all_gather_async(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
@@ -244,7 +244,6 @@ std::vector<ttnn::Tensor> all_gather_matmul(
     const std::optional<const std::string>& activation,
     const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const ttnn::CoreGrid> core_grid) {
-    std::vector<IDevice*> devices = input_tensor.active_physical_devices();
     return all_gather_matmul_impl(
         input_tensor,
         weight_tensor,
@@ -262,7 +261,7 @@ std::vector<ttnn::Tensor> all_gather_matmul(
         activation,
         compute_kernel_config,
         core_grid,
-        devices);
+        ttnn::ccl::get_active_physical_devices(input_tensor));
 }
 
 std::vector<ttnn::Tensor> all_gather_matmul(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
@@ -450,7 +450,7 @@ Tensor all_reduce(
     TT_FATAL(
         std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr, "All Reduce op is only supported for Fast Dispatch");
 
-    std::vector<IDevice*> devices = input_tensor.active_physical_devices();
+    std::vector<IDevice*> devices = ttnn::ccl::get_active_physical_devices(input_tensor);
     uint32_t num_devices = devices.size();
     TT_FATAL(num_devices > 1, "all_reduce op will only work for num_devices > 1, but has {}", num_devices);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
@@ -43,7 +43,8 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
     const std::optional<size_t> num_preferred_links,
     std::optional<tt::tt_metal::SubDeviceId> worker_subdevice_id_opt) {
     MemoryConfig out_memory_config = memory_config.value_or(input_tensor.memory_config());
-    uint32_t dim = find_scatter_dim(input_tensor.get_padded_shape(), input_tensor.active_physical_devices().size());
+    uint32_t dim =
+        find_scatter_dim(input_tensor.get_padded_shape(), ttnn::ccl::get_active_physical_devices(input_tensor).size());
     ttnn::Tensor scattered_tensor = ttnn::operations::experimental::ccl::reduce_scatter(
         input_tensor,
         dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_op.cpp
@@ -223,10 +223,7 @@ Tensor all_to_all_async(
         std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr,
         "all_to_all_async op is only supported for Fast Dispatch");
 
-    std::vector<IDevice*> devices;
-    for (const auto& spec : input_tensor.device_storage().specs) {
-        devices.push_back(input_tensor.mesh_device()->get_device(spec.first));
-    }
+    std::vector<IDevice*> devices = ttnn::ccl::get_active_physical_devices(input_tensor);
 
     uint32_t num_devices = devices.size();
     TT_FATAL(num_devices > 0, "all_to_all_async requires at least one device, but has {}", num_devices);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -353,10 +353,6 @@ Tensor reduce_scatter(
     ttnn::ccl::Topology topology,
     const std::optional<size_t> num_links_preferred,
     std::optional<SubDeviceId> worker_subdevice_id_opt) {
-    std::vector<IDevice*> devices;
-    for (const auto& spec : input_tensor.device_storage().specs) {
-        devices.push_back(input_tensor.mesh_device()->get_device(spec.first));
-    }
     return reduce_scatter_impl(
         input_tensor,
         dim,
@@ -367,7 +363,7 @@ Tensor reduce_scatter(
         topology,
         num_links_preferred,
         worker_subdevice_id_opt,
-        devices);
+        ttnn::ccl::get_active_physical_devices(input_tensor));
 }
 
 std::vector<Tensor> reduce_scatter(

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
@@ -63,7 +63,6 @@ Tensor tensor_reshape(
                         const auto& tensor_spec = tensor.tensor_spec();
                         auto page_size_bytes = tensor_spec.compute_page_size_bytes();
                         device_buffer->set_page_size(page_size_bytes);
-                        device_storage.update_specs(new_spec);
                         return Tensor(std::move(device_storage), new_spec, tensor.get_distributed_tensor_config());
                     } else {
                         auto device_buffer = device_storage.get_buffer();
@@ -104,11 +103,9 @@ Tensor tensor_reshape(
                         auto page_size_bytes = upd_spec.compute_page_size_bytes();
                         device_buffer->set_page_size(page_size_bytes);
 
-                        device_storage.update_specs(upd_spec);
                         return Tensor(std::move(device_storage), upd_spec, tensor.get_distributed_tensor_config());
                     }
                 } else {
-                    device_storage.update_specs(new_spec);
                     return Tensor(std::move(device_storage), new_spec, tensor.get_distributed_tensor_config());
                 }
             } else if constexpr (std::is_same_v<T, tt::tt_metal::HostStorage>) {


### PR DESCRIPTION
### Ticket
[22258](https://github.com/tenstorrent/tt-metal/issues/22258)

### Problem description
Per-device tensor specs aren't properly supported by TTNN, and were restricted to be uniform in https://github.com/tenstorrent/tt-metal/pull/22655.

Need to clean up per-device specs from the code.

### What's changed
Remove per-device specs from `MultiDeviceHostStorage` and `DeviceStorage`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15333486281)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15333615506)
- [x] New/Existing tests provide coverage for changes