### PR TITLE
#21846: Throw when zero dimension on shard shape encountered

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -142,6 +142,12 @@ public:
             tt::round_up(shard_spec.shape[0], tile_height) / tile_height,
             tt::round_up(shard_spec.shape[1], tile_width) / tile_width};
 
+        TT_FATAL(
+            shard_shape[0] != 0 and shard_shape[1] != 0,
+            "Shard shape must not contain zero dimensions but got {{{}, {}}}",
+            shard_shape[0],
+            shard_shape[1]);
+
         const auto [N, C, Ht, Wt] = get_shape_dims(tensor);
         const auto unrolled_Ht = N * C * Ht;
         last_shard_shape = {


### PR DESCRIPTION
### Ticket
#21846

### Problem description
The binary_ng program factory does not correctly handle all cases for sharded tensors, specifically when involving  interleaved input tensors that are broadcasted. Based on the shard spec of the sharded output tensor, it may result in the computation of a zero dimension in the "shard shape" of the interleaved tensor, causing the program to abort when it subsequently attempts to divide by zero.

### What's changed
In the short-term, throw an exception when a zero dimension is encountered so that the Forge compiler can catch the exception without aborting. Long-term, we want to refactor the binary_ng program factory to properly handle this case, since the kernel should be able to support this scenario without issue.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15333707836) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes