### PR TITLE
Added Perf Test for BinaryMultSiLU on Llama 3.3 70B model 

### DIFF
--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
@@ -19,6 +19,7 @@ from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
         ("PagedUpdateCacheDeviceOperation", 4.5, 0.1),
         ("RotaryEmbeddingLlamaFusedQK", 4.15, 0.05),
         ("Embeddings", 3.4, 0.1),
+        ("BinaryDeviceOperation", 2.71, 0.05),
     ],
 )
 def test_llama_tg_ops_perf_device(op_name, expected_kernel_duration_us, perf_margin):

--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
@@ -26,7 +26,7 @@ def test_llama_tg_ops_perf_device(op_name, expected_kernel_duration_us, perf_mar
     batch = 32
     test = "llama-distributed-ln"
     subdir = "llama-unit-tests"
-    num_iterations = 1
+    num_iterations = 3
 
     profiler = BenchmarkProfiler()
     benchmark_data = BenchmarkData()

--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
@@ -26,7 +26,7 @@ def test_llama_tg_ops_perf_device(op_name, expected_kernel_duration_us, perf_mar
     batch = 32
     test = "llama-distributed-ln"
     subdir = "llama-unit-tests"
-    num_iterations = 3
+    num_iterations = 1
 
     profiler = BenchmarkProfiler()
     benchmark_data = BenchmarkData()

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_ops.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_ops.py
@@ -28,6 +28,7 @@ from tests.tt_eager.python_api_testing.unit_testing.misc.test_rotary_embedding_l
     run_test_rotary_embedding_llama,
     run_test_row_major_rotary_embedding_llama,
 )
+from tests.tt_eager.python_api_testing.unit_testing.misc.test_eltwise_binary import run_elt_binary_mul_with_sub_devices
 
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_embedding import run_embeddings_tests
 
@@ -197,6 +198,51 @@ def test_llama_tg_ScaledDotProductAttentionDecode(
         q_layout=q_layout,
     )
     assert device.num_program_cache_entries() == 1
+
+
+## Op Tests for BinaryMult + SiLU
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
+@pytest.mark.parametrize("batch_size", [1])
+@pytest.mark.parametrize("seq_len", [32])
+@pytest.mark.parametrize("dim", [512])
+@pytest.mark.parametrize("num_heads", [1])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
+@pytest.mark.parametrize("pcc", [0.9995])
+def test_llama_tg_BinaryDeviceOperation(use_program_cache, device, batch_size, seq_len, dim, num_heads, dtype, pcc):
+    sub_core_grid = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
+            ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 9)),
+        ]
+    )
+    ff1_crs_rs_out = ttnn.num_cores_to_corerangeset_in_subcoregrids(
+        ttnn.CoreCoord(1, 0), 30, sub_core_grid, row_wise=True
+    )
+    in_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            ff1_crs_rs_out,
+            [32, 32],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+    out_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            ff1_crs_rs_out,
+            [32, 32],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+    run_elt_binary_mul_with_sub_devices(
+        batch_size, num_heads, seq_len, dim, dtype, in_mem_config, out_mem_config, device, None, None, pcc
+    )
 
 
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_ops.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_ops.py
@@ -8,6 +8,7 @@ import pytest
 from models.utility_functions import comp_pcc
 
 from models.utility_functions import skip_for_blackhole
+from tests.ttnn.unit_tests.operations.ccl.test_new_all_reduce import FF1_CRS_RS_OUT
 from tests.ttnn.unit_tests.operations.test_distributed_layernorm_sharded import (
     create_input_and_weight_tensors,
     create_tt_tensors,
@@ -213,20 +214,11 @@ def test_llama_tg_ScaledDotProductAttentionDecode(
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
 @pytest.mark.parametrize("pcc", [0.9995])
 def test_llama_tg_BinaryDeviceOperation(use_program_cache, device, batch_size, seq_len, dim, num_heads, dtype, pcc):
-    sub_core_grid = ttnn.CoreRangeSet(
-        [
-            ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
-            ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 9)),
-        ]
-    )
-    ff1_crs_rs_out = ttnn.num_cores_to_corerangeset_in_subcoregrids(
-        ttnn.CoreCoord(1, 0), 30, sub_core_grid, row_wise=True
-    )
     in_mem_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         ttnn.BufferType.L1,
         ttnn.ShardSpec(
-            ff1_crs_rs_out,
+            FF1_CRS_RS_OUT,
             [32, 32],
             ttnn.ShardOrientation.ROW_MAJOR,
         ),
@@ -235,7 +227,7 @@ def test_llama_tg_BinaryDeviceOperation(use_program_cache, device, batch_size, s
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         ttnn.BufferType.L1,
         ttnn.ShardSpec(
-            ff1_crs_rs_out,
+            FF1_CRS_RS_OUT,
             [32, 32],
             ttnn.ShardOrientation.ROW_MAJOR,
         ),

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_ops.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_ops.py
@@ -4,7 +4,7 @@
 import ttnn
 import torch
 import pytest
-
+import os
 from models.utility_functions import comp_pcc
 
 from models.utility_functions import skip_for_blackhole
@@ -207,7 +207,15 @@ def test_llama_tg_ScaledDotProductAttentionDecode(
     [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
     indirect=True,
 )
-@pytest.mark.parametrize("mesh_cluster_shape", [(8, 4)])
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("seq_len", [32])
 @pytest.mark.parametrize("dim", [512])
@@ -215,10 +223,10 @@ def test_llama_tg_ScaledDotProductAttentionDecode(
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
 @pytest.mark.parametrize("pcc", [0.9995])
 def test_llama_tg_BinaryDeviceOperation(
-    use_program_cache, device, mesh_device, mesh_cluster_shape, batch_size, seq_len, dim, num_heads, dtype, pcc
+    use_program_cache, mesh_device, batch_size, seq_len, dim, num_heads, dtype, pcc
 ):
-    mesh_mapper = ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 3), mesh_shape=mesh_cluster_shape)
-    mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, 3), mesh_shape=mesh_cluster_shape)
+    mesh_mapper = ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 3), mesh_shape=tuple(mesh_device.shape))
+    mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, 3), mesh_shape=tuple(mesh_device.shape))
     in_mem_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         ttnn.BufferType.L1,
@@ -245,7 +253,7 @@ def test_llama_tg_BinaryDeviceOperation(
         dtype,
         in_mem_config,
         out_mem_config,
-        device,
+        mesh_device,
         mesh_mapper,
         mesh_composer,
         pcc,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_ops.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_ops.py
@@ -207,6 +207,7 @@ def test_llama_tg_ScaledDotProductAttentionDecode(
     [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
     indirect=True,
 )
+@pytest.mark.parametrize("mesh_cluster_shape", [(8, 4)])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("seq_len", [32])
 @pytest.mark.parametrize("dim", [512])
@@ -214,10 +215,10 @@ def test_llama_tg_ScaledDotProductAttentionDecode(
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
 @pytest.mark.parametrize("pcc", [0.9995])
 def test_llama_tg_BinaryDeviceOperation(
-    use_program_cache, device, mesh_device, batch_size, seq_len, dim, num_heads, dtype, pcc
+    use_program_cache, device, mesh_device, mesh_cluster_shape, batch_size, seq_len, dim, num_heads, dtype, pcc
 ):
-    mesh_mapper = ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 3), mesh_shape=mesh_device.cluster_shape)
-    mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, 3), mesh_shape=mesh_device.cluster_shape)
+    mesh_mapper = ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 3), mesh_shape=mesh_cluster_shape)
+    mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, 3), mesh_shape=mesh_cluster_shape)
     in_mem_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         ttnn.BufferType.L1,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_ops.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_ops.py
@@ -213,7 +213,11 @@ def test_llama_tg_ScaledDotProductAttentionDecode(
 @pytest.mark.parametrize("num_heads", [1])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
 @pytest.mark.parametrize("pcc", [0.9995])
-def test_llama_tg_BinaryDeviceOperation(use_program_cache, device, batch_size, seq_len, dim, num_heads, dtype, pcc):
+def test_llama_tg_BinaryDeviceOperation(
+    use_program_cache, device, mesh_device, batch_size, seq_len, dim, num_heads, dtype, pcc
+):
+    mesh_mapper = ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 3), mesh_shape=mesh_device.cluster_shape)
+    mesh_composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(1, 3), mesh_shape=mesh_device.cluster_shape)
     in_mem_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         ttnn.BufferType.L1,
@@ -233,7 +237,17 @@ def test_llama_tg_BinaryDeviceOperation(use_program_cache, device, batch_size, s
         ),
     )
     run_elt_binary_mul_with_sub_devices(
-        batch_size, num_heads, seq_len, dim, dtype, in_mem_config, out_mem_config, device, None, None, pcc
+        batch_size,
+        num_heads,
+        seq_len,
+        dim,
+        dtype,
+        in_mem_config,
+        out_mem_config,
+        device,
+        mesh_mapper,
+        mesh_composer,
+        pcc,
     )
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_binary.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_binary.py
@@ -125,6 +125,45 @@ def test_run_elt_binary_add_with_sub_devices(device):
     assert passing
 
 
+def run_elt_binary_mul_with_sub_devices(
+    batch, num_heads, seq_len, dim, dtype, in_mem_config, out_mem_config, device, mesh_mapper, mesh_composer, pcc
+):
+    input_shape = [batch, num_heads, seq_len, dim]
+    in0 = torch.randn(input_shape)
+    in1 = torch.randn(input_shape)
+    in0_ref = in0.clone()
+    in1_ref = in1.clone()
+    in0_t = ttnn.from_torch(
+        in0,
+        device=device,
+        mesh_mapper=mesh_mapper,
+        dtype=dtype,
+        memory_config=in_mem_config,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    in1_t = ttnn.from_torch(
+        in1,
+        device=device,
+        mesh_mapper=mesh_mapper,
+        dtype=dtype,
+        memory_config=in_mem_config,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    out_t = ttnn.mul(
+        in0_t,
+        in1_t,
+        input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
+        dtype=ttnn.bfloat8_b,
+        memory_config=out_mem_config,
+    )
+    tt_out = ttnn.to_torch(out_t, mesh_composer=mesh_composer)
+    tt_out = tt_out[:, :1, :, :dim]
+    torch_silu = torch.nn.SiLU()
+    passing, output = comp_pcc(tt_out, torch.mul(torch_silu(in0_ref), in1_ref), pcc)
+    logger.info(output)
+    assert passing
+
+
 @run_for_wormhole_b0()
 @pytest.mark.parametrize("device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}], indirect=True)
 def test_run_elt_binary_mul_with_sub_devices(device):
@@ -133,9 +172,12 @@ def test_run_elt_binary_mul_with_sub_devices(device):
     if unharvested_grid_size[0] > compute_grid_size.x or unharvested_grid_size[1] > compute_grid_size.y:
         pytest.skip(f"Need {unharvested_grid_size} grid size to run this test but core grid is {compute_grid_size}")
 
+    pcc = 0.999
     shape = (1, 1, 32, 896)
+    dtype = ttnn.bfloat8_b
+    mesh_mapper = None
+    mesh_composer = None
     torch.manual_seed(10)
-
     start_core = ttnn.CoreCoord(1, 0)
     core_grid = ttnn.CoreRangeSet(
         [
@@ -145,40 +187,12 @@ def test_run_elt_binary_mul_with_sub_devices(device):
     )
     shard_grid = ttnn.num_cores_to_corerangeset_in_subcoregrids(start_core, 28, core_grid, row_wise=True)
     shard_spec = ttnn.ShardSpec(shard_grid, (32, 32), ttnn.ShardOrientation.ROW_MAJOR)
-    output_mem_config = ttnn.MemoryConfig(
+    in_mem_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         ttnn.BufferType.L1,
         shard_spec,
     )
-    in0 = torch.randn(shape).bfloat16().float()
-    in1 = torch.randn(shape).bfloat16().float()
-    in0_t = ttnn.from_torch(
-        in0,
-        device=device,
-        dtype=ttnn.bfloat8_b,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=output_mem_config,
+    out_mem_config = in_mem_config
+    run_elt_binary_mul_with_sub_devices(
+        *shape, dtype, in_mem_config, out_mem_config, device, mesh_mapper, mesh_composer, pcc
     )
-    in0 = ttnn.to_torch(in0_t)
-    in1_t = ttnn.from_torch(
-        in0,
-        device=device,
-        dtype=ttnn.bfloat8_b,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=output_mem_config,
-    )
-    in1 = ttnn.to_torch(in1_t)
-
-    out_t = ttnn.mul(
-        in0_t,
-        in1_t,
-        input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
-        dtype=ttnn.bfloat8_b,
-        memory_config=output_mem_config,
-    )
-
-    out = ttnn.to_torch(out_t)
-    torch_silu = torch.nn.SiLU()
-    passing, output = comp_pcc(out, torch.mul(torch_silu(in0), in1), 0.999)
-    logger.info(output)
-    assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_binary.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_binary.py
@@ -157,7 +157,6 @@ def run_elt_binary_mul_with_sub_devices(
         memory_config=out_mem_config,
     )
     tt_out = ttnn.to_torch(out_t, mesh_composer=mesh_composer)
-    tt_out = tt_out[:, :1, :, :dim]
     torch_silu = torch.nn.SiLU()
     passing, output = comp_pcc(tt_out, torch.mul(torch_silu(in0_ref), in1_ref), pcc)
     logger.info(output)


### PR DESCRIPTION
### Ticket
#22766 

### Problem description
There was missing ops performance testing for BinaryMultSiLU on Llama 3.3 70B model on TG. Unit tests for this op should be added for ensuring op performance meets desired PCC, also a performance test to call underlying unit test to meet expected performance target.

### What's changed
- Added unit test for binary multiplication with silu activation under `tests_llama_ops.py`
- Added generic function for testing silu multiplication in `tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_binary.py` for reusability
- Added additional op perf test for this operation to be run in `test_llama_ops_perf_TG_llama.py`

### Checklist
- [Unit Tests + Perf Tests ](https://github.com/tenstorrent/tt-metal/actions/runs/15576295505) All passing except falcon perf tests
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/15546034708)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes