### PR TITLE
Fix misplaced const (delete dead code)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -138,7 +138,6 @@ Checks: >
   -misc-const-correctness,
   -misc-definitions-in-headers,
   -misc-include-cleaner,
-  -misc-misplaced-const,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-redundant-expression,

--- a/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
@@ -316,8 +316,8 @@ struct ArchDependentTypes<true> {
 
 template <>
 struct ArchDependentTypes<false> {
-    using workers_list_t = ccl::WorkerXY *;
-    static const workers_list_t WORKERS_LIST_UNINITIALIZED_VALUE;
+    using const_workers_list_t = const ccl::WorkerXY *;
+    static const_workers_list_t WORKERS_LIST_UNINITIALIZED_VALUE;
 };
 
 

--- a/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
@@ -305,21 +305,5 @@ inline void advance_worker_global_page_interleaved (
 static constexpr uint32_t UNINITIALIZED_VALUE_U32 = std::numeric_limits<uint32_t>::max();
 static constexpr uint16_t UNINITIALIZED_VALUE_U16 = std::numeric_limits<uint16_t>::max();
 
-template <bool T>
-struct ArchDependentTypes;
-
-template <>
-struct ArchDependentTypes<true> {
-    using workers_list_t = std::vector<ccl::WorkerXY>;
-    static const workers_list_t WORKERS_LIST_UNINITIALIZED_VALUE;
-};
-
-template <>
-struct ArchDependentTypes<false> {
-    using const_workers_list_t = const ccl::WorkerXY *;
-    static const_workers_list_t WORKERS_LIST_UNINITIALIZED_VALUE;
-};
-
-
 }  // namespace ccl
 }  // namespace ttnn


### PR DESCRIPTION
### Ticket
#22776 

### Problem description
We think it's a const object, but actually it's a const pointer (ie: a reference) and the pointee is still non-const.  Not what was intended.

### What's changed
Make the pointee const.