### PR TITLE
Split private Kernel code into KernelImpl

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
@@ -58,7 +58,7 @@ TEST_F(DeviceFixture, TensixTestIncompleteKernelBinaryWithPersistentCache) {
             device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
 
         const auto& kernels = program.get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
-        const string full_kernel_name = kernels.at(kernel_handle)->impl().get_full_kernel_name();
+        const string full_kernel_name = KernelImpl::from(*kernels.at(kernel_handle)).get_full_kernel_name();
 
         const string successful_marker_path =
             build_state.get_out_path() + full_kernel_name + SUCCESSFUL_JIT_BUILD_MARKER_FILE_NAME;
@@ -108,8 +108,10 @@ TEST_F(DeviceFixture, TensixTestEquivalentDataMovementKernelsWithDifferentProces
             device->build_id(), tensix_core_type, dm_class_idx, riscv_1_id);
 
         const auto& kernels = program.get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
-        const string full_kernel_name_riscv_0 = kernels.at(kernel_handle_riscv_0)->impl().get_full_kernel_name();
-        const string full_kernel_name_riscv_1 = kernels.at(kernel_handle_riscv_1)->impl().get_full_kernel_name();
+        const string full_kernel_name_riscv_0 =
+            KernelImpl::from(*kernels.at(kernel_handle_riscv_0)).get_full_kernel_name();
+        const string full_kernel_name_riscv_1 =
+            KernelImpl::from(*kernels.at(kernel_handle_riscv_1)).get_full_kernel_name();
 
         const string elf_file_path_riscv_0 = build_state_riscv_0.get_target_out_path(full_kernel_name_riscv_0);
         const string elf_file_path_riscv_1 = build_state_riscv_1.get_target_out_path(full_kernel_name_riscv_1);

--- a/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
@@ -31,6 +31,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/utils.hpp>
+#include "impl/kernels/kernel_impl.hpp"
 
 using namespace tt::tt_metal;
 
@@ -57,7 +58,7 @@ TEST_F(DeviceFixture, TensixTestIncompleteKernelBinaryWithPersistentCache) {
             device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
 
         const auto& kernels = program.get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
-        const string full_kernel_name = kernels.at(kernel_handle)->get_full_kernel_name();
+        const string full_kernel_name = kernels.at(kernel_handle)->impl().get_full_kernel_name();
 
         const string successful_marker_path =
             build_state.get_out_path() + full_kernel_name + SUCCESSFUL_JIT_BUILD_MARKER_FILE_NAME;
@@ -107,8 +108,8 @@ TEST_F(DeviceFixture, TensixTestEquivalentDataMovementKernelsWithDifferentProces
             device->build_id(), tensix_core_type, dm_class_idx, riscv_1_id);
 
         const auto& kernels = program.get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
-        const string full_kernel_name_riscv_0 = kernels.at(kernel_handle_riscv_0)->get_full_kernel_name();
-        const string full_kernel_name_riscv_1 = kernels.at(kernel_handle_riscv_1)->get_full_kernel_name();
+        const string full_kernel_name_riscv_0 = kernels.at(kernel_handle_riscv_0)->impl().get_full_kernel_name();
+        const string full_kernel_name_riscv_1 = kernels.at(kernel_handle_riscv_1)->impl().get_full_kernel_name();
 
         const string elf_file_path_riscv_0 = build_state_riscv_0.get_target_out_path(full_kernel_name_riscv_0);
         const string elf_file_path_riscv_1 = build_state_riscv_1.get_target_out_path(full_kernel_name_riscv_1);

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -44,6 +44,7 @@
 #include "llrt.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/program/program_impl.hpp"
+#include "impl/kernels/kernel_impl.hpp"
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
@@ -195,11 +196,11 @@ int main(int argc, char** argv) {
             uint32_t mask =
                 tt_metal::BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key;
             tt_metal::detail::CompileProgram(device, program);
-            compute_binaries.insert({mask, compute_kernel->binaries(mask)});
+            compute_binaries.insert({mask, compute_kernel->impl().binaries(mask)});
             TT_FATAL(compute_binaries.at(mask).size() == 3, "Expected 3 Compute binaries!");
-            brisc_binaries.insert({mask, riscv0_kernel->binaries(mask)});
+            brisc_binaries.insert({mask, riscv0_kernel->impl().binaries(mask)});
             TT_FATAL(brisc_binaries.at(mask).size() == 1, "Expected 1 BRISC binary!");
-            ncrisc_binaries.insert({mask, riscv1_kernel->binaries(mask)});
+            ncrisc_binaries.insert({mask, riscv1_kernel->impl().binaries(mask)});
             TT_FATAL(ncrisc_binaries.at(mask).size() == 1, "Expected 1 NCRISC binary!");
         }
 
@@ -248,9 +249,9 @@ int main(int argc, char** argv) {
                             program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].value());
                         auto riscv1_kernel = tt_metal::detail::GetKernel(
                             program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].value());
-                        TT_FATAL(compute_kernel->binaries(mask) == compute_binaries.at(mask), "Error");
-                        TT_FATAL(riscv0_kernel->binaries(mask) == brisc_binaries.at(mask), "Error");
-                        TT_FATAL(riscv1_kernel->binaries(mask) == ncrisc_binaries.at(mask), "Error");
+                        TT_FATAL(compute_kernel->impl().binaries(mask) == compute_binaries.at(mask), "Error");
+                        TT_FATAL(riscv0_kernel->impl().binaries(mask) == brisc_binaries.at(mask), "Error");
+                        TT_FATAL(riscv1_kernel->impl().binaries(mask) == ncrisc_binaries.at(mask), "Error");
 
                         std::string kernel_name = get_latest_kernel_binary_path(
                             tt_metal::BuildEnvManager::get_instance()

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -196,11 +196,11 @@ int main(int argc, char** argv) {
             uint32_t mask =
                 tt_metal::BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key;
             tt_metal::detail::CompileProgram(device, program);
-            compute_binaries.insert({mask, compute_kernel->impl().binaries(mask)});
+            compute_binaries.insert({mask, tt_metal::KernelImpl::from(*compute_kernel).binaries(mask)});
             TT_FATAL(compute_binaries.at(mask).size() == 3, "Expected 3 Compute binaries!");
-            brisc_binaries.insert({mask, riscv0_kernel->impl().binaries(mask)});
+            brisc_binaries.insert({mask, tt_metal::KernelImpl::from(*riscv0_kernel).binaries(mask)});
             TT_FATAL(brisc_binaries.at(mask).size() == 1, "Expected 1 BRISC binary!");
-            ncrisc_binaries.insert({mask, riscv1_kernel->impl().binaries(mask)});
+            ncrisc_binaries.insert({mask, tt_metal::KernelImpl::from(*riscv1_kernel).binaries(mask)});
             TT_FATAL(ncrisc_binaries.at(mask).size() == 1, "Expected 1 NCRISC binary!");
         }
 
@@ -249,9 +249,15 @@ int main(int argc, char** argv) {
                             program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].value());
                         auto riscv1_kernel = tt_metal::detail::GetKernel(
                             program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].value());
-                        TT_FATAL(compute_kernel->impl().binaries(mask) == compute_binaries.at(mask), "Error");
-                        TT_FATAL(riscv0_kernel->impl().binaries(mask) == brisc_binaries.at(mask), "Error");
-                        TT_FATAL(riscv1_kernel->impl().binaries(mask) == ncrisc_binaries.at(mask), "Error");
+                        TT_FATAL(
+                            tt_metal::KernelImpl::from(*compute_kernel).binaries(mask) == compute_binaries.at(mask),
+                            "Error");
+                        TT_FATAL(
+                            tt_metal::KernelImpl::from(*riscv0_kernel).binaries(mask) == brisc_binaries.at(mask),
+                            "Error");
+                        TT_FATAL(
+                            tt_metal::KernelImpl::from(*riscv1_kernel).binaries(mask) == ncrisc_binaries.at(mask),
+                            "Error");
 
                         std::string kernel_name = get_latest_kernel_binary_path(
                             tt_metal::BuildEnvManager::get_instance()

--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -156,8 +156,6 @@ protected:
     std::map<std::string, std::string> defines_;        // preprocessor defines. this is to be able to generate generic instances.
     std::set<CoreCoord> logical_cores_;
 
-    virtual uint8_t expected_num_binaries() const = 0;
-
     virtual std::string config_hash() const = 0;
 
 private:

--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -129,9 +129,6 @@ public:
 
     bool is_idle_eth() const;
 
-    KernelImpl& impl();
-    const KernelImpl& impl() const;
-
 protected:
     int watcher_kernel_id_;
     KernelSource kernel_src_;
@@ -156,10 +153,10 @@ private:
     void register_kernel_with_watcher();
 
     Kernel(
-        const KernelSource &kernel_src,
-        const CoreRangeSet &core_range_set,
-        const std::vector<uint32_t> &compile_args,
-        const std::map<std::string, std::string> &defines);
+        const KernelSource& kernel_src,
+        const CoreRangeSet& core_range_set,
+        const std::vector<uint32_t>& compile_args,
+        const std::map<std::string, std::string>& defines);
 
     // Only allow KernelImpl to inherit from Kernel.
     friend class KernelImpl;

--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -74,12 +74,6 @@ struct KernelSource {
 
 class Kernel {
 public:
-    Kernel(
-        const KernelSource &kernel_src,
-        const CoreRangeSet &core_range_set,
-        const std::vector<uint32_t> &compile_args,
-        const std::map<std::string, std::string> &defines);
-
     virtual ~Kernel() {}
 
     std::string name() const;
@@ -160,6 +154,15 @@ protected:
 
 private:
     void register_kernel_with_watcher();
+
+    Kernel(
+        const KernelSource &kernel_src,
+        const CoreRangeSet &core_range_set,
+        const std::vector<uint32_t> &compile_args,
+        const std::map<std::string, std::string> &defines);
+
+    // Only allow KernelImpl to inherit from Kernel.
+    friend class KernelImpl;
 };
 
 std::ostream& operator<<(std::ostream& os, const DataMovementProcessor& processor);

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -32,6 +32,7 @@
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/jit_build/genfiles.hpp"
 #include <umd/device/types/arch.h>
+#include "kernel_impl.hpp"
 
 namespace tt {
 
@@ -83,7 +84,7 @@ void Kernel::register_kernel_with_watcher() {
     }
 }
 
-void Kernel::register_kernel_elf_paths_with_watcher(IDevice& device) {
+void KernelImpl::register_kernel_elf_paths_with_watcher(IDevice& device) const {
     TT_ASSERT(this->kernel_full_name_.size() > 0, "Kernel full name not set!");
     watcher_register_kernel_elf_paths(this->watcher_kernel_id_, this->file_paths(device));
 }
@@ -125,13 +126,13 @@ CoreType Kernel::get_kernel_core_type() const {
     return CoreType::WORKER;
 }
 
-const std::string& Kernel::get_full_kernel_name() const { return this->kernel_full_name_; }
+const std::string& KernelImpl::get_full_kernel_name() const { return this->kernel_full_name_; }
 
 void Kernel::add_defines(const std::map<std::string, std::string>& defines) {
     this->defines_.insert(defines.begin(), defines.end());
 }
 
-void Kernel::process_defines(const std::function<void(const string &define, const string &value)> callback) const {
+void KernelImpl::process_defines(const std::function<void(const string& define, const string& value)> callback) const {
     for (const auto &[define, value] : this->defines_) {
         callback(define, value);
     }
@@ -139,7 +140,7 @@ void Kernel::process_defines(const std::function<void(const string &define, cons
 
 void DataMovementKernel::process_defines(
     const std::function<void(const string &define, const string &value)> callback) const {
-    Kernel::process_defines(callback);
+    KernelImpl::process_defines(callback);
     callback("NOC_INDEX", std::to_string(this->config_.noc));
     callback("NOC_MODE", std::to_string(this->config_.noc_mode));
 }
@@ -155,7 +156,7 @@ void ComputeKernel::process_defines(
 
 void EthernetKernel::process_defines(
     const std::function<void(const string &define, const string &value)> callback) const {
-    Kernel::process_defines(callback);
+    KernelImpl::process_defines(callback);
     callback("NOC_INDEX", std::to_string(this->config_.noc));
     // pass default noc mode as eth does not need it, just for compile to pass
     callback("NOC_MODE", std::to_string(NOC_MODE::DM_DEDICATED_NOC));
@@ -179,7 +180,8 @@ std::string_view EthernetKernel::get_compiler_opt_level() const {
 
 std::string_view EthernetKernel::get_linker_opt_level() const { return this->get_compiler_opt_level(); }
 
-void Kernel::process_compile_time_args(const std::function<void(const std::vector<uint32_t>& values)> callback) const {
+void KernelImpl::process_compile_time_args(
+    const std::function<void(const std::vector<uint32_t>& values)> callback) const {
     callback(this->compile_time_args());
 }
 
@@ -192,7 +194,7 @@ uint8_t ComputeKernel::expected_num_binaries() const {
     return 3;
 }
 
-std::vector<ll_api::memory const*> const& Kernel::binaries(uint32_t build_key) const {
+const std::vector<const ll_api::memory*>& KernelImpl::binaries(uint32_t build_key) const {
     auto iter = binaries_.find(build_key);
     TT_ASSERT(iter != binaries_.end(), "binary not found");
     if (iter->second.size() != expected_num_binaries()) {
@@ -363,13 +365,13 @@ bool Kernel::is_idle_eth() const {
     return std::holds_alternative<EthernetConfig>(this->config()) && std::get<EthernetConfig>(this->config()).eth_mode == Eth::IDLE;
 }
 
-uint32_t Kernel::get_binary_packed_size(IDevice* device, int index) const {
+uint32_t KernelImpl::get_binary_packed_size(IDevice* device, int index) const {
     // In testing situations we can query the size w/o a binary
     auto iter = binaries_.find(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
     return iter != this->binaries_.end() ? iter->second[index]->get_packed_size() : 0;
 }
 
-uint32_t Kernel::get_binary_text_size(IDevice* device, int index) const {
+uint32_t KernelImpl::get_binary_text_size(IDevice* device, int index) const {
     // In testing situations we can query the size w/o a binary
     auto iter = binaries_.find(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
     return iter != this->binaries_.end() ? iter->second[index]->get_text_size() : 0;
@@ -421,7 +423,7 @@ void ComputeKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_
     jit_build_subset(build_states, this);
 }
 
-void Kernel::set_binaries(uint32_t build_key, std::vector<ll_api::memory const*>&& binaries) {
+void KernelImpl::set_binaries(uint32_t build_key, std::vector<const ll_api::memory*>&& binaries) {
     // Try inserting an empry vector, as that is cheap to construct
     // and avoids an additonal move.
     auto pair = binaries_.insert({build_key, {}});

--- a/tt_metal/impl/kernels/kernel_impl.hpp
+++ b/tt_metal/impl/kernels/kernel_impl.hpp
@@ -38,6 +38,8 @@ protected:
     // TODO: break this dependency by https://github.com/tenstorrent/tt-metal/issues/3381
     std::unordered_map<chip_id_t, std::vector<const ll_api::memory*>> binaries_;
 
+    virtual uint8_t expected_num_binaries() const = 0;
+
     virtual std::vector<std::string> file_paths(IDevice& device) const = 0;
 };
 

--- a/tt_metal/impl/kernels/kernel_impl.hpp
+++ b/tt_metal/impl/kernels/kernel_impl.hpp
@@ -26,6 +26,11 @@ public:
 
     void register_kernel_elf_paths_with_watcher(IDevice& device) const;
 
+    // KernelImpl and subclasses are the only implementations of Kernel.
+    static KernelImpl& from(Kernel& kernel) { return static_cast<KernelImpl&>(kernel); }
+
+    static const KernelImpl& from(const Kernel& kernel) { return static_cast<const KernelImpl&>(kernel); }
+
 protected:
     KernelImpl(
         const KernelSource& kernel_src,
@@ -151,9 +156,5 @@ private:
     std::string config_hash() const override;
     std::vector<std::string> file_paths(IDevice& device) const override;
 };
-
-// KernelImpl and subclasses should be the only implementations of Kernel.
-inline KernelImpl& Kernel::impl() { return *static_cast<KernelImpl*>(this); }
-inline const KernelImpl& Kernel::impl() const { return *static_cast<const KernelImpl*>(this); }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/kernels/kernel_impl.hpp
+++ b/tt_metal/impl/kernels/kernel_impl.hpp
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/tt-metalium/kernel.hpp"
+
+namespace tt::tt_metal {
+
+class KernelImpl : public Kernel, public JitBuildSettings {
+public:
+    const std::vector<const ll_api::memory*>& binaries(uint32_t build_key) const;
+    uint32_t get_binary_packed_size(IDevice* device, int index) const override;
+    uint32_t get_binary_text_size(IDevice* device, int index) const;
+    void set_binaries(uint32_t build_key, std::vector<const ll_api::memory*>&& binaries);
+
+    const string& get_full_kernel_name() const override;
+    void process_defines(const std::function<void(const string& define, const string& value)>) const override;
+    void process_compile_time_args(const std::function<void(const std::vector<uint32_t>& values)>) const override;
+
+    virtual void set_build_options(JitBuildOptions& build_options) const {}
+    virtual void generate_binaries(IDevice* device, JitBuildOptions& build_options) const = 0;
+    virtual bool binaries_exist_on_disk(const IDevice* device) const = 0;
+    virtual void read_binaries(IDevice* device) = 0;
+
+    void register_kernel_elf_paths_with_watcher(IDevice& device) const;
+
+protected:
+    KernelImpl(
+        const KernelSource& kernel_src,
+        const CoreRangeSet& core_range_set,
+        const std::vector<uint32_t>& compile_args,
+        const std::map<std::string, std::string>& defines) :
+        Kernel(kernel_src, core_range_set, compile_args, defines) {}
+    // DataMovement kernels have one binary each and Compute kernels have three binaries
+    // Different set of binaries per device because kernel compilation is device dependent
+    // TODO: break this dependency by https://github.com/tenstorrent/tt-metal/issues/3381
+    std::unordered_map<chip_id_t, std::vector<const ll_api::memory*>> binaries_;
+
+    virtual std::vector<std::string> file_paths(IDevice& device) const = 0;
+};
+
+class DataMovementKernel : public KernelImpl {
+public:
+    DataMovementKernel(const KernelSource& kernel_src, const CoreRangeSet& cr_set, const DataMovementConfig& config) :
+        KernelImpl(kernel_src, cr_set, config.compile_args, config.defines), config_(config) {
+        this->dispatch_class_ =
+            magic_enum::enum_integer(HalProcessorClassType::DM) + magic_enum::enum_integer(config.processor);
+    }
+
+    ~DataMovementKernel() {}
+
+    RISCV processor() const override;
+
+    void generate_binaries(IDevice* device, JitBuildOptions& build_options) const override;
+    bool binaries_exist_on_disk(const IDevice* device) const override;
+    void read_binaries(IDevice* device) override;
+
+    bool configure(
+        IDevice* device, const CoreCoord& logical_core, uint32_t base_address, const uint32_t offsets[]) const override;
+
+    Config config() const override { return this->config_; }
+
+    void process_defines(const std::function<void(const string& define, const string& value)>) const override;
+
+    std::string_view get_compiler_opt_level() const override;
+
+    std::string_view get_linker_opt_level() const override;
+
+private:
+    const DataMovementConfig config_;
+
+    uint8_t expected_num_binaries() const override;
+
+    std::string config_hash() const override;
+
+    std::vector<std::string> file_paths(IDevice& device) const override;
+};
+
+class EthernetKernel : public KernelImpl {
+public:
+    EthernetKernel(const KernelSource& kernel_src, const CoreRangeSet& cr_set, const EthernetConfig& config) :
+        KernelImpl(kernel_src, cr_set, config.compile_args, config.defines), config_(config) {
+        this->dispatch_class_ =
+            magic_enum::enum_integer(HalProcessorClassType::DM) + magic_enum::enum_integer(config.processor);
+    }
+
+    ~EthernetKernel() {}
+
+    RISCV processor() const override;
+
+    void generate_binaries(IDevice* device, JitBuildOptions& build_options) const override;
+    bool binaries_exist_on_disk(const IDevice* device) const override;
+    void read_binaries(IDevice* device) override;
+
+    bool configure(
+        IDevice* device, const CoreCoord& logical_core, uint32_t base_address, const uint32_t offsets[]) const override;
+
+    Config config() const override { return this->config_; }
+
+    void process_defines(const std::function<void(const string& define, const string& value)>) const override;
+
+    std::string_view get_compiler_opt_level() const override;
+
+    std::string_view get_linker_opt_level() const override;
+
+private:
+    const EthernetConfig config_;
+
+    uint8_t expected_num_binaries() const override;
+
+    std::string config_hash() const override;
+    std::vector<std::string> file_paths(IDevice& device) const override;
+};
+
+class ComputeKernel : public KernelImpl {
+public:
+    ComputeKernel(const KernelSource& kernel_src, const CoreRangeSet& cr_set, const ComputeConfig& config) :
+        KernelImpl(kernel_src, cr_set, config.compile_args, config.defines), config_(config) {
+        this->dispatch_class_ = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
+    }
+
+    ~ComputeKernel() {}
+
+    RISCV processor() const override;
+
+    void set_build_options(JitBuildOptions& build_options) const override;
+    void generate_binaries(IDevice* device, JitBuildOptions& build_options) const override;
+    bool binaries_exist_on_disk(const IDevice* device) const override;
+    void read_binaries(IDevice* device) override;
+
+    bool configure(
+        IDevice* device, const CoreCoord& logical_core, uint32_t base_address, const uint32_t offsets[]) const override;
+
+    Config config() const override { return this->config_; }
+
+    void process_defines(const std::function<void(const string& define, const string& value)>) const override;
+
+    std::string_view get_compiler_opt_level() const override;
+
+    std::string_view get_linker_opt_level() const override;
+
+private:
+    const ComputeConfig config_;
+
+    uint8_t expected_num_binaries() const override;
+
+    std::string config_hash() const override;
+    std::vector<std::string> file_paths(IDevice& device) const override;
+};
+
+// KernelImpl and subclasses should be the only implementations of Kernel.
+inline KernelImpl& Kernel::impl() { return *static_cast<KernelImpl*>(this); }
+inline const KernelImpl& Kernel::impl() const { return *static_cast<const KernelImpl*>(this); }
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/kernels/kernel_impl.hpp
+++ b/tt_metal/impl/kernels/kernel_impl.hpp
@@ -26,10 +26,17 @@ public:
 
     void register_kernel_elf_paths_with_watcher(IDevice& device) const;
 
-    // KernelImpl and subclasses are the only implementations of Kernel.
-    static KernelImpl& from(Kernel& kernel) { return static_cast<KernelImpl&>(kernel); }
+    static KernelImpl& from(Kernel& kernel) {
+        // KernelImpl and subclasses are the only implementations of Kernel.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        return static_cast<KernelImpl&>(kernel);
+    }
 
-    static const KernelImpl& from(const Kernel& kernel) { return static_cast<const KernelImpl&>(kernel); }
+    static const KernelImpl& from(const Kernel& kernel) {
+        // KernelImpl and subclasses are the only implementations of Kernel.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        return static_cast<const KernelImpl&>(kernel);
+    }
 
 protected:
     KernelImpl(

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -300,12 +300,13 @@ uint32_t finalize_kernel_bins(
             auto& optional_id = kg->kernel_ids[class_id];
             if (optional_id) {
                 const auto kernel = kernels.at(optional_id.value());
-                const std::vector<const ll_api::memory*>& binaries = kernel->impl().binaries(
+                const auto& kernel_impl = KernelImpl::from(*kernel);
+                const std::vector<const ll_api::memory*>& binaries = kernel_impl.binaries(
                     BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
                 // TODO: this is really ugly, save me future-HAL!
                 if (programmable_core_type_index ==
                     hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {
-                    uint32_t binary_packed_size = kernel->impl().get_binary_packed_size(device, 0);
+                    uint32_t binary_packed_size = kernel_impl.get_binary_packed_size(device, 0);
 
                     if (class_id == DISPATCH_CLASS_TENSIX_DM0) {
                         kg->kernel_bin_sizes[0] = binary_packed_size;
@@ -320,15 +321,14 @@ uint32_t finalize_kernel_bins(
                         offset += binary_packed_size;
                         offset = tt::align(offset, l1_alignment);
 
-                        uint32_t binary_text_size = kernel->impl().get_binary_text_size(device, 0);
+                        uint32_t binary_text_size = kernel_impl.get_binary_text_size(device, 0);
                         TT_ASSERT(binary_text_size >> 4 <= std::numeric_limits<uint16_t>::max());
                         kg->launch_msg.kernel_config.ncrisc_kernel_size16 = (binary_text_size + 15) >> 4;
                     } else {
                         constexpr uint32_t max_math_processors_count = 3;
                         for (uint32_t proc_type_index = 0; proc_type_index < max_math_processors_count;
                              proc_type_index++) {
-                            uint32_t binary_packed_size =
-                                kernel->impl().get_binary_packed_size(device, proc_type_index);
+                            uint32_t binary_packed_size = kernel_impl.get_binary_packed_size(device, proc_type_index);
                             kg->kernel_bin_sizes[2 + proc_type_index] = binary_packed_size;
                             kg->kernel_text_offsets[2 + proc_type_index] = offset;
                             kg->launch_msg.kernel_config.kernel_text_offset[2 + proc_type_index] = offset;
@@ -337,7 +337,7 @@ uint32_t finalize_kernel_bins(
                         }
                     }
                 } else {
-                    uint32_t binary_packed_size = kernel->impl().get_binary_packed_size(device, 0);
+                    uint32_t binary_packed_size = kernel_impl.get_binary_packed_size(device, 0);
                     kg->kernel_bin_sizes[class_id] = binary_packed_size;
 
                     // No kernel config buffer on active eth yet

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -62,6 +62,7 @@
 #include "vector_aligned.hpp"
 #include "dispatch/worker_config_buffer.hpp"
 #include "tt_metal/distributed/mesh_workload_impl.hpp"
+#include "kernels/kernel_impl.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -299,12 +300,12 @@ uint32_t finalize_kernel_bins(
             auto& optional_id = kg->kernel_ids[class_id];
             if (optional_id) {
                 const auto kernel = kernels.at(optional_id.value());
-                const std::vector<const ll_api::memory*>& binaries = kernel->binaries(
+                const std::vector<const ll_api::memory*>& binaries = kernel->impl().binaries(
                     BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
                 // TODO: this is really ugly, save me future-HAL!
                 if (programmable_core_type_index ==
                     hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {
-                    uint32_t binary_packed_size = kernel->get_binary_packed_size(device, 0);
+                    uint32_t binary_packed_size = kernel->impl().get_binary_packed_size(device, 0);
 
                     if (class_id == DISPATCH_CLASS_TENSIX_DM0) {
                         kg->kernel_bin_sizes[0] = binary_packed_size;
@@ -319,14 +320,15 @@ uint32_t finalize_kernel_bins(
                         offset += binary_packed_size;
                         offset = tt::align(offset, l1_alignment);
 
-                        uint32_t binary_text_size = kernel->get_binary_text_size(device, 0);
+                        uint32_t binary_text_size = kernel->impl().get_binary_text_size(device, 0);
                         TT_ASSERT(binary_text_size >> 4 <= std::numeric_limits<uint16_t>::max());
                         kg->launch_msg.kernel_config.ncrisc_kernel_size16 = (binary_text_size + 15) >> 4;
                     } else {
                         constexpr uint32_t max_math_processors_count = 3;
                         for (uint32_t proc_type_index = 0; proc_type_index < max_math_processors_count;
                              proc_type_index++) {
-                            uint32_t binary_packed_size = kernel->get_binary_packed_size(device, proc_type_index);
+                            uint32_t binary_packed_size =
+                                kernel->impl().get_binary_packed_size(device, proc_type_index);
                             kg->kernel_bin_sizes[2 + proc_type_index] = binary_packed_size;
                             kg->kernel_text_offsets[2 + proc_type_index] = offset;
                             kg->launch_msg.kernel_config.kernel_text_offset[2 + proc_type_index] = offset;
@@ -335,7 +337,7 @@ uint32_t finalize_kernel_bins(
                         }
                     }
                 } else {
-                    uint32_t binary_packed_size = kernel->get_binary_packed_size(device, 0);
+                    uint32_t binary_packed_size = kernel->impl().get_binary_packed_size(device, 0);
                     kg->kernel_bin_sizes[class_id] = binary_packed_size;
 
                     // No kernel config buffer on active eth yet

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -81,6 +81,7 @@
 #include "util.hpp"
 #include "utils.hpp"
 #include "host_api.hpp"
+#include "kernels/kernel_impl.hpp"
 
 namespace tt {
 class tt_hlk_desc;
@@ -127,7 +128,7 @@ void GenerateBinaries(IDevice* device, JitBuildOptions &build_options, const std
     try {
         jit_build_genfiles_descriptors(
             BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, build_options);
-        kernel->generate_binaries(device, build_options);
+        kernel->impl().generate_binaries(device, build_options);
     } catch (std::runtime_error &ex) {
         TT_THROW("Failed to generate binaries for {} {}", kernel->name(), ex.what());
     }
@@ -1077,8 +1078,8 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
             } else {
                 sub_kernels = {kernel->processor()};
             }
-            const auto& binaries =
-                kernel->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
+            const auto& binaries = kernel->impl().binaries(
+                BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
             const auto core_type = kernel->get_kernel_programmable_core_type();
             std::vector<uint32_t> dst_base_addrs;
             std::vector<uint32_t> page_offsets;
@@ -1402,7 +1403,7 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                 [kernel, device, this] {
                     JitBuildOptions build_options(
                         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env);
-                    kernel->set_build_options(build_options);
+                    kernel->impl().set_build_options(build_options);
                     if (this->compiled_.empty()) {
                         this->set_remote_circular_buffer_init(kernel);
                     }
@@ -1418,9 +1419,9 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                     kernel->set_full_name(kernel_path_suffix);
                     build_options.set_name(kernel_path_suffix);
 
-                    kernel->register_kernel_elf_paths_with_watcher(*device);
+                    kernel->impl().register_kernel_elf_paths_with_watcher(*device);
 
-                    if (enable_persistent_kernel_cache && kernel->binaries_exist_on_disk(device)) {
+                    if (enable_persistent_kernel_cache && kernel->impl().binaries_exist_on_disk(device)) {
                         if (not detail::HashLookup::inst().exists(kernel_hash)) {
                             detail::HashLookup::inst().add(kernel_hash);
                             detail::HashLookup::inst().add_generated_bin(kernel_hash);
@@ -1439,7 +1440,7 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
 
     for (auto &kernels : kernels_) {
         for (auto &[id, kernel] : kernels) {
-            launch_build_step([kernel, device] { kernel->read_binaries(device); }, events);
+            launch_build_step([kernel, device] { kernel->impl().read_binaries(device); }, events);
         }
     }
     sync_events();

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -33,6 +33,7 @@
 #include "data_types.hpp"
 #include "device.hpp"
 #include "impl/context/metal_context.hpp"
+#include "kernels/kernel_impl.hpp"
 #include "dispatch/dispatch_settings.hpp"
 #include "device/device_impl.hpp"
 #include "hal_types.hpp"

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -221,12 +221,11 @@ static inline json get_kernels_json(chip_id_t device_id, const Program& program)
     for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
         auto kernel = tt::tt_metal::detail::GetKernel(program, kernel_id).get();
         if (kernel->processor() == RISCV::COMPUTE) {
-            ComputeKernel* computeKernel = static_cast<ComputeKernel*>(kernel);
-            MathFidelity mathFidelity = std::get<ComputeConfig>(computeKernel->config()).math_fidelity;
+            MathFidelity mathFidelity = std::get<ComputeConfig>(kernel->config()).math_fidelity;
             json computeKernelObj;
             computeKernelObj["math_fidelity"] = fmt::format("{}", magic_enum::enum_name(mathFidelity));
-            computeKernelObj["source"] = computeKernel->kernel_source().source_;
-            computeKernelObj["name"] = computeKernel->get_full_kernel_name();
+            computeKernelObj["source"] = kernel->kernel_source().source_;
+            computeKernelObj["name"] = kernel->get_full_kernel_name();
             computeKernels.push_back(computeKernelObj);
             if (device != nullptr) {
                 if (kernelSizes["trisc_0_max_kernel_size"] < kernel->get_binary_packed_size(device, 0)) {


### PR DESCRIPTION
### Problem description
Some Kernel methods and all the the subclasses shouldn't be exposed to API consumers, but we have nowhere else to put them besides api/tt-metalium/kernel.hpp.

### What's changed
Split some parts of Kernel (particularly those related to binaries) into a KernelImpl subclass, and make all the existing subclasses subclasses of that. Put KernelImpl and those subclasses into tt_metal/impl/kernels/kernel_impl.hpp. Add a static method to downcast from a Kernel to a KernelImpl.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes