### PR TITLE
 #22219: Reduce init cleanup - first pass

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -942,6 +942,7 @@ INPUT                  = tt_metal/hw/inc/compile_time_args.h \
                          tt_metal/include/compute_kernel_api/eltwise_unary/trigonometry.h \
                          tt_metal/include/compute_kernel_api/bcast.h \
                          tt_metal/include/compute_kernel_api/cb_api.h \
+                         tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h \
                          tt_metal/include/compute_kernel_api/eltwise_binary.h \
                          tt_metal/include/compute_kernel_api/matmul.h \
                          tt_metal/include/compute_kernel_api/pack.h \

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/compute.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/compute.rst
@@ -1,6 +1,8 @@
 Compute APIs
 ============
 
+This page will soon contain the summary of tt-metal concepts relevant for the usage of Compute API.
+
 .. toctree::
 
   copy_tile
@@ -32,6 +34,7 @@ Compute APIs
   erfinv_tile
   gelu_tile
   heaviside_tile
+  compute_kernel_hw_startup
   isinf_tile
   isnan_tile
   i0_tile

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/compute_kernel_hw_startup.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/compute_kernel_hw_startup.rst
@@ -1,0 +1,5 @@
+compute_kernel_hw_startup
+=========================
+
+.. doxygenfunction:: compute_kernel_hw_startup(uint32_t icb0, uint32_t icb1, uint32_t ocb)
+.. doxygenfunction:: compute_kernel_hw_startup(uint32_t icb0, uint32_t ocb)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/reduce_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/reduce_tile.rst
@@ -1,4 +1,5 @@
 reduce_tile
 ===========
 
-.. doxygenfunction:: reduce_tile(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)
+.. doxygenfunction:: reduce_init
+.. doxygenfunction:: reduce_tile

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -60,7 +60,6 @@ enum ReduceDim : uint8_t { H = 0, W = 1, HW = 2 };
 
 enum ReduceType : uint8_t { SUM = 0, AVG = 1, MAX = 2 };
 struct ReduceConfig {
-    bool short_init = false;
     tt_metal::Tile tile_shape = tt_metal::Tile({TILE_HEIGHT, TILE_WIDTH});
     std::vector<uint32_t> shape;
     ReduceDim reduce_dim;
@@ -79,7 +78,6 @@ struct ReduceConfig {
     bool fp32_dest_acc_en = false;
     // Whether or not to sync full/half DST between MATH and PACK:
     bool dst_full_sync_en = false;
-    bool at_start = false;
     MathFidelity math_fidelity = MathFidelity::HiFi4;
 };
 
@@ -349,7 +347,6 @@ void run_single_core_reduce_program(tt_metal::IDevice* device, const ReduceConfi
         uint(Ht),
         uint(Wt),
         uint(NC),
-        test_config.at_start,
     };
 
     std::map<string, string> reduce_defines = {{"REDUCE_DIM", get_reduce_dim_define_string(test_config.reduce_dim)}};
@@ -366,9 +363,6 @@ void run_single_core_reduce_program(tt_metal::IDevice* device, const ReduceConfi
             reduce_defines["REDUCE_OP"] = "PoolType::MAX";
             break;
         }
-    }
-    if (test_config.short_init) {
-        reduce_defines["SHORT_INIT"] = "1";
     }
     reduce_defines["MATH_ONLY"] = test_config.math_only_reduce ? "1" : "0";
     reduce_defines["DST_ACCUM_MODE"] = test_config.fp32_dest_acc_en ? "1" : "0";
@@ -447,15 +441,13 @@ void run_single_core_reduce_program(tt_metal::IDevice* device, const ReduceConfi
     EXPECT_TRUE(pass);
     log_info(
         LogTest,
-        "TileDimH = {}, TileDimW = {}, MathFid = {}, ReduceType = {}, FP32DestAcc = {}, DstSyncFull = {}, at_start = "
-        "{}",
+        "TileDimH = {}, TileDimW = {}, MathFid = {}, ReduceType = {}, FP32DestAcc = {}, DstSyncFull = {}",
         test_config.tile_shape.get_tile_shape()[0],
         test_config.tile_shape.get_tile_shape()[1],
         test_config.math_fidelity,
         test_config.reduce_type,
         test_config.fp32_dest_acc_en,
-        test_config.dst_full_sync_en,
-        test_config.at_start);
+        test_config.dst_full_sync_en);
 }
 
 }  // namespace unit_tests::compute::reduce
@@ -477,25 +469,22 @@ TEST_F(DeviceFixture, TensixComputeReduceH) {
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 for (bool dst_full_sync_en : {true, false}) {
-                    for (bool at_start : {true, false}) {
-                        ReduceConfig test_config = {
-                            .shape = shape,
-                            .reduce_dim = ReduceDim::H,
-                            .reduce_type = ReduceType(reduce_type),
-                            .data_gen_rand_max = 10.0f,
-                            .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                            .data_gen_offset = -10.0f,
-                            .atol = 1e-2f,
-                            .rtol = 0.08f,
-                            .golden_function = ::unit_tests::compute::gold_reduce_h,
-                            .result_shape = result_shape,
-                            .fp32_dest_acc_en = fp32_dest_acc_en,
-                            .dst_full_sync_en = dst_full_sync_en,
-                            .at_start = at_start,
-                            .math_fidelity = MathFidelity(math_fid),
-                        };
-                        run_single_core_reduce_program(this->devices_.at(0), test_config);
-                    }
+                    ReduceConfig test_config = {
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::H,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = ::unit_tests::compute::gold_reduce_h,
+                        .result_shape = result_shape,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid),
+                    };
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
                 }
             }
         }
@@ -516,25 +505,22 @@ TEST_F(DeviceFixture, TensixComputeReduceW) {
                     continue;
                 }
                 for (bool dst_full_sync_en : {true, false}) {
-                    for (bool at_start : {true, false}) {
-                        ReduceConfig test_config = {
-                            .shape = shape,
-                            .reduce_dim = ReduceDim::W,
-                            .reduce_type = ReduceType(reduce_type),
-                            .data_gen_rand_max = 10.0f,
-                            .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                            .data_gen_offset = -10.0f,
-                            .atol = 1e-2f,
-                            .rtol = 0.08f,
-                            .golden_function = ::unit_tests::compute::gold_reduce_w,
-                            .result_shape = result_shape,
-                            .fp32_dest_acc_en = fp32_dest_acc_en,
-                            .dst_full_sync_en = dst_full_sync_en,
-                            .at_start = at_start,
-                            .math_fidelity = MathFidelity(math_fid),
-                        };
-                        run_single_core_reduce_program(this->devices_.at(0), test_config);
-                    }
+                    ReduceConfig test_config = {
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::W,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = ::unit_tests::compute::gold_reduce_w,
+                        .result_shape = result_shape,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid),
+                    };
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
                 }
             }
         }
@@ -556,24 +542,21 @@ TEST_F(DeviceFixture, TensixComputeReduceHW) {
                     continue;
                 }
                 for (bool dst_full_sync_en : {true, false}) {
-                    for (bool at_start : {true, false}) {
-                        ReduceConfig test_config = {
-                            .shape = shape,
-                            .reduce_dim = ReduceDim::HW,
-                            .reduce_type = ReduceType(reduce_type),
-                            .data_gen_rand_max = 10.0f,
-                            .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                            .data_gen_offset = -10.0f,
-                            .atol = 1e-2f,
-                            .rtol = 0.08f,
-                            .golden_function = ::unit_tests::compute::gold_reduce_hw,
-                            .result_shape = result_shape,
-                            .fp32_dest_acc_en = fp32_dest_acc_en,
-                            .dst_full_sync_en = dst_full_sync_en,
-                            .at_start = at_start,
-                            .math_fidelity = MathFidelity(math_fid)};
-                        run_single_core_reduce_program(this->devices_.at(0), test_config);
-                    }
+                    ReduceConfig test_config = {
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::HW,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = ::unit_tests::compute::gold_reduce_hw,
+                        .result_shape = result_shape,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid)};
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
                 }
             }
         }
@@ -595,25 +578,22 @@ TEST_F(DeviceFixture, TensixComputeReduceHMathOnly) {
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 for (bool dst_full_sync_en : {true, false}) {
-                    for (bool at_start : {true, false}) {
-                        ReduceConfig test_config = {
-                            .shape = shape,
-                            .reduce_dim = ReduceDim::H,
-                            .reduce_type = ReduceType(reduce_type),
-                            .data_gen_rand_max = 10.0f,
-                            .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                            .data_gen_offset = -10.0f,
-                            .atol = 1e-2f,
-                            .rtol = 0.08f,
-                            .golden_function = ::unit_tests::compute::gold_reduce_h,
-                            .result_shape = result_shape,
-                            .math_only_reduce = true,
-                            .fp32_dest_acc_en = fp32_dest_acc_en,
-                            .dst_full_sync_en = dst_full_sync_en,
-                            .at_start = at_start,
-                            .math_fidelity = MathFidelity(math_fid)};
-                        run_single_core_reduce_program(this->devices_.at(0), test_config);
-                    }
+                    ReduceConfig test_config = {
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::H,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = ::unit_tests::compute::gold_reduce_h,
+                        .result_shape = result_shape,
+                        .math_only_reduce = true,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid)};
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
                 }
             }
         }
@@ -634,32 +614,29 @@ TEST_F(DeviceFixture, TensixComputeReduceWMathOnly) {
                     continue;
                 }
                 for (bool dst_full_sync_en : {true, false}) {
-                    for (bool at_start : {true, false}) {
-                        ReduceConfig test_config = {
-                            .shape = shape,
-                            .reduce_dim = ReduceDim::W,
-                            .reduce_type = ReduceType(reduce_type),
-                            .data_gen_rand_max = 10.0f,
-                            .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                            .data_gen_offset = -10.0f,
-                            .atol = 1e-2f,
-                            .rtol = 0.08f,
-                            .golden_function = ::unit_tests::compute::gold_reduce_w,
-                            .result_shape = result_shape,
-                            .math_only_reduce = true,
-                            .fp32_dest_acc_en = fp32_dest_acc_en,
-                            .dst_full_sync_en = dst_full_sync_en,
-                            .at_start = at_start,
-                            .math_fidelity = MathFidelity(math_fid)};
-                        run_single_core_reduce_program(this->devices_.at(0), test_config);
-                    }
+                    ReduceConfig test_config = {
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::W,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = ::unit_tests::compute::gold_reduce_w,
+                        .result_shape = result_shape,
+                        .math_only_reduce = true,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid)};
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
                 }
             }
         }
     }
 }
-// Disabled due to GH issue #14510
-TEST_F(DeviceFixture, DISABLED_TensixComputeReduceHWMathOnly) {
+
+TEST_F(DeviceFixture, TensixComputeReduceHWMathOnly) {
     std::vector<uint32_t> shape = {1, 2, 7 * TILE_HEIGHT, 5 * TILE_WIDTH};
     std::vector<uint32_t> result_shape = {shape[0], shape[1], 32, 32};
     for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
@@ -674,144 +651,22 @@ TEST_F(DeviceFixture, DISABLED_TensixComputeReduceHWMathOnly) {
                     continue;
                 }
                 for (bool dst_full_sync_en : {true, false}) {
-                    for (bool at_start : {true, false}) {
-                        ReduceConfig test_config = {
-                            .shape = shape,
-                            .reduce_dim = ReduceDim::HW,
-                            .reduce_type = ReduceType(reduce_type),
-                            .data_gen_rand_max = 10.0f,
-                            .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                            .data_gen_offset = -10.0f,
-                            .atol = 1e-2f,
-                            .rtol = 0.08f,
-                            .golden_function = ::unit_tests::compute::gold_reduce_hw,
-                            .result_shape = result_shape,
-                            .math_only_reduce = true,
-                            .fp32_dest_acc_en = fp32_dest_acc_en,
-                            .dst_full_sync_en = dst_full_sync_en,
-                            .at_start = at_start,
-                            .math_fidelity = MathFidelity(math_fid)};
-                        run_single_core_reduce_program(this->devices_.at(0), test_config);
-                    }
-                }
-            }
-        }
-    }
-}
-
-TEST_F(DeviceFixture, TensixComputeReduceHShortInit) {
-    if (this->arch_ != tt::ARCH::BLACKHOLE) {
-        // (issue #10181: disabling due to sporadic failures in slow dispatch mode)
-        GTEST_SKIP();
-    }
-    std::vector<uint32_t> shape = {1, 3, 19 * TILE_HEIGHT, 17 * TILE_WIDTH};
-    std::vector<uint32_t> result_shape = {shape[0], shape[1], TILE_HEIGHT, shape[3]};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
-        // MathFidelity : {0, 2, 3, 4}; so skip value 1
-        if (math_fid == 1) {
-            continue;
-        }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
-            for (bool fp32_dest_acc_en : {true, false}) {
-                for (bool dst_full_sync_en : {true, false}) {
-                    for (bool at_start : {true, false}) {
-                        ReduceConfig test_config = {
-                            .short_init = true,
-                            .shape = shape,
-                            .reduce_dim = ReduceDim::H,
-                            .reduce_type = ReduceType(reduce_type),
-                            .data_gen_rand_max = 10.0f,
-                            .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                            .data_gen_offset = -10.0f,
-                            .atol = 1e-2f,
-                            .rtol = 0.08f,
-                            .golden_function = ::unit_tests::compute::gold_reduce_h,
-                            .result_shape = result_shape,
-                            .fp32_dest_acc_en = fp32_dest_acc_en,
-                            .dst_full_sync_en = dst_full_sync_en,
-                            .at_start = at_start,
-                            .math_fidelity = MathFidelity(math_fid)};
-                        run_single_core_reduce_program(this->devices_.at(0), test_config);
-                    }
-                }
-            }
-        }
-    }
-}
-
-TEST_F(DeviceFixture, TensixComputeReduceWShortInit) {
-    std::vector<uint32_t> shape = {1, 3, 17 * TILE_HEIGHT, 19 * TILE_WIDTH};
-    std::vector<uint32_t> result_shape = {shape[0], shape[1], shape[2], 32};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
-        // MathFidelity : {0, 2, 3, 4}; so skip value 1
-        if (math_fid == 1) {
-            continue;
-        }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
-            for (bool fp32_dest_acc_en : {true, false}) {
-                if ((fp32_dest_acc_en) && (this->arch_ == tt::ARCH::GRAYSKULL)) {
-                    continue;
-                }
-                for (bool dst_full_sync_en : {true, false}) {
-                    for (bool at_start : {true, false}) {
-                        ReduceConfig test_config = {
-                            .short_init = true,
-                            .shape = shape,
-                            .reduce_dim = ReduceDim::W,
-                            .reduce_type = ReduceType(reduce_type),
-                            .data_gen_rand_max = 10.0f,
-                            .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                            .data_gen_offset = -10.0f,
-                            .atol = 1e-2f,
-                            .rtol = 0.08f,
-                            .golden_function = ::unit_tests::compute::gold_reduce_w,
-                            .result_shape = result_shape,
-                            .fp32_dest_acc_en = fp32_dest_acc_en,
-                            .dst_full_sync_en = dst_full_sync_en,
-                            .at_start = at_start,
-                            .math_fidelity = MathFidelity(math_fid)};
-                        run_single_core_reduce_program(this->devices_.at(0), test_config);
-                    }
-                }
-            }
-        }
-    }
-}
-// Disabled due to GH issue #14510
-TEST_F(DeviceFixture, DISABLED_TensixComputeReduceHWShortInit) {
-    std::vector<uint32_t> shape = {1, 2, 7 * TILE_HEIGHT, 5 * TILE_WIDTH};
-    std::vector<uint32_t> result_shape = {shape[0], shape[1], 32, 32};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
-        // MathFidelity : {0, 2, 3, 4}; so skip value 1
-        if (math_fid == 1) {
-            continue;
-        }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
-            for (bool fp32_dest_acc_en : {true, false}) {
-                // Currently fp32 dest unsupported with reduce scalar
-                if (fp32_dest_acc_en) {
-                    continue;
-                }
-                for (bool dst_full_sync_en : {true, false}) {
-                    for (bool at_start : {true, false}) {
-                        ReduceConfig test_config = {
-                            .short_init = true,
-                            .shape = shape,
-                            .reduce_dim = ReduceDim::HW,
-                            .reduce_type = ReduceType(reduce_type),
-                            .data_gen_rand_max = 10.0f,
-                            .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                            .data_gen_offset = -10.0f,
-                            .atol = 1e-2f,
-                            .rtol = 0.08f,
-                            .golden_function = ::unit_tests::compute::gold_reduce_hw,
-                            .result_shape = result_shape,
-                            .fp32_dest_acc_en = fp32_dest_acc_en,
-                            .dst_full_sync_en = dst_full_sync_en,
-                            .at_start = at_start,
-                            .math_fidelity = MathFidelity(math_fid)};
-                        run_single_core_reduce_program(this->devices_.at(0), test_config);
-                    }
+                    ReduceConfig test_config = {
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::HW,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = ::unit_tests::compute::gold_reduce_hw,
+                        .result_shape = result_shape,
+                        .math_only_reduce = true,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid)};
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
                 }
             }
         }
@@ -833,68 +688,23 @@ TEST_F(DeviceFixture, TensixComputeReduceWTinyTiles) {
                     continue;
                 }
                 for (bool dst_full_sync_en : {true, false}) {
-                    for (bool at_start : {true, false}) {
-                        ReduceConfig test_config = {
-                            .tile_shape = tile_shape,
-                            .shape = shape,
-                            .reduce_dim = ReduceDim::W,
-                            .reduce_type = ReduceType(reduce_type),
-                            .data_gen_rand_max = 0.0f,
-                            .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                            .data_gen_offset = 1.0f,
-                            .atol = 1e-2f,
-                            .rtol = 0.08f,
-                            .golden_function = ::unit_tests::compute::gold_reduce_w,
-                            .result_shape = result_shape,
-                            .fp32_dest_acc_en = fp32_dest_acc_en,
-                            .dst_full_sync_en = dst_full_sync_en,
-                            .at_start = at_start,
-                            .math_fidelity = MathFidelity(math_fid),
-                        };
-                        run_single_core_reduce_program(this->devices_.at(0), test_config);
-                    }
-                }
-            }
-        }
-    }
-}
-
-TEST_F(DeviceFixture, TensixComputeReduceWTinyTilesShortInit) {
-    tt_metal::Tile tile_shape = tt_metal::Tile({TILE_HEIGHT / 2, TILE_WIDTH});
-    std::vector<uint32_t> shape = {1, 1, 1 * tile_shape.get_tile_shape()[0], 13 * tile_shape.get_tile_shape()[1]};
-    std::vector<uint32_t> result_shape = {shape[0], shape[1], shape[2], tile_shape.get_tile_shape()[1]};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
-        // MathFidelity : {0, 2, 3, 4}; so skip value 1
-        if (math_fid == 1) {
-            continue;
-        }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
-            for (bool fp32_dest_acc_en : {true, false}) {
-                if ((fp32_dest_acc_en) && (this->arch_ == tt::ARCH::GRAYSKULL)) {
-                    continue;
-                }
-                for (bool dst_full_sync_en : {true, false}) {
-                    for (bool at_start : {true, false}) {
-                        ReduceConfig test_config = {
-                            .short_init = true,
-                            .tile_shape = tile_shape,
-                            .shape = shape,
-                            .reduce_dim = ReduceDim::W,
-                            .reduce_type = ReduceType(reduce_type),
-                            .data_gen_rand_max = 0.0f,
-                            .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                            .data_gen_offset = 1.0f,
-                            .atol = 1e-2f,
-                            .rtol = 0.08f,
-                            .golden_function = ::unit_tests::compute::gold_reduce_w,
-                            .result_shape = result_shape,
-                            .fp32_dest_acc_en = fp32_dest_acc_en,
-                            .dst_full_sync_en = dst_full_sync_en,
-                            .at_start = at_start,
-                            .math_fidelity = MathFidelity(math_fid),
-                        };
-                        run_single_core_reduce_program(this->devices_.at(0), test_config);
-                    }
+                    ReduceConfig test_config = {
+                        .tile_shape = tile_shape,
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::W,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 0.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = 1.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = ::unit_tests::compute::gold_reduce_w,
+                        .result_shape = result_shape,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid),
+                    };
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
                 }
             }
         }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
@@ -98,7 +98,7 @@ void MAIN {
          */
         ACQ();
         cb_reserve_back(cb_ex, 1 * onetile);
-        reduce_init_delta<false>(cb_x, cb_scaler, cb_ex);
+        reduce_init(cb_x, cb_scaler, cb_ex);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_x, wt + blk);
             for (uint32_t j = 0; j < blk; j++) {
@@ -107,7 +107,7 @@ void MAIN {
             // we don't pop cb_x until we compute Ex
         }
         pack_tile(dst0, cb_ex);
-        reduce_revert_delta(cb_ex);
+        reduce_uninit();
         REL();
 
         cb_push_back(cb_ex, 1);
@@ -154,7 +154,7 @@ void MAIN {
          * TODO(AP): can save space here by reusing CB
          */
         cb_reserve_back(cb_ex2, 1);
-        reduce_init_delta<false>(cb_xmm2, cb_scaler, cb_ex2);
+        reduce_init(cb_xmm2, cb_scaler, cb_ex2);
         ACQ();
         cb_wait_front(cb_xmm2, Wt);
         // cb_wait_front(cb_xmm, Wt);
@@ -167,7 +167,7 @@ void MAIN {
         }
         cb_pop_front(cb_xmm2, Wt);
         pack_tile(dst0, cb_ex2);
-        reduce_revert_delta(cb_ex2);
+        reduce_uninit();
         REL();
 
         cb_push_back(cb_ex2, 1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/max_pool.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/max_pool.cpp
@@ -77,7 +77,7 @@ inline void reduce_h(
     uint32_t out_cb_id) {
     cb_wait_front(in_cb_id, in_ntiles_hwc * out_nelems);
     cb_reserve_back(out_cb_id, out_ntiles_c * out_nelems);
-    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_COL>(in_cb_id, in_scalar_cb_id, out_cb_id);
+    reduce_init<PoolType::MAX, ReduceDim::REDUCE_COL>(in_cb_id, in_scalar_cb_id, out_cb_id);
     uint32_t base_tile_id = 0;
     for (uint32_t c_i = 0; c_i < in_ntiles_c * out_nelems; ++c_i) {
         // add to accumulator all the in_ntiles_hw in a column of tiles
@@ -91,7 +91,7 @@ inline void reduce_h(
         release_dst();
         base_tile_id += in_ntiles_hw;
     }
-    reduce_revert_delta(out_cb_id);
+    reduce_uninit();
     cb_push_back(out_cb_id, out_ntiles_c * out_nelems);
     cb_pop_front(in_cb_id, in_ntiles_hwc * out_nelems);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/max_pool_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/max_pool_multi_core.cpp
@@ -77,7 +77,7 @@ inline void reduce_h(
     uint32_t out_cb_id) {
     cb_wait_front(in_cb_id, in_ntiles_hwc * out_nelems);
     cb_reserve_back(out_cb_id, out_ntiles_c * out_nelems);
-    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_COL>(in_cb_id, in_scalar_cb_id, out_cb_id);
+    reduce_init<PoolType::MAX, ReduceDim::REDUCE_COL>(in_cb_id, in_scalar_cb_id, out_cb_id);
     uint32_t base_tile_id = 0;
     for (uint32_t c_i = 0; c_i < in_ntiles_c * out_nelems; ++c_i) {
         // add to accumulator all the in_ntiles_hw in a column of tiles
@@ -91,7 +91,7 @@ inline void reduce_h(
         release_dst();
         base_tile_id += in_ntiles_hw;
     }
-    reduce_revert_delta(out_cb_id);
+    reduce_uninit();
     cb_push_back(out_cb_id, out_ntiles_c * out_nelems);
     cb_pop_front(in_cb_id, in_ntiles_hwc * out_nelems);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
@@ -6,50 +6,13 @@
 
 #include "compute_kernel_api/reduce.h"
 
-/* This dummy initialization function is called prior to reduce_init to ensure proper
- * initialization of the HW and to test reduce_init_short/reduce_init_delta calls.
- *
- * - If SHORT_INIT is defined, this function provides API calls
- *   which initialize the HW properly when supplemented with reduce_init_short or
- *   reduce_init_delta (note that these two inits are the same except for the "at_start"
- *   argument; reference reduce.h for more details).
- * - If SHORT_INIT is not defined, only the PACK configuration function is called with
- *   a negative value of the defined "at_start" template argument because full reduce_init
- *   provides other API calls.
- *
- * If "at_start = 1", the value that is passed to llk_pack_reduce_config_v2 is 0.
- * If "at_start = 0", the value that is passed to llk_pack_reduce_config_v2 is 1.
- *
- * After dummy_init is called, the proper reduce init call will be invoked with the defined
- * value of the argument, not the negated value. This will ensure that the "at_start"
- * argument is tested. Reference llk_pack_reduce_config_v2 for more details.
- */
-template <bool at_start, PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void dummy_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
-#ifdef SHORT_INIT
-    UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb, icb_scaler)));
-
-    MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb_scaler)));
-
-    PACK((llk_pack_init()));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
-#endif
-    PACK((llk_pack_reduce_config_v2<reduce_dim, DST_ACCUM_MODE, !at_start, false>(ocb)));
-}
-
 namespace NAMESPACE {
 void MAIN {
     constexpr uint32_t Ht = get_compile_time_arg_val(0);
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
-    constexpr bool at_start = get_compile_time_arg_val(3);
-    dummy_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
-#ifndef SHORT_INIT
-    reduce_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
-#else
-    reduce_init_delta<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
-#endif
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
+    reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
 
     cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {
@@ -79,8 +42,6 @@ void MAIN {
             release_dst();
         }
     }
-#ifdef SHORT_INIT
-    reduce_revert_delta(tt::CBIndex::c_16);
-#endif
+    reduce_uninit();
 }
 }  // namespace NAMESPACE

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
@@ -6,50 +6,13 @@
 
 #include "compute_kernel_api/reduce.h"
 
-/* This dummy initialization function is called prior to reduce_init to ensure proper
- * initialization of the HW and to test reduce_init_short/reduce_init_delta calls.
- *
- * - If SHORT_INIT is defined, this function provides API calls
- *   which initialize the HW properly when supplemented with reduce_init_short or
- *   reduce_init_delta (note that these two inits are the same except for the "at_start"
- *   argument; reference reduce.h for more details).
- * - If SHORT_INIT is not defined, only the PACK configuration function is called with
- *   a negative value of the defined "at_start" template argument because full reduce_init
- *   provides other API calls.
- *
- * If "at_start = 1", the value that is passed to llk_pack_reduce_config_v2 is 0.
- * If "at_start = 0", the value that is passed to llk_pack_reduce_config_v2 is 1.
- *
- * After dummy_init is called, the proper reduce init call will be invoked with the defined
- * value of the argument, not the negated value. This will ensure that the "at_start"
- * argument is tested. Reference llk_pack_reduce_config_v2 for more details.
- */
-template <bool at_start, PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void dummy_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
-#ifdef SHORT_INIT
-    UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb, icb_scaler)));
-
-    MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb_scaler)));
-
-    PACK((llk_pack_init()));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
-#endif
-    PACK((llk_pack_reduce_config_v2<reduce_dim, DST_ACCUM_MODE, !at_start, false>(ocb)));
-}
-
 namespace NAMESPACE {
 void MAIN {
     constexpr uint32_t Ht = get_compile_time_arg_val(0);
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
-    constexpr bool at_start = get_compile_time_arg_val(3);
-    dummy_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
-#ifndef SHORT_INIT
-    reduce_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
-#else
-    reduce_init_delta<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
-#endif
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
+    reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
 
     cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {
@@ -78,8 +41,6 @@ void MAIN {
         cb_push_back(tt::CBIndex::c_16, onetile);
         release_dst();
     }
-#ifdef SHORT_INIT
-    reduce_revert_delta(tt::CBIndex::c_16);
-#endif
+    reduce_uninit();
 }
 }  // namespace NAMESPACE

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
@@ -6,50 +6,13 @@
 
 #include "compute_kernel_api/reduce.h"
 
-/* This dummy initialization function is called prior to reduce_init to ensure proper
- * initialization of the HW and to test reduce_init_short/reduce_init_delta calls.
- *
- * - If SHORT_INIT is defined, this function provides API calls
- *   which initialize the HW properly when supplemented with reduce_init_short or
- *   reduce_init_delta (note that these two inits are the same except for the "at_start"
- *   argument; reference reduce.h for more details).
- * - If SHORT_INIT is not defined, only the PACK configuration function is called with
- *   a negative value of the defined "at_start" template argument because full reduce_init
- *   provides other API calls.
- *
- * If "at_start = 1", the value that is passed to llk_pack_reduce_config_v2 is 0.
- * If "at_start = 0", the value that is passed to llk_pack_reduce_config_v2 is 1.
- *
- * After dummy_init is called, the proper reduce init call will be invoked with the defined
- * value of the argument, not the negated value. This will ensure that the "at_start"
- * argument is tested. Reference llk_pack_reduce_config_v2 for more details.
- */
-template <bool at_start, PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void dummy_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
-#ifdef SHORT_INIT
-    UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb, icb_scaler)));
-
-    MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb_scaler)));
-
-    PACK((llk_pack_init()));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
-#endif
-    PACK((llk_pack_reduce_config_v2<reduce_dim, DST_ACCUM_MODE, !at_start, false>(ocb)));
-}
-
 namespace NAMESPACE {
 void MAIN {
     constexpr uint32_t Ht = get_compile_time_arg_val(0);
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
-    constexpr bool at_start = get_compile_time_arg_val(3);
-    dummy_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
-#ifndef SHORT_INIT
-    reduce_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
-#else
-    reduce_init_delta<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
-#endif
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
+    reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
 
     cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {
@@ -79,8 +42,6 @@ void MAIN {
             release_dst();
         }
     }
-#ifdef SHORT_INIT
-    reduce_revert_delta(tt::CBIndex::c_16);
-#endif
+    reduce_uninit();
 }
 }  // namespace NAMESPACE

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
@@ -111,7 +111,7 @@ void MAIN {
          * compute E[(x)^2]
          */
         cb_reserve_back(cb_ex2, 1);
-        reduce_init_delta<false>(cb_x2, cb_scaler, cb_ex2);
+        reduce_init(cb_x2, cb_scaler, cb_ex2);
         ACQ();
         cb_wait_front(cb_x2, Wt);
         // cb_wait_front(cb_xmm, Wt);
@@ -123,7 +123,7 @@ void MAIN {
             // reduce_tile(cb_xmm, cb_scaler, wt+wtr, scaler0, dst0);
         }
         cb_pop_front(cb_x2, Wt);
-        reduce_revert_delta(cb_ex2);
+        reduce_uninit();
         pack_tile(dst0, cb_ex2);
         REL();
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
@@ -125,13 +125,13 @@ void MAIN {
 
         ACQ();
         cb_reserve_back(cb_recipsumexps, onetile);
-        reduce_init_delta<false>(cb_exps, cb_bcast_scaler, cb_recipsumexps);
+        reduce_init(cb_exps, cb_bcast_scaler, cb_recipsumexps);
         for (uint32_t wt = 0; wt < Wt; wt++) {
             cb_wait_front(cb_exps, wt + 1);        // must be a cumulative wait for correctness
             constexpr uint32_t bcast_scaler0 = 0;  // 0th index from bcast_scaler CB
             reduce_tile(cb_exps, cb_bcast_scaler, wt, bcast_scaler0, dst0);
         }
-        reduce_revert_delta(cb_recipsumexps);
+        reduce_uninit();
         recip_tile_init();
         recip_tile(dst0);  // DST[0] = 1/sum(exp(x))
         pack_tile(dst0, cb_recipsumexps);

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/compute/cross_entropy_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/compute/cross_entropy_bw_kernel.cpp
@@ -173,7 +173,7 @@ void reduce_max_value() {
     const uint32_t reduction_register = 0;
     tile_regs_acquire();
     reconfig_data_format(cb_max_value_before_reduction, cb_reduction_scaler);
-    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_ROW>(
+    reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>(
         cb_max_value_before_reduction, cb_reduction_scaler, cb_max_value_after_reduction);
     reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW>(
         cb_max_value_before_reduction,
@@ -181,7 +181,7 @@ void reduce_max_value() {
         /* tile_idx */ 0,
         /* tile_idx */ 0,
         reduction_register);
-    reduce_revert_delta<ReduceDim::REDUCE_ROW>(cb_max_value_after_reduction);
+    reduce_uninit();
     tile_regs_commit();
 
     tile_regs_wait();
@@ -330,7 +330,7 @@ void reduce_sum_exp_x() {
     const uint32_t reduction_register = 0;
 
     // reconfig_data_format(cb_exp_sum_before_reduction, cb_reduction_scaler);
-    // reduce_init_delta<false, PoolType::SUM, ReduceDim::REDUCE_ROW>(
+    // reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(
     //     cb_exp_sum_before_reduction, cb_reduction_scaler, cb_exp_sum_after_reduction);
     // reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(
     //     cb_exp_sum_before_reduction,
@@ -338,7 +338,7 @@ void reduce_sum_exp_x() {
     //     /* tile_idx */ 0,
     //     /* tile_idx */ 0,
     //     /* reduction_register */ reduction_register);
-    // reduce_revert_delta<ReduceDim::REDUCE_ROW>(cb_exp_sum_after_reduction);
+    // reduce_uninit();
 
     // We used matmul_tiles instead of reduce_tile, because reduce_tile causes a loss of precision. The same issue has
     // been observed in moreh’s ops.

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/compute/cross_entropy_fw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/compute/cross_entropy_fw_kernel.cpp
@@ -164,7 +164,7 @@ void reduce_max_value() {
     const uint32_t reduction_register = 0;
     tile_regs_acquire();
     reconfig_data_format(cb_max_value_before_reduction, cb_scaler);
-    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_ROW>(
+    reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>(
         cb_max_value_before_reduction, cb_scaler, cb_max_value_after_reduction);
     reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW>(
         cb_max_value_before_reduction,
@@ -172,7 +172,7 @@ void reduce_max_value() {
         /* tile_idx */ 0,
         /* tile_idx */ 0,
         reduction_register);
-    reduce_revert_delta<ReduceDim::REDUCE_ROW>(cb_max_value_before_reduction);
+    reduce_uninit();
     tile_regs_commit();
 
     tile_regs_wait();
@@ -315,7 +315,7 @@ void reduce_log_sum_exp_x() {
     tile_regs_acquire();
     const uint32_t reduction_register = 0;
     reconfig_data_format(cb_exp_sum_before_reduction, cb_scaler);
-    reduce_init_delta<false, PoolType::SUM, ReduceDim::REDUCE_ROW>(
+    reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(
         cb_exp_sum_before_reduction, cb_scaler, cb_exp_sum_after_reduction);
     reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(
         cb_exp_sum_before_reduction,
@@ -323,7 +323,7 @@ void reduce_log_sum_exp_x() {
         /* tile_idx */ 0,
         /* tile_idx */ 0,
         /* reduction_register */ reduction_register);
-    reduce_revert_delta<ReduceDim::REDUCE_ROW>(cb_exp_sum_before_reduction);
+    reduce_uninit();
 
     // log(sum(exp(x - max(x))))
     log_tile_init();

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/kernels/compute/rmsnorm_fw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/kernels/compute/rmsnorm_fw_kernel.cpp
@@ -297,7 +297,7 @@ void MAIN {
 
             const uint32_t reduction_register = 0;
             reconfig_data_format(cb_rms_before_reduction_intermediate, cb_scaler);
-            reduce_init_delta<false, PoolType::SUM, ReduceDim::REDUCE_ROW>(
+            reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(
                 cb_rms_before_reduction_intermediate, cb_scaler, cb_rms_after_reduction_intermediate);
             reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(
                 cb_rms_before_reduction_intermediate,
@@ -305,7 +305,7 @@ void MAIN {
                 /* tile_idx */ 0,
                 /* tile_idx */ 0,
                 reduction_register);
-            reduce_revert_delta<ReduceDim::REDUCE_ROW>(cb_rms_before_reduction_intermediate);
+            reduce_uninit();
 
             const uint32_t eps_register = 1U;
             reconfig_data_format_srca(cb_eps);

--- a/tt-train/sources/ttml/metal/ops/softmax/device/kernels/compute/softmax_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/kernels/compute/softmax_kernel.cpp
@@ -173,7 +173,7 @@ void reduce_max_value() {
     const uint32_t reduction_register = 0;
     tile_regs_acquire();
     reconfig_data_format(cb_max_value_before_reduction, cb_reduction_scaler);
-    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_ROW>(
+    reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>(
         cb_max_value_before_reduction, cb_reduction_scaler, cb_max_value_after_reduction);
     reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW>(
         cb_max_value_before_reduction,
@@ -181,7 +181,7 @@ void reduce_max_value() {
         /* tile_idx */ 0,
         /* tile_idx */ 0,
         reduction_register);
-    reduce_revert_delta<ReduceDim::REDUCE_ROW>(cb_max_value_after_reduction);
+    reduce_uninit();
     tile_regs_commit();
 
     tile_regs_wait();
@@ -341,7 +341,7 @@ void reduce_sum_exp_x() {
     const uint32_t reduction_register = 0;
 
     // reconfig_data_format(cb_exp_sum_before_reduction, cb_reduction_scaler);
-    // reduce_init_delta<false, PoolType::SUM, ReduceDim::REDUCE_ROW>(
+    // reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(
     //     cb_exp_sum_before_reduction, cb_reduction_scaler, cb_exp_sum_after_reduction);
     // reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(
     //     cb_exp_sum_before_reduction,
@@ -349,7 +349,7 @@ void reduce_sum_exp_x() {
     //     /* tile_idx */ 0,
     //     /* tile_idx */ 0,
     //     /* reduction_register */ reduction_register);
-    // reduce_revert_delta<ReduceDim::REDUCE_ROW>(cb_exp_sum_after_reduction);
+    // reduce_uninit();
 
     // We used matmul_tiles instead of reduce_tile, because reduce_tile causes a loss of precision. The same issue has
     // been observed in moreh’s ops.

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -151,6 +151,7 @@ target_sources(
             include/compute_kernel_api/cb_api.h
             include/compute_kernel_api/common.h
             include/compute_kernel_api/common_globals.h
+            include/compute_kernel_api/compute_kernel_hw_startup.h
             include/compute_kernel_api/eltwise_binary.h
             include/compute_kernel_api/eltwise_unary/eltwise_unary.h
             include/compute_kernel_api/eltwise_unary/exp.h

--- a/tt_metal/include/compute_kernel_api/common.h
+++ b/tt_metal/include/compute_kernel_api/common.h
@@ -9,6 +9,7 @@
 #include "compute_kernel_api/pack.h"
 #include "compute_kernel_api/reconfig_data_format.h"
 #include "compute_kernel_api/cb_api.h"
+#include "compute_kernel_api/compute_kernel_hw_startup.h"
 
 extern uint32_t tt_l1_ptr* rta_l1_base;
 extern uint32_t tt_l1_ptr* crta_l1_base;

--- a/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h
+++ b/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common.h"
+
+#ifdef TRISC_UNPACK
+#include "llk_unpack_AB_api.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs the required hardware initialization for all subsequent operations in the compute kernel. This function should be
+ * called exactly once at the very beginning of the kernel, before any operation-specific initialization functions (such as
+ * reduce_init, tilize_init, etc.). The circular buffer (CB) IDs provided to this function must match those used in the next
+ * operation-specific initialization function. If the operands for the next operation require a different data format than
+ * what was configured here, you must call one of the reconfig_data_format functions before proceeding with the next
+ * initialization. Similarly, if the next operation requires different properties (such as tile or face dimensions), you must
+ * ensure that the same CB IDs are used as in this function.
+ *
+ * NOTE: This function performs MMIO writes, which are slow and almost exclusively require the idle state of the execution
+ * units that should be configured (PACK, MATH, UNPACK, CFG, etc.). This is why it is unsafe to call this function in the
+ * middle of a kernel execution. This function should be called only once at the beginning of the kernel, before any other
+ * calls to Compute API are made (either init or other). Calling this function after other API calls may lead cause race
+ * conditions and undefined behavior which can be hard to debug.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name  | Description                                                     | Type     | Valid Range | Required |
+ * |------------|-------|-----------------------------------------------------------------|----------|-------------|----------|
+ * | Function   | icb0  | The identifier of the circular buffer (CB) containing operand A | uint32_t | 0 to 31     | True     |
+ * | Function   | icb1  | The identifier of the circular buffer (CB) containing operand B | uint32_t | 0 to 31     | True     |
+ * | Function   | ocb   | The identifier of the output circular buffer (CB)               | uint32_t | 0 to 31     | True     |
+ */
+// clang-format on
+ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
+    UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
+
+    MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
+    MATH((llk_math_hw_configure_disaggregated<false /*untilize*/, false /*skip_inputs*/>(icb0, icb1)));
+
+    PACK((llk_pack_init<false /*untilize*/, false /*zero_output*/, false /*tilize*/>(ocb)));
+    PACK((llk_pack_hw_configure_disaggregated<
+          DST_ACCUM_MODE,
+          false /*untilize*/,
+          ReluType::NO_RELU,
+          0 /*relu_treshold*/,
+          false /*tilize*/>(ocb)));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false /*untilize*/>(ocb)));
+}
+
+// clang-format off
+/**
+ * Convenience overload for hardware initialization when only one input circular buffer is used.
+ * Both input operands (srcA and srcB) will be programmed using the same circular buffer identifier (`icb0`).
+ * Internally, this calls the three-parameter version with `icb0` passed for both input operands.
+ *
+ * | Param Type | Name  | Description                                                        | Type     | Valid Range | Required |
+ * |------------|-------|--------------------------------------------------------------------|----------|-------------|----------|
+ * | Function   | icb0  | The identifier of the circular buffer (CB) used for both input ops | uint32_t | 0 to 31     | True     |
+ * | Function   | ocb   | The identifier of the output circular buffer (CB)                  | uint32_t | 0 to 31     | True     |
+ */
+// clang-format on
+ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t ocb) { compute_kernel_hw_startup(icb0, icb0, ocb); }
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -15,85 +15,110 @@
 
 namespace ckernel {
 
-template <bool at_start, PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
+// clang-format off
+/**
+ * Performs the necessary hardware and software initialization for reduce operation for provided circular buffer identifiers (CB IDs). In order for reduce
+ * operation to be performed, this function call must be followed by a call to `reduce_tile` or `reduce_tile_math`.
+ * If another reduce op is needed which uses different CB IDs, then another reduce_init needs to be called as a part of that reduce operation.
+ *
+ * The `icb_scaler` circular buffer must contain the scaling factors for the reduction. The most straightforward way of filling the `icb_scaler` with the scaling
+ * factors is to populate first row of each face with the followin values:
+ * - If `reduce_type = SUM`, all scaling factors should preferably be 1.
+ * - If `reduce_type = AVG`, all scaling factors should preferably be 1/N (where N is the number of elements being averaged, except if the reduction dimension is scalar,
+ * in which case the scaling factor should be 1/sqrt(N)).
+ * - If `reduce_type = MAX`, all scaling factors should preferably be 1.
+ *
+ * NOTE: For SUM and AVG operations, the value in `icb_scaler` is a scaling factor of the final sum of values across rows/columns/both, so there is no real constraint in terms
+ * of it's value. For MAX operation, maximum value will be obtained as expected, but it will be scaled by the values in `icb_scaler`. In any case, it is recommended to use the
+ * above-mentioned scaling factors to ensure that operations function as intended. Refer to ISA documentation for more details.
+ * NOTE: For other valid ways of populating the `icb_scaler`, refer to the ISA documentation.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name         | Description                                                     | Type      | Valid Range                                    | Required |
+ * |------------|--------------|-----------------------------------------------------------------|-----------|------------------------------------------------|----------|
+ * | Template   | reduce_type  | The type of reduce op - sum, average or maximum                 | PoolType  | {SUM, AVG, MAX}                                | True     |
+ * | Template   | reduce_dim   | The dimension of reduce op - row, column or both                | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
+ * | Function   | icb          | The identifier of the circular buffer (CB) containing operand A | uint32_t  | 0 to 31                                        | True     |
+ * | Function   | icb_scaler   | CB holding scaling factors (see above)                          | uint32_t  | 0 to 31                                        | True     |
+ * | Function   | ocb          | The identifier of the output circular buffer (CB)               | uint32_t  | 0 to 31                                        | True     |
+ */
+// clang-format on
+template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
 ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
-    UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb, icb_scaler)));
-    UNPACK((llk_unpack_AB_reduce_init<reduce_dim>(icb, icb_scaler)));
-
-    MATH((llk_math_reduce_init<reduce_type, reduce_dim, MATH_FIDELITY>()));
-    MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb_scaler)));
-
-    PACK((llk_pack_init()));
-    PACK((llk_pack_reduce_config_v2<reduce_dim, DST_ACCUM_MODE, at_start, false>(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
-}
-
-template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_init_short(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
     UNPACK((llk_unpack_AB_reduce_init<reduce_dim>(icb, icb_scaler)));
     MATH((llk_math_reduce_init<reduce_type, reduce_dim, MATH_FIDELITY>()));
-    PACK((llk_pack_reduce_config_v2<reduce_dim, DST_ACCUM_MODE, false, false>(ocb)));
-}
-
-template <bool at_start, PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_init_delta(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
-    // FIXME: API Update needed in compute kernel?
-    UNPACK((llk_unpack_AB_reduce_init<reduce_dim>(icb0, icb1)));
-    MATH((llk_math_reduce_init<reduce_type, reduce_dim, MATH_FIDELITY>()));
-    PACK((llk_pack_reduce_config_v2<reduce_dim, DST_ACCUM_MODE, at_start, false>(ocb)));
-}
-
-template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_init_delta_no_pack(uint32_t icb0, uint32_t icb1) {
-    // FIXME: API Update needed in compute kernel?
-    UNPACK((llk_unpack_AB_init<>(icb0, icb1)));
-
-    MATH((llk_math_reduce_init<reduce_type, reduce_dim, MATH_FIDELITY>()));
-}
-
-template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_init_delta_math() {
-    MATH((llk_math_reduce_init<reduce_type, reduce_dim, MATH_FIDELITY>()));
-}
-
-template <ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_revert_delta(uint32_t ocb) {
-    PACK((llk_pack_reduce_config_v2<reduce_dim, DST_ACCUM_MODE, false, true>(ocb)));
+    PACK((llk_pack_reduce_mask_config<false /*untilize*/, reduce_dim>()));
 }
 
 // clang-format off
 /**
- * Performs a reduction operation *B = reduce(A)* using reduce_func for
- * dimension reduction on a tile in the CB at a given index and writes the
- * result to the DST register at index *dst_tile_index*. Reduction can be
- * either of type *Reduce::R*, *Reduce::C* or *Reduce::RC*, identifying the
- * dimension(s) to be reduced in size to 1. The DST register buffer must be in
- * acquired state via *acquire_dst* call.
+ * Resets the packer edge mask configuration to its default state by clearing any previously set masks. Needs to be called after
+ * reduce_tile if the next operation requires default packer state. In case that the next operation is reduce operation across the
+ * same dimension, this call can be omitted. If this function is not called, the packer will continue to use the edge masks set
+ * by the latest reduce_init call, which may lead to incorrect packing behavior in subsequent operations.
  *
- * The templates takes reduce_type which can be ReduceFunc::Sum, ReduceFunc::Max
- * and reduce_dim which can be Reduce::R, Reduce::C, Reduce::RC.
- * They can also be specified by defines REDUCE_OP and REDUCE_DIM.
+ * NOTE: This function is not in line with our programming model, and will be removed by the end of 2025.
  *
- * This call is blocking and is only available on the compute engine.
+ * | Param Type | Name | Description                                      | Type | Valid Range | Required |
+ * |------------|------|--------------------------------------------------|------|-------------|----------|
+ * | Function   | —    | No parameters                                    |  —   |      —      |    —     |
+ */
+// clang-format on
+ALWI void reduce_uninit() { PACK((llk_pack_reduce_mask_clear())); }
+
+// clang-format off
+/**
+ * Performs a reduction operation *B = reduce(A)* using reduce_func for dimension reduction on a tile in the CB at a given index and writes the
+ * result to the DST register at index *dst_tile_index*. Reduction can be of type *Reduce::R*, *Reduce::C*, or *Reduce::RC*, identifying the
+ * dimension(s) to be reduced in size to 1. The DST register buffer must be in acquired state via *acquire_dst* call.
  *
+ * The `icb_scaler` circular buffer must contain the scaling factors for the reduction. The most straightforward way of filling the `icb_scaler` with the scaling
+ * factors is to populate first row of each face with the followin values:
+ * - If `reduce_type = SUM`, all scaling factors should preferably be 1.
+ * - If `reduce_type = AVG`, all scaling factors should preferably be 1/N (where N is the number of elements being averaged, except if the reduction dimension is scalar,
+ * in which case the scaling factor should be 1/sqrt(N)).
+ * - If `reduce_type = MAX`, all scaling factors should preferably be 1.
+ *
+ * The templates take `reduce_type` which can be `ReduceFunc::Sum`, `ReduceFunc::Avg`, or `ReduceFunc::Max` and `reduce_dim` which can be `Reduce::R`, `Reduce::C`, or
+ * `Reduce::RC`. They can also be specified by defines REDUCE_OP and REDUCE_DIM.
+ *
+ * NOTE: Before the next operation is initialized, the `reduce_uninit` function must be called to reset the packer state to default.
+ * NOTE: For SUM and AVG operations, the value in `icb_scaler` is a scaling factor of the final sum of values across rows/columns/both, so there is no real constraint in terms
+ * of it's value. For MAX operation, maximum value will be obtained as expected, but it will be scaled by the values in `icb_scaler`. In any case, it is recommended to use the
+ * above-mentioned scaling factors to ensure that operations function as intended. Refer to ISA documentation for more details.
+ * NOTE: For other valid ways of populating the `icb_scaler`, refer to the ISA documentation.
  * Return value: None
  *
- * | Argument       | Description                                                     | Type     | Valid Range                                    | Required |
- * |----------------|-----------------------------------------------------------------|----------|------------------------------------------------|----------|
- * | icb0           | The identifier of the circular buffer (CB) containing A         | uint32_t | 0 to 31                                        | True     |
- * | icb1           | CB for Scaling factor applied to each element of the result.    | uint32_t | 0 to 31                                        | True     |
- * | itile0         | The index of the tile within the first CB                       | uint32_t | Must be less than the size of the CB           | True     |
- * | itile1         | The index of the tile within the scaling factor CB.             | uint32_t | Must be less than the size of the CB           | True     |
- * | idst           | The index of the tile in DST REG for the result                 | uint32_t | Must be less than the acquired size of DST REG | True     |
+ * | Param Type | Name     | Description                                                     | Type     | Valid Range                                    | Required |
+ * |------------|----------|-----------------------------------------------------------------|----------|------------------------------------------------|----------|
+ * | Template   | reduce_type | The type of reduce op - sum, average or maximum              | PoolType | {SUM, AVG, MAX}                                | True     |
+ * | Template   | reduce_dim  | The dimension of reduce op - row, column or both             | ReduceDim| {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
+ * | Function   | icb      | The identifier of the circular buffer (CB) containing operand A | uint32_t | 0 to 31                                        | True     |
+ * | Function   | icb_scaler  | CB holding scaling factors (see above)                          | uint32_t | 0 to 31                                        | True     |
+ * | Function   | itile    | The index of the tile within the first CB                       | uint32_t | Must be less than the size of the CB           | True     |
+ * | Function   | itile_sclaer | The index of the tile within the scaling factor CB.             | uint32_t | Must be less than the size of the CB           | True     |
+ * | Function   | idst     | The index of the tile in DST REG for the result                 | uint32_t | Must be less than the acquired size of DST REG | True     |
  */
 // clang-format on
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_tile(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst) {
-    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(icb0, icb1, idst)));
-    UNPACK((llk_unpack_AB(icb0, icb1, itile0, itile1)));
+ALWI void reduce_tile(uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_t itile_sclaer, uint32_t idst) {
+    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(icb, icb_scaler, idst)));
+    UNPACK((llk_unpack_AB(icb, icb_scaler, itile, itile_sclaer)));
 }
 
+// clang-format off
+/**
+ * Performs a math-only reduction operation on a tile in the DST register. Assumes that source tiles are already in source registers.
+ *
+ * | Param Type | Name         | Description                                                     | Type      | Valid Range                                    | Required |
+ * |------------|--------------|-----------------------------------------------------------------|-----------|------------------------------------------------|----------|
+ * | Template   | reduce_type  | The type of reduce op - sum, average or maximum                 | PoolType  | {SUM, AVG, MAX}                                | True     |
+ * | Template   | reduce_dim   | The dimension of reduce op - row, column or both                | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
+ * | Function   | idst         | The index of the tile in DST REG for the result                 | uint32_t  | Must be less than the acquired size of DST REG | True     |
+ * | Function   | num_faces    | Number of faces to reduce (optional, default 4)                 | uint32_t  | >= 1                                           | False    |
+ */
+// clang-format on
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
 ALWI void reduce_tile_math(uint32_t idst, uint32_t num_faces = 4) {
     MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(idst, num_faces)));

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/ssm_1d_sum_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/ssm_1d_sum_reduce.cpp
@@ -37,9 +37,9 @@ FORCE_INLINE void reduce(uint32_t cb_in, uint32_t cb_scalar, uint32_t cb_out) {
     tile_regs_acquire();
     tile_regs_wait();
 
-    reduce_init_delta<false, REDUCE_OP, REDUCE_DIM>(cb_in, cb_scalar, cb_out);
+    reduce_init<REDUCE_OP, REDUCE_DIM>(cb_in, cb_scalar, cb_out);
     reduce_tile(cb_in, cb_scalar, 0, 0, 0);
-    reduce_revert_delta<REDUCE_DIM>(cb_out);
+    reduce_uninit();
 
     cb_reserve_back(cb_out, ONE_TILE);
     pack_tile(0, cb_out);
@@ -63,8 +63,9 @@ void MAIN {
     constexpr uint32_t intermed_cb_id2 = get_compile_time_arg_val(4);
     constexpr uint32_t output_cb_id = get_compile_time_arg_val(5);
 
-    reduce_init<true>(input_cb_id, scalar_cb_id, intermed_cb_id1);
-    reduce_revert_delta<REDUCE_DIM>(intermed_cb_id1);  // Required or else the first tile is wrong
+    compute_kernel_hw_startup(input_cb_id, scalar_cb_id, intermed_cb_id1);
+    reduce_init(input_cb_id, scalar_cb_id, intermed_cb_id1);
+    reduce_uninit();  // Required or else the first tile is wrong
 
     for (uint32_t block_h_id = 0; block_h_id < input_num_blocks_h; block_h_id++) {
         cb_wait_front(scalar_cb_id, ONE_TILE);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
@@ -134,9 +134,9 @@ void MAIN {
     cb_wait_front(cb_xpowadd, onetile);
     cb_reserve_back(cb_y, onetile);
 
-    reduce_init_delta<false>(cb_xpowadd, cb_one, cb_y);
+    reduce_init(cb_xpowadd, cb_one, cb_y);
     reduce_tile(cb_xpowadd, cb_one, 0, 0, dst0);
-    reduce_revert_delta(cb_y);
+    reduce_uninit();
     tile_regs_commit();
 
     tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
@@ -47,10 +47,10 @@ void MAIN {
         }
 
         cb_wait_front(tt::CBIndex::c_24, onetile);
-        reduce_init_delta<false>(tt::CBIndex::c_24, tt::CBIndex::c_2, tt::CBIndex::c_16);
+        reduce_init(tt::CBIndex::c_24, tt::CBIndex::c_2, tt::CBIndex::c_16);
         reduce_tile(tt::CBIndex::c_24, tt::CBIndex::c_2, 0, 0, 0);
         cb_pop_front(tt::CBIndex::c_24, onetile);
-        reduce_revert_delta(tt::CBIndex::c_16);
+        reduce_uninit();
 
         if (last_out) {
             cb_reserve_back(tt::CBIndex::c_16, onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_large_kernel.cpp
@@ -162,9 +162,9 @@ void MAIN {
         cb_wait_front(cb_xsum, onetile);
         cb_reserve_back(cb_ex, onetile);
 
-        reduce_init_delta_with_dt<false>(cb_ex, cb_xsum, cb_scaler);
+        reduce_init_delta_with_dt(cb_ex, cb_xsum, cb_scaler);
         reduce_tile(cb_xsum, cb_scaler, first_tile, first_tile, dst0);
-        reduce_revert_delta(cb_ex);
+        reduce_uninit();
 
         tile_regs_commit();
 
@@ -325,9 +325,9 @@ void MAIN {
         cb_wait_front(cb_xmm2sum, onetile);
         cb_reserve_back(cb_var, onetile);
 
-        reduce_init_delta_with_dt<false>(cb_var, cb_xmm2sum, cb_scaler);
+        reduce_init_delta_with_dt(cb_var, cb_xmm2sum, cb_scaler);
         reduce_tile(cb_xmm2sum, cb_scaler, first_tile, first_tile, dst0);
-        reduce_revert_delta(cb_var);
+        reduce_uninit();
         tile_regs_commit();
 
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_small_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_small_kernel.cpp
@@ -169,9 +169,9 @@ void MAIN {
         cb_wait_front(cb_xsum, onetile);
         cb_reserve_back(cb_ex, onetile);
 
-        reduce_init_delta_with_dt<false>(cb_ex, cb_xsum, cb_scaler);
+        reduce_init_delta_with_dt(cb_ex, cb_xsum, cb_scaler);
         reduce_tile(cb_xsum, cb_scaler, first_tile, first_tile, dst0);
-        reduce_revert_delta(cb_ex);
+        reduce_uninit();
         tile_regs_commit();
 
         tile_regs_wait();
@@ -306,9 +306,9 @@ void MAIN {
         cb_wait_front(cb_xmm2sum, onetile);
         cb_reserve_back(cb_var, onetile);
 
-        reduce_init_delta_with_dt<false>(cb_var, cb_xmm2sum, cb_scaler);
+        reduce_init_delta_with_dt(cb_var, cb_xmm2sum, cb_scaler);
         reduce_tile(cb_xmm2sum, cb_scaler, first_tile, first_tile, dst0);
-        reduce_revert_delta(cb_var);
+        reduce_uninit();
         tile_regs_commit();
 
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_gamma_beta_grad_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_gamma_beta_grad_kernel.cpp
@@ -274,9 +274,9 @@ void MAIN {
 
             if (is_lastdim_layernorm || is_groupnorm) {
                 // Sum[y * dy]
-                reduce_init_delta_with_dt<false>(cb_dgamma, cb_ydyadd, cb_scaler);
+                reduce_init_delta_with_dt(cb_dgamma, cb_ydyadd, cb_scaler);
                 reduce_tile(cb_ydyadd, cb_scaler, 0, 0, dst0);
-                reduce_revert_delta(cb_dgamma);
+                reduce_uninit();
             } else {
                 // Just copy
                 copy_tile_init_with_dt(cb_ydyadd);
@@ -300,9 +300,9 @@ void MAIN {
 
             if (is_lastdim_layernorm || is_groupnorm) {
                 // Sum[dy]
-                reduce_init_delta_with_dt<false>(cb_dbeta, cb_dyadd, cb_scaler);
+                reduce_init_delta_with_dt(cb_dbeta, cb_dyadd, cb_scaler);
                 reduce_tile(cb_dyadd, cb_scaler, 0, 0, dst0);
-                reduce_revert_delta(cb_dbeta);
+                reduce_uninit();
             } else {
                 // Just copy
                 copy_tile_init_with_dt(cb_dyadd);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_large_kernel.cpp
@@ -308,9 +308,9 @@ void MAIN {
         cb_wait_front(cb_dyadd, onetile);
         cb_reserve_back(cb_dysum, onetile);
 
-        reduce_init_delta_with_dt<false>(cb_dysum, cb_dyadd, cb_scaler);
+        reduce_init_delta_with_dt(cb_dysum, cb_dyadd, cb_scaler);
         reduce_tile(cb_dyadd, cb_scaler, 0, 0, dst0);
-        reduce_revert_delta(cb_dysum);
+        reduce_uninit();
         tile_regs_commit();
 
         tile_regs_wait();
@@ -326,9 +326,9 @@ void MAIN {
         cb_wait_front(cb_ydyadd, onetile);
         cb_reserve_back(cb_ydysum, onetile);
 
-        reduce_init_delta_with_dt<false>(cb_ydysum, cb_ydyadd, cb_scaler);
+        reduce_init_delta_with_dt(cb_ydysum, cb_ydyadd, cb_scaler);
         reduce_tile(cb_ydyadd, cb_scaler, 0, 0, dst0);
-        reduce_revert_delta(cb_ydysum);
+        reduce_uninit();
         tile_regs_commit();
 
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_small_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_small_kernel.cpp
@@ -277,9 +277,9 @@ void MAIN {
         cb_wait_front(cb_dyadd, onetile);
         cb_reserve_back(cb_dysum, onetile);
 
-        reduce_init_delta_with_dt<false>(cb_dysum, cb_dyadd, cb_scaler);
+        reduce_init_delta_with_dt(cb_dysum, cb_dyadd, cb_scaler);
         reduce_tile(cb_dyadd, cb_scaler, 0, 0, dst0);
-        reduce_revert_delta(cb_dysum);
+        reduce_uninit();
         tile_regs_commit();
 
         tile_regs_wait();
@@ -351,9 +351,9 @@ void MAIN {
         cb_wait_front(cb_ydyadd, onetile);
         cb_reserve_back(cb_ydysum, onetile);
 
-        reduce_init_delta_with_dt<false>(cb_ydysum, cb_ydyadd, cb_scaler);
+        reduce_init_delta_with_dt(cb_ydysum, cb_ydyadd, cb_scaler);
         reduce_tile(cb_ydyadd, cb_scaler, 0, 0, dst0);
-        reduce_revert_delta(cb_ydysum);
+        reduce_uninit();
         tile_regs_commit();
 
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_multi_core_h.cpp
@@ -102,9 +102,9 @@ void MAIN {
 #if defined FP32_DEST_ACC_EN
                 reconfig_data_format(cb_reduce, cb_scaler);
 #endif
-                reduce_init_delta<false>(cb_reduce, cb_scaler, cb_out0);
+                reduce_init(cb_reduce, cb_scaler, cb_out0);
                 reduce_tile(cb_reduce, cb_scaler, 0, 0, 0);
-                reduce_revert_delta(cb_out0);
+                reduce_uninit();
 
                 if (do_mask) {
                     cb_pop_front(cb_intermed0, onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_single_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_single_core_hw.cpp
@@ -101,9 +101,9 @@ void MAIN {
 #if defined FP32_DEST_ACC_EN
                 reconfig_data_format(cb_reduce, cb_scaler);
 #endif
-                reduce_init_delta<false>(cb_reduce, cb_scaler, cb_out0);
+                reduce_init(cb_reduce, cb_scaler, cb_out0);
                 reduce_tile((do_mask) ? (cb_intermed0) : (cb_in0), cb_scaler, 0, 0, 0);
-                reduce_revert_delta(cb_out0);
+                reduce_uninit();
 
                 if (do_mask) {
                     cb_pop_front(cb_intermed0, onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp
@@ -48,13 +48,13 @@ void MAIN {
 
             if (!is_h_single_tile) {
                 tile_regs_acquire();
-                reduce_init_delta_with_dt<false, REDUCE_OP, REDUCE_DIM>(cb_accum_dst, cb_input, cb_scaler);
+                reduce_init_delta_with_dt<REDUCE_OP, REDUCE_DIM>(cb_accum_dst, cb_input, cb_scaler);
                 for (uint32_t ht = 0; ht < Ht - 1; ++ht) {
                     cb_wait_front(cb_input, onetile);
                     reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
                     cb_pop_front(cb_input, onetile);
                 }
-                reduce_revert_delta(cb_accum_dst);
+                reduce_uninit();
                 cb_reserve_back(cb_accum_dst, onetile);
                 tile_regs_commit();
 
@@ -96,9 +96,9 @@ void MAIN {
                 copy_tile(cb_accum_dst, 0, reduce_dst_idx);
             }
 
-            reduce_init_delta_with_dt<false, REDUCE_OP, REDUCE_DIM>(cb_out, cb_input, cb_scaler);
+            reduce_init_delta_with_dt<REDUCE_OP, REDUCE_DIM>(cb_out, cb_input, cb_scaler);
             reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
-            reduce_revert_delta(cb_out);
+            reduce_uninit();
             tile_regs_commit();
 
             cb_reserve_back(cb_out, onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
@@ -131,9 +131,9 @@ void MAIN {
         cb_wait_front(cb_xpowadd, onetile);
         cb_reserve_back(cb_xpowsum, onetile);
 
-        reduce_init_delta_with_dt<false>(cb_xpowsum, cb_xpowadd, cb_one);
+        reduce_init_delta_with_dt(cb_xpowsum, cb_xpowadd, cb_one);
         reduce_tile(cb_xpowadd, cb_one, 0, 0, dst0);
-        reduce_revert_delta(cb_xpowsum);
+        reduce_uninit();
         tile_regs_commit();
 
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
@@ -131,9 +131,9 @@ void MAIN {
         cb_wait_front(cb_xpowadd, onetile);
         cb_reserve_back(cb_xpowsum, onetile);
 
-        reduce_init_delta_with_dt<false>(cb_xpowsum, cb_xpowadd, cb_one);
+        reduce_init_delta_with_dt(cb_xpowsum, cb_xpowadd, cb_one);
         reduce_tile(cb_xpowadd, cb_one, 0, 0, dst0);
-        reduce_revert_delta(cb_xpowsum);
+        reduce_uninit();
         tile_regs_commit();
 
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
@@ -136,9 +136,9 @@ void MAIN {
         cb_wait_front(cb_cal, onetile);
         cb_reserve_back(cb_reduce, onetile);
 
-        reduce_init_delta_with_dt<false, REDUCE_OP, REDUCE_DIM>(cb_reduce, cb_cal, cb_one);
+        reduce_init_delta_with_dt<REDUCE_OP, REDUCE_DIM>(cb_reduce, cb_cal, cb_one);
         reduce_tile(cb_cal, cb_one, 0, 0, dst0);
-        reduce_revert_delta(cb_reduce);
+        reduce_uninit();
         tile_regs_commit();
 
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
@@ -134,9 +134,9 @@ void MAIN {
         cb_wait_front(cb_cal, onetile);
         cb_reserve_back(cb_reduce, onetile);
 
-        reduce_init_delta_with_dt<false, REDUCE_OP, REDUCE_DIM>(cb_reduce, cb_cal, cb_one);
+        reduce_init_delta_with_dt<REDUCE_OP, REDUCE_DIM>(cb_reduce, cb_cal, cb_one);
         reduce_tile(cb_cal, cb_one, 0, 0, dst0);
-        reduce_revert_delta(cb_reduce);
+        reduce_uninit();
         tile_regs_commit();
 
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp
@@ -38,10 +38,9 @@ void MAIN {
         if (Ht == 1) {
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/0, /*popm=*/0);
 
-            reduce_tile_to_cb<false, PoolType::MAX, REDUCE_DIM>(
-                cb_tmp, cb_bcast_scaler, cb_max, Ht, /*pop0=*/1, /*pop1=*/0);
+            reduce_tile_to_cb<PoolType::MAX, REDUCE_DIM>(cb_tmp, cb_bcast_scaler, cb_max, Ht, /*pop0=*/1, /*pop1=*/0);
         } else {
-            reduce_tile_to_cb<false, PoolType::MAX, REDUCE_DIM>(
+            reduce_tile_to_cb<PoolType::MAX, REDUCE_DIM>(
                 cb_in0, cb_bcast_scaler, cb_max, Ht - 1, /*pop0=*/0, /*pop1=*/0);
 
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, Ht - 1, 0, /*pop0=*/0, /*popm=*/0);
@@ -54,9 +53,9 @@ void MAIN {
             copy_tile(cb_max, 0, dst0);
 
             constexpr uint32_t bcast_scaler0 = 0;  // 0th index from bcast_scaler CB
-            reduce_init_delta_with_dt<false, PoolType::MAX, REDUCE_DIM>(cb_max, cb_tmp, cb_bcast_scaler);
+            reduce_init_delta_with_dt<PoolType::MAX, REDUCE_DIM>(cb_max, cb_tmp, cb_bcast_scaler);
             reduce_tile<PoolType::MAX, REDUCE_DIM>(cb_tmp, cb_bcast_scaler, 0, bcast_scaler0, dst0);
-            reduce_revert_delta(cb_max);
+            reduce_uninit();
             tile_regs_commit();
 
             tile_regs_wait();
@@ -120,11 +119,11 @@ void MAIN {
 
 #ifdef LOG
         // log(sum)
-        reduce_and_log_tile_to_cb<false, PoolType::SUM, REDUCE_DIM>(
+        reduce_and_log_tile_to_cb<PoolType::SUM, REDUCE_DIM>(
             cb_exps, cb_bcast_scaler, cb_recipsumexps, Ht, /*pop0=*/Ht, /*pop1=*/0);
 #else
         // 1/sum
-        reduce_and_recip_tile_to_cb<false, PoolType::SUM, REDUCE_DIM>(
+        reduce_and_recip_tile_to_cb<PoolType::SUM, REDUCE_DIM>(
             cb_exps, cb_bcast_scaler, cb_recipsumexps, Ht, /*pop0=*/0, /*pop1=*/0);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp
@@ -34,13 +34,12 @@ void MAIN {
         if (Ht == 1) {
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/1, /*popm=*/0);
 
-            reduce_tile_to_cb<false, PoolType::MAX, REDUCE_DIM>(
-                cb_tmp, cb_bcast_scaler, cb_max, Ht, /*pop0=*/1, /*pop1=*/0);
+            reduce_tile_to_cb<PoolType::MAX, REDUCE_DIM>(cb_tmp, cb_bcast_scaler, cb_max, Ht, /*pop0=*/1, /*pop1=*/0);
         } else {
             cb_reserve_back(cb_max, onetile);
 
             tile_regs_acquire();
-            reduce_init_delta_with_dt<false, PoolType::MAX, REDUCE_DIM>(cb_max, cb_in0, cb_bcast_scaler);
+            reduce_init_delta_with_dt<PoolType::MAX, REDUCE_DIM>(cb_max, cb_in0, cb_bcast_scaler);
             for (uint32_t h = 0; h < Ht - 1; ++h) {
                 cb_wait_front(cb_in0, onetile);
 
@@ -49,7 +48,7 @@ void MAIN {
 
                 cb_pop_front(cb_in0, onetile);
             }
-            reduce_revert_delta(cb_max);
+            reduce_uninit();
             tile_regs_commit();
 
             tile_regs_wait();
@@ -68,9 +67,9 @@ void MAIN {
             copy_tile(cb_max, 0, dst0);
 
             constexpr uint32_t bcast_scaler0 = 0;  // 0th index from bcast_scaler CB
-            reduce_init_delta_with_dt<false, PoolType::MAX, REDUCE_DIM>(cb_max, cb_tmp, cb_bcast_scaler);
+            reduce_init_delta_with_dt<PoolType::MAX, REDUCE_DIM>(cb_max, cb_tmp, cb_bcast_scaler);
             reduce_tile<PoolType::MAX, REDUCE_DIM>(cb_tmp, cb_bcast_scaler, 0, bcast_scaler0, dst0);
-            reduce_revert_delta(cb_max);
+            reduce_uninit();
             tile_regs_commit();
 
             tile_regs_wait();
@@ -127,11 +126,11 @@ void MAIN {
 
 #ifdef LOG
         // compute log(sum)
-        reduce_and_log_tile_to_cb<false, PoolType::SUM, REDUCE_DIM>(
+        reduce_and_log_tile_to_cb<PoolType::SUM, REDUCE_DIM>(
             cb_add, cb_bcast_scaler, cb_recipsumexps, /*size=*/1, /*pop0=*/1, /*pop1=*/0);
 #else
         // compute 1/sum(exp(x))
-        reduce_and_recip_tile_to_cb<false, PoolType::SUM, REDUCE_DIM>(
+        reduce_and_recip_tile_to_cb<PoolType::SUM, REDUCE_DIM>(
             cb_add, cb_bcast_scaler, cb_recipsumexps, /*size=*/1, /*pop0=*/1, /*pop1=*/0);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
@@ -39,10 +39,9 @@ void MAIN {
         if (Wt == 1) {
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/0, /*popm=*/0);
 
-            reduce_tile_to_cb<false, PoolType::MAX, REDUCE_DIM>(
-                cb_tmp, cb_bcast_scaler, cb_max, Wt, /*pop0=*/1, /*pop1=*/0);
+            reduce_tile_to_cb<PoolType::MAX, REDUCE_DIM>(cb_tmp, cb_bcast_scaler, cb_max, Wt, /*pop0=*/1, /*pop1=*/0);
         } else {
-            reduce_tile_to_cb<false, PoolType::MAX, REDUCE_DIM>(
+            reduce_tile_to_cb<PoolType::MAX, REDUCE_DIM>(
                 cb_in0, cb_bcast_scaler, cb_max, Wt - 1, /*pop0=*/0, /*pop1=*/0);
 
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, Wt - 1, 0, /*pop0=*/0, /*popm=*/0);
@@ -55,9 +54,9 @@ void MAIN {
             copy_tile(cb_max, 0, dst0);
 
             constexpr uint32_t bcast_scaler0 = 0;  // 0th index from bcast_scaler CB
-            reduce_init_delta_with_dt<false, PoolType::MAX, REDUCE_DIM>(cb_max, cb_tmp, cb_bcast_scaler);
+            reduce_init_delta_with_dt<PoolType::MAX, REDUCE_DIM>(cb_max, cb_tmp, cb_bcast_scaler);
             reduce_tile<PoolType::MAX, REDUCE_DIM>(cb_tmp, cb_bcast_scaler, 0, bcast_scaler0, dst0);
-            reduce_revert_delta(cb_max);
+            reduce_uninit();
             tile_regs_commit();
 
             tile_regs_wait();
@@ -121,11 +120,11 @@ void MAIN {
 
 #ifdef LOG
         // log(sum)
-        reduce_and_log_tile_to_cb<false, PoolType::SUM, REDUCE_DIM>(
+        reduce_and_log_tile_to_cb<PoolType::SUM, REDUCE_DIM>(
             cb_exps, cb_bcast_scaler, cb_recipsumexps, Wt, /*pop0=*/Wt, /*pop1=*/0);
 #else
         // 1/sum
-        reduce_and_recip_tile_to_cb<false, PoolType::SUM, REDUCE_DIM>(
+        reduce_and_recip_tile_to_cb<PoolType::SUM, REDUCE_DIM>(
             cb_exps, cb_bcast_scaler, cb_recipsumexps, Wt, /*pop0=*/0, /*pop1=*/0);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
@@ -34,13 +34,12 @@ void MAIN {
         if (Wt == 1) {
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/1, /*popm=*/0);
 
-            reduce_tile_to_cb<false, PoolType::MAX, REDUCE_DIM>(
-                cb_tmp, cb_bcast_scaler, cb_max, Wt, /*pop0=*/1, /*pop1=*/0);
+            reduce_tile_to_cb<PoolType::MAX, REDUCE_DIM>(cb_tmp, cb_bcast_scaler, cb_max, Wt, /*pop0=*/1, /*pop1=*/0);
         } else {
             cb_reserve_back(cb_max, onetile);
 
             tile_regs_acquire();
-            reduce_init_delta_with_dt<false, PoolType::MAX, REDUCE_DIM>(cb_max, cb_in0, cb_bcast_scaler);
+            reduce_init_delta_with_dt<PoolType::MAX, REDUCE_DIM>(cb_max, cb_in0, cb_bcast_scaler);
             for (uint32_t w = 0; w < Wt - 1; ++w) {
                 cb_wait_front(cb_in0, onetile);
 
@@ -49,7 +48,7 @@ void MAIN {
 
                 cb_pop_front(cb_in0, onetile);
             }
-            reduce_revert_delta(cb_max);
+            reduce_uninit();
             tile_regs_commit();
 
             tile_regs_wait();
@@ -68,9 +67,9 @@ void MAIN {
             copy_tile(cb_max, 0, dst0);
 
             constexpr uint32_t bcast_scaler0 = 0;  // 0th index from bcast_scaler CB
-            reduce_init_delta_with_dt<false, PoolType::MAX, REDUCE_DIM>(cb_max, cb_tmp, cb_bcast_scaler);
+            reduce_init_delta_with_dt<PoolType::MAX, REDUCE_DIM>(cb_max, cb_tmp, cb_bcast_scaler);
             reduce_tile<PoolType::MAX, REDUCE_DIM>(cb_tmp, cb_bcast_scaler, 0, bcast_scaler0, dst0);
-            reduce_revert_delta(cb_max);
+            reduce_uninit();
             tile_regs_commit();
 
             tile_regs_wait();
@@ -128,11 +127,11 @@ void MAIN {
 
 #ifdef LOG
         // compute log(sum)
-        reduce_and_log_tile_to_cb<false, PoolType::SUM, REDUCE_DIM>(
+        reduce_and_log_tile_to_cb<PoolType::SUM, REDUCE_DIM>(
             cb_add, cb_bcast_scaler, cb_recipsumexps, /*size=*/1, /*pop0=*/1, /*pop1=*/0);
 #else
         // compute 1/sum(exp(x))
-        reduce_and_recip_tile_to_cb<false, PoolType::SUM, REDUCE_DIM>(
+        reduce_and_recip_tile_to_cb<PoolType::SUM, REDUCE_DIM>(
             cb_add, cb_bcast_scaler, cb_recipsumexps, /*size=*/1, /*pop0=*/1, /*pop1=*/0);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp
@@ -35,19 +35,17 @@ void MAIN {
             // apply mask
             mask_tile_to_cb(cb_dy, cb_mask, cb_inter2, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
-            reduce_tile_to_cb<false, REDUCE_OP, REDUCE_DIM>(
-                cb_inter2, cb_bcast_scaler, cb_sum, 1, /*pop0=*/1, /*pop=1*/ 0);
+            reduce_tile_to_cb<REDUCE_OP, REDUCE_DIM>(cb_inter2, cb_bcast_scaler, cb_sum, 1, /*pop0=*/1, /*pop=1*/ 0);
         } else {
             constexpr auto cb_inter0 = tt::CBIndex::c_24;
-            reduce_tile_to_cb<false, REDUCE_OP, REDUCE_DIM>(
+            reduce_tile_to_cb<REDUCE_OP, REDUCE_DIM>(
                 cb_dy, cb_bcast_scaler, cb_inter0, Ht - 1, /*pop0=*/0, /*pop=1*/ 0);
 
             constexpr auto cb_inter1 = tt::CBIndex::c_25;
             mask_tile_to_cb(cb_dy, cb_mask, cb_inter1, /*itile=*/Ht - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
             constexpr auto cb_inter2 = tt::CBIndex::c_26;
-            reduce_tile_to_cb<false, REDUCE_OP, REDUCE_DIM>(
-                cb_inter1, cb_bcast_scaler, cb_inter2, 1, /*pop0=*/1, /*pop=1*/ 0);
+            reduce_tile_to_cb<REDUCE_OP, REDUCE_DIM>(cb_inter1, cb_bcast_scaler, cb_inter2, 1, /*pop0=*/1, /*pop=1*/ 0);
 
             add_tiles_to_cb(cb_inter0, cb_inter2, cb_sum);
         }
@@ -81,7 +79,7 @@ void MAIN {
         }
 
         // step 2, compute sum(y * dy)
-        reduce_tile_to_cb<false, REDUCE_OP, REDUCE_DIM>(cb_ydy, cb_bcast_scaler, cb_sum, Ht, /*pop0=*/Ht, /*pop=1*/ 0);
+        reduce_tile_to_cb<REDUCE_OP, REDUCE_DIM>(cb_ydy, cb_bcast_scaler, cb_sum, Ht, /*pop0=*/Ht, /*pop=1*/ 0);
 
         // step 3, compute final result
         for (uint32_t h = 0; h < Ht; ++h) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp
@@ -51,7 +51,7 @@ void MAIN {
             }
         }
 
-        reduce_tile_to_cb<false, REDUCE_OP, REDUCE_DIM>(cb_add, cb_bcast_scaler, cb_sum, 1, /*pop0=*/1, /*pop1=*/0);
+        reduce_tile_to_cb<REDUCE_OP, REDUCE_DIM>(cb_add, cb_bcast_scaler, cb_sum, 1, /*pop0=*/1, /*pop1=*/0);
 
         for (uint32_t h = 0; h < Ht; ++h) {
             // exp(y)
@@ -85,8 +85,7 @@ void MAIN {
         }
 
         // step 2, compute sum(y * dy)
-        reduce_tile_to_cb<false, REDUCE_OP, REDUCE_DIM>(
-            cb_add, cb_bcast_scaler, cb_sum, /*size=*/1, /*pop0=*/1, /*pop1=*/0);
+        reduce_tile_to_cb<REDUCE_OP, REDUCE_DIM>(cb_add, cb_bcast_scaler, cb_sum, /*size=*/1, /*pop0=*/1, /*pop1=*/0);
 
         // step 3, compute final result
         for (uint32_t h = 0; h < Ht; ++h) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp
@@ -35,19 +35,17 @@ void MAIN {
             // apply mask
             mask_tile_to_cb(cb_dy, cb_mask, cb_inter2, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
-            reduce_tile_to_cb<false, REDUCE_OP, REDUCE_DIM>(
-                cb_inter2, cb_bcast_scaler, cb_sum, 1, /*pop0=*/1, /*pop=1*/ 0);
+            reduce_tile_to_cb<REDUCE_OP, REDUCE_DIM>(cb_inter2, cb_bcast_scaler, cb_sum, 1, /*pop0=*/1, /*pop=1*/ 0);
         } else {
             constexpr auto cb_inter0 = tt::CBIndex::c_24;
-            reduce_tile_to_cb<false, REDUCE_OP, REDUCE_DIM>(
+            reduce_tile_to_cb<REDUCE_OP, REDUCE_DIM>(
                 cb_dy, cb_bcast_scaler, cb_inter0, Wt - 1, /*pop0=*/0, /*pop=1*/ 0);
 
             constexpr auto cb_inter1 = tt::CBIndex::c_25;
             mask_tile_to_cb(cb_dy, cb_mask, cb_inter1, /*itile=*/Wt - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
 
             constexpr auto cb_inter2 = tt::CBIndex::c_26;
-            reduce_tile_to_cb<false, REDUCE_OP, REDUCE_DIM>(
-                cb_inter1, cb_bcast_scaler, cb_inter2, 1, /*pop0=*/1, /*pop=1*/ 0);
+            reduce_tile_to_cb<REDUCE_OP, REDUCE_DIM>(cb_inter1, cb_bcast_scaler, cb_inter2, 1, /*pop0=*/1, /*pop=1*/ 0);
 
             add_tiles_to_cb(cb_inter0, cb_inter2, cb_sum);
         }
@@ -81,7 +79,7 @@ void MAIN {
         }
 
         // step 2, compute sum(y * dy)
-        reduce_tile_to_cb<false, REDUCE_OP, REDUCE_DIM>(cb_ydy, cb_bcast_scaler, cb_sum, Wt, /*pop0=*/Wt, /*pop=1*/ 0);
+        reduce_tile_to_cb<REDUCE_OP, REDUCE_DIM>(cb_ydy, cb_bcast_scaler, cb_sum, Wt, /*pop0=*/Wt, /*pop=1*/ 0);
 
         // step 3, compute final result
         for (uint32_t w = 0; w < Wt; w += onetile) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp
@@ -51,7 +51,7 @@ void MAIN {
             }
         }
 
-        reduce_tile_to_cb<false, REDUCE_OP, REDUCE_DIM>(cb_add, cb_bcast_scaler, cb_sum, 1, /*pop0=*/1, /*pop1=*/0);
+        reduce_tile_to_cb<REDUCE_OP, REDUCE_DIM>(cb_add, cb_bcast_scaler, cb_sum, 1, /*pop0=*/1, /*pop1=*/0);
 
         for (uint32_t w = 0; w < Wt; w += onetile) {
             // exp(y)
@@ -83,7 +83,7 @@ void MAIN {
         }
 
         // step 2, compute sum(y * dy)
-        reduce_tile_to_cb<false, REDUCE_OP, REDUCE_DIM>(cb_add, cb_bcast_scaler, cb_sum, 1, /*pop0=*/1, /*pop1=*/0);
+        reduce_tile_to_cb<REDUCE_OP, REDUCE_DIM>(cb_add, cb_bcast_scaler, cb_sum, 1, /*pop0=*/1, /*pop1=*/0);
 
         // step 3, compute final result
         for (uint32_t w = 0; w < Wt; w += onetile) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp
@@ -47,9 +47,9 @@ void MAIN {
 #if defined FP32_DEST_ACC_EN
                     reconfig_data_format(cb_input, cb_scaler);
 #endif
-                    reduce_init_delta<false>(cb_input, cb_scaler, cb_accum_dst);
+                    reduce_init(cb_input, cb_scaler, cb_accum_dst);
                     reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
-                    reduce_revert_delta(cb_accum_dst);
+                    reduce_uninit();
 
                     cb_pop_front(cb_input, onetile);
                 }
@@ -104,9 +104,9 @@ void MAIN {
 #if defined FP32_DEST_ACC_EN
             reconfig_data_format(cb_input, cb_scaler);
 #endif
-            reduce_init_delta<false>(cb_input, cb_scaler, cb_out);
+            reduce_init(cb_input, cb_scaler, cb_out);
             reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
-            reduce_revert_delta(cb_out);
+            reduce_uninit();
             tile_regs_commit();
 
             cb_reserve_back(cb_out, onetile);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -315,7 +315,7 @@ void MAIN {
 
                 // Partial/E[x]
                 index_h_offset = 0;
-                reduce_init_delta<false>(cb_x, cb_scaler, cb_ex_partial);
+                reduce_init(cb_x, cb_scaler, cb_ex_partial);
                 cb_reserve_back(cb_ex_partial, 1);
                 tile_regs_acquire();
                 cb_wait_front(cb_scaler, 1);
@@ -334,14 +334,14 @@ void MAIN {
                 tile_regs_release();
                 cb_pop_front(cb_x, out_block_hw_normal);
                 cb_push_back(cb_ex_partial, 1);
-                reduce_revert_delta(cb_ex_partial);
+                reduce_uninit();
 
                 cb_wait_front(cb_ex_partial, 1);
             }
             // End Local Redcue
             // Start Global Reduce
             if constexpr (is_mcast_sender) {
-                reduce_init_delta<false>(cb_ex_external, cb_scaler_global, cb_ex_global);
+                reduce_init(cb_ex_external, cb_scaler_global, cb_ex_global);
                 cb_reserve_back(cb_ex_global, 1);
                 if (num_cores_per_mcast_group > 1) {
                     cb_reserve_back(cb_ex, 1);
@@ -357,7 +357,7 @@ void MAIN {
                 tile_regs_wait();
                 pack_tile(dst0, cb_ex_global);
                 tile_regs_release();
-                reduce_revert_delta(cb_ex_global);
+                reduce_uninit();
                 cb_push_back(cb_ex_global, 1);
                 if (num_cores_per_mcast_group > 1) {
                     cb_push_back(cb_ex, 1);
@@ -465,7 +465,7 @@ void MAIN {
 
                 // Partial-Var(x)
                 index_h_offset = 0;
-                reduce_init_delta<false>(cb_xmm, cb_scaler, cb_ex2_partial);
+                reduce_init(cb_xmm, cb_scaler, cb_ex2_partial);
                 cb_reserve_back(cb_ex2_partial, 1);
                 tile_regs_acquire();
                 cb_wait_front(cb_xmm, out_block_hw_normal);
@@ -483,12 +483,12 @@ void MAIN {
                 tile_regs_release();
                 cb_push_back(cb_ex2_partial, 1);
                 cb_pop_front(cb_xmm, out_block_hw_normal);
-                reduce_revert_delta(cb_ex2_partial);
+                reduce_uninit();
             }
             // End Local Reduce
             // Start Global Reduce
             if constexpr (is_mcast_sender) {
-                reduce_init_delta<false>(cb_ex_external, cb_scaler_global, cb_ex2_global);
+                reduce_init(cb_ex_external, cb_scaler_global, cb_ex2_global);
                 cb_reserve_back(cb_ex2_global, 1);
                 if (num_cores_per_mcast_group > 1) {
                     cb_reserve_back(cb_ex2, 1);
@@ -504,7 +504,7 @@ void MAIN {
                 tile_regs_wait();
                 pack_tile(dst0, cb_ex2_global);
                 tile_regs_release();
-                reduce_revert_delta(cb_ex2_global);
+                reduce_uninit();
                 cb_push_back(cb_ex2_global, 1);
                 if (num_cores_per_mcast_group > 1) {
                     cb_push_back(cb_ex2, 1);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -199,7 +199,7 @@ void MAIN {
 
             // Partial-E[x]
             index_h_offset = 0;
-            reduce_init_delta<false>(cb_x, cb_scaler, cb_ex_partial);
+            reduce_init(cb_x, cb_scaler, cb_ex_partial);
             cb_reserve_back(cb_ex_partial, 1);
             tile_regs_acquire();
             cb_wait_front(cb_scaler, 1);
@@ -216,10 +216,10 @@ void MAIN {
             pack_tile(dst0, cb_ex_partial);
             tile_regs_release();
             cb_push_back(cb_ex_partial, 1);
-            reduce_revert_delta(cb_ex_partial);
+            reduce_uninit();
 
             if constexpr (is_mcast_sender and num_cores_per_mcast_group > 1) {
-                reduce_init_delta<false>(cb_ex_external, cb_scaler_global, cb_ex_global);
+                reduce_init(cb_ex_external, cb_scaler_global, cb_ex_global);
                 cb_reserve_back(cb_ex_global, 1);
                 cb_reserve_back(cb_ex, 1);
                 tile_regs_acquire();
@@ -231,7 +231,7 @@ void MAIN {
                 tile_regs_wait();
                 pack_tile(dst0, cb_ex_global);
                 tile_regs_release();
-                reduce_revert_delta(cb_ex_global);
+                reduce_uninit();
                 cb_push_back(cb_ex_global, 1);
                 cb_push_back(cb_ex, 1);
             }
@@ -316,7 +316,7 @@ void MAIN {
 
             // Partial-Var(x)
             index_h_offset = 0;
-            reduce_init_delta<false>(cb_xmm, cb_scaler, cb_ex_partial);
+            reduce_init(cb_xmm, cb_scaler, cb_ex_partial);
             cb_reserve_back(cb_ex_partial, 1);
             tile_regs_acquire();
             cb_wait_front(cb_xmm, block_hw);
@@ -334,10 +334,10 @@ void MAIN {
             tile_regs_release();
             cb_push_back(cb_ex_partial, 1);
             cb_pop_front(cb_xmm, block_hw);
-            reduce_revert_delta(cb_ex_partial);
+            reduce_uninit();
 
             if constexpr (is_mcast_sender and num_cores_per_mcast_group > 1) {
-                reduce_init_delta<false>(cb_ex_external, cb_scaler_global, cb_ex_global);
+                reduce_init(cb_ex_external, cb_scaler_global, cb_ex_global);
                 cb_reserve_back(cb_ex_global, 1);
                 cb_reserve_back(cb_ex, 1);
                 tile_regs_acquire();
@@ -349,7 +349,7 @@ void MAIN {
                 tile_regs_wait();
                 pack_tile(dst0, cb_ex_global);
                 tile_regs_release();
-                reduce_revert_delta(cb_ex_global);
+                reduce_uninit();
                 cb_push_back(cb_ex_global, 1);
                 cb_push_back(cb_ex, 1);
             }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
@@ -122,7 +122,7 @@ void MAIN {
          */
         ACQ();
         cb_reserve_back(cb_ex, onetile);
-        reduce_init_delta<false>(cb_x, cb_scaler, cb_ex);
+        reduce_init(cb_x, cb_scaler, cb_ex);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_x, wt + blk);
             for (uint32_t j = 0; j < blk; j++) {
@@ -131,7 +131,7 @@ void MAIN {
             // we don't pop cb_x until we compute Ex
         }
         pack_tile(dst0, cb_ex);
-        reduce_revert_delta(cb_ex);
+        reduce_uninit();
         REL();
 
         cb_push_back(cb_ex, 1);
@@ -193,7 +193,7 @@ void MAIN {
             reconfig_data_format(cb_xmm2, cb_scaler);
         }
         cb_reserve_back(cb_ex2, 1);
-        reduce_init_delta<false>(cb_xmm2, cb_scaler, cb_ex2);
+        reduce_init(cb_xmm2, cb_scaler, cb_ex2);
         ACQ();
         cb_wait_front(cb_xmm2, Wt);
         // cb_wait_front(cb_xmm, Wt);
@@ -206,7 +206,7 @@ void MAIN {
         }
         cb_pop_front(cb_xmm2, Wt);
         pack_tile(dst0, cb_ex2);
-        reduce_revert_delta(cb_ex2);
+        reduce_uninit();
         REL();
 
         cb_push_back(cb_ex2, 1);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
@@ -79,7 +79,7 @@ void MAIN {
         reconfig_data_format(cb_in, cb_scaler);
         pack_reconfig_data_format(cb_ex);
         cb_reserve_back(cb_ex, onetile);
-        reduce_init_delta<false>(cb_in, cb_scaler, cb_ex);
+        reduce_init(cb_in, cb_scaler, cb_ex);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_in, blk);
             for (uint32_t j = 0; j < blk; j++) {
@@ -89,7 +89,7 @@ void MAIN {
         }
 #ifdef FUSE_PRE_ADD
         reconfig_data_format_srca(cb_in, cb_inb);
-        reduce_init_delta<false>(cb_inb, cb_scaler, cb_ex);
+        reduce_init(cb_inb, cb_scaler, cb_ex);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_inb, blk);
             for (uint32_t j = 0; j < blk; j++) {
@@ -100,7 +100,7 @@ void MAIN {
 #endif
         tile_regs_commit();
         pack_tile(dst0, cb_ex);
-        reduce_revert_delta(cb_ex);
+        reduce_uninit();
         tile_regs_release();
         cb_push_back(cb_ex, onetile);
         // End of
@@ -167,14 +167,14 @@ void MAIN {
             }
             cb_wait_front(cb_xmm, blk);
             reconfig_data_format(cb_xmm, cb_scaler);
-            reduce_init_delta<false>(cb_xmm, cb_scaler, cb_ex2);
+            reduce_init(cb_xmm, cb_scaler, cb_ex2);
             // accumulates squared residual
             for (uint32_t j = 0; j < blk; j++) {
                 reduce_tile(cb_xmm, cb_scaler, j, scaler0, dst0);
             }
             cb_pop_front(cb_xmm, blk);
             cb_reserve_back(cb_ex2, onetile);
-            reduce_revert_delta(cb_ex2);
+            reduce_uninit();
             tile_regs_commit();
             pack_tile(dst0, cb_ex2);
             cb_push_back(cb_ex2, onetile);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
@@ -142,7 +142,7 @@ void MAIN {
 #ifndef RMSNORM
     // E[x],
     index_h_offset = 0;
-    reduce_init_delta<false>(cb_in, cb_scaler, cb_ex_partial);
+    reduce_init(cb_in, cb_scaler, cb_ex_partial);
     cb_wait_front(cb_scaler, 1);
     cb_reserve_back(cb_ex_partial, block_h);
     for (uint32_t i = 0; i < block_h; i++) {
@@ -156,14 +156,14 @@ void MAIN {
         tile_regs_release();
         index_h_offset += block_w;
     }
-    reduce_revert_delta(cb_ex_partial);
+    reduce_uninit();
     cb_push_back(cb_ex_partial, block_h);
 
     reconfig_data_format_srca(cb_in, cb_ex_external);
 
     // global reduce, cb_ex <-- cb_ex_external, cb_ex_partial
     if constexpr (is_allgather_worker) {
-        reduce_init_delta<false>(cb_ex_external, cb_scaler_global, cb_ex);
+        reduce_init(cb_ex_external, cb_scaler_global, cb_ex);
         cb_reserve_back(cb_ex, num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {
@@ -183,7 +183,7 @@ void MAIN {
             pack_tile(dst0, cb_ex);
             tile_regs_release();
         }
-        reduce_revert_delta(cb_ex);
+        reduce_uninit();
         cb_push_back(cb_ex, num_tiles_per_allgather_worker);
         cb_wait_front(cb_ex, num_tiles_per_allgather_worker);
     }
@@ -262,7 +262,7 @@ void MAIN {
     cb_wait_front(cb_scaler, 1);
 #endif
     cb_reserve_back(cb_ex_partial2, block_h);
-    reduce_init_delta<false>(cb_xmm2, cb_scaler, cb_ex_partial2);
+    reduce_init(cb_xmm2, cb_scaler, cb_ex_partial2);
     index_h_offset = 0;
     for (uint32_t i = 0; i < block_h; i++) {
         tile_regs_acquire();
@@ -275,13 +275,13 @@ void MAIN {
         tile_regs_release();
         index_h_offset += block_w;
     }
-    reduce_revert_delta(cb_ex_partial2);
+    reduce_uninit();
     cb_pop_front(cb_xmm2, num_tiles_per_block);
     cb_push_back(cb_ex_partial2, block_h);
 
     // global reduce, cb_ex <-- cb_ex_external, cb_ex_partial
     if constexpr (is_allgather_worker) {
-        reduce_init_delta<false>(cb_ex_external2, cb_scaler_global, cb_ex2);
+        reduce_init(cb_ex_external2, cb_scaler_global, cb_ex2);
         cb_reserve_back(cb_ex2, num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {
@@ -302,7 +302,7 @@ void MAIN {
             pack_tile(dst0, cb_ex2);
             tile_regs_release();
         }
-        reduce_revert_delta(cb_ex2);
+        reduce_uninit();
         cb_push_back(cb_ex2, num_tiles_per_allgather_worker);
 
         if (enable_sqrt) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -108,7 +108,7 @@ void MAIN {
 #endif
 
             cb_wait_front(cb_scaler_global, 1);
-            reduce_init_delta<false>(cb_stats, cb_scaler_global, cb_var);
+            reduce_init(cb_stats, cb_scaler_global, cb_var);
             tile_regs_acquire();
             // striding over cb_stats, consisting [E(X), E(X^2)] from all the distributed devices in interleaved order
             for (uint32_t w = 0; w < stats_tiles * num_distributed_blocks; w++) {
@@ -130,7 +130,7 @@ void MAIN {
             pack_tile(dst1, cb_ex2);
 #endif
             tile_regs_release();
-            reduce_revert_delta(cb_var);
+            reduce_uninit();
 #ifdef RMSNORM
             cb_push_back(cb_var, stats_tiles);
 #else

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -119,7 +119,7 @@ void MAIN {
 #endif
     // E[x],
     index_h_offset = 0;
-    reduce_init_delta<false>(cb_in0, cb_scaler, cb_ex_partial2);
+    reduce_init(cb_in0, cb_scaler, cb_ex_partial2);
 
     cb_reserve_back(cb_ex_partial2, block_h);
     for (uint32_t i = 0; i < block_h; i++) {
@@ -133,7 +133,7 @@ void MAIN {
         tile_regs_release();
         index_h_offset += block_w;
     }
-    reduce_revert_delta(cb_ex_partial2);
+    reduce_uninit();
     cb_push_back(cb_ex_partial2, block_h);
     reconfig_data_format_srcb(cb_scaler, cb_in);
 #else
@@ -177,7 +177,7 @@ void MAIN {
 
     cb_reserve_back(cb_ex_partial2, block_h);  // RMS E(x2) #Layernorm //E(x) and E(x^2)
 
-    reduce_init_delta<false>(cb_x2, cb_scaler, cb_ex_partial2);
+    reduce_init(cb_x2, cb_scaler, cb_ex_partial2);
     index_h_offset = 0;
     for (uint32_t i = 0; i < block_h; i++) {
         tile_regs_acquire();
@@ -191,7 +191,7 @@ void MAIN {
         tile_regs_release();
         index_h_offset += block_w;
     }
-    reduce_revert_delta(cb_ex_partial2);
+    reduce_uninit();
     cb_pop_front(cb_x2, num_tiles_per_block);
     cb_push_back(cb_ex_partial2, block_h);
 
@@ -200,7 +200,7 @@ void MAIN {
         cb_wait_front(cb_scaler_global, 1);
         reconfig_data_format_srca(cb_x2, cb_ex_external2);
         reconfig_data_format_srcb(cb_scaler, cb_scaler_global);
-        reduce_init_delta<false>(cb_ex_external2, cb_scaler_global, cb_reduction_out);
+        reduce_init(cb_ex_external2, cb_scaler_global, cb_reduction_out);
         cb_reserve_back(cb_reduction_out, num_tiles_per_partial_result * num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {  // loops over height
@@ -225,7 +225,7 @@ void MAIN {
 #endif
             tile_regs_release();
         }
-        reduce_revert_delta(cb_reduction_out);
+        reduce_uninit();
         cb_push_back(cb_reduction_out, num_tiles_per_partial_result * num_tiles_per_allgather_worker);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
@@ -88,7 +88,7 @@ void MAIN {
          * cb_stats = [sum(x0**2), sum(x0), sum(x1**2), sum(x1), ...]
          * RMSNorm packs mean(x**2) into cb_var. Layernorm just uses cb_stats_reduced.
          */
-        reduce_init_delta<false>(cb_stats, cb_reduce, cb_stats_reduced);
+        reduce_init(cb_stats, cb_reduce, cb_stats_reduced);
         cb_wait_front(cb_stats, stats_tiles_cols);
         cb_reserve_back(cb_stats_reduced, stats_tile_stride);
 #ifdef RMSNORM
@@ -117,7 +117,7 @@ void MAIN {
         cb_push_back(cb_var, 1);
 #endif
 
-        reduce_revert_delta(cb_stats_reduced);
+        reduce_uninit();
 
 #ifndef RMSNORM
         /*

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather.cpp
@@ -68,7 +68,7 @@ void MAIN {
          */
         reconfig_data_format(cb_x2, cb_reduce);
         pack_reconfig_data_format(cb_out);
-        reduce_init_delta<false>(cb_x2, cb_reduce, cb_out);
+        reduce_init(cb_x2, cb_reduce, cb_out);
         cb_wait_front(cb_x2, Wt);
         cb_reserve_back(cb_out, onetile);
         ACQ();
@@ -80,7 +80,7 @@ void MAIN {
         cb_push_back(cb_out, onetile);
         cb_pop_front(cb_x2, Wt);
 
-        reduce_revert_delta(cb_out);
+        reduce_uninit();
 
 #ifndef RMSNORM
 
@@ -89,7 +89,7 @@ void MAIN {
          */
         reconfig_data_format(cb_inp, cb_reduce);
         pack_reconfig_data_format(cb_out);
-        reduce_init_delta<false>(cb_inp, cb_reduce, cb_out);
+        reduce_init(cb_inp, cb_reduce, cb_out);
         cb_reserve_back(cb_out, onetile);
         ACQ();
         for (uint32_t wtr = 0; wtr < Wt; wtr++) {
@@ -99,7 +99,7 @@ void MAIN {
         REL();
         cb_push_back(cb_out, onetile);
 
-        reduce_revert_delta(cb_out);
+        reduce_uninit();
 
 #endif
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
@@ -30,13 +30,13 @@ void calc_numeric_stable(
     reconfig_data_format(cb_in, cb_bcast_scaler);
     cb_reserve_back(cb_max, 1);
     cb_wait_front(cb_bcast_scaler, 1);
-    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_in, cb_bcast_scaler, cb_max);
+    reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_in, cb_bcast_scaler, cb_max);
     for (uint32_t wt = 0; wt < Wt; wt++) {
         cb_wait_front(cb_in, wt + 1);
         constexpr uint32_t bcast_scaler0 = 0;
         reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_in, cb_bcast_scaler, wt, bcast_scaler0, 0);
     }
-    reduce_revert_delta<ReduceDim::REDUCE_ROW>(cb_max);
+    reduce_uninit();
     pack_tile(0, cb_max);
     cb_push_back(cb_max, 1);
     REL();
@@ -253,13 +253,13 @@ void MAIN {
 
         ACQ();
         cb_reserve_back(cb_recipsumexps, onetile);
-        reduce_init_delta<false>(cb_exps, cb_bcast_scaler, cb_recipsumexps);
+        reduce_init(cb_exps, cb_bcast_scaler, cb_recipsumexps);
         for (uint32_t wt = 0; wt < Wt; wt++) {
             cb_wait_front(cb_exps, wt + 1);        // must be a cumulative wait for correctness
             constexpr uint32_t bcast_scaler0 = 0;  // 0th index from bcast_scaler CB
             reduce_tile(cb_exps, cb_bcast_scaler, wt, bcast_scaler0, dst0);
         }
-        reduce_revert_delta(cb_recipsumexps);
+        reduce_uninit();
         recip_tile_init();
         recip_tile(dst0);  // DST[0] = 1/sum(exp(x))
         pack_tile(dst0, cb_recipsumexps);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_large_tensor.cpp
@@ -441,7 +441,7 @@ void reduce_cb(
 
     reconfig_data_format(cb_in, cb_scaler);
     pack_reconfig_data_format(cb_out);
-    reduce_init_delta<false, reduce_type, ReduceDim::REDUCE_ROW>(cb_in, cb_scaler, cb_out);
+    reduce_init<reduce_type, ReduceDim::REDUCE_ROW>(cb_in, cb_scaler, cb_out);
     tile_regs_acquire();
     cb_reserve_back(cb_out, 1);
     for (uint32_t cur_tile = 0; cur_tile < cb_length_t; cur_tile++) {
@@ -473,7 +473,7 @@ void reduce_cb(
     pack_tile(0, cb_out);
     cb_push_back(cb_out, 1);
     tile_regs_release();
-    reduce_revert_delta<ReduceDim::REDUCE_ROW>(cb_out);
+    reduce_uninit();
 }
 void apply_recip(uint32_t cb_in, uint32_t cb_recip, uint32_t cb_out, uint32_t cb_length_t, uint32_t blk) {
     reconfig_data_format(cb_in, cb_recip);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
@@ -23,13 +23,13 @@ ALWI void calc_numeric_stable(uint32_t cb_in, uint32_t cb_bcast_scaler, uint32_t
     reconfig_data_format(cb_in, cb_bcast_scaler);
     pack_reconfig_data_format(cb_max);
     cb_reserve_back(cb_max, 1);
-    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_in, cb_bcast_scaler, cb_max);
+    reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_in, cb_bcast_scaler, cb_max);
     cb_wait_front(cb_bcast_scaler, 1);
     for (uint32_t w = 0; w < block_w; w++) {
         constexpr uint32_t bcast_scaler0 = 0;
         reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_in, cb_bcast_scaler, w, bcast_scaler0, 0);
     }
-    reduce_revert_delta<ReduceDim::REDUCE_ROW>(cb_max);
+    reduce_uninit();
     pack_tile(0, cb_max);
     cb_push_back(cb_max, 1);
     REL();
@@ -201,7 +201,7 @@ void MAIN {
 
         // sum(exp(x))
         ACQ();
-        reduce_init_delta<false>(cb_exps, cb_bcast_scaler, cb_recipsumexps);
+        reduce_init(cb_exps, cb_bcast_scaler, cb_recipsumexps);
         cb_wait_front(cb_exps, block_w);
         cb_wait_front(cb_bcast_scaler, 1);
         cb_reserve_back(cb_recipsumexps, 1);
@@ -209,7 +209,7 @@ void MAIN {
             constexpr uint32_t bcast_scaler0 = 0;
             reduce_tile(cb_exps, cb_bcast_scaler, w, bcast_scaler0, dst0);
         }
-        reduce_revert_delta(cb_recipsumexps);
+        reduce_uninit();
         recip_tile_init();
         recip_tile(dst0);
         pack_tile(dst0, cb_recipsumexps);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
@@ -13,7 +13,9 @@ void MAIN {
     uint32_t NC = get_compile_time_arg_val(2);
     uint32_t row_chunk = get_compile_time_arg_val(3);
 
-    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
+    reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
+
     cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
 
     constexpr int onetile = 1;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
@@ -12,7 +12,8 @@ void MAIN {
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
 
-    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
+    reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 
     cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
@@ -18,7 +18,8 @@ void MAIN {
     uint32_t NC = get_compile_time_arg_val(2);
 
 #ifndef REDUCE_ROW_SUM_VIA_MM
-    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
+    reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 #else
     mm_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 #endif

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/compute/moe.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/compute/moe.cpp
@@ -179,7 +179,7 @@ void reduce_c() {
     // Precondition: scale_cb has 1 produced
     // Postcondition: out_cb has rows produced
     reconfig_data_format(in0_cb, scale_cb);
-    reduce_init_delta<false, pool_type, reduce_dim>(in0_cb, scale_cb, out_cb);
+    reduce_init<pool_type, reduce_dim>(in0_cb, scale_cb, out_cb);
 
     const uint32_t num_tiles = rows * cols;
     cb_wait_front(scale_cb, 1);
@@ -201,7 +201,7 @@ void reduce_c() {
         release_dst();
     }
 
-    reduce_revert_delta<reduce_dim>(out_cb);
+    reduce_uninit();
     UNPACK(tensix_sync());  // Workaround for issue #9370
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
@@ -161,7 +161,7 @@ void reduce_c() {
     // Precondition: scale_cb has 1 produced
     // Postcondition: out_cb has rows produced
     reconfig_data_format(in0_cb, scale_cb);
-    reduce_init_delta<false, pool_type, reduce_dim>(in0_cb, scale_cb, out_cb);
+    reduce_init<pool_type, reduce_dim>(in0_cb, scale_cb, out_cb);
 
     const uint32_t num_tiles = rows * cols;
     cb_wait_front(scale_cb, 1);
@@ -183,7 +183,7 @@ void reduce_c() {
         release_dst();
     }
 
-    reduce_revert_delta<reduce_dim>(out_cb);
+    reduce_uninit();
     UNPACK(tensix_sync());  // Workaround for issue #9370
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -59,11 +59,11 @@ void reduce_c(uint32_t out_cb, uint32_t prev_cb, bool do_eltwise_max = false) {
 
     for (uint32_t i = 0; i < rows; i++) {
         acquire_dst();
-        reduce_init_delta<false, pool_type, reduce_dim>(in0_cb, scale_cb, out_cb);
+        reduce_init<pool_type, reduce_dim>(in0_cb, scale_cb, out_cb);
         for (uint32_t j = 0; j < cols; j++) {
             reduce_tile<pool_type, reduce_dim>(in0_cb, scale_cb, i * cols + j, 0, reduce_dst_idx);
         }
-        reduce_revert_delta<reduce_dim>(out_cb);
+        reduce_uninit();
         if (do_eltwise_max) {
             copy_tile_to_dst_init_short(prev_cb);
             copy_tile(prev_cb, i, prev_max_dst_idx);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -77,7 +77,7 @@ void reduce_c(uint32_t cols) {
     // Precondition: scale_cb has 1 produced
     // Postcondition: out_cb has rows produced
 
-    reduce_init_delta<false, pool_type, reduce_dim>(in0_cb, scale_cb, out_cb);
+    reduce_init<pool_type, reduce_dim>(in0_cb, scale_cb, out_cb);
 
     const uint32_t num_tiles = rows * cols;
     cb_wait_front(scale_cb, 1);
@@ -98,7 +98,7 @@ void reduce_c(uint32_t cols) {
         release_dst();
     }
 
-    reduce_revert_delta<reduce_dim>(out_cb);
+    reduce_uninit();
 }
 
 void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {


### PR DESCRIPTION
### Ticket
#22939 

### Problem description
Compute API currently has a lot of unused or redundant function arguments, and even unused functions. Furthermore, the programming model is violated at several places and the boundary between full and short inits is not clear. Lastly, some ops require calling an `_uninit`/`_revert` function, but not all, which introduces more confusion. We will do a series of PRs to fix these issues for all ops so that in the end Compute kernels look like this:
```
compute_kernel_hw_startup # called once at the start of the kernel
<op1>_init # called before op1
<op1>_tile / <op1>_block # We will add block ops where applicable
<op2>_init
<op2>_tile / <op2>_block
...
```

### What's changed
This PR addresses the mentioned drawbacks of Compute API for **reduce** op. It is the initial PR that doesn't fix all the problems, but does the following:

* Added `compute_kernel_hw_startup` function in a separate header file.
* `reduce_init_short` renamed to `reduce_init` and full init removed. Please note that `reduce_init_delta` with a parameter `at_start = False` is the same as `reduce_init`.
* Remove unused Compute API like `reduce_init_delta_math` and `reduce_init_delta_no_pack`
* Adapt API calls in all kernels to reflect the changes.
* Add documentation skeleton for functions that will remain in `reduce.h` at the end of the effort.

### 🔍 Review Process Suggestion:
* Code owners should check their files and see whether all `reduce_` init and revert calls are modified. All `reduce_init_delta` calls should be swapped with `reduce_init` calls, while `reduce_revert_delta` calls mustn't pass any arguments.
* LLK team will review `reduce.h` for functional, structural and code documentation chang
* Everybody please mind that this PR just scratches the surface of the [enormous cleanup effort](https://github.com/tenstorrent/tt-metal/issues/22907) the LLK team has planned, which aims to make our Compute APIs robust, uniform and intuitive. I look forward to your remarks, but bigger cleanup and/or refactoring requests might end up as a separate issue. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes - [#34626](https://github.com/tenstorrent/tt-metal/actions/runs/15739668423)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) - fails the same way as main [#6782](https://github.com/tenstorrent/tt-metal/actions/runs/15740117711/job/44405523846)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) - fails same as main [#9546](https://github.com/tenstorrent/tt-metal/actions/runs/15734114747/job/44342651301)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) - waiting for CI to get fixed [#6934](https://github.com/tenstorrent/tt-metal/actions/runs/15734118652/job/44342734705)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes
