### PR TITLE
Enable weights double buffering on height sharded conv2d

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -21,7 +21,7 @@ from models.experimental.functional_unet.tests.common import UNET_TRACE_REGION_S
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1407.0),),
+    ((1, 4, 1420.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"
@@ -61,7 +61,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput",
-    ((1, 4, 256, 30.0, 1254.0),),
+    ((1, 4, 256, 30.0, 1315.0),),
 )
 def test_unet_trace_perf(
     batch: int,

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -116,7 +116,7 @@ def test_unet_trace_perf(
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2491.0),)
+    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2526.0),)
 )
 def test_unet_trace_perf_multi_device(
     batch: int,

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -61,7 +61,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput",
-    ((1, 4, 256, 30.0, 1315.0),),
+    ((1, 4, 256, 30.0, 1271.0),),
 )
 def test_unet_trace_perf(
     batch: int,

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -116,7 +116,7 @@ def test_unet_trace_perf(
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2526.0),)
+    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2519.0),)
 )
 def test_unet_trace_perf_multi_device(
     batch: int,

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -179,6 +179,7 @@ class UNetConv2D:
             output_layout=output_layout,
             reshard_if_not_optimal=reshard_if_not_optimal,
             reallocate_halo_output=reallocate_halo_output,
+            enable_weights_double_buffer=True,
         )
 
         if override_core_grid is not None:

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -74,7 +74,7 @@ struct Conv2dConfig {
     // Increased perf, but increased L1 usage.
     bool enable_act_double_buffer = false;
 
-    // Used on for block sharded convolutions
+    // Used on for height and block sharded convolutions
     bool enable_weights_double_buffer = false;
 
     // Only for height sharding.


### PR DESCRIPTION
Weights double buffering already accidentally worked for height sharded conv2d. This commit makes it official.
Added Unit tests for the feature for BS and HS.

Enable the feature on Unet shallow to get 15 fps e2e on a single chip.

More details:
In case of height sharded conv2d, weights reader will read weights in kernel_height iterations. By default it allocates CB for only one slice.
In case act_block_h_override is used, weights are already fully buffered, to avoid reloading weights in multiple interactions on activation matrix height. In those cases this "new" feature won't have any effect. This case in conv2d factory is called "fully_buffer_weights".

CI is having a bad day, I'll post pipelines next week.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15348481173)
- [x] [Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/15375607785)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/15391734760) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15375602134) 
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15375597984)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/15375614380)