### PR TITLE
Add sharding support for RM tensors in ttnn.copy

### DIFF
--- a/tests/ttnn/unit_tests/test_copy.py
+++ b/tests/ttnn/unit_tests/test_copy.py
@@ -35,6 +35,7 @@ def test_copy(shape, layout, dtype, device):
 
 # Test for block sharding
 @pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.Layout.TILE, ttnn.Layout.ROW_MAJOR])
 @pytest.mark.parametrize("shape", [[128, 64]])
 @pytest.mark.parametrize(
     "shard_scheme",
@@ -42,15 +43,15 @@ def test_copy(shape, layout, dtype, device):
         ttnn.TensorMemoryLayout.BLOCK_SHARDED,
     ],
 )
-def test_copy_block_sharded(device, shape, shard_scheme, dtype):
+def test_copy_block_sharded(device, layout, shape, shard_scheme, dtype):
     torch.manual_seed(1234)
     if dtype == ttnn.uint32:
         input_torch = torch.randint(1, 100, shape, dtype=torch.int32)
     else:
         input_torch = torch.randn(shape)
     output_torch = torch.zeros(shape)
-    ttnn_input = ttnn.from_torch(input_torch, dtype, layout=ttnn.Layout.TILE)
-    ttnn_output = ttnn.from_torch(output_torch, dtype, layout=ttnn.Layout.TILE)
+    ttnn_input = ttnn.from_torch(input_torch, dtype, layout=layout)
+    ttnn_output = ttnn.from_torch(output_torch, dtype, layout=layout)
 
     num_cores_x = 2
     num_cores_y = 2
@@ -89,6 +90,7 @@ def test_copy_block_sharded(device, shape, shard_scheme, dtype):
 
 # Test for width sharding
 @pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.Layout.TILE, ttnn.Layout.ROW_MAJOR])
 @pytest.mark.parametrize("shape", [[1, 2, 96, 128]])
 @pytest.mark.parametrize(
     "shard_scheme",
@@ -96,15 +98,15 @@ def test_copy_block_sharded(device, shape, shard_scheme, dtype):
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
     ],
 )
-def test_copy_width_sharded(device, shape, shard_scheme, dtype):
+def test_copy_width_sharded(device, layout, shape, shard_scheme, dtype):
     torch.manual_seed(1234)
     if dtype == ttnn.uint32:
         input_torch = torch.randint(1, 100, shape, dtype=torch.int32)
     else:
         input_torch = torch.randn(shape)
     output_torch = torch.zeros(shape)
-    ttnn_input = ttnn.from_torch(input_torch, dtype, layout=ttnn.Layout.TILE)
-    ttnn_output = ttnn.from_torch(output_torch, dtype, layout=ttnn.Layout.TILE)
+    ttnn_input = ttnn.from_torch(input_torch, dtype, layout=layout)
+    ttnn_output = ttnn.from_torch(output_torch, dtype, layout=layout)
 
     num_cores = 2
     shard_grid = ttnn.CoreRangeSet(
@@ -147,6 +149,7 @@ def test_copy_width_sharded(device, shape, shard_scheme, dtype):
 
 # Test for height sharding
 @pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.Layout.TILE, ttnn.Layout.ROW_MAJOR])
 @pytest.mark.parametrize("shape", [[512, 64]])
 @pytest.mark.parametrize(
     "shard_scheme",
@@ -154,15 +157,15 @@ def test_copy_width_sharded(device, shape, shard_scheme, dtype):
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
     ],
 )
-def test_copy_height_sharded(device, shape, shard_scheme, dtype):
+def test_copy_height_sharded(device, layout, shape, shard_scheme, dtype):
     torch.manual_seed(1234)
     if dtype == ttnn.uint32:
         input_torch = torch.randint(1, 100, shape, dtype=torch.int32)
     else:
         input_torch = torch.randn(shape)
     output_torch = torch.zeros(shape)
-    ttnn_input = ttnn.from_torch(input_torch, dtype=dtype, layout=ttnn.Layout.TILE)
-    ttnn_output = ttnn.from_torch(output_torch, dtype=dtype, layout=ttnn.Layout.TILE)
+    ttnn_input = ttnn.from_torch(input_torch, dtype=dtype, layout=layout)
+    ttnn_output = ttnn.from_torch(output_torch, dtype=dtype, layout=layout)
 
     num_cores = 8
     shard_grid = ttnn.CoreRangeSet(

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -28,11 +28,6 @@ void CopyDeviceOperation::validate_with_output_tensors(
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to copy need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to copy need to be allocated in buffers on device!");
 
-    if (input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
-        input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED ||
-        input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
-        TT_FATAL(input_tensor_a.get_layout() == Layout::TILE, "Input layout should be TILE for SHARDED input");
-    }
     if (input_tensors.size() == 2) {
         const auto& dst_tensor = input_tensors[1];
         TT_FATAL(input_tensor_a.get_padded_shape() == dst_tensor.get_padded_shape(), "Error");

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
@@ -88,16 +88,14 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
             (std::uint32_t)src0_cb_index,
             (std::uint32_t)src_is_dram,
             (std::uint32_t)src_stick_size_is_power_of_two,
-            (std::uint32_t)src_log2_stick_size,
-            (std::uint32_t)full_input_row};
+            (std::uint32_t)src_log2_stick_size};
         bool dst_stick_size_is_power_of_two = is_power_of_two_at_least_32(output_unit_size);
         uint32_t dst_log2_stick_size = dst_stick_size_is_power_of_two ? (std::uint32_t)log2(output_unit_size) : 0;
         writer_compile_time_args = {
             (std::uint32_t)output_cb_index,
             (std::uint32_t)dst_is_dram,
             (std::uint32_t)dst_stick_size_is_power_of_two,
-            (std::uint32_t)dst_log2_stick_size,
-            (std::uint32_t)full_output_row};
+            (std::uint32_t)dst_log2_stick_size};
     }
     std::map<string, string> kernel_defines;
     if (sharded) {
@@ -170,9 +168,13 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
             tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
         } else {
             std::vector<uint32_t> reader_runtime_args = {
-                src_buffer->address(), input_unit_size, num_units_per_core, start_id};
+                src_buffer->address(), input_unit_size, num_units_per_core, start_id, full_input_row / input_unit_size};
             std::vector<uint32_t> writer_runtime_args = {
-                dst_buffer->address(), output_unit_size, num_units_per_core, start_id};
+                dst_buffer->address(),
+                output_unit_size,
+                num_units_per_core,
+                start_id,
+                full_output_row / output_unit_size};
             if (sharded) {
                 shard_builder::extend_sharding_run_time_args(input, reader_runtime_args);
                 shard_builder::extend_sharding_run_time_args(input, writer_runtime_args);

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
@@ -108,17 +108,23 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
     if (backwards) {
         kernel_defines["BACKWARDS"] = "1";
     }
+    std::string reader_rm_path =
+        sharded ? "ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp"
+                : "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/reader_unary_stick_layout_interleaved_start_id.cpp";
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         tilized ? "ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_start_id.cpp"
-                : "ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp",
+                : reader_rm_path,
         all_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, kernel_defines));
 
+    std::string writer_rm_path =
+        sharded ? "ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp"
+                : "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp";
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         tilized ? "ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_start_id.cpp"
-                : "ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp",
+                : writer_rm_path,
         all_cores,
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, kernel_defines));
 

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
@@ -23,13 +23,22 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
     tt::tt_metal::Program program{};
 
     bool tilized = output.get_layout() == Layout::TILE;
-
+    bool sharded = input.memory_config().memory_layout() != TensorMemoryLayout::INTERLEAVED;
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
     uint32_t input_unit_size = tilized ? tt::tt_metal::detail::TileSize(input_cb_data_format)
                                        : input.get_padded_shape()[-1] * input.element_size();
+    uint32_t full_input_row = input_unit_size;
+    if (sharded && !tilized) {
+        input_unit_size = input.memory_config().shard_spec()->shape[1] * input.element_size();
+    }
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
     uint32_t output_unit_size = tilized ? tt::tt_metal::detail::TileSize(output_cb_data_format)
                                         : output.get_padded_shape()[-1] * output.element_size();
+    uint32_t full_output_row = output_unit_size;
+    if (sharded && !tilized) {
+        output_unit_size = output.memory_config().shard_spec()->shape[1] * output.element_size();
+    }
+
     bool convert_dtype = input_cb_data_format != output_cb_data_format;
 
     uint32_t num_units = tilized ? output.volume() / TILE_HW : output.volume() / output.get_padded_shape()[-1];
@@ -67,7 +76,6 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
     auto dst_buffer = output.buffer();
     bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool sharded = input.memory_config().memory_layout() != TensorMemoryLayout::INTERLEAVED;
 
     std::vector<uint32_t> reader_compile_time_args, writer_compile_time_args;
     if (tilized) {
@@ -80,14 +88,16 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
             (std::uint32_t)src0_cb_index,
             (std::uint32_t)src_is_dram,
             (std::uint32_t)src_stick_size_is_power_of_two,
-            (std::uint32_t)src_log2_stick_size};
+            (std::uint32_t)src_log2_stick_size,
+            (std::uint32_t)full_input_row};
         bool dst_stick_size_is_power_of_two = is_power_of_two_at_least_32(output_unit_size);
         uint32_t dst_log2_stick_size = dst_stick_size_is_power_of_two ? (std::uint32_t)log2(output_unit_size) : 0;
         writer_compile_time_args = {
             (std::uint32_t)output_cb_index,
             (std::uint32_t)dst_is_dram,
             (std::uint32_t)dst_stick_size_is_power_of_two,
-            (std::uint32_t)dst_log2_stick_size};
+            (std::uint32_t)dst_log2_stick_size,
+            (std::uint32_t)full_output_row};
     }
     std::map<string, string> kernel_defines;
     if (sharded) {
@@ -101,14 +111,14 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         tilized ? "ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_start_id.cpp"
-                : "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/reader_unary_stick_layout_interleaved_start_id.cpp",
+                : "ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp",
         all_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, kernel_defines));
 
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         tilized ? "ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_start_id.cpp"
-                : "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp",
+                : "ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp",
         all_cores,
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, kernel_defines));
 
@@ -153,17 +163,16 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
             tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
             tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
         } else {
-            tt::tt_metal::SetRuntimeArgs(
-                program,
-                unary_reader_kernel_id,
-                core,
-                {src_buffer->address(), input_unit_size, num_units_per_core, start_id});
-
-            tt::tt_metal::SetRuntimeArgs(
-                program,
-                unary_writer_kernel_id,
-                core,
-                {dst_buffer->address(), output_unit_size, num_units_per_core, start_id});
+            std::vector<uint32_t> reader_runtime_args = {
+                src_buffer->address(), input_unit_size, num_units_per_core, start_id};
+            std::vector<uint32_t> writer_runtime_args = {
+                dst_buffer->address(), output_unit_size, num_units_per_core, start_id};
+            if (sharded) {
+                shard_builder::extend_sharding_run_time_args(input, reader_runtime_args);
+                shard_builder::extend_sharding_run_time_args(input, writer_runtime_args);
+            }
+            tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
+            tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
         }
         if (backwards) {
             start_id -= num_units_per_core;

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
@@ -12,37 +12,37 @@ void kernel_main() {
     uint32_t stick_size = get_arg_val<uint32_t>(1);
     uint32_t num_sticks = get_arg_val<uint32_t>(2);
     uint32_t start_id = get_arg_val<uint32_t>(3);
+    uint32_t num_shards = get_arg_val<uint32_t>(4);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr bool src0_is_dram = get_compile_time_arg_val(1) == 1;
     constexpr bool src_stick_size_is_pow2 = get_compile_time_arg_val(2) == 1;
     constexpr uint32_t src_log_base_2_of_page_size = get_compile_time_arg_val(3);
-    constexpr uint32_t full_row = get_compile_time_arg_val(4);
 
     typedef ShardedInfo<
+        get_compile_time_arg_val(4),
         get_compile_time_arg_val(5),
         get_compile_time_arg_val(6),
         get_compile_time_arg_val(7),
         get_compile_time_arg_val(8),
         get_compile_time_arg_val(9),
-        get_compile_time_arg_val(10),
-        get_compile_time_arg_val(11)>
+        get_compile_time_arg_val(10)>
         tensor_shard_info;
 
     const auto [mapping_table, rt_increment] =
-        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(4));
+        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(5));
     experimental::ShardedAddrGen<tensor_shard_info> s0 = {.bank_base_address = src_addr, .shard_array = mapping_table};
 
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_sticks;
     for (uint32_t i = start_id; i != end_id; --i) {
-        for (uint32_t k = full_row / stick_size - 1; k >= 0; k--) {
+        for (uint32_t k = num_shards - 1; k >= 0; k--) {
 #else
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        for (uint32_t k = 0; k < full_row / stick_size; k++) {
+        for (uint32_t k = 0; k < num_shards; k++) {
 #endif
-            uint32_t stick_index = i * full_row / stick_size + k;
+            uint32_t stick_index = i * num_shards + k;
             cb_reserve_back(cb_id_in0, 1);
             uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
             uint64_t src_noc_addr = get_noc_addr(stick_index, s0);

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
@@ -19,7 +19,6 @@ void kernel_main() {
     constexpr uint32_t src_log_base_2_of_page_size = get_compile_time_arg_val(3);
     constexpr uint32_t full_row = get_compile_time_arg_val(4);
 
-#ifdef SHARDED
     typedef ShardedInfo<
         get_compile_time_arg_val(5),
         get_compile_time_arg_val(6),
@@ -33,10 +32,6 @@ void kernel_main() {
     const auto [mapping_table, rt_increment] =
         experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(4));
     experimental::ShardedAddrGen<tensor_shard_info> s0 = {.bank_base_address = src_addr, .shard_array = mapping_table};
-#else
-    const auto s0 = get_interleaved_addr_gen<src0_is_dram, src_stick_size_is_pow2>(
-        src_addr, stick_size, src_log_base_2_of_page_size);
-#endif
 
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_sticks;

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t stick_size = get_arg_val<uint32_t>(1);
+    uint32_t num_sticks = get_arg_val<uint32_t>(2);
+    uint32_t start_id = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr bool src0_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr bool src_stick_size_is_pow2 = get_compile_time_arg_val(2) == 1;
+    constexpr uint32_t src_log_base_2_of_page_size = get_compile_time_arg_val(3);
+    constexpr uint32_t full_row = get_compile_time_arg_val(4);
+
+#ifdef SHARDED
+    typedef ShardedInfo<
+        get_compile_time_arg_val(5),
+        get_compile_time_arg_val(6),
+        get_compile_time_arg_val(7),
+        get_compile_time_arg_val(8),
+        get_compile_time_arg_val(9),
+        get_compile_time_arg_val(10),
+        get_compile_time_arg_val(11)>
+        tensor_shard_info;
+
+    const auto [mapping_table, rt_increment] =
+        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(4));
+    experimental::ShardedAddrGen<tensor_shard_info> s0 = {.bank_base_address = src_addr, .shard_array = mapping_table};
+#else
+    const auto s0 = get_interleaved_addr_gen<src0_is_dram, src_stick_size_is_pow2>(
+        src_addr, stick_size, src_log_base_2_of_page_size);
+#endif
+
+#ifdef BACKWARDS
+    uint32_t end_id = start_id - num_sticks;
+    for (uint32_t i = start_id; i != end_id; --i) {
+        for (uint32_t k = full_row / stick_size - 1; k >= 0; k--) {
+#else
+    uint32_t end_id = start_id + num_sticks;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        for (uint32_t k = 0; k < full_row / stick_size; k++) {
+#endif
+            uint32_t stick_index = i * full_row / stick_size + k;
+            cb_reserve_back(cb_id_in0, 1);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+            uint64_t src_noc_addr = get_noc_addr(stick_index, s0);
+            noc_async_read(src_noc_addr, l1_write_addr, stick_size);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in0, 1);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_start_id.cpp
@@ -7,7 +7,6 @@
 #include "ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
 void kernel_main() {
-    DPRINT << "writer_unary_start_id" << ENDL();
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
@@ -20,7 +20,6 @@ void kernel_main() {
     constexpr uint32_t dst_log_base_2_of_page_size = get_compile_time_arg_val(3);
     constexpr uint32_t full_row = get_compile_time_arg_val(4);
 
-#ifdef SHARDED
     typedef ShardedInfo<
         get_compile_time_arg_val(5),
         get_compile_time_arg_val(6),
@@ -34,10 +33,6 @@ void kernel_main() {
     const auto [mapping_table, rt_increment] =
         experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(4));
     experimental::ShardedAddrGen<tensor_shard_info> s0 = {.bank_base_address = dst_addr, .shard_array = mapping_table};
-#else
-    const auto s0 = get_interleaved_addr_gen<dst0_is_dram, dst_stick_size_is_pow2>(
-        dst_addr, stick_size, dst_log_base_2_of_page_size);
-#endif
 
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_sticks;

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
@@ -12,38 +12,38 @@ void kernel_main() {
     uint32_t stick_size = get_arg_val<uint32_t>(1);
     uint32_t num_sticks = get_arg_val<uint32_t>(2);
     uint32_t start_id = get_arg_val<uint32_t>(3);
+    uint32_t num_shards = get_arg_val<uint32_t>(4);
 
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
 
     constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
     constexpr bool dst_stick_size_is_pow2 = get_compile_time_arg_val(2) == 1;
     constexpr uint32_t dst_log_base_2_of_page_size = get_compile_time_arg_val(3);
-    constexpr uint32_t full_row = get_compile_time_arg_val(4);
 
     typedef ShardedInfo<
+        get_compile_time_arg_val(4),
         get_compile_time_arg_val(5),
         get_compile_time_arg_val(6),
         get_compile_time_arg_val(7),
         get_compile_time_arg_val(8),
         get_compile_time_arg_val(9),
-        get_compile_time_arg_val(10),
-        get_compile_time_arg_val(11)>
+        get_compile_time_arg_val(10)>
         tensor_shard_info;
 
     const auto [mapping_table, rt_increment] =
-        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(4));
+        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(5));
     experimental::ShardedAddrGen<tensor_shard_info> s0 = {.bank_base_address = dst_addr, .shard_array = mapping_table};
 
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_sticks;
     for (uint32_t i = start_id; i != end_id; --i) {
-        for (uint32_t k = full_row / stick_size - 1; k >= 0; k--) {
+        for (uint32_t k = num_shards - 1; k >= 0; k--) {
 #else
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        for (uint32_t k = 0; k < full_row / stick_size; k++) {
+        for (uint32_t k = 0; k < num_shards; k++) {
 #endif
-            uint32_t stick_index = i * full_row / stick_size + k;
+            uint32_t stick_index = i * num_shards + k;
             cb_wait_front(cb_id_out0, 1);
             uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
             uint64_t dst_noc_addr = get_noc_addr(stick_index, s0);

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
@@ -1,0 +1,60 @@
+//  SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t stick_size = get_arg_val<uint32_t>(1);
+    uint32_t num_sticks = get_arg_val<uint32_t>(2);
+    uint32_t start_id = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
+
+    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr bool dst_stick_size_is_pow2 = get_compile_time_arg_val(2) == 1;
+    constexpr uint32_t dst_log_base_2_of_page_size = get_compile_time_arg_val(3);
+    constexpr uint32_t full_row = get_compile_time_arg_val(4);
+
+#ifdef SHARDED
+    typedef ShardedInfo<
+        get_compile_time_arg_val(5),
+        get_compile_time_arg_val(6),
+        get_compile_time_arg_val(7),
+        get_compile_time_arg_val(8),
+        get_compile_time_arg_val(9),
+        get_compile_time_arg_val(10),
+        get_compile_time_arg_val(11)>
+        tensor_shard_info;
+
+    const auto [mapping_table, rt_increment] =
+        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(4));
+    experimental::ShardedAddrGen<tensor_shard_info> s0 = {.bank_base_address = dst_addr, .shard_array = mapping_table};
+#else
+    const auto s0 = get_interleaved_addr_gen<dst0_is_dram, dst_stick_size_is_pow2>(
+        dst_addr, stick_size, dst_log_base_2_of_page_size);
+#endif
+
+#ifdef BACKWARDS
+    uint32_t end_id = start_id - num_sticks;
+    for (uint32_t i = start_id; i != end_id; --i) {
+        for (uint32_t k = full_row / stick_size - 1; k >= 0; k--) {
+#else
+    uint32_t end_id = start_id + num_sticks;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        for (uint32_t k = 0; k < full_row / stick_size; k++) {
+#endif
+            uint32_t stick_index = i * full_row / stick_size + k;
+            cb_wait_front(cb_id_out0, 1);
+            uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+            uint64_t dst_noc_addr = get_noc_addr(stick_index, s0);
+            noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
+            noc_async_write_barrier();
+            cb_pop_front(cb_id_out0, 1);
+        }
+    }
+}


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/22323#issuecomment-2902145760

### Problem description
In https://github.com/tenstorrent/tt-metal/pull/22591, we added support for ttnn.copy for sharded tensors in tile layout only

### What's changed
This PR adds the support for sharded RM tensors for the copy operation 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15329510054
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes