### PR TITLE
Clean up of height sharded conv2d weights kernel reader

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -4,39 +4,36 @@
 
 #include "dataflow_api.h"
 #include "height_sharded_reader_common.hpp"
+#include "debug/debug.h"
 
 void kernel_main() {
     // This writer is for output tensor in tile format
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_id_act_second_reader = get_compile_time_arg_val(4);
-    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(5);
-    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(6);
-    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(7);
-    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(8);
-    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(9);
-    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(14);
+    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(0);
+    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_act_second_reader = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(5);
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(7);
 
     // Bias arg. Unused if bias fusion is not enabled.
-    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(15);
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(14);
 
-    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(16);
-    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(17);
-    constexpr uint32_t output_rows_tiles = get_compile_time_arg_val(18);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(15);
 
     // Split reader args
-    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(19);
+    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(17);
     constexpr uint32_t split_reader = act_block_h_datums != 0;
-    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(20);
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(21);
-    constexpr uint32_t weight_size_w = get_compile_time_arg_val(22);
-    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(23);
-    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(24);
-    constexpr uint32_t act_block_h_datums_first_reader = get_compile_time_arg_val(25);
-    constexpr uint32_t act_block_h_datums_last_block = get_compile_time_arg_val(26);
-    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(27) == 1;
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(28);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(29);
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(18);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(19);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(20);
+    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(21);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(22);
+    constexpr uint32_t act_block_h_datums_first_reader = get_compile_time_arg_val(23);
+    constexpr uint32_t act_block_h_datums_last_block = get_compile_time_arg_val(24);
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(25) == 1;
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(26);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(27);
 
     constexpr uint32_t act_block_h_datums_read_last_block =
         act_block_h_datums_last_block > act_block_h_datums
@@ -44,11 +41,7 @@ void kernel_main() {
             : 0;
     constexpr uint32_t act_block_h_datums_first_reader_read = act_block_h_datums_first_reader / 2;
 
-    uint32_t i = 2;
-    const uint32_t out_start_tile_id = get_arg_val<uint32_t>(i++);
-    const uint32_t out_start_tile_id_h = get_arg_val<uint32_t>(i++);
-    const uint32_t out_start_tile_id_w = get_arg_val<uint32_t>(i++);
-    i += 1;
+    uint32_t i = 0;
     uint32_t noop = get_arg_val<uint32_t>(i++);
 
     if (noop) {
@@ -83,108 +76,95 @@ void kernel_main() {
 
 // read in bias if enabled (done only once for all batches)
 #ifdef FUSE_BIAS
-    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(2);
     bool load_bias = true;
 #endif
 
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
-    constexpr uint32_t num_coalesced_reads = weight_size_w;
     constexpr uint32_t coalesced_read_bytes =
-        ((dilation_w == 1) ? num_coalesced_reads * conv_act_c_read_bytes : conv_act_c_read_bytes);
+        ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
 
     // OUTER most loop is looping over out blocks in width dim because blocks from compute are in col major order.
     const uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
-    for (uint32_t bw = 0; bw < out_num_blocks_w; bw++) {
-        // coalesce reads along weight_size_w
-        uint32_t start_reader_idx;
-        if constexpr (split_reader) {
-            start_reader_idx = 0;
-            start_reader_idx = act_block_h_datums_first_reader / 2;
-        }
+    // coalesce reads along weight_size_w
+    uint32_t start_reader_idx;
+    if constexpr (split_reader) {
+        start_reader_idx = 0;
+        start_reader_idx = act_block_h_datums_first_reader / 2;
+    }
+    for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
+        // MCAST RECEIVE WEIGHTS
+        // read weight blocks inner dim
+        // read weight slice - 1 block of weights in width dim and full weight matrix height
+        // read slice only once for all activation blocks
 
-        bool read_weights = true;
-        for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
-            // MCAST RECEIVE WEIGHTS
-            // read weight blocks inner dim
-            // read weight slice - 1 block of weights in width dim and full weight matrix height
-            // read slice only once for all activation blocks
+        uint32_t reader_offset = act_l1_read_addr;
+        for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
+            if constexpr (split_reader) {
+                // Do the second half of the reads for act
+                noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+                reader_idx = start_reader_idx;
+                cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
+                uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                uint32_t act_block_h_datums_read_curr =
+                    bh == out_num_blocks_h - 1 ? act_block_h_datums_read_last_block : act_block_h_datums_read;
+                read_sticks<
+                    dilation_w,
+                    coalesced_read_bytes,
+                    conv_act_c_read_bytes,
+                    act_block_w_extra_align_bytes,
+                    stride_w_bytes,
+                    weight_size_w>(
+                    act_block_h_datums_read_curr,
+                    packed_reader_indices_ptr,
+                    reader_offset,
+                    l1_write_addr_act,
+                    reader_idx);
+                noc_async_read_barrier();
+                cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
 
-            // TODO: Not sure how this loop works with the additional reader; we don't have a use case for this right
-            // now
-            for (uint32_t weight_tile_h_outer_i = 0; weight_tile_h_outer_i < weight_block_height_num_outer;
-                 weight_tile_h_outer_i++) {
-                uint32_t reader_offset = act_l1_read_addr;
-                for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
-                    if constexpr (split_reader) {
-                        // Do the second half of the reads for act
-                        noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
-                        reader_idx = start_reader_idx;
-                        cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
-                        uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
-                        uint32_t act_block_h_datums_read_curr =
-                            bh == out_num_blocks_h - 1 ? act_block_h_datums_read_last_block : act_block_h_datums_read;
-                        read_sticks<
-                            dilation_w,
-                            coalesced_read_bytes,
-                            conv_act_c_read_bytes,
-                            act_block_w_extra_align_bytes,
-                            stride_w_bytes,
-                            weight_size_w>(
-                            act_block_h_datums_read_curr,
-                            packed_reader_indices_ptr,
-                            reader_offset,
-                            l1_write_addr_act,
-                            reader_idx);
-                        noc_async_read_barrier();
-                        cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
-
-                        reader_offset += window_outer_offset;
-                    }
-
-                    // Receive weights
-                    cb_reserve_back(cb_id_weight, weight_block_num_tiles);
-                    if (bh == 0) {
-                        // Set weights semaphore value to INVALID
-                        noc_semaphore_set(weights_mcast_receiver_semaphore_addr_ptr, INVALID);
-
-                        // Atomic increment source core counter
-                        noc_semaphore_inc(weights_mcast_sender_semaphore_noc_addr, 1);
-
-                        // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts
-                        // data)
-                        noc_semaphore_wait(weights_mcast_receiver_semaphore_addr_ptr, VALID);
-                    }
-
-                    cb_push_back(cb_id_weight, weight_block_num_tiles);
-
-                }  // for weight_block_height_num_outer
+                reader_offset += window_outer_offset;
             }
 
-#ifdef FUSE_BIAS
-            if (load_bias) {
-                cb_reserve_back(bias_cb_id, bias_ntiles);
-
+            // Receive weights
+            cb_reserve_back(cb_id_weight, weight_block_num_tiles);
+            if (bh == 0) {
                 // Set weights semaphore value to INVALID
                 noc_semaphore_set(weights_mcast_receiver_semaphore_addr_ptr, INVALID);
 
                 // Atomic increment source core counter
                 noc_semaphore_inc(weights_mcast_sender_semaphore_noc_addr, 1);
 
-                // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts data)
+                // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts
+                // data)
                 noc_semaphore_wait(weights_mcast_receiver_semaphore_addr_ptr, VALID);
-
-                cb_push_back(bias_cb_id, bias_ntiles);
-                load_bias = false;
             }
+
+            cb_push_back(cb_id_weight, weight_block_num_tiles);
+        }
+
+#ifdef FUSE_BIAS
+        if (load_bias) {
+            cb_reserve_back(bias_cb_id, bias_ntiles);
+
+            // Set weights semaphore value to INVALID
+            noc_semaphore_set(weights_mcast_receiver_semaphore_addr_ptr, INVALID);
+
+            // Atomic increment source core counter
+            noc_semaphore_inc(weights_mcast_sender_semaphore_noc_addr, 1);
+
+            // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts data)
+            noc_semaphore_wait(weights_mcast_receiver_semaphore_addr_ptr, VALID);
+
+            cb_push_back(bias_cb_id, bias_ntiles);
+            load_bias = false;
+        }
 #endif
 
-            if constexpr (split_reader) {
-                // Increment reader index for next block in height dim
-                start_reader_idx = reader_idx + act_block_h_datums_first_reader_read;
-            }
-        }  // out_num_blocks_h
-    }  // out_num_blocks_w
+        if constexpr (split_reader) {
+            // Increment reader index for next block in height dim
+            start_reader_idx = reader_idx + act_block_h_datums_first_reader_read;
+        }
+    }  // out_num_blocks_h
 
-    cb_wait_front(cb_id_out0, output_rows_tiles);
     noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -4,43 +4,43 @@
 
 #include "dataflow_api.h"
 #include "height_sharded_reader_common.hpp"
+#include "debug/debug.h"
 
 void kernel_main() {
     // This writer is for output tensor in tile format
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_id_act_second_reader = get_compile_time_arg_val(4);
-    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(5);
-    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(6);
-    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(7);
-    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(8);
-    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(9);
-    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(10);
-    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(11);
-    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(12);
-    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(13);
-    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(14);
+    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(0);
+    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t bias_in_dram = get_compile_time_arg_val(2) == 1;
+    constexpr uint32_t cb_id_act_second_reader = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(5);
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(7);
+
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(8);
+    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(10);
+    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(11);
+    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(12);
 
     // Bias arg. Unused if bias fusion is not enabled.
-    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(15);
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(14);
 
-    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(16);
-    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(17);
-    constexpr uint32_t output_rows_tiles = get_compile_time_arg_val(18);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(15);
 
     // Split reader args
-    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(19);
+    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(17);
     constexpr uint32_t split_reader = act_block_h_datums != 0;
-    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(20);
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(21);
-    constexpr uint32_t weight_size_w = get_compile_time_arg_val(22);
-    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(23);
-    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(24);
-    constexpr uint32_t act_block_h_datums_first_reader = get_compile_time_arg_val(25);
-    constexpr uint32_t act_block_h_datums_last_block = get_compile_time_arg_val(26);
-    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(27) == 1;
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(28);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(29);
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(18);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(19);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(20);
+    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(21);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(22);
+    constexpr uint32_t act_block_h_datums_first_reader = get_compile_time_arg_val(23);
+    constexpr uint32_t act_block_h_datums_last_block = get_compile_time_arg_val(24);
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(25) == 1;
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(26);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(27);
 
     constexpr uint32_t act_block_h_datums_read_last_block =
         act_block_h_datums_last_block > act_block_h_datums
@@ -53,8 +53,6 @@ void kernel_main() {
     // Bias arg. Unused if bias fusion is not enabled.
     const uint32_t bias_addr = get_arg_val<uint32_t>(i++);
 
-    const uint32_t out_start_tile_id = get_arg_val<uint32_t>(i++);
-    const uint32_t out_start_tile_id_h = get_arg_val<uint32_t>(i++);
     const uint32_t out_start_tile_id_w = get_arg_val<uint32_t>(i++);
     const uint32_t bias_tile_offset = get_arg_val<uint32_t>(i++);
 
@@ -108,8 +106,6 @@ void kernel_main() {
 
     // read in bias if enabled (done only once for all batches)
 #ifdef FUSE_BIAS
-    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t bias_in_dram = get_compile_time_arg_val(3) == 1;
 
     constexpr uint32_t bias_pagesize = get_tile_size(bias_cb_id);
     constexpr DataFormat bias_df = get_dataformat(bias_cb_id);
@@ -118,188 +114,118 @@ void kernel_main() {
 
     bool load_bias = true;
 #endif
-
     constexpr uint32_t weight_tile_nbytes = get_tile_size(cb_id_weight);
+    constexpr uint32_t tile_mcast_bytes = weight_tile_nbytes * weight_block_num_tiles;
     constexpr DataFormat weight_df = get_dataformat(cb_id_weight);
     const InterleavedAddrGenFast<true> s_weight = {
         .bank_base_address = weight_addr_dram_base, .page_size = weight_tile_nbytes, .data_format = weight_df};
 
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
-    constexpr uint32_t num_coalesced_reads = weight_size_w;
     constexpr uint32_t coalesced_read_bytes =
-        ((dilation_w == 1) ? num_coalesced_reads * conv_act_c_read_bytes : conv_act_c_read_bytes);
+        ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
 
     // OUTER most loop is looping over out blocks in width dim because blocks from compute are in col major order.
     // Write out col major blocks in row major layout to output
-    uint32_t weight_start_tile_id = out_start_tile_id_w;
     constexpr uint32_t weight_inner_block_stride_h =
         weight_next_block_stride_h / weight_block_height_num_outer;  // TODO: Pass as args
     const uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
-    // DPRINT << "weight_start_tile_id=" << weight_start_tile_id << ENDL();
-    for (uint32_t bw = 0; bw < out_num_blocks_w; bw++) {
-        // coalesce reads along weight_size_w
-        uint32_t start_reader_idx;
-        if constexpr (split_reader) {
-            start_reader_idx = 0;
-            start_reader_idx = act_block_h_datums_first_reader / 2;
-        }
+    // coalesce reads along weight_size_w
+    uint32_t start_reader_idx;
+    if constexpr (split_reader) {
+        start_reader_idx = 0;
+        start_reader_idx = act_block_h_datums_first_reader / 2;
+    }
 
-        for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
-            // READ WEIGHTS + MCAST SEND WEIGHTS
-            // read weight blocks inner dim
-            // read weight slice - 1 block of weights in width dim and full weight matrix height
-            // read slice only once for all activation blocks
-            uint32_t weight_h_offset = 0;
+    for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
+        // READ WEIGHTS + MCAST SEND WEIGHTS
+        // read weight blocks inner dim
+        // read weight slice - 1 block of weights in width dim and full weight matrix height
+        // read slice only once for all activation blocks
+        uint32_t weight_h_offset = 0;
 
-            // TODO: Not sure how this loop works with the additional reader; we don't have a use case for this right
-            // now
-            for (uint32_t weight_tile_h_outer_i = 0; weight_tile_h_outer_i < weight_block_height_num_outer;
-                 weight_tile_h_outer_i++) {
-                uint32_t weight_current_block_start_tile_id = weight_start_tile_id;
+        uint32_t weight_current_block_start_tile_id = 0;
 
-                uint32_t reader_offset = act_l1_read_addr;
-                for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
-                    if constexpr (split_reader) {
-                        // Do the second half of the reads for act
-                        noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
-                        reader_idx = start_reader_idx;
-                        cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
-                        uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
-                        uint32_t act_block_h_datums_read_curr =
-                            bh == out_num_blocks_h - 1 ? act_block_h_datums_read_last_block : act_block_h_datums_read;
-                        read_sticks<
-                            dilation_w,
-                            coalesced_read_bytes,
-                            conv_act_c_read_bytes,
-                            act_block_w_extra_align_bytes,
-                            stride_w_bytes,
-                            weight_size_w>(
-                            act_block_h_datums_read_curr,
-                            packed_reader_indices_ptr,
-                            reader_offset,
-                            l1_write_addr_act,
-                            reader_idx);
-                        noc_async_read_barrier();
-                        cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
+        uint32_t reader_offset = act_l1_read_addr;
+        for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
+            if constexpr (split_reader) {
+                // Do the second half of the reads for act
+                noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+                reader_idx = start_reader_idx;
+                cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
+                uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                uint32_t act_block_h_datums_read_curr =
+                    bh == out_num_blocks_h - 1 ? act_block_h_datums_read_last_block : act_block_h_datums_read;
+                read_sticks<
+                    dilation_w,
+                    coalesced_read_bytes,
+                    conv_act_c_read_bytes,
+                    act_block_w_extra_align_bytes,
+                    stride_w_bytes,
+                    weight_size_w>(
+                    act_block_h_datums_read_curr,
+                    packed_reader_indices_ptr,
+                    reader_offset,
+                    l1_write_addr_act,
+                    reader_idx);
+                noc_async_read_barrier();
+                cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
 
-                        reader_offset += window_outer_offset;
-                    }
+                reader_offset += window_outer_offset;
+            }
 
-                    // Do weights read + mcast
-                    cb_reserve_back(cb_id_weight, weight_block_num_tiles);
-                    if (bh == 0) {
-                        uint32_t weight_write_l1_addr = get_write_ptr(cb_id_weight);
-                        uint32_t weight_row_start_tile_id = weight_current_block_start_tile_id + weight_h_offset;
-
-                        // mcast args
-                        uint32_t weights_start_address = weight_write_l1_addr;
-                        uint32_t weights_block_size_bytes = 0;
-
-                        // loop over weight block tiles along h
-                        for (uint32_t weight_tile_h_i = 0; weight_tile_h_i < weight_block_height_ntiles;
-                             ++weight_tile_h_i) {
-                            uint32_t weight_tile_id = weight_row_start_tile_id;
-                            // loop over weight block tiles along w
-                            for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles;
-                                 ++weight_tile_w_i) {
-                                // DPRINT << "weight_tile_id=" << weight_tile_id << ENDL();
-                                noc_async_read_tile(weight_tile_id, s_weight, weight_write_l1_addr);
-                                weight_write_l1_addr += weight_tile_nbytes;
-                                weights_block_size_bytes += weight_tile_nbytes;
-                                weight_tile_id += 1;
-                            }  // for weight_block_w
-                            weight_row_start_tile_id += weight_stride_h;
-                        }  // for weight_block_h
-                        noc_async_read_barrier();
-
-#ifndef SKIP_MCAST
-                        // wait until all weights mcast destinations have atomically incremented the weights
-                        // semaphore_addr (i.e. its value should be weights_mcast_num_dests), then reset the
-                        // semaphore_addr value back to zero for the next block
-                        noc_semaphore_wait(weights_mcast_sender_semaphore_addr_ptr, weights_mcast_num_dests);
-                        noc_semaphore_set(weights_mcast_sender_semaphore_addr_ptr, 0);
-
-                        // Now we have the block in the CB address, we can mcast to dests!
-                        uint64_t weights_multicast_data_addr = get_noc_multicast_addr(
-                            weights_mcast_dest_noc_start_x,
-                            weights_mcast_dest_noc_start_y,
-                            weights_mcast_dest_noc_end_x,
-                            weights_mcast_dest_noc_end_y,
-                            weights_start_address);
-                        // num_dests must not include source, since we are NOT really doing a local copy!
-                        noc_async_write_multicast(
-                            weights_start_address,
-                            weights_multicast_data_addr,
-                            weights_block_size_bytes,
-                            weights_mcast_num_cores,
-                            true);
-
-                        // Note: no need for write barrier, since these two multicasts are done on the same noc id and
-                        // same vc even though cmd bufs are different Also, this only works because we are setting VCs
-                        // statically (using NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                        // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and
-                        // may not be sent in order they are issued
-                        noc_async_writes_flushed();
-#endif
-
-                        // We should also multicast the flag to destinations
-                        // num_dests must not include source, since we are NOT really doing a local copy!
-                        noc_semaphore_set_multicast(
-                            weights_mcast_receiver_semaphore_addr,
-                            weights_mcast_receiver_semaphore_noc_addr,
-                            weights_mcast_num_cores,
-                            false);
-#endif
-
-                        weight_current_block_start_tile_id += weight_next_block_stride_h;
-                    }
-
-                    cb_push_back(cb_id_weight, weight_block_num_tiles);
-                }  // for num_blocks_weight_h
-                weight_h_offset += weight_inner_block_stride_h;
-            }  // for weight_block_height_num_outer
-
-#ifdef FUSE_BIAS
-            if (load_bias) {
-                cb_reserve_back(bias_cb_id, bias_ntiles);
-                uint32_t bias_l1_addr = get_write_ptr(bias_cb_id);
+            // Do weights read + mcast
+            cb_reserve_back(cb_id_weight, weight_block_num_tiles);
+            if (bh == 0) {
+                uint32_t weight_write_l1_addr = get_write_ptr(cb_id_weight);
+                uint32_t weight_row_start_tile_id = weight_current_block_start_tile_id + weight_h_offset;
 
                 // mcast args
-                uint32_t bias_start_address = bias_l1_addr;
-                uint32_t bias_block_size_bytes = 0;
-                for (uint32_t bias_tile = bias_tile_offset; bias_tile < bias_tile_offset + bias_ntiles; ++bias_tile) {
-                    noc_async_read_tile(bias_tile, s_bias, bias_l1_addr);
-                    bias_l1_addr += bias_pagesize;
-                    bias_block_size_bytes += bias_pagesize;
-                }
+                uint32_t weights_start_address = weight_write_l1_addr;
+                uint32_t weights_block_size_bytes = 0;
+
+                // loop over weight block tiles along h
+                for (uint32_t weight_tile_h_i = 0; weight_tile_h_i < weight_block_height_ntiles; ++weight_tile_h_i) {
+                    uint32_t weight_tile_id = weight_row_start_tile_id;
+                    // loop over weight block tiles along w
+                    for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles; ++weight_tile_w_i) {
+                        // DPRINT << "weight_tile_id=" << weight_tile_id << ENDL();
+                        noc_async_read_tile(weight_tile_id, s_weight, weight_write_l1_addr);
+                        weight_write_l1_addr += weight_tile_nbytes;
+                        weights_block_size_bytes += weight_tile_nbytes;
+                        weight_tile_id += 1;
+                    }  // for weight_block_w
+                    weight_row_start_tile_id += weight_stride_h;
+                }  // for weight_block_h
                 noc_async_read_barrier();
 
-// MCAST BIAS (shares some mcast args with weights)
 #ifndef SKIP_MCAST
-                // wait until all weights mcast destinations have atomically incremented the weights semaphore_addr
-                // (i.e. its value should be weights_mcast_num_dests), then reset the semaphore_addr value back to zero
-                // for the next block
+                // wait until all weights mcast destinations have atomically incremented the weights
+                // semaphore_addr (i.e. its value should be weights_mcast_num_dests), then reset the
+                // semaphore_addr value back to zero for the next block
                 noc_semaphore_wait(weights_mcast_sender_semaphore_addr_ptr, weights_mcast_num_dests);
                 noc_semaphore_set(weights_mcast_sender_semaphore_addr_ptr, 0);
 
                 // Now we have the block in the CB address, we can mcast to dests!
-                uint64_t bias_multicast_data_addr = get_noc_multicast_addr(
+                uint64_t weights_multicast_data_addr = get_noc_multicast_addr(
                     weights_mcast_dest_noc_start_x,
                     weights_mcast_dest_noc_start_y,
                     weights_mcast_dest_noc_end_x,
                     weights_mcast_dest_noc_end_y,
-                    bias_start_address);
+                    weights_start_address);
                 // num_dests must not include source, since we are NOT really doing a local copy!
                 noc_async_write_multicast(
-                    bias_start_address, bias_multicast_data_addr, bias_block_size_bytes, weights_mcast_num_cores, true);
+                    weights_start_address,
+                    weights_multicast_data_addr,
+                    weights_block_size_bytes,
+                    weights_mcast_num_cores,
+                    true);
 
-                // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc
-                // even though cmd bufs are different Also, this only works because we are setting VCs statically (using
-                // NOC_CMD_STATIC_VC).
+                // Note: no need for write barrier, since these two multicasts are done on the same noc id and
+                // same vc even though cmd bufs are different Also, this only works because we are setting VCs
+                // statically (using NOC_CMD_STATIC_VC).
 #ifdef ARCH_BLACKHOLE
-                // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not
-                // be sent in order they are issued
+                // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and
+                // may not be sent in order they are issued
                 noc_async_writes_flushed();
 #endif
 
@@ -312,18 +238,71 @@ void kernel_main() {
                     false);
 #endif
 
-                cb_push_back(bias_cb_id, bias_ntiles);
-                load_bias = false;
+                weight_current_block_start_tile_id += weight_next_block_stride_h;
             }
+
+            cb_push_back(cb_id_weight, weight_block_num_tiles);
+        }  // for num_blocks_weight_h
+        weight_h_offset += weight_inner_block_stride_h;
+
+#ifdef FUSE_BIAS
+        if (load_bias) {
+            cb_reserve_back(bias_cb_id, bias_ntiles);
+            uint32_t bias_l1_addr = get_write_ptr(bias_cb_id);
+
+            // mcast args
+            uint32_t bias_start_address = bias_l1_addr;
+            uint32_t bias_block_size_bytes = 0;
+            for (uint32_t bias_tile = bias_tile_offset; bias_tile < bias_tile_offset + bias_ntiles; ++bias_tile) {
+                noc_async_read_tile(bias_tile, s_bias, bias_l1_addr);
+                bias_l1_addr += bias_pagesize;
+                bias_block_size_bytes += bias_pagesize;
+            }
+            noc_async_read_barrier();
+
+// MCAST BIAS (shares some mcast args with weights)
+#ifndef SKIP_MCAST
+            // wait until all weights mcast destinations have atomically incremented the weights semaphore_addr
+            // (i.e. its value should be weights_mcast_num_dests), then reset the semaphore_addr value back to zero
+            // for the next block
+            noc_semaphore_wait(weights_mcast_sender_semaphore_addr_ptr, weights_mcast_num_dests);
+            noc_semaphore_set(weights_mcast_sender_semaphore_addr_ptr, 0);
+
+            // Now we have the block in the CB address, we can mcast to dests!
+            uint64_t bias_multicast_data_addr = get_noc_multicast_addr(
+                weights_mcast_dest_noc_start_x,
+                weights_mcast_dest_noc_start_y,
+                weights_mcast_dest_noc_end_x,
+                weights_mcast_dest_noc_end_y,
+                bias_start_address);
+            // num_dests must not include source, since we are NOT really doing a local copy!
+            noc_async_write_multicast(
+                bias_start_address, bias_multicast_data_addr, bias_block_size_bytes, weights_mcast_num_cores, true);
+
+            // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc
+            // even though cmd bufs are different Also, this only works because we are setting VCs statically (using
+            // NOC_CMD_STATIC_VC).
+#ifdef ARCH_BLACKHOLE
+            // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not
+            // be sent in order they are issued
+            noc_async_writes_flushed();
 #endif
-            if constexpr (split_reader) {
-                start_reader_idx = reader_idx + act_block_h_datums_first_reader_read;
-            }
-        }  // out_num_blocks_h
 
-        // Increment weight start tile id for next block in width dim
-        weight_start_tile_id += weight_next_block_stride_w;
-    }  // out_num_blocks_w
+            // We should also multicast the flag to destinations
+            // num_dests must not include source, since we are NOT really doing a local copy!
+            noc_semaphore_set_multicast(
+                weights_mcast_receiver_semaphore_addr,
+                weights_mcast_receiver_semaphore_noc_addr,
+                weights_mcast_num_cores,
+                false);
+#endif
 
-    cb_wait_front(cb_id_out0, output_rows_tiles);
+            cb_push_back(bias_cb_id, bias_ntiles);
+            load_bias = false;
+        }
+#endif
+        if constexpr (split_reader) {
+            start_reader_idx = reader_idx + act_block_h_datums_first_reader_read;
+        }
+    }  // out_num_blocks_h
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdint>
 #include "dataflow_api.h"
 
 #define ENABLE_DEBUG 0
@@ -13,23 +14,16 @@
 
 void kernel_main() {
     // This writer is for output tensor in tile format
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(1);
-
-    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(8);
-    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(9);
+    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(0);
+    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(7);
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(8);
 
     // Bias arg. Unused if bias fusion is not enabled.
-    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(15);
-    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(16);
-    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(17);
-    constexpr uint32_t output_rows_tiles = get_compile_time_arg_val(18);
-
-    uint32_t i = 2;
-    const uint32_t out_start_tile_id = get_arg_val<uint32_t>(i++);
-    const uint32_t out_start_tile_id_h = get_arg_val<uint32_t>(i++);
-    const uint32_t out_start_tile_id_w = get_arg_val<uint32_t>(i++);
-    i += 1;
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(14);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(15);
+    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(16);
+    uint32_t i = 0;
     uint32_t noop = get_arg_val<uint32_t>(i++);
     if (noop) {
         return;
@@ -40,7 +34,6 @@ void kernel_main() {
     const uint32_t weights_mcast_sender_noc_y = get_arg_val<uint32_t>(i++);
     const uint32_t weights_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
     const uint32_t weights_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
-    const uint32_t out_aligned_page_size = get_arg_val<uint32_t>(i++);
 
     volatile tt_l1_ptr uint32_t* weights_mcast_receiver_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(weights_mcast_receiver_semaphore_addr);
@@ -49,7 +42,6 @@ void kernel_main() {
 
 // read in bias if enabled (done only once for all batches)
 #ifdef FUSE_BIAS
-    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(2);
     bool load_bias = true;
 #endif
 
@@ -97,6 +89,5 @@ void kernel_main() {
         }  // out_num_blocks_h
     }  // out_num_blocks_w
 
-    cb_wait_front(cb_id_out0, output_rows_tiles);
     noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -13,31 +13,29 @@
 
 void kernel_main() {
     // This writer is for output tensor in tile format
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(0);
+    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t bias_in_dram = get_compile_time_arg_val(2) == 1;
 
-    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(7);
-    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(8);
-    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(9);
-    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(10);
-    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(11);
-    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(12);
-    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(13);
-    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(14);
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(7);
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(8);
+    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(10);
+    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(11);
+    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(12);
+    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(13);
 
     // Bias arg. Unused if bias fusion is not enabled.
-    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(15);
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(14);
 
-    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(16);
-    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(17);
-    constexpr uint32_t output_rows_tiles = get_compile_time_arg_val(18);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(15);
+    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(16);
 
     uint32_t i = 0;
     const uint32_t weight_addr_dram_base = get_arg_val<uint32_t>(i++);
     // Bias arg. Unused if bias fusion is not enabled.
     const uint32_t bias_addr = get_arg_val<uint32_t>(i++);
-    const uint32_t out_start_tile_id = get_arg_val<uint32_t>(i++);
-    const uint32_t out_start_tile_id_h = get_arg_val<uint32_t>(i++);
     const uint32_t out_start_tile_id_w = get_arg_val<uint32_t>(i++);
     const uint32_t bias_tile_offset = get_arg_val<uint32_t>(i++);
 
@@ -55,7 +53,6 @@ void kernel_main() {
     const uint32_t weights_mcast_num_cores = get_arg_val<uint32_t>(i++);
     const uint32_t weights_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
     const uint32_t weights_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
-    const uint32_t out_aligned_page_size = get_arg_val<uint32_t>(i++);
 
 #ifndef SKIP_MCAST
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
@@ -77,9 +74,6 @@ void kernel_main() {
 
 // read in bias if enabled (done only once for all batches)
 #ifdef FUSE_BIAS
-    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t bias_in_dram = get_compile_time_arg_val(3) == 1;
-
     constexpr uint32_t bias_pagesize = get_tile_size(bias_cb_id);
     constexpr DataFormat bias_df = get_dataformat(bias_cb_id);
     const InterleavedAddrGenFast<bias_in_dram> s_bias = {
@@ -235,8 +229,6 @@ void kernel_main() {
         // Increment weight start tile id for next block in width dim
         weight_start_tile_id += weight_next_block_stride_w;
     }  // out_num_blocks_w
-
-    cb_wait_front(cb_id_out0, output_rows_tiles);
 
     noc_async_write_barrier();
 }


### PR DESCRIPTION
Clean up of unused runtime args, compile time args and superfluous loops for height sharded weights reader.

CI is having a bad day, I'll post green pipelines next week.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15348476581)
- [x] [Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/15375605595) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15375600402)
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15375596111)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/15376458534)