### PR TITLE
Revert "Revert "Modify active links from UMD for partial cluster" (#22675)"

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -56,8 +56,10 @@ static void test_sems_across_core_types(
             continue;
         }
 
-        const auto& eth_cores =
+        const auto& eth_cores_unordered =
             active_eth ? device->get_active_ethernet_cores() : device->get_inactive_ethernet_cores();
+
+        std::set<CoreCoord> eth_cores(eth_cores_unordered.begin(), eth_cores_unordered.end());
         if (eth_cores.size() > 0) {
             auto program = tt::tt_metal::CreateProgram();
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -124,8 +124,10 @@ TEST_F(DispatchFixture, EthTestBlank) {
     Program program = CreateProgram();
 
     // TODO: tweak when FD supports idle eth
-    const auto& eth_cores =
+    const auto& eth_cores_unordered =
         this->slow_dispatch_ ? device->get_inactive_ethernet_cores() : device->get_active_ethernet_cores();
+
+    std::set<CoreCoord> eth_cores(eth_cores_unordered.begin(), eth_cores_unordered.end());
 
     if (eth_cores.size() > 0) {
         CoreCoord eth_core = *eth_cores.begin();

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1002,6 +1002,16 @@ void Cluster::reserve_ethernet_cores_for_tunneling() {
                         }
                     }
                 }
+                // We want to also add the eth cores that are connected to other chips possibly outside the opened
+                // cluster.
+                const auto& soc_desc = get_soc_desc(chip_id);
+                for (const auto& eth_channel : cluster_desc_->get_active_eth_channels(chip_id)) {
+                    auto eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
+                    if (this->device_eth_routing_info_.at(chip_id).find(eth_core) ==
+                        this->device_eth_routing_info_.at(chip_id).end()) {
+                        this->device_eth_routing_info_.at(chip_id).insert({eth_core, EthRouterMode::IDLE});
+                    }
+                }
             } else {
                 // Slow dispatch mode
                 for (const auto &[connected_chip_id, active_eth_cores] :
@@ -1031,35 +1041,32 @@ std::unordered_set<chip_id_t> Cluster::get_ethernet_connected_device_ids(chip_id
 std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
     chip_id_t chip_id, bool skip_reserved_tunnel_cores) const {
     std::unordered_set<CoreCoord> active_ethernet_cores;
+    const auto& soc_desc = get_soc_desc(chip_id);
     if (arch_ == ARCH::BLACKHOLE) {
         // Can't just use `get_ethernet_cores_grouped_by_connected_chips` because there are some active ethernet cores
         // without links. Only risc1 on these cores is available for Metal and should not be classified as idle
         // to ensure that Metal does not try to program both riscs.
-        const auto& soc_desc = get_soc_desc(chip_id);
         std::set<uint32_t> logical_active_eth_channels = cluster_desc_->get_active_eth_channels(chip_id);
         for (auto logical_active_eth_channel : logical_active_eth_channels) {
             tt::umd::CoreCoord logical_active_eth =
                 soc_desc.get_eth_core_for_channel(logical_active_eth_channel, CoordSystem::LOGICAL);
             active_ethernet_cores.insert(CoreCoord(logical_active_eth.x, logical_active_eth.y));
         }
-
     } else {
-        const auto& connected_chips = this->get_ethernet_cores_grouped_by_connected_chips(chip_id);
-        for (const auto& [other_chip_id, eth_cores] : connected_chips) {
-            for (const auto& eth_core : eth_cores) {
-                const auto& routing_info = this->device_eth_routing_info_.at(chip_id).at(eth_core);
-                if ((routing_info == EthRouterMode::BI_DIR_TUNNELING or
-                     routing_info == EthRouterMode::FABRIC_ROUTER) and
-                    skip_reserved_tunnel_cores) {
-                    continue;
-                }
-                if (this->frequent_retrain_cores_.at(chip_id).find(eth_core) !=
-                    this->frequent_retrain_cores_.at(chip_id).end()) {
-                    continue;
-                }
-
-                active_ethernet_cores.insert(eth_core);
+        std::set<uint32_t> logical_active_eth_channels = cluster_desc_->get_active_eth_channels(chip_id);
+        for (const auto& eth_channel : logical_active_eth_channels) {
+            tt::umd::CoreCoord eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
+            const auto& routing_info = this->device_eth_routing_info_.at(chip_id).at(eth_core);
+            if ((routing_info == EthRouterMode::BI_DIR_TUNNELING or routing_info == EthRouterMode::FABRIC_ROUTER) and
+                skip_reserved_tunnel_cores) {
+                continue;
             }
+            if (this->frequent_retrain_cores_.at(chip_id).find(eth_core) !=
+                this->frequent_retrain_cores_.at(chip_id).end()) {
+                continue;
+            }
+
+            active_ethernet_cores.insert(eth_core);
         }
     }
     return active_ethernet_cores;


### PR DESCRIPTION
This reverts commit 17c897f7c80034e6fe46a416f309138785b765ff.

### Ticket

### Problem description
Original change didn't test on 6U cluster.
Now the issue was fixed by https://github.com/tenstorrent/tt-metal/pull/22755

### What's changed
For the original change description, see: https://github.com/tenstorrent/tt-metal/pull/22392

### Checklist
All runs on brosko/active_links_rerevert :
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15361973832
- [x] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15349800432
- [x] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/15349802852
- [x] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/15349805140
- [x] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15349807494
- [x] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/15349810176
- [x] (TG) TG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15349812418
- [x] (TG) TG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/15349814619
- [x] Galaxy Quick : https://github.com/tenstorrent/tt-metal/actions/runs/15349816756