### PR TITLE
Revert "[skip ci] Enhance build-artifact.yaml"

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -1,8 +1,5 @@
 name: "Build tt-metal artifacts"
 
-permissions:
-  packages: write
-
 on:
   workflow_call:
     inputs:
@@ -232,7 +229,7 @@ jobs:
             build_command="$build_command --build-umd-tests"
           fi
 
-          $build_command
+          nice -n 19 $build_command
 
       - name: 🛠️ Compile
         run: |
@@ -243,18 +240,18 @@ jobs:
         if: ${{ inputs.profile }}
         run: |
           echo "maxNameLength = 300" > ClangBuildAnalyzer.ini
-          ClangBuildAnalyzer --all build capture.bin
-          ClangBuildAnalyzer --analyze capture.bin
+          nice -n 19 ClangBuildAnalyzer --all build capture.bin
+          nice -n 19 ClangBuildAnalyzer --analyze capture.bin
 
       - name: 📦 Package
         run: |
-          cmake --build build --target package
+          nice -n 19 cmake --build build --target package
           ls -1sh build/*.deb build/*.ddeb || true
 
       - name: 🐍 Build wheel
         if: ${{ inputs.build-wheel }}
         run: |
-          python3 -m build --wheel
+          nice -n 19 python3 -m build --wheel
 
       - name: Publish ccache summary
         run: |


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#22769

```
[Invalid workflow file: .github/workflows/tt-metal-l2-nightly.yaml#L27](https://github.com/tenstorrent/tt-metal/actions/runs/15339617007/workflow)
The workflow is not valid. .github/workflows/tt-metal-l2-nightly.yaml (Line: 27, Col: 3): Error calling workflow 'tenstorrent/tt-metal/.github/workflows/build-artifact.yaml@2a5617e5e23cfbe1121fddf72088836a64e1983d'. The workflow is requesting 'packages: write', but is only allowed 'packages: read'.
```

The changed permission likely cannot be added to the reusable build-artifact.yaml unless caller workflows also set the permission 