### PR TITLE
#19531: add extra perf info to sweeps message

### DIFF
--- a/tests/sweep_framework/sweep_utils/roofline_utils.py
+++ b/tests/sweep_framework/sweep_utils/roofline_utils.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2054 TenstorrentAI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from loguru import logger
+from tests.ttnn.utils_for_testing import check_with_pcc
+
+
+def get_product(lst):
+    count = 1
+    for val in lst:
+        count *= val
+    return count
+
+
+def get_byte_count(tensor):
+    shape = tensor.padded_shape
+    dtype = tensor.dtype
+    if dtype == ttnn.float32:
+        count = 4
+    elif dtype == ttnn.bfloat16:
+        count = 2
+    elif dtype == ttnn.bfloat8_b:
+        count = 1.0625
+    else:
+        logger.warning("NEED TO PROVIDE DATA TYPE SIZE")
+        count = 1
+    return count * get_product(tensor.shape)
+
+
+WH_DRAM_THROUGHPUT = 256  # bytes/ns
+
+
+def get_rooofline_message(tensors, throughput=WH_DRAM_THROUGHPUT):
+    byte_count = 0
+    for tensor in tensors:
+        byte_count += get_byte_count(tensor)
+
+    # bytes / bytes/ns = ns
+    roofline = byte_count / throughput
+    return f"ROOFLINE {roofline} BYTECOUNT {byte_count}"
+
+
+def update_check_result(check_result, messages):
+    status, message = check_result
+    if not status:
+        return check_result
+    new_message = message
+    for msg in messages:
+        new_message += " " + msg
+    return (status, new_message)
+
+
+def get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts=None):
+    check_result = check_with_pcc(torch_output_tensor, output_tensor, expected_pcc)
+    messages = [get_rooofline_message(tensors)]
+    if flop_counts:
+        messages.append(f"FLOP_COUNT {get_product(flop_counts)}")
+    updated_check_result = update_check_result(check_result, messages)
+    return [updated_check_result, e2e_perf]
+
+
+def get_updated_message(message, perf_result):
+    key = "DEVICE FW DURATION [ns]"
+    if key in perf_result:
+        value = float(perf_result[key])
+        tokens = message.split()
+        for i in range(len(tokens)):
+            if tokens[i] == "ROOFLINE":
+                message += f" ROOFLINE% {float(tokens[i+1])/value}"
+            if tokens[i] == "FLOP_COUNT":
+                message += f" TFLOPS {float(tokens[i+1])/1e3/value}"  # flop_count / tera(10^12)*nano(10^-9) / ns
+    return message

--- a/tests/sweep_framework/sweep_utils/roofline_utils.py
+++ b/tests/sweep_framework/sweep_utils/roofline_utils.py
@@ -49,7 +49,7 @@ def update_check_result(check_result, messages):
     new_message = message
     for msg in messages:
         new_message += " " + msg
-    return (status, new_message)
+    return (status, "PCC " + new_message)
 
 
 def get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts=None):
@@ -62,6 +62,8 @@ def get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2
 
 
 def get_updated_message(message, perf_result):
+    if perf_result is None:
+        return message
     key = "DEVICE FW DURATION [ns]"
     if key in perf_result:
         value = float(perf_result[key])

--- a/tests/sweep_framework/sweeps/matmul/short/matmul_default.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_default.py
@@ -10,7 +10,8 @@ import torch
 import ttnn
 
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
+from tests.ttnn.utils_for_testing import start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
 
@@ -100,12 +101,14 @@ def run_matmul(
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.matmul(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(output_tensor)
+    op_output_tensor = ttnn.matmul(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 
     expected_pcc = 0.99
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor_a, input_tensor_b, op_output_tensor]
+    flop_counts = list(m_n_sizes) + [2, k_size, batch_sizes[0]]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))

--- a/tests/sweep_framework/sweeps/reduction/traces/sum_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/sum_traces.py
@@ -8,7 +8,8 @@ import pytest
 import torch
 import ttnn
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
+from tests.ttnn.utils_for_testing import start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
 TIMEOUT = 15
@@ -635,11 +636,12 @@ def run_sum(device, params):
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
-    output_tensor = ttnn.to_torch(output_tensor)
+    op_output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor, op_output_tensor]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
 
 
 @pytest.mark.parametrize("params", parameters["pytorch"]["params"])

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -62,22 +62,19 @@ def gather_single_test_perf(device, test_passed):
         logger.error("No profiling data available. Ensure you are running with the profiler build.")
         return None
     elif len(opPerfData) > 1:
-        logger.info("Composite op detected in device perf measurement. Composite op perf is not supported. Failing.")
-        if ADD_PERF_MESSAGE:
-            try:
-                for key in opPerfData[0].keys():
-                    value = opPerfData[0][key]
-                    for i in range(1, len(opPerfData)):
-                        if key in opPerfData[i]:
-                            if type(value) == str:
-                                opPerfData[0][key] = str(float(value) + float(opPerfData[i][key]))
-                            else:
-                                opPerfData[0][key] = value + opPerfData[i][key]
-                return opPerfData[0]
-            except Exception as e:
-                logger.info(e)
-                return None
-        else:
+        logger.info("Composite op detected in device perf measurement. Will aggregate results.")
+        try:
+            for key in opPerfData[0].keys():
+                value = opPerfData[0][key]
+                for i in range(1, len(opPerfData)):
+                    if key in opPerfData[i]:
+                        if type(value) == str:
+                            opPerfData[0][key] = str(float(value) + float(opPerfData[i][key]))
+                        else:
+                            opPerfData[0][key] = value + opPerfData[i][key]
+            return opPerfData[0]
+        except Exception as e:
+            logger.info(e)
             return None
     else:
         return opPerfData[0]
@@ -108,8 +105,7 @@ def run(test_module, input_queue, output_queue):
                 e2e_perf = None
             if MEASURE_DEVICE_PERF:
                 perf_result = gather_single_test_perf(device, status)
-                if ADD_PERF_MESSAGE:
-                    message = get_updated_message(message, perf_result)
+                message = get_updated_message(message, perf_result)
                 output_queue.put([status, message, e2e_perf, perf_result])
             else:
                 output_queue.put([status, message, e2e_perf, None])
@@ -510,13 +506,6 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--add-perf-message",
-        required=False,
-        action="store_true",
-        help="Add perf information to message. Requires --device-perf",
-    )
-
-    parser.add_argument(
         "--dry-run",
         action="store_true",
         required=False,
@@ -558,9 +547,6 @@ if __name__ == "__main__":
 
     global MEASURE_DEVICE_PERF
     MEASURE_DEVICE_PERF = args.device_perf
-
-    global ADD_PERF_MESSAGE
-    ADD_PERF_MESSAGE = args.add_perf_message
 
     global DRY_RUN
     DRY_RUN = args.dry_run


### PR DESCRIPTION
### Ticket
Link to Github Issue #19531

### Problem description
We need more information from sweeps about perf

### What's changed
- add utils to process tensor byte counts, flop counts, and combine them with tracy info
- modify a couple of tests to pass the counts
- add functionality to combine tracy data from multiple device ops

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes N/A
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) N/A
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). N/A
- [ ] New/Existing tests provide coverage for changes

Local testing shows expected messages on elastic:
matmul, with flop info:
```
0.999964267269671 ROOFLINE 66064.0 BYTECOUNT 16912384 FLOP_COUNT 3963617280 ROOFLINE% 0.4402945782931787 TFLOPS 26.416190342897128
```
sum, without flop count:
```
1.0 ROOFLINE 15976.578125 BYTECOUNT 4090004 ROOFLINE% 0.03998142673923924
```