### PR TITLE
Re-attempt: Add ring + 4 links support to the llama_reduce_scatter

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_6U.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_6U.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+
+from models.utility_functions import skip_for_grayskull
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+from tests.ttnn.unit_tests.operations.ccl.test_new_all_reduce import (
+    SUB_DEVICE_CRS,
+    QKV_CRS,
+    RING_CRS,
+    FF1_CRS,
+    FF1_CRS_RS_OUT,
+    NORM_CRS,
+)
+
+from tests.ttnn.unit_tests.operations.ccl.test_llama_reduce_scatter_async_TG import run_reduce_scatter_test
+
+from conftest import is_6u
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "trace_region_size": 300000,
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("trace_mode", [True])
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        (8, 4),
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("num_links", [3, 4])
+@pytest.mark.parametrize("topology", [ttnn.Topology.Ring, ttnn.Topology.Linear])
+def test_fabric_reduce_scatter_tg_trace_6u(mesh_device, trace_mode, num_links, topology):
+    # Only run these tests on unharvested TG
+    device_grid = (mesh_device.compute_with_storage_grid_size().x, mesh_device.compute_with_storage_grid_size().y)
+    if device_grid != (7, 10):
+        pytest.skip("Not a Galaxy!")
+
+    if not is_6u():
+        pytest.skip("Not 6U!")
+
+    dim = 3
+    shard_height = 32
+    shard_width = 160
+    num_devices_scatter = 4
+    num_devices_fracture = 8
+    num_cores = 24
+    num_iters = 75
+    warmup_iters = 10
+    trace_mode = trace_mode
+    num_links = 4
+
+    run_reduce_scatter_test(
+        mesh_device,
+        dim,
+        shard_height,
+        shard_width,
+        num_devices_scatter,
+        num_devices_fracture,
+        num_cores,
+        num_iters,
+        warmup_iters,
+        trace_mode,
+        num_links=num_links,
+        scheme="random",
+        topology=topology,
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}],
+    indirect=True,
+)
+@pytest.mark.parametrize("trace_mode", [False])
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        (8, 4),
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("num_links", [3, 4])
+@pytest.mark.parametrize("topology", [ttnn.Topology.Ring, ttnn.Topology.Linear])
+def test_fabric_reduce_scatter_tg_no_trace_6u(mesh_device, trace_mode, num_links, topology):
+    # Only run these tests on unharvested TG
+    device_grid = (mesh_device.compute_with_storage_grid_size().x, mesh_device.compute_with_storage_grid_size().y)
+    if device_grid != (7, 10):
+        pytest.skip("Not a Galaxy!")
+
+    if not is_6u():
+        pytest.skip("Not 6U!")
+
+    dim = 3
+    shard_height = 32
+    shard_width = 160
+    num_devices_scatter = 4
+    num_devices_fracture = 8
+    num_cores = 24
+    num_iters = 30
+    warmup_iters = 0
+    trace_mode = trace_mode
+    num_links = 4
+
+    run_reduce_scatter_test(
+        mesh_device,
+        dim,
+        shard_height,
+        shard_width,
+        num_devices_scatter,
+        num_devices_fracture,
+        num_cores,
+        num_iters,
+        warmup_iters,
+        trace_mode,
+        num_links=num_links,
+        scheme="random",
+        topology=topology,
+    )

--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
@@ -31,6 +31,7 @@ PACKET_WORKER_CRS = ttnn.CoreRangeSet(
 
 
 def gen_tensor(dim, shard_height, shard_width, num_devices_scatter, num_devices_fracture, num_cores, scheme="random"):
+    torch.manual_seed(2005)
     factor = 0
     torch_fracture_tensors = []
     for _ in range(num_devices_fracture):
@@ -71,6 +72,7 @@ def run_reduce_scatter_test(
     output_grid=None,
     dtype=ttnn.bfloat8_b,
     profiler=BenchmarkProfiler(),
+    topology=ttnn.Topology.Linear,
 ):
     mesh_device.enable_program_cache()
     num_pages_per_packet = 4
@@ -225,6 +227,7 @@ def run_reduce_scatter_test(
                 mesh_device=mesh_device,
                 num_links=num_links,
                 memory_config=output_mem_config,
+                topology=topology,
             )
             if not trace_mode:
                 ttnn.synchronize_device(mesh_device)
@@ -314,7 +317,7 @@ def run_reduce_scatter_test(
     "device_params",
     [
         {
-            "trace_region_size": 237568,
+            "trace_region_size": 300000,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
         }
@@ -403,6 +406,7 @@ def test_fabric_reduce_scatter_tg_no_trace(mesh_device, trace_mode):
         trace_mode,
         num_links=3,
         scheme="random",
+        topology=ttnn.Topology.Linear,
     )
 
 
@@ -410,7 +414,7 @@ def test_fabric_reduce_scatter_tg_no_trace(mesh_device, trace_mode):
     "device_params",
     [
         {
-            "trace_region_size": 90000,
+            "trace_region_size": 100000,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
         }
@@ -468,7 +472,7 @@ def test_fabric_reduce_scatter_regular_grid_2_dev(
     "device_params",
     [
         {
-            "trace_region_size": 90000,
+            "trace_region_size": 100000,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.cpp
@@ -133,7 +133,8 @@ LlamaReduceScatterDeviceOperation::invoke(
     const uint32_t cluster_axis,
     const uint32_t ring_devices,
     const uint32_t num_links,
-    const std::optional<ttnn::MemoryConfig>& memory_config) {
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    tt::tt_fabric::Topology topology) {
     return {
         operation_attributes_t{
             .dim = (dim < 0 ? uint32_t(input_tensor.get_logical_shape().rank() + dim) : (uint32_t)dim),
@@ -143,6 +144,7 @@ LlamaReduceScatterDeviceOperation::invoke(
             .output_mem_config = memory_config,
             .ring_devices = ring_devices,
             .num_links = num_links,
+            .topology = topology,
         },
         tensor_args_t{.input_tensor = input_tensor, .intermediate_packet_buffer = intermediate_packet_buffer}};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.hpp
@@ -15,6 +15,7 @@
 #include "ttnn/decorators.hpp"
 #include "ttnn/global_semaphore.hpp"
 #include <tt-metalium/sub_device.hpp>
+#include <tt-metalium/fabric_edm_types.hpp>
 
 namespace ttnn::operations::experimental::ccl {
 
@@ -27,6 +28,7 @@ struct LlamaReduceScatterDeviceOperation {
         const std::optional<MemoryConfig> output_mem_config;
         const uint32_t ring_devices;
         const uint32_t num_links;
+        tt::tt_fabric::Topology topology;
     };
     struct tensor_args_t {
         const Tensor input_tensor;
@@ -97,7 +99,8 @@ struct LlamaReduceScatterDeviceOperation {
         const uint32_t cluster_axis,
         const uint32_t ring_devices,
         const uint32_t num_links,
-        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        tt::tt_fabric::Topology topology = tt::tt_fabric::Topology::Linear);
 };
 }  // namespace ttnn::operations::experimental::ccl
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
@@ -22,7 +22,7 @@ namespace ttnn::operations::experimental::ccl {
 
 namespace detail {
 
-std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index) {
+std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index, tt::tt_fabric::Topology topology) {
     ttnn::SmallVector<uint32_t> device_order;
     device_order.reserve(ring_size - 1);
     // Add all indices except ring_index
@@ -32,11 +32,34 @@ std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index) {
         }
     }
 
-    // Sort based on absolute difference from ring_index in descending order
-    std::sort(device_order.begin(), device_order.end(), [ring_index](uint32_t a, uint32_t b) {
-        return std::abs(static_cast<int>(a) - static_cast<int>(ring_index)) >
-               std::abs(static_cast<int>(b) - static_cast<int>(ring_index));
-    });
+    if (topology == tt::tt_fabric::Topology::Linear) {
+        // Sort based on absolute difference from ring_index in descending order
+        std::sort(device_order.begin(), device_order.end(), [ring_index](uint32_t a, uint32_t b) {
+            return std::abs(static_cast<int>(a) - static_cast<int>(ring_index)) >
+                   std::abs(static_cast<int>(b) - static_cast<int>(ring_index));
+        });
+    } else if (topology == tt::tt_fabric::Topology::Ring) {
+        // Sort based on ring distance
+        // 0 -> 1 -> 2 -> ... -> ring_size - 1 -> 0
+        std::sort(device_order.begin(), device_order.end(), [ring_index, ring_size](uint32_t a, uint32_t b) {
+            // Calculate shortest distance for 'a' from 'ring_index' in a ring of 'ring_size'
+            // Cast to int for std::abs to work as expected with unsigned differences.
+            // This is safe as ring_index and device IDs (a, b) are expected to be much smaller than INT_MAX.
+            uint32_t diff_a = std::abs(static_cast<int>(a) - static_cast<int>(ring_index));
+            uint32_t dist_a = std::min(diff_a, ring_size - diff_a);
+
+            // Calculate shortest distance for 'b' from 'ring_index'
+            uint32_t diff_b = std::abs(static_cast<int>(b) - static_cast<int>(ring_index));
+            uint32_t dist_b = std::min(diff_b, ring_size - diff_b);
+
+            if (dist_a != dist_b) {
+                return dist_a > dist_b;
+            }
+            // Tie-breaking: if distances are equal, sort by the device ID itself.
+            // This ensures a stable and predictable order for devices at the same distance.
+            return a < b;
+        });
+    }
 
     // Convert to string format
     std::string result = "{";
@@ -161,18 +184,6 @@ std::vector<std::vector<ReadRequest>> distribute_work_evenly(
     return schedule;
 }
 
-uint32_t find_atomic_inc_core(std::vector<std::vector<ReadRequest>> schedule) {
-    uint32_t atomic_inc_core = 0;
-    uint32_t min_packets = schedule[0].size();
-    for (uint32_t i = 1; i < schedule.size(); ++i) {
-        if (schedule[i].size() < min_packets) {
-            min_packets = schedule[i].size();
-            atomic_inc_core = i;
-        }
-    }
-    return atomic_inc_core;
-}
-
 std::vector<ReadRequest> flatten_schedule(const std::vector<std::vector<ReadRequest>>& schedule) {
     // create a flattened schedule
     std::vector<ReadRequest> schedule_flattened;
@@ -276,6 +287,8 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at(
     const uint32_t ring_size = operation_attributes.ring_devices;
     const uint32_t num_devices = ring_size;
 
+    auto topology = operation_attributes.topology;
+
     uint32_t ring_index = 0;  // Initialize device index
     std::optional<IDevice*> forward_device = std::nullopt;
     std::optional<IDevice*> backward_device = std::nullopt;
@@ -283,20 +296,25 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at(
     std::vector<IDevice*> devices = (operation_attributes.cluster_axis == 0)
                                         ? mesh_view.get_devices_on_column(mesh_coordinate[1])
                                         : mesh_view.get_devices_on_row(mesh_coordinate[0]);
+
     for (uint32_t i = 0; i < ring_size; ++i) {
         if (devices.at(i) == target_device) {
             ring_index = i;
             if (i != 0) {
                 backward_device = devices.at(i - 1);
+            } else if (topology == ttnn::ccl::Topology::Ring) {
+                backward_device = devices.at(ring_size - 1);
             }
             if (i != ring_size - 1) {
                 forward_device = devices.at(i + 1);
+            } else if (topology == ttnn::ccl::Topology::Ring) {
+                forward_device = devices.at(0);
             }
         }
     }
     uint32_t num_links = operation_attributes.num_links;
 
-    std::string device_order = detail::device_order_array_string(ring_size, ring_index);
+    std::string device_order = detail::device_order_array_string(ring_size, ring_index, topology);
 
     std::map<std::string, std::string> reader_defines = {{"DEVICE_ORDER", device_order}};
 
@@ -343,9 +361,6 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at(
     // Get OP Config, topology config
     std::vector<Tensor> input_tensors = {input_tensor};
     std::vector<Tensor> output_tensors = {output_tensor};
-
-    const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, ttnn::ccl::Topology::Linear);
-    LineTopology line_topology(ring_size, ring_index);
 
     // need to drop unused cores in shard spec
     auto input_grid = input_shard_spec.grid;
@@ -629,7 +644,8 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at(
         output_cores_per_device,
         packet_receiver_worker_core.x,
         packet_receiver_worker_core.y,
-        num_packet_worker_cores};
+        num_packet_worker_cores,
+        topology == tt::tt_fabric::Topology::Ring ? 1u : 0u};
 
     auto writer_defines = reader_defines;
     bool skip_write_back = output_cores == packet_worker_cores and num_pages_per_packet == output_tiles_per_core_width;
@@ -686,10 +702,8 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at(
 
     uint32_t link_idx = 0;
 
-    bool forward_fabric_connection =
-        !(line_topology.is_first_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD));
-    bool backward_fabric_connection =
-        !(line_topology.is_last_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD));
+    bool forward_fabric_connection = forward_device.has_value();
+    bool backward_fabric_connection = backward_device.has_value();
 
     for (auto core : all_cores) {
         std::vector<uint32_t> writer_runtime_args = {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter.cpp
@@ -25,7 +25,8 @@ ttnn::Tensor ExecuteLlamaReduceScatter::invoke(
     const uint32_t cluster_axis,
     const MeshDevice& mesh_device,
     const uint32_t num_links,
-    const std::optional<ttnn::MemoryConfig>& memory_config) {
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    tt::tt_fabric::Topology topology) {
     const auto& mesh_view = mesh_device.get_view();
     const uint32_t ring_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
 
@@ -40,7 +41,8 @@ ttnn::Tensor ExecuteLlamaReduceScatter::invoke(
         cluster_axis,
         ring_devices,
         num_links,
-        memory_config);
+        memory_config,
+        topology);
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter.hpp
@@ -7,6 +7,7 @@
 #include "ttnn/decorators.hpp"
 #include "ttnn/global_semaphore.hpp"
 #include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/fabric_edm_types.hpp>
 
 namespace ttnn {
 namespace operations::experimental::ccl {
@@ -22,7 +23,8 @@ struct ExecuteLlamaReduceScatter {
         const uint32_t cluster_axis,
         const MeshDevice& mesh_device,
         const uint32_t num_links,
-        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        tt::tt_fabric::Topology topology = tt::tt_fabric::Topology::Linear);
 };
 
 }  // namespace operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter_pybind.cpp
@@ -10,6 +10,8 @@
 #include "ttnn-pybind/decorators.hpp"
 #include "llama_reduce_scatter.hpp"
 #include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/fabric_edm_types.hpp>
+
 
 namespace py = pybind11;
 
@@ -67,6 +69,7 @@ void py_bind_llama_reduce_scatter(py::module& module) {
                const MeshDevice& mesh_device,
                const uint32_t num_links,
                const std::optional<ttnn::MemoryConfig>& memory_config,
+               tt::tt_fabric::Topology topology,
                QueueId queue_id) {
                 return self(
                     queue_id,
@@ -78,7 +81,8 @@ void py_bind_llama_reduce_scatter(py::module& module) {
                     cluster_axis,
                     mesh_device,
                     num_links,
-                    memory_config);
+                    memory_config,
+                    topology);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("intermediate_packet_buffer").noconvert(),
@@ -90,7 +94,9 @@ void py_bind_llama_reduce_scatter(py::module& module) {
             py::kw_only(),
             py::arg("num_links") = 1,
             py::arg("memory_config") = std::nullopt,
+            py::arg("topology") = tt::tt_fabric::Topology::Linear,
             py::arg("queue_id") = DefaultQueueId,
+
         });
 }
 


### PR DESCRIPTION
Symlink broke previous attempt. Here's a redo without the symlink.
1. Add 6u-specific tests
2. Add a test for 4 links
3. Add optimized ring support to the op
4. Add ring specific tests

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15326723247
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes 
- [ ] TG tests https://github.com/tenstorrent/tt-metal/actions/runs/15326712589