### PR TITLE
[tt-train] RMSNorm backward kernel implementation

### DIFF
--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -752,7 +752,8 @@ int main(int argc, char **argv) {
     std::visit(
         [&](auto &&arg) {
             if constexpr (requires { arg.vocab_size; }) {
-                arg.vocab_size = round_up_to_tile(tokenizer->get_vocab_size(), (device_config.enable_tp ? num_devices : 1U) * 32U);
+                arg.vocab_size =
+                    round_up_to_tile(tokenizer->get_vocab_size(), (device_config.enable_tp ? num_devices : 1U) * 32U);
             } else {
                 throw std::runtime_error(
                     "Unsupported transformer configuration type: " + std::string(typeid(arg).name()));

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -34,6 +34,7 @@ set(METAL_OPS_FILES
     # Common
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/common/program_utils.hpp
     # RMSNorm
+    # RMSNorm Forward
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_fw/rmsnorm_fw.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_fw/rmsnorm_fw.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation_types.hpp
@@ -41,6 +42,14 @@ set(METAL_OPS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_fw/device/rmsnorm_fw_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_fw/device/rmsnorm_fw_program_factory.cpp
+    # RMSNorm Backward
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_bw/rmsnorm_bw.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_bw/rmsnorm_bw.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation_types.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_bw/device/rmsnorm_bw_program_factory.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_bw/device/rmsnorm_bw_program_factory.cpp
     # CrossEntropy
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_fw/cross_entropy_fw.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_fw/cross_entropy_fw.hpp

--- a/tt-train/sources/ttml/metal/operations.hpp
+++ b/tt-train/sources/ttml/metal/operations.hpp
@@ -7,6 +7,7 @@
 #include "ops/cross_entropy_bw/cross_entropy_bw.hpp"
 #include "ops/cross_entropy_fw/cross_entropy_fw.hpp"
 #include "ops/profiler_no_op/profiler_no_op.hpp"
+#include "ops/rmsnorm_bw/rmsnorm_bw.hpp"
 #include "ops/rmsnorm_fw/rmsnorm_fw.hpp"
 #include "ops/softmax/softmax.hpp"
 
@@ -14,6 +15,9 @@ namespace ttml::metal {
 
 constexpr auto rmsnorm_fw =
     ttnn::register_operation<"ttml::metal::rmsnorm_fw", ttml::metal::ops::rmsnorm_fw::RMSNormForwardOperation>();
+
+constexpr auto rmsnorm_bw =
+    ttnn::register_operation<"ttml::metal::rmsnorm_bw", ttml::metal::ops::rmsnorm_bw::RMSNormBackwardOperation>();
 
 constexpr auto cross_entropy_fw = ttnn::register_operation<
     "ttml::metal::cross_entropy_fw",

--- a/tt-train/sources/ttml/metal/ops/common/compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/ops/common/compute_utils.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <cstdint>
+
+#include "compute_kernel_api/pack.h"
+#include "compute_kernel_api/reg_api.h"
+
+inline void pack_and_push(uint32_t reg, uint32_t cb) {
+    // NOTE:
+    // The order of commit and wait does not matter when adjacent, as they affect different threads.
+    // Commit releases the lock for math, letting pack start, while wait ensures math is done.
+    // Prefer commit first, then wait, so this function should be called after tile_regs_commit().
+    constexpr uint32_t onetile = 1U;
+    cb_reserve_back(cb, onetile);
+    tile_regs_wait();
+    pack_reconfig_data_format(cb);
+    pack_tile(reg, cb);
+    tile_regs_release();
+    cb_push_back(cb, onetile);
+}
+
+inline void pack_and_push_block(uint32_t cb_output, uint32_t block_size) {
+    // NOTE:
+    // Packs multiple tiles (block_size) from consecutive registers to output circular buffer.
+    // Should be called after tile_regs_commit() for proper synchronization.
+    cb_reserve_back(cb_output, block_size);
+    tile_regs_wait();
+    pack_reconfig_data_format(cb_output);
+    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
+        pack_tile(block_idx, cb_output);
+    }
+    tile_regs_release();
+    cb_push_back(cb_output, block_size);
+};

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/kernels/compute/rmsnorm_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/kernels/compute/rmsnorm_bw_kernel.cpp
@@ -1,0 +1,412 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api/bcast.h"
+#include "compute_kernel_api/cb_api.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_binary_sfpu.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_unary/recip.h"
+#include "compute_kernel_api/mask.h"
+#include "compute_kernel_api/matmul.h"
+#include "compute_kernel_api/reconfig_data_format.h"
+#include "compute_kernel_api/reg_api.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "tt-train/sources/ttml/metal/ops/common/compute_utils.hpp"
+
+namespace NAMESPACE {
+
+constexpr uint32_t num_rows_per_core = get_compile_time_arg_val(0);
+constexpr uint32_t block_size = get_compile_time_arg_val(1);
+constexpr uint32_t mask_w = get_compile_time_arg_val(2);
+constexpr uint32_t Wt = get_compile_time_arg_val(3);
+
+// CBs with input data
+constexpr uint32_t cb_input_idx = tt::CBIndex::c_0;
+constexpr uint32_t cb_mask_w_idx = tt::CBIndex::c_1;
+constexpr uint32_t cb_scaler_idx = tt::CBIndex::c_2;
+constexpr uint32_t cb_gamma_idx = tt::CBIndex::c_3;
+constexpr uint32_t cb_rms_a_idx = tt::CBIndex::c_4;
+constexpr uint32_t cb_dL_out_idx = tt::CBIndex::c_5;
+constexpr uint32_t cb_mat_mul_reduce = tt::CBIndex::c_6;
+// CBs with output data
+constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_7;
+constexpr uint32_t cb_dL_dgamma_components = tt::CBIndex::c_8;
+// CBs with intermediate computations
+constexpr uint32_t cb_recip_rms_a_bcasted_idx = tt::CBIndex::c_9;
+constexpr uint32_t cb_scale_idx = tt::CBIndex::c_10;
+constexpr uint32_t cb_scale_bcasted_idx = tt::CBIndex::c_11;
+
+constexpr uint32_t onetile = 1;
+
+#ifdef DO_MASK_W
+constexpr bool do_mask_w = true;
+#else
+constexpr bool do_mask_w = false;
+#endif
+
+// ============================================================================
+// The following functions are register-only helpers. They perform intermediate
+// computations using registers but do not write results directly to CBs.
+// ============================================================================
+
+inline void compute_gained_dL_dout(uint32_t col, uint32_t working_register, uint32_t tile_register) {
+    // The output of this function is gained_dL_dout, which is stored in working_register.
+
+    // Compute scaled_gain = gamma * 1/rms_a
+    // NOTE: cb_recip_rms_a_bcasted is ready to be used, so we do not need to wait for it.
+    mul_tiles_init(cb_gamma_idx, cb_recip_rms_a_bcasted_idx);
+    mul_tiles(cb_gamma_idx, cb_recip_rms_a_bcasted_idx, col, 0, working_register);
+
+    // Compute gained_dL_dout = scaled_gain * dL_out
+    copy_tile_init(cb_dL_out_idx);
+    copy_tile(cb_dL_out_idx, col, tile_register);
+    mul_binary_tile_init();
+    mul_binary_tile(working_register, tile_register);
+}
+
+inline void compute_dL_da(
+    const uint32_t input_tile_idx,
+    const uint32_t dL_da_register,
+    const uint32_t rhs_register,
+    const uint32_t tile_register) {
+    // Computes gradient with respect to input activation (dL_da) for RMSNorm backward pass.
+    // Formula: dL_da = gained_dL_dout - (scale * a) / (c * rms_a^2)
+    // where gained_dL_dout = (gamma / rms_a) * dL_dout
+
+    // Compute scaled_outer = scale * a (broadcasted multiplication)
+    reconfig_data_format(cb_input_idx, cb_scale_bcasted_idx);
+    mul_tiles_init(cb_input_idx, cb_scale_bcasted_idx);
+    mul_tiles(cb_input_idx, cb_scale_bcasted_idx, /* tile_idx */ input_tile_idx, /* tile_idx */ 0, rhs_register);
+
+    // Compute rhs = scaled_outer / (c * rms_a^2)
+    // Uses pre-computed reciprocal of rms_a and scaler (1/c) for efficiency
+    reconfig_data_format(cb_recip_rms_a_bcasted_idx, cb_recip_rms_a_bcasted_idx);
+    copy_tile_init(cb_recip_rms_a_bcasted_idx);
+    copy_tile(cb_recip_rms_a_bcasted_idx, /* tile_idx */ 0, tile_register);
+    mul_binary_tile_init();
+    mul_binary_tile(rhs_register, tile_register);
+    mul_binary_tile(rhs_register, tile_register);
+    copy_tile_init(cb_scaler_idx);
+    copy_tile(cb_scaler_idx, /* tile_idx */ 0, tile_register);
+    mul_binary_tile_init();
+    mul_binary_tile(rhs_register, tile_register);
+
+    // Compute final result: dL_da = gained_dL_dout - rhs
+    compute_gained_dL_dout(input_tile_idx, dL_da_register, tile_register);
+    sub_binary_tile_init();
+    sub_binary_tile(dL_da_register, rhs_register);
+}
+
+inline void compute_dL_dgamma_components(
+    const uint32_t input_tile_idx, const uint32_t dL_dg_components_register, const uint32_t tile_register) {
+    // Computes gradient components with respect to gamma (dL_dgamma_components) for RMSNorm backward pass.
+    // Formula: dL_dgamma_components = dL_dout * (a / rms_a)
+    // These components will be reduced across batches and sequence dimensions outside the kernel.
+
+    // Compute normalized_a = a / rms_a (using pre-computed reciprocal)
+    reconfig_data_format(cb_input_idx, cb_recip_rms_a_bcasted_idx);
+    mul_tiles_init(cb_input_idx, cb_recip_rms_a_bcasted_idx);
+    mul_tiles(
+        cb_input_idx,
+        cb_recip_rms_a_bcasted_idx,
+        /* tile_idx */ input_tile_idx,
+        /* tile_idx */ 0,
+        dL_dg_components_register);
+
+    // Compute dL_dgamma_components = normalized_a * dL_dout
+    copy_tile_init(cb_dL_out_idx);
+    copy_tile(cb_dL_out_idx, /* tile_idx */ input_tile_idx, tile_register);
+    mul_binary_tile_init();
+    mul_binary_tile(dL_dg_components_register, tile_register);
+}
+
+// ============================================================================
+// Functions below compute final results for a pipeline stage and write them to
+// circular buffers (CBs). These functions produce outputs that are consumed by
+// later stages.
+// ============================================================================
+
+inline void compute_recip_rms_a_bcasted() {
+    // Computes reciprocal of RMS activation (1/rms_a) and broadcasts it across columns.
+    const uint32_t reg_rms_a = 0;
+    tile_regs_acquire();
+    unary_bcast_init<BroadcastType::COL>(cb_rms_a_idx, cb_recip_rms_a_bcasted_idx);
+    unary_bcast<BroadcastType::COL>(cb_rms_a_idx, /* tile idx */ 0, /* reg tile idx */ reg_rms_a);
+    recip_tile_init();
+    recip_tile(reg_rms_a);
+    tile_regs_commit();
+    pack_and_push(reg_rms_a, cb_recip_rms_a_bcasted_idx);
+}
+
+#ifdef EVERYTHING_FITS_IN_L1
+inline void compute_scale(const uint32_t row) {
+    // Computes scale factor for RMSNorm backward pass: scale = sum(a * gained_dL_dout, dim=C)
+    // where gained_dL_dout = (gamma / rms_a) * dL_dout
+    // The result is reduced along the inner dimension and used in dL_da computation.
+
+    const uint32_t scale_register = 0U;
+    const uint32_t intermediate_register = 1U;
+    const uint32_t tile_register = 2U;
+    tile_regs_acquire();
+    // Gamma is constant among all rows so if everything fits in L1, we can read it only once.
+    if (row == 0) {
+        cb_wait_front(cb_gamma_idx, Wt);
+    }
+    cb_wait_front(cb_dL_out_idx, Wt);
+    cb_wait_front(cb_input_idx, Wt);
+    for (uint32_t col = 0; col < Wt; col++) {
+        // If col == 0, we use scale_register as the working register to aviod unnecessary copying of data.
+        auto working_register = col == 0 ? scale_register : intermediate_register;
+
+        compute_gained_dL_dout(col, working_register, tile_register);
+
+        // Compute and accumulate scale components: a * gained_dL_dout
+        copy_tile_init(cb_input_idx);
+        copy_tile(cb_input_idx, col, tile_register);
+        mul_binary_tile_init();
+        mul_binary_tile(working_register, tile_register);
+
+        // Mask the tile if needed
+        if constexpr (do_mask_w) {
+            if (col + 1 == Wt) {
+                // Limitation: mask_tile only works when the mask register is immediately next to the data register.
+                const uint32_t mask_register = working_register + 1U;
+
+                copy_tile_init(cb_mask_w_idx);
+                copy_tile(cb_mask_w_idx, /* tile_idx */ 0, /* register idx */ mask_register);
+
+                mask_tile_init();
+                mask_tile(working_register, mask_register);
+            }
+        }
+
+        // Add scale_components to scale
+        if (col > 0) {
+            add_binary_tile_init();
+            add_binary_tile(scale_register, working_register);
+        }
+    }
+    tile_regs_commit();
+
+    pack_and_push(scale_register, cb_scale_idx);
+
+    cb_wait_front(cb_scale_idx, onetile);
+    const uint32_t reducted_scale_register = 0U;
+    tile_regs_acquire();
+
+    // Reduce scale along the inner dimension (C).
+
+    // NOTE: Currently, there is a bug in reduce_tile that causes precision issues. To avoid this, we use a
+    // workaround of matmul with appropriate scale. Once the bug is fixed, we can switch back to reduce_tile.
+    reconfig_data_format(cb_scale_idx, cb_mat_mul_reduce);
+    mm_init(cb_scale_idx, cb_mat_mul_reduce, cb_scale_idx, 0);
+    matmul_tiles(
+        cb_scale_idx,
+        cb_mat_mul_reduce,
+        /* tile_idx */ 0,
+        /* tile_idx */ 0,
+        reducted_scale_register,
+        /* transpose */ 0);
+    tile_regs_commit();
+
+    // Pop the non-reduced scale tile from the CB.
+    cb_pop_front(cb_scale_idx, onetile);
+    pack_and_push(reducted_scale_register, cb_scale_idx);
+}
+#else
+inline void compute_scale(const uint32_t row) {
+    // Computes scale factor for RMSNorm backward pass: scale = sum(a * gained_dL_dout, dim=C)
+    // where gained_dL_dout = (gamma / rms_a) * dL_dout
+    // The result is reduced along the inner dimension and used in dL_da computation.
+
+    const uint32_t scale_register = 0U;
+    const uint32_t intermediate_register = 1U;
+    const uint32_t tile_register = 2U;
+    tile_regs_acquire();
+    for (uint32_t col = 0; col < Wt;) {
+        cb_wait_front(cb_gamma_idx, block_size);
+        cb_wait_front(cb_dL_out_idx, block_size);
+        cb_wait_front(cb_input_idx, block_size);
+        for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx, ++col) {
+            // If col == 0, we use scale_register as the working register to aviod unnecessary copying of data.
+            auto working_register = col == 0 ? scale_register : intermediate_register;
+
+            compute_gained_dL_dout(block_idx, working_register, tile_register);
+
+            // Compute and accumulate scale components: a * gained_dL_dout
+            copy_tile_init(cb_input_idx);
+            copy_tile(cb_input_idx, block_idx, tile_register);
+            mul_binary_tile_init();
+            mul_binary_tile(working_register, tile_register);
+
+            // Mask the tile if needed
+            if constexpr (do_mask_w) {
+                if (col + 1 == Wt) {
+                    // Limitation: mask_tile only works when the mask register is immediately next to the data register.
+                    const uint32_t mask_register =
+                        working_register + 1U;  // mask register should be next to data register
+
+                    copy_tile_init(cb_mask_w_idx);
+                    copy_tile(cb_mask_w_idx, /* tile_idx */ 0, /* register idx */ mask_register);
+
+                    mask_tile_init();
+                    mask_tile(working_register, mask_register);
+                }
+            }
+
+            // Add scale_components to scale
+            if (col > 0) {
+                add_binary_tile_init();
+                add_binary_tile(scale_register, working_register);
+            }
+        }
+        // Pop tiles that are not needed anymore.
+        cb_pop_front(cb_gamma_idx, block_size);
+        cb_pop_front(cb_dL_out_idx, block_size);
+        cb_pop_front(cb_input_idx, block_size);
+    }
+    tile_regs_commit();
+
+    pack_and_push(scale_register, cb_scale_idx);
+
+    cb_wait_front(cb_scale_idx, onetile);
+    const uint32_t reducted_scale_register = 0U;
+    tile_regs_acquire();
+
+    // Reduce scale along the inner dimension (C).
+
+    // NOTE: Currently, there is a bug in reduce_tile that causes precision issues. To avoid this, we use a
+    // workaround of matmul with appropriate scale. Once the bug is fixed, we can switch back to reduce_tile.
+    reconfig_data_format(cb_scale_idx, cb_mat_mul_reduce);
+    mm_init(cb_scale_idx, cb_mat_mul_reduce, cb_scale_idx, 0);
+    matmul_tiles(
+        cb_scale_idx,
+        cb_mat_mul_reduce,
+        /* tile_idx */ 0,
+        /* tile_idx */ 0,
+        reducted_scale_register,
+        /* transpose */ 0);
+    tile_regs_commit();
+
+    // Pop the non-reduced scale tile from the CB.
+    cb_pop_front(cb_scale_idx, onetile);
+    pack_and_push(reducted_scale_register, cb_scale_idx);
+}
+#endif  // EVERYTHING_FITS_IN_L1
+
+inline void bcast_scale() {
+    // Broadcasts the reduced scale factor across columns.
+    cb_reserve_back(cb_scale_bcasted_idx, onetile);
+    const uint32_t reg_scale_bcasted = 0;
+    tile_regs_acquire();
+    reconfig_data_format(cb_scale_idx, cb_scale_bcasted_idx);
+
+    unary_bcast_init<BroadcastType::COL>(cb_scale_idx, cb_scale_bcasted_idx);
+    unary_bcast<BroadcastType::COL>(cb_scale_idx, /* tile idx */ 0, /* reg tile idx */ reg_scale_bcasted);
+    tile_regs_commit();
+
+    pack_and_push(reg_scale_bcasted, cb_scale_bcasted_idx);
+}
+
+inline void MAIN {
+    if constexpr (do_mask_w) {
+        cb_wait_front(cb_mask_w_idx, onetile);
+    }
+    cb_wait_front(cb_scaler_idx, onetile);
+    cb_wait_front(cb_mat_mul_reduce, onetile);
+
+    init_sfpu(cb_input_idx, cb_dL_da_idx);
+    binary_op_init_common(cb_input_idx, cb_gamma_idx, cb_dL_da_idx);
+    for (uint32_t row = 0; row < num_rows_per_core; ++row) {
+        cb_wait_front(cb_rms_a_idx, onetile);
+        // This value is constant for the whole row, so we can compute it once per row.
+        compute_recip_rms_a_bcasted();
+        cb_wait_front(cb_recip_rms_a_bcasted_idx, onetile);
+        // To compute scale we must iterate over all inner dimension.
+        compute_scale(row);
+        // Wait for the reducted cb_scale to be ready.
+        cb_wait_front(cb_scale_idx, onetile);
+        bcast_scale();
+        cb_wait_front(cb_scale_bcasted_idx, onetile);
+
+        for (uint32_t col = 0; col < Wt; col += block_size) {
+            cb_reserve_back(cb_dL_da_idx, block_size);
+            cb_reserve_back(cb_dL_dgamma_components, block_size);
+#ifndef EVERYTHING_FITS_IN_L1
+            cb_wait_front(cb_gamma_idx, block_size);
+            cb_wait_front(cb_dL_out_idx, block_size);
+            cb_wait_front(cb_input_idx, block_size);
+#endif
+            // Compute dL_da.
+            {
+                uint32_t dL_da_register;  // Depending on the block_idx, it will be 0 or 1.
+                const uint32_t rhs_register = 2U;
+                const uint32_t tile_register = 3U;
+                tile_regs_acquire();
+                for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
+#ifdef EVERYTHING_FITS_IN_L1
+                    const uint32_t input_tile_idx = col + block_idx;
+#else
+                    const uint32_t input_tile_idx = block_idx;
+#endif
+                    dL_da_register = block_idx;
+                    compute_dL_da(
+                        input_tile_idx,
+                        dL_da_register,
+                        rhs_register,
+                        tile_register);  // Compute dL_da for the current tile.
+                }
+                tile_regs_commit();
+
+                pack_and_push_block(cb_dL_da_idx, block_size);
+            }
+
+            // Compute dL_dgamma_components.
+            {
+                uint32_t dL_dg_components_register;  // Depending on the block_idx, it will be 0 or 1.
+                const uint32_t tile_register = 2U;
+                tile_regs_acquire();
+                for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
+#ifdef EVERYTHING_FITS_IN_L1
+                    const uint32_t input_tile_idx = col + block_idx;
+#else
+                    const uint32_t input_tile_idx = block_idx;
+#endif
+                    dL_dg_components_register = block_idx;
+                    compute_dL_dgamma_components(
+                        input_tile_idx,
+                        dL_dg_components_register,
+                        tile_register);  // Compute dL_dg_components for the current tile.
+                }
+                tile_regs_commit();
+
+                pack_and_push_block(cb_dL_dgamma_components, block_size);
+            }
+#ifndef EVERYTHING_FITS_IN_L1
+            cb_pop_front(cb_gamma_idx, block_size);
+            cb_pop_front(cb_dL_out_idx, block_size);
+            cb_pop_front(cb_input_idx, block_size);
+#endif
+        }
+#ifdef EVERYTHING_FITS_IN_L1
+        cb_pop_front(cb_dL_out_idx, Wt);
+        cb_pop_front(cb_input_idx, Wt);
+#endif
+        cb_pop_front(cb_rms_a_idx, onetile);
+        cb_pop_front(cb_recip_rms_a_bcasted_idx, onetile);
+        cb_pop_front(cb_scale_idx, onetile);
+        cb_pop_front(cb_scale_bcasted_idx, onetile);
+    }
+#ifdef EVERYTHING_FITS_IN_L1
+    cb_pop_front(cb_gamma_idx, Wt);
+#endif
+    cb_pop_front(cb_scaler_idx, onetile);
+    cb_pop_front(cb_mat_mul_reduce, onetile);
+    if constexpr (do_mask_w) {
+        cb_pop_front(cb_mask_w_idx, onetile);
+    }
+}
+
+}  // namespace NAMESPACE

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/kernels/dataflow/reader_rmsnorm_bw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/kernels/dataflow/reader_rmsnorm_bw_interleaved_start_id.cpp
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "tt-train/sources/ttml/metal/ops/common/dataflow_utils.hpp"
+
+// CBs with input data
+constexpr uint32_t cb_input_idx = tt::CBIndex::c_0;
+constexpr uint32_t cb_mask_w_idx = tt::CBIndex::c_1;
+constexpr uint32_t cb_scaler_idx = tt::CBIndex::c_2;
+constexpr uint32_t cb_gamma_idx = tt::CBIndex::c_3;
+constexpr uint32_t cb_rms_a_idx = tt::CBIndex::c_4;
+constexpr uint32_t cb_dL_out_idx = tt::CBIndex::c_5;
+constexpr uint32_t cb_mat_mul_reduce = tt::CBIndex::c_6;
+// CBs with output data
+constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_7;
+constexpr uint32_t cb_dL_dgamma_components = tt::CBIndex::c_8;
+// CBs with intermediate computations
+constexpr uint32_t cb_recip_rms_a_bcasted_idx = tt::CBIndex::c_9;
+constexpr uint32_t cb_scale_idx = tt::CBIndex::c_10;
+constexpr uint32_t cb_scale_bcasted_idx = tt::CBIndex::c_11;
+
+constexpr uint32_t packed_scaler = get_compile_time_arg_val(0);
+constexpr uint32_t block_size = get_compile_time_arg_val(1);
+constexpr uint32_t mask_w = get_compile_time_arg_val(2);
+constexpr uint32_t Wt = get_compile_time_arg_val(3);
+
+#ifdef DO_MASK_W
+constexpr bool do_mask_w = true;
+#else
+constexpr bool do_mask_w = false;
+#endif
+
+inline void read_tiles(
+    const uint32_t cb_idx,
+    const InterleavedAddrGenFast<true>& addr_gen,
+    const uint32_t start_tile,
+    const uint32_t num_tiles,
+    const uint32_t tile_bytes) {
+    // Reads `num_tiles` tiles from DRAM starting at logical tile index `start_tile` into circular buffer `cb_idx`.
+    cb_reserve_back(cb_idx, num_tiles);
+    uint32_t l1_write_addr = get_write_ptr(cb_idx);
+    for (uint32_t k = 0; k < num_tiles; ++k) {
+        noc_async_read_tile(start_tile + k, addr_gen, l1_write_addr);
+        l1_write_addr += tile_bytes;
+    }
+}
+
+void kernel_main() {
+    uint32_t runtime_args_counter = 0U;
+    uint32_t input_address = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t gamma_address = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t rms_a_address = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dL_out_address = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t num_rows_to_process = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t start_row = get_arg_val<uint32_t>(runtime_args_counter++);
+
+    constexpr uint16_t one = 0x00003F80;  // (bfloat16)1.0 -> uint16_t
+    constexpr uint16_t zero = 0x0;
+    constexpr uint16_t minus_inf = 0xFF80;  // (bfloat16)-inf -> uint16_t
+    // Generate mask tile.
+    if constexpr (do_mask_w) {
+        generate_mask_tile(cb_mask_w_idx, one, zero, mask_w);
+    }
+    // Generate tile with scalar.
+    generate_tile_with_packed_bfloat16_value(cb_scaler_idx, packed_scaler);
+    // Generate tile for matmul row reduce.
+    generate_matmul_row_reduce_tile(cb_mat_mul_reduce);
+
+    const uint32_t tile_bytes = get_tile_size(cb_input_idx);
+    const DataFormat data_format = get_dataformat(cb_input_idx);
+
+    const InterleavedAddrGenFast</* is_dram */ true> input_address_generator = {
+        .bank_base_address = input_address, .page_size = tile_bytes, .data_format = data_format};
+
+    const InterleavedAddrGenFast</* is_dram */ true> gamma_address_generator = {
+        .bank_base_address = gamma_address, .page_size = tile_bytes, .data_format = data_format};
+
+    const InterleavedAddrGenFast</* is_dram */ true> rms_a_address_generator = {
+        .bank_base_address = rms_a_address, .page_size = tile_bytes, .data_format = data_format};
+
+    const InterleavedAddrGenFast</* is_dram */ true> dL_out_address_generator = {
+        .bank_base_address = dL_out_address, .page_size = tile_bytes, .data_format = data_format};
+
+    // Read input tensors row by row, reading each row's data twice due to compute requirements
+    uint32_t end_row = start_row + num_rows_to_process;
+    for (uint32_t r = start_row; r < end_row; ++r) {
+        // Read RMS(a) once per row - shape [B,1,S,1], one scalar per row
+        read_tiles(cb_rms_a_idx, rms_a_address_generator, r, 1, tile_bytes);
+        noc_async_read_barrier();
+        cb_push_back(cb_rms_a_idx, 1);
+
+        // First pass: read row data for first compute phase
+        for (uint32_t c = 0; c < Wt; c += block_size) {
+            uint32_t row_tile_idx = (r * Wt) + c;
+
+            read_tiles(cb_input_idx, input_address_generator, row_tile_idx, block_size, tile_bytes);
+            read_tiles(cb_dL_out_idx, dL_out_address_generator, row_tile_idx, block_size, tile_bytes);
+#ifndef EVERYTHING_FITS_IN_L1
+            // If not everything fits in L1, we need to reread gamma for each row.
+            read_tiles(cb_gamma_idx, gamma_address_generator, c, block_size, tile_bytes);
+#else
+            // If everything fits in L1, we can read gamma only once.
+            if (r == start_row) {
+                read_tiles(cb_gamma_idx, gamma_address_generator, c, block_size, tile_bytes);
+            }
+#endif
+
+            noc_async_read_barrier();
+            cb_push_back(cb_input_idx, block_size);
+            cb_push_back(cb_dL_out_idx, block_size);
+#ifndef EVERYTHING_FITS_IN_L1
+            cb_push_back(cb_gamma_idx, block_size);
+#else
+            if (r == start_row) {
+                cb_push_back(cb_gamma_idx, block_size);
+            }
+#endif
+        }
+
+#ifndef EVERYTHING_FITS_IN_L1
+        // Second pass: read row data again for second compute phase
+        for (uint32_t c = 0; c < Wt; c += block_size) {
+            uint32_t row_tile_idx = (r * Wt) + c;
+
+            read_tiles(cb_input_idx, input_address_generator, row_tile_idx, block_size, tile_bytes);
+            read_tiles(cb_dL_out_idx, dL_out_address_generator, row_tile_idx, block_size, tile_bytes);
+            read_tiles(cb_gamma_idx, gamma_address_generator, c, block_size, tile_bytes);
+
+            noc_async_read_barrier();
+            cb_push_back(cb_input_idx, block_size);
+            cb_push_back(cb_dL_out_idx, block_size);
+            cb_push_back(cb_gamma_idx, block_size);
+        }
+#endif
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/kernels/dataflow/writer_rmsnorm_bw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/kernels/dataflow/writer_rmsnorm_bw_interleaved_start_id.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+// CBs with input data
+constexpr uint32_t cb_input_idx = tt::CBIndex::c_0;
+constexpr uint32_t cb_mask_w_idx = tt::CBIndex::c_1;
+constexpr uint32_t cb_scaler_idx = tt::CBIndex::c_2;
+constexpr uint32_t cb_gamma_idx = tt::CBIndex::c_3;
+constexpr uint32_t cb_rms_a_idx = tt::CBIndex::c_4;
+constexpr uint32_t cb_dL_out_idx = tt::CBIndex::c_5;
+constexpr uint32_t cb_mat_mul_reduce = tt::CBIndex::c_6;
+// CBs with output data
+constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_7;
+constexpr uint32_t cb_dL_dgamma_components = tt::CBIndex::c_8;
+// CBs with intermediate computations
+constexpr uint32_t cb_recip_rms_a_bcasted_idx = tt::CBIndex::c_9;
+constexpr uint32_t cb_scale_idx = tt::CBIndex::c_10;
+constexpr uint32_t cb_scale_bcasted_idx = tt::CBIndex::c_11;
+
+constexpr uint32_t block_size = get_compile_time_arg_val(0);
+constexpr uint32_t Wt = get_compile_time_arg_val(1);
+
+constexpr uint32_t onetile = 1;
+
+inline void write_cb_block_to_dram(
+    uint32_t cb_idx,
+    const InterleavedAddrGenFast</* is dram */ true>& addr_gen,
+    uint32_t start_idx,
+    uint32_t block_size,
+    uint32_t tile_bytes) {
+    cb_wait_front(cb_idx, block_size);
+    uint32_t l1_read_addr = get_read_ptr(cb_idx);
+    for (uint32_t block_idx = 0; block_idx < block_size; ++block_idx) {
+        noc_async_write_tile(start_idx + block_idx, addr_gen, l1_read_addr);
+        l1_read_addr += tile_bytes;
+    }
+}
+
+void kernel_main() {
+    uint32_t runtime_args_counter = 0;
+    uint32_t da_output_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dgamma_output_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t num_rows_to_process = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t start_row = get_arg_val<uint32_t>(runtime_args_counter++);
+
+    const uint32_t tile_bytes = get_tile_size(cb_dL_da_idx);
+    const DataFormat data_format = get_dataformat(cb_dL_da_idx);
+
+    const InterleavedAddrGenFast</* is dram */ true> da_output_addr_generator = {
+        .bank_base_address = da_output_addr, .page_size = tile_bytes, .data_format = data_format};
+
+    const InterleavedAddrGenFast</* is dram */ true> dgamma_output_addr_generator = {
+        .bank_base_address = dgamma_output_addr, .page_size = tile_bytes, .data_format = data_format};
+
+    uint32_t end_row = start_row + num_rows_to_process;
+    for (uint32_t r = start_row; r < end_row; ++r) {
+        // Write da (gradient w.r.t. input) and dgamma_components (partial gradients w.r.t. gamma) in blocks.
+        // We interleave the writes to avoid waiting for the entire Wt tiles at once.
+        // NOTE: The final dL_dgamma (gradient w.r.t. gamma) requires reduction across batches, which is performed on
+        // the host. Here, we output the per-tile components for host-side reduction.
+        for (uint32_t c = 0; c < Wt; c += block_size) {
+            uint32_t start_idx = (r * Wt) + c;
+
+            // Write dL_da block
+            write_cb_block_to_dram(cb_dL_da_idx, da_output_addr_generator, start_idx, block_size, tile_bytes);
+
+            // Write dL_dgamma_components block
+            write_cb_block_to_dram(
+                cb_dL_dgamma_components, dgamma_output_addr_generator, start_idx, block_size, tile_bytes);
+            noc_async_write_barrier();
+
+            cb_pop_front(cb_dL_dgamma_components, block_size);
+            cb_pop_front(cb_dL_da_idx, block_size);
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.cpp
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "rmsnorm_bw_device_operation.hpp"
+
+#include "rmsnorm_bw_program_factory.hpp"
+
+namespace ttml::metal::ops::rmsnorm_bw::device {
+
+RMSNormBackwardDeviceOperation::program_factory_t RMSNormBackwardDeviceOperation::select_program_factory(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    return RMSNormBackwardProgramFactory{};
+}
+
+void RMSNormBackwardDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(args, tensor_args);
+}
+
+void RMSNormBackwardDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
+        TT_FATAL(
+            tensor.device()->arch() == tt::ARCH::WORMHOLE_B0,
+            "RMSNormBackward operation is only supported on Wormhole. Device arch: {}. Tensor name {}",
+            magic_enum::enum_name(tensor.device()->arch()),
+            name);
+
+        TT_FATAL(
+            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            "RMSNormBackward operation requires {} to be on Device. Input storage type: {}",
+            name,
+            static_cast<int>(tensor.storage_type()));
+
+        TT_FATAL(
+            tensor.buffer() != nullptr,
+            "Operands to RMSNormBackward need to be allocated in buffers on the device. Buffer is null. Tensor name {}",
+            name);
+
+        TT_FATAL(
+            tensor.layout() == tt::tt_metal::Layout::TILE,
+            "RMSNormBackward operation requires tensor to be in Tile layout. {} tensor layout: {}",
+            name,
+            static_cast<int>(tensor.layout()));
+
+        TT_FATAL(
+            tensor.dtype() == tt::tt_metal::DataType::BFLOAT16,
+            "RMSNormBackward operation requires tensor to be of BFLOAT16 data type. {} tensor data type: {}",
+            name,
+            static_cast<int>(tensor.dtype()));
+
+        TT_FATAL(
+            tensor.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED,
+            "RMSNormBackward operation requires Interleaved memory layout. {} "
+            "memory layout: `{}`",
+            name,
+            static_cast<int>(tensor.memory_config().memory_layout()));
+    };
+
+    const auto& input_tensor = tensor_args.input;
+    const auto& gamma_tensor = tensor_args.gamma;
+    const auto& rms_tensor = tensor_args.rms;
+    const auto& dL_dout_tensor = tensor_args.dL_dout;
+    const auto& preallocated_da_tensor = tensor_args.preallocated_da;
+    const auto& preallocated_dgamma_components_tensor = tensor_args.preallocated_dgamma_components;
+
+    check_tensor(input_tensor, "Input");
+    check_tensor(gamma_tensor, "Gamma");
+    check_tensor(rms_tensor, "RMS");
+    check_tensor(dL_dout_tensor, "dL_dout");
+    if (preallocated_da_tensor.has_value()) {
+        check_tensor(preallocated_da_tensor.value(), "Preallocated dL_da");
+    }
+    if (preallocated_dgamma_components_tensor.has_value()) {
+        check_tensor(preallocated_dgamma_components_tensor.value(), "Preallocated dL_dgamma_components");
+    }
+}
+
+spec_return_value_t RMSNormBackwardDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    spec_return_value_t output_specs;
+    output_specs.reserve(2U);
+
+    if (tensor_args.preallocated_da.has_value()) {
+        output_specs.push_back(tensor_args.preallocated_da->tensor_spec());
+    } else {
+        output_specs.emplace_back(
+            tensor_args.input.logical_shape(),
+            tt::tt_metal::TensorLayout(
+                tensor_args.input.dtype(), tt::tt_metal::Layout::TILE, tensor_args.input.memory_config()));
+    }
+
+    if (tensor_args.preallocated_dgamma_components.has_value()) {
+        output_specs.push_back(tensor_args.preallocated_dgamma_components->tensor_spec());
+    } else {
+        // Since we cannot compute dL_dgamma in the kernel, we need to return dL_dgamma_components, which will be
+        // reduced outside the kernel. The shape of dL_dgamma_components is the same as the input shape.
+        output_specs.emplace_back(
+            tensor_args.input.logical_shape(),
+            tt::tt_metal::TensorLayout(
+                tensor_args.gamma.dtype(), tt::tt_metal::Layout::TILE, tensor_args.gamma.memory_config()));
+    }
+
+    return output_specs;
+}
+
+tensor_return_value_t RMSNormBackwardDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    tensor_return_value_t output_tensors;
+    output_tensors.reserve(2U);
+
+    spec_return_value_t output_specs = compute_output_specs(args, tensor_args);
+
+    if (tensor_args.preallocated_da.has_value()) {
+        output_tensors.push_back(tensor_args.preallocated_da.value());
+    } else {
+        output_tensors.push_back(create_device_tensor(output_specs[0], tensor_args.input.device()));
+    }
+
+    if (tensor_args.preallocated_dgamma_components.has_value()) {
+        output_tensors.push_back(tensor_args.preallocated_dgamma_components.value());
+    } else {
+        output_tensors.push_back(create_device_tensor(output_specs[1], tensor_args.gamma.device()));
+    }
+
+    return output_tensors;
+}
+
+ttsl::hash::hash_t RMSNormBackwardDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    const auto& input_logical_shape = input_tensor.logical_shape();
+    auto program_factory = select_program_factory(args, tensor_args);
+    tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<RMSNormBackwardDeviceOperation>(
+        args, program_factory.index(), input_tensor.dtype(), input_logical_shape);
+
+    return hash;
+}
+
+std::tuple<RMSNormBackwardDeviceOperation::operation_attributes_t, RMSNormBackwardDeviceOperation::tensor_args_t>
+RMSNormBackwardDeviceOperation::invoke(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& gamma_tensor,
+    const ttnn::Tensor& rms_tensor,
+    const ttnn::Tensor& dL_dout_tensor,
+    float epsilon,
+    const std::optional<ttnn::Tensor>& preallocated_da,
+    const std::optional<ttnn::Tensor>& preallocated_dgamma_components) {
+    return {
+        operation_attributes_t{
+            .epsilon = epsilon,
+        },
+        tensor_args_t{
+            .input = input_tensor,
+            .gamma = gamma_tensor,
+            .rms = rms_tensor,
+            .dL_dout = dL_dout_tensor,
+            .preallocated_da = preallocated_da,
+            .preallocated_dgamma_components = preallocated_dgamma_components,
+        }};
+}
+
+}  // namespace ttml::metal::ops::rmsnorm_bw::device

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.hpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "metal/ttnn_all_includes.hpp"
+#include "rmsnorm_bw_device_operation_types.hpp"
+#include "rmsnorm_bw_program_factory.hpp"
+
+namespace ttml::metal::ops::rmsnorm_bw::device {
+
+struct RMSNormBackwardDeviceOperation {
+    using operation_attributes_t = operation_attributes_t;
+    using tensor_args_t = tensor_args_t;
+    using spec_return_value_t = spec_return_value_t;
+    using tensor_return_value_t = tensor_return_value_t;
+    using program_factory_t = std::variant<RMSNormBackwardProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const ttnn::Tensor& input_tensor,
+        const ttnn::Tensor& gamma_tensor,
+        const ttnn::Tensor& rms_tensor,
+        const ttnn::Tensor& dL_dout_tensor,
+        float epsilon = 1e-6F,
+        const std::optional<ttnn::Tensor>& preallocated_da = std::nullopt,
+        const std::optional<ttnn::Tensor>& preallocated_dgamma_components = std::nullopt);
+};
+
+}  // namespace ttml::metal::ops::rmsnorm_bw::device
+
+namespace ttnn::prim {
+constexpr auto ttml_rmsnorm_bw = ttnn::register_operation<
+    "ttnn::prim::ttml_rmsnorm_bw",
+    ttml::metal::ops::rmsnorm_bw::device::RMSNormBackwardDeviceOperation>();
+}

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation_types.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal::ops::rmsnorm_bw::device {
+
+// Attributes for the backward operation (add more if needed)
+struct operation_attributes_t {
+    float epsilon = 1e-6F;
+};
+
+// Tensors required for backward
+struct tensor_args_t {
+    ttnn::Tensor input;
+    ttnn::Tensor gamma;
+    ttnn::Tensor rms;
+    ttnn::Tensor dL_dout;
+    std::optional<ttnn::Tensor> preallocated_da = std::nullopt;
+    std::optional<ttnn::Tensor> preallocated_dgamma_components = std::nullopt;
+};
+
+// Output tensor specs and tensors
+using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+using tensor_return_value_t = std::vector<ttnn::Tensor>;
+
+}  // namespace ttml::metal::ops::rmsnorm_bw::device

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_program_factory.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+#include "rmsnorm_bw_device_operation_types.hpp"
+
+namespace ttml::metal::ops::rmsnorm_bw::device {
+
+struct RMSNormBackwardProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle rmsnorm_bw_reader_kernel_id;
+        tt::tt_metal::KernelHandle rmsnorm_bw_writer_kernel_id;
+        tt::tt_metal::KernelHandle rmsnorm_bw_kernel_group_1_id;
+        tt::tt_metal::KernelHandle rmsnorm_bw_kernel_group_2_id;
+        CoreRangeSet core_group_1;
+        CoreRangeSet core_group_2;
+        uint32_t num_cores{};
+        uint32_t num_cores_y{};
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttml::metal::ops::rmsnorm_bw::device

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/rmsnorm_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/rmsnorm_bw.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "rmsnorm_bw.hpp"
+
+#include "core/compute_kernel_config.hpp"
+#include "device/rmsnorm_bw_device_operation.hpp"
+
+namespace ttml::metal::ops::rmsnorm_bw {
+
+std::vector<std::optional<ttnn::Tensor>> RMSNormBackwardOperation::invoke(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& gamma_tensor,
+    const ttnn::Tensor& rms_tensor,
+    const ttnn::Tensor& dL_dout_tensor) {
+    auto result = ttnn::prim::ttml_rmsnorm_bw(
+        input_tensor,   // [B,1,S,C]
+        gamma_tensor,   // [1,1,1,C]
+        rms_tensor,     //[B,1,S,1]
+        dL_dout_tensor  //[B,1,S,C]
+    );
+
+    // dL_dgamma requires sum over batches so we cannot perform this sum in the kernel. Instead we return the
+    // dL_dgamma_components and reduce it here.
+    return {
+        result[0],
+        ttnn::sum(
+            result[1],
+            /* dim_arg */ ttnn::SmallVector<int>{0, 1, 2},
+            /* keep_dim */ true,
+            /* output_mem_config */ std::nullopt,
+            /*compute_kernel_config */ core::ComputeKernelConfig::precise())  // [B,1,S,C] -> [1,1,1,C]
+    };
+}
+
+}  // namespace ttml::metal::ops::rmsnorm_bw

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/rmsnorm_bw.hpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/rmsnorm_bw.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal::ops::rmsnorm_bw {
+
+struct RMSNormBackwardOperation {
+    static std::vector<std::optional<ttnn::Tensor>> invoke(
+        const ttnn::Tensor& input_tensor,
+        const ttnn::Tensor& gamma_tensor,
+        const ttnn::Tensor& rms_tensor,  // intermediate from fw
+        const ttnn::Tensor& dL_dout_tensor);
+};
+
+}  // namespace ttml::metal::ops::rmsnorm_bw

--- a/tt-train/sources/ttml/modules/rms_norm_module.cpp
+++ b/tt-train/sources/ttml/modules/rms_norm_module.cpp
@@ -24,9 +24,9 @@ RMSNormLayer::RMSNormLayer(uint32_t features, float epsilon, bool use_composite)
 
 autograd::TensorPtr RMSNormLayer::operator()(const autograd::TensorPtr& tensor) {
     if (m_use_composite) {
-        return ops::rmsnorm(tensor, m_gamma, m_epsilon);
-    } else {
         return ops::rmsnorm_composite(tensor, m_gamma, m_epsilon);
+    } else {
+        return ops::rmsnorm(tensor, m_gamma, m_epsilon);
     }
 }
 

--- a/tt-train/sources/ttml/ops/rmsnorm_op.cpp
+++ b/tt-train/sources/ttml/ops/rmsnorm_op.cpp
@@ -44,100 +44,20 @@ autograd::TensorPtr rmsnorm(const autograd::TensorPtr &tensor, const autograd::T
     auto rms_a = rmsnorm_fw_result[1].value();
     auto out = autograd::create_tensor(rmsnorm_fw_result[0].value());
 
-    autograd::GradFunction grad = [B, S, C, tensor, gamma, out, rms_a, device]() {
-        auto a = tensor->get_value();  // [B,1,S,C]
-        auto g = gamma->get_value();   // [1,1,1,C]
+    autograd::GradFunction grad = [B, S, C, tensor, gamma, out, rms_a, epsilon]() {
+        auto dL_dout = out->get_grad();
 
-        // c is the number of activations; in the RMS1orm paper they call this
-        // "n". it is renamed here to avoid confusion with 1.
-        auto c = static_cast<float>(a.logical_shape()[-1]);
+        auto grads = ttml::metal::rmsnorm_bw(tensor->get_value(), gamma->get_value(), rms_a, dL_dout);
 
-        auto dL_dout = out->get_grad();  // Grad w.r.t normalized arctivations, hence [B,1,S,C]
-
-        constexpr auto none = ttsl::Span<const ttnn::operations::unary::UnaryWithParam>{};
-
-        auto scaled_gain = ttnn::divide(
-            g,
-            rms_a,
-            /*dtype*/ std::nullopt,
-            /*memory_config*/ std::nullopt,
-            /*output*/ std::nullopt,
-            /*activations*/ none,
-            /*input_tensor_a_activations*/ none,
-            /*input_tensor_b_activations*/ none,
-            /*use_legacy*/ false);                                   // [1,1,1,C] x [B,1,S,1] -> [B,1,S,C] (bcast)
-        auto gained_dL_dout = ttnn::multiply(scaled_gain, dL_dout);  // [B,1,S,C] x [B,1,S,C] -> [B,1,S,C]
-
-        // notation:
-        // _ · _ <- usual dot product
-        // _ @ _ <- matrix multiplication
-        // _ *. _ <- Hadamard product/eltwise multiplication with broadcasting
-        // _ /. _ <- eltwise division with broadcasting
-
-        // have a : [B,1,S,C]
-
-        // want to obtain scaled_outer = gained_dL_dout @ ((a@a^T)/n*rms(a)^2)
-
-        // to avoid computing the large outer product matrix explicitly, we
-        // instead compute
-        // scale = (a^T · gained_dL_dout) : [B,1,S,C] x [B,1,S,C] -> [1]
-        // scaled_outer = scale *. a : [1] x [B,1,S,C] -> [B,1,S,C]
-
-        auto scale = ttml::ttnn_fixed::sum_over_dim(
-            ttnn::multiply(a, gained_dL_dout, std::nullopt, std::nullopt, std::nullopt, none, none, none, false),
-            3);  // [B,1,S,C] x [B,1,S,C] -> [B,1,S,C] -> [B,1,S,1]
-
-        auto scaled_outer = ttnn::multiply(
-            scale, a, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);  // [B,1,S,1] x [B,1,S,C] ->
-                                                                                           // [B,1,S,C] (bcast)
-
-        auto ms_a = ttnn::square(rms_a);  // [B,1,S,1] -> [B,1,S,1]
-
-        auto c_by_ms_a = ttnn::multiply(
-            ms_a, c, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);  // [B,1,S,1] x [1] ->
-                                                                                          // [B,1,S,1] (bcast)
-
-        auto rhs = ttnn::divide(
-            scaled_outer,
-            c_by_ms_a,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            none,
-            none,
-            none,
-            false);  // [B,1,S,C] x [B,1,S,1] -> [B,1,S,C] (bcast)
-
-        auto dL_da = ttnn::subtract(
-            gained_dL_dout,
-            rhs,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            none,
-            none,
-            none,
-            false);  // [B,1,S,C] x [B,1,S,C] -> [B,1,S,C]; checked by add_grad
-        tensor->add_grad(dL_da);
-
-        // dL_dgamma = (a / rms(a)) * dL_dout -> requires sum over batch due to broadcasting
-        auto dL_dg_components = ttnn::multiply(
-            dL_dout,
-            ttnn::divide(a, rms_a, std::nullopt, std::nullopt, std::nullopt, none, none, none, false),
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            none,
-            none,
-            none,
-            false);  // [B,1,S,C] x [B,1,S,1] -> [B,1,S,C] (bcast); checked by add_grad
-        auto dL_dg = ttnn::sum(
-            dL_dg_components,
-            /* dim_arg */ ttnn::SmallVector<int>{0, 1, 2},
-            /* keep_dim */ true,
-            /* output_mem_config */ std::nullopt,
-            /*compute_kernel_config */ core::ComputeKernelConfig::precise());  // [B,1,S,C] -> [1,1,1,C]
-        gamma->add_grad(dL_dg);
+        if (grads.size() != 2U) {
+            throw std::runtime_error("rmsnorm_bw returned unexpected number of gradients");
+        }
+        if (grads[0].has_value()) {
+            tensor->add_grad(grads[0].value());
+        }
+        if (grads[1].has_value()) {
+            gamma->add_grad(grads[1].value());
+        }
     };
 
     auto links = autograd::get_links(tensor, gamma);
@@ -227,7 +147,8 @@ autograd::TensorPtr rmsnorm_composite(
             /*activations*/ none,
             /*input_tensor_a_activations*/ none,
             /*input_tensor_b_activations*/ none,
-            /*use_legacy*/ false);                                   // [1,1,1,C] x [B,1,S,1] -> [B,1,S,C] (bcast)
+            /*use_legacy*/ false);  // [1,1,1,C] x [B,1,S,1] -> [B,1,S,C] (bcast)
+
         auto gained_dL_dout = ttnn::multiply(
             scaled_gain,
             dL_dout,
@@ -308,6 +229,7 @@ autograd::TensorPtr rmsnorm_composite(
             /* keep_dim */ true,
             /* output_mem_config */ std::nullopt,
             /*compute_kernel_config */ core::ComputeKernelConfig::precise());  // [B,1,S,C] -> [1,1,1,C]
+
         gamma->add_grad(dL_dg);
     };
 

--- a/tt-train/tests/ops/rmsnorm_op_test.cpp
+++ b/tt-train/tests/ops/rmsnorm_op_test.cpp
@@ -25,12 +25,18 @@ protected:
     }
 };
 
-// Forward and backward tests are given by comparing with results from PyTorch:
-// For test tensor `x` of shape [N,C,H,W] we set x.requires_grad = True
-// and compute the RMSNorm as `x_norm_sum = torch.nn.functional.rms_norm(x).sum()`
-// and compute its gradient with respect to `x` as `x_grad = torch.autograd.grad(x_norm_sum, x)[0]`
-// We then compare the results of the RMSNorm and its gradient with the results of the RMSNorm and its gradient
-// computed by the RMSNorm op in TTML.
+// ============================================================================
+// Section 1: RMSNorm Kernel vs PyTorch Reference Implementation
+// ============================================================================
+// These tests validate the optimized RMSNorm kernel implementation against
+// PyTorch's reference implementation to ensure numerical correctness.
+//
+// Test methodology:
+// 1. Create test tensor `x` of shape [N,C,H,W] with x.requires_grad = True
+// 2. Compute PyTorch RMSNorm: `x_norm_sum = torch.nn.functional.rms_norm(x).sum()`
+// 3. Compute PyTorch gradient: `x_grad = torch.autograd.grad(x_norm_sum, x)[0]`
+// 4. Compare TTML kernel results with PyTorch reference results
+// ============================================================================
 TEST_F(RMSNormOpTest, RMSNorm_Small_Forward) {
     using namespace ttml;
     float eps = 0.0078125F;  // default in PyTorch for bf16
@@ -47,39 +53,6 @@ TEST_F(RMSNormOpTest, RMSNorm_Small_Forward) {
     EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 1e-2F));
 }
 
-TEST_F(RMSNormOpTest, RMSNorm_Compare_Kernel_Composite) {
-    std::vector<std::vector<uint32_t>> shapes = {
-        {1U, 1U, 1U, 1024U},
-        {1U, 1U, 1U, 1U << 20U},
-        {32U, 1U, 1024U, 4096U},
-        {32U, 1U, 1024U, 4091U},
-        {32U, 1U, 1024U, 4079U},
-        {1U, 1U, 1U, (1U << 20U) - 1U},
-        {1U, 1U, 1U, (1U << 20U) - 18U}};
-
-    auto* device = &ttml::autograd::ctx().get_device();
-
-    constexpr uint32_t iterations = 2U;
-    for (const auto& shape : shapes) {
-        for (uint32_t iter = 0; iter < iterations; ++iter) {
-            xt::xarray<float> x_data = xt::random::rand(shape, 0.F, 1.F);
-            auto x = ttml::autograd::create_tensor(ttml::core::from_xtensor(x_data, device));
-            auto gamma =
-                ttml::autograd::create_tensor(ttml::core::ones(ttml::core::create_shape({1, 1, 1, shape[3]}), device));
-
-            auto result = ttml::ops::rmsnorm(x, gamma, 0.0078125F);
-            auto result_xtensor = ttml::core::to_xtensor(result->get_value());
-
-            auto expected_result = ttml::ops::rmsnorm_composite(x, gamma, 0.0078125F);
-            auto expected_result_xtensor = ttml::core::to_xtensor(expected_result->get_value());
-
-            EXPECT_TRUE(xt::allclose(result_xtensor, expected_result_xtensor, 1.0e-3F, 3e-2F));
-
-            ttml::autograd::ctx().reset_graph();
-        }
-    }
-}
-
 TEST_F(RMSNormOpTest, RMSNorm_Small_Backward) {
     using namespace ttml;
     float eps = 0.0078125F;  // default in PyTorch for bf16
@@ -94,7 +67,7 @@ TEST_F(RMSNormOpTest, RMSNorm_Small_Backward) {
     auto result_xtensor = core::to_xtensor(result->get_value());
 
     auto target = autograd::create_tensor(core::zeros_like(result->get_value()));
-    auto mse_result = ttml::ops::mse_loss(result, target);
+    auto mse_result = ops::mse_loss(result, target);
     mse_result->backward();
     auto example_tensor_grad = core::to_xtensor(example_tensor->get_grad());
     auto expected_example_tensor_grad = xt::xarray<float>(
@@ -169,7 +142,7 @@ TEST_F(RMSNormOpTest, RMSNorm_Backward_Batch) {
     auto result_xtensor = core::to_xtensor(result->get_value());
 
     auto target = autograd::create_tensor(core::zeros_like(result->get_value()));
-    auto mse_result = ttml::ops::mse_loss(result, target);
+    auto mse_result = ops::mse_loss(result, target);
     mse_result->backward();
 
     auto example_tensor_grad = core::to_xtensor(example_tensor->get_grad());
@@ -181,6 +154,16 @@ TEST_F(RMSNormOpTest, RMSNorm_Backward_Batch) {
     EXPECT_TRUE(xt::allclose(gamma_grad, expected_gamma_grad, 5e-2F));
 }
 
+// ============================================================================
+// Section 2: RMSNorm Composite vs PyTorch Reference Implementation
+// ============================================================================
+// These tests validate the composite RMSNorm implementation (built from basic ops)
+// against PyTorch's reference implementation to ensure numerical correctness.
+//
+// The composite implementation serves as a reference for the optimized kernel
+// and uses standard operations like power, mean, sqrt, and multiply.
+// Same test methodology as Section 1, but using rmsnorm_composite() instead.
+// ============================================================================
 TEST_F(RMSNormOpTest, CompositeRMSNorm_Small_Forward) {
     using namespace ttml;
     float eps = 0.0078125F;  // default in PyTorch for bf16
@@ -211,7 +194,7 @@ TEST_F(RMSNormOpTest, CompositeRMSNorm_Small_Backward) {
     auto result_xtensor = core::to_xtensor(result->get_value());
 
     auto target = autograd::create_tensor(core::zeros_like(result->get_value()));
-    auto mse_result = ttml::ops::mse_loss(result, target);
+    auto mse_result = ops::mse_loss(result, target);
     mse_result->backward();
     auto example_tensor_grad = core::to_xtensor(example_tensor->get_grad());
     auto expected_example_tensor_grad = xt::xarray<float>(
@@ -286,7 +269,7 @@ TEST_F(RMSNormOpTest, CompositeRMSNorm_Backward_Batch) {
     auto result_xtensor = core::to_xtensor(result->get_value());
 
     auto target = autograd::create_tensor(core::zeros_like(result->get_value()));
-    auto mse_result = ttml::ops::mse_loss(result, target);
+    auto mse_result = ops::mse_loss(result, target);
     mse_result->backward();
 
     auto example_tensor_grad = core::to_xtensor(example_tensor->get_grad());
@@ -296,4 +279,196 @@ TEST_F(RMSNormOpTest, CompositeRMSNorm_Backward_Batch) {
     auto gamma_grad = core::to_xtensor(gamma->get_grad());
     xt::xarray<float> expected_gamma_grad = {{{{0.36111F, 0.37644F, 0.39589F, 0.41945F, 0.44712F}}}};
     EXPECT_TRUE(xt::allclose(gamma_grad, expected_gamma_grad, 5e-2F));
+}
+
+// ============================================================================
+// Section 3: RMSNorm Kernel vs Composite Implementation Comparison
+// ============================================================================
+// These tests compare the optimized RMSNorm kernel implementation against the
+// composite implementation to ensure they produce identical results across
+// different tensor shapes, sizes, and edge cases.
+//
+// This validation ensures that the kernel optimization maintains correctness
+// while providing performance benefits. Both implementations should produce
+// identical forward and backward pass results.
+// ============================================================================
+
+/**
+ * Helper function to compare kernel vs composite implementations of RMSNorm
+ *
+ * This function tests both forward and backward passes to ensure:
+ * 1. Forward pass: kernel and composite produce identical results
+ * 2. Backward pass: gradients computed by both implementations match
+ * 3. All outputs and gradients are finite (no NaN/Inf values)
+ *
+ * @param shape Input tensor shape [N, C, H, W] where:
+ *   - N: batch size
+ *   - C: number of channels (normalized dimension)
+ *   - H: height
+ *   - W: width
+ *
+ * Test cases cover various scenarios:
+ * - Alignment: C % 32 == 0 (aligned) vs C % 32 != 0 (unaligned/masking)
+ * - Memory: fits in L1 cache vs exceeds L1 cache capacity
+ * - Block size: odd C (block_size=1) vs even C (block_size=2)
+ * - Scale: small to very large C dimensions
+ */
+static void CompareKernelVsComposite(const std::vector<uint32_t>& shape) {
+    using namespace ttml;
+    auto* device = &autograd::ctx().get_device();
+    float eps = 0.0078125F;
+
+    // Generate random input data
+    xt::random::seed(42);
+    std::array<uint32_t, 4> gamma_shape = {1, 1, 1, shape[3]};
+    xt::xarray<float> x_data = xt::random::rand<float>(shape, -1.0F, 1.0F);
+
+    xt::xarray<float> gamma_data = xt::random::rand<float>(gamma_shape, 0.0F, 1.0F);
+
+    // Test forward pass - kernel vs composite
+    auto x_kernel = autograd::create_tensor(core::from_xtensor(x_data, device));
+    auto gamma_kernel = autograd::create_tensor(core::from_xtensor(gamma_data, device));
+    auto result_kernel = ops::rmsnorm(x_kernel, gamma_kernel, eps);
+    auto result_kernel_xtensor = core::to_xtensor(result_kernel->get_value());
+
+    auto x_composite = autograd::create_tensor(core::from_xtensor(x_data, device));
+    auto gamma_composite = autograd::create_tensor(core::from_xtensor(gamma_data, device));
+    auto result_composite = ops::rmsnorm_composite(x_composite, gamma_composite, eps);
+    auto result_composite_xtensor = core::to_xtensor(result_composite->get_value());
+
+    // Verify output shape matches input shape
+    EXPECT_EQ(result_kernel_xtensor.shape(), x_data.shape());
+    EXPECT_EQ(result_composite_xtensor.shape(), x_data.shape());
+
+    // Compare forward results
+    EXPECT_TRUE(xt::allclose(result_kernel_xtensor, result_composite_xtensor, 1.0e-3F, 3e-2F));
+    EXPECT_TRUE(xt::all(xt::isfinite(result_kernel_xtensor)));
+    EXPECT_TRUE(xt::all(xt::isfinite(result_composite_xtensor)));
+
+    // Test backward pass - kernel vs composite
+    auto target_composite = autograd::create_tensor(core::zeros_like(result_composite->get_value()));
+    auto mse_composite = ops::mse_loss(result_composite, target_composite);
+    mse_composite->backward();
+    auto target_kernel = autograd::create_tensor(core::zeros_like(result_kernel->get_value()));
+    auto mse_kernel = ops::mse_loss(result_kernel, target_kernel);
+    mse_kernel->backward();
+
+    // Since composite is finite, the kernel should also be finite
+    auto x_grad_composite = core::to_xtensor(x_composite->get_grad());
+    auto gamma_grad_composite = core::to_xtensor(gamma_composite->get_grad());
+    auto x_grad_kernel = core::to_xtensor(x_kernel->get_grad());
+    auto gamma_grad_kernel = core::to_xtensor(gamma_kernel->get_grad());
+    // Should be composite here
+
+    // Verify gradients have correct shapes and are finite
+    EXPECT_EQ(x_grad_kernel.shape(), x_data.shape());
+    EXPECT_EQ(gamma_grad_kernel.shape()[3], shape[3]);
+    EXPECT_TRUE(xt::all(xt::isfinite(x_grad_kernel)));
+    EXPECT_TRUE(xt::all(xt::isfinite(gamma_grad_kernel)));
+
+    EXPECT_EQ(x_grad_composite.shape(), x_data.shape());
+    EXPECT_EQ(gamma_grad_composite.shape()[3], shape[3]);
+    EXPECT_TRUE(xt::all(xt::isfinite(x_grad_composite)));
+    EXPECT_TRUE(xt::all(xt::isfinite(gamma_grad_composite)));
+
+    // Compare backward results
+    EXPECT_TRUE(xt::allclose(x_grad_kernel, x_grad_composite, 1.0e-3F, 3e-2F));
+    EXPECT_TRUE(xt::allclose(gamma_grad_kernel, gamma_grad_composite, 1.0e-3F, 3e-2F));
+
+    autograd::ctx().reset_graph();
+}
+
+// ============================================================================
+// Section 3: Test Cases - RMSNorm Kernel vs Composite Comparison
+// ============================================================================
+// These tests systematically compare the optimized kernel implementation
+// against the composite implementation across different scenarios:
+//
+// - Memory usage patterns: L1 cache fit vs overflow
+// - Tensor alignment: 32-byte aligned vs unaligned (masking required)
+// - Block sizes: odd vs even C dimensions
+// - Scale testing: small to very large tensor dimensions
+// - Training scenarios: realistic model shapes (NanoLlama, etc.)
+// ============================================================================
+
+// Test aligned dimensions (C % 32 == 0) that fit in L1 cache
+TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_FitsInL1) {
+    // C = 1024 (32 * 32), fits in L1 cache
+    CompareKernelVsComposite({1U, 1U, 1U, 1024U});
+
+    // C = 4096 (32 * 128), largest size that fits in L1 cache (1 << 12)
+    CompareKernelVsComposite({1U, 1U, 1U, 4096U});
+}
+
+// Test aligned dimensions (C % 32 == 0) that fit in L1 except for gamma
+TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_L1ExceptGamma) {
+    // C = 8192 (1 << 13), fits in L1 except gamma parameter
+    CompareKernelVsComposite({1U, 1U, 1U, 8192U});
+}
+
+// Test aligned dimensions (C % 32 == 0) that don't fit in L1 cache
+TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_DoesNotFitInL1) {
+    // C = 16384 (1 << 14), does not fit in L1 cache
+    CompareKernelVsComposite({1U, 1U, 1U, 16384U});
+}
+
+// Test aligned dimensions (C % 32 == 0) with very large C
+TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_VeryLargeC) {
+    // C = 1048576 (1 << 20), very large C dimension (1M elements)
+    CompareKernelVsComposite({1U, 1U, 1U, 1048576U});
+}
+
+// Test unaligned dimensions (C % 32 != 0) that fit in L1 cache
+TEST_F(RMSNormOpTest, RMSNorm_Compare_Unaligned_FitsInL1) {
+    // C = 1023 (32 * 31 + 31), requires masking, fits in L1
+    CompareKernelVsComposite({1U, 1U, 1U, 1023U});
+
+    // C = 4095 (32 * 127 + 31), requires masking, fits in L1
+    CompareKernelVsComposite({1U, 1U, 1U, 4095U});
+}
+
+// Test unaligned dimensions (C % 32 != 0) that don't fit in L1 cache
+TEST_F(RMSNormOpTest, RMSNorm_Compare_Unaligned_DoesNotFitInL1) {
+    // C = 16383 (1 << 14 - 1), requires masking, does not fit in L1
+    CompareKernelVsComposite({1U, 1U, 1U, 16383U});
+}
+
+// Test unaligned dimensions (C % 32 != 0) with very large C
+TEST_F(RMSNormOpTest, RMSNorm_Compare_Unaligned_VeryLargeC) {
+    // C = 1048575 (1 << 20 - 1), very large C with masking
+    CompareKernelVsComposite({1U, 1U, 1U, 1048575U});
+
+    // C = 1048558 (1 << 20 - 18), very large C with different masking pattern
+    CompareKernelVsComposite({1U, 1U, 1U, 1048558U});
+}
+
+// Test block_size = 1 (C is odd)
+TEST_F(RMSNormOpTest, RMSNorm_Compare_BlockSize1_OddC) {
+    CompareKernelVsComposite({1U, 1U, 1U, 33U});   // C = 33 (odd)
+    CompareKernelVsComposite({1U, 1U, 1U, 127U});  // C = 127 (odd)
+}
+
+// Test block_size = 2 (C is even)
+TEST_F(RMSNormOpTest, RMSNorm_Compare_BlockSize2_EvenC) {
+    CompareKernelVsComposite({1U, 1U, 1U, 34U});   // C = 34 (even)
+    CompareKernelVsComposite({1U, 1U, 1U, 126U});  // C = 126 (even)
+}
+
+// Test training-like shapes with realistic model dimensions
+TEST_F(RMSNormOpTest, RMSNorm_Compare_TrainingShapes_NanoLlama) {
+    // NanoLlama training shape: batch=64, seq_len=256, hidden_dim=384
+    CompareKernelVsComposite({64U, 1U, 256U, 384U});
+}
+
+// Test small batch and sequence dimensions (non-1 values)
+TEST_F(RMSNormOpTest, RMSNorm_Compare_SmallBatch_NonUnit) {
+    CompareKernelVsComposite({2U, 1U, 4U, 64U});
+    CompareKernelVsComposite({32U, 1U, 64U, 128U});
+}
+
+// Test different masking patterns with larger batches
+TEST_F(RMSNormOpTest, RMSNorm_Compare_Masking_Patterns) {
+    CompareKernelVsComposite({32U, 1U, 1024U, 4091U});  // C % 32 = 11
+    CompareKernelVsComposite({32U, 1U, 1024U, 4079U});  // C % 32 = 31
+    CompareKernelVsComposite({32U, 1U, 1024U, 4097U});  // C % 32 = 1
 }


### PR DESCRIPTION
## Ticket
[[Feature Request] RMSNorm backward kernel implementation](https://github.com/tenstorrent/tt-metal/issues/14194)

## Problem description
Since the RMSNorm backward operation was using a high-level composite `ttnn` implementation, it has now been replaced with a custom fused kernel for improved performance. The new kernel provides better efficiency while maintaining numerical correctness.

## What's changed
- **Added custom RMSNorm backward kernel** with fused compute operations
- **Implemented dual-mode operation**: L1-fit mode for smaller tensors and block-based mode for larger tensors
- **Replaced composite ttnn implementation** with direct kernel calls in `rmsnorm_op.cpp`
- **Added comprehensive test coverage** including:
  - Alignment scenarios: C % 32 == 0 (aligned) vs C % 32 != 0 (unaligned/masking)
  - Memory patterns: fits in L1 cache vs exceeds L1 cache capacity
  - Block sizes: odd C (block_size=1) vs even C (block_size=2)
  - Scale testing: small to very large C dimensions (up to 1M elements)
  - Training shapes: realistic model dimensions (NanoLlama: B=64, S=256, C=384)
- **Added compute_utils functions** - common functions used by compute kernel
- **Switched NanoLlama** to use new RMSNorm backward implementation

## Comparison with composite
Mean step times across different configurations (5000 steps for NanoLlama):
- **Composite (baseline)**: 279.84 ms
- **FW-only kernel**: 264.58 ms (5.5% improvement)
- **BW-only kernel**: 254.13 ms (9.2% improvement)  
- **Both kernels**: 238.64 ms (14.7% improvement)

The implementation maintains full backward compatibility while providing significant performance improvements for RMSNorm operations in the training pipeline.

Step time comparison across all configurations (5000 steps for NanoLlama):
<img width="2000" height="1000" alt="image" src="https://github.com/user-attachments/assets/e1cfb22f-0f1b-453f-a24b-1cde9c149e2a" />


Performance comparison (5000 steps for NanoLlama):
<img width="2000" height="1000" alt="image" src="https://github.com/user-attachments/assets/cf1c8046-94df-4f70-adc7-c23da51ab6bb" />

Loss comparison showing numerical correctness (5000 steps for NanoLlama):
<img width="2000" height="1000" alt="image" src="https://github.com/user-attachments/assets/c1e38219-8712-4ddc-91d0-0681fe2fd531" />


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes
