### PR TITLE
FDKernel updates for running dispatch on fabric

### DIFF
--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -418,13 +418,12 @@ void DispatchKernel::CreateKernel() {
         static_config_.is_h_variant.value(),
     };
     TT_ASSERT(compile_args.size() == 42);
-    auto my_virtual_core = device_->virtual_core_from_logical_core(logical_core_, GetCoreType());
-    auto upstream_virtual_core =
-        device_->virtual_core_from_logical_core(dependent_config_.upstream_logical_core.value(), GetCoreType());
+    auto my_virtual_core = get_virtual_core_coord(logical_core_, GetCoreType());
+    auto upstream_virtual_core = get_virtual_core_coord(dependent_config_.upstream_logical_core.value(), GetCoreType());
     auto downstream_virtual_core =
-        device_->virtual_core_from_logical_core(dependent_config_.downstream_logical_core.value(), GetCoreType());
+        get_virtual_core_coord(dependent_config_.downstream_logical_core.value(), GetCoreType());
     auto downstream_s_virtual_core =
-        device_->virtual_core_from_logical_core(dependent_config_.downstream_s_logical_core.value(), GetCoreType());
+        get_virtual_core_coord(dependent_config_.downstream_s_logical_core.value(), GetCoreType());
 
     auto my_virtual_noc_coords = device_->virtual_noc0_coordinate(noc_selection_.non_dispatch_noc, my_virtual_core);
     auto upstream_virtual_noc_coords =

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -115,6 +115,24 @@ FDKernel* FDKernel::Generate(
     }
 }
 
+uint32_t FDKernel::get_programmable_core_type_index(CoreType dispatch_core_type, bool is_active_eth_core) {
+    // TODO(#22895): Too many core types. Consolidate programmable_core_type_index with ProgrammableCoreType and
+    // CoreType
+    uint32_t programmable_core_type_index =
+        (dispatch_core_type == CoreType::WORKER)
+            ? MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)
+        : is_active_eth_core
+            ? MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH)
+            : MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::IDLE_ETH);
+
+    return programmable_core_type_index;
+}
+
+CoreCoord FDKernel::get_virtual_core_coord(const tt_cxy_pair& logical_cxy, const CoreType& core_type) {
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    return cluster.get_virtual_coordinate_from_logical_coordinates(logical_cxy, core_type);
+}
+
 void FDKernel::configure_kernel_variant(
     const string& path,
     const std::vector<uint32_t>& compile_args,
@@ -123,13 +141,7 @@ void FDKernel::configure_kernel_variant(
     bool send_to_brisc,
     bool force_watcher_no_inline,
     KernelBuildOptLevel opt_level) {
-    // TODO: just pass in the programmable index
-    uint32_t programmable_core_type_index =
-        (GetCoreType() == CoreType::WORKER)
-            ? MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)
-        : is_active_eth_core
-            ? MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH)
-            : MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::IDLE_ETH);
+    uint32_t programmable_core_type_index = get_programmable_core_type_index(GetCoreType(), is_active_eth_core);
 
     std::map<string, string> defines = {
         {"DISPATCH_KERNEL", "1"},

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -120,6 +120,15 @@ public:
         noc_selection_t noc_selection,
         tt::tt_metal::DispatchWorkerType type);
 
+    // Translate DispatchCoreType to programmable core type index
+    static uint32_t get_programmable_core_type_index(CoreType dispatch_core_type, bool is_active_eth_core = false);
+
+    // Translate core coord using the chip_id from the logical_cxy
+    //
+    // IDevice::virtual_core_from_logical_core uses the chip_id of the device instance whereas this function uses the
+    // chip_id specified in the logical coordinate.
+    static CoreCoord get_virtual_core_coord(const tt_cxy_pair& logical_cxy, const CoreType& core_type);
+
     // Register another kernel as upstream/downstream of this one
     void AddUpstreamKernel(FDKernel* upstream) { upstream_kernels_.push_back(upstream); }
     void AddDownstreamKernel(FDKernel* downstream) { downstream_kernels_.push_back(downstream); }

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -397,13 +397,12 @@ void PrefetchKernel::CreateKernel() {
         static_config_.is_h_variant.value(),
     };
     TT_ASSERT(compile_args.size() == 36);
-    auto my_virtual_core = device_->virtual_core_from_logical_core(logical_core_, GetCoreType());
-    auto upstream_virtual_core =
-        device_->virtual_core_from_logical_core(dependent_config_.upstream_logical_core.value(), GetCoreType());
+    auto my_virtual_core = get_virtual_core_coord(logical_core_, GetCoreType());
+    auto upstream_virtual_core = get_virtual_core_coord(dependent_config_.upstream_logical_core.value(), GetCoreType());
     auto downstream_virtual_core =
-        device_->virtual_core_from_logical_core(dependent_config_.downstream_logical_core.value(), GetCoreType());
+        get_virtual_core_coord(dependent_config_.downstream_logical_core.value(), GetCoreType());
     auto downstream_s_virtual_core =
-        device_->virtual_core_from_logical_core(dependent_config_.downstream_s_logical_core.value(), GetCoreType());
+        get_virtual_core_coord(dependent_config_.downstream_s_logical_core.value(), GetCoreType());
 
     auto my_virtual_noc_coords = device_->virtual_noc0_coordinate(noc_selection_.non_dispatch_noc, my_virtual_core);
     auto upstream_virtual_noc_coords =


### PR DESCRIPTION
### Ticket
[#18726](https://github.com/tenstorrent/tt-metal/issues/18726)

### Problem description
- Dispatch on fabric: Upstream/downstream kernels are specified directly even if they are on the remote chip. `device_-> virtual_core_from_logical_core` uses the device ID instead of chip ID from the passed in coordinate

### What's changed
- Directly call Cluster to translate coordinates
- get_programmable_core_type_index will be reused. Move that into a function in FDKernel

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15355759404
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/15355935348
TG
https://github.com/tenstorrent/tt-metal/actions/runs/15355932995