### PR TITLE
[skip ci] Remove dead fwd declarations

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,6 @@ Checks: >
   -bugprone-branch-clone,
   -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,
-  -bugprone-forward-declaration-namespace,
   -bugprone-forwarding-reference-overload,
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-integer-division,

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -54,7 +54,6 @@ namespace tt::tt_metal {
 
 class SubDeviceManagerTracker;
 class ThreadPool;
-class ProgramCache;
 class TraceDescriptor;
 
 namespace distributed {

--- a/tt_metal/impl/lightmetal/lightmetal_capture.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_capture.hpp
@@ -16,7 +16,6 @@ class Command;
 
 // Forward decl for light_metal_binary_generated.h
 namespace tt::tt_metal::flatbuffer {
-struct TraceDescriptor;
 struct TraceDescriptorByTraceId;
 }  // namespace tt::tt_metal::flatbuffer
 

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -40,7 +40,6 @@ struct CreateCircularBufferCommand;
 struct LightMetalCompareCommand;
 struct RuntimeArg;
 
-struct TraceDescriptor;
 struct TraceDescriptorByTraceId;
 struct LightMetalBinary;
 }  // namespace tt::tt_metal::flatbuffer

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.hpp
@@ -23,7 +23,6 @@ class IDevice;
 
 namespace ttnn::ccl {
 class WorkerEdmInterfaceArgs;
-class SenderWorkerAdapterSpec;
 
 namespace worker_detail {
 


### PR DESCRIPTION
### Ticket
#22841 

### Problem description
Some forward declarations are in the wrong namespace, so they're actually doing nothing.

### What's changed
* Enable the linter check
* Remove the dead fwd declarations