### PR TITLE
#22258: Changes to multi-device sharding to support multi-host

### DIFF
--- a/tests/tt_metal/distributed/test_distributed_host_buffer.cpp
+++ b/tests/tt_metal/distributed/test_distributed_host_buffer.cpp
@@ -60,9 +60,9 @@ TEST(DistributedHostBufferTest, GetBuffer) {
 
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
 
-    buffer.emplace_shard(distributed::MeshCoordinate(0), HostBuffer(std::vector<int>{1, 2, 3}));
-    buffer.emplace_shard(distributed::MeshCoordinate(1), HostBuffer(std::vector<int>{4, 5, 6}));
-    buffer.emplace_shard(distributed::MeshCoordinate(2), HostBuffer(std::vector<int>{7, 8, 9}));
+    buffer.emplace_shard(distributed::MeshCoordinate(0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
+    buffer.emplace_shard(distributed::MeshCoordinate(1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
+    buffer.emplace_shard(distributed::MeshCoordinate(2), []() { return HostBuffer(std::vector<int>{7, 8, 9}); });
 
     auto optional_buffer = buffer.get_shard(distributed::MeshCoordinate(0));
     ASSERT_TRUE(optional_buffer.has_value());
@@ -88,12 +88,12 @@ TEST(DistributedHostBufferTest, WithLocalMeshShape) {
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
     EXPECT_EQ(buffer.shape().mesh_size(), 6);  // 2×3 = 6
 
-    buffer.emplace_shard(distributed::MeshCoordinate(0, 0), HostBuffer(std::vector<int>{1, 2, 3}));
-    buffer.emplace_shard(distributed::MeshCoordinate(0, 1), HostBuffer(std::vector<int>{4, 5, 6}));
-    buffer.emplace_shard(distributed::MeshCoordinate(0, 2), HostBuffer(std::vector<int>{7, 8, 9}));
-    buffer.emplace_shard(distributed::MeshCoordinate(1, 0), HostBuffer(std::vector<int>{10, 11, 12}));
-    buffer.emplace_shard(distributed::MeshCoordinate(1, 1), HostBuffer(std::vector<int>{13, 14, 15}));
-    buffer.emplace_shard(distributed::MeshCoordinate(1, 2), HostBuffer(std::vector<int>{16, 17, 18}));
+    buffer.emplace_shard(distributed::MeshCoordinate(0, 0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
+    buffer.emplace_shard(distributed::MeshCoordinate(0, 1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
+    buffer.emplace_shard(distributed::MeshCoordinate(0, 2), []() { return HostBuffer(std::vector<int>{7, 8, 9}); });
+    buffer.emplace_shard(distributed::MeshCoordinate(1, 0), []() { return HostBuffer(std::vector<int>{10, 11, 12}); });
+    buffer.emplace_shard(distributed::MeshCoordinate(1, 1), []() { return HostBuffer(std::vector<int>{13, 14, 15}); });
+    buffer.emplace_shard(distributed::MeshCoordinate(1, 2), []() { return HostBuffer(std::vector<int>{16, 17, 18}); });
 
     EXPECT_THAT(
         buffer.shard_coords(),
@@ -137,8 +137,8 @@ TEST(DistributedHostBufferTest, Transform) {
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
     EXPECT_EQ(buffer.shape().mesh_size(), 2);
 
-    buffer.emplace_shard(distributed::MeshCoordinate(0), HostBuffer(std::vector<int>{1, 2, 3}));
-    buffer.emplace_shard(distributed::MeshCoordinate(1), HostBuffer(std::vector<int>{4, 5, 6}));
+    buffer.emplace_shard(distributed::MeshCoordinate(0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
+    buffer.emplace_shard(distributed::MeshCoordinate(1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
 
     auto transformed_buffer = buffer.transform([](const HostBuffer& buffer) {
         auto span = buffer.view_as<int>();
@@ -166,9 +166,9 @@ TEST(DistributedHostBufferTest, TransformWithLocalShape) {
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
     EXPECT_EQ(buffer.shape().mesh_size(), 3);  // 3×1 = 3
 
-    buffer.emplace_shard(distributed::MeshCoordinate(0, 0), HostBuffer(std::vector<int>{1, 2, 3}));
-    buffer.emplace_shard(distributed::MeshCoordinate(1, 0), HostBuffer(std::vector<int>{4, 5, 6}));
-    buffer.emplace_shard(distributed::MeshCoordinate(2, 0), HostBuffer(std::vector<int>{7, 8, 9}));
+    buffer.emplace_shard(distributed::MeshCoordinate(0, 0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
+    buffer.emplace_shard(distributed::MeshCoordinate(1, 0), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
+    buffer.emplace_shard(distributed::MeshCoordinate(2, 0), []() { return HostBuffer(std::vector<int>{7, 8, 9}); });
 
     auto transformed_buffer = buffer.transform([](const HostBuffer& buffer) {
         auto span = buffer.view_as<int>();
@@ -196,8 +196,8 @@ TEST(DistributedHostBufferTest, Apply) {
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
     EXPECT_EQ(buffer.shape().mesh_size(), 2);
 
-    buffer.emplace_shard(distributed::MeshCoordinate(0), HostBuffer(std::vector<int>{1, 2, 3}));
-    buffer.emplace_shard(distributed::MeshCoordinate(1), HostBuffer(std::vector<int>{4, 5, 6}));
+    buffer.emplace_shard(distributed::MeshCoordinate(0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
+    buffer.emplace_shard(distributed::MeshCoordinate(1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
 
     std::vector<std::vector<int>> values;
     buffer.apply([&values](const HostBuffer& buffer) {
@@ -218,9 +218,9 @@ TEST(DistributedHostBufferTest, ApplyWithLocalShape) {
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
     EXPECT_EQ(buffer.shape().mesh_size(), 3);  // 3×1 = 3
 
-    buffer.emplace_shard(distributed::MeshCoordinate(0, 0), HostBuffer(std::vector<int>{1, 2, 3}));
-    buffer.emplace_shard(distributed::MeshCoordinate(1, 0), HostBuffer(std::vector<int>{4, 5, 6}));
-    buffer.emplace_shard(distributed::MeshCoordinate(2, 0), HostBuffer(std::vector<int>{7, 8, 9}));
+    buffer.emplace_shard(distributed::MeshCoordinate(0, 0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
+    buffer.emplace_shard(distributed::MeshCoordinate(1, 0), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
+    buffer.emplace_shard(distributed::MeshCoordinate(2, 0), []() { return HostBuffer(std::vector<int>{7, 8, 9}); });
 
     std::vector<std::vector<int>> values;
     buffer.apply([&values](const HostBuffer& buffer) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -411,36 +411,4 @@ TEST_F(TensorDistributionT3000Test, NdMapperShard3D) {
     EXPECT_THAT(aggregated_tensor.to_vector<float>(), Pointwise(FloatEq(), expected_data));
 }
 
-TEST_F(TensorDistributionT3000Test, ShardBorrowedTensor) {
-    constexpr size_t kNumRows = 2;
-    constexpr size_t kNumCols = 4;
-    ASSERT_EQ(mesh_device_->shape(), MeshShape(kNumRows, kNumCols));
-    const int num_devices = kNumRows * kNumCols;
-
-    std::vector<float> test_data;
-    for (int i = 0; i < num_devices * 1024; i++) {
-        test_data.push_back(i);
-    }
-    int num_references_created = 0;
-    Tensor input_tensor = Tensor::from_borrowed_data(
-        tt::stl::Span(test_data),
-        ttnn::Shape{num_devices, 1024},
-        /*on_creation_callback=*/[&num_references_created]() { num_references_created++; },
-        /*on_destruction_callback=*/[]() {});
-    EXPECT_EQ(num_references_created, 1);  // self
-
-    auto mapper = shard_tensor_to_mesh_mapper(*mesh_device_, 0);
-    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
-
-    // Validate that we didn't make any copies by updating `test_data`.
-    // Borrowed shards should reflect the changes.
-    for (int i = 0; i < test_data.size(); i++) {
-        test_data[i] = i * 7;
-    }
-
-    auto composer = concat_mesh_to_tensor_composer(*mesh_device_, /*dim=*/0);
-    Tensor concatenated_tensor = aggregate_tensor(sharded_tensor, *composer);
-    EXPECT_THAT(concatenated_tensor.to_vector<float>(), Pointwise(FloatEq(), test_data));
-}
-
 }  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
@@ -209,7 +209,7 @@ TEST(PartitionTest, ChunkDoesNotAccessData) {
 
     tt::stl::Span<const uint8_t> protected_span(static_cast<uint8_t*>(mapped_mem), total_size);
     auto xexpr = xt::adapt(
-        protected_span.data(), total_size, xt::no_ownership(), xt::svector<long>(shape.cbegin(), shape.cend()));
+        protected_span.data(), total_size, xt::no_ownership(), std::vector<size_t>(shape.cbegin(), shape.cend()));
 
     // Verify that our set up actually works by attempting to read the protected memory region, and catching a segfault.
     bool segfault_occurred = false;

--- a/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
@@ -38,6 +38,7 @@ namespace {
 using ::testing::SizeIs;
 using ::tt::tt_metal::Tensor;
 using ::ttnn::experimental::xtensor::chunk;
+using ::ttnn::experimental::xtensor::chunk_ndim;
 using ::ttnn::experimental::xtensor::concat;
 
 TEST(PartitionTest, ChunkBasicNonDivisible3) {
@@ -66,6 +67,19 @@ TEST(PartitionTest, ChunkBasicLessChunksThanProvided) {
     EXPECT_EQ(chunks[2].shape()[0], 3u);  // next chunk size 3
     EXPECT_EQ(chunks[3].shape()[0], 3u);  // next chunk size 3
     EXPECT_EQ(chunks[4].shape()[0], 1u);  // last chunk size 1
+}
+
+TEST(PartitionTest, ChunkFewerChunksThanRequested) {
+    xt::xarray<float> tensor = xt::arange<float>(5);
+
+    auto chunks = chunk(tensor, 7, 0);
+
+    ASSERT_THAT(chunks, SizeIs(5));
+    EXPECT_EQ(chunks[0].shape()[0], 1u);
+    EXPECT_EQ(chunks[1].shape()[0], 1u);
+    EXPECT_EQ(chunks[2].shape()[0], 1u);
+    EXPECT_EQ(chunks[3].shape()[0], 1u);
+    EXPECT_EQ(chunks[4].shape()[0], 1u);
 }
 
 TEST(PartitionTest, DefaultAxis) {
@@ -237,6 +251,196 @@ TEST(PartitionTest, ChunkDoesNotAccessData) {
     // Cleanup.
     ASSERT_EQ(sigaction(SIGSEGV, &old_action, nullptr), 0);
     ASSERT_EQ(munmap(mapped_mem, total_size), 0);
+}
+
+TEST(PartitionTest, ChunkNdimEmpty) {
+    xt::xarray<float> tensor = xt::arange<float>(24);
+    tensor.reshape({2, 3, 4});
+
+    auto chunks = chunk_ndim(tensor, {}, {});
+
+    ASSERT_THAT(chunks, SizeIs(1));
+    EXPECT_TRUE(xt::allclose(chunks[0], tensor));
+}
+
+TEST(PartitionTest, ChunkNdimMismatchedSizes) {
+    xt::xarray<float> tensor = xt::arange<float>(24);
+    tensor.reshape({2, 3, 4});
+
+    EXPECT_ANY_THROW(chunk_ndim(tensor, {2, 3}, {0}));
+    EXPECT_ANY_THROW(chunk_ndim(tensor, {2}, {0, 1}));
+}
+
+TEST(PartitionTest, ChunkNdimNegativeChunks) {
+    xt::xarray<float> tensor = xt::arange<float>(24);
+    tensor.reshape({2, 3, 4});
+
+    EXPECT_ANY_THROW(chunk_ndim(tensor, {-1, 2}, {0, 1}));
+    EXPECT_ANY_THROW(chunk_ndim(tensor, {2, 0}, {0, 1}));
+}
+
+TEST(PartitionTest, ChunkNdimNonUniqueDims) {
+    xt::xarray<float> tensor = xt::arange<float>(24);
+    tensor.reshape({2, 3, 4});
+
+    EXPECT_ANY_THROW(chunk_ndim(tensor, {2, 2}, {0, 0}));
+    EXPECT_ANY_THROW(chunk_ndim(tensor, {2, 2, 3}, {0, 1, 0}));
+}
+
+TEST(PartitionTest, ChunkNdimDimsOutOfRange) {
+    xt::xarray<float> tensor = xt::arange<float>(24);
+    tensor.reshape({2, 3, 4});
+
+    EXPECT_ANY_THROW(chunk_ndim(tensor, {2}, {3}));
+    EXPECT_ANY_THROW(chunk_ndim(tensor, {2}, {-1}));
+    EXPECT_ANY_THROW(chunk_ndim(tensor, {2, 2}, {0, 5}));
+}
+
+TEST(PartitionTest, ChunkNdimRowMajorOrder) {
+    xt::xarray<float> tensor = xt::arange<float>(24);
+    tensor.reshape({2, 3, 4});
+
+    auto chunks = chunk_ndim(tensor, {2, 2}, {0, 1});
+
+    ASSERT_THAT(chunks, SizeIs(4));
+
+    // Expected order: [0,0], [0,1], [1,0], [1,1] in row-major
+    // [0,0]: first half of dim 0, first half of dim 1
+    EXPECT_TRUE(xt::allclose(chunks[0], xt::view(tensor, xt::range(0, 1), xt::range(0, 2), xt::all())));
+    // [0,1]: first half of dim 0, second half of dim 1
+    EXPECT_TRUE(xt::allclose(chunks[1], xt::view(tensor, xt::range(0, 1), xt::range(2, 3), xt::all())));
+    // [1,0]: second half of dim 0, first half of dim 1
+    EXPECT_TRUE(xt::allclose(chunks[2], xt::view(tensor, xt::range(1, 2), xt::range(0, 2), xt::all())));
+    // [1,1]: second half of dim 0, second half of dim 1
+    EXPECT_TRUE(xt::allclose(chunks[3], xt::view(tensor, xt::range(1, 2), xt::range(2, 3), xt::all())));
+}
+
+TEST(PartitionTest, ChunkNdimFewerChunksThanRequested) {
+    xt::xarray<float> tensor = xt::arange<float>(12);
+    tensor.reshape({3, 4});
+
+    // Request 5 chunks along dim 0 (size 3), 6 chunks along dim 1 (size 4)
+    auto chunks = chunk_ndim(tensor, {5, 6}, {0, 1});
+
+    // Should get 3*4 = 12 chunks (capped by actual dimension sizes)
+    ASSERT_THAT(chunks, SizeIs(12));
+
+    // Each chunk should be 1x1
+    for (const auto& chunk : chunks) {
+        EXPECT_EQ(chunk.shape()[0], 1u);
+        EXPECT_EQ(chunk.shape()[1], 1u);
+    }
+
+    for (size_t i = 0; i < 3; ++i) {
+        for (size_t j = 0; j < 4; ++j) {
+            size_t chunk_idx = i * 4 + j;
+            EXPECT_FLOAT_EQ(chunks[chunk_idx](0, 0), tensor(i, j));
+        }
+    }
+}
+
+TEST(PartitionTest, ChunkNdimBasicMultiDim) {
+    xt::xarray<int> tensor = xt::arange<int>(60);
+    tensor.reshape({3, 4, 5});
+
+    auto chunks = chunk_ndim(tensor, {2, 2}, {0, 2});
+
+    ASSERT_THAT(chunks, SizeIs(4));
+
+    // Check shapes: dim 0 split into [2,1], dim 2 split into [3,2]
+    EXPECT_EQ(chunks[0].shape()[0], 2u);  // [0,0]
+    EXPECT_EQ(chunks[0].shape()[2], 3u);
+
+    EXPECT_EQ(chunks[1].shape()[0], 2u);  // [0,1]
+    EXPECT_EQ(chunks[1].shape()[2], 2u);
+
+    EXPECT_EQ(chunks[2].shape()[0], 1u);  // [1,0]
+    EXPECT_EQ(chunks[2].shape()[2], 3u);
+
+    EXPECT_EQ(chunks[3].shape()[0], 1u);  // [1,1]
+    EXPECT_EQ(chunks[3].shape()[2], 2u);
+
+    EXPECT_TRUE(xt::allclose(chunks[0], xt::view(tensor, xt::range(0, 2), xt::all(), xt::range(0, 3))));
+    EXPECT_TRUE(xt::allclose(chunks[1], xt::view(tensor, xt::range(0, 2), xt::all(), xt::range(3, 5))));
+    EXPECT_TRUE(xt::allclose(chunks[2], xt::view(tensor, xt::range(2, 3), xt::all(), xt::range(0, 3))));
+    EXPECT_TRUE(xt::allclose(chunks[3], xt::view(tensor, xt::range(2, 3), xt::all(), xt::range(3, 5))));
+}
+
+TEST(PartitionTest, ChunkNdimSingleDimension) {
+    xt::xarray<float> tensor = xt::arange<float>(10);
+
+    auto chunks = chunk_ndim(tensor, {3}, {0});
+
+    ASSERT_THAT(chunks, SizeIs(3));
+    EXPECT_EQ(chunks[0].shape()[0], 4u);
+    EXPECT_EQ(chunks[1].shape()[0], 4u);
+    EXPECT_EQ(chunks[2].shape()[0], 2u);
+
+    EXPECT_TRUE(xt::allclose(chunks[0], xt::view(tensor, xt::range(0, 4))));
+    EXPECT_TRUE(xt::allclose(chunks[1], xt::view(tensor, xt::range(4, 8))));
+    EXPECT_TRUE(xt::allclose(chunks[2], xt::view(tensor, xt::range(8, 10))));
+}
+
+TEST(PartitionTest, ChunkNdimThreeDimensions) {
+    xt::xarray<double> tensor = xt::arange<double>(24);
+    tensor.reshape({2, 3, 4});
+
+    auto chunks = chunk_ndim(tensor, {2, 2, 2}, {0, 1, 2});
+
+    ASSERT_THAT(chunks, SizeIs(8));
+
+    // In row-major order with dims {0, 1, 2}, chunks are ordered as:
+    // [0]: (0,0,0), [1]: (0,0,1), [2]: (0,1,0), [3]: (0,1,1)
+    // [4]: (1,0,0), [5]: (1,0,1), [6]: (1,1,0), [7]: (1,1,1)
+
+    // Verify dimension 0 chunks
+    for (size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(chunks[i].shape()[0], 1u);      // first half of dim 0
+        EXPECT_EQ(chunks[i + 4].shape()[0], 1u);  // second half of dim 0
+    }
+
+    // Verify dimension 1 chunks - every 2 chunks alternate between dim1=0 and dim1=1
+    for (size_t i = 0; i < 8; i += 4) {
+        EXPECT_EQ(chunks[i].shape()[1], 2u);      // (x,0,0) - first half of dim 1
+        EXPECT_EQ(chunks[i + 1].shape()[1], 2u);  // (x,0,1) - first half of dim 1
+        EXPECT_EQ(chunks[i + 2].shape()[1], 1u);  // (x,1,0) - second half of dim 1
+        EXPECT_EQ(chunks[i + 3].shape()[1], 1u);  // (x,1,1) - second half of dim 1
+    }
+
+    // Verify dimension 2 chunks - alternates every chunk
+    for (size_t i = 0; i < 8; i += 2) {
+        EXPECT_EQ(chunks[i].shape()[2], 2u);      // (x,x,0) - first half of dim 2
+        EXPECT_EQ(chunks[i + 1].shape()[2], 2u);  // (x,x,1) - second half of dim 2
+    }
+
+    EXPECT_TRUE(xt::allclose(chunks[0], xt::view(tensor, xt::range(0, 1), xt::range(0, 2), xt::range(0, 2))));
+    EXPECT_TRUE(xt::allclose(chunks[1], xt::view(tensor, xt::range(0, 1), xt::range(0, 2), xt::range(2, 4))));
+    EXPECT_TRUE(xt::allclose(chunks[2], xt::view(tensor, xt::range(0, 1), xt::range(2, 3), xt::range(0, 2))));
+    EXPECT_TRUE(xt::allclose(chunks[3], xt::view(tensor, xt::range(0, 1), xt::range(2, 3), xt::range(2, 4))));
+    EXPECT_TRUE(xt::allclose(chunks[4], xt::view(tensor, xt::range(1, 2), xt::range(0, 2), xt::range(0, 2))));
+    EXPECT_TRUE(xt::allclose(chunks[5], xt::view(tensor, xt::range(1, 2), xt::range(0, 2), xt::range(2, 4))));
+    EXPECT_TRUE(xt::allclose(chunks[6], xt::view(tensor, xt::range(1, 2), xt::range(2, 3), xt::range(0, 2))));
+    EXPECT_TRUE(xt::allclose(chunks[7], xt::view(tensor, xt::range(1, 2), xt::range(2, 3), xt::range(2, 4))));
+}
+
+TEST(PartitionTest, ChunkNdimNonContiguousDims) {
+    xt::xarray<int> tensor = xt::arange<int>(120);
+    tensor.reshape({2, 3, 4, 5});
+
+    auto chunks = chunk_ndim(tensor, {2, 2}, {0, 2});
+
+    ASSERT_THAT(chunks, SizeIs(4));
+
+    // Verify dimensions 1 and 3 remain unchanged
+    for (const auto& chunk : chunks) {
+        EXPECT_EQ(chunk.shape()[1], 3u);
+        EXPECT_EQ(chunk.shape()[3], 5u);
+    }
+
+    EXPECT_TRUE(xt::allclose(chunks[0], xt::view(tensor, xt::range(0, 1), xt::all(), xt::range(0, 2), xt::all())));
+    EXPECT_TRUE(xt::allclose(chunks[1], xt::view(tensor, xt::range(0, 1), xt::all(), xt::range(2, 4), xt::all())));
+    EXPECT_TRUE(xt::allclose(chunks[2], xt::view(tensor, xt::range(1, 2), xt::all(), xt::range(0, 2), xt::all())));
+    EXPECT_TRUE(xt::allclose(chunks[3], xt::view(tensor, xt::range(1, 2), xt::all(), xt::range(2, 4), xt::all())));
 }
 
 }  // namespace

--- a/tt-train/sources/ttml/core/distributed_mapping.hpp
+++ b/tt-train/sources/ttml/core/distributed_mapping.hpp
@@ -13,7 +13,8 @@ namespace ttml::core {
 
 template <typename T>
 std::vector<xt::xarray<T>> chunk(const xt::xarray<T>& tensor, int num_chunks, int dim) {
-    return ttnn::experimental::xtensor::chunk(tensor, num_chunks, dim);
+    auto chunks = ttnn::experimental::xtensor::chunk(tensor, num_chunks, dim);
+    return std::vector<xt::xarray<T>>(chunks.begin(), chunks.end());
 }
 
 template <class Derived, typename T>

--- a/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
@@ -59,7 +59,7 @@ public:
     distributed::MeshShape shape() const;
 
     // Returns the coordinates of populated shards in the buffer.
-    std::unordered_set<distributed::MeshCoordinate> shard_coords() const;
+    const std::unordered_set<distributed::MeshCoordinate>& shard_coords() const;
 
 private:
     std::optional<distributed::MeshCoordinate> global_to_local(const distributed::MeshCoordinate& coord) const;

--- a/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
@@ -42,7 +42,7 @@ public:
     // Emplaces the shard at the specified `coord`.
     // No-op if the index is out of local bounds.
     // Throws if the index is out of global bounds.
-    void emplace_shard(const distributed::MeshCoordinate& coord, HostBuffer buffer);
+    void emplace_shard(const distributed::MeshCoordinate& coord, const std::function<HostBuffer()>& buffer_fn);
 
     // `transform` and `apply` functions abstract away the details of the underlying data storage.
     // `linear_index` will be supplied by `DistributedHostBuffer` to indicate the position of the buffer.

--- a/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
@@ -39,10 +39,10 @@ public:
     // Throws if the index is out of global bounds.
     std::optional<HostBuffer> get_shard(const distributed::MeshCoordinate& coord) const;
 
-    // Emplaces the shard at the specified `coord`.
+    // Emplaces the shard at the specified `coord`, calling `produce_buffer` to create the buffer only when needed.
     // No-op if the index is out of local bounds.
     // Throws if the index is out of global bounds.
-    void emplace_shard(const distributed::MeshCoordinate& coord, const std::function<HostBuffer()>& buffer_fn);
+    void emplace_shard(const distributed::MeshCoordinate& coord, const std::function<HostBuffer()>& produce_buffer);
 
     // `transform` and `apply` functions abstract away the details of the underlying data storage.
     // `linear_index` will be supplied by `DistributedHostBuffer` to indicate the position of the buffer.

--- a/tt_metal/distributed/distributed_host_buffer.cpp
+++ b/tt_metal/distributed/distributed_host_buffer.cpp
@@ -66,7 +66,7 @@ std::optional<HostBuffer> DistributedHostBuffer::get_shard(const distributed::Me
 }
 
 void DistributedHostBuffer::emplace_shard(
-    const distributed::MeshCoordinate& coord, const std::function<HostBuffer()>& buffer_fn) {
+    const distributed::MeshCoordinate& coord, const std::function<HostBuffer()>& produce_buffer) {
     TT_FATAL(
         distributed::MeshCoordinateRange(global_shape_).contains(coord),
         "Coordinate {} is outside the global shape bounds {}",
@@ -76,7 +76,7 @@ void DistributedHostBuffer::emplace_shard(
     populated_shards_.insert(coord);
     auto local_coord_opt = global_to_local(coord);
     if (local_coord_opt.has_value()) {
-        local_buffers_.at(*local_coord_opt) = buffer_fn();
+        local_buffers_.at(*local_coord_opt) = produce_buffer();
     }
 }
 

--- a/tt_metal/distributed/distributed_host_buffer.cpp
+++ b/tt_metal/distributed/distributed_host_buffer.cpp
@@ -65,7 +65,8 @@ std::optional<HostBuffer> DistributedHostBuffer::get_shard(const distributed::Me
     return local_coord_opt.has_value() ? std::optional<HostBuffer>(local_buffers_.at(*local_coord_opt)) : std::nullopt;
 }
 
-void DistributedHostBuffer::emplace_shard(const distributed::MeshCoordinate& coord, HostBuffer buffer) {
+void DistributedHostBuffer::emplace_shard(
+    const distributed::MeshCoordinate& coord, const std::function<HostBuffer()>& buffer_fn) {
     TT_FATAL(
         distributed::MeshCoordinateRange(global_shape_).contains(coord),
         "Coordinate {} is outside the global shape bounds {}",
@@ -75,7 +76,7 @@ void DistributedHostBuffer::emplace_shard(const distributed::MeshCoordinate& coo
     populated_shards_.insert(coord);
     auto local_coord_opt = global_to_local(coord);
     if (local_coord_opt.has_value()) {
-        local_buffers_.at(*local_coord_opt) = std::move(buffer);
+        local_buffers_.at(*local_coord_opt) = buffer_fn();
     }
 }
 

--- a/tt_metal/distributed/distributed_host_buffer.cpp
+++ b/tt_metal/distributed/distributed_host_buffer.cpp
@@ -101,7 +101,7 @@ void DistributedHostBuffer::apply(const ApplyFn& fn) const {
 
 distributed::MeshShape DistributedHostBuffer::shape() const { return global_shape_; }
 
-std::unordered_set<distributed::MeshCoordinate> DistributedHostBuffer::shard_coords() const {
+const std::unordered_set<distributed::MeshCoordinate>& DistributedHostBuffer::shard_coords() const {
     return populated_shards_;
 }
 

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -15,7 +15,7 @@ namespace ttnn::distributed {
 class TensorToMesh {
 public:
     virtual ~TensorToMesh() = default;
-    virtual std::vector<Tensor> map(const Tensor& tensor) const = 0;
+    virtual Tensor operator()(const Tensor& tensor) const = 0;
     virtual tt::tt_metal::DistributedTensorConfig config() const = 0;
 };
 

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -4,105 +4,39 @@
 
 #pragma once
 
-#include <algorithm>
-
 #include <xtensor/views/xstrided_view.hpp>
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/tensor/xtensor/xtensor_all_includes.hpp"
 
 namespace ttnn::experimental::xtensor {
 namespace detail {
 
-template <typename XtExpr>
-auto chunk_xexpression(XtExpr& expr, tt::stl::SmallVector<int> num_chunks, tt::stl::SmallVector<int> dims) {
-    using StridedView = decltype(xt::strided_view(expr, std::declval<xt::xstrided_slice_vector>()));
-    if (num_chunks.empty()) {
-        xt::xstrided_slice_vector indices(expr.dimension(), xt::all());
-        return std::vector<StridedView>{xt::strided_view(expr, indices)};
-    }
-
-    TT_FATAL(num_chunks.size() == dims.size(), "num_chunks and dims must have the same size");
-    auto sorted_dims = dims;
-    std::sort(sorted_dims.begin(), sorted_dims.end());
-    TT_FATAL(std::unique(sorted_dims.begin(), sorted_dims.end()) == sorted_dims.end(), "dims must be unique");
-    TT_FATAL(
-        std::all_of(num_chunks.begin(), num_chunks.end(), [](size_t size) { return size > 0; }),
-        "num_chunks must be > 0; got num_chunks: {}",
-        num_chunks);
-    TT_FATAL(
-        std::all_of(dims.begin(), dims.end(), [&expr](size_t dim) { return dim >= 0 && dim < expr.dimension(); }),
-        "invalid dimension index; got dims: {}, tensor dimension: {}",
-        dims,
-        expr.dimension());
-
-    tt::stl::SmallVector<std::vector<std::pair<int, int>>> dim_ranges;
-    tt::stl::SmallVector<size_t> num_chunks_per_dim;
-    for (size_t i = 0; i < dims.size(); ++i) {
-        int dim = dims[i];
-        int num_chunks_along_dim = num_chunks[i];
-        int size_along_dim = static_cast<int>(expr.shape()[dim]);
-        int chunk_size = (size_along_dim + num_chunks_along_dim - 1) / num_chunks_along_dim;
-
-        std::vector<std::pair<int, int>> ranges;
-        ranges.reserve(num_chunks_along_dim);
-
-        int start = 0;
-        for (int chunk_idx = 0; chunk_idx < num_chunks_along_dim && start < size_along_dim; ++chunk_idx) {
-            int current_chunk_size = std::min(chunk_size, size_along_dim - start);
-            int end = start + current_chunk_size;
-            ranges.emplace_back(start, end);
-            start = end;
-        }
-        num_chunks_per_dim.push_back(ranges.size());
-        dim_ranges.push_back(std::move(ranges));
-    }
-
-    const size_t total_chunks =
-        std::accumulate(num_chunks_per_dim.begin(), num_chunks_per_dim.end(), 1, std::multiplies<size_t>());
-
-    std::vector<StridedView> chunk_views;
-    tt::stl::SmallVector<size_t> current_indices(dims.size(), 0);
-    for (size_t chunk_idx = 0; chunk_idx < total_chunks; ++chunk_idx) {
-        xt::xstrided_slice_vector indices(expr.dimension(), xt::all());
-        for (size_t i = 0; i < dims.size(); ++i) {
-            int dim = dims[i];
-            auto [start, end] = dim_ranges[i][current_indices[i]];
-            indices[dim] = xt::range(start, end);
-        }
-
-        auto chunk_view = xt::strided_view(expr, indices);
-        chunk_views.push_back(chunk_view);
-
-        for (int i = static_cast<int>(dims.size()) - 1; i >= 0; --i) {
-            if (++current_indices[i] < num_chunks_per_dim[i]) {
-                break;
-            }
-            current_indices[i] = 0;
-        }
-    }
-
-    return chunk_views;
-}
+// Helper to compute the type of an unowned strided view over an `xt::xexpression`.
+template <typename T>
+auto compute_strided_view() -> decltype(xt::strided_view(
+    std::declval<const xt::xexpression<T>&>().derived_cast(), std::declval<xt::xstrided_slice_vector>()));
 
 }  // namespace detail
 
+template <typename T>
+using StridedView = decltype(detail::compute_strided_view<T>());
+
+template <typename T>
+using StridedViews = std::vector<StridedView<T>>;
+
 // IMPORTANT: `chunk` and `concatenate` are not yet part of the public ttnn API.
 //
-// Splits a tensor into chunks along the specified dimension.
-std::vector<tt::tt_metal::Tensor> chunk(const tt::tt_metal::Tensor& tensor, int num_chunks, int dim = 0);
-
-// Overload for `xt::xexpression` that returns a view over the specified dimension.
+// Splits an xtensor expression into chunks along the specified dimension, and returns a vector of un-owned strided
+// views.
 template <typename T>
-auto chunk(const xt::xexpression<T>& expr, int num_chunks, int dim = 0) {
-    return detail::chunk_xexpression(expr.derived_cast(), {num_chunks}, {dim});
-}
+StridedViews<T> chunk(const xt::xexpression<T>& expr, int num_chunks, int dim = 0);
 
-// Overload for `xt::xexpression` that performs multi-dimensional chunking.
-// The returned chunks are ordered in row-major order relative to the supplied `dims`.
+// Overload that performs multi-dimensional chunking.
+// Chunking is done in row-major order relative to the supplied `dims`, and returned in the vector in the same order.
+// `num_chunks` and `dims` must have the same length. When empty, no chunking is performed, and the entire tensor is
+// returned as a single chunk.
 template <typename T>
-auto chunk_ndim(const xt::xexpression<T>& expr, tt::stl::SmallVector<int> num_chunks, tt::stl::SmallVector<int> dims) {
-    return detail::chunk_xexpression(expr.derived_cast(), num_chunks, dims);
-}
+StridedViews<T> chunk_ndim(
+    const xt::xexpression<T>& expr, tt::stl::SmallVector<int> num_chunks, tt::stl::SmallVector<int> dims);
 
 // Concatenates a list of tensors along the specified dimension.
 tt::tt_metal::Tensor concat(const std::vector<tt::tt_metal::Tensor>& tensors, int dim = 0);

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -4,25 +4,66 @@
 
 #pragma once
 
+#include <xtensor/views/xstrided_view.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/xtensor/xtensor_all_includes.hpp"
 
 namespace ttnn::experimental::xtensor {
+namespace detail {
 
-// IMPORTANT: `chunk` and `concatenate` are not yet part of the public ttnn API. Internally, they rely on the `xtensor`
-// library for efficient host-side operations.
+template <typename XtExpr>
+auto chunk_xexpression(XtExpr& expr, int num_chunks, int dim) {
+    using StridedView = decltype(xt::strided_view(expr, std::declval<xt::xstrided_slice_vector>()));
 
+    TT_FATAL(num_chunks > 0, "num_chunks must be > 0; got num_chunks: {}", num_chunks);
+    TT_FATAL(
+        dim >= 0 && dim < expr.dimension(),
+        "invalid dimension index; got dim: {}, tensor dimension: {}",
+        dim,
+        expr.dimension());
+
+    if (num_chunks == 1) {
+        xt::xstrided_slice_vector indices(expr.dimension(), xt::all());
+        return std::vector<StridedView>{xt::strided_view(expr, indices)};
+    }
+
+    const int size_along_dim = static_cast<int>(expr.shape()[dim]);
+    const int chunk_size = (size_along_dim + num_chunks - 1) / num_chunks;
+    int remaining_size = size_along_dim;
+
+    std::vector<StridedView> chunk_views;
+    chunk_views.reserve(static_cast<std::size_t>(num_chunks));
+    int start = 0;
+    int end = 0;
+    for (int i = 0; i < num_chunks && end < size_along_dim; ++i) {
+        int current_chunk_size = std::min(chunk_size, remaining_size);
+        remaining_size -= current_chunk_size;
+        end = start + current_chunk_size;
+
+        // Build indices for slicing
+        xt::xstrided_slice_vector indices(expr.dimension(), xt::all());
+        indices[dim] = xt::range(start, end);
+
+        auto chunk_view = xt::strided_view(expr, indices);
+        chunk_views.push_back(chunk_view);
+        start = end;
+    }
+
+    return chunk_views;
+}
+
+}  // namespace detail
+
+// IMPORTANT: `chunk` and `concatenate` are not yet part of the public ttnn API.
+//
 // Splits a tensor into chunks along the specified dimension.
 std::vector<tt::tt_metal::Tensor> chunk(const tt::tt_metal::Tensor& tensor, int num_chunks, int dim = 0);
 
-// Overload for `xt::xarray`.
+// Overload for `xt::xexpression`.
 template <typename T>
-std::vector<xt::xarray<T>> chunk(const xt::xarray<T>& tensor, int num_chunks, int dim = 0);
-
-// Overload for `tt::stl::Span` that performs zero-copy chunking on the outermost dimension (dim = 0).
-template <typename T>
-std::vector<std::pair<tt::stl::Span<T>, ttnn::Shape>> chunk(
-    tt::stl::Span<T> span, const ttnn::Shape& shape, int num_chunks);
+auto chunk(const xt::xexpression<T>& expr, int num_chunks, int dim = 0) {
+    return detail::chunk_xexpression(expr.derived_cast(), num_chunks, dim);
+}
 
 // Concatenates a list of tensors along the specified dimension.
 tt::tt_metal::Tensor concat(const std::vector<tt::tt_metal::Tensor>& tensors, int dim = 0);

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -73,7 +73,7 @@ auto chunk_xexpression(XtExpr& expr, tt::stl::SmallVector<int> num_chunks, tt::s
         auto chunk_view = xt::strided_view(expr, indices);
         chunk_views.push_back(chunk_view);
 
-        for (size_t i = 0; i < dims.size(); ++i) {
+        for (int i = static_cast<int>(dims.size()) - 1; i >= 0; --i) {
             if (++current_indices[i] < num_chunks_per_dim[i]) {
                 break;
             }

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -27,6 +27,7 @@ using StridedViews = std::vector<StridedView<T>>;
 //
 // Splits an xtensor expression into chunks along the specified dimension, and returns a vector of un-owned strided
 // views.
+// The value of `dim` must not be negative.
 template <typename T>
 StridedViews<T> chunk(const xt::xexpression<T>& expr, int num_chunks, int dim = 0);
 
@@ -34,6 +35,7 @@ StridedViews<T> chunk(const xt::xexpression<T>& expr, int num_chunks, int dim = 
 // Chunking is done in row-major order relative to the supplied `dims`, and returned in the vector in the same order.
 // `num_chunks` and `dims` must have the same length. When empty, no chunking is performed, and the entire tensor is
 // returned as a single chunk.
+// The values of `dims` must not be negative.
 template <typename T>
 StridedViews<T> chunk_ndim(
     const xt::xexpression<T>& expr, tt::stl::SmallVector<int> num_chunks, tt::stl::SmallVector<int> dims);

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include <xtensor/views/xstrided_view.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/xtensor/xtensor_all_includes.hpp"
@@ -12,41 +14,70 @@ namespace ttnn::experimental::xtensor {
 namespace detail {
 
 template <typename XtExpr>
-auto chunk_xexpression(XtExpr& expr, int num_chunks, int dim) {
+auto chunk_xexpression(XtExpr& expr, tt::stl::SmallVector<int> chunk_sizes, tt::stl::SmallVector<int> dims) {
     using StridedView = decltype(xt::strided_view(expr, std::declval<xt::xstrided_slice_vector>()));
-
-    TT_FATAL(num_chunks > 0, "num_chunks must be > 0; got num_chunks: {}", num_chunks);
-    TT_FATAL(
-        dim >= 0 && dim < expr.dimension(),
-        "invalid dimension index; got dim: {}, tensor dimension: {}",
-        dim,
-        expr.dimension());
-
-    if (num_chunks == 1) {
+    if (chunk_sizes.empty()) {
         xt::xstrided_slice_vector indices(expr.dimension(), xt::all());
         return std::vector<StridedView>{xt::strided_view(expr, indices)};
     }
 
-    const int size_along_dim = static_cast<int>(expr.shape()[dim]);
-    const int chunk_size = (size_along_dim + num_chunks - 1) / num_chunks;
-    int remaining_size = size_along_dim;
+    TT_FATAL(chunk_sizes.size() == dims.size(), "chunk_sizes and dims must have the same size");
+    TT_FATAL(std::is_sorted(dims.begin(), dims.end()), "dims must be sorted");
+    TT_FATAL(std::unique(dims.begin(), dims.end()) == dims.end(), "dims must be unique");
+    TT_FATAL(
+        std::all_of(chunk_sizes.begin(), chunk_sizes.end(), [](size_t size) { return size > 0; }),
+        "chunk_sizes must be > 0; got chunk_sizes: {}",
+        chunk_sizes);
+    TT_FATAL(
+        std::all_of(dims.begin(), dims.end(), [&expr](size_t dim) { return dim >= 0 && dim < expr.dimension(); }),
+        "invalid dimension index; got dims: {}, tensor dimension: {}",
+        dims,
+        expr.dimension());
+
+    tt::stl::SmallVector<std::vector<std::pair<int, int>>> dim_ranges;
+    tt::stl::SmallVector<size_t> num_chunks_per_dim;
+    for (size_t i = 0; i < dims.size(); ++i) {
+        int dim = dims[i];
+        int num_chunks = chunk_sizes[i];
+        int size_along_dim = static_cast<int>(expr.shape()[dim]);
+        int chunk_size = (size_along_dim + num_chunks - 1) / num_chunks;
+
+        std::vector<std::pair<int, int>> ranges;
+        ranges.reserve(num_chunks);
+
+        int start = 0;
+        for (int chunk_idx = 0; chunk_idx < num_chunks && start < size_along_dim; ++chunk_idx) {
+            int current_chunk_size = std::min(chunk_size, size_along_dim - start);
+            int end = start + current_chunk_size;
+            ranges.emplace_back(start, end);
+            start = end;
+        }
+        num_chunks_per_dim.push_back(ranges.size());
+        dim_ranges.push_back(std::move(ranges));
+    }
+
+    const size_t total_chunks =
+        std::accumulate(num_chunks_per_dim.begin(), num_chunks_per_dim.end(), 1, std::multiplies<size_t>());
 
     std::vector<StridedView> chunk_views;
-    chunk_views.reserve(static_cast<std::size_t>(num_chunks));
-    int start = 0;
-    int end = 0;
-    for (int i = 0; i < num_chunks && end < size_along_dim; ++i) {
-        int current_chunk_size = std::min(chunk_size, remaining_size);
-        remaining_size -= current_chunk_size;
-        end = start + current_chunk_size;
-
-        // Build indices for slicing
+    tt::stl::SmallVector<size_t> current_indices(dims.size(), 0);
+    for (size_t chunk_idx = 0; chunk_idx < total_chunks; ++chunk_idx) {
         xt::xstrided_slice_vector indices(expr.dimension(), xt::all());
-        indices[dim] = xt::range(start, end);
+        for (size_t i = 0; i < dims.size(); ++i) {
+            int dim = dims[i];
+            auto [start, end] = dim_ranges[i][current_indices[i]];
+            indices[dim] = xt::range(start, end);
+        }
 
         auto chunk_view = xt::strided_view(expr, indices);
         chunk_views.push_back(chunk_view);
-        start = end;
+
+        for (size_t i = 0; i < dims.size(); ++i) {
+            if (++current_indices[i] < num_chunks_per_dim[i]) {
+                break;
+            }
+            current_indices[i] = 0;
+        }
     }
 
     return chunk_views;
@@ -62,7 +93,12 @@ std::vector<tt::tt_metal::Tensor> chunk(const tt::tt_metal::Tensor& tensor, int 
 // Overload for `xt::xexpression`.
 template <typename T>
 auto chunk(const xt::xexpression<T>& expr, int num_chunks, int dim = 0) {
-    return detail::chunk_xexpression(expr.derived_cast(), num_chunks, dim);
+    return detail::chunk_xexpression(expr.derived_cast(), {num_chunks}, {dim});
+}
+
+template <typename T>
+auto chunk_ndim(const xt::xexpression<T>& expr, tt::stl::SmallVector<int> chunk_sizes, tt::stl::SmallVector<int> dims) {
+    return detail::chunk_xexpression(expr.derived_cast(), chunk_sizes, dims);
 }
 
 // Concatenates a list of tensors along the specified dimension.

--- a/ttnn/core/tensor/xtensor/partition.cpp
+++ b/ttnn/core/tensor/xtensor/partition.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "tensor/xtensor/partition.hpp"
+
 #include <tt_stl/span.hpp>
 #include "ttnn/operations/functions.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"
@@ -16,113 +18,6 @@
 #include <xtensor/views/xview.hpp>
 
 namespace ttnn::experimental::xtensor {
-namespace {
-
-template <typename XtExpr>
-auto chunk_xexpression(XtExpr& expr, int num_chunks, int dim) {
-    using StridedView = decltype(xt::strided_view(expr, std::declval<xt::xstrided_slice_vector>()));
-
-    TT_FATAL(num_chunks > 0, "num_chunks must be > 0; got num_chunks: {}", num_chunks);
-    TT_FATAL(
-        dim >= 0 && dim < expr.dimension(),
-        "invalid dimension index; got dim: {}, tensor dimension: {}",
-        dim,
-        expr.dimension());
-
-    if (num_chunks == 1) {
-        xt::xstrided_slice_vector indices(expr.dimension(), xt::all());
-        return std::vector<StridedView>{xt::strided_view(expr, indices)};
-    }
-
-    const int size_along_dim = static_cast<int>(expr.shape()[dim]);
-    const int chunk_size = (size_along_dim + num_chunks - 1) / num_chunks;
-    int remaining_size = size_along_dim;
-
-    std::vector<StridedView> chunk_views;
-    chunk_views.reserve(static_cast<std::size_t>(num_chunks));
-    int start = 0;
-    int end = 0;
-    for (int i = 0; i < num_chunks && end < size_along_dim; ++i) {
-        int current_chunk_size = std::min(chunk_size, remaining_size);
-        remaining_size -= current_chunk_size;
-        end = start + current_chunk_size;
-
-        // Build indices for slicing
-        xt::xstrided_slice_vector indices(expr.dimension(), xt::all());
-        indices[dim] = xt::range(start, end);
-
-        auto chunk_view = xt::strided_view(expr, indices);
-        chunk_views.push_back(chunk_view);
-        start = end;
-    }
-
-    return chunk_views;
-}
-}  // namespace
-
-template <typename T>
-std::vector<std::pair<tt::stl::Span<T>, ttnn::Shape>> chunk(
-    tt::stl::Span<T> span, const ttnn::Shape& shape, int num_chunks) {
-    const std::vector<size_t> shape_vector(shape.cbegin(), shape.cend());
-    auto xtensor = xt::adapt(span.data(), span.size(), xt::no_ownership(), shape_vector);
-    auto chunk_views = chunk_xexpression(xtensor, num_chunks, /*dim=*/0);
-
-    std::vector<std::pair<tt::stl::Span<T>, ttnn::Shape>> chunk_spans;
-    chunk_spans.reserve(chunk_views.size());
-    std::transform(chunk_views.begin(), chunk_views.end(), std::back_inserter(chunk_spans), [](auto&& v) {
-        tt::stl::Span<T> data(v.data() + v.data_offset(), v.size());
-        return std::make_pair(data, get_shape_from_xarray(v));
-    });
-    return chunk_spans;
-}
-
-template <typename T>
-std::vector<xt::xarray<T>> chunk(const xt::xarray<T>& xtensor, int num_chunks, int dim) {
-    auto chunked_views = chunk_xexpression(xtensor, num_chunks, dim);
-    std::vector<xt::xarray<T>> chunked_xtensors;
-    chunked_xtensors.reserve(chunked_views.size());
-    std::transform(chunked_views.begin(), chunked_views.end(), std::back_inserter(chunked_xtensors), [](auto&& v) {
-        return xt::xarray<T>(v);
-    });
-    return chunked_xtensors;
-}
-
-template std::vector<xt::xarray<bfloat16>> chunk(const xt::xarray<bfloat16>&, int, int);
-template std::vector<xt::xarray<float>> chunk(const xt::xarray<float>&, int, int);
-template std::vector<xt::xarray<double>> chunk(const xt::xarray<double>&, int, int);
-template std::vector<xt::xarray<int32_t>> chunk(const xt::xarray<int32_t>&, int, int);
-template std::vector<xt::xarray<uint8_t>> chunk(const xt::xarray<uint8_t>&, int, int);
-template std::vector<xt::xarray<uint16_t>> chunk(const xt::xarray<uint16_t>&, int, int);
-template std::vector<xt::xarray<uint32_t>> chunk(const xt::xarray<uint32_t>&, int, int);
-
-template std::vector<std::pair<tt::stl::Span<bfloat16>, ttnn::Shape>> chunk(
-    tt::stl::Span<bfloat16>, const ttnn::Shape&, int);
-template std::vector<std::pair<tt::stl::Span<float>, ttnn::Shape>> chunk(tt::stl::Span<float>, const ttnn::Shape&, int);
-template std::vector<std::pair<tt::stl::Span<double>, ttnn::Shape>> chunk(
-    tt::stl::Span<double>, const ttnn::Shape&, int);
-template std::vector<std::pair<tt::stl::Span<int32_t>, ttnn::Shape>> chunk(
-    tt::stl::Span<int32_t>, const ttnn::Shape&, int);
-template std::vector<std::pair<tt::stl::Span<uint8_t>, ttnn::Shape>> chunk(
-    tt::stl::Span<uint8_t>, const ttnn::Shape&, int);
-template std::vector<std::pair<tt::stl::Span<uint16_t>, ttnn::Shape>> chunk(
-    tt::stl::Span<uint16_t>, const ttnn::Shape&, int);
-template std::vector<std::pair<tt::stl::Span<uint32_t>, ttnn::Shape>> chunk(
-    tt::stl::Span<uint32_t>, const ttnn::Shape&, int);
-
-template std::vector<std::pair<tt::stl::Span<const bfloat16>, ttnn::Shape>> chunk(
-    tt::stl::Span<const bfloat16>, const ttnn::Shape&, int);
-template std::vector<std::pair<tt::stl::Span<const float>, ttnn::Shape>> chunk(
-    tt::stl::Span<const float>, const ttnn::Shape&, int);
-template std::vector<std::pair<tt::stl::Span<const double>, ttnn::Shape>> chunk(
-    tt::stl::Span<const double>, const ttnn::Shape&, int);
-template std::vector<std::pair<tt::stl::Span<const int32_t>, ttnn::Shape>> chunk(
-    tt::stl::Span<const int32_t>, const ttnn::Shape&, int);
-template std::vector<std::pair<tt::stl::Span<const uint8_t>, ttnn::Shape>> chunk(
-    tt::stl::Span<const uint8_t>, const ttnn::Shape&, int);
-template std::vector<std::pair<tt::stl::Span<const uint16_t>, ttnn::Shape>> chunk(
-    tt::stl::Span<const uint16_t>, const ttnn::Shape&, int);
-template std::vector<std::pair<tt::stl::Span<const uint32_t>, ttnn::Shape>> chunk(
-    tt::stl::Span<const uint32_t>, const ttnn::Shape&, int);
 
 // TODO: optimize concat to perform concatenation based off views.
 template <typename T>
@@ -202,38 +97,16 @@ Tensor concat_impl(const std::vector<Tensor>& tensors, const tt::tt_metal::Tenso
 template <typename T>
 std::vector<Tensor> chunk_impl(
     const Tensor& tensor, const tt::tt_metal::TensorLayout& layout, int num_chunks, int dim) {
-    // If the physical representation of the tensor matches its logical representation, chunk based off the underlying
-    // buffer directly.
-    const bool data_viewable = layout.get_layout() == ttnn::Layout::ROW_MAJOR &&
-                               tensor.tensor_spec().physical_shape() == tensor.tensor_spec().logical_2d_shape() &&
-                               tensor.tensor_spec().data_type() == tt::tt_metal::convert_to_data_type<T>();
-    if (dim == 0 && data_viewable) {
-        tt::tt_metal::HostBuffer buffer = tt::tt_metal::host_buffer::get_host_buffer(tensor);
+    xt::xarray<T> xtensor = to_xtensor<T>(tensor);
+    auto xtensor_chunks = ttnn::experimental::xtensor::chunk(xtensor, num_chunks, dim);
 
-        auto chunk_spans = chunk(buffer.view_as<T>(), tensor.tensor_spec().logical_shape(), num_chunks);
-
-        std::vector<Tensor> tensors;
-        tensors.reserve(chunk_spans.size());
-        std::transform(chunk_spans.begin(), chunk_spans.end(), std::back_inserter(tensors), [&](auto& chunk) {
-            // Create chunks pinned to the original buffer.
-            auto& [data, shape] = chunk;
-            tt::tt_metal::HostBuffer chunk_buffer(data, buffer.pin());
-            return Tensor(std::move(chunk_buffer), TensorSpec(shape, layout));
-        });
-        return tensors;
-    } else {
-        // Slow path - involves conversion to xtensor and data copying.
-        xt::xarray<T> xtensor = to_xtensor<T>(tensor);
-        auto xtensor_chunks = chunk<T>(xtensor, num_chunks, dim);
-
-        std::vector<Tensor> tensors;
-        tensors.reserve(xtensor_chunks.size());
-        for (const auto& c : xtensor_chunks) {
-            TensorSpec chunk_spec(get_shape_from_xarray(c), layout);
-            tensors.push_back(from_xtensor<T>(c, chunk_spec));
-        }
-        return tensors;
+    std::vector<Tensor> tensors;
+    tensors.reserve(xtensor_chunks.size());
+    for (const auto& c : xtensor_chunks) {
+        TensorSpec chunk_spec(get_shape_from_xarray(c), layout);
+        tensors.push_back(from_xtensor<T>(c, chunk_spec));
     }
+    return tensors;
 }
 
 }  // namespace


### PR DESCRIPTION
### Ticket
#22258

### Problem description
Currently, multi-device sharding makes a lot of unnecessary copies, which won't work in multi-host environments.

### What's changed
This PR re-implements the multi-device sharding algorithm:
1. The old implementation iterated over all mesh dimensions, either progressively replicating or sharding along each axis.
2. Now, we "batch" sharding operations first, after which the replication stage simply copies references to the sharded views.

The sharding operations are using the new `chunk_ndim`, which in turn uses xtensor's `strided_view` done across several dimensions at once. The type of `chunk` and `chunk_ndim` is now a vector of unowned `StridedView` - this avoids making copies and accessing data.
* See a test in `test_partition.cpp` that sets up a memory-protected region using `mmap` to validate that we don't read the data during the chunking process.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15430201401)
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15366250748)
- [X] New/Existing tests provide coverage for changes