### PR TITLE
#22219: Tilize init cleanup - first pass

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/tilize.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/tilize.rst
@@ -2,8 +2,9 @@ tilize
 ======
 
 .. doxygenfunction:: tilize_init(uint32_t icb, uint32_t block, uint32_t ocb)
-.. doxygenfunction:: tilize_init_short(uint32_t icb, uint32_t block, uint32_t ocb)
+.. doxygenfunction:: tilizeA_B_reduce_init(uint32_t icb0, uint32_t icb1_scaler, uint32_t block, uint32_t ocb, uint32_t num_faces = 4, uint32_t face_r_dim = 16)
 .. doxygenfunction:: tilize_init_short_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t block, uint32_t ocb)
 .. doxygenfunction:: tilize_block(uint32_t icb, uint32_t block, uint32_t ocb)
+.. doxygenfunction:: unpack_tilizeA_B_block(uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t tile_idx_b, uint32_t num_faces = 4, uint32_t srca_face_r_dim = 16)
 .. doxygenfunction:: tilize_uninit(uint32_t icb, uint32_t ocb)
 .. doxygenfunction:: tilize_uninit_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t ocb)

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_tilize_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_tilize_untilize.cpp
@@ -26,7 +26,7 @@
 
 inline void tilize_in(
     uint32_t in_cb_id, uint32_t in_subblock_h, uint32_t in_block_w, uint32_t in_num_subblocks, uint32_t out_cb_id) {
-    tilize_init_short(in_cb_id, in_block_w, out_cb_id);
+    tilize_init(in_cb_id, in_block_w, out_cb_id);
     for (uint32_t in_subblock = 0; in_subblock < in_num_subblocks; ++in_subblock) {
         for (uint32_t h = 0; h < in_subblock_h; ++h) {
             cb_wait_front(in_cb_id, in_block_w);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block.cpp
@@ -13,7 +13,7 @@
 
 inline void tilize_activation(
     uint32_t in0_cb, uint32_t in0_subblock_h, uint32_t in0_block_w, uint32_t in0_num_subblocks, uint32_t out_cb) {
-    tilize_init_short(in0_cb, in0_block_w, out_cb);
+    tilize_init(in0_cb, in0_block_w, out_cb);
 
     for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
         for (uint32_t h = 0; h < in0_subblock_h; h++) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_generalized.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_generalized.cpp
@@ -10,7 +10,7 @@
 
 inline void tilize_activation(
     uint32_t in0_cb, uint32_t in0_subblock_h, uint32_t in0_block_w, uint32_t in0_num_subblocks, uint32_t out_cb) {
-    tilize_init_short(in0_cb, in0_block_w, out_cb);
+    tilize_init(in0_cb, in0_block_w, out_cb);
 
     for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
         for (uint32_t h = 0; h < in0_subblock_h; h++) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/max_pool.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/max_pool.cpp
@@ -49,7 +49,7 @@ inline void tilize(
     uint32_t in_ntiles_hwc,
     uint32_t window_hw_padded,
     uint32_t out_cb_id) {
-    tilize_init_short(in_cb_id, in_ntiles_hwc, out_cb_id);
+    tilize_init(in_cb_id, in_ntiles_hwc, out_cb_id);
     for (uint32_t out_elem_i = 0; out_elem_i < out_nelems; ++out_elem_i) {
         cb_wait_front(in_cb_id, 1);
         cb_reserve_back(out_cb_id, in_ntiles_hwc);
@@ -116,6 +116,7 @@ void MAIN {
     const uint32_t nbatch = get_compile_time_arg_val(10);
     const uint32_t out_h_per_core = get_compile_time_arg_val(11);
 
+    compute_kernel_hw_startup(in_cb_id, in_tiled_cb_id);
     tilize_init(in_cb_id, in_ntiles_hwc, in_tiled_cb_id);
 
 #if DEBUG_PRINT == 1

--- a/tests/tt_metal/tt_metal/test_kernels/compute/max_pool_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/max_pool_multi_core.cpp
@@ -49,7 +49,7 @@ inline void tilize(
     uint32_t in_ntiles_hwc,
     uint32_t window_hw_padded,
     uint32_t out_cb_id) {
-    tilize_init_short(in_cb_id, in_ntiles_hwc, out_cb_id);
+    tilize_init(in_cb_id, in_ntiles_hwc, out_cb_id);
     for (uint32_t out_elem_i = 0; out_elem_i < out_nelems; ++out_elem_i) {
         cb_wait_front(in_cb_id, 1);
         cb_reserve_back(out_cb_id, in_ntiles_hwc);
@@ -118,6 +118,7 @@ void MAIN {
     const uint32_t nsticks_per_core = get_compile_time_arg_val(12);
     const uint32_t nsticks_per_core_by_nblocks = get_compile_time_arg_val(13);
 
+    compute_kernel_hw_startup(in_cb_id, in_tiled_cb_id);
     tilize_init(in_cb_id, in_ntiles_hwc, in_tiled_cb_id);
 
 #if DEBUG_PRINT == 1

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rotary_embedding.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rotary_embedding.cpp
@@ -51,7 +51,7 @@ ALWI void UNTILIZE_TILES(uint32_t in0_cb, uint32_t out_cb, uint32_t num_tiles) {
 }
 
 ALWI void TILIZE_ROWS(uint32_t in0_cb, uint32_t sync_cb, uint32_t out_cb, uint32_t num_tiles) {
-    tilize_init_short(in0_cb, num_tiles, out_cb);
+    tilize_init(in0_cb, num_tiles, out_cb);
     cb_wait_front(sync_cb, num_tiles);
     cb_reserve_back(out_cb, num_tiles);
     tilize_block(in0_cb, num_tiles, out_cb);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/tilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/tilize.cpp
@@ -12,10 +12,11 @@ void MAIN {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
 #ifndef SHORT_INIT
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
     tilize_init(tt::CBIndex::c_0, per_core_block_tile_cnt, tt::CBIndex::c_16);
 #else
     unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
-    tilize_init_short(tt::CBIndex::c_0, per_core_block_tile_cnt, tt::CBIndex::c_16);
+    tilize_init(tt::CBIndex::c_0, per_core_block_tile_cnt, tt::CBIndex::c_16);
 #endif
 
     for (uint32_t b = 0; b < per_core_block_cnt; ++b) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/transformer_attn_matmul.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/transformer_attn_matmul.cpp
@@ -72,7 +72,7 @@ void MAIN {
                 cb_reserve_back(tt::CBIndex::c_16, onetile);
 
                 // tilize CB::intermed2 and write to CBIndex::c_16
-                tilize_init_short(cb_intermed2, 1, out_cb_id);
+                tilize_init(cb_intermed2, 1, out_cb_id);
                 tilize_block(cb_intermed2, 1, out_cb_id);
                 cb_push_back(out_cb_id, 1);
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B.cpp
@@ -11,16 +11,9 @@
 // #include "debug/dprint.h"
 inline void tilizeA_B_binary_init(
     uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t ocb, uint32_t num_faces = 4, uint32_t face_r_dim = 16) {
-    UNPACK((llk_unpack_tilizeA_B_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
     UNPACK((llk_unpack_tilizeA_B_init<true, true>(icb0, icb1, block, num_faces, face_r_dim, face_r_dim)));
 
-    MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb0, icb1)));
     MATH((llk_math_eltwise_binary_init<ELWADD, NONE>(0 /*transpose*/, 0 /*acc_to_dest*/)));
-
-    PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
-    PACK((llk_pack_init(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>(ocb)));
 }
 
 inline void add_tiles_math(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst) {
@@ -32,6 +25,7 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
     tilizeA_B_binary_init(tt::CBIndex::c_0, tt::CBIndex::c_1, per_core_block_tile_cnt, tt::CBIndex::c_16);
 
     for (uint32_t b = 0; b < per_core_block_cnt; ++b) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/update_cache.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/update_cache.cpp
@@ -42,7 +42,7 @@ void MAIN {
             cb_pop_front(cache_cb, Wt);
             untilize_uninit(cache_cb);
 
-            tilize_init_short(untilized_cache2_cb, Wt, out_cb);
+            tilize_init(untilized_cache2_cb, Wt, out_cb);
             cb_wait_front(untilized_cache2_cb, Wt);
             cb_reserve_back(out_cb, Wt);
             tilize_block(untilized_cache2_cb, Wt, out_cb);

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -16,31 +16,52 @@
 
 namespace ckernel {
 
+// clang-format off
 /**
- * Initialize the tilize operation. To be called once at beginning of a kernel.
+ * Initializes the tilize operation. Should be called once at the beginning of a kernel.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name   | Description                                   | Type     | Valid Range | Required |
+ * |----------- |--------|-----------------------------------------------|----------|-------------|----------|
+ * | Function   | icb    | Input circular buffer identifier              | uint32_t | 0 to 31     | True     |
+ * | Function   | block  | Size of tile block to work on                 | uint32_t | > 0         | True     |
+ * | Function   | ocb    | Output circular buffer identifier             | uint32_t | 0 to 31     | True     |
  */
+// clang-format on
 ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb) {
+    UNPACK((llk_unpack_tilize_init(icb, block)));
     MATH((llk_math_eltwise_unary_datacopy_init<
           A2D,
           DST_ACCUM_MODE,
           BroadcastType::NONE,
           false /*is_int_en*/,
           true /*tilize en*/>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
-    MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb)));
-
-    PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false, ReluType::NO_RELU, 0, true /*tilize en*/>(ocb)));
-    PACK((llk_pack_init<false, false, true /*tilize en*/>(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>(ocb)));
-
-    UNPACK((llk_unpack_tilize_hw_configure_disaggregated<DST_ACCUM_MODE>(icb)));
-    UNPACK((llk_unpack_tilize_init(icb, block)));
+#ifdef ARCH_BLACKHOLE
+    PACK((llk_pack_init<false /*untilize*/, false /*skip_inputs*/, true /*tilize en*/>(ocb)));
+#endif
 }
 
 #if (defined(REDUCE_OP) and defined(REDUCE_DIM)) or defined(__DOXYGEN__)
+
+// clang-format off
 /**
- * Initialize the tilize operation. To be called once at beginning of a kernel.
+ * Initializes the tilize operation with reduction. Should be called once at the beginning of a kernel.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name           | Description                              | Type     | Valid Range | Required |
+ * |------------|----------------|------------------------------------------|----------|-------------|----------|
+ * | Template   | neginf_srcA    | NegInf source A flag                     | bool     | true/false  | False    |
+ * | Template   | zero_srcA_reduce| Zero source A for reduce flag           | bool     | true/false  | False    |
+ * | Function   | icb0           | Input circular buffer A identifier       | uint32_t | 0 to 31     | True     |
+ * | Function   | icb1_scaler    | Input circular buffer for scaler         | uint32_t | 0 to 31     | True     |
+ * | Function   | block          | Size of tile block to work on            | uint32_t | > 0         | True     |
+ * | Function   | ocb            | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
+ * | Function   | num_faces      | Number of faces per tile                 | uint32_t | 1 to 4      | False    |
+ * | Function   | face_r_dim     | Number of rows in each face              | uint32_t | 1 to 16     | False    |
  */
+// clang-format on
 template <bool neginf_srcA = true, bool zero_srcA_reduce = false>
 ALWI void tilizeA_B_reduce_init(
     uint32_t icb0,
@@ -65,57 +86,18 @@ ALWI void tilizeA_B_reduce_init(
 
 // clang-format off
 /**
- * Initialize unpack_tilizeA_B and matmul for the dot product operation.
- * To be called once at beginning of a kernel.
+ * Re-initializes the tilize operation and reconfigures the unpacker with CB data type.
  *
  * Return value: None
  *
- * | Argument       | Description                                              | Data type | Valid range | Required |
- * |----------------|----------------------------------------------------------|-----------|-------------|----------|
- * | icb0           | The identifier of the source A circular buffer (CB)      | uint32_t  | 0 to 31     | Yes      |
- * | icb1           | The identifier of the source B circular buffer (CB)      | uint32_t  | 0 to 31     | Yes      |
- * | block          | Size of tile block to work on for source A               | uint32_t  | > 0         | Yes      |
- * | ocb            | The identifier of the output circular buffer (CB)        | uint32_t  | 0 to 31     | Yes      |
- * | num_faces      | The number of faces to in each tile being unpacked       | uint32_t  | 1 to 4      | Yes      |
- * | face_r_dim     | The number of rows in each face                          | uint32_t  | 1 to 16     | Yes      |
- * */
+ * | Param Type | Name     | Description                              | Type     | Valid Range | Required |
+ * |----------- |----------|------------------------------------------|----------|-------------|----------|
+ * | Function   | old_icb  | Previous input circular buffer identifier| uint32_t | 0 to 31     | True     |
+ * | Function   | new_icb  | New input circular buffer identifier     | uint32_t | 0 to 31     | True     |
+ * | Function   | block    | Size of tile block to work on            | uint32_t | > 0         | True     |
+ * | Function   | ocb      | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
+ */
 // clang-format on
-ALWI void tilizeA_B_dot_product_init(
-    uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t ocb, uint32_t num_faces = 4, uint32_t face_r_dim = 16) {
-    UNPACK((llk_unpack_tilizeA_B_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
-    UNPACK((llk_unpack_tilizeA_B_init<false, false, true>(icb0, icb1, block, num_faces, face_r_dim, face_r_dim)));
-
-    MATH((llk_math_matmul_init<MATH_FIDELITY>(icb0, icb1)));
-    MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb0, icb1)));
-
-    PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
-    PACK((llk_pack_init(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>(ocb)));
-}
-
-/**
- * Re-initialize for the tilize operation. This can be called after a full init.
- */
-ALWI void tilize_init_short(uint32_t icb, uint32_t block, uint32_t ocb) {
-    MATH((llk_math_eltwise_unary_datacopy_init<
-          A2D,
-          DST_ACCUM_MODE,
-          BroadcastType::NONE,
-          false /*is_int_en*/,
-          true /*tilize en*/>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
-    UNPACK((llk_unpack_tilize_init(icb, block)));
-
-#ifdef ARCH_BLACKHOLE
-    PACK((llk_pack_init<false, false, true /*tilize en*/>(ocb)));
-#endif
-}
-
-ALWI void tilize_init_unpack(uint32_t icb, uint32_t block) { UNPACK((llk_unpack_tilize_init(icb, block))); }
-
-/**
- * Re-initialize for the tilize operation. This also reconfigure the unpacker with CB data type.
- */
 ALWI void tilize_init_short_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t block, uint32_t ocb) {
     MATH((llk_math_eltwise_unary_datacopy_init<
           A2D,
@@ -134,9 +116,19 @@ ALWI void tilize_init_short_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t
 #endif
 }
 
+// clang-format off
 /**
- * Perform tilize operation on a block. This simply loops over the provided blocks.
+ * Performs the tilize operation on a block.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name   | Description                              | Type     | Valid Range | Required |
+ * |----------- |--------|------------------------------------------|----------|-------------|----------|
+ * | Function   | icb    | Input circular buffer identifier         | uint32_t | 0 to 31     | True     |
+ * | Function   | block  | Size of tile block to work on            | uint32_t | > 0         | True     |
+ * | Function   | ocb    | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
  */
+// clang-format on
 ALWI void tilize_block(uint32_t icb, uint32_t block, uint32_t ocb) {
     UNPACK((llk_unpack_tilize_block(icb, block)));
 
@@ -156,9 +148,31 @@ ALWI void tilize_block(uint32_t icb, uint32_t block, uint32_t ocb) {
     }
 }
 
-ALWI void unpack_tilize_block(uint32_t icb, uint32_t block) { UNPACK((llk_unpack_tilize_block(icb, block))); }
-
-template <bool neginf_srcA = true, std::uint32_t reload_srcB = true, bool zero_srcA = false, bool zero_srcA_reduce = false>
+// clang-format off
+/**
+ * Unpacks and tilizes a block from two input CBs.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name             | Description                              | Type         | Valid Range | Required |
+ * |------------|------------------|------------------------------------------|--------------|-------------|----------|
+ * | Template   | neginf_srcA      | NegInf source A flag                     | bool         | true/false  | False    |
+ * | Template   | reload_srcB      | Reload source B flag                     | std::uint32_t| true/false  | False    |
+ * | Template   | zero_srcA        | Zero source A flag                       | bool         | true/false  | False    |
+ * | Template   | zero_srcA_reduce | Zero source A for reduce flag            | bool         | true/false  | False    |
+ * | Function   | icb0             | Input circular buffer A identifier       | uint32_t     | 0 to 31     | True     |
+ * | Function   | icb1             | Input circular buffer B identifier       | uint32_t     | 0 to 31     | True     |
+ * | Function   | block            | Size of tile block to work on            | uint32_t     | > 0         | True     |
+ * | Function   | tile_idx_b       | Tile index for source B                  | uint32_t     | >= 0        | True     |
+ * | Function   | num_faces        | Number of faces per tile                 | uint32_t     | 1 to 4      | False    |
+ * | Function   | srca_face_r_dim  | Number of rows in each face (A)          | uint32_t     | 1 to 16     | False    |
+ */
+// clang-format on
+template <
+    bool neginf_srcA = true,
+    std::uint32_t reload_srcB = true,
+    bool zero_srcA = false,
+    bool zero_srcA_reduce = false>
 ALWI void unpack_tilizeA_B_block(
     uint32_t icb0,
     uint32_t icb1,
@@ -172,46 +186,36 @@ ALWI void unpack_tilizeA_B_block(
 
 // clang-format off
 /**
- * Loads a single tile from the specified input CBs into SRCA and SRCB.
- * The function will employ one unpacker to unpack and tilize data from the
- * first input CB into SRCA, and the second unpacker to unpack from the
- * second input CB into SRCB. For the tile_idx_b and block to be valid
- * for this call, cb_wait_front(n) had to be previously called on each
- * input CB to ensure that at least some number n>0 of tiles are available
- * in the input CBs. The CB index 0 then references the first tile in the
- * received section of the CB, up to index n-1 (in a FIFO order). The DST
- * register buffer must be in acquired state via *acquire_dst* call.
- * This call is blocking and is only available on the compute engine.
+ * Uninitializes the tilize operation before re-initializing for another operation.
  *
  * Return value: None
  *
- * | Argument       | Description                                              | Data type | Valid range                          | Required |
- * |----------------|----------------------------------------------------------|-----------|--------------------------------------|----------|
- * | icb0           | The identifier of the source A circular buffer (CB)      | uint32_t  | 0 to 31                              | Yes      |
- * | icb1.          | The identifier of the source B circular buffer (CB)      | uint32_t  | 0 to 31                              | Yes      |
- * | block          | Size of tile block to work on for source A               | uint32_t  | > 0                                  | Yes      |
- * | tile_idx_b     | The index of the tile to copy from the source B input CB | uint32_t  | Must be less than the size of the CB | Yes      |
- * | num_faces      | The number of faces to in each tile being unpacked       | uint32_t  | 1 to 4                               | Yes      |
- * */
-// clang-format on
-ALWI void unpack_tilizeA_B_dot_product_block(
-    uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t tile_idx_b, uint32_t num_faces = 4) {
-    UNPACK((llk_unpack_tilizeA_B_block<false, false, true>(icb0, icb1, block, tile_idx_b, num_faces)));
-}
-
-/**
- * Uninitialize tilize operation before re-initializing for another operation.
+ * | Param Type | Name   | Description                              | Type     | Valid Range | Required |
+ * |----------- |--------|------------------------------------------|----------|-------------|----------|
+ * | Function   | icb    | Input circular buffer identifier         | uint32_t | 0 to 31     | True     |
+ * | Function   | ocb    | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
  */
+// clang-format on
 ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {
     UNPACK((llk_unpack_tilize_uninit(icb)));
 #ifdef ARCH_BLACKHOLE
-    PACK((llk_pack_init(ocb)));
+    PACK((llk_pack_init<false /*untilize*/, false /*skip_inputs*/, false /*tilize en*/>(ocb)));
 #endif
 }
 
+// clang-format off
 /**
- * Uninitialize the tilize operation along with re-configuring unpacker with the CB data types.
+ * Uninitializes the tilize operation and reconfigures the unpacker with CB data types.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name     | Description                              | Type     | Valid Range | Required |
+ * |----------- |----------|------------------------------------------|----------|-------------|----------|
+ * | Function   | old_icb  | Previous input circular buffer identifier| uint32_t | 0 to 31     | True     |
+ * | Function   | new_icb  | New input circular buffer identifier     | uint32_t | 0 to 31     | True     |
+ * | Function   | ocb      | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
  */
+// clang-format on
 ALWI void tilize_uninit_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t ocb) {
     UNPACK((llk_unpack_tilize_uninit(old_icb)));
     UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE>(old_icb, new_icb)));

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/bmm_tilize_untilize.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/bmm_tilize_untilize.cpp
@@ -32,7 +32,7 @@ inline void tilize_in(
     // UNPACK(( kernel_sleep(100) ));
     UNPACK((llk_unpack_reconfig_data_format(1, 0, 0, 0)));
     MATH((llk_math_reconfig_data_format(1, 0, 0, 0)));
-    tilize_init_short(in_cb_id, in_block_w, out_cb_id);
+    tilize_init(in_cb_id, in_block_w, out_cb_id);
     for (uint32_t in_subblock = 0; in_subblock < in_num_subblocks; ++in_subblock) {
         for (uint32_t h = 0; h < in_subblock_h; ++h) {
             cb_wait_front(in_cb_id, in_block_w);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/tilize.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/tilize.cpp
@@ -14,6 +14,7 @@ void MAIN {
     uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
     // UNPACK(( DPRINT << "Block count=" << uint32_t(per_core_block_cnt) << " tile count=" << per_core_block_tile_cnt <<
     // ENDL() ));
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
     tilize_init(tt::CBIndex::c_0, per_core_block_tile_cnt, tt::CBIndex::c_16);
 
     for (uint32_t b = 0; b < per_core_block_cnt; ++b) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -25,7 +25,7 @@ ALWI void REL() { release_dst(); }
 
 inline void tilize_in(
     uint32_t in_cb_id, uint32_t in_subblock_h, uint32_t in_block_w, uint32_t in_num_subblocks, uint32_t out_cb_id) {
-    tilize_init_short(in_cb_id, in_block_w, out_cb_id);
+    tilize_init(in_cb_id, in_block_w, out_cb_id);
     for (uint32_t in_subblock = 0; in_subblock < in_num_subblocks; ++in_subblock) {
         for (uint32_t h = 0; h < in_subblock_h; ++h) {
             cb_wait_front(in_cb_id, in_block_w);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -22,7 +22,7 @@
 
 inline void tilize_in(
     uint32_t in_cb_id, uint32_t in_subblock_h, uint32_t in_block_w, uint32_t in_num_subblocks, uint32_t out_cb_id) {
-    tilize_init_short(in_cb_id, in_block_w, out_cb_id);
+    tilize_init(in_cb_id, in_block_w, out_cb_id);
     for (uint32_t in_subblock = 0; in_subblock < in_num_subblocks; ++in_subblock) {
         for (uint32_t h = 0; h < in_subblock_h; ++h) {
             cb_wait_front(in_cb_id, in_block_w);

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_rm_single_tile_size.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_rm_single_tile_size.cpp
@@ -25,7 +25,7 @@ void MAIN {
 
     for (uint32_t n = 0; n < num_blocks; n++) {
         // tilize input via unpack and then pack
-        tilize_init_short(cb_in, 1, cb_tilize);
+        tilize_init(cb_in, 1, cb_tilize);
 
         cb_wait_front(cb_in, x_block_size);
         cb_reserve_back(cb_tilize, 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_tiled.cpp
@@ -36,7 +36,7 @@ void MAIN {
 
     for (uint32_t block = start_block; block < end_block; block++) {
         // tilize input via unpack and then pack
-        tilize_init_short(cb_in, 1, cb_tilize);
+        tilize_init(cb_in, 1, cb_tilize);
 
         cb_wait_front(cb_in, 1);
         cb_reserve_back(cb_tilize, 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize.cpp
@@ -12,6 +12,7 @@ void MAIN {
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
     constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(2);
     constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(3);
+    compute_kernel_hw_startup(cb_id_in0, cb_id_out0);
     tilize_init(cb_id_in0, per_core_block_tile_cnt, cb_id_out0);
 
     for (uint32_t b = 0; b < per_core_block_cnt; ++b) {

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp
@@ -14,6 +14,7 @@ void MAIN {
     const uint32_t block_size_row = get_compile_time_arg_val(1);
     const uint32_t third_dim = get_compile_time_arg_val(2);
 
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
     tilize_init(tt::CBIndex::c_0, block_size_row, tt::CBIndex::c_16);
     for (uint32_t b = 0; b < block_size_col * third_dim; ++b) {
         cb_wait_front(tt::CBIndex::c_0, block_size_row);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -143,7 +143,7 @@ void MAIN {
 
     for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
         // tilize input
-        tilize_init_short(cb_in, Wt, cb_tilize);
+        tilize_init(cb_in, Wt, cb_tilize);
         for (uint32_t h = 0; h < Ht; ++h) {
             cb_wait_front(cb_in, Wt);
             cb_reserve_back(cb_tilize, Wt);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/tilize_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/tilize_compute.cpp
@@ -14,6 +14,7 @@ void MAIN {
     uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
     uint32_t cb_in_idx = get_compile_time_arg_val(2);
     uint32_t cb_out_idx = get_compile_time_arg_val(3);
+    compute_kernel_hw_startup(cb_in_idx, cb_out_idx);
     tilize_init(cb_in_idx, per_core_block_tile_cnt, cb_out_idx);
 
     for (uint32_t b = 0; b < per_core_block_cnt; ++b) {

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp
@@ -51,6 +51,7 @@ void MAIN {
     constexpr uint32_t total_sticks_per_block = get_compile_time_arg_val(5);
     constexpr uint32_t is_input_in_dram = get_compile_time_arg_val(6);
 
+    compute_kernel_hw_startup(cb_in, cb_tiled_in);
     if constexpr (!is_input_in_dram) {
         cb_push_back(cb_in, total_sticks_per_block);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
@@ -194,7 +194,7 @@ void MAIN {
                     for (uint32_t w_block = w_out_start; w_block < w_out_end; w_block += W_block_size) {
                         // Tilize row-major patches
                         uint32_t patch_rows_left = num_patches;
-                        tilize_init_short(cb_vol2col_rm, matmul_K_t, cb_vol2col_tiled);
+                        tilize_init(cb_vol2col_rm, matmul_K_t, cb_vol2col_tiled);
                         for (uint32_t patch_t = 0; patch_t < matmul_M_t; patch_t++) {
                             // Reader produces row pages, which may not be tile aligned. Wait on the correct number of
                             // rows.

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/paged_fused_update_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/paged_fused_update_cache.cpp
@@ -59,7 +59,7 @@ void MAIN {
         reconfig_data_format_srca(cache_cb, untilized_cache2_cb);
         pack_reconfig_data_format(untilized_cache_cb, out_cb);
 
-        tilize_init_short(untilized_cache2_cb, Wt, out_cb);
+        tilize_init(untilized_cache2_cb, Wt, out_cb);
 
         // Wait on writer to update block. Tilize.
         cb_wait_front(untilized_cache2_cb, Wt);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/paged_row_major_fused_update_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/paged_row_major_fused_update_cache.cpp
@@ -50,7 +50,7 @@ void MAIN {
         reconfig_data_format_srca(cache_cb, untilized_cache2_cb);
         pack_reconfig_data_format(untilized_cache_cb, out_cb);
 
-        tilize_init_short(untilized_cache2_cb, Wt, out_cb);
+        tilize_init(untilized_cache2_cb, Wt, out_cb);
 
         // Wait on writer to update block. Tilize.
         cb_wait_front(untilized_cache2_cb, Wt);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/update_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/update_cache.cpp
@@ -46,7 +46,7 @@ void MAIN {
         reconfig_data_format_srca(cache_cb, untilized_cache2_cb);
         pack_reconfig_data_format(untilized_cache_cb, out_cb);
 
-        tilize_init_short(untilized_cache2_cb, Wt, out_cb);
+        tilize_init(untilized_cache2_cb, Wt, out_cb);
 
         // Wait on writer to update block. Tilize.
         cb_wait_front(untilized_cache2_cb, Wt);

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
@@ -50,7 +50,7 @@ FORCE_INLINE void pack_block_tiles_into_rows(uint32_t cb_in, uint32_t cb_out, ui
     reconfig_data_format_srca(cb_in);
     pack_reconfig_data_format(cb_out);
 
-    tilize_init_short(cb_in, NUM_TILES_IN_TILIZED_CHUNK, cb_out);
+    tilize_init(cb_in, NUM_TILES_IN_TILIZED_CHUNK, cb_out);
 
     cb_wait_front(cb_in, NUM_TILES_IN_TILIZED_CHUNK);
     cb_reserve_back(cb_out, num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/rotary_embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/rotary_embedding.cpp
@@ -51,7 +51,7 @@ ALWI void UNTILIZE_TILES(uint32_t in0_cb, uint32_t out_cb, uint32_t num_tiles) {
 }
 
 ALWI void TILIZE_ROWS(uint32_t in0_cb, uint32_t sync_cb, uint32_t out_cb, uint32_t num_tiles) {
-    tilize_init_short(in0_cb, num_tiles, out_cb);
+    tilize_init(in0_cb, num_tiles, out_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(sync_cb, num_tiles);
     cb_reserve_back(out_cb, num_tiles);

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/compute/update_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/compute/update_cache.cpp
@@ -47,7 +47,7 @@ void MAIN {
             reconfig_data_format_srca(cache_cb, untilized_cache2_cb);
             pack_reconfig_data_format(untilized_cache_cb, out_cb);
 
-            tilize_init_short(untilized_cache2_cb, Wt, out_cb);
+            tilize_init(untilized_cache2_cb, Wt, out_cb);
 
             for (uint32_t g = 0; g < granularity; ++g) {
                 // Wait on writer to update block. Tilize.

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -215,7 +215,7 @@ void MAIN {
 #else
     constexpr uint32_t cb_in_rm = cb_in0;
 #endif
-    tilize_init_short(cb_in_rm, per_core_N, cb_in);
+    tilize_init(cb_in_rm, per_core_N, cb_in);
     for (uint32_t m = 0; m < per_core_M; ++m) {
 #ifdef READER_REPACK
         cb_wait_front(cb_in_rm, per_core_N);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -144,7 +144,7 @@ void MAIN {
 #else
     constexpr uint32_t cb_in_rm = cb_in0;
 #endif
-    tilize_init_short(cb_in_rm, per_core_N, cb_in);
+    tilize_init(cb_in_rm, per_core_N, cb_in);
     for (uint32_t m = 0; m < per_core_M; ++m) {
 #ifdef READER_REPACK
         cb_wait_front(cb_in_rm, per_core_N);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -137,6 +137,7 @@ void MAIN {
     }
 
     if constexpr (tilize_q) {
+        compute_kernel_hw_startup(cb_q_rm, cb_q_in);
         tilize_init(cb_q_rm, q_chunk_tiles, cb_q_in);
         cb_wait_front(cb_q_rm, q_chunk_tiles);
         cb_reserve_back(cb_q_in, q_chunk_tiles);


### PR DESCRIPTION
### Ticket
#22940 

### Problem description
Compute API currently has a lot of unused or redundant function arguments, and even unused functions. Furthermore, the programming model is violated at several places and the boundary between full and short inits is not clear. Lastly, some ops require calling an `_uninit`/`_revert` function, but not all, which introduces more confusion. We will do a series of PRs to fix these issues for all ops so that in the end Compute kernels look like this:
```
compute_kernel_hw_startup # called once at the start of the kernel
<op1>_init # called before op1
<op1>_tile / <op1>_block # We will add block ops where applicable
<op2>_init
<op2>_tile / <op2>_block
...
```

### What's changed
This PR addresses the mentioned drawbacks of Compute API for **tilize** op. It is the initial PR that doesn't fix all the problems, but does the following:

* Uses `compute_kernel_hw_startup` function at kernel beginnings.
* `tilize_init_short` renamed to `tilize_init` and old full init removed. 
* Remove unused Compute API like `tilize_init_unpack` and `unpack_tilize_block`
* Adapt API calls in all kernels to reflect the changes.
* Add documentation skeleton for functions that will remain in `tilize.h` at the end of the effort.

### Review Process Suggestion:
* Code owners should check their files and see whether all `tilize_` init and uninit calls are modified. All `tilize_init_short` calls should be swapped with `tilize_init` calls.
* LLK team will review `tilize.h` for functional, structural and code documentation changes. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/15873590382
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/15873549061
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) - waiting for CI to get fixed
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) - waiting for CI to get fixed
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes
