### PR TITLE
Fix SDXL Failing CI

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
@@ -364,7 +364,7 @@ operation::ProgramWithCallbacks padded_slice_rm_multi_core(
         auto src_tensor = input_tensors.at(0);
         auto dst_tensor = output_tensors.at(0);
         TT_FATAL(dst_tensor.is_sharded(), "Output tensor must be sharded");
-        UpdateDynamicCircularBufferAddress(program, cb_src0, *src_tensor.buffer());
+        UpdateDynamicCircularBufferAddress(program, cb_src0, *dst_tensor.buffer());
 
         auto all_runtime_args = get_padded_slice_runtime_args_rm_sharded_output(
             src_tensor, dst_tensor, output_tensor_start, actual_output_shape, iter_cores, max_read_size);


### PR DESCRIPTION
### Problem description
Padded Slice override runtime args uses src instead of dst buffer for CB. 

### What's changed
Fixed bug in padded slice override runtime args. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15392171375)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15392217136) (if applicable)
- [x] Nightly L2 [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15392537589)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15392201408)
- [x] Frequent Models [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15392192854)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15392516938) 
- [x] New/Existing tests provide coverage for changes