### PR TITLE
Make 2D socket tests use randomized chips

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -945,7 +945,8 @@ std::shared_ptr<Program> create_sender_program(
     std::size_t data_size,
     const CoreCoord& sender_logical_coord,
     chip_id_t sender_physical_device_id,
-    chip_id_t recv_physical_device_id) {
+    chip_id_t recv_physical_device_id,
+    uint32_t sender_link_idx) {
     auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     const auto& fabric_context = control_plane->get_fabric_context();
 
@@ -976,7 +977,12 @@ std::shared_ptr<Program> create_sender_program(
         CreateCircularBuffer(*sender_program, sender_logical_coord, sender_cb_reserved_packet_header_config);
     std::vector<uint32_t> sender_rtas;
     tt_fabric::append_fabric_connection_rt_args(
-        sender_physical_device_id, recv_physical_device_id, 0, *sender_program, {sender_logical_coord}, sender_rtas);
+        sender_physical_device_id,
+        recv_physical_device_id,
+        sender_link_idx,
+        *sender_program,
+        {sender_logical_coord},
+        sender_rtas);
     tt_metal::SetRuntimeArgs(*sender_program, sender_kernel, sender_logical_coord, sender_rtas);
 
     return sender_program;
@@ -993,7 +999,9 @@ std::shared_ptr<Program> create_split_reduce_program(
     const CoreCoord& reduce_logical_coord,
     chip_id_t sender0_physical_device_id,
     chip_id_t sender1_physical_device_id,
-    chip_id_t recv_physical_device_id) {
+    chip_id_t recv_physical_device_id,
+    uint32_t sender0_link_idx,
+    uint32_t sender1_link_idx) {
     auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     const auto& fabric_context = control_plane->get_fabric_context();
 
@@ -1109,9 +1117,19 @@ std::shared_ptr<Program> create_split_reduce_program(
     std::vector<uint32_t> recv_rtas_1;
 
     tt_fabric::append_fabric_connection_rt_args(
-        recv_physical_device_id, sender0_physical_device_id, 0, *recv_program, {recv_logical_coord_0}, recv_rtas_0);
+        recv_physical_device_id,
+        sender0_physical_device_id,
+        sender0_link_idx,
+        *recv_program,
+        {recv_logical_coord_0},
+        recv_rtas_0);
     tt_fabric::append_fabric_connection_rt_args(
-        recv_physical_device_id, sender1_physical_device_id, 0, *recv_program, {recv_logical_coord_1}, recv_rtas_1);
+        recv_physical_device_id,
+        sender1_physical_device_id,
+        sender1_link_idx,
+        *recv_program,
+        {recv_logical_coord_1},
+        recv_rtas_1);
 
     tt_metal::SetRuntimeArgs(*recv_program, recv_kernel_0, recv_logical_coord_0, recv_rtas_0);
     tt_metal::SetRuntimeArgs(*recv_program, recv_kernel_1, recv_logical_coord_1, recv_rtas_1);
@@ -1130,7 +1148,10 @@ std::shared_ptr<Program> create_reduce_program(
     chip_id_t sender0_physical_device_id,
     chip_id_t sender1_physical_device_id,
     chip_id_t reducer_physical_device_id,
-    chip_id_t recv_physical_device_id) {
+    chip_id_t recv_physical_device_id,
+    uint32_t sender0_link_idx,
+    uint32_t sender1_link_idx,
+    uint32_t recv_link_idx) {
     auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     const auto& fabric_context = control_plane->get_fabric_context();
 
@@ -1194,15 +1215,30 @@ std::shared_ptr<Program> create_reduce_program(
     std::vector<uint32_t> recv_rtas;
 
     tt_fabric::append_fabric_connection_rt_args(
-        reducer_physical_device_id, sender0_physical_device_id, 0, *reduce_program, reduce_logical_coord, recv_rtas);
+        reducer_physical_device_id,
+        sender0_physical_device_id,
+        sender0_link_idx,
+        *reduce_program,
+        reduce_logical_coord,
+        recv_rtas);
     tt_fabric::append_fabric_connection_rt_args(
-        reducer_physical_device_id, sender1_physical_device_id, 0, *reduce_program, reduce_logical_coord, recv_rtas);
+        reducer_physical_device_id,
+        sender1_physical_device_id,
+        sender1_link_idx,
+        *reduce_program,
+        reduce_logical_coord,
+        recv_rtas);
 
     tt_metal::SetRuntimeArgs(*reduce_program, recv_kernel, reduce_logical_coord, recv_rtas);
 
     std::vector<uint32_t> send_rtas;
     tt_fabric::append_fabric_connection_rt_args(
-        reducer_physical_device_id, recv_physical_device_id, 0, *reduce_program, reduce_logical_coord, send_rtas);
+        reducer_physical_device_id,
+        recv_physical_device_id,
+        recv_link_idx,
+        *reduce_program,
+        reduce_logical_coord,
+        send_rtas);
     tt_metal::SetRuntimeArgs(*reduce_program, send_kernel, reduce_logical_coord, send_rtas);
 
     return reduce_program;
@@ -1216,7 +1252,8 @@ std::shared_ptr<Program> create_recv_program(
     const CoreCoord& recv_logical_coord,
     const CoreCoord& output_logical_coord,
     chip_id_t sender_physical_device_id,
-    chip_id_t recv_physical_device_id) {
+    chip_id_t recv_physical_device_id,
+    uint32_t recv_link_idx) {
     auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     const auto& fabric_context = control_plane->get_fabric_context();
 
@@ -1257,7 +1294,12 @@ std::shared_ptr<Program> create_recv_program(
     std::vector<uint32_t> recv_rtas;
 
     tt_fabric::append_fabric_connection_rt_args(
-        recv_physical_device_id, sender_physical_device_id, 0, *recv_program, {recv_logical_coord}, recv_rtas);
+        recv_physical_device_id,
+        sender_physical_device_id,
+        recv_link_idx,
+        *recv_program,
+        {recv_logical_coord},
+        recv_rtas);
 
     tt_metal::SetRuntimeArgs(*recv_program, recv_kernel, recv_logical_coord, recv_rtas);
 
@@ -1269,11 +1311,13 @@ void test_multi_sender_single_recv(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& sender_1,
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& reducer,
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& receiver,
+    const std::vector<uint32_t>& link_indices,
     std::size_t socket_fifo_size,
     std::size_t page_size,
     std::size_t data_size,
     std::size_t num_interations,
     bool split_reducer) {
+    TT_ASSERT(link_indices.size() == 3, "Link indices must be of size 3");
     // Used to setup fabric connections
     const uint32_t sender_0_physical_device_id = sender_0->get_device(MeshCoordinate(0, 0))->id();
     const uint32_t sender_1_physical_device_id = sender_1->get_device(MeshCoordinate(0, 0))->id();
@@ -1379,7 +1423,8 @@ void test_multi_sender_single_recv(
         data_size,
         sender_logical_coord,
         sender_0_physical_device_id,
-        reducer_physical_device_id);
+        reducer_physical_device_id,
+        0);
     auto sender_program_1 = create_sender_program(
         send_socket_1,
         sender_data_buffer_1,
@@ -1387,7 +1432,8 @@ void test_multi_sender_single_recv(
         data_size,
         sender_logical_coord,
         sender_1_physical_device_id,
-        reducer_physical_device_id);
+        reducer_physical_device_id,
+        0);
     std::shared_ptr<Program> reduce_program = nullptr;
     std::shared_ptr<Program> sender_program_2 = nullptr;
     if (split_reducer) {
@@ -1402,7 +1448,9 @@ void test_multi_sender_single_recv(
             reduce_logical_coord,
             sender_0_physical_device_id,
             sender_1_physical_device_id,
-            reducer_physical_device_id);
+            reducer_physical_device_id,
+            link_indices[0],
+            link_indices[1]);
         sender_program_2 = create_sender_program(
             send_socket_2,
             reduce_data_buffer,
@@ -1410,7 +1458,8 @@ void test_multi_sender_single_recv(
             data_size,
             reduce_logical_coord,
             reducer_physical_device_id,
-            receiver_physical_device_id);
+            receiver_physical_device_id,
+            link_indices[2]);
 
     } else {
         reduce_program = create_reduce_program(
@@ -1424,7 +1473,10 @@ void test_multi_sender_single_recv(
             sender_0_physical_device_id,
             sender_1_physical_device_id,
             reducer_physical_device_id,
-            receiver_physical_device_id);
+            receiver_physical_device_id,
+            link_indices[0],
+            link_indices[1],
+            link_indices[2]);
     }
     auto recv_program = create_recv_program(
         recv_socket_2,
@@ -1434,7 +1486,8 @@ void test_multi_sender_single_recv(
         recv0_logical_coord,
         output_logical_coord,
         reducer_physical_device_id,
-        receiver_physical_device_id);
+        receiver_physical_device_id,
+        0);
 
     auto sender_0_mesh_workload = CreateMeshWorkload();
     MeshCoordinateRange devices_0(sender_0->shape());
@@ -1561,7 +1614,8 @@ void test_multi_connection_multi_device_data_copy(
             data_size,
             sender_logical_core,
             sender_physical_id,
-            recv_physical_id);
+            recv_physical_id,
+            0);
         auto recv_program = create_recv_program(
             recv_socket,
             recv_data_buffer,
@@ -1570,7 +1624,8 @@ void test_multi_connection_multi_device_data_copy(
             recv_logical_core,
             recv_logical_core,
             sender_physical_id,
-            recv_physical_id);
+            recv_physical_id,
+            0);
 
         AddProgramToMeshWorkload(
             sender_mesh_workload, std::move(*sender_program), MeshCoordinateRange(connection.sender_core.device_coord));
@@ -1586,17 +1641,38 @@ void test_multi_connection_multi_device_data_copy(
     }
 }
 
+std::pair<MeshCoordinate, MeshCoordinate> get_random_mesh_coordinates(const MeshShape& mesh_shape) {
+    std::srand(std::time(nullptr));  // Seed the RNG
+    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
+    if (tt_fabric::is_2d_fabric_config(fabric_config)) {
+        auto coord0 = MeshCoordinate(rand() % mesh_shape[0], rand() % mesh_shape[1]);
+        auto coord1 = coord0;
+        while (coord1 == coord0) {
+            coord1 = MeshCoordinate(rand() % mesh_shape[0], rand() % mesh_shape[1]);
+        }
+        log_info(LogTest, "Random mesh coordinates: {} {}", coord0, coord1);
+        return {coord0, coord1};
+    } else {
+        // 1D fabric config requires neighboring devices for now
+        auto coord0 = MeshCoordinate(0, 0);
+        auto coord1 = MeshCoordinate(1, 0);
+        return {coord0, coord1};
+    }
+}
+
 template <typename FixtureT>
 void run_single_connection_multi_device_socket_with_workers(FixtureT* fixture) {
-    auto md0 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
-    auto md1 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 0));
+    auto [coord0, coord1] = get_random_mesh_coordinates(fixture->get_mesh_device()->shape());
+    auto md0 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), coord0);
+    auto md1 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), coord1);
     test_single_connection_multi_device_socket_with_workers(md0, md1, 1024, 64, 1024);
 }
 
 template <typename FixtureT>
 void run_single_connection_multi_device_socket(FixtureT* fixture) {
-    auto md0 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
-    auto md1 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 0));
+    auto [coord0, coord1] = get_random_mesh_coordinates(fixture->get_mesh_device()->shape());
+    auto md0 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), coord0);
+    auto md1 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), coord1);
     test_single_connection_multi_device_socket(md0, md1, 1024, 64, 1024, false);
     test_single_connection_multi_device_socket(md0, md1, 1024, 64, 2048, false);
     test_single_connection_multi_device_socket(md0, md1, 4096, 1088, 9792, false);
@@ -1604,10 +1680,10 @@ void run_single_connection_multi_device_socket(FixtureT* fixture) {
 
 template <typename FixtureT>
 void run_single_connection_multi_device_socket_with_cbs(FixtureT* fixture) {
-    auto tile_size_bytes = tile_size(tt::DataFormat::UInt32);
-
-    auto md0 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
-    auto md1 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 0));
+    constexpr auto tile_size_bytes = tile_size(tt::DataFormat::UInt32);
+    auto [coord0, coord1] = get_random_mesh_coordinates(fixture->get_mesh_device()->shape());
+    auto md0 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), coord0);
+    auto md1 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), coord1);
 
     test_single_connection_multi_device_socket(
         md0, md1, 2 * tile_size_bytes, tile_size_bytes, 4 * tile_size_bytes, true);
@@ -1623,10 +1699,62 @@ void run_single_connection_multi_device_socket_with_cbs(FixtureT* fixture) {
 
 template <typename FixtureT>
 void run_multi_sender_single_recv(FixtureT* fixture, bool split_reducer) {
-    auto sender_0 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
-    auto sender_1 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 2));
-    auto reducer = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 1));
-    auto receiver = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 1));
+    std::vector<MeshCoordinate> coordinates;
+    std::vector<uint32_t> link_indices;
+    if (tt_fabric::is_2d_fabric_config(tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config())) {
+        auto mesh_device = fixture->get_mesh_device();
+        auto mesh_shape = mesh_device->shape();
+        coordinates.resize(mesh_shape.mesh_size(), MeshCoordinate(0, 0));
+        int idx = 0;
+        std::generate(coordinates.begin(), coordinates.end(), [&idx, mesh_shape]() mutable {
+            int x = idx % mesh_shape[0];
+            int y = idx / mesh_shape[0];
+            ++idx;
+            return MeshCoordinate(x, y);
+        });
+        auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+        while (true) {
+            link_indices.clear();
+            std::shuffle(coordinates.begin(), coordinates.end(), std::mt19937(std::random_device()()));
+            auto sender_0_physical_chip_id = mesh_device->get_device(coordinates[0])->id();
+            auto sender_1_physical_chip_id = mesh_device->get_device(coordinates[1])->id();
+            auto reducer_physical_chip_id = mesh_device->get_device(coordinates[2])->id();
+            auto receiver_physical_chip_id = mesh_device->get_device(coordinates[3])->id();
+            auto reducer_fabric_node_id =
+                control_plane->get_fabric_node_id_from_physical_chip_id(reducer_physical_chip_id);
+
+            std::unordered_set<tt_fabric::chan_id_t> used_channels;
+            for (auto dst_chip_id : {sender_0_physical_chip_id, sender_1_physical_chip_id, receiver_physical_chip_id}) {
+                auto dst_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(dst_chip_id);
+                auto forwarding_direction =
+                    control_plane->get_forwarding_direction(reducer_fabric_node_id, dst_fabric_node_id).value();
+                const auto candidate_eth_chans = control_plane->get_active_fabric_eth_channels_in_direction(
+                    reducer_fabric_node_id, forwarding_direction);
+
+                const auto forwarding_links = get_forwarding_link_indices_in_direction(
+                    reducer_physical_chip_id, dst_chip_id, forwarding_direction);
+                for (auto link_idx : forwarding_links) {
+                    if (used_channels.find(candidate_eth_chans[link_idx]) == used_channels.end()) {
+                        used_channels.insert(candidate_eth_chans[link_idx]);
+                        link_indices.push_back(link_idx);
+                        break;
+                    }
+                }
+            }
+            if (used_channels.size() == 3) {
+                break;
+            }
+        }
+
+    } else {
+        coordinates = {MeshCoordinate(0, 0), MeshCoordinate(0, 2), MeshCoordinate(0, 1), MeshCoordinate(1, 1)};
+        link_indices = {0, 0, 0};
+    }
+
+    auto sender_0 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), coordinates[0]);
+    auto sender_1 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), coordinates[1]);
+    auto reducer = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), coordinates[2]);
+    auto receiver = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), coordinates[3]);
 
     log_info(LogTest, "Sender 0 ID: {}", sender_0->get_device(MeshCoordinate(0, 0))->id());
     log_info(LogTest, "Sender 1 ID: {}", sender_1->get_device(MeshCoordinate(0, 0))->id());
@@ -1635,11 +1763,11 @@ void run_multi_sender_single_recv(FixtureT* fixture, bool split_reducer) {
 
     uint32_t num_interations = 10;
     test_multi_sender_single_recv(
-        sender_0, sender_1, reducer, receiver, 1024, 64, 1024, num_interations, split_reducer);
+        sender_0, sender_1, reducer, receiver, link_indices, 1024, 64, 1024, num_interations, split_reducer);
     test_multi_sender_single_recv(
-        sender_0, sender_1, reducer, receiver, 2048, 64, 5120, num_interations, split_reducer);
+        sender_0, sender_1, reducer, receiver, link_indices, 2048, 64, 5120, num_interations, split_reducer);
     test_multi_sender_single_recv(
-        sender_0, sender_1, reducer, receiver, 4096, 1088, 9792, num_interations, split_reducer);
+        sender_0, sender_1, reducer, receiver, link_indices, 4096, 1088, 9792, num_interations, split_reducer);
 }
 
 template <typename FixtureT>
@@ -1914,8 +2042,9 @@ TEST_F(MeshSocketTest2DFabric, MultiConnectionMultiDeviceTest) {
 
 // Verify that sockets are correctly created on different sub devices
 TEST_F(MeshSocketTest2DFabric, SocketsOnSubDevice) {
-    auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
-    auto md1 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 0));
+    auto [coord0, coord1] = get_random_mesh_coordinates(mesh_device_->shape());
+    auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), coord0);
+    auto md1 = mesh_device_->create_submesh(MeshShape(1, 1), coord1);
     constexpr uint32_t socket_fifo_size = 1024;
 
     // Create sockets in global memory space. This socket is persistent, it lives regardless
@@ -2009,8 +2138,9 @@ TEST_F(MeshSocketTest2DFabric, SocketsOnSubDevice) {
 }
 
 TEST_F(MeshSocketTest, AssertOnDuplicateCores) {
-    auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
-    auto md1 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 0));
+    auto [coord0, coord1] = get_random_mesh_coordinates(mesh_device_->shape());
+    auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), coord0);
+    auto md1 = mesh_device_->create_submesh(MeshShape(1, 1), coord1);
     constexpr uint32_t socket_fifo_size = 1024;
 
     SocketConnection socket_connection = {

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -30,7 +30,7 @@ FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::Cluster
 std::vector<uint32_t> get_forwarding_link_indices_in_direction(
     chip_id_t src_chip_id, chip_id_t dst_chip_id, RoutingDirection direction);
 
-// returns which links on a given src chip are avaialable for forwarding the data to a dst chip
+// returns which links on a given src chip are available for forwarding the data to a dst chip
 // these link indices can then be used to establish connection with the fabric routers
 std::vector<uint32_t> get_forwarding_link_indices(chip_id_t src_chip_id, chip_id_t dst_chip_id);
 

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1148,16 +1148,12 @@ void build_tt_fabric_program(
             auto eth_chans_dir1 = active_fabric_eth_channels.at(dir1);
             auto eth_chans_dir2 = active_fabric_eth_channels.at(dir2);
 
-            auto eth_chans_dir1_it = eth_chans_dir1.begin();
-            auto eth_chans_dir2_it = eth_chans_dir2.begin();
-
             // since tunneling cores are not guaraneteed to be reserved on the same routing plane, iterate through
             // the ordered eth channels in both directions
             uint32_t num_links = std::min(eth_chans_dir1.size(), eth_chans_dir2.size());
-            uint32_t link = 0;
-            while (eth_chans_dir1_it != eth_chans_dir1.end() && eth_chans_dir2_it != eth_chans_dir2.end()) {
-                auto eth_chan_dir1 = *eth_chans_dir1_it;
-                auto eth_chan_dir2 = *eth_chans_dir2_it;
+            for (uint32_t link = 0; link < num_links; link++) {
+                auto eth_chan_dir1 = eth_chans_dir1[link];
+                auto eth_chan_dir2 = eth_chans_dir2[link];
 
                 auto& edm_builder1 = edm_builders.at(eth_chan_dir1);
                 auto& edm_builder2 = edm_builders.at(eth_chan_dir2);
@@ -1168,14 +1164,10 @@ void build_tt_fabric_program(
                 auto edm_noc_vc = link & edm_builder1.config.MAX_EDM_NOC_VC;
                 edm_builder1.config.edm_noc_vc = edm_noc_vc;
                 edm_builder2.config.edm_noc_vc = edm_noc_vc;
-                link++;
 
                 if (is_galaxy) {
                     get_optimal_noc_for_edm(edm_builder1, edm_builder2, num_links, topology);
                 }
-
-                eth_chans_dir1_it++;
-                eth_chans_dir2_it++;
             }
         }
     };


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
2D socket tests were originally only testing between chip neighbours like 1D, but this is not a requirement/restriction.

### What's changed
Enable picking random chips for 2D socket tests to test non-neighbour routing.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15396124908
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes
https://github.com/tenstorrent/tt-metal/actions/runs/15410157799/job/43385544141