### PR TITLE
[skip ci] Unity builds for TT-NN sublibs

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(ttnn_core ${LIB_TYPE})
 add_library(TT::NN::Core ALIAS ttnn_core)
 
 target_compile_definitions(ttnn_core PUBLIC "$<$<CXX_COMPILER_ID:GNU>:DISABLE_NAMESPACE_STATIC_ASSERT>")
+target_precompile_headers(ttnn_core REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_core)
 
 set(TENSOR_FLATBUFFER_SCHEMAS
     ${CMAKE_CURRENT_SOURCE_DIR}/core/tensor/flatbuffer/mesh_coordinate.fbs

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -24,7 +24,6 @@ add_library(TT::NN::Core ALIAS ttnn_core)
 
 target_compile_definitions(ttnn_core PUBLIC "$<$<CXX_COMPILER_ID:GNU>:DISABLE_NAMESPACE_STATIC_ASSERT>")
 target_precompile_headers(ttnn_core REUSE_FROM TT::CommonPCH)
-TT_ENABLE_UNITY_BUILD(ttnn_core)
 
 set(TENSOR_FLATBUFFER_SCHEMAS
     ${CMAKE_CURRENT_SOURCE_DIR}/core/tensor/flatbuffer/mesh_coordinate.fbs

--- a/ttnn/cpp/ttnn/operations/bernoulli/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/bernoulli/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_bernoulli ${LIB_TYPE})
 add_library(TT::NN::Ops::Bernoulli ALIAS ttnn_op_bernoulli)
 
 target_precompile_headers(ttnn_op_bernoulli REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_bernoulli)
 
 target_sources(
     ttnn_op_bernoulli

--- a/ttnn/cpp/ttnn/operations/ccl/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/ccl/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_ccl ${LIB_TYPE})
 add_library(TT::NN::Ops::CCL ALIAS ttnn_op_ccl)
 
 target_precompile_headers(ttnn_op_ccl REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_ccl)
 
 target_sources(
     ttnn_op_ccl

--- a/ttnn/cpp/ttnn/operations/conv/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/conv/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_conv ${LIB_TYPE})
 add_library(TT::NN::Ops::Conv ALIAS ttnn_op_conv)
 
 target_precompile_headers(ttnn_op_conv REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_conv)
 
 target_sources(
     ttnn_op_conv

--- a/ttnn/cpp/ttnn/operations/core/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/core/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_core ${LIB_TYPE})
 add_library(TT::NN::Ops::Core ALIAS ttnn_op_core)
 
 target_precompile_headers(ttnn_op_core REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_core)
 
 target_sources(
     ttnn_op_core

--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_data_movement ${LIB_TYPE})
 add_library(TT::NN::Ops::DataMovement ALIAS ttnn_op_data_movement)
 
 target_precompile_headers(ttnn_op_data_movement REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_data_movement)
 
 target_sources(
     ttnn_op_data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+#pragma once
 
 namespace ttnn::operations::data_movement::detail {
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_eltwise_binary ${LIB_TYPE})
 add_library(TT::NN::Ops::Eltwise::Binary ALIAS ttnn_op_eltwise_binary)
 
 target_precompile_headers(ttnn_op_eltwise_binary REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_eltwise_binary)
 
 target_sources(
     ttnn_op_eltwise_binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(ttnn_op_eltwise_binary_backward ${LIB_TYPE})
 add_library(TT::NN::Ops::Eltwise::Binary::Backward ALIAS ttnn_op_eltwise_binary_backward)
 
-target_precompile_headers(ttnn_op_eltwise_binary REUSE_FROM TT::CommonPCH)
+target_precompile_headers(ttnn_op_eltwise_binary_backward REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_eltwise_binary_backward)
 
 target_sources(ttnn_op_eltwise_binary_backward PRIVATE binary_backward.cpp)
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_eltwise_binary_ng ${LIB_TYPE})
 add_library(TT::NN::Ops::Eltwise::Binary::NG ALIAS ttnn_op_eltwise_binary_ng)
 
 target_precompile_headers(ttnn_op_eltwise_binary_ng REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_eltwise_binary_ng)
 
 target_sources(
     ttnn_op_eltwise_binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/complex/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_eltwise_complex ${LIB_TYPE})
 add_library(TT::NN::Ops::Eltwise::Complex ALIAS ttnn_op_eltwise_complex)
 
 target_precompile_headers(ttnn_op_eltwise_complex REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_eltwise_complex)
 
 target_sources(ttnn_op_eltwise_complex PRIVATE complex.cpp)
 

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_eltwise_complex_binary ${LIB_TYPE})
 add_library(TT::NN::Ops::Eltwise::Complex::Binary ALIAS ttnn_op_eltwise_complex_binary)
 
 target_precompile_headers(ttnn_op_eltwise_complex_binary REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_eltwise_complex_binary)
 
 target_sources(ttnn_op_eltwise_complex_binary PRIVATE device/complex_binary_op.cpp)
 

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_eltwise_complex_unary ${LIB_TYPE})
 add_library(TT::NN::Ops::Eltwise::Complex::Unary ALIAS ttnn_op_eltwise_complex_unary)
 
 target_precompile_headers(ttnn_op_eltwise_complex_unary REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_eltwise_complex_unary)
 
 target_sources(ttnn_op_eltwise_complex_unary PRIVATE device/complex_unary_op.cpp)
 

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_eltwise_complex_unary_backward ${LIB_TYPE})
 add_library(TT::NN::Ops::Eltwise::Complex::Unary::Backward ALIAS ttnn_op_eltwise_complex_unary_backward)
 
 target_precompile_headers(ttnn_op_eltwise_complex_unary_backward REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_eltwise_complex_unary_backward)
 
 target_sources(ttnn_op_eltwise_complex_unary_backward PRIVATE device/complex_unary_backward_op.cpp)
 

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_eltwise_quantization ${LIB_TYPE})
 add_library(TT::NN::Ops::Eltwise::Quantization ALIAS ttnn_op_eltwise_quantization)
 
 target_precompile_headers(ttnn_op_eltwise_quantization REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_eltwise_quantization)
 
 target_sources(ttnn_op_eltwise_quantization PRIVATE quantization.cpp)
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_eltwise_ternary ${LIB_TYPE})
 add_library(TT::NN::Ops::Eltwise::Ternary ALIAS ttnn_op_eltwise_ternary)
 
 target_precompile_headers(ttnn_op_eltwise_ternary REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_eltwise_ternary)
 
 target_sources(
     ttnn_op_eltwise_ternary

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_eltwise_ternary_backward ${LIB_TYPE})
 add_library(TT::NN::Ops::Eltwise::Ternary::Backward ALIAS ttnn_op_eltwise_ternary_backward)
 
 target_precompile_headers(ttnn_op_eltwise_ternary_backward REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_eltwise_ternary_backward)
 
 target_sources(ttnn_op_eltwise_ternary_backward PRIVATE ternary_backward.cpp)
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_eltwise_unary ${LIB_TYPE})
 add_library(TT::NN::Ops::Eltwise::Unary ALIAS ttnn_op_eltwise_unary)
 
 target_precompile_headers(ttnn_op_eltwise_unary REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_eltwise_unary)
 
 target_sources(
     ttnn_op_eltwise_unary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/CMakeLists.txt
@@ -2,7 +2,6 @@ add_library(ttnn_op_eltwise_unary ${LIB_TYPE})
 add_library(TT::NN::Ops::Eltwise::Unary ALIAS ttnn_op_eltwise_unary)
 
 target_precompile_headers(ttnn_op_eltwise_unary REUSE_FROM TT::CommonPCH)
-TT_ENABLE_UNITY_BUILD(ttnn_op_eltwise_unary)
 
 target_sources(
     ttnn_op_eltwise_unary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_eltwise_unary_backward ${LIB_TYPE})
 add_library(TT::NN::Ops::Eltwise::Unary::Backward ALIAS ttnn_op_eltwise_unary_backward)
 
 target_precompile_headers(ttnn_op_eltwise_unary_backward REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_eltwise_unary_backward)
 
 target_sources(ttnn_op_eltwise_unary_backward PRIVATE unary_backward.cpp)
 

--- a/ttnn/cpp/ttnn/operations/embedding/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/embedding/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_embedding ${LIB_TYPE})
 add_library(TT::NN::Ops::Embedding ALIAS ttnn_op_embedding)
 
 target_precompile_headers(ttnn_op_embedding REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_embedding)
 
 target_sources(
     ttnn_op_embedding

--- a/ttnn/cpp/ttnn/operations/embedding_backward/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_embedding_backward ${LIB_TYPE})
 add_library(TT::NN::Ops::Embedding::Backward ALIAS ttnn_op_embedding_backward)
 
 target_precompile_headers(ttnn_op_embedding_backward REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_embedding_backward)
 
 target_sources(
     ttnn_op_embedding_backward

--- a/ttnn/cpp/ttnn/operations/examples/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/examples/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_examples ${LIB_TYPE})
 add_library(TT::NN::Ops::Examples ALIAS ttnn_op_examples)
 
 target_precompile_headers(ttnn_op_examples REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_examples)
 
 target_sources(
     ttnn_op_examples

--- a/ttnn/cpp/ttnn/operations/experimental/auto_format/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/auto_format/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_auto_format ${LIB_TYPE})
 add_library(TT::NN::Ops::Experimental::AutoFormat ALIAS ttnn_op_experimental_auto_format)
 
 target_precompile_headers(ttnn_op_experimental_auto_format REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_auto_format)
 
 target_sources(ttnn_op_experimental_auto_format PRIVATE auto_format.cpp)
 

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_bcast_to ${LIB_TYPE})
 add_library(TT::NN::Ops::Experimental::BcastTo ALIAS ttnn_op_experimental_bcast_to)
 
 target_precompile_headers(ttnn_op_experimental_bcast_to REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_bcast_to)
 
 target_sources(
     ttnn_op_experimental_bcast_to

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_ccl ${LIB_TYPE})
 add_library(TT::NN::Ops::Experimental::CCL ALIAS ttnn_op_experimental_ccl)
 
 target_precompile_headers(ttnn_op_experimental_ccl REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_ccl)
 
 target_sources(
     ttnn_op_experimental_ccl

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_cnn OBJECT)
 add_library(TT::NN::Ops::Experimental::CNN ALIAS ttnn_op_experimental_cnn)
 
 target_precompile_headers(ttnn_op_experimental_cnn REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_cnn)
 
 target_sources(
     ttnn_op_experimental_cnn

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_conv3d ${LIB_TYPE})
 add_library(TT::NN::Ops::Experimental::Conv3d ALIAS ttnn_op_experimental_conv3d)
 
 target_precompile_headers(ttnn_op_experimental_conv3d REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_conv3d)
 
 target_sources(
     ttnn_op_experimental_conv3d

--- a/ttnn/cpp/ttnn/operations/experimental/copy/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/copy/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_copy ${LIB_TYPE})
 add_library(TT::NN::Ops::Experimental::Copy ALIAS ttnn_op_experimental_copy)
 
 target_precompile_headers(ttnn_op_experimental_copy REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_copy)
 
 target_sources(ttnn_op_experimental_copy PRIVATE typecast/typecast.cpp)
 

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_dropout ${LIB_TYPE})
 add_library(TT::NN::Ops::Experimental::Dropout ALIAS ttnn_op_experimental_dropout)
 
 target_precompile_headers(ttnn_op_experimental_dropout REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_dropout)
 
 target_sources(
     ttnn_op_experimental_dropout

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_matmul ${LIB_TYPE})
 add_library(TT::NN::Ops::Experimental::Matmul ALIAS ttnn_op_experimental_matmul)
 
 target_precompile_headers(ttnn_op_experimental_matmul REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_matmul)
 
 target_sources(
     ttnn_op_experimental_matmul

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_paged_cache ${LIB_TYPE})
 add_library(TT::NN::Ops::Experimental::PagedCache ALIAS ttnn_op_experimental_paged_cache)
 
 target_precompile_headers(ttnn_op_experimental_paged_cache REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_paged_cache)
 
 target_sources(
     ttnn_op_experimental_paged_cache

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_plusone ${LIB_TYPE})
 add_library(TT::NN::Ops::Experimental::PlusOne ALIAS ttnn_op_experimental_plusone)
 
 target_precompile_headers(ttnn_op_experimental_plusone REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_plusone)
 
 target_sources(
     ttnn_op_experimental_plusone

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_reduction ${LIB_TYPE})
 add_library(TT::NN::Ops::Experimental::Reduction ALIAS ttnn_op_experimental_reduction)
 
 target_precompile_headers(ttnn_op_experimental_reduction REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_reduction)
 
 target_sources(
     ttnn_op_experimental_reduction

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_reshape ${LIB_TYPE})
 add_library(TT::NN::Ops::Experimental::Reshape ALIAS ttnn_op_experimental_reshape)
 
 target_precompile_headers(ttnn_op_experimental_reshape REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_reshape)
 
 target_sources(ttnn_op_experimental_reshape PRIVATE view.cpp)
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_ssm ${LIB_TYPE})
 add_library(TT::NN::Ops::Experimental::SSM ALIAS ttnn_op_experimental_ssm)
 
 target_precompile_headers(ttnn_op_experimental_ssm REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_ssm)
 
 target_sources(
     ttnn_op_experimental_ssm

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_transformer ${LIB_TYPE})
 add_library(TT::NN::Ops::Experimental::Transformer ALIAS ttnn_op_experimental_transformer)
 
 target_precompile_headers(ttnn_op_experimental_transformer REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_transformer)
 
 target_sources(
     ttnn_op_experimental_transformer

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_experimental_unary_backward ${LIB_TYPE})
 add_library(TT::NN::Ops::Experimental::UnaryBackward ALIAS ttnn_op_experimental_unary_backward)
 
 target_precompile_headers(ttnn_op_experimental_unary_backward REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_unary_backward)
 
 target_sources(
     ttnn_op_experimental_unary_backward

--- a/ttnn/cpp/ttnn/operations/full/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/full/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_full ${LIB_TYPE})
 add_library(TT::NN::Ops::Full ALIAS ttnn_op_full)
 
 target_precompile_headers(ttnn_op_full REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_full)
 
 target_sources(
     ttnn_op_full

--- a/ttnn/cpp/ttnn/operations/full_like/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/full_like/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_full_like ${LIB_TYPE})
 add_library(TT::NN::Ops::FullLike ALIAS ttnn_op_full_like)
 
 target_precompile_headers(ttnn_op_full_like REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_full_like)
 
 target_sources(
     ttnn_op_full_like

--- a/ttnn/cpp/ttnn/operations/index_fill/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/index_fill/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_index_fill ${LIB_TYPE})
 add_library(TT::NN::Ops::IndexFill ALIAS ttnn_op_index_fill)
 
 target_precompile_headers(ttnn_op_index_fill REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_index_fill)
 
 target_sources(
     ttnn_op_index_fill

--- a/ttnn/cpp/ttnn/operations/kv_cache/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/kv_cache/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_kv_cache ${LIB_TYPE})
 add_library(TT::NN::Ops::KvCache ALIAS ttnn_op_kv_cache)
 
 target_precompile_headers(ttnn_op_kv_cache REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_kv_cache)
 
 target_sources(
     ttnn_op_kv_cache

--- a/ttnn/cpp/ttnn/operations/loss/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/loss/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_loss ${LIB_TYPE})
 add_library(TT::NN::Ops::Loss ALIAS ttnn_op_loss)
 
 target_precompile_headers(ttnn_op_loss REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_loss)
 
 target_sources(ttnn_op_loss PRIVATE loss.cpp)
 

--- a/ttnn/cpp/ttnn/operations/matmul/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/matmul/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_matmul ${LIB_TYPE})
 add_library(TT::NN::Ops::Matmul ALIAS ttnn_op_matmul)
 
 target_precompile_headers(ttnn_op_matmul REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_matmul)
 
 target_sources(
     ttnn_op_matmul

--- a/ttnn/cpp/ttnn/operations/moreh/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/moreh/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_moreh ${LIB_TYPE})
 add_library(TT::NN::Ops::Moreh ALIAS ttnn_op_moreh)
 
 target_precompile_headers(ttnn_op_moreh REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_moreh)
 
 target_sources(
     ttnn_op_moreh

--- a/ttnn/cpp/ttnn/operations/normalization/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/normalization/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_normalization ${LIB_TYPE})
 add_library(TT::NN::Ops::Normalization ALIAS ttnn_op_normalization)
 
 target_precompile_headers(ttnn_op_normalization REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_normalization)
 
 target_sources(
     ttnn_op_normalization

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
@@ -265,7 +265,8 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_post_allgather_multi_cor
         TT_FATAL(gamma_stick_size_is_power_of_two, "Only power of 2 gammas are supported");
         reader_compile_time_args.push_back((std::uint32_t)gamma_stick_size_is_power_of_two);
         // if (gamma_stick_size_is_power_of_two) {
-        uint32_t gamma_log2_stick_size = gamma_stick_size_is_power_of_two ? (std::uint32_t)log2(gamma_stick_size) : 0;
+        uint32_t gamma_log2_stick_size =
+            gamma_stick_size_is_power_of_two ? (std::uint32_t)std::log2(gamma_stick_size) : 0;
         reader_compile_time_args.push_back((std::uint32_t)gamma_log2_stick_size);
     }
 

--- a/ttnn/cpp/ttnn/operations/pool/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/pool/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_pool ${LIB_TYPE})
 add_library(TT::NN::Ops::Pool ALIAS ttnn_op_pool)
 
 target_precompile_headers(ttnn_op_pool REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_pool)
 
 target_sources(
     ttnn_op_pool

--- a/ttnn/cpp/ttnn/operations/prefetcher/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/prefetcher/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_prefetcher ${LIB_TYPE})
 add_library(TT::NN::Ops::Prefetcher ALIAS ttnn_op_prefetcher)
 
 target_precompile_headers(ttnn_op_prefetcher REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_prefetcher)
 
 target_sources(
     ttnn_op_prefetcher

--- a/ttnn/cpp/ttnn/operations/reduction/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/reduction/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_reduction ${LIB_TYPE})
 add_library(TT::NN::Ops::Reduction ALIAS ttnn_op_reduction)
 
 target_precompile_headers(ttnn_op_reduction REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_reduction)
 
 target_sources(
     ttnn_op_reduction

--- a/ttnn/cpp/ttnn/operations/sliding_window/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/sliding_window/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_sliding_window ${LIB_TYPE})
 add_library(TT::NN::Ops::SlidingWindow ALIAS ttnn_op_sliding_window)
 
 target_precompile_headers(ttnn_op_sliding_window REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_sliding_window)
 
 target_sources(
     ttnn_op_sliding_window

--- a/ttnn/cpp/ttnn/operations/transformer/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/transformer/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_transformer ${LIB_TYPE})
 add_library(TT::NN::Ops::Transformer ALIAS ttnn_op_transformer)
 
 target_precompile_headers(ttnn_op_transformer REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_transformer)
 
 target_sources(
     ttnn_op_transformer

--- a/ttnn/cpp/ttnn/operations/uniform/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/uniform/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ttnn_op_uniform ${LIB_TYPE})
 add_library(TT::NN::Ops::Uniform ALIAS ttnn_op_uniform)
 
 target_precompile_headers(ttnn_op_uniform REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_uniform)
 
 target_sources(
     ttnn_op_uniform


### PR DESCRIPTION
### Ticket
Follow-up to #22600

### Problem description
Unity builds got lost in the de-monolithification of TT-NN.

### What's changed
* Reenable unity builds on the sublibs
* Put in a missing include guard on a header
* Changed `log2` -> `std::log2` at once call site