### PR TITLE
Convert vector of TensorSpecs into Tensors

### DIFF
--- a/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -81,6 +82,12 @@ auto query_op_constraints(Op op, IDevice* device, Args&&... args) {
         auto transform_arg = [device](auto&& arg) {
             if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, TensorSpec>) {
                 return create_device_tensor(arg, device);
+            } else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, std::vector<TensorSpec>>) {
+                std::vector<Tensor> result(arg.size());
+                std::transform(arg.begin(), arg.end(), result.begin(), [device](auto&& item) {
+                    return create_device_tensor(item, device);
+                });
+                return result;
             } else {
                 return std::forward<decltype(arg)>(arg);
             }


### PR DESCRIPTION
A contraint/runtime query may contain a vector of TensorSpecs which need to be converted into a vector of Tensors for the op to consume.

This applies to the Concat Op.

### Ticket
Needed by the constraint API for Concat Op (https://github.com/tenstorrent/tt-mlir/issues/3554)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes