### PR TITLE
Migrate ControlPlane Under MetalContext

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -558,7 +558,7 @@ void test_single_connection_multi_device_socket(
     auto recv_virtual_coord = md1->worker_core_from_logical_core(recv_logical_coord);
 
     auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& fabric_context = control_plane->get_fabric_context();
     auto fabric_max_packet_size = fabric_context.get_fabric_max_payload_size_bytes();
     auto packet_header_size_bytes = fabric_context.get_fabric_packet_header_size_bytes();
@@ -758,7 +758,7 @@ void test_single_connection_multi_device_socket_with_workers(
     auto output_virtual_coord = md1->worker_core_from_logical_core(output_logical_coord);
 
     auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& fabric_context = control_plane->get_fabric_context();
 
     auto fabric_max_packet_size = fabric_context.get_fabric_max_payload_size_bytes();
@@ -945,9 +945,8 @@ std::shared_ptr<Program> create_sender_program(
     std::size_t data_size,
     const CoreCoord& sender_logical_coord,
     chip_id_t sender_physical_device_id,
-    chip_id_t recv_physical_device_id,
-    uint32_t sender_link_idx) {
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    chip_id_t recv_physical_device_id) {
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& fabric_context = control_plane->get_fabric_context();
 
     auto fabric_max_packet_size = fabric_context.get_fabric_max_payload_size_bytes();
@@ -979,7 +978,7 @@ std::shared_ptr<Program> create_sender_program(
     tt_fabric::append_fabric_connection_rt_args(
         sender_physical_device_id,
         recv_physical_device_id,
-        sender_link_idx,
+        0,
         *sender_program,
         {sender_logical_coord},
         sender_rtas);
@@ -999,10 +998,8 @@ std::shared_ptr<Program> create_split_reduce_program(
     const CoreCoord& reduce_logical_coord,
     chip_id_t sender0_physical_device_id,
     chip_id_t sender1_physical_device_id,
-    chip_id_t recv_physical_device_id,
-    uint32_t sender0_link_idx,
-    uint32_t sender1_link_idx) {
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    chip_id_t recv_physical_device_id) {
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& fabric_context = control_plane->get_fabric_context();
 
     auto packet_header_size_bytes = fabric_context.get_fabric_packet_header_size_bytes();
@@ -1119,14 +1116,14 @@ std::shared_ptr<Program> create_split_reduce_program(
     tt_fabric::append_fabric_connection_rt_args(
         recv_physical_device_id,
         sender0_physical_device_id,
-        sender0_link_idx,
+        0,
         *recv_program,
         {recv_logical_coord_0},
         recv_rtas_0);
     tt_fabric::append_fabric_connection_rt_args(
         recv_physical_device_id,
         sender1_physical_device_id,
-        sender1_link_idx,
+        0,
         *recv_program,
         {recv_logical_coord_1},
         recv_rtas_1);
@@ -1148,11 +1145,8 @@ std::shared_ptr<Program> create_reduce_program(
     chip_id_t sender0_physical_device_id,
     chip_id_t sender1_physical_device_id,
     chip_id_t reducer_physical_device_id,
-    chip_id_t recv_physical_device_id,
-    uint32_t sender0_link_idx,
-    uint32_t sender1_link_idx,
-    uint32_t recv_link_idx) {
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    chip_id_t recv_physical_device_id) {
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& fabric_context = control_plane->get_fabric_context();
 
     auto packet_header_size_bytes = fabric_context.get_fabric_packet_header_size_bytes();
@@ -1217,14 +1211,14 @@ std::shared_ptr<Program> create_reduce_program(
     tt_fabric::append_fabric_connection_rt_args(
         reducer_physical_device_id,
         sender0_physical_device_id,
-        sender0_link_idx,
+        0,
         *reduce_program,
         reduce_logical_coord,
         recv_rtas);
     tt_fabric::append_fabric_connection_rt_args(
         reducer_physical_device_id,
         sender1_physical_device_id,
-        sender1_link_idx,
+        0,
         *reduce_program,
         reduce_logical_coord,
         recv_rtas);
@@ -1235,7 +1229,7 @@ std::shared_ptr<Program> create_reduce_program(
     tt_fabric::append_fabric_connection_rt_args(
         reducer_physical_device_id,
         recv_physical_device_id,
-        recv_link_idx,
+        0,
         *reduce_program,
         reduce_logical_coord,
         send_rtas);
@@ -1252,9 +1246,8 @@ std::shared_ptr<Program> create_recv_program(
     const CoreCoord& recv_logical_coord,
     const CoreCoord& output_logical_coord,
     chip_id_t sender_physical_device_id,
-    chip_id_t recv_physical_device_id,
-    uint32_t recv_link_idx) {
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    chip_id_t recv_physical_device_id) {
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& fabric_context = control_plane->get_fabric_context();
 
     auto packet_header_size_bytes = fabric_context.get_fabric_packet_header_size_bytes();
@@ -1296,7 +1289,7 @@ std::shared_ptr<Program> create_recv_program(
     tt_fabric::append_fabric_connection_rt_args(
         recv_physical_device_id,
         sender_physical_device_id,
-        recv_link_idx,
+        0,
         *recv_program,
         {recv_logical_coord},
         recv_rtas);
@@ -1423,8 +1416,7 @@ void test_multi_sender_single_recv(
         data_size,
         sender_logical_coord,
         sender_0_physical_device_id,
-        reducer_physical_device_id,
-        0);
+        reducer_physical_device_id);
     auto sender_program_1 = create_sender_program(
         send_socket_1,
         sender_data_buffer_1,
@@ -1432,8 +1424,7 @@ void test_multi_sender_single_recv(
         data_size,
         sender_logical_coord,
         sender_1_physical_device_id,
-        reducer_physical_device_id,
-        0);
+        reducer_physical_device_id);
     std::shared_ptr<Program> reduce_program = nullptr;
     std::shared_ptr<Program> sender_program_2 = nullptr;
     if (split_reducer) {
@@ -1448,9 +1439,7 @@ void test_multi_sender_single_recv(
             reduce_logical_coord,
             sender_0_physical_device_id,
             sender_1_physical_device_id,
-            reducer_physical_device_id,
-            link_indices[0],
-            link_indices[1]);
+            reducer_physical_device_id);
         sender_program_2 = create_sender_program(
             send_socket_2,
             reduce_data_buffer,
@@ -1458,8 +1447,7 @@ void test_multi_sender_single_recv(
             data_size,
             reduce_logical_coord,
             reducer_physical_device_id,
-            receiver_physical_device_id,
-            link_indices[2]);
+            receiver_physical_device_id);
 
     } else {
         reduce_program = create_reduce_program(
@@ -1473,10 +1461,7 @@ void test_multi_sender_single_recv(
             sender_0_physical_device_id,
             sender_1_physical_device_id,
             reducer_physical_device_id,
-            receiver_physical_device_id,
-            link_indices[0],
-            link_indices[1],
-            link_indices[2]);
+            receiver_physical_device_id);
     }
     auto recv_program = create_recv_program(
         recv_socket_2,
@@ -1486,8 +1471,7 @@ void test_multi_sender_single_recv(
         recv0_logical_coord,
         output_logical_coord,
         reducer_physical_device_id,
-        receiver_physical_device_id,
-        0);
+        receiver_physical_device_id);
 
     auto sender_0_mesh_workload = CreateMeshWorkload();
     MeshCoordinateRange devices_0(sender_0->shape());
@@ -1614,8 +1598,7 @@ void test_multi_connection_multi_device_data_copy(
             data_size,
             sender_logical_core,
             sender_physical_id,
-            recv_physical_id,
-            0);
+            recv_physical_id);
         auto recv_program = create_recv_program(
             recv_socket,
             recv_data_buffer,
@@ -1624,8 +1607,7 @@ void test_multi_connection_multi_device_data_copy(
             recv_logical_core,
             recv_logical_core,
             sender_physical_id,
-            recv_physical_id,
-            0);
+            recv_physical_id);
 
         AddProgramToMeshWorkload(
             sender_mesh_workload, std::move(*sender_program), MeshCoordinateRange(connection.sender_core.device_coord));
@@ -1712,7 +1694,7 @@ void run_multi_sender_single_recv(FixtureT* fixture, bool split_reducer) {
             ++idx;
             return MeshCoordinate(x, y);
         });
-        auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+        auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
         while (true) {
             link_indices.clear();
             std::shuffle(coordinates.begin(), coordinates.end(), std::mt19937(std::random_device()()));
@@ -1786,7 +1768,7 @@ void run_multi_connection_multi_device_data_copy(FixtureT* fixture) {
 
 // Sanity test with a single connection
 TEST_F(MeshSocketTest, SingleConnectionSingleDeviceConfig) {
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
     auto current_device_id = md0->get_device(MeshCoordinate(0, 0))->id();
     auto current_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(current_device_id);
@@ -1838,7 +1820,7 @@ TEST_F(MeshSocketTest, SingleConnectionSingleDeviceConfig) {
 
 // Test multiple connections
 TEST_F(MeshSocketTest, MultiConnectionSingleDeviceConfig) {
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
     auto current_device_id = md0->get_device(MeshCoordinate(0, 0))->id();
     auto current_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(current_device_id);
@@ -1918,7 +1900,7 @@ TEST_F(MeshSocketTest, MultiConnectionSingleDeviceConfig) {
 
 // Test random connections across multiple devices
 TEST_F(MeshSocketTest2DFabric, MultiConnectionMultiDeviceTest) {
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto md0 = mesh_device_->create_submesh(MeshShape(1, 4), MeshCoordinate(0, 0));
     auto md1 = mesh_device_->create_submesh(MeshShape(1, 4), MeshCoordinate(1, 0));
     std::unordered_map<MeshCoordinate, chip_id_t> sender_device_coord_to_id;

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -103,7 +103,7 @@ public:
     void SetUp(
         const std::string& mesh_graph_desc_file,
         const std::map<FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
-        tt::tt_metal::MetalContext::instance().get_cluster().set_custom_control_plane_mesh_graph(
+        tt::tt_metal::MetalContext::instance().set_custom_control_plane_mesh_graph(
             mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
         this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC);
     }
@@ -113,7 +113,7 @@ private:
 
     void TearDown() override {
         BaseFabricFixture::TearDown();
-        tt::tt_metal::MetalContext::instance().get_cluster().set_default_control_plane_mesh_graph();
+        tt::tt_metal::MetalContext::instance().set_default_control_plane_mesh_graph();
     }
 };
 

--- a/tests/tt_metal/tt_fabric/common/utils.cpp
+++ b/tests/tt_metal/tt_fabric/common/utils.cpp
@@ -23,15 +23,15 @@ bool find_device_with_neighbor_in_multi_direction(
     std::unordered_map<RoutingDirection, std::vector<chip_id_t>>& dst_physical_device_ids_by_dir,
     const std::unordered_map<RoutingDirection, uint32_t>& mcast_hops,
     std::optional<RoutingDirection> incoming_direction) {
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     auto devices = fixture->get_devices();
     // Find a device with enough neighbours in the specified direction
     bool connection_found = false;
     for (auto* device : devices) {
-        src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(device->id());
+        src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->id());
         if (incoming_direction.has_value()) {
-            if (!control_plane->get_intra_chip_neighbors(src_fabric_node_id, incoming_direction.value()).size()) {
+            if (!control_plane.get_intra_chip_neighbors(src_fabric_node_id, incoming_direction.value()).size()) {
                 // This potential source will not have the requested incoming direction, skip
                 continue;
             }
@@ -45,11 +45,11 @@ bool find_device_with_neighbor_in_multi_direction(
             auto& temp_physical_end_device_ids = temp_physical_end_device_ids_by_dir[routing_direction];
             auto curr_fabric_node_id = src_fabric_node_id;
             for (uint32_t i = 0; i < num_hops; i++) {
-                auto neighbors = control_plane->get_intra_chip_neighbors(curr_fabric_node_id, routing_direction);
+                auto neighbors = control_plane.get_intra_chip_neighbors(curr_fabric_node_id, routing_direction);
                 if (neighbors.size() > 0) {
                     temp_end_fabric_node_ids.emplace_back(curr_fabric_node_id.mesh_id, neighbors[0]);
                     temp_physical_end_device_ids.push_back(
-                        control_plane->get_physical_chip_id_from_fabric_node_id(temp_end_fabric_node_ids.back()));
+                        control_plane.get_physical_chip_id_from_fabric_node_id(temp_end_fabric_node_ids.back()));
                     curr_fabric_node_id = temp_end_fabric_node_ids.back();
                 } else {
                     direction_found = false;
@@ -78,17 +78,17 @@ bool find_device_with_neighbor_in_direction(
     chip_id_t& src_physical_device_id,
     chip_id_t& dst_physical_device_id,
     RoutingDirection direction) {
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     auto devices = fixture->get_devices();
     for (auto* device : devices) {
-        src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(device->id());
+        src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->id());
 
         // Get neighbours within a mesh in the given direction
-        auto neighbors = control_plane->get_intra_chip_neighbors(src_fabric_node_id, direction);
+        auto neighbors = control_plane.get_intra_chip_neighbors(src_fabric_node_id, direction);
         if (neighbors.size() > 0) {
             src_physical_device_id = device->id();
             dst_fabric_node_id = FabricNodeId(src_fabric_node_id.mesh_id, neighbors[0]);
-            dst_physical_device_id = control_plane->get_physical_chip_id_from_fabric_node_id(dst_fabric_node_id);
+            dst_physical_device_id = control_plane.get_physical_chip_id_from_fabric_node_id(dst_fabric_node_id);
             return true;
         }
     }

--- a/tests/tt_metal/tt_fabric/common/utils.cpp
+++ b/tests/tt_metal/tt_fabric/common/utils.cpp
@@ -23,7 +23,7 @@ bool find_device_with_neighbor_in_multi_direction(
     std::unordered_map<RoutingDirection, std::vector<chip_id_t>>& dst_physical_device_ids_by_dir,
     const std::unordered_map<RoutingDirection, uint32_t>& mcast_hops,
     std::optional<RoutingDirection> incoming_direction) {
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     auto devices = fixture->get_devices();
     // Find a device with enough neighbours in the specified direction
@@ -78,7 +78,7 @@ bool find_device_with_neighbor_in_direction(
     chip_id_t& src_physical_device_id,
     chip_id_t& dst_physical_device_id,
     RoutingDirection direction) {
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto devices = fixture->get_devices();
     for (auto* device : devices) {
         src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(device->id());

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -106,11 +106,11 @@ std::shared_ptr<tt_metal::Program> create_receiver_program(
 
 void RunTestLineMcast(
     BaseFabricFixture* fixture, RoutingDirection unicast_dir, const std::vector<McastRoutingInfo>& mcast_routing_info) {
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    auto user_meshes = control_plane->get_user_physical_mesh_ids();
+    auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto user_meshes = control_plane.get_user_physical_mesh_ids();
     bool system_accomodates_mcast = false;
     for (const auto& mesh : user_meshes) {
-        auto mesh_shape = control_plane->get_physical_mesh_shape(mesh);
+        auto mesh_shape = control_plane.get_physical_mesh_shape(mesh);
         // Need at least 8 chips for all mcast tests
         if (mesh_shape.mesh_size() >= 8) {
             system_accomodates_mcast = true;
@@ -148,8 +148,8 @@ void RunTestLineMcast(
 
     // Compute coordinates of the remote chip that sends an mcast request to the mcast sender
     FabricNodeId sender_id =
-        FabricNodeId(mcast_start_id.mesh_id, control_plane->get_intra_chip_neighbors(mcast_start_id, unicast_dir)[0]);
-    auto sender_phys_id = control_plane->get_physical_chip_id_from_fabric_node_id(sender_id);
+        FabricNodeId(mcast_start_id.mesh_id, control_plane.get_intra_chip_neighbors(mcast_start_id, unicast_dir)[0]);
+    auto sender_phys_id = control_plane.get_physical_chip_id_from_fabric_node_id(sender_id);
     // Compute physical IDs for mcast group chips
     std::vector<chip_id_t> mcast_group_phys_ids = {};
     for (const auto& routing_info : mcast_routing_info) {
@@ -161,12 +161,12 @@ void RunTestLineMcast(
     CoreCoord sender_logical_core = {0, 0};    // This core on the sender (remote chip) will make the mcast request
     CoreCoord receiver_logical_core = {1, 0};  // Data will be forwarded to this core on al chips in the mcast group
 
-    const auto& fabric_context = control_plane->get_fabric_context();
+    const auto& fabric_context = control_plane.get_fabric_context();
     const auto topology = fabric_context.get_fabric_topology();
     const auto& edm_config = fabric_context.get_fabric_router_config();
     uint32_t is_2d_fabric = edm_config.topology == Topology::Mesh;
 
-    auto routers = control_plane->get_forwarding_eth_chans_to_chip(sender_id, mcast_start_id);
+    auto routers = control_plane.get_forwarding_eth_chans_to_chip(sender_id, mcast_start_id);
     if (routers.size() == 0) {
         log_info(
             tt::LogTest,
@@ -192,7 +192,7 @@ void RunTestLineMcast(
     auto receiver_noc_encoding =
         tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
 
-    auto mesh_shape = control_plane->get_physical_mesh_shape(sender_id.mesh_id);
+    auto mesh_shape = control_plane.get_physical_mesh_shape(sender_id.mesh_id);
 
     auto worker_mem_map = generate_worker_mem_map(sender_device, edm_config.topology);
     uint32_t num_packets = 100;
@@ -231,7 +231,7 @@ void RunTestLineMcast(
     std::vector<uint32_t> mcast_header_rtas(4, 0);
     for (const auto& routing_info : mcast_routing_info) {
         mcast_header_rtas[static_cast<uint32_t>(
-            control_plane->routing_direction_to_eth_direction(routing_info.mcast_dir))] = routing_info.num_mcast_hops;
+            control_plane.routing_direction_to_eth_direction(routing_info.mcast_dir))] = routing_info.num_mcast_hops;
     }
     sender_runtime_args.insert(sender_runtime_args.end(), mcast_header_rtas.begin(), mcast_header_rtas.end());
     // append the EDM connection rt args
@@ -297,7 +297,7 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
     CoreCoord sender_logical_core = {0, 0};
     CoreCoord receiver_logical_core = {1, 0};
 
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
 
     FabricNodeId src_fabric_node_id(MeshId{0}, 0);
     FabricNodeId dst_fabric_node_id(MeshId{0}, 0);
@@ -315,7 +315,7 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
     std::vector<chan_id_t> eth_chans;
     chan_id_t edm_port;
 
-    const auto& fabric_context = control_plane->get_fabric_context();
+    const auto& fabric_context = control_plane.get_fabric_context();
     const auto topology = fabric_context.get_fabric_topology();
     const auto& edm_config = fabric_context.get_fabric_router_config();
     uint32_t is_2d_fabric = topology == Topology::Mesh;
@@ -331,12 +331,12 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
                 fabric_hops)) {
             GTEST_SKIP() << "No path found between sender and receivers";
         }
-        mesh_shape = control_plane->get_physical_mesh_shape(src_fabric_node_id.mesh_id);
+        mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
         dst_physical_device_id = physical_end_device_ids_by_dir[direction][num_hops - 1];
         dst_fabric_node_id = end_fabric_node_ids_by_dir[direction][num_hops - 1];
 
         // get a port to connect to
-        eth_chans = control_plane->get_active_fabric_eth_channels_in_direction(src_fabric_node_id, direction);
+        eth_chans = control_plane.get_active_fabric_eth_channels_in_direction(src_fabric_node_id, direction);
         if (eth_chans.size() == 0) {
             GTEST_SKIP() << "No active eth chans to connect to";
         }
@@ -350,11 +350,11 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
         // pick the first two in the list to be src and dst devices for the test.
         src_physical_device_id = devices[random_dev_list[0]]->id();
         dst_physical_device_id = devices[random_dev_list[1]]->id();
-        src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(src_physical_device_id);
-        dst_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(dst_physical_device_id);
-        mesh_shape = control_plane->get_physical_mesh_shape(src_fabric_node_id.mesh_id);
+        src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device_id);
+        dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dst_physical_device_id);
+        mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
 
-        eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_fabric_node_id, dst_fabric_node_id);
+        eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_fabric_node_id, dst_fabric_node_id);
         if (eth_chans.size() == 0) {
             log_info(
                 tt::LogTest,
@@ -378,7 +378,7 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
     tt::log_info(tt::LogTest, "Src MeshId {} ChipId {}", src_fabric_node_id.mesh_id, src_fabric_node_id.chip_id);
     tt::log_info(tt::LogTest, "Dst MeshId {} ChipId {}", dst_fabric_node_id.mesh_id, dst_fabric_node_id.chip_id);
 
-    auto edm_direction = control_plane->get_eth_chan_direction(src_fabric_node_id, edm_port);
+    auto edm_direction = control_plane.get_eth_chan_direction(src_fabric_node_id, edm_port);
     CoreCoord edm_eth_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
         src_physical_device_id, edm_port);
 
@@ -522,9 +522,9 @@ void run_unicast_test_bw_chips(
     CoreCoord sender_logical_core = {0, 0};
     CoreCoord receiver_logical_core = {1, 0};
 
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    auto src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(src_physical_device_id);
-    auto dst_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(dst_physical_device_id);
+    const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device_id);
+    auto dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dst_physical_device_id);
 
     auto* sender_device = DevicePool::instance().get_active_device(src_physical_device_id);
     auto* receiver_device = DevicePool::instance().get_active_device(dst_physical_device_id);
@@ -535,7 +535,7 @@ void run_unicast_test_bw_chips(
         tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
 
     const auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
-    const auto topology = control_plane->get_fabric_context().get_fabric_topology();
+    const auto topology = control_plane.get_fabric_context().get_fabric_topology();
     uint32_t is_2d_fabric = topology == Topology::Mesh;
 
     // test parameters
@@ -569,7 +569,7 @@ void run_unicast_test_bw_chips(
             .compile_args = compile_time_args,
             .defines = defines});
 
-    auto mesh_shape = control_plane->get_physical_mesh_shape(src_fabric_node_id.mesh_id);
+    auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
     tt::log_info(tt::LogTest, "mesh dimensions {:x}", mesh_shape.dims());
     tt::log_info(tt::LogTest, "mesh dimension 0 {:x}", mesh_shape[0]);
     tt::log_info(tt::LogTest, "mesh dimension 1 {:x}", mesh_shape[1]);
@@ -654,7 +654,7 @@ void run_unicast_test_bw_chips(
 }
 
 void RunTestUnicastConnAPI(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDirection direction) {
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
 
     FabricNodeId src_fabric_node_id(MeshId{0}, 0);
     FabricNodeId dst_fabric_node_id(MeshId{0}, 0);
@@ -671,8 +671,8 @@ void RunTestUnicastConnAPI(BaseFabricFixture* fixture, uint32_t num_hops, Routin
     tt::log_info(tt::LogTest, "Dst MeshId {} ChipId {}", dst_fabric_node_id.mesh_id, dst_fabric_node_id.chip_id);
     tt::log_info(tt::LogTest, "Dst Device is {} hops in direction: {}", num_hops, direction);
 
-    chip_id_t src_physical_device_id = control_plane->get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
-    chip_id_t dst_physical_device_id = control_plane->get_physical_chip_id_from_fabric_node_id(dst_fabric_node_id);
+    chip_id_t src_physical_device_id = control_plane.get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
+    chip_id_t dst_physical_device_id = control_plane.get_physical_chip_id_from_fabric_node_id(dst_fabric_node_id);
 
     run_unicast_test_bw_chips(fixture, src_physical_device_id, dst_physical_device_id, num_hops);
 }
@@ -680,7 +680,7 @@ void RunTestUnicastConnAPI(BaseFabricFixture* fixture, uint32_t num_hops, Routin
 void RunTestUnicastConnAPIRandom(BaseFabricFixture* fixture) {
     const auto topology = tt::tt_metal::MetalContext::instance()
                               .get_control_plane()
-                              ->get_fabric_context()
+                              .get_fabric_context()
                               .get_fabric_topology();
     uint32_t is_2d_fabric = topology == Topology::Mesh;
     if (!is_2d_fabric) {
@@ -741,13 +741,13 @@ void RunTestMCastConnAPI(
     CoreCoord receiver_logical_core = {1, 0};
     std::vector<tt_metal::Program> receiver_programs;
 
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // use control plane to find a mesh with 3 devices
-    auto user_meshes = control_plane->get_user_physical_mesh_ids();
+    auto user_meshes = control_plane.get_user_physical_mesh_ids();
     std::optional<MeshId> mesh_id;
     for (const auto& mesh : user_meshes) {
-        auto mesh_shape = control_plane->get_physical_mesh_shape(mesh);
+        auto mesh_shape = control_plane.get_physical_mesh_shape(mesh);
         if (mesh_shape.mesh_size() >= 3) {
             mesh_id = mesh;
             break;
@@ -767,7 +767,7 @@ void RunTestMCastConnAPI(
     fabric_hops[bwd_dir] = bwd_hops;
 
     tt::tt_metal::distributed::MeshShape mesh_shape;
-    const auto topology = control_plane->get_fabric_context().get_fabric_topology();
+    const auto topology = control_plane.get_fabric_context().get_fabric_topology();
     uint32_t is_2d_fabric = topology == Topology::Mesh;
 
     // Get the mcast sender device and mcast receiver devices that satisfy the input number of hops in forward and
@@ -789,7 +789,7 @@ void RunTestMCastConnAPI(
         GTEST_SKIP() << "Skipping Test";
     }
 
-    mesh_shape = control_plane->get_physical_mesh_shape(src_fabric_node_id.mesh_id);
+    mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
     auto left_recv_phys_chip_id = physical_end_device_ids_by_dir[fwd_dir][fwd_hops - 1];
     auto left_first_hop_phys_chip_id = physical_end_device_ids_by_dir[fwd_dir][0];
     auto right_recv_phys_chip_id = physical_end_device_ids_by_dir[bwd_dir][bwd_hops - 1];
@@ -990,7 +990,7 @@ TEST_F(Fabric1DFixture, DISABLED_TestEDMConnectionStressTestQuick) {
     size_t num_times_to_connect = 20000;  // How many times each worker connects during its turn
 
     log_debug(tt::LogTest, "Starting EDM connection stress test");
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     log_debug(tt::LogTest, "Control plane found");
 
     std::pair<MeshId, chip_id_t> src_mesh_chip_id;
@@ -998,10 +998,10 @@ TEST_F(Fabric1DFixture, DISABLED_TestEDMConnectionStressTestQuick) {
     chip_id_t not_used_1;
     chip_id_t not_used_2;
     // use control plane to find a mesh with 3 devices
-    auto user_meshes = control_plane->get_user_physical_mesh_ids();
+    auto user_meshes = control_plane.get_user_physical_mesh_ids();
     std::optional<MeshId> mesh_id;
     for (const auto& mesh : user_meshes) {
-        auto mesh_shape = control_plane->get_physical_mesh_shape(mesh);
+        auto mesh_shape = control_plane.get_physical_mesh_shape(mesh);
         if (mesh_shape.mesh_size() > 1) {
             mesh_id = mesh;
             break;
@@ -1013,9 +1013,9 @@ TEST_F(Fabric1DFixture, DISABLED_TestEDMConnectionStressTestQuick) {
 
     log_debug(tt::LogTest, "Mesh ID: {}", mesh_id.value());
     auto src_physical_device_id =
-        control_plane->get_physical_chip_id_from_fabric_node_id(FabricNodeId(mesh_id.value(), 0));
+        control_plane.get_physical_chip_id_from_fabric_node_id(FabricNodeId(mesh_id.value(), 0));
     auto dst_physical_device_id =
-        control_plane->get_physical_chip_id_from_fabric_node_id(FabricNodeId(mesh_id.value(), 1));
+        control_plane.get_physical_chip_id_from_fabric_node_id(FabricNodeId(mesh_id.value(), 1));
 
     auto* sender_device = DevicePool::instance().get_active_device(src_physical_device_id);
     auto* receiver_device = DevicePool::instance().get_active_device(dst_physical_device_id);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -106,7 +106,7 @@ std::shared_ptr<tt_metal::Program> create_receiver_program(
 
 void RunTestLineMcast(
     BaseFabricFixture* fixture, RoutingDirection unicast_dir, const std::vector<McastRoutingInfo>& mcast_routing_info) {
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto user_meshes = control_plane->get_user_physical_mesh_ids();
     bool system_accomodates_mcast = false;
     for (const auto& mesh : user_meshes) {
@@ -297,7 +297,7 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
     CoreCoord sender_logical_core = {0, 0};
     CoreCoord receiver_logical_core = {1, 0};
 
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     FabricNodeId src_fabric_node_id(MeshId{0}, 0);
     FabricNodeId dst_fabric_node_id(MeshId{0}, 0);
@@ -397,7 +397,7 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
     uint32_t num_packets = 10;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
-    const auto fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
+    const auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
 
     // common compile time args for sender and receiver
     std::vector<uint32_t> compile_time_args = {
@@ -522,7 +522,7 @@ void run_unicast_test_bw_chips(
     CoreCoord sender_logical_core = {0, 0};
     CoreCoord receiver_logical_core = {1, 0};
 
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(src_physical_device_id);
     auto dst_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(dst_physical_device_id);
 
@@ -534,7 +534,7 @@ void run_unicast_test_bw_chips(
     auto receiver_noc_encoding =
         tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
 
-    const auto fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
+    const auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     const auto topology = control_plane->get_fabric_context().get_fabric_topology();
     uint32_t is_2d_fabric = topology == Topology::Mesh;
 
@@ -654,7 +654,7 @@ void run_unicast_test_bw_chips(
 }
 
 void RunTestUnicastConnAPI(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDirection direction) {
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     FabricNodeId src_fabric_node_id(MeshId{0}, 0);
     FabricNodeId dst_fabric_node_id(MeshId{0}, 0);
@@ -679,7 +679,6 @@ void RunTestUnicastConnAPI(BaseFabricFixture* fixture, uint32_t num_hops, Routin
 
 void RunTestUnicastConnAPIRandom(BaseFabricFixture* fixture) {
     const auto topology = tt::tt_metal::MetalContext::instance()
-                              .get_cluster()
                               .get_control_plane()
                               ->get_fabric_context()
                               .get_fabric_topology();
@@ -742,7 +741,7 @@ void RunTestMCastConnAPI(
     CoreCoord receiver_logical_core = {1, 0};
     std::vector<tt_metal::Program> receiver_programs;
 
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // use control plane to find a mesh with 3 devices
     auto user_meshes = control_plane->get_user_physical_mesh_ids();
@@ -814,7 +813,7 @@ void RunTestMCastConnAPI(
     uint32_t num_packets = 100;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
-    const auto fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
+    const auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
 
     // common compile time args for sender and receiver
     std::vector<uint32_t> compile_time_args = {
@@ -991,7 +990,7 @@ TEST_F(Fabric1DFixture, DISABLED_TestEDMConnectionStressTestQuick) {
     size_t num_times_to_connect = 20000;  // How many times each worker connects during its turn
 
     log_debug(tt::LogTest, "Starting EDM connection stress test");
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     log_debug(tt::LogTest, "Control plane found");
 
     std::pair<MeshId, chip_id_t> src_mesh_chip_id;

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -148,7 +148,7 @@ void RunAsyncWriteTest(
     FabricNodeId end_fabric_node_id(MeshId{0}, 0);
     chip_id_t physical_end_device_id;
 
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Find a device with a neighbour in the specified direction
     if (!find_device_with_neighbor_in_direction(
@@ -165,7 +165,7 @@ void RunAsyncWriteTest(
     tt::log_info(tt::LogTest, "{} from {} to {}", test_type, start_fabric_node_id.chip_id, end_fabric_node_id.chip_id);
 
     // Get the optimal channels (no internal hops) on the start chip that will forward in the direction of the end chip
-    auto router_chans = control_plane->get_forwarding_eth_chans_to_chip(start_fabric_node_id, end_fabric_node_id);
+    auto router_chans = control_plane.get_forwarding_eth_chans_to_chip(start_fabric_node_id, end_fabric_node_id);
 
     auto* sender_device = DevicePool::instance().get_active_device(physical_start_device_id);
     auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_id);
@@ -211,7 +211,7 @@ void RunAsyncWriteTest(
     // Create the sender program
     std::vector<uint32_t> sender_compile_time_args = {
         (uint32_t)mode, (uint32_t)test_mode::TEST_ASYNC_WRITE, (uint32_t)is_raw_write};
-    auto outbound_eth_channels = control_plane->get_active_fabric_eth_channels(start_fabric_node_id);
+    auto outbound_eth_channels = control_plane.get_active_fabric_eth_channels(start_fabric_node_id);
     auto router_virtual_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
         physical_start_device_id, *router_chans.begin());
     std::vector<uint32_t> sender_runtime_args = {
@@ -265,7 +265,7 @@ void RunAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode) {
     FabricNodeId end_fabric_node_id(MeshId{0}, 0);
     chip_id_t physical_end_device_id;
 
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Find a device with a neighbour in the East direction
     if (!find_device_with_neighbor_in_direction(
@@ -279,7 +279,7 @@ void RunAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode) {
     }
 
     // Get the optimal channels (no internal hops) on the start chip that will forward in the direction of the end chip
-    auto router_chans = control_plane->get_forwarding_eth_chans_to_chip(start_fabric_node_id, end_fabric_node_id);
+    auto router_chans = control_plane.get_forwarding_eth_chans_to_chip(start_fabric_node_id, end_fabric_node_id);
 
     auto* sender_device = DevicePool::instance().get_active_device(physical_start_device_id);
     auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_id);
@@ -319,7 +319,7 @@ void RunAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode) {
     }
     defines["DISABLE_LOW_LATENCY_ROUTING"] = "";
     std::vector<uint32_t> sender_compile_time_args = {(uint32_t)mode, (uint32_t)TEST_ATOMIC_INC, 0};
-    auto outbound_eth_channels = control_plane->get_active_fabric_eth_channels(start_fabric_node_id);
+    auto outbound_eth_channels = control_plane.get_active_fabric_eth_channels(start_fabric_node_id);
     auto router_virtual_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
         physical_start_device_id, *router_chans.begin());
     std::vector<uint32_t> sender_runtime_args = {
@@ -365,7 +365,7 @@ void RunAsyncWriteAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode, bo
     FabricNodeId end_fabric_node_id(MeshId{0}, 0);
     chip_id_t physical_end_device_id;
 
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Find a device with a neighbour in the East direction
     if (!find_device_with_neighbor_in_direction(
@@ -379,7 +379,7 @@ void RunAsyncWriteAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode, bo
     }
 
     // Get the optimal channels (no internal hops) on the start chip that will forward in the direction of the end chip
-    auto router_chans = control_plane->get_forwarding_eth_chans_to_chip(start_fabric_node_id, end_fabric_node_id);
+    auto router_chans = control_plane.get_forwarding_eth_chans_to_chip(start_fabric_node_id, end_fabric_node_id);
 
     auto* sender_device = DevicePool::instance().get_active_device(physical_start_device_id);
     auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_id);
@@ -438,7 +438,7 @@ void RunAsyncWriteAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode, bo
     defines["DISABLE_LOW_LATENCY_ROUTING"] = "";
     std::vector<uint32_t> sender_compile_time_args = {
         (uint32_t)mode, (uint32_t)TEST_ASYNC_WRITE_ATOMIC_INC, (uint32_t)is_raw_write};
-    auto outbound_eth_channels = control_plane->get_active_fabric_eth_channels(start_fabric_node_id);
+    auto outbound_eth_channels = control_plane.get_active_fabric_eth_channels(start_fabric_node_id);
     auto router_virtual_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
         physical_start_device_id, *router_chans.begin());
     std::vector<uint32_t> sender_runtime_args = {
@@ -500,7 +500,7 @@ void RunAsyncWriteMulticastTest(
         mcast_hops[RoutingDirection::E] = 1;
     }
 
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Find a device with enough neighbours in the specified directions
     if (!find_device_with_neighbor_in_multi_direction(
@@ -606,7 +606,7 @@ void RunAsyncWriteMulticastTest(
     std::unordered_map<RoutingDirection, uint32_t> sender_router_noc_xys;
     for (auto& [routing_direction, end_fabric_node_ids] : end_fabric_node_ids_by_dir) {
         auto router_chans =
-            control_plane->get_forwarding_eth_chans_to_chip(start_fabric_node_id, end_fabric_node_ids[0]);
+            control_plane.get_forwarding_eth_chans_to_chip(start_fabric_node_id, end_fabric_node_ids[0]);
         const auto& sender_virtual_router_coord =
             tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
                 physical_start_device_id, *router_chans.begin());
@@ -617,7 +617,7 @@ void RunAsyncWriteMulticastTest(
     }
 
     // Prepare runtime args based on whether it's multidirectional or not
-    auto outbound_eth_channels = control_plane->get_active_fabric_eth_channels(start_fabric_node_id);
+    auto outbound_eth_channels = control_plane.get_active_fabric_eth_channels(start_fabric_node_id);
     std::vector<uint32_t> sender_runtime_args;
 
     if (multidirectional) {

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -148,7 +148,7 @@ void RunAsyncWriteTest(
     FabricNodeId end_fabric_node_id(MeshId{0}, 0);
     chip_id_t physical_end_device_id;
 
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Find a device with a neighbour in the specified direction
     if (!find_device_with_neighbor_in_direction(
@@ -265,7 +265,7 @@ void RunAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode) {
     FabricNodeId end_fabric_node_id(MeshId{0}, 0);
     chip_id_t physical_end_device_id;
 
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Find a device with a neighbour in the East direction
     if (!find_device_with_neighbor_in_direction(
@@ -365,7 +365,7 @@ void RunAsyncWriteAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode, bo
     FabricNodeId end_fabric_node_id(MeshId{0}, 0);
     chip_id_t physical_end_device_id;
 
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Find a device with a neighbour in the East direction
     if (!find_device_with_neighbor_in_direction(
@@ -500,7 +500,7 @@ void RunAsyncWriteMulticastTest(
         mcast_hops[RoutingDirection::E] = 1;
     }
 
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Find a device with enough neighbours in the specified directions
     if (!find_device_with_neighbor_in_multi_direction(

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -106,8 +106,8 @@ WorkerMemoryMap create_worker_memory_map(const uint32_t base_l1_address) {
 
 // first generates the physical chip id matrix and then returns the sequence of connected chip ids
 std::vector<chip_id_t> get_physical_chip_sequence(uint32_t num_seq_chips) {
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
-    tt::tt_fabric::MeshId mesh_id = control_plane->get_user_physical_mesh_ids()[0];
+    auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    tt::tt_fabric::mesh_id_t mesh_id = control_plane->get_user_physical_mesh_ids()[0];
 
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     uint32_t chip_id_offset = 0;

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -106,8 +106,8 @@ WorkerMemoryMap create_worker_memory_map(const uint32_t base_l1_address) {
 
 // first generates the physical chip id matrix and then returns the sequence of connected chip ids
 std::vector<chip_id_t> get_physical_chip_sequence(uint32_t num_seq_chips) {
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    tt::tt_fabric::mesh_id_t mesh_id = control_plane->get_user_physical_mesh_ids()[0];
+    auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
+    tt::tt_fabric::MeshId mesh_id = control_plane.get_user_physical_mesh_ids()[0];
 
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     uint32_t chip_id_offset = 0;
@@ -121,7 +121,7 @@ std::vector<chip_id_t> get_physical_chip_sequence(uint32_t num_seq_chips) {
     std::unordered_map<tt_fabric::RoutingDirection, chip_id_t> chip_0_neigbors;
     std::optional<tt_fabric::RoutingDirection> chip_1_direction = std::nullopt;
     for (const auto& direction : routing_directions) {
-        auto neighbors = control_plane->get_intra_chip_neighbors(FabricNodeId(mesh_id, 0), direction);
+        auto neighbors = control_plane.get_intra_chip_neighbors(FabricNodeId(mesh_id, 0), direction);
         if (neighbors.empty()) {
             continue;
         }
@@ -204,7 +204,7 @@ std::vector<chip_id_t> get_physical_chip_sequence(uint32_t num_seq_chips) {
                 throw std::runtime_error("Failed to setup neighbor map, logical chip id exceeding bounds");
             }
             chip_id_t phys_chip_id =
-                control_plane->get_physical_chip_id_from_fabric_node_id(FabricNodeId(mesh_id, logical_chip_id));
+                control_plane.get_physical_chip_id_from_fabric_node_id(FabricNodeId(mesh_id, logical_chip_id));
             physical_chip_matrix[i][j] = phys_chip_id;
             logical_chip_id += row_offset;
         }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -36,7 +36,7 @@ TEST_F(ControlPlaneFixture, TestTGControlPlaneInit) {
 }
 
 TEST_F(ControlPlaneFixture, TestTGMeshAPIs) {
-    const auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto user_meshes = control_plane->get_user_physical_mesh_ids();
     EXPECT_EQ(user_meshes.size(), 1);
     EXPECT_EQ(user_meshes[0], MeshId{4});
@@ -157,7 +157,7 @@ TEST_F(ControlPlaneFixture, TestQuantaGalaxyControlPlaneInit) {
 }
 
 TEST_F(ControlPlaneFixture, TestQuantaGalaxyMeshAPIs) {
-    const auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto user_meshes = control_plane->get_user_physical_mesh_ids();
     EXPECT_EQ(user_meshes.size(), 1);
     EXPECT_EQ(user_meshes[0], MeshId{0});

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -36,15 +36,15 @@ TEST_F(ControlPlaneFixture, TestTGControlPlaneInit) {
 }
 
 TEST_F(ControlPlaneFixture, TestTGMeshAPIs) {
-    const auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    auto user_meshes = control_plane->get_user_physical_mesh_ids();
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto user_meshes = control_plane.get_user_physical_mesh_ids();
     EXPECT_EQ(user_meshes.size(), 1);
     EXPECT_EQ(user_meshes[0], MeshId{4});
-    EXPECT_EQ(control_plane->get_physical_mesh_shape(MeshId{0}), tt::tt_metal::distributed::MeshShape(1, 1));
-    EXPECT_EQ(control_plane->get_physical_mesh_shape(MeshId{1}), tt::tt_metal::distributed::MeshShape(1, 1));
-    EXPECT_EQ(control_plane->get_physical_mesh_shape(MeshId{2}), tt::tt_metal::distributed::MeshShape(1, 1));
-    EXPECT_EQ(control_plane->get_physical_mesh_shape(MeshId{3}), tt::tt_metal::distributed::MeshShape(1, 1));
-    EXPECT_EQ(control_plane->get_physical_mesh_shape(MeshId{4}), tt::tt_metal::distributed::MeshShape(4, 8));
+    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{0}), tt::tt_metal::distributed::MeshShape(1, 1));
+    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{1}), tt::tt_metal::distributed::MeshShape(1, 1));
+    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{2}), tt::tt_metal::distributed::MeshShape(1, 1));
+    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{3}), tt::tt_metal::distributed::MeshShape(1, 1));
+    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{4}), tt::tt_metal::distributed::MeshShape(4, 8));
 }
 
 TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
@@ -110,8 +110,8 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kControlPlaneInit) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
     auto global_control_plane = std::make_unique<GlobalControlPlane>(
         t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
-    auto control_plane = global_control_plane->get_local_node_control_plane();
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
+    auto& control_plane = global_control_plane->get_local_node_control_plane();
+    control_plane.configure_routing_tables_for_fabric_ethernet_channels();
 }
 
 TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
@@ -120,22 +120,22 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
     auto global_control_plane = std::make_unique<GlobalControlPlane>(
         t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
-    auto control_plane = global_control_plane->get_local_node_control_plane();
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
+    auto& control_plane = global_control_plane->get_local_node_control_plane();
+    control_plane.configure_routing_tables_for_fabric_ethernet_channels();
     // TODO: Query this
     constexpr uint32_t num_routing_planes = 2;
-    for (const auto& src_mesh : control_plane->get_user_physical_mesh_ids()) {
-        for (const auto& dst_mesh : control_plane->get_user_physical_mesh_ids()) {
-            auto src_mesh_shape = control_plane->get_physical_mesh_shape(src_mesh);
+    for (const auto& src_mesh : control_plane.get_user_physical_mesh_ids()) {
+        for (const auto& dst_mesh : control_plane.get_user_physical_mesh_ids()) {
+            auto src_mesh_shape = control_plane.get_physical_mesh_shape(src_mesh);
             auto src_mesh_size = src_mesh_shape[0] * src_mesh_shape[1];
-            auto dst_mesh_shape = control_plane->get_physical_mesh_shape(dst_mesh);
+            auto dst_mesh_shape = control_plane.get_physical_mesh_shape(dst_mesh);
             auto dst_mesh_size = dst_mesh_shape[0] * dst_mesh_shape[1];
-            auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(
-                FabricNodeId(MeshId{src_mesh}, std::rand() % src_mesh_size), std::rand() % num_routing_planes);
+            auto valid_chans = control_plane.get_valid_eth_chans_on_routing_plane(
+                FabricNodeId(src_mesh, std::rand() % src_mesh_size), std::rand() % num_routing_planes);
             for (auto chan : valid_chans) {
-                auto path = control_plane->get_fabric_route(
-                    FabricNodeId(MeshId{src_mesh}, std::rand() % src_mesh_size),
-                    FabricNodeId(MeshId{dst_mesh}, std::rand() % dst_mesh_size),
+                auto path = control_plane.get_fabric_route(
+                    FabricNodeId(src_mesh, std::rand() % src_mesh_size),
+                    FabricNodeId(dst_mesh, std::rand() % dst_mesh_size),
                     chan);
                 EXPECT_EQ(path.size() > 0, true);
             }
@@ -157,11 +157,11 @@ TEST_F(ControlPlaneFixture, TestQuantaGalaxyControlPlaneInit) {
 }
 
 TEST_F(ControlPlaneFixture, TestQuantaGalaxyMeshAPIs) {
-    const auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    auto user_meshes = control_plane->get_user_physical_mesh_ids();
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto user_meshes = control_plane.get_user_physical_mesh_ids();
     EXPECT_EQ(user_meshes.size(), 1);
     EXPECT_EQ(user_meshes[0], MeshId{0});
-    EXPECT_EQ(control_plane->get_physical_mesh_shape(MeshId{0}), tt::tt_metal::distributed::MeshShape(8, 4));
+    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{0}), tt::tt_metal::distributed::MeshShape(8, 4));
 }
 
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
@@ -336,7 +336,7 @@ int main(int argc, char** argv) {
     test_params.buffer_size_bytes_header_only_channel = sizeof(tt::tt_fabric::PacketHeader);
 
     // for now, just use one device for running benchmarks
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto mesh_id = control_plane->get_user_physical_mesh_ids()[0];
     chip_id_t logical_chip_id = 0;
     auto physical_chip_id =

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
@@ -336,11 +336,11 @@ int main(int argc, char** argv) {
     test_params.buffer_size_bytes_header_only_channel = sizeof(tt::tt_fabric::PacketHeader);
 
     // for now, just use one device for running benchmarks
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    auto mesh_id = control_plane->get_user_physical_mesh_ids()[0];
+    auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto mesh_id = control_plane.get_user_physical_mesh_ids()[0];
     chip_id_t logical_chip_id = 0;
     auto physical_chip_id =
-        control_plane->get_physical_chip_id_from_fabric_node_id(tt::tt_fabric::FabricNodeId(mesh_id, logical_chip_id));
+        control_plane.get_physical_chip_id_from_fabric_node_id(tt::tt_fabric::FabricNodeId(mesh_id, logical_chip_id));
 
     std::map<chip_id_t, tt::tt_metal::IDevice*> devices = tt::tt_metal::detail::CreateDevices({physical_chip_id});
     tt::tt_metal::IDevice* device = devices.at(physical_chip_id);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -172,7 +172,7 @@ struct test_board_t {
         tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::CUSTOM);
 
         device_handle_map = tt::tt_metal::detail::CreateDevices(available_chip_ids);
-        control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+        control_plane = &tt::tt_metal::MetalContext::instance().get_control_plane();
         control_plane->write_routing_tables_to_all_chips();
 
         if (num_chips_to_use != available_chip_ids.size()) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -172,7 +172,7 @@ struct test_board_t {
         tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::CUSTOM);
 
         device_handle_map = tt::tt_metal::detail::CreateDevices(available_chip_ids);
-        control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+        control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
         control_plane->write_routing_tables_to_all_chips();
 
         if (num_chips_to_use != available_chip_ids.size()) {

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -147,7 +147,7 @@ public:
 
     void initialize_host_mapping();
 
-    tt::tt_fabric::ControlPlane* get_local_node_control_plane() { return control_plane_.get(); }
+    tt::tt_fabric::ControlPlane& get_local_node_control_plane() { return *control_plane_; }
 
 private:
     std::unique_ptr<RoutingTableGenerator> routing_table_generator_;

--- a/tt_metal/distributed/coordinate_translation.cpp
+++ b/tt_metal/distributed/coordinate_translation.cpp
@@ -21,7 +21,7 @@ namespace tt::tt_metal::distributed {
 
 const MeshContainer<PhysicalMeshCoordinate>& get_system_mesh_coordinate_translation_map() {
     static tt::stl::Indestructible<MeshContainer<PhysicalMeshCoordinate>> kTranslationMap([]() {
-        const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+        const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
         TT_FATAL(control_plane != nullptr, "Control plane must be initialized before MeshDevice can be created.");
 
         const auto mesh_ids = control_plane->get_user_physical_mesh_ids();

--- a/tt_metal/distributed/coordinate_translation.cpp
+++ b/tt_metal/distributed/coordinate_translation.cpp
@@ -21,10 +21,9 @@ namespace tt::tt_metal::distributed {
 
 const MeshContainer<PhysicalMeshCoordinate>& get_system_mesh_coordinate_translation_map() {
     static tt::stl::Indestructible<MeshContainer<PhysicalMeshCoordinate>> kTranslationMap([]() {
-        const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-        TT_FATAL(control_plane != nullptr, "Control plane must be initialized before MeshDevice can be created.");
+        const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
-        const auto mesh_ids = control_plane->get_user_physical_mesh_ids();
+        const auto mesh_ids = control_plane.get_user_physical_mesh_ids();
         TT_FATAL(!mesh_ids.empty(), "There are no user physical meshes in the system found by control plane.");
 
         if (mesh_ids.size() > 1) {
@@ -32,7 +31,7 @@ const MeshContainer<PhysicalMeshCoordinate>& get_system_mesh_coordinate_translat
         }
 
         const auto mesh_id = mesh_ids.front();
-        const auto mesh_shape = control_plane->get_physical_mesh_shape(mesh_id);
+        const auto mesh_shape = control_plane.get_physical_mesh_shape(mesh_id);
 
         // Validate that the physical chip ids are unique.
         std::unordered_set<chip_id_t> unique_chip_ids;
@@ -41,7 +40,7 @@ const MeshContainer<PhysicalMeshCoordinate>& get_system_mesh_coordinate_translat
         physical_coordinates.reserve(mesh_shape.mesh_size());
         for (int logical_chip_id = 0; logical_chip_id < mesh_shape.mesh_size(); ++logical_chip_id) {
             // Query the control plane to get the physical chip id from logical chip id
-            const auto physical_chip_id = control_plane->get_physical_chip_id_from_fabric_node_id(
+            const auto physical_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(
                 tt::tt_fabric::FabricNodeId(mesh_id, logical_chip_id));
             TT_FATAL(
                 unique_chip_ids.insert(physical_chip_id).second,

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -68,7 +68,7 @@ uint32_t get_sender_receiver_chip_fabric_encoding(
                std::abs(static_cast<int>(sender_global_coord[1]) - static_cast<int>(recv_global_coord[1]));
     } else {
         // 2D/Mesh Fabric requires looking up "logical" encodings from the control plane
-        auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+        auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
         if (is_sender) {
             return control_plane->get_fabric_node_id_from_physical_chip_id(recv_physical_device_id).chip_id;
         } else {
@@ -179,7 +179,7 @@ void write_socket_configs(
     auto grouped_connections = group_socket_connections(config, socket_endpoint);
     auto peer_addr = peer_config_buffer->address();
 
-    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
+    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
 
     if (is_sender) {
         std::vector<sender_socket_md> config_data(config_buffer->size() / sizeof(sender_socket_md), sender_socket_md());

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -68,11 +68,11 @@ uint32_t get_sender_receiver_chip_fabric_encoding(
                std::abs(static_cast<int>(sender_global_coord[1]) - static_cast<int>(recv_global_coord[1]));
     } else {
         // 2D/Mesh Fabric requires looking up "logical" encodings from the control plane
-        auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+        auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
         if (is_sender) {
-            return control_plane->get_fabric_node_id_from_physical_chip_id(recv_physical_device_id).chip_id;
+            return control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id).chip_id;
         } else {
-            return control_plane->get_fabric_node_id_from_physical_chip_id(sender_physical_device_id).chip_id;
+            return control_plane.get_fabric_node_id_from_physical_chip_id(sender_physical_device_id).chip_id;
         }
     }
 }

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -56,8 +56,8 @@ bool is_TG_gateway_connection(const chip_id_t src_chip_id, const chip_id_t dst_c
 namespace tt::tt_fabric {
 
 size_t get_tt_fabric_channel_buffer_size_bytes() {
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    return control_plane->get_fabric_context().get_fabric_channel_buffer_size_bytes();
+    const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
+    return control_plane.get_fabric_context().get_fabric_channel_buffer_size_bytes();
 }
 
 void append_fabric_connection_rt_args(
@@ -74,12 +74,12 @@ void append_fabric_connection_rt_args(
         src_chip_id,
         dst_chip_id);
 
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
 
-    const auto src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(src_chip_id);
-    const auto dst_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(dst_chip_id);
+    const auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_chip_id);
+    const auto dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dst_chip_id);
 
-    const auto& fabric_context = control_plane->get_fabric_context();
+    const auto& fabric_context = control_plane.get_fabric_context();
     const auto topology = fabric_context.get_fabric_topology();
     const bool is_2d_fabric = topology == Topology::Mesh;
 
@@ -96,14 +96,14 @@ void append_fabric_connection_rt_args(
     // get the direction in which the data will be forwarded from the src_chip_id
     std::optional<RoutingDirection> forwarding_direction;
     if (is_2d_fabric) {
-        forwarding_direction = control_plane->get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
+        forwarding_direction = control_plane.get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
     } else {
         // TODO: Workaround for #22524 routing tables not having wraparound links
         // for 1D fabric, we loop to match the dst chip since we need to ensure src and dst are on the same line
         // remove this once control plane has row/col info/view
         for (const auto& direction : FabricContext::routing_directions) {
             // This assumes all neighbor chips to the dst mesh are the same
-            auto neighbors = control_plane->get_chip_neighbors(src_fabric_node_id, direction);
+            auto neighbors = control_plane.get_chip_neighbors(src_fabric_node_id, direction);
             auto neighbor_mesh_chips = neighbors.find(dst_fabric_node_id.mesh_id);
             if (neighbor_mesh_chips == neighbors.end() ||
                 (std::find(
@@ -124,7 +124,7 @@ void append_fabric_connection_rt_args(
         dst_chip_id);
 
     const auto candidate_eth_chans =
-        control_plane->get_active_fabric_eth_channels_in_direction(src_fabric_node_id, forwarding_direction.value());
+        control_plane.get_active_fabric_eth_channels_in_direction(src_fabric_node_id, forwarding_direction.value());
     TT_FATAL(
         link_idx < candidate_eth_chans.size(),
         "requested link idx {}, out of bounds, max available {}",
@@ -141,7 +141,7 @@ void append_fabric_connection_rt_args(
         dst_chip_id);
 
     const auto fabric_router_channel = candidate_eth_chans[link_idx];
-    const auto router_direction = control_plane->routing_direction_to_eth_direction(forwarding_direction.value());
+    const auto router_direction = control_plane.routing_direction_to_eth_direction(forwarding_direction.value());
 
     CoreCoord fabric_router_virtual_core =
         tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -56,7 +56,7 @@ bool is_TG_gateway_connection(const chip_id_t src_chip_id, const chip_id_t dst_c
 namespace tt::tt_fabric {
 
 size_t get_tt_fabric_channel_buffer_size_bytes() {
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     return control_plane->get_fabric_context().get_fabric_channel_buffer_size_bytes();
 }
 
@@ -74,7 +74,7 @@ void append_fabric_connection_rt_args(
         src_chip_id,
         dst_chip_id);
 
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     const auto src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(src_chip_id);
     const auto dst_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(dst_chip_id);

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -19,7 +19,7 @@ namespace tt::tt_fabric {
 std::unordered_map<MeshId, bool> FabricContext::check_for_wrap_around_mesh() const {
     std::unordered_map<MeshId, bool> wrap_around_mesh;
 
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto mesh_ids = control_plane->get_user_physical_mesh_ids();
     for (const auto& mesh_id : mesh_ids) {
         if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::TG) {

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -19,8 +19,8 @@ namespace tt::tt_fabric {
 std::unordered_map<MeshId, bool> FabricContext::check_for_wrap_around_mesh() const {
     std::unordered_map<MeshId, bool> wrap_around_mesh;
 
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    auto mesh_ids = control_plane->get_user_physical_mesh_ids();
+    auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto mesh_ids = control_plane.get_user_physical_mesh_ids();
     for (const auto& mesh_id : mesh_ids) {
         if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::TG) {
             // skip wrapping around mesh for TG since the corner chips connected to the gateway will be
@@ -32,7 +32,7 @@ std::unordered_map<MeshId, bool> FabricContext::check_for_wrap_around_mesh() con
         const uint32_t corner_chip_id = 0;
         uint32_t corner_chip_connections = 0;
         for (const auto& direction : FabricContext::routing_directions) {
-            if (!control_plane->get_intra_chip_neighbors(FabricNodeId(mesh_id, corner_chip_id), direction).empty()) {
+            if (!control_plane.get_intra_chip_neighbors(FabricNodeId(mesh_id, corner_chip_id), direction).empty()) {
                 corner_chip_connections++;
             }
         }

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -61,19 +61,19 @@ FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::Cluster
 
 std::vector<uint32_t> get_forwarding_link_indices_in_direction(
     chip_id_t src_chip_id, chip_id_t dst_chip_id, RoutingDirection direction) {
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    const auto src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(src_chip_id);
-    const auto dst_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(dst_chip_id);
-    const bool is_2d_fabric = control_plane->get_fabric_context().get_fabric_topology() == Topology::Mesh;
+    const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_chip_id);
+    const auto dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dst_chip_id);
+    const bool is_2d_fabric = control_plane.get_fabric_context().get_fabric_topology() == Topology::Mesh;
 
     const std::vector<chan_id_t>& fabric_channels =
-        control_plane->get_active_fabric_eth_channels_in_direction(src_fabric_node_id, direction);
+        control_plane.get_active_fabric_eth_channels_in_direction(src_fabric_node_id, direction);
 
     // the subset of routers that support forwarding b/w those chips
     std::vector<chan_id_t> forwarding_channels;
     if (is_2d_fabric) {
         forwarding_channels =
-            control_plane->get_forwarding_eth_chans_to_chip(src_fabric_node_id, dst_fabric_node_id, direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_fabric_node_id, dst_fabric_node_id, direction);
     } else {
         // for 1D check if each port has an active connection to the dst_chip_id
         const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
@@ -100,12 +100,12 @@ std::vector<uint32_t> get_forwarding_link_indices_in_direction(
 }
 
 std::vector<uint32_t> get_forwarding_link_indices(chip_id_t src_chip_id, chip_id_t dst_chip_id) {
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    const auto src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(src_chip_id);
-    const auto dst_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(dst_chip_id);
+    const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_chip_id);
+    const auto dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dst_chip_id);
 
     // find the forwarding direction b/w src and dest chip
-    const auto& forwarding_direction = control_plane->get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
+    const auto& forwarding_direction = control_plane.get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
     if (!forwarding_direction.has_value()) {
         return {};
     }
@@ -150,8 +150,8 @@ void set_routing_mode(uint16_t routing_mode) {
         !(routing_mode & ROUTING_MODE_2D) || !(routing_mode & (ROUTING_MODE_LINE | ROUTING_MODE_RING)),
         "2D routing mode cannot be combined with LINE or RING topology");
 
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    control_plane->set_routing_mode(routing_mode);
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    control_plane.set_routing_mode(routing_mode);
 }
 
 void set_routing_mode(Topology topology, tt::tt_metal::FabricConfig fabric_config, uint32_t dimension /*, take more*/) {

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -61,7 +61,7 @@ FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::Cluster
 
 std::vector<uint32_t> get_forwarding_link_indices_in_direction(
     chip_id_t src_chip_id, chip_id_t dst_chip_id, RoutingDirection direction) {
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(src_chip_id);
     const auto dst_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(dst_chip_id);
     const bool is_2d_fabric = control_plane->get_fabric_context().get_fabric_topology() == Topology::Mesh;
@@ -100,7 +100,7 @@ std::vector<uint32_t> get_forwarding_link_indices_in_direction(
 }
 
 std::vector<uint32_t> get_forwarding_link_indices(chip_id_t src_chip_id, chip_id_t dst_chip_id) {
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(src_chip_id);
     const auto dst_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(dst_chip_id);
 
@@ -150,7 +150,7 @@ void set_routing_mode(uint16_t routing_mode) {
         !(routing_mode & ROUTING_MODE_2D) || !(routing_mode & (ROUTING_MODE_LINE | ROUTING_MODE_RING)),
         "2D routing mode cannot be combined with LINE or RING topology");
 
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     control_plane->set_routing_mode(routing_mode);
 }
 

--- a/tt_metal/fabric/fabric_mux_config.hpp
+++ b/tt_metal/fabric/fabric_mux_config.hpp
@@ -165,7 +165,7 @@ struct FabricMuxConfig {
     std::vector<uint32_t> get_fabric_mux_compile_time_args() const {
         const auto& fabric_router_config = tt::tt_metal::MetalContext::instance()
                                                .get_control_plane()
-                                               ->get_fabric_context()
+                                               .get_fabric_context()
                                                .get_fabric_router_config();
         return std::vector<uint32_t>{
             this->num_full_size_channels,

--- a/tt_metal/fabric/fabric_mux_config.hpp
+++ b/tt_metal/fabric/fabric_mux_config.hpp
@@ -164,7 +164,6 @@ struct FabricMuxConfig {
 
     std::vector<uint32_t> get_fabric_mux_compile_time_args() const {
         const auto& fabric_router_config = tt::tt_metal::MetalContext::instance()
-                                               .get_cluster()
                                                .get_control_plane()
                                                ->get_fabric_context()
                                                .get_fabric_router_config();

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -15,6 +15,10 @@
 #include "tt_metal/llrt/get_platform_architecture.hpp"
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/control_plane.hpp>
+#include "tt_metal/fabric/fabric_host_utils.hpp"
+#include <filesystem>
+#include <tt-metalium/device_pool.hpp>
 
 namespace tt::tt_metal {
 
@@ -228,6 +232,86 @@ void MetalContext::clear_launch_messages_on_eth_cores(chip_id_t device_id) {
     for (const auto& eth_core : cluster_->get_inactive_ethernet_cores(device_id)) {
         clear_ethernet_core(eth_core);
     }
+}
+
+tt::tt_fabric::ControlPlane* MetalContext::get_control_plane() {
+    if (global_control_plane_.get() == nullptr) {
+        this->initialize_control_plane();
+    }
+    return global_control_plane_->get_local_node_control_plane();
+}
+
+void MetalContext::set_custom_control_plane_mesh_graph(
+    const std::string& mesh_graph_desc_file,
+    const std::map<tt_fabric::FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
+    TT_FATAL(
+        !DevicePool::is_initialized() || DevicePool::instance().get_all_active_devices().size() == 0,
+        "Modifying control plane requires no devices to be active");
+    TT_FATAL(global_control_plane_.get() == nullptr, "Control plane has already been initialized");
+    
+    global_control_plane_ = std::make_unique<tt::tt_fabric::GlobalControlPlane>(
+        mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
+}
+
+void MetalContext::set_default_control_plane_mesh_graph() {
+    TT_FATAL(
+        !DevicePool::is_initialized() || DevicePool::instance().get_all_active_devices().size() == 0,
+        "Modifying control plane requires no devices to be active");
+    global_control_plane_.reset();
+    this->initialize_control_plane();
+    this->initialize_fabric_config(fabric_config_);
+}
+
+void MetalContext::initialize_fabric_config(tt_metal::FabricConfig fabric_config) {
+    fabric_config_ = fabric_config;
+    cluster_->initialize_fabric_config(fabric_config);
+    
+    // Initialize fabric context in control plane if fabric is enabled
+    if (fabric_config != tt_metal::FabricConfig::DISABLED) {
+        if (tt::tt_fabric::is_tt_fabric_config(fabric_config)) {
+            this->get_control_plane()->initialize_fabric_context(fabric_config);
+        }
+    } else {
+        this->get_control_plane()->clear_fabric_context();
+    }
+    
+    this->get_control_plane()->configure_routing_tables_for_fabric_ethernet_channels();
+}
+
+tt_metal::FabricConfig MetalContext::get_fabric_config() const {
+    return fabric_config_;
+}
+
+void MetalContext::initialize_control_plane() {
+    // Default mode, auto select mesh graph descriptor. In future, we can add a way for user to specify custom
+    // descriptors
+    std::string mesh_graph_descriptor;
+    auto cluster_type = cluster_->get_cluster_type();
+    switch (cluster_type) {
+        case tt::ClusterType::N150: mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::N300: mesh_graph_descriptor = "n300_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::T3K: mesh_graph_descriptor = "t3k_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::GALAXY:
+            if (tt::tt_fabric::get_fabric_type(this->fabric_config_, cluster_type) ==
+                tt::tt_fabric::FabricType::TORUS_2D) {
+                mesh_graph_descriptor = "quanta_galaxy_torus_2d_graph_descriptor.yaml";
+            } else {
+                mesh_graph_descriptor = "quanta_galaxy_mesh_graph_descriptor.yaml";
+            }
+            break;
+        case tt::ClusterType::TG: mesh_graph_descriptor = "tg_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::P100: mesh_graph_descriptor = "p100_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::P150: mesh_graph_descriptor = "p150_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::P150_X2: mesh_graph_descriptor = "p150_x2_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::P150_X4: mesh_graph_descriptor = "p150_x4_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::SIMULATOR_WORMHOLE_B0: mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::SIMULATOR_BLACKHOLE: mesh_graph_descriptor = "p150_mesh_graph_descriptor.yaml"; break;
+        default: TT_THROW("Unknown cluster type"); // TODO: we could expose this as a custom mesh graph option
+    }
+    const std::filesystem::path mesh_graph_desc_path = std::filesystem::path(rtoptions_.get_root_dir()) /
+                                                       "tt_metal/fabric/mesh_graph_descriptors" / mesh_graph_descriptor;
+
+    global_control_plane_ = std::make_unique<tt::tt_fabric::GlobalControlPlane>(mesh_graph_desc_path.string());
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -239,7 +239,6 @@ tt::tt_fabric::ControlPlane& MetalContext::get_control_plane() {
     if (!global_control_plane_) {
         this->initialize_control_plane();
     }
-    TT_FATAL(global_control_plane_, "Global control plane is not initialized. Did you call InitializeFabricConfig?");
     return global_control_plane_->get_local_node_control_plane();
 }
 
@@ -252,6 +251,7 @@ void MetalContext::set_custom_control_plane_mesh_graph(
 
     global_control_plane_ = std::make_unique<tt::tt_fabric::GlobalControlPlane>(
         mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
+    this->initialize_fabric_config(fabric_config_);
 }
 
 void MetalContext::set_default_control_plane_mesh_graph() {

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -264,7 +264,7 @@ void MetalContext::set_default_control_plane_mesh_graph() {
 
 void MetalContext::initialize_fabric_config(tt_metal::FabricConfig fabric_config) {
     fabric_config_ = fabric_config;
-    cluster_->initialize_fabric_config(fabric_config);
+    cluster_->configure_ethernet_cores_for_fabric_routers(fabric_config);
 
     // Initialize fabric context in control plane if fabric is enabled
     if (fabric_config != tt_metal::FabricConfig::DISABLED) {

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -55,7 +55,7 @@ public:
         const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs, const BankMapping& l1_bank_remap);
 
     // Control plane accessors
-    tt::tt_fabric::ControlPlane* get_control_plane();
+    tt::tt_fabric::ControlPlane& get_control_plane();
     void set_custom_control_plane_mesh_graph(
         const std::string& mesh_graph_desc_file,
         const std::map<tt_fabric::FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping);

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -22,6 +22,11 @@
 #include <unordered_set>
 #include <vector>
 
+namespace tt::tt_fabric {
+class GlobalControlPlane;
+class ControlPlane;
+}  // namespace tt::tt_fabric
+
 namespace tt::tt_metal {
 
 // A class to manage one-time initialization and teardown (FW, dispatch, fabric, cluster) and access to related state.
@@ -49,6 +54,15 @@ public:
     void initialize(
         const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs, const BankMapping& l1_bank_remap);
 
+    // Control plane accessors
+    tt::tt_fabric::ControlPlane* get_control_plane();
+    void set_custom_control_plane_mesh_graph(
+        const std::string& mesh_graph_desc_file,
+        const std::map<tt_fabric::FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping);
+    void set_default_control_plane_mesh_graph();
+    void initialize_fabric_config(tt_metal::FabricConfig fabric_config);
+    tt_metal::FabricConfig get_fabric_config() const;
+
 private:
     friend class tt::stl::Indestructible<MetalContext>;
     MetalContext();
@@ -58,6 +72,7 @@ private:
     void clear_l1_state(chip_id_t device_id);
     void clear_dram_state(chip_id_t device_id);
     void clear_launch_messages_on_eth_cores(chip_id_t device_id);
+    void initialize_control_plane();
 
     bool initialized_ = false;
     bool teardown_registered_ = false;
@@ -76,6 +91,8 @@ private:
     std::unique_ptr<dispatch_core_manager> dispatch_core_manager_;
     std::unique_ptr<DispatchQueryManager> dispatch_query_manager_;
     std::array<std::unique_ptr<DispatchMemMap>, magic_enum::enum_count<CoreType>()> dispatch_mem_map_;
+    std::unique_ptr<tt::tt_fabric::GlobalControlPlane> global_control_plane_;
+    tt_metal::FabricConfig fabric_config_ = tt_metal::FabricConfig::DISABLED;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -147,7 +147,7 @@ std::tuple<chip_id_t, CoreCoord> Device::get_connected_ethernet_core(CoreCoord e
 }
 
 std::vector<CoreCoord> Device::get_ethernet_sockets(chip_id_t connected_chip_id) const {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config() !=
+    if (tt::tt_metal::MetalContext::instance().get_fabric_config() !=
         tt::tt_metal::FabricConfig::DISABLED) {
         return tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_routers_between_src_and_dest(
             this->id_, connected_chip_id);

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -321,8 +321,7 @@ void DevicePool::initialize_active_devices() const {
             // TODO: need to write routing tables for unified 2d fabric.
             // write routing tables to all ethernet cores
             tt::tt_metal::MetalContext::instance()
-                .get_control_plane()
-                ->write_routing_tables_to_all_chips();
+                .get_control_plane().write_routing_tables_to_all_chips();
         }
 
         // Initialize fabric on mmio device
@@ -492,8 +491,8 @@ void DevicePool::wait_for_fabric_router_sync() const {
         return;
     }
 
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    const auto& fabric_context = control_plane->get_fabric_context();
+    const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& fabric_context = control_plane.get_fabric_context();
 
     auto wait_for_handshake = [&](IDevice* dev) {
         if (!dev) {
@@ -741,8 +740,8 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
     // Terminate fabric routers
     const auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (tt::tt_fabric::is_tt_fabric_config(fabric_config)) {
-        const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-        const auto& fabric_context = control_plane->get_fabric_context();
+        const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
+        const auto& fabric_context = control_plane.get_fabric_context();
         auto [termination_signal_address, signal] = fabric_context.get_fabric_router_termination_address_and_signal();
         std::vector<uint32_t> termination_signal(1, signal);
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -314,14 +314,13 @@ void DevicePool::initialize_active_devices() const {
     const auto& active_devices = this->get_all_active_devices();
 
     // Activate fabric (must be before FD)
-    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
+    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (tt_fabric::is_tt_fabric_config(fabric_config)) {
         log_info(tt::LogMetal, "Initializing Fabric");
         if (tt_fabric::is_2d_fabric_config(fabric_config)) {
             // TODO: need to write routing tables for unified 2d fabric.
             // write routing tables to all ethernet cores
             tt::tt_metal::MetalContext::instance()
-                .get_cluster()
                 .get_control_plane()
                 ->write_routing_tables_to_all_chips();
         }
@@ -470,7 +469,7 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
         }
     }
 
-    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
+    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     // Only can launch Fabric if all devices are active
     if (tt_fabric::is_tt_fabric_config(fabric_config)) {
         for (int i = 0; i < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices(); i++) {
@@ -488,12 +487,12 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
 }
 
 void DevicePool::wait_for_fabric_router_sync() const {
-    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
+    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (!tt::tt_fabric::is_tt_fabric_config(fabric_config)) {
         return;
     }
 
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& fabric_context = control_plane->get_fabric_context();
 
     auto wait_for_handshake = [&](IDevice* dev) {
@@ -740,9 +739,9 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
     }
 
     // Terminate fabric routers
-    const auto fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
+    const auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (tt::tt_fabric::is_tt_fabric_config(fabric_config)) {
-        const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+        const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
         const auto& fabric_context = control_plane->get_fabric_context();
         auto [termination_signal_address, signal] = fabric_context.get_fabric_router_termination_address_and_signal();
         std::vector<uint32_t> termination_signal(1, signal);

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -167,7 +167,7 @@ KernelHandle FDKernel::configure_kernel_variant(
     if (rt_options.watcher_dispatch_disabled()) {
         defines["FORCE_WATCHER_OFF"] = "1";
     }
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config() != FabricConfig::FABRIC_2D) {
+    if (tt::tt_metal::MetalContext::instance().get_fabric_config() != FabricConfig::FABRIC_2D) {
         defines["FVC_MODE_PULL"] = "1";
     }
     if (!DPrintServerReadsDispatchCores(device_->id())) {

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
@@ -58,8 +58,8 @@ void RelayMux::GenerateStaticConfigs() {
     static_config_.num_full_size_channels = kernels_requiring_full_size_channel;
     static_config_.num_header_only_channels = kernels_requiring_header_only_channel;
 
-    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
-    const auto& fabric_context = control_plane->get_fabric_context();
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& fabric_context = control_plane.get_fabric_context();
     static_config_.buffer_size_bytes = fabric_context.get_fabric_packet_header_size_bytes() + k_BufferSize;
 
     // FabricMuxConfig only accepts Worker or Idle Eth. Eth is not accepted.

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1264,7 +1264,7 @@ void build_tt_fabric_program(
     Program* fabric_program_ptr,
     std::unordered_map<tt::tt_fabric::chan_id_t, tt::tt_fabric::FabricEriscDatamoverBuilder>& edm_builders) {
     using namespace tt_fabric;
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(device->id());
     const bool is_TG = (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::TG);
     auto soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
@@ -1436,7 +1436,7 @@ std::unique_ptr<Program> create_and_compile_tt_fabric_program(IDevice* device) {
     std::unique_ptr<Program> fabric_program_ptr = std::make_unique<Program>();
     std::unordered_map<tt::tt_fabric::chan_id_t, tt::tt_fabric::FabricEriscDatamoverBuilder> edm_builders;
 
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto& fabric_context = control_plane->get_fabric_context();
 
     build_tt_fabric_program(device, fabric_program_ptr.get(), edm_builders);
@@ -1497,7 +1497,7 @@ std::unique_ptr<Program> create_and_compile_tt_fabric_program(IDevice* device) {
 }
 
 std::unique_ptr<Program> create_and_compile_fabric_program(IDevice* device) {
-    auto fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
+    auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (tt_fabric::is_tt_fabric_config(fabric_config)) {
         return create_and_compile_tt_fabric_program(device);
     }
@@ -1507,7 +1507,7 @@ std::unique_ptr<Program> create_and_compile_fabric_program(IDevice* device) {
 void configure_fabric_cores(IDevice* device) {
     std::vector<uint32_t> router_zero_buf(1, 0);
     auto soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(device->id());
     const auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(fabric_node_id);
     const auto addresses_to_clear = control_plane->get_fabric_context().get_fabric_router_addresses_to_clear();

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1264,15 +1264,15 @@ void build_tt_fabric_program(
     Program* fabric_program_ptr,
     std::unordered_map<tt::tt_fabric::chan_id_t, tt::tt_fabric::FabricEriscDatamoverBuilder>& edm_builders) {
     using namespace tt_fabric;
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    auto fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(device->id());
+    const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->id());
     const bool is_TG = (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::TG);
     auto soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
-    const auto& fabric_context = control_plane->get_fabric_context();
+    const auto& fabric_context = control_plane.get_fabric_context();
     const auto& edm_config = fabric_context.get_fabric_router_config();
 
     if (is_TG && device->is_mmio_capable()) {
-        auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(fabric_node_id);
+        auto router_chans_and_direction = control_plane.get_active_fabric_eth_channels(fabric_node_id);
         for (const auto& [eth_chan, eth_direction] : router_chans_and_direction) {
             // remote chip id is only used to dertmine the handshake master, no functional impact
             // for now treat the mmio chips as the handshake master
@@ -1302,11 +1302,11 @@ void build_tt_fabric_program(
     const bool is_2D_routing = topology == Topology::Mesh;
 
     for (const auto& direction : tt::tt_fabric::FabricContext::routing_directions) {
-        auto active_eth_chans = control_plane->get_active_fabric_eth_channels_in_direction(fabric_node_id, direction);
+        auto active_eth_chans = control_plane.get_active_fabric_eth_channels_in_direction(fabric_node_id, direction);
         if (active_eth_chans.empty()) {
             continue;
         }
-        auto neighbors = control_plane->get_chip_neighbors(fabric_node_id, direction);
+        auto neighbors = control_plane.get_chip_neighbors(fabric_node_id, direction);
         auto intra_chip_neighbors = neighbors.find(fabric_node_id.mesh_id);
         if (intra_chip_neighbors != neighbors.end()) {
             // only count the number of unique intra chip neighbors
@@ -1333,7 +1333,7 @@ void build_tt_fabric_program(
         }
 
         FabricNodeId neighbor_fabric_node_id = FabricNodeId(neighbors.begin()->first, neighbors.begin()->second[0]);
-        chip_neighbors[direction] = control_plane->get_physical_chip_id_from_fabric_node_id(neighbor_fabric_node_id);
+        chip_neighbors[direction] = control_plane.get_physical_chip_id_from_fabric_node_id(neighbor_fabric_node_id);
 
         active_fabric_eth_channels.insert({direction, active_eth_chans});
     }
@@ -1346,9 +1346,9 @@ void build_tt_fabric_program(
     const bool wrap_around_mesh = fabric_context.is_wrap_around_mesh(fabric_node_id.mesh_id);
 
     for (const auto& [direction, remote_physical_chip_id] : chip_neighbors) {
-        auto remote_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(remote_physical_chip_id);
+        auto remote_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(remote_physical_chip_id);
         bool is_dateline = remote_fabric_node_id.mesh_id == fabric_node_id.mesh_id && check_dateline(
-                                                                                          *control_plane,
+                                                                                          control_plane,
                                                                                           topology,
                                                                                           fabric_node_id.mesh_id,
                                                                                           fabric_node_id.chip_id,
@@ -1369,7 +1369,7 @@ void build_tt_fabric_program(
                 true,  /* enable_persistent_mode */
                 false, /* build_in_worker_connection_mode */
                 is_dateline,
-                control_plane->routing_direction_to_eth_direction(direction));
+                control_plane.routing_direction_to_eth_direction(direction));
             edm_builders.insert({eth_chan, edm_builder});
         }
     }
@@ -1436,8 +1436,8 @@ std::unique_ptr<Program> create_and_compile_tt_fabric_program(IDevice* device) {
     std::unique_ptr<Program> fabric_program_ptr = std::make_unique<Program>();
     std::unordered_map<tt::tt_fabric::chan_id_t, tt::tt_fabric::FabricEriscDatamoverBuilder> edm_builders;
 
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    auto& fabric_context = control_plane->get_fabric_context();
+    const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto& fabric_context = control_plane.get_fabric_context();
 
     build_tt_fabric_program(device, fabric_program_ptr.get(), edm_builders);
     fabric_context.set_num_fabric_initialized_routers(device->id(), edm_builders.size());
@@ -1507,10 +1507,10 @@ std::unique_ptr<Program> create_and_compile_fabric_program(IDevice* device) {
 void configure_fabric_cores(IDevice* device) {
     std::vector<uint32_t> router_zero_buf(1, 0);
     auto soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    const auto fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(device->id());
-    const auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(fabric_node_id);
-    const auto addresses_to_clear = control_plane->get_fabric_context().get_fabric_router_addresses_to_clear();
+    const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->id());
+    const auto router_chans_and_direction = control_plane.get_active_fabric_eth_channels(fabric_node_id);
+    const auto addresses_to_clear = control_plane.get_fabric_context().get_fabric_router_addresses_to_clear();
     for (const auto& [router_chan, _] : router_chans_and_direction) {
         auto router_logical_core = soc_desc.get_eth_core_for_channel(router_chan, CoordSystem::LOGICAL);
         for (const auto& address : addresses_to_clear) {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -377,6 +377,12 @@ void syncDeviceDevice(chip_id_t device_id_sender, chip_id_t device_id_receiver) 
     }
 
     if (device_sender != nullptr and device_receiver != nullptr) {
+        FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+        TT_FATAL(
+            fabric_config != FabricConfig::DISABLED,
+            "Cannot support device to device synchronization when TT-Fabric is disabled.");
+        log_info("Calling {} when TT-Fabric is enabled. This may take a while", __FUNCTION__);
+
         constexpr std::uint16_t sample_count = 240;
         constexpr std::uint16_t sample_size = 16;
         constexpr std::uint16_t channel_count = 1;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1099,7 +1099,7 @@ std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
 
 void Cluster::initialize_fabric_config(tt_metal::FabricConfig fabric_config) {
     this->fabric_config_ = fabric_config;
-    
+
     if (fabric_config != tt_metal::FabricConfig::DISABLED) {
         this->reserve_ethernet_cores_for_fabric_routers();
     } else {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1097,9 +1097,7 @@ std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
     return active_ethernet_cores;
 }
 
-void Cluster::initialize_fabric_config(tt_metal::FabricConfig fabric_config) {
-    this->fabric_config_ = fabric_config;
-
+void Cluster::configure_ethernet_cores_for_fabric_routers(tt_metal::FabricConfig fabric_config) {
     if (fabric_config != tt_metal::FabricConfig::DISABLED) {
         this->reserve_ethernet_cores_for_fabric_routers();
     } else {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -190,7 +190,6 @@ bool Cluster::is_galaxy_cluster() const { return this->cluster_type_ == ClusterT
 
 ClusterType Cluster::get_cluster_type() const { return this->cluster_type_; }
 
-tt_metal::FabricConfig Cluster::get_fabric_config() const { return this->fabric_config_; }
 
 BoardType Cluster::get_board_type(chip_id_t chip_id) const {
   return this->cluster_desc_->get_board_type(chip_id);
@@ -1098,50 +1097,14 @@ std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
     return active_ethernet_cores;
 }
 
-tt::tt_fabric::ControlPlane* Cluster::get_control_plane() {
-    if (global_control_plane_.get() == nullptr) {
-        this->initialize_control_plane();
-    }
-    return global_control_plane_->get_local_node_control_plane();
-}
-
-void Cluster::set_custom_control_plane_mesh_graph(
-    const std::string& mesh_graph_desc_file,
-    const std::map<tt_fabric::FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
-    TT_FATAL(
-        !DevicePool::is_initialized() || DevicePool::instance().get_all_active_devices().size() == 0,
-        "Modifying control plane requires no devices to be active");
-    if (global_control_plane_.get() != nullptr) {
-        global_control_plane_.reset();
-    }
-    global_control_plane_ = std::make_unique<tt::tt_fabric::GlobalControlPlane>(
-        mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
-    this->initialize_fabric_config(fabric_config_);
-}
-
-void Cluster::set_default_control_plane_mesh_graph() {
-    TT_FATAL(
-        !DevicePool::is_initialized() || DevicePool::instance().get_all_active_devices().size() == 0,
-        "Modifying control plane requires no devices to be active");
-    if (global_control_plane_.get() != nullptr) {
-        global_control_plane_.reset();
-    }
-    this->initialize_control_plane();
-    this->initialize_fabric_config(fabric_config_);
-}
-
 void Cluster::initialize_fabric_config(tt_metal::FabricConfig fabric_config) {
     this->fabric_config_ = fabric_config;
+    
     if (fabric_config != tt_metal::FabricConfig::DISABLED) {
         this->reserve_ethernet_cores_for_fabric_routers();
-        if (tt::tt_fabric::is_tt_fabric_config(fabric_config)) {
-            this->get_control_plane()->initialize_fabric_context(fabric_config);
-        }
     } else {
         this->release_ethernet_cores_for_fabric_routers();
-        this->get_control_plane()->clear_fabric_context();
     }
-    this->get_control_plane()->configure_routing_tables_for_fabric_ethernet_channels();
 }
 
 void Cluster::reserve_ethernet_cores_for_fabric_routers() {
@@ -1424,36 +1387,6 @@ uint32_t Cluster::get_device_tunnel_depth(chip_id_t chip_id) const {
     return (mmio_device_id == chip_id) ? 0 : this->cluster_desc_->get_ethernet_link_distance(chip_id, mmio_device_id);
 }
 
-void Cluster::initialize_control_plane() {
-    // Default mode, auto select mesh graph descriptor. In future, we can add a way for user to specify custom
-    // descriptors
-    std::string mesh_graph_descriptor;
-    switch (this->cluster_type_) {
-        case tt::ClusterType::N150: mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::N300: mesh_graph_descriptor = "n300_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::T3K: mesh_graph_descriptor = "t3k_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::GALAXY:
-            if (tt::tt_fabric::get_fabric_type(this->fabric_config_, this->cluster_type_) ==
-                tt::tt_fabric::FabricType::TORUS_2D) {
-                mesh_graph_descriptor = "quanta_galaxy_torus_2d_graph_descriptor.yaml";
-            } else {
-                mesh_graph_descriptor = "quanta_galaxy_mesh_graph_descriptor.yaml";
-            }
-            break;
-        case tt::ClusterType::TG: mesh_graph_descriptor = "tg_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::P100: mesh_graph_descriptor = "p100_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::P150: mesh_graph_descriptor = "p150_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::P150_X2: mesh_graph_descriptor = "p150_x2_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::P150_X4: mesh_graph_descriptor = "p150_x4_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::SIMULATOR_WORMHOLE_B0: mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::SIMULATOR_BLACKHOLE: mesh_graph_descriptor = "p150_mesh_graph_descriptor.yaml"; break;
-        default: TT_THROW("Unknown cluster type"); // TODO: we could expose this as a custom mesh graph option
-    }
-    const std::filesystem::path mesh_graph_desc_path = std::filesystem::path(rtoptions_.get_root_dir()) /
-                                                       "tt_metal/fabric/mesh_graph_descriptors" / mesh_graph_descriptor;
-
-    global_control_plane_ = std::make_unique<tt::tt_fabric::GlobalControlPlane>(mesh_graph_desc_path.string());
-}
 
 std::uint32_t Cluster::get_ubb_asic_id(chip_id_t physical_chip_id) const {
     auto unique_chip_id = this->get_unique_chip_ids().at(physical_chip_id);

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -302,7 +302,8 @@ public:
         return this->tunnels_from_mmio_device.at(mmio_chip_id);
     }
 
-    void initialize_fabric_config(tt_metal::FabricConfig fabric_config);
+    // Configures ethernet cores for fabric routers depending on whether fabric is enabled
+    void configure_ethernet_cores_for_fabric_routers(tt_metal::FabricConfig fabric_config);
 
     // Returns whether we are running on Galaxy.
     bool is_galaxy_cluster() const;
@@ -399,8 +400,6 @@ private:
 
     // Releases all reserved ethernet cores for fabric routers
     void release_ethernet_cores_for_fabric_routers();
-
-    tt_metal::FabricConfig fabric_config_ = tt_metal::FabricConfig::DISABLED;
 
     // Tunnels setup in cluster
     std::map<chip_id_t, std::vector<std::vector<chip_id_t>>> tunnels_from_mmio_device = {};

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -302,14 +302,6 @@ public:
         return this->tunnels_from_mmio_device.at(mmio_chip_id);
     }
 
-    tt::tt_fabric::ControlPlane* get_control_plane();
-
-    void set_custom_control_plane_mesh_graph(
-        const std::string& mesh_graph_desc_file,
-        const std::map<tt_fabric::FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping);
-
-    void set_default_control_plane_mesh_graph();
-
     void initialize_fabric_config(tt_metal::FabricConfig fabric_config);
 
     // Returns whether we are running on Galaxy.
@@ -319,8 +311,6 @@ public:
     BoardType get_board_type(chip_id_t chip_id) const;
 
     ClusterType get_cluster_type() const;
-
-    tt_metal::FabricConfig get_fabric_config() const;
 
     bool is_base_routing_fw_enabled() const;
 
@@ -370,8 +360,6 @@ private:
     // This should be removed when we handle retraining or dropped links in control plane properly
     void disable_ethernet_cores_with_retrain();
 
-    // Initialize control plane, which has mapping of physical device id to MeshGraph config
-    void initialize_control_plane();
 
     // Set tunnels from mmio
     void set_tunnels_from_mmio_device();
@@ -413,8 +401,6 @@ private:
     void release_ethernet_cores_for_fabric_routers();
 
     tt_metal::FabricConfig fabric_config_ = tt_metal::FabricConfig::DISABLED;
-
-    std::unique_ptr<tt::tt_fabric::GlobalControlPlane> global_control_plane_;
 
     // Tunnels setup in cluster
     std::map<chip_id_t, std::vector<std::vector<chip_id_t>>> tunnels_from_mmio_device = {};

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -376,7 +376,7 @@ bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t 
 }
 
 void InitializeFabricConfig(FabricConfig fabric_config) {
-    tt::tt_metal::MetalContext::instance().get_cluster().initialize_fabric_config(fabric_config);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config(fabric_config);
 }
 
 std::map<chip_id_t, IDevice*> CreateDevices(
@@ -1072,8 +1072,8 @@ KernelHandle CreateDataMovementKernel(
         kernel_name);
 
     std::shared_ptr<Kernel> kernel = std::make_shared<DataMovementKernel>(kernel_src, core_range_set, config);
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    auto mode = control_plane->get_routing_mode();
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto mode = control_plane.get_routing_mode();
     if (mode != ROUTING_MODE_UNDEFINED) {
         kernel->add_defines({{"ROUTING_MODE", std::to_string(static_cast<int>(mode))}});
     }
@@ -1101,8 +1101,8 @@ KernelHandle CreateEthernetKernel(
     const bool are_both_noc_in_use = data_movement_config_status.noc0_in_use && data_movement_config_status.noc1_in_use;
 
     std::shared_ptr<Kernel> kernel = std::make_shared<EthernetKernel>(kernel_src, core_range_set, config);
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    auto mode = control_plane->get_routing_mode();
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto mode = control_plane.get_routing_mode();
     if (mode != ROUTING_MODE_UNDEFINED) {
         kernel->add_defines({{"ROUTING_MODE", std::to_string(static_cast<int>(mode))}});
     }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1072,7 +1072,7 @@ KernelHandle CreateDataMovementKernel(
         kernel_name);
 
     std::shared_ptr<Kernel> kernel = std::make_shared<DataMovementKernel>(kernel_src, core_range_set, config);
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto mode = control_plane->get_routing_mode();
     if (mode != ROUTING_MODE_UNDEFINED) {
         kernel->add_defines({{"ROUTING_MODE", std::to_string(static_cast<int>(mode))}});
@@ -1101,7 +1101,7 @@ KernelHandle CreateEthernetKernel(
     const bool are_both_noc_in_use = data_movement_config_status.noc0_in_use && data_movement_config_status.noc1_in_use;
 
     std::shared_ptr<Kernel> kernel = std::make_shared<EthernetKernel>(kernel_src, core_range_set, config);
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto mode = control_plane->get_routing_mode();
     if (mode != ROUTING_MODE_UNDEFINED) {
         kernel->add_defines({{"ROUTING_MODE", std::to_string(static_cast<int>(mode))}});


### PR DESCRIPTION
### Ticket
None

### Problem description
ControlPlane was added to Cluster before `MetalContext` had existed. Cluster was handling both hardware cluster management AND control plane management. Control plane is a higher-level abstraction that orchestrates fabric communication so it makes more sense to have it in MetalContext as the coordination point.

### What's changed
  1. Architectural Refactoring: Moved GlobalControlPlane and ControlPlane management from the Cluster class to MetalContext
  2. API Update: Changed get_control_plane() to return a reference instead of a pointer

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/15404079367
https://github.com/tenstorrent/tt-metal/actions/runs/15437228938
- [x] [T3K Unit Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml): https://github.com/tenstorrent/tt-metal/actions/runs/15405746104
https://github.com/tenstorrent/tt-metal/actions/runs/15437237340