### PR TITLE
cleanup fabric API violations (1 of n)

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
@@ -272,9 +272,9 @@ inline void RunPersistent1dFabricLatencyTest(
         // reserve CB
         tt_metal::CircularBufferConfig cb_src0_config =
             tt_metal::CircularBufferConfig(
-                packet_header_cb_size_in_headers * sizeof(tt::tt_fabric::PacketHeader),
+                packet_header_cb_size_in_headers * tt::tt_fabric::get_tt_fabric_packet_header_size_bytes(),
                 {{packet_header_cb_index, cb_df}})
-                .set_page_size(packet_header_cb_index, sizeof(tt::tt_fabric::PacketHeader));
+                .set_page_size(packet_header_cb_index, tt::tt_fabric::get_tt_fabric_packet_header_size_bytes());
         CBHandle sender_workers_cb = CreateCircularBuffer(program, worker_cores, cb_src0_config);
 
         if (!use_device_init_fabric) {

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -22,6 +22,8 @@ namespace tt::tt_fabric {
 
 size_t get_tt_fabric_channel_buffer_size_bytes();
 
+size_t get_tt_fabric_packet_header_size_bytes();
+
 // Used to get the run-time args for estabilishing connection with the fabric router.
 // The API appends the connection specific run-time args to the set of exisiting
 // run-time args for the worker programs, which allows the workers to conveniently

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -60,6 +60,11 @@ size_t get_tt_fabric_channel_buffer_size_bytes() {
     return control_plane->get_fabric_context().get_fabric_channel_buffer_size_bytes();
 }
 
+size_t get_tt_fabric_packet_header_size_bytes() {
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    return control_plane->get_fabric_context().get_fabric_packet_header_size_bytes();
+}
+
 void append_fabric_connection_rt_args(
     const chip_id_t src_chip_id,
     const chip_id_t dst_chip_id,

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/erisc_datamover_builder.hpp>
+#include <tt-metalium/fabric.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/program.hpp>
@@ -56,9 +57,8 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
         TT_FATAL(device_sequence.size() > 2, "Ring topology only supports more than 2 devices");
     }
 
-    static constexpr std::size_t edm_buffer_size =
-        tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
-        sizeof(tt::tt_fabric::PacketHeader);
+    const std::size_t edm_buffer_size = tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
+                                        tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
     const auto config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, topology);
     TT_ASSERT(device_sequence.size() == program_sequence.size());
 
@@ -314,9 +314,8 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
     bool build_in_worker_connection_mode,
     Topology topology) :
     device_sequence({local_device}), programs({program}) {
-    static constexpr std::size_t edm_buffer_size =
-        tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
-        sizeof(tt::tt_fabric::PacketHeader);
+    const std::size_t edm_buffer_size = tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
+                                        tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
     const auto config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, topology);
 
     log_trace(tt::LogOp, "device id={}", local_device->id());
@@ -528,9 +527,8 @@ EdmLineFabricOpInterface::generate_local_chip_fabric_termination_infos(tt::tt_me
 
 std::vector<tt::tt_fabric::edm_termination_info_t>
 EdmLineFabricOpInterface::generate_ordered_termination_info_farthest_to_nearest() const {
-    static constexpr std::size_t edm_buffer_size =
-        tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
-        sizeof(tt::tt_fabric::PacketHeader);
+    const std::size_t edm_buffer_size = tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
+                                        tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
     static const auto config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size);
     TT_ASSERT(device_sequence.size() > 0);
     const size_t num_hops = device_sequence.size() - 1;


### PR DESCRIPTION
Route fabric packet header size lookup to use fabric API instead of `sizeof(packet_header_type)`

### Ticket
[#20621](https://github.com/tenstorrent/tt-metal/issues/20621)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/15404180161
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/15404182341


Closes #20297