### PR TITLE
cleanup fabric API violations (2 of n)

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -914,6 +914,7 @@ bool RunLocalTestWithMultiInputReaders(
     std::optional<ttnn::ccl::SyncModeSpec> sync_details;
     std::optional<CoreCoord> teardown_worker_core;
     std::optional<ttnn::ccl::cmd::CclHostLowLevelCommandSequence> teardown_command_stream;
+    TT_FATAL(enable_persistent_fabric, "Non-persistent fabric is not supported for this test");
     if (fabric_enabled && !enable_persistent_fabric) {
         teardown_worker_core = worker_core;
 
@@ -2815,6 +2816,8 @@ void Run1DFabricPacketSendTest(
                                              size_t link,
                                              bool is_connected_in_direction,
                                              IDevice* connected_device,
+                                             // not updated to CCL line direction because this is a metal/fabric level
+                                             // test
                                              ttnn::ccl::EdmLineFabricOpInterface::Direction direction,
                                              std::vector<uint32_t>& rt_args_out) {
                 rt_args_out.push_back(is_connected_in_direction);

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -26,19 +26,19 @@ void SyncModeSpec::add_signal(uint32_t sem_id, uint32_t wait_count) {
 
 LineTopology::LineTopology(size_t line_size, size_t line_index) : _line_size(line_size), _line_index(line_index) {}
 
-bool LineTopology::is_first_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction direction) const {
-    if (direction == ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD) {
+bool LineTopology::is_first_device_in_line(ttnn::ccl::LineDirection direction) const {
+    if (direction == ttnn::ccl::LineDirection::FORWARD) {
         return _line_index == 0;
     } else {
-        TT_ASSERT(direction == ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+        TT_ASSERT(direction == ttnn::ccl::LineDirection::BACKWARD);
         return _line_index == _line_size - 1;
     }
 }
-bool LineTopology::is_last_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction direction) const {
-    if (direction == ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD) {
+bool LineTopology::is_last_device_in_line(ttnn::ccl::LineDirection direction) const {
+    if (direction == ttnn::ccl::LineDirection::BACKWARD) {
         return _line_index == 0;
     } else {
-        TT_ASSERT(direction == ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
+        TT_ASSERT(direction == ttnn::ccl::LineDirection::FORWARD);
         return _line_index == _line_size - 1;
     }
 }
@@ -49,8 +49,8 @@ size_t LineTopology::line_size() const { return _line_size; }
 
 size_t LineTopology::line_index() const { return _line_index; }
 
-size_t LineTopology::get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction direction) const {
-    if (direction == ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD) {
+size_t LineTopology::get_distance_to_end_of_line(ttnn::ccl::LineDirection direction) const {
+    if (direction == ttnn::ccl::LineDirection::FORWARD) {
         return (_line_size - _line_index) - 1;
     } else {
         return _line_index;
@@ -1501,10 +1501,8 @@ std::tuple<size_t, size_t, bool> get_forward_backward_configuration(
     size_t num_targets_backward = 0;
     if (topology == Topology::Linear) {
         LineTopology line_topology(ring_size, ring_index);
-        num_targets_forward =
-            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
-        num_targets_backward =
-            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+        num_targets_forward = line_topology.get_distance_to_end_of_line(ttnn::ccl::LineDirection::FORWARD);
+        num_targets_backward = line_topology.get_distance_to_end_of_line(ttnn::ccl::LineDirection::BACKWARD);
     } else if (topology == ccl::Topology::Ring) {
         // TODO: Commonize
         num_targets_forward = tt::div_up(ring_size - 1, 2);

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -16,11 +16,15 @@
 #include <tt-metalium/program.hpp>
 #include "ttnn/tensor/types.hpp"
 #include <tt-metalium/erisc_datamover_builder.hpp>
-#include "erisc_datamover_builder_helper.hpp"
 #include "cpp/ttnn/operations/ccl/common/host/ccl_command_stream_builders.hpp"
 
 namespace ttnn {
 namespace ccl {
+
+enum class LineDirection: uint8_t {
+    FORWARD,
+    BACKWARD,
+};
 
 // Creates a mesh workload by calling the `create_program` function for each coordinate in the `tensor_coords` set.
 tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload_from_programs(
@@ -70,8 +74,8 @@ class LineTopology {
         size_t line_size,
         size_t line_index);
 
-    bool is_first_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction direction) const;
-    bool is_last_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction direction) const;
+    bool is_first_device_in_line(ttnn::ccl::LineDirection direction) const;
+    bool is_last_device_in_line(ttnn::ccl::LineDirection direction) const;
 
     bool is_at_end_of_line() const;
 
@@ -79,7 +83,7 @@ class LineTopology {
 
     size_t line_index() const;
 
-    size_t get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction direction) const;
+    size_t get_distance_to_end_of_line(ttnn::ccl::LineDirection direction) const;
 
     ttnn::ccl::Topology topology() const;
 

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.hpp
@@ -9,6 +9,7 @@
 #include "ttnn/operations/ccl/common/uops/ccl_command.hpp"
 #include "ttnn/operations/ccl/common/uops/ccl_host_commands.hpp"
 #include "cpp/ttnn/operations/ccl/common/host/command_backend_runtime_args_overrider.hpp"
+#include "cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.hpp"
 
 #include <cstdint>
 #include <optional>

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program.cpp
@@ -224,10 +224,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_multi_core_with_w
     size_t num_targets_backward = 0;
     if (topology == ccl::Topology::Linear) {
         LineTopology line_topology(ring_size, ring_index);
-        num_targets_forward =
-            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
-        num_targets_backward =
-            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+        num_targets_forward = line_topology.get_distance_to_end_of_line(ttnn::ccl::LineDirection::FORWARD);
+        num_targets_backward = line_topology.get_distance_to_end_of_line(ttnn::ccl::LineDirection::BACKWARD);
     } else if (topology == ccl::Topology::Ring) {
         // TODO: Commonize
         num_targets_forward = tt::div_up(ring_size - 1, 2);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
@@ -94,10 +94,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
     std::vector<Tensor> temp_tensors = {temp_tensor};
     const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, temp_tensors, topology);
     LineTopology line_topology(ring_size, ring_index);
-    const size_t num_targets_forward =
-        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
-    const size_t num_targets_backward =
-        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+    const size_t num_targets_forward = line_topology.get_distance_to_end_of_line(ttnn::ccl::LineDirection::FORWARD);
+    const size_t num_targets_backward = line_topology.get_distance_to_end_of_line(ttnn::ccl::LineDirection::BACKWARD);
 
     // To overlap NLP local data with all gather, we divide the batches for each device into:
     //      - local batch (starts with start_local)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
@@ -756,10 +756,8 @@ LlamaReduceScatterCreateHeadsDeviceOperation::LlamaReduceScatterCreateHeads::cre
     bool forward_fabric_connection = false, backward_fabric_connection = false;
     if (operation_attributes.topology == ttnn::ccl::Topology::Linear) {
         LineTopology line_topology(ring_size, ring_index);
-        forward_fabric_connection =
-            !(line_topology.is_first_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD));
-        backward_fabric_connection =
-            !(line_topology.is_last_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD));
+        forward_fabric_connection = !(line_topology.is_first_device_in_line(ttnn::ccl::LineDirection::BACKWARD));
+        backward_fabric_connection = !(line_topology.is_last_device_in_line(ttnn::ccl::LineDirection::BACKWARD));
     } else if (operation_attributes.topology == ttnn::ccl::Topology::Ring) {
         forward_fabric_connection = true;
         backward_fabric_connection = true;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
@@ -107,10 +107,10 @@ enum fabric_lifetime_mode {
 enum LineDirection { FORWARD, BACKWARD };
 static_assert(
     static_cast<size_t>(LineDirection::FORWARD) ==
-    static_cast<size_t>(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD));
+    static_cast<size_t>(ttnn::ccl::LineDirection::FORWARD));
 static_assert(
     static_cast<size_t>(LineDirection::BACKWARD) ==
-    static_cast<size_t>(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD));
+    static_cast<size_t>(ttnn::ccl::LineDirection::BACKWARD));
 
 constexpr LineDirection relay_to_final_output_dir = LineDirection::FORWARD;
 // TODO: promote to header
@@ -1209,7 +1209,7 @@ static void populate_partial_reduce_rt_args(
     std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& reader_rt_args_overrider_map,
     std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& writer_rt_args_overrider_map) {
     using namespace ttnn::ccl::worker_detail;
-    using Direction = ttnn::ccl::EdmLineFabricOpInterface::Direction;
+    using Direction = ttnn::ccl::LineDirection;
 
     auto const& all_tensors = builder_config.all_tensors.get();
     auto const& kernel_ids = builder_config.kernel_ids.get();
@@ -1526,7 +1526,7 @@ static void create_end_of_line_worker_runtime_args(
     std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& writer_rt_args_overrider_map) {
     using namespace ttnn::ccl::worker_detail;
     using namespace ttnn::ccl::cmd;
-    using Direction = ttnn::ccl::EdmLineFabricOpInterface::Direction;
+    using Direction = ttnn::ccl::LineDirection;
     Program& program = builder_config.program.get();
     IDevice* device = builder_config.device;
     ProgramTensorsBundle const& all_tensors = builder_config.all_tensors.get();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp
@@ -115,10 +115,8 @@ operation::ProgramWithCallbacks frmsnorm_multi_core_sharded(
     size_t num_targets_backward = 0;
     if (topology == ccl::Topology::Linear) {
         ccl::LineTopology line_topology(ring_size, ring_index);
-        num_targets_forward =
-            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
-        num_targets_backward =
-            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+        num_targets_forward = line_topology.get_distance_to_end_of_line(ttnn::ccl::LineDirection::FORWARD);
+        num_targets_backward = line_topology.get_distance_to_end_of_line(ttnn::ccl::LineDirection::BACKWARD);
     } else if (topology == ccl::Topology::Ring) {
         num_targets_forward = tt::div_up(ring_size - 1, 2);
         num_targets_backward = ring_size - 1 - num_targets_forward;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
@@ -156,10 +156,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_create_qkv_heads_minima
     size_t num_targets_backward = 0;
     if (topology == ccl::Topology::Linear) {
         LineTopology line_topology(ring_size, ring_index);
-        num_targets_forward =
-            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
-        num_targets_backward =
-            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+        num_targets_forward = line_topology.get_distance_to_end_of_line(ttnn::ccl::LineDirection::FORWARD);
+        num_targets_backward = line_topology.get_distance_to_end_of_line(ttnn::ccl::LineDirection::BACKWARD);
     } else if (topology == ccl::Topology::Ring) {
         // TODO: Commonize
         num_targets_forward = tt::div_up(ring_size - 1, 2);


### PR DESCRIPTION
Move `EdmLineFabricOpInterface::Direction` out of `EdmLineFabricOpInterface` out of metalium API. Move enum to CCL/TTNN concept. If needed it can be promoted to fabric in the future.

### Ticket
https://github.com/tenstorrent/tt-metal/issues/20621

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/15404453978
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/15404455359
- [x] New/Existing tests provide coverage for changes