### PR TITLE
#22843 APC test_binary_bcast.py::test_binary_sharded failure

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -439,6 +439,7 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
     ),
 )
 def test_binary_sharded(a_shape, b_shape, a_config, b_config, out_config, dtype_pt, dtype_tt, device):
+    torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=dtype_pt), dtype_tt)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=dtype_pt), dtype_tt)(b_shape)
 
@@ -461,7 +462,6 @@ def test_binary_sharded(a_shape, b_shape, a_config, b_config, out_config, dtype_
     out_tt = ttnn.add(a_tt, b_tt, memory_config=out_config, use_legacy=None)
     assert_with_pcc(ttnn.to_torch(out_tt), out_pt)
 
-
 @pytest.mark.parametrize(
     "a_shape, b_shape",
     ((torch.Size([5, 7, 64, 128]), torch.Size([5, 7, 64, 128])),),
@@ -480,6 +480,7 @@ def test_binary_sharded(a_shape, b_shape, a_config, b_config, out_config, dtype_
     ),
 )
 def test_binary_sharded_core_grid(device, a_shape, b_shape, sharded_core_grid, memory_lay_out):
+    torch.manual_seed(0)
     sharded_config = ttnn.create_sharded_memory_config(
         [160, 128],  # 14 cores
         core_grid=sharded_core_grid,
@@ -554,6 +555,7 @@ def test_binary_sharded_core_grid(device, a_shape, b_shape, sharded_core_grid, m
     ([ttnn.float32]),
 )
 def test_binary_sfpu_ops(input_shapes, dtype, ttnn_fn, device):
+    torch.manual_seed(0)
     a_shape, b_shape = input_shapes
 
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(a_shape)
@@ -621,6 +623,7 @@ def test_binary_sfpu_ops(input_shapes, dtype, ttnn_fn, device):
     ([ttnn.float32]),
 )
 def test_binary_sfpu_opt_out(input_shapes, dtype, ttnn_fn, device):
+    torch.manual_seed(0)
     a_shape, b_shape, out_shape = input_shapes
 
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(a_shape)
@@ -682,6 +685,7 @@ def test_binary_sfpu_opt_out(input_shapes, dtype, ttnn_fn, device):
     ([ttnn.int32]),
 )
 def test_binary_sfpu_bitwise_ops(input_shapes, dtype, ttnn_fn, device):
+    torch.manual_seed(0)
     a_shape, b_shape = input_shapes
 
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=torch.int32), dtype)(a_shape)
@@ -736,6 +740,7 @@ def test_binary_sfpu_bitwise_ops(input_shapes, dtype, ttnn_fn, device):
     ([ttnn.int32]),
 )
 def test_bitwise_opt_output(input_shapes, dtype, ttnn_fn, device):
+    torch.manual_seed(0)
     a_shape, b_shape, out_shape = input_shapes
 
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=torch.int32), dtype)(a_shape)
@@ -959,6 +964,7 @@ def test_bf4b_bf8b(a_shape, b_shape, input_dtype, pcc, ttnn_fn, device):
     binary_inplace_fns,
 )
 def test_inplace_binary_ops_fp32(input_shapes, ttnn_fn, device):
+    torch.manual_seed(0)
     a_shape, b_shape = input_shapes
     ttnn_op = getattr(ttnn, ttnn_fn)
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -1104,6 +1110,7 @@ def test_binary_opt_output_invalid_bcast(a_shape, b_shape, out_shape, ttnn_fn, d
     ),
 )
 def test_binary_sharded_bcast_w(device, dtype_pt, dtype_tt):
+    torch.manual_seed(0)
     a_shape = torch.Size([5, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([5, 7, 2 * 32, 1])
 
@@ -1178,6 +1185,7 @@ def test_binary_sharded_bcast_w(device, dtype_pt, dtype_tt):
     ),
 )
 def test_binary_sharded_invalid_bcast(a_shape, b_shape, a_shard_size, b_shard_size, core_range, device):
+    torch.manual_seed(0)
     a_sharded_config = ttnn.create_sharded_memory_config(
         a_shard_size,
         core_grid=core_range,
@@ -1214,6 +1222,7 @@ def test_binary_sharded_invalid_bcast(a_shape, b_shape, a_shard_size, b_shard_si
     ),
 )
 def test_binary_sharded_small_tile(a_shape, b_shape, shard_type, shard_size, core_range, device):
+    torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
 
@@ -1326,6 +1335,7 @@ def test_binary_sharded_small_tile(a_shape, b_shape, shard_type, shard_size, cor
     ),
 )
 def test_binary_sharded_col_major(a_shape, b_shape, shard_type, shard_size, core_range, ttnn_fn, device):
+    torch.manual_seed(0)
     golden_function = ttnn.get_golden_function(ttnn_fn)
 
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
@@ -1386,6 +1396,7 @@ def test_binary_sharded_col_major(a_shape, b_shape, shard_type, shard_size, core
     ),
 )
 def test_binary_sharded_auto(a_shape, b_shape, shard_type, core_coord, device):
+    torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
 
@@ -1427,6 +1438,7 @@ def test_binary_sharded_auto(a_shape, b_shape, shard_type, core_coord, device):
     ([ttnn.ShardStrategy.HEIGHT, [64, 96], ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (2, 5))})],),
 )
 def test_binary_sharded_uneven(a_shape, b_shape, shard_type, shard_size, core_range, device):
+    torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
 
@@ -1471,6 +1483,7 @@ def test_binary_sharded_uneven(a_shape, b_shape, shard_type, shard_size, core_ra
     ),
 )
 def test_binary_sharded_uneven_invalid(a_shape, b_shape, shard_type, shard_size, core_range, device):
+    torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
 
@@ -1673,6 +1686,7 @@ def test_binary_sharded_scalar_col_major(scalar, a_shape, shard_type, shard_size
     ),
 )
 def test_binary_sharded_bcast_w_size(a_shape, b_shape, a_shard_size, b_shard_size, core_range, device):
+    torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
 
@@ -1731,6 +1745,7 @@ def test_binary_sharded_bcast_w_size(a_shape, b_shape, a_shard_size, b_shard_siz
 def test_binary_sharded_invalid_spec(
     a_shape, b_shape, a_strategy, b_strategy, a_shard_size, b_shard_size, a_core_range, b_core_range, device
 ):
+    torch.manual_seed(0)
     a_sharded_config = ttnn.create_sharded_memory_config(
         a_shard_size,
         core_grid=a_core_range,
@@ -2155,6 +2170,7 @@ def test_binary_subtile_row_b_col_a_bcast(a_shape, b_shape, device):
 @pytest.mark.parametrize("bcast_dim", [ttnn.BcastOpDim.H, ttnn.BcastOpDim.W, ttnn.BcastOpDim.HW])
 @pytest.mark.parametrize("math_op", [ttnn.BcastOpMath.ADD, ttnn.BcastOpMath.SUB, ttnn.BcastOpMath.MUL])
 def test_bcast(input_shape_a, device, bcast_dim, math_op):
+    torch.manual_seed(0)
     input_shape_b = list(input_shape_a)
 
     if bcast_dim == ttnn.BcastOpDim.H or bcast_dim == ttnn.BcastOpDim.HW:

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -462,6 +462,7 @@ def test_binary_sharded(a_shape, b_shape, a_config, b_config, out_config, dtype_
     out_tt = ttnn.add(a_tt, b_tt, memory_config=out_config, use_legacy=None)
     assert_with_pcc(ttnn.to_torch(out_tt), out_pt)
 
+
 @pytest.mark.parametrize(
     "a_shape, b_shape",
     ((torch.Size([5, 7, 64, 128]), torch.Size([5, 7, 64, 128])),),


### PR DESCRIPTION
### Ticket
Reopen for not exact, but closely related
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26540)

### Problem description
ND test failure for some sfpu ops, due to recent accuracy tuning.

### What's changed
Use fixed random seed to make test deterministic.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes