### PR TITLE
#21896: Use NLPCreateHeads in sdxl cross-attentions

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
@@ -110,12 +110,8 @@ class TtAttention(nn.Module):
                 bias=None,
             )
 
-            inner_dim = list(k_heads.shape)[-1]
-            head_dim = inner_dim // self.heads
-
             q_heads, _, _ = ttnn.experimental.nlp_create_qkv_heads(
                 q_heads,
-                # q_heads,
                 num_heads=self.heads,
                 num_kv_heads=0,
                 transpose_k_heads=False,
@@ -123,7 +119,6 @@ class TtAttention(nn.Module):
 
             v_heads, _, _ = ttnn.experimental.nlp_create_qkv_heads(
                 v_heads,
-                # v_heads,
                 num_heads=self.heads,
                 num_kv_heads=0,
                 transpose_k_heads=False,
@@ -131,20 +126,10 @@ class TtAttention(nn.Module):
 
             k_heads, _, _ = ttnn.experimental.nlp_create_qkv_heads(
                 k_heads,
-                # k_heads,
                 num_heads=self.heads,
                 num_kv_heads=0,
                 transpose_k_heads=False,
             )
-
-            # q_heads = ttnn.reshape(q_heads, [B, -1, self.heads, head_dim])
-            # q_heads = ttnn.transpose(q_heads, 1, 2)
-
-            # k_heads = ttnn.reshape(k_heads, [B, -1, self.heads, head_dim])
-            # k_heads = ttnn.transpose(k_heads, 1, 2)
-
-            # v_heads = ttnn.reshape(v_heads, [B, -1, self.heads, head_dim])
-            # v_heads = ttnn.transpose(v_heads, 1, 2)
 
         hidden_states = ttnn.transformer.scaled_dot_product_attention(
             q_heads,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
@@ -113,14 +113,38 @@ class TtAttention(nn.Module):
             inner_dim = list(k_heads.shape)[-1]
             head_dim = inner_dim // self.heads
 
-            q_heads = ttnn.reshape(q_heads, [B, -1, self.heads, head_dim])
-            q_heads = ttnn.transpose(q_heads, 1, 2)
+            q_heads, _, _ = ttnn.experimental.nlp_create_qkv_heads(
+                q_heads,
+                # q_heads,
+                num_heads=self.heads,
+                num_kv_heads=0,
+                transpose_k_heads=False,
+            )
 
-            k_heads = ttnn.reshape(k_heads, [B, -1, self.heads, head_dim])
-            k_heads = ttnn.transpose(k_heads, 1, 2)
+            v_heads, _, _ = ttnn.experimental.nlp_create_qkv_heads(
+                v_heads,
+                # v_heads,
+                num_heads=self.heads,
+                num_kv_heads=0,
+                transpose_k_heads=False,
+            )
 
-            v_heads = ttnn.reshape(v_heads, [B, -1, self.heads, head_dim])
-            v_heads = ttnn.transpose(v_heads, 1, 2)
+            k_heads, _, _ = ttnn.experimental.nlp_create_qkv_heads(
+                k_heads,
+                # k_heads,
+                num_heads=self.heads,
+                num_kv_heads=0,
+                transpose_k_heads=False,
+            )
+
+            # q_heads = ttnn.reshape(q_heads, [B, -1, self.heads, head_dim])
+            # q_heads = ttnn.transpose(q_heads, 1, 2)
+
+            # k_heads = ttnn.reshape(k_heads, [B, -1, self.heads, head_dim])
+            # k_heads = ttnn.transpose(k_heads, 1, 2)
+
+            # v_heads = ttnn.reshape(v_heads, [B, -1, self.heads, head_dim])
+            # v_heads = ttnn.transpose(v_heads, 1, 2)
 
         hidden_states = ttnn.transformer.scaled_dot_product_attention(
             q_heads,


### PR DESCRIPTION
### Ticket
#21896 

### Problem description
The previous PR got complicated to merge, use this workaround before that happens

### What's changed
3 NLPCreate heads calls for Q, K V instead of reshapes and transposes
Unet perf: 
672ms -> 612ms

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15419918677/job/43392572518 <- unrelated falcon7b failure
- [x] Frequent model tests https://github.com/tenstorrent/tt-metal/actions/runs/15419350454/job/43390773118  <- unreleated bert failure
