### PR TITLE
fix regression from recent mux changes

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
@@ -141,6 +141,7 @@ void create_mux_kernel(
     // std::vector<uint32_t> mux_ct_args = mux_kernel_config->get_fabric_mux_compile_time_args();
     auto default_channel_type = tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
     size_t mux_status_address = mux_kernel_config->get_status_address();
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     std::vector<uint32_t> mux_ct_args = {
         test_params.num_full_size_channels,
         test_params.num_buffers_full_size_channel,
@@ -157,7 +158,8 @@ void create_mux_kernel(
         drainer_kernel_config->get_status_address(),
         drainer_kernel_config->num_buffers_full_size_channel,
         test_params.num_full_size_channel_iters,
-        test_params.num_iters_between_teardown_checks};
+        test_params.num_iters_between_teardown_checks,
+        hal.get_programmable_core_type_index(tt::tt_metal::HalProgrammableCoreType::TENSIX)};
 
     // semaphores needed to build connection with drainer core using the build_from_args API
     auto worker_flow_control_semaphore_id = tt::tt_metal::CreateSemaphore(program_handle, mux_logical_core, 0);


### PR DESCRIPTION
There was a recent change to use stateful APIs in mux. The mux BW tests were missed with the update and now fail compile. This fixes the regression

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/15420054331
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/15420056201
- [ ] Metal Microbenchmark: https://github.com/tenstorrent/tt-metal/actions/runs/15420059552