### PR TITLE
[skip ci] Add support for building Tracy with TIMER FALLBACK for VMs

### DIFF
--- a/cmake/tracy.cmake
+++ b/cmake/tracy.cmake
@@ -1,6 +1,8 @@
 # Built as outlined in Tracy documentation (pg.12)
 set(TRACY_HOME ${PROJECT_SOURCE_DIR}/tt_metal/third_party/tracy)
 
+option(ENABLE_TRACY_TIMER_FALLBACK "Enable Tracy timer fallback" OFF)
+
 if(NOT ENABLE_TRACY)
     # Stub Tracy::TracyClient to provide the headers which themselves provide stubs
     add_library(TracyClient INTERFACE)
@@ -28,6 +30,9 @@ set_target_properties(
 )
 
 target_compile_definitions(TracyClient PUBLIC TRACY_ENABLE)
+if(ENABLE_TRACY_TIMER_FALLBACK)
+    target_compile_definitions(TracyClient PUBLIC TRACY_TIMER_FALLBACK)
+endif()
 target_compile_options(
     TracyClient
     PUBLIC

--- a/cmake/tracy.cmake
+++ b/cmake/tracy.cmake
@@ -34,6 +34,7 @@ target_compile_definitions(
     PUBLIC
         TRACY_ENABLE
         "$<$<BOOL:${ENABLE_TRACY_TIMER_FALLBACK}>:TRACY_TIMER_FALLBACK>"
+)
 target_compile_options(
     TracyClient
     PUBLIC

--- a/cmake/tracy.cmake
+++ b/cmake/tracy.cmake
@@ -29,10 +29,10 @@ set_target_properties(
             "tracy"
 )
 
-target_compile_definitions(TracyClient PUBLIC TRACY_ENABLE)
-if(ENABLE_TRACY_TIMER_FALLBACK)
-    target_compile_definitions(TracyClient PUBLIC TRACY_TIMER_FALLBACK)
-endif()
+target_compile_definitions(TracyClient PUBLIC
+    TRACY_ENABLE
+    "$<$<BOOL:${ENABLE_TRACY_TIMER_FALLBACK}>:TRACY_TIMER_FALLBACK>"
+)
 target_compile_options(
     TracyClient
     PUBLIC

--- a/cmake/tracy.cmake
+++ b/cmake/tracy.cmake
@@ -29,10 +29,11 @@ set_target_properties(
             "tracy"
 )
 
-target_compile_definitions(TracyClient PUBLIC
-    TRACY_ENABLE
-    "$<$<BOOL:${ENABLE_TRACY_TIMER_FALLBACK}>:TRACY_TIMER_FALLBACK>"
-)
+target_compile_definitions(
+    TracyClient
+    PUBLIC
+        TRACY_ENABLE
+        "$<$<BOOL:${ENABLE_TRACY_TIMER_FALLBACK}>:TRACY_TIMER_FALLBACK>"
 target_compile_options(
     TracyClient
     PUBLIC


### PR DESCRIPTION
### Ticket
#20161 

### Problem description
VMs can experience " Inability to obtain precise timestamps, resulting in error messages such as CPU doesn’t support RDTSC instruction, or CPU doesn’t support invariant TSC. "

### What's changed
Add an option to build Tracy with the fallback timer, to make it safe to use in VMs.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes