### PR TITLE
#22169: Adopt distributed host buffer in TT-NN

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -65,8 +65,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
     ttnn::SmallVector<int64_t> reduce_dims = {3};
     Tensor np_out = ttnn::moreh_sum(np_tensor, reduce_dims, false, std::nullopt, std::nullopt, std::nullopt);
     Tensor np_out_host = np_out.cpu();
-    auto buffer = std::get<MultiDeviceHostStorage>(np_out_host.storage()).get_buffer(0);
-    const auto golden_output = buffer.view_as<bfloat16>();
+    auto buffer = std::get<MultiDeviceHostStorage>(np_out_host.get_storage()).get_shard_at_origin();
+    const auto golden_output = buffer->view_as<bfloat16>();
     // Events for host - device synchronization
     // Running sum-reduce with preallocated output
     // Preallocate Input and Output Tensors on Device

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -96,12 +96,10 @@ std::vector<tt::tt_metal::HostBuffer> get_as(const ttnn::Tensor& tensor) {
             if constexpr (std::is_same_v<StorageType, tt::tt_metal::HostStorage>) {
                 return {storage.buffer};
             } else if constexpr (std::is_same_v<StorageType, tt::tt_metal::MultiDeviceHostStorage>) {
-                auto num_buffers = storage.num_buffers();
                 std::vector<tt::tt_metal::HostBuffer> buffers;
-                buffers.reserve(num_buffers);
-                for (uint32_t i = 0; i < num_buffers; ++i) {
-                    buffers.push_back(storage.get_buffer(i));
-                }
+                buffers.reserve(storage.distributed_buffer().shard_coords().size());
+                storage.distributed_buffer().apply(
+                    [&buffers](const tt::tt_metal::HostBuffer& shard) { buffers.push_back(shard); });
                 return buffers;
             } else {
                 throw std::runtime_error("Tensor must be on host");

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -145,6 +145,7 @@ public:
     class Iterator {
     public:
         Iterator& operator++();
+        Iterator operator++(int);
         const MeshCoordinate& operator*() const;
         bool operator==(const Iterator& other) const;
         bool operator!=(const Iterator& other) const;

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -231,6 +231,12 @@ MeshCoordinateRange::Iterator::Iterator(
     const MeshCoordinateRange* range, const MeshCoordinate& current, size_t linear_index) :
     range_(range), current_coord_(current), linear_index_(linear_index) {}
 
+MeshCoordinateRange::Iterator MeshCoordinateRange::Iterator::operator++(int) {
+    Iterator tmp = *this;
+    ++(*this);
+    return tmp;
+}
+
 MeshCoordinateRange::Iterator& MeshCoordinateRange::Iterator::operator++() {
     ++linear_index_;
 

--- a/tt_metal/distributed/distributed_host_buffer.cpp
+++ b/tt_metal/distributed/distributed_host_buffer.cpp
@@ -107,7 +107,6 @@ DistributedHostBuffer DistributedHostBuffer::transform(
     const std::vector<size_t> indices_to_process = get_populated_local_shard_indices();
     const auto& local_shards = local_shards_.values();
     std::vector<Shard> transformed_shards(local_shards.size());
-
     if (policy == ProcessShardExecutionPolicy::SEQUENTIAL || indices_to_process.size() < 2) {
         std::for_each(indices_to_process.begin(), indices_to_process.end(), [&](size_t i) {
             transformed_shards[i] = Shard{.buffer = fn(local_shards[i].buffer), .is_populated = true};
@@ -119,12 +118,10 @@ DistributedHostBuffer DistributedHostBuffer::transform(
         });
         detail::GetExecutor().run(taskflow).wait();
     }
-
-    DistributedHostBuffer transformed_buffer(
+    return DistributedHostBuffer(
         global_shape_,
         local_offset_,
         distributed::MeshContainer<Shard>(local_shards_.shape(), std::move(transformed_shards)));
-    return transformed_buffer;
 }
 
 void DistributedHostBuffer::apply(const ApplyFn& fn, ProcessShardExecutionPolicy policy) const {

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -50,19 +50,23 @@ struct DeviceStorage {
 
 class MultiDeviceHostStorage {
 public:
+    // TODO: #15840 - Remove this once `HostStorage` and `MultiDeviceHostStorage` are unified.
+    std::optional<HostBuffer> get_shard_at_origin() const;
+
+    // Constructor that creates a linearized distributed host buffer from a vector of host buffers.
+    // The buffer is re-shaped upon a write to device, to fit the actual shape of the device.
+    // TODO: #22169 - Remove this once there are no more usages of this constructor.
     explicit MultiDeviceHostStorage(std::vector<HostBuffer> buffers);
+
+    explicit MultiDeviceHostStorage(DistributedHostBuffer buffer);
+
+    const DistributedHostBuffer& distributed_buffer() const;
 
     static constexpr auto attribute_names = std::forward_as_tuple();
     auto attribute_values() const { return std::forward_as_tuple(); }
 
-    // Returns `HostBuffer` at position `buffer_index`;
-    HostBuffer get_buffer(int buffer_index) const;
-
-    // Returns the number of `HostBuffer`s in the storage;
-    size_t num_buffers() const;
-
 private:
-    std::vector<HostBuffer> buffers_;
+    DistributedHostBuffer distributed_buffer_;
 };
 
 using Storage = std::variant<HostStorage, DeviceStorage, MultiDeviceHostStorage>;

--- a/ttnn/api/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_attributes.hpp
@@ -21,9 +21,6 @@ public:
     const TensorSpec& get_tensor_spec() const;
     const DistributedTensorConfig& get_distributed_tensor_config() const;
 
-    // Determines mesh coordinates for the tensor based on the strategy and the mesh shape.
-    std::vector<distributed::MeshCoordinate> determine_distribution(const distributed::MeshShape& mesh_shape) const;
-
 private:
     Storage storage_;
     TensorSpec tensor_spec_;

--- a/ttnn/api/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_ops.hpp
@@ -27,8 +27,6 @@ Tensor tensor_to_device(
 
 Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, IDevice* worker);
 
-Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distributed::MeshDevice* mesh_device);
-
 Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, QueueId cq_id);
 
 void tensor_print(const Tensor& input_tensor);

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tensor/host_buffer/functions.hpp"
+#include "tensor/storage.hpp"
 #include "tt-metalium/shape.hpp"
 #include "tt-metalium/mesh_coord.hpp"
 #include <tt_stl/small_vector.hpp>
@@ -41,7 +42,7 @@ bool increment_indices(const tt::stl::SmallVector<int>& limits, tt::stl::SmallVe
 // Note the shapes of all shards must be the same; resulting in a uniform tensor spec.
 TensorSpec compute_tensor_spec_for_shards(
     const auto& xtensor_shards_views, const tt::tt_metal::TensorLayout& global_layout) {
-    std::optional<ttnn::Shape> shard_shape;
+    std::optional<Shape> shard_shape;
     for (const auto& [_, xtensor_view] : xtensor_shards_views) {
         if (!xtensor_view.has_value()) {
             continue;
@@ -63,11 +64,30 @@ TensorSpec compute_tensor_spec_for_shards(
 
 class NdTensorToMesh : public TensorToMesh {
 public:
+    // Specifies how a tensor sharded over a specific shape will be distributed to a mesh device, which potentially
+    // has a different shape.
+    enum class DistributionMode {
+        // Tensor shards will be distributed in row-major order over a mesh device.
+        ROW_MAJOR,
+
+        // Shards will be mapped to a mesh device as is, preserving coordinates.
+        // This requires a submesh to fit within the mesh device.
+        SUBMESH,
+    };
+
     NdTensorToMesh(
-        const ttnn::MeshShape& shape,
+        const MeshDevice& mesh_device,
+        DistributionMode distribution_mode,
+        const MeshShape& distribution_shape,
         const MeshMapperConfig& config,
         const tt::tt_metal::DistributedTensorConfig& distributed_tensor_config) :
-        shape_(shape), config_(config), distributed_tensor_config_(distributed_tensor_config) {}
+        global_shape_(mesh_device.shape()),
+        local_shape_(mesh_device.shape()),
+        local_offset_(MeshCoordinate::zero_coordinate(mesh_device.shape().dims())),
+        distribution_mode_(distribution_mode),
+        distribution_shape_(distribution_shape),
+        config_(config),
+        distributed_tensor_config_(distributed_tensor_config) {}
 
     Tensor operator()(const Tensor& tensor) const override {
         switch (tensor.tensor_spec().data_type()) {
@@ -111,13 +131,13 @@ private:
         tt::stl::SmallVector<int> tensor_dims;
         tt::stl::SmallVector<size_t> replicate_dims;
         size_t sharded_mesh_size = 1;
-        for (size_t mesh_dim_idx = 0; mesh_dim_idx < shape_.dims(); ++mesh_dim_idx) {
+        for (size_t mesh_dim_idx = 0; mesh_dim_idx < distribution_shape_.dims(); ++mesh_dim_idx) {
             const auto& placement = config_.placements[mesh_dim_idx];
             if (const auto* shard_placement = std::get_if<MeshMapperConfig::Shard>(&placement)) {
                 shard_dims.push_back(mesh_dim_idx);
-                num_chunks_per_dim.push_back(shape_[mesh_dim_idx]);
+                num_chunks_per_dim.push_back(distribution_shape_[mesh_dim_idx]);
                 tensor_dims.push_back(shard_placement->dim);
-                sharded_mesh_size *= shape_[mesh_dim_idx];
+                sharded_mesh_size *= distribution_shape_[mesh_dim_idx];
             } else {
                 replicate_dims.push_back(mesh_dim_idx);
             }
@@ -126,19 +146,19 @@ private:
         auto chunks = experimental::xtensor::chunk_ndim(input_xtensor, num_chunks_per_dim, tensor_dims);
         TT_FATAL(chunks.size() >= 1, "No chunks were produced");
         TT_FATAL(
-            shape_.dims() == 1 || chunks.size() == sharded_mesh_size,
+            distribution_shape_.dims() == 1 || chunks.size() == sharded_mesh_size,
             "ND sharding requires the number of chunks {} to match the mesh dimension size {}",
             chunks.size(),
             sharded_mesh_size);
 
         using StridedViewRef = std::reference_wrapper<experimental::xtensor::StridedView<decltype(input_xtensor)>>;
-        MeshContainer<std::optional<StridedViewRef>> sharded_xtensor_views(shape_, std::nullopt);
+        MeshContainer<std::optional<StridedViewRef>> sharded_xtensor_views(distribution_shape_, std::nullopt);
 
         // Distribute chunks to appropriate mesh coordinates.
         size_t chunk_idx = 0;
         tt::stl::SmallVector<int> shard_indices(shard_dims.size(), 0);
         do {
-            tt::stl::SmallVector<uint32_t> mesh_coords(shape_.dims(), 0);
+            tt::stl::SmallVector<uint32_t> mesh_coords(distribution_shape_.dims(), 0);
             for (size_t i = 0; i < shard_dims.size(); ++i) {
                 mesh_coords[shard_dims[i]] = shard_indices[i];
             }
@@ -151,7 +171,7 @@ private:
 
         tt::stl::SmallVector<int> replicate_sizes;
         for (size_t replicate_mesh_dim : replicate_dims) {
-            replicate_sizes.push_back(shape_[replicate_mesh_dim]);
+            replicate_sizes.push_back(distribution_shape_[replicate_mesh_dim]);
         }
 
         // Fill in gaps along replicated dimensions:
@@ -176,15 +196,28 @@ private:
             }
         }
 
-        const TensorSpec shard_spec =
-            compute_tensor_spec_for_shards(sharded_xtensor_views, tensor.tensor_spec().tensor_layout());
+        return create_tensor<T>(sharded_xtensor_views, tensor.tensor_spec().tensor_layout());
+    }
 
-        // TODO: #22169 - For multi-host, supply mesh device global/local shape, along with local offset.
+    template <typename T>
+    Tensor create_tensor(const auto& sharded_xtensor_views, const tt::tt_metal::TensorLayout& global_layout) const {
+        const TensorSpec shard_spec = compute_tensor_spec_for_shards(sharded_xtensor_views, global_layout);
+
         auto distributed_buffer =
-            tt::tt_metal::DistributedHostBuffer::create(shape_, shape_, MeshCoordinate::zero_coordinate(shape_.dims()));
+            tt::tt_metal::DistributedHostBuffer::create(global_shape_, local_shape_, local_offset_);
+        const auto global_range = MeshCoordinateRange(global_shape_);
+
+        auto get_dst_coord = [this, row_major_dst = global_range.begin()](const MeshCoordinate& src_coord) mutable {
+            switch (distribution_mode_) {
+                case DistributionMode::ROW_MAJOR: return *(row_major_dst++);
+                case DistributionMode::SUBMESH: return src_coord;
+            }
+            TT_THROW("Unreachable");
+        };
+
         for (const auto& [coord, xtensor_view] : sharded_xtensor_views) {
             if (xtensor_view.has_value()) {
-                distributed_buffer.emplace_shard(coord, [&xtensor_view, &shard_spec, &coord]() {
+                distributed_buffer.emplace_shard(get_dst_coord(coord), [&xtensor_view, &shard_spec, &coord]() {
                     xt::xarray<T> data(xtensor_view->get());
                     auto shard_tensor = experimental::xtensor::from_xtensor<T>(data, shard_spec);
                     return tt::tt_metal::host_buffer::get_host_buffer(shard_tensor);
@@ -192,26 +225,23 @@ private:
             }
         }
 
-        // TODO: #22169 - Directly create a multi-host distributed tensor from the distributed host buffer.
-        std::vector<Tensor> tensors;
-        for (const auto& coord : MeshCoordinateRange(shape_)) {
-            auto shard = distributed_buffer.get_shard(coord);
-            if (shard.has_value() && !shard->view_bytes().empty()) {
-                tensors.push_back(Tensor(std::move(*shard), shard_spec));
-            }
-        }
-
-        return aggregate_as_tensor(tensors, config());
+        return Tensor(tt::tt_metal::MultiDeviceHostStorage(std::move(distributed_buffer)), shard_spec, config());
     }
 
-    ttnn::MeshShape shape_;
+    // MeshDevice parameters.
+    MeshShape global_shape_;
+    MeshShape local_shape_;
+    MeshCoordinate local_offset_;
+    DistributionMode distribution_mode_ = DistributionMode::ROW_MAJOR;
+
+    MeshShape distribution_shape_;
     MeshMapperConfig config_;
     tt::tt_metal::DistributedTensorConfig distributed_tensor_config_;
 };
 
 class NdMeshToTensor : public MeshToTensor {
 public:
-    NdMeshToTensor(const ttnn::MeshShape& shape, const MeshComposerConfig& config) : shape_(shape), config_(config) {}
+    NdMeshToTensor(const MeshShape& shape, const MeshComposerConfig& config) : shape_(shape), config_(config) {}
 
     Tensor compose(const std::vector<Tensor>& tensors) const override {
         TT_FATAL(
@@ -251,7 +281,7 @@ public:
     }
 
 private:
-    ttnn::MeshShape shape_;
+    MeshShape shape_;
     MeshComposerConfig config_;
 };
 
@@ -259,6 +289,8 @@ private:
 
 std::unique_ptr<TensorToMesh> replicate_tensor_to_mesh_mapper(MeshDevice& mesh_device) {
     return std::make_unique<NdTensorToMesh>(
+        mesh_device,
+        NdTensorToMesh::DistributionMode::ROW_MAJOR,
         MeshShape(mesh_device.num_devices()),
         MeshMapperConfig{
             .placements =
@@ -270,6 +302,8 @@ std::unique_ptr<TensorToMesh> replicate_tensor_to_mesh_mapper(MeshDevice& mesh_d
 
 std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_device, int dim) {
     return std::make_unique<NdTensorToMesh>(
+        mesh_device,
+        NdTensorToMesh::DistributionMode::ROW_MAJOR,
         MeshShape(mesh_device.num_devices()),
         MeshMapperConfig{
             .placements =
@@ -288,7 +322,7 @@ std::unique_ptr<MeshToTensor> concat_mesh_to_tensor_composer(MeshDevice& mesh_de
 }
 
 std::unique_ptr<TensorToMesh> create_mesh_mapper(
-    MeshDevice& mesh_device, const MeshMapperConfig& config, const std::optional<ttnn::MeshShape>& shape) {
+    MeshDevice& mesh_device, const MeshMapperConfig& config, const std::optional<MeshShape>& shape) {
     const auto distributed_shape = shape.value_or(mesh_device.shape());
     TT_FATAL(
         distributed_shape.mesh_size() <= mesh_device.shape().mesh_size(),
@@ -302,6 +336,26 @@ std::unique_ptr<TensorToMesh> create_mesh_mapper(
         distributed_shape,
         config);
 
+    // Select distribution mode.
+    const auto distribution_mode = [&]() {
+        if (!shape.has_value()) {
+            // When no shape is supplied, row-major order is equivalent to submesh.
+            return NdTensorToMesh::DistributionMode::SUBMESH;
+        } else if (shape->dims() != mesh_device.shape().dims()) {
+            // Shapes have different dimensions, so a reshape will be required.
+            return NdTensorToMesh::DistributionMode::ROW_MAJOR;
+        } else {
+            // Check if `shape` fits within the mesh device. If it does, we can use submesh distribution. Otherwise,
+            // a reshape will be required, and shards will be distributed in row-major order over the mesh device.
+            for (size_t i = 0; i < shape->dims(); ++i) {
+                if ((*shape)[i] > mesh_device.shape()[i]) {
+                    return NdTensorToMesh::DistributionMode::ROW_MAJOR;
+                }
+            }
+            return NdTensorToMesh::DistributionMode::SUBMESH;
+        }
+    }();
+
     // TODO: #22258 - `DistributedTensorConfig` will be replaced by distributed host buffer, which can be used directly
     // in Tensor storage.
     tt::tt_metal::DistributedTensorConfig distributed_tensor_config;
@@ -312,11 +366,12 @@ std::unique_ptr<TensorToMesh> create_mesh_mapper(
         distributed_tensor_config = tt::tt_metal::DistributedTensorConfig{tt::tt_metal::AllGatherTensor{}};
     }
 
-    return std::make_unique<NdTensorToMesh>(distributed_shape, config, distributed_tensor_config);
+    return std::make_unique<NdTensorToMesh>(
+        mesh_device, distribution_mode, distributed_shape, config, distributed_tensor_config);
 }
 
 std::unique_ptr<MeshToTensor> create_mesh_composer(
-    MeshDevice& mesh_device, const MeshComposerConfig& config, const std::optional<ttnn::MeshShape>& shape) {
+    MeshDevice& mesh_device, const MeshComposerConfig& config, const std::optional<MeshShape>& shape) {
     const auto distributed_shape = shape.value_or(mesh_device.shape());
     TT_FATAL(
         distributed_shape.mesh_size() <= mesh_device.shape().mesh_size(),

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -7,6 +7,7 @@
 
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/host_buffer.hpp>
+#include <tt-metalium/distributed_host_buffer.hpp>
 #include <flatbuffers/flatbuffers.h>
 
 #include "ttnn/tensor/types.hpp"
@@ -39,7 +40,7 @@ tt::tt_metal::distributed::MeshCoordinate from_flatbuffer(const flatbuffer::Mesh
 
 flatbuffers::Offset<flatbuffer::MeshShape> to_flatbuffer(
     const tt::tt_metal::distributed::MeshShape& shape, flatbuffers::FlatBufferBuilder& builder) {
-    auto dimensions_vector = builder.CreateVector(std::vector<uint32_t>(shape.view().begin(), shape.view().end()));
+    auto dimensions_vector = builder.CreateVector(std::vector<uint32_t>(shape.cbegin(), shape.cend()));
     return flatbuffer::CreateMeshShape(builder, dimensions_vector);
 }
 
@@ -98,8 +99,8 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
             const auto& host_storage = std::get<tt::tt_metal::HostStorage>(storage);
             buffer_size = host_storage.buffer.view_bytes().size();
         } else {
-            const auto buffer = std::get<tt::tt_metal::MultiDeviceHostStorage>(storage).get_buffer(0);
-            buffer_size = buffer.view_bytes().size();
+            const auto buffer = std::get<tt::tt_metal::MultiDeviceHostStorage>(storage).get_shard_at_origin();
+            buffer_size = buffer->view_bytes().size();
         }
 
         auto inline_storage = ttnn::flatbuffer::InlineFileStorage(/*offset=*/0, buffer_size);
@@ -120,29 +121,28 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
 
         std::vector<flatbuffers::Offset<ttnn::flatbuffer::TensorShard>> shards_vector;
         uint64_t data_offset = 0;
-        for (std::size_t i = 0; i < multi_device_storage.num_buffers(); i++) {
-            const auto& buffer = multi_device_storage.get_buffer(i);
-            const std::size_t buffer_size = buffer.view_bytes().size();
+        for (const auto& coord : multi_device_storage.distributed_buffer().shard_coords()) {
+            if (const auto& buffer = multi_device_storage.distributed_buffer().get_shard(coord); buffer.has_value()) {
+                const std::size_t buffer_size = buffer->view_bytes().size();
 
-            auto inline_storage = ttnn::flatbuffer::InlineFileStorage(data_offset, buffer_size);
+                auto inline_storage = ttnn::flatbuffer::InlineFileStorage(data_offset, buffer_size);
+                auto mesh_coord_offset = to_flatbuffer(coord, builder);
 
-            auto shard_offset = ttnn::flatbuffer::CreateTensorShard(
-                builder,
-                ttnn::flatbuffer::TensorBuffer::InlineFileStorage,
-                builder.CreateStruct(inline_storage).Union());
+                auto shard_offset = ttnn::flatbuffer::CreateTensorShard(
+                    builder,
+                    ttnn::flatbuffer::TensorBuffer::InlineFileStorage,
+                    builder.CreateStruct(inline_storage).Union(),
+                    mesh_coord_offset);
 
-            shards_vector.push_back(shard_offset);
-            data_offset += buffer_size;
+                shards_vector.push_back(shard_offset);
+                data_offset += buffer_size;
+            }
         }
         auto shards = builder.CreateVector(shards_vector);
 
-        flatbuffers::Offset<ttnn::flatbuffer::MeshShape> mesh_shape_offset;
-        if (const auto* shard_2d = std::get_if<tt::tt_metal::ShardTensor2D>(&strategy)) {
-            ttnn::MeshShape mesh_shape{shard_2d->shard_mesh.x, shard_2d->shard_mesh.y};
-            mesh_shape_offset = to_flatbuffer(mesh_shape, builder);
-        }
-        auto sharded_tensor = ttnn::flatbuffer::CreateShardedTensor(builder, mesh_shape_offset, shards);
+        auto mesh_shape_offset = to_flatbuffer(multi_device_storage.distributed_buffer().shape(), builder);
 
+        auto sharded_tensor = ttnn::flatbuffer::CreateShardedTensor(builder, mesh_shape_offset, shards);
         auto tensor_offset = ttnn::flatbuffer::CreateTensor(
             builder, tensor_spec_offset, ttnn::flatbuffer::TensorType::ShardedTensor, sharded_tensor.Union());
 
@@ -171,25 +171,25 @@ Tensor from_flatbuffer(const ttnn::flatbuffer::Tensor* fb_tensor, tt::stl::Span<
             return Tensor(std::move(host_buffer), spec);
         }
         case ttnn::flatbuffer::TensorType::ShardedTensor: {
-            auto sharded = fb_tensor->tensor_type_as_ShardedTensor();
+            const auto* sharded = fb_tensor->tensor_type_as_ShardedTensor();
+
+            const auto* mesh_shape = sharded->mesh_shape();
+            TT_FATAL(mesh_shape != nullptr, "Mesh shape is required for sharded tensor");
+            const tt::tt_metal::distributed::MeshShape ttnn_mesh_shape = from_flatbuffer(mesh_shape);
 
             tt::tt_metal::DistributedTensorConfig strategy;
-            auto* mesh_shape = sharded->mesh_shape();
-            if (mesh_shape != nullptr) {
-                const tt::tt_metal::distributed::MeshShape ttnn_mesh_shape = from_flatbuffer(mesh_shape);
+            if (ttnn_mesh_shape.dims() == 2) {
                 strategy = tt::tt_metal::ShardTensor2D{
                     tt::tt_metal::ShardMesh{.y = ttnn_mesh_shape[0], .x = ttnn_mesh_shape[1]}};
             }
 
             const size_t num_shards = sharded->shards()->size();
 
-            std::vector<tt::tt_metal::HostBuffer> buffers;
-            std::vector<TensorSpec> specs(num_shards, spec);
-            buffers.reserve(num_shards);
-            for (size_t i = 0; i < num_shards; i++) {
-                auto* shard = sharded->shards()->Get(i);
+            auto distributed_buffer = tt::tt_metal::DistributedHostBuffer::create(ttnn_mesh_shape);
+            for (size_t i = 0; i < sharded->shards()->size(); ++i) {
+                const auto* shard = sharded->shards()->Get(i);
 
-                auto* inline_storage = shard->buffer_as<ttnn::flatbuffer::InlineFileStorage>();
+                const auto* inline_storage = shard->buffer_as<ttnn::flatbuffer::InlineFileStorage>();
                 TT_FATAL(
                     inline_storage != nullptr, "Only InlineFileStorage is supported in flatbuffer deserialization");
 
@@ -199,10 +199,13 @@ Tensor from_flatbuffer(const ttnn::flatbuffer::Tensor* fb_tensor, tt::stl::Span<
                 tt::tt_metal::HostBuffer host_buffer = create_host_buffer_from_bytes(size, spec);
                 TT_FATAL(offset + size <= tensor_data.size(), "Tensor data out of bounds for shard {}", i);
                 std::memcpy(static_cast<void*>(host_buffer.view_bytes().data()), tensor_data.data() + offset, size);
-                buffers.push_back(std::move(host_buffer));
+
+                TT_FATAL(shard->mesh_coordinate() != nullptr, "Mesh coordinate is required for each shard");
+                const auto coord = from_flatbuffer(shard->mesh_coordinate());
+                distributed_buffer.emplace_shard(coord, [&host_buffer]() { return std::move(host_buffer); });
             }
 
-            tt::tt_metal::MultiDeviceHostStorage multi_device_storage{std::move(buffers)};
+            tt::tt_metal::MultiDeviceHostStorage multi_device_storage{std::move(distributed_buffer)};
 
             return Tensor(std::move(multi_device_storage), spec, strategy);
         }

--- a/ttnn/core/tensor/host_buffer/functions.cpp
+++ b/ttnn/core/tensor/host_buffer/functions.cpp
@@ -19,10 +19,9 @@ HostBuffer get_host_buffer(const Tensor& tensor) {
             [](const HostStorage& storage) { return storage.buffer; },
             [](const MultiDeviceHostStorage& storage) {
                 TT_FATAL(
-                    storage.num_buffers() == 1,
-                    "Can't get a single buffer from multi device host storage, got {}",
-                    storage.num_buffers());
-                return storage.get_buffer(0);
+                    storage.distributed_buffer().shape().mesh_size() == 1,
+                    "Can't get a single buffer from multi device host storage");
+                return *storage.get_shard_at_origin();
             },
             [](const auto&) -> HostBuffer { TT_THROW("Tensor must have HostStorage or MultiDeviceHostStorage"); },
         },

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -13,6 +13,9 @@
 
 #include <tt_stl/overloaded.hpp>
 
+#include "distributed/distributed_tensor_config.hpp"
+#include "tensor/tensor_spec.hpp"
+#include "tt-metalium/mesh_coord.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/storage.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
@@ -117,18 +120,21 @@ void dump_multi_device_host_storage(
     const MultiDeviceHostStorage& storage,
     const DistributedTensorConfig& strategy,
     const TensorSpec& tensor_spec) {
-    uint64_t num_buffers = storage.num_buffers();
+    std::vector<HostBuffer> buffers;
+    storage.distributed_buffer().apply([&](const HostBuffer& shard) { buffers.push_back(shard); });
+
+    uint64_t num_buffers = buffers.size();
     safe_fwrite(&num_buffers, sizeof(num_buffers), 1, output_file);
 
     // Use the user-specified strategy which defines how it gets distributed when mapped onto multi-device
     safe_fwrite(&strategy, sizeof(strategy), 1, output_file);
 
     if (std::holds_alternative<ReplicateTensor>(strategy)) {
-        dump_host_storage(output_file, storage.get_buffer(0), tensor_spec.data_type());
+        dump_host_storage(output_file, buffers.front(), tensor_spec.data_type());
         dump_tensor_spec(tensor_spec, output_file);
     } else {
         for (int i = 0; i < num_buffers; i++) {
-            dump_host_storage(output_file, storage.get_buffer(i), tensor_spec.data_type());
+            dump_host_storage(output_file, buffers[i], tensor_spec.data_type());
         }
         for (int i = 0; i < num_buffers; i++) {
             dump_tensor_spec(tensor_spec, output_file);
@@ -161,7 +167,9 @@ DistributedStorage load_multi_device_host_storage(
     safe_fread(&strategy, sizeof(strategy), 1, input_file);
 
     std::vector<HostBuffer> buffers;
-    std::vector<ttnn::TensorSpec> specs;
+    // Tensor spec was serialized, but now TTNN enforces uniform tensor specs.
+    // Load the spec without using it, to correctly read the file.
+    auto ignore_spec = [](const TensorSpec&) {};
     if (std::holds_alternative<ReplicateTensor>(strategy)) {
         uint64_t size = 0;
         safe_fread(&size, sizeof(size), 1, input_file);
@@ -169,13 +177,11 @@ DistributedStorage load_multi_device_host_storage(
         safe_fread(data.data(), sizeof(T) * size, 1, input_file);
         HostBuffer buffer = HostBuffer(std::move(data));
         buffers.push_back(std::move(buffer));
-        auto spec = load_tensor_spec(input_file);
-        specs.push_back(spec);
+        ignore_spec(load_tensor_spec(input_file));
 
         auto num_devices = mesh_device ? mesh_device->num_devices() : 1;
         for (std::size_t i = 1; i < num_devices; ++i) {
             buffers.push_back(buffers[0]);
-            specs.push_back(spec);
         }
 
     } else {
@@ -188,7 +194,7 @@ DistributedStorage load_multi_device_host_storage(
             buffers.push_back(std::move(buffer));
         }
         for (std::size_t i = 0; i < num_buffers; ++i) {
-            specs.push_back(load_tensor_spec(input_file));
+            ignore_spec(load_tensor_spec(input_file));
         }
     }
 
@@ -386,10 +392,11 @@ void dump_tensor_flatbuffer(const std::string& file_name, const Tensor& tensor) 
                 TT_THROW("Device storage isn't supported in flatbuffer serialization");
             },
             [&output_file](const MultiDeviceHostStorage& storage) {
-                for (std::size_t i = 0; i < storage.num_buffers(); i++) {
-                    const auto& buffer = storage.get_buffer(i);
-                    auto buffer_view = buffer.view_bytes();
-                    safe_fwrite(buffer_view.data(), buffer_view.size(), 1, output_file);
+                for (const auto& shard : storage.distributed_buffer().shard_coords()) {
+                    if (auto buffer = storage.distributed_buffer().get_shard(shard); buffer.has_value()) {
+                        auto buffer_view = buffer->view_bytes();
+                        safe_fwrite(buffer_view.data(), buffer_view.size(), 1, output_file);
+                    }
                 }
             }},
         cpu_tensor.storage());

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
+#include <vector>
 
 #include "tt-metalium/mesh_coord.hpp"
 
@@ -51,13 +52,20 @@ bool DeviceStorage::is_uniform_storage() const {
     return coords.size() == mesh_buffer->device()->num_devices();
 }
 
-MultiDeviceHostStorage::MultiDeviceHostStorage(std::vector<HostBuffer> buffers) : buffers_(std::move(buffers)) {}
-
-HostBuffer MultiDeviceHostStorage::get_buffer(int buffer_index) const {
-    TT_FATAL(buffer_index < buffers_.size(), "Buffer not found for buffer_index {}", buffer_index);
-    return buffers_[buffer_index];
+std::optional<HostBuffer> MultiDeviceHostStorage::get_shard_at_origin() const {
+    return distributed_buffer_.get_shard(
+        distributed::MeshCoordinate::zero_coordinate(distributed_buffer_.shape().dims()));
 }
 
-size_t MultiDeviceHostStorage::num_buffers() const { return buffers_.size(); }
+const DistributedHostBuffer& MultiDeviceHostStorage::distributed_buffer() const { return distributed_buffer_; }
+
+MultiDeviceHostStorage::MultiDeviceHostStorage(std::vector<HostBuffer> buffers) :
+    distributed_buffer_(DistributedHostBuffer::create(tt::tt_metal::distributed::MeshShape(buffers.size()))) {
+    for (size_t i = 0; i < buffers.size(); ++i) {
+        distributed_buffer_.emplace_shard(
+            tt::tt_metal::distributed::MeshCoordinate(i), [&buffers, i]() { return std::move(buffers[i]); });
+    }
+}
+MultiDeviceHostStorage::MultiDeviceHostStorage(DistributedHostBuffer buffer) : distributed_buffer_(std::move(buffer)) {}
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -766,10 +766,9 @@ void write_tensor(const Tensor& host_tensor, Tensor device_tensor, QueueId cq_id
                         },
                         [](const MultiDeviceHostStorage& host_storage) -> const void* {
                             TT_ASSERT(
-                                host_storage.num_buffers() == 1,
+                                host_storage.distributed_buffer().shape().mesh_size() == 1,
                                 "Cannot copy multi-buffer host storage to a single device");
-                            auto buffer = host_storage.get_buffer(0);
-                            return buffer.view_bytes().data();
+                            return host_storage.get_shard_at_origin()->view_bytes().data();
                         },
                         [](auto&&) -> const void* { TT_THROW("Unreachable"); },
                     },

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -9,7 +9,6 @@
 #include <unistd.h>
 
 #include "tt-metalium/memory_pin.hpp"
-#include "tt-metalium/logger.hpp"
 #include "tt-metalium/mesh_buffer.hpp"
 #include "tt-metalium/mesh_device.hpp"
 #include "tt-metalium/mesh_command_queue.hpp"

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -9,6 +9,7 @@
 #include <unistd.h>
 
 #include "tt-metalium/memory_pin.hpp"
+#include "tt-metalium/logger.hpp"
 #include "tt-metalium/mesh_buffer.hpp"
 #include "tt-metalium/mesh_device.hpp"
 #include "tt-metalium/mesh_command_queue.hpp"
@@ -582,12 +583,11 @@ Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking, ttnn::QueueId cq
     // Initialize vector of host buffers that data will be read into
     std::vector<HostBuffer> buffers(num_buffers);
     std::vector<distributed::MeshCommandQueue::ShardDataTransfer> shard_data_transfers;
-    std::vector<TensorSpec> specs;
-    specs.reserve(num_buffers);
     shard_data_transfers.reserve(num_buffers);
 
     // For performance, batch host-side allocations, then split the memory chunk across shards using host buffer
     // borrowing.
+    // TODO: #22169 - Use read API for a DistributedHostBuffer.
     {
         ZoneScopedN("AllocateBuffer");
         const size_t shard_size = tensor.get_tensor_spec().compute_packed_buffer_size_bytes() / sizeof(T);
@@ -740,16 +740,17 @@ Tensor to_device<bfloat8_b>(
     return to_device<uint32_t>(tensor, target_device, memory_config, cq_id);
 }
 
-template <typename T>
+namespace {
+
 DeviceStorage replicate_to_mesh_buffer(
     const HostStorage& storage,
     distributed::MeshDevice* mesh_device,
     const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer,
     const TensorSpec& tensor_spec,
     ttnn::QueueId cq_id) {
-    auto data_to_write = host_buffer::get_as<T>(storage.buffer);
+    auto data_to_write = storage.buffer.view_bytes();
     const auto expected_packed_buffer_size_bytes = tensor_spec.compute_packed_buffer_size_bytes();
-    const auto input_size_bytes = data_to_write.size() * sizeof(T);
+    const auto input_size_bytes = data_to_write.size();
     TT_FATAL(
         input_size_bytes == expected_packed_buffer_size_bytes,
         "Host data with total size {}B does not match expected size {}B of device buffer!",
@@ -767,45 +768,22 @@ DeviceStorage replicate_to_mesh_buffer(
     return DeviceStorage(mesh_buffer, std::move(coords));
 }
 
-template <typename T>
 DeviceStorage shard_to_mesh_buffer(
-    const MultiDeviceHostStorage& storage,
-    distributed::MeshDevice* mesh_device,
+    const DistributedHostBuffer& distributed_host_buffer,
     const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer,
-    const TensorSpec& tensor_spec,
-    const std::vector<distributed::MeshCoordinate>& coords,
     ttnn::QueueId cq_id) {
-    const auto& mesh_shape = mesh_device->shape();
-    TT_FATAL(
-        coords.size() == storage.num_buffers(),
-        "Number of shards {} does not match number of buffers {}",
-        coords.size(),
-        storage.num_buffers());
-
-    std::vector<distributed::MeshCommandQueue::ShardDataTransfer> shard_data_transfers;
-    shard_data_transfers.reserve(storage.num_buffers());
-
-    const auto expected_packed_buffer_size_bytes = tensor_spec.compute_packed_buffer_size_bytes();
-    for (int i = 0; i < storage.num_buffers(); ++i) {
-        const auto& shard_host_buffer = storage.get_buffer(i);
-
-        auto data_to_write = host_buffer::get_as<T>(shard_host_buffer);
-        const auto input_size_bytes = data_to_write.size() * sizeof(T);
-        TT_FATAL(
-            input_size_bytes == expected_packed_buffer_size_bytes,
-            "Host data with total size {}B does not match expected size {}B of device buffer!",
-            input_size_bytes,
-            expected_packed_buffer_size_bytes);
-        shard_data_transfers.push_back(distributed::MeshCommandQueue::ShardDataTransfer{
-            .shard_coord = coords[i],
-            .host_data = const_cast<void*>(reinterpret_cast<const void*>(data_to_write.data())),
-            .region = BufferRegion(0, input_size_bytes)});
-    }
-
-    mesh_device->mesh_command_queue(*cq_id).enqueue_write_shards(mesh_buffer, shard_data_transfers, /*blocking=*/false);
-
-    return DeviceStorage(std::move(mesh_buffer), coords);
+    mesh_buffer->device()->mesh_command_queue(*cq_id).enqueue_write(
+        mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+    std::vector<distributed::MeshCoordinate> coords;
+    coords.reserve(distributed_host_buffer.shard_coords().size());
+    std::copy(
+        distributed_host_buffer.shard_coords().begin(),
+        distributed_host_buffer.shard_coords().end(),
+        std::back_inserter(coords));
+    return DeviceStorage(mesh_buffer, std::move(coords));
 }
+
+}  // namespace
 
 template <typename T>
 DeviceStorage to_device_mesh_buffer(
@@ -818,13 +796,46 @@ DeviceStorage to_device_mesh_buffer(
         tt::stl::overloaded{
             [&mesh_buffer, &tensor_spec, cq_id](const HostStorage& storage) {
                 // Replicate data across devices in a mesh.
-                return replicate_to_mesh_buffer<T>(storage, mesh_buffer->device(), mesh_buffer, tensor_spec, cq_id);
+                return replicate_to_mesh_buffer(storage, mesh_buffer->device(), mesh_buffer, tensor_spec, cq_id);
             },
             [&mesh_buffer, &tensor_spec, cq_id, &host_tensor_attributes](const MultiDeviceHostStorage& storage) {
                 // Shard multi device host shards across devices in a mesh.
-                auto* mesh_device = mesh_buffer->device();
-                auto coords = host_tensor_attributes.determine_distribution(mesh_device->shape());
-                return shard_to_mesh_buffer<T>(storage, mesh_device, mesh_buffer, tensor_spec, coords, cq_id);
+                if (storage.distributed_buffer().shape() == mesh_buffer->device()->shape()) {
+                    return shard_to_mesh_buffer(storage.distributed_buffer(), mesh_buffer, cq_id);
+                } else {
+                    // Reshape distributed host buffer.
+                    // TODO: #22169 - there are 2 reasons for this code path - legacy serialization path that stored
+                    // multi device host tensors without the necessary metadata, and `aggregate_as_tensor` calls that
+                    // similarly lack the metadata to properly distribute the shards across the mesh.
+                    auto* mesh_device = mesh_buffer->device();
+
+                    TT_FATAL(
+                        storage.distributed_buffer().shape().mesh_size() <= mesh_device->shape().mesh_size(),
+                        "Distributed host buffer has more shards than the mesh device");
+
+                    auto dst_distributed_host_buffer = DistributedHostBuffer::create(mesh_device->shape());
+
+                    const auto dst_range = [mesh_device, &host_tensor_attributes]() {
+                        if (auto* shard2d_strategy =
+                                std::get_if<ShardTensor2D>(&host_tensor_attributes.get_distributed_tensor_config())) {
+                            distributed::MeshShape distribution_shape(
+                                shard2d_strategy->shard_mesh.y, shard2d_strategy->shard_mesh.x);
+                            return distributed::MeshCoordinateRange(distribution_shape);
+                        } else {
+                            return distributed::MeshCoordinateRange(mesh_device->shape());
+                        }
+                    }();
+
+                    std::vector<HostBuffer> shards;
+                    storage.distributed_buffer().apply([&](const HostBuffer& shard) { shards.push_back(shard); });
+
+                    auto dst_coord_it = dst_range.begin();
+                    for (int i = 0; i < shards.size(); ++i, ++dst_coord_it) {
+                        dst_distributed_host_buffer.emplace_shard(
+                            *dst_coord_it, [&shards, i]() { return std::move(shards[i]); });
+                    }
+                    return shard_to_mesh_buffer(dst_distributed_host_buffer, mesh_buffer, cq_id);
+                }
             },
             [](const auto& s) -> DeviceStorage { TT_THROW("Unexpected storage type {}", tt::stl::get_type_name(s)); }},
         host_storage);

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -82,22 +82,12 @@ Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, QueueId cq_id) {
 Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, IDevice* worker) {
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::to_layout", input_tensor, target_layout, worker);
-    TT_ASSERT(
+    TT_FATAL(
         input_tensor.storage_type() != StorageType::DEVICE, "Bring tensor to host before converting to target layout");
     Tensor output = tensor_impl::to_layout_wrapper(input_tensor, target_layout);
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
-}
-
-Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distributed::MeshDevice* mesh_device) {
-    ZoneScoped;
-    TT_FATAL(
-        is_cpu_tensor(input_tensor) || is_multi_device_host_tensor(input_tensor),
-        "to(layout) must be called on host tensors with MULTI_DEVICE_HOST_STORAGE when multiple "
-        "workers "
-        "are specified");
-    return tensor_to_layout(input_tensor, target_layout, mesh_device);
 }
 
 void tensor_print(const Tensor& input_tensor) {

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -97,41 +97,7 @@ Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distri
         "to(layout) must be called on host tensors with MULTI_DEVICE_HOST_STORAGE when multiple "
         "workers "
         "are specified");
-
-    GraphTracker::instance().track_function_start("Tensor::to_layout", input_tensor, target_layout, mesh_device);
-    if (mesh_device) {
-        // Mesh Device provided - have a handle to the thread-pool
-        Tensor tensor_modified_layout = std::visit(
-            tt::stl::overloaded{
-                [&](const HostStorage& s) { return tensor_impl::to_layout_wrapper(input_tensor, target_layout); },
-                [&](const MultiDeviceHostStorage& s) {
-                    // TODO: #22045 - Move to `transform` and use OMP parallel for.
-                    std::vector<Tensor> shards(s.num_buffers());
-                    for (std::size_t shard_idx = 0; shard_idx < s.num_buffers(); ++shard_idx) {
-                        // Multi-Thread Host tilization of shards.
-                        mesh_device->enqueue_to_thread_pool([shard_idx, &s, &shards, target_layout, &input_tensor]() {
-                            ZoneScopedN("HostTilize");
-                            Tensor shard(s.get_buffer(shard_idx), input_tensor.tensor_spec());
-                            shards[shard_idx] = tensor_impl::to_layout_wrapper(shard, target_layout);
-                        });
-                    }
-                    mesh_device->wait_for_thread_pool();
-                    return ttnn::distributed::aggregate_as_tensor(shards, input_tensor.distributed_tensor_config());
-                },
-                [&](const DeviceStorage& s) -> Tensor { TT_THROW("Unexpected storage type"); },
-            },
-            input_tensor.storage());
-
-        tensor_modified_layout = tt::tt_metal::set_tensor_id(tensor_modified_layout);
-        GraphTracker::instance().track_function_end(tensor_modified_layout);
-        return tensor_modified_layout;
-    }
-
-    // Running without worker threads (non-async)
-    auto output = tensor_impl::to_layout_wrapper(input_tensor, target_layout);
-    output = tt::tt_metal::set_tensor_id(output);
-    GraphTracker::instance().track_function_end(output);
-    return output;
+    return tensor_to_layout(input_tensor, target_layout, mesh_device);
 }
 
 void tensor_print(const Tensor& input_tensor) {

--- a/ttnn/core/tensor/tensor_utils.cpp
+++ b/ttnn/core/tensor/tensor_utils.cpp
@@ -102,30 +102,37 @@ bool is_device_tensor(const Tensor& tensor) { return tensor.storage_type() == St
 
 Tensor transform(const Tensor& tensor, const std::function<Tensor(const Tensor&)>& transform_func) {
     TT_FATAL(is_multi_device_host_tensor(tensor), "transform only supports multi-device host tensors");
-    const auto& storage = std::get<MultiDeviceHostStorage>(tensor.storage());
-
-    std::vector<TensorSpec> transformed_specs;
-    std::vector<HostBuffer> transformed_buffers;
-    transformed_buffers.reserve(storage.num_buffers());
-    transformed_specs.reserve(storage.num_buffers());
-    for (size_t i = 0; i < storage.num_buffers(); i++) {
-        Tensor transformed_tensor_shard = transform_func(Tensor(storage.get_buffer(i), tensor.tensor_spec()));
-        transformed_specs.push_back(transformed_tensor_shard.tensor_spec());
-        auto* host_storage = std::get_if<HostStorage>(&transformed_tensor_shard.storage());
-        TT_FATAL(host_storage != nullptr, "transform function must return a host tensor");
-        transformed_buffers.push_back(std::move(host_storage->buffer));
-    }
-    TensorSpec reference_spec = transformed_specs.front();
-    MultiDeviceHostStorage transformed_storage(std::move(transformed_buffers));
-    return Tensor(std::move(transformed_storage), reference_spec, tensor.distributed_tensor_config());
+    // TODO: #15840 - Push this down to OPs, so that instead of transforming the multi-device shards as `Tensor`, we
+    // operate on buffers directly. OPs code should not differentiate between host and multi-device host storage.
+    std::optional<TensorSpec> transformed_spec;
+    DistributedHostBuffer transformed_buffer =
+        std::get<MultiDeviceHostStorage>(tensor.storage())
+            .distributed_buffer()
+            .transform([&](const HostBuffer& buffer) {
+                auto transformed_tensor = transform_func(Tensor(buffer, tensor.get_tensor_spec()));
+                auto* host_storage = std::get_if<HostStorage>(&transformed_tensor.get_storage());
+                TT_FATAL(host_storage != nullptr, "transform function must return a host tensor");
+                if (transformed_spec.has_value()) {
+                    TT_FATAL(
+                        *transformed_spec == transformed_tensor.get_tensor_spec(),
+                        "All shards must have the same spec");
+                } else {
+                    transformed_spec = transformed_tensor.get_tensor_spec();
+                }
+                return std::move(host_storage->buffer);
+            });
+    transformed_spec = transformed_spec.value_or(tensor.get_tensor_spec());
+    return Tensor(
+        MultiDeviceHostStorage(std::move(transformed_buffer)),
+        *transformed_spec,
+        tensor.get_distributed_tensor_config());
 }
 
 void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& callable) {
     TT_FATAL(is_multi_device_host_tensor(tensor), "apply only supports multi-device host tensors");
-    const auto& storage = std::get<MultiDeviceHostStorage>(tensor.storage());
-    for (size_t i = 0; i < storage.num_buffers(); i++) {
-        callable(Tensor(storage.get_buffer(i), tensor.tensor_spec()));
-    }
+    std::get<MultiDeviceHostStorage>(tensor.storage()).distributed_buffer().apply([&](const HostBuffer& buffer) {
+        callable(Tensor(buffer, tensor.get_tensor_spec()));
+    });
 }
 
 ShardDivisionSpec compute_shard_division_spec(const Shape2D& shape, const Shape2D& shard_shape) {

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -468,8 +468,10 @@ HostBuffer get_host_buffer_from_tensor(const Tensor& tt_tensor, const bool padde
         tt::stl::overloaded{
             [](const HostStorage& storage) { return storage.buffer; },
             [](const MultiDeviceHostStorage& storage) {
-                TT_FATAL(storage.num_buffers() == 1, "Can't get a single buffer from multi device host storage");
-                return storage.get_buffer(0);
+                TT_FATAL(
+                    storage.distributed_buffer().shape().mesh_size() == 1,
+                    "Can't get a single buffer from multi device host storage");
+                return *storage.get_shard_at_origin();
             },
             [&tt_tensor](auto&&) -> HostBuffer {
                 TT_THROW(


### PR DESCRIPTION
### Ticket
#22169

### Problem description
Adopting a multi-host aware wrapper `DistributedHostBuffer` in TTNN.

### What's changed
Use `DistributedHostBuffer` in `MultiDeviceHostStorage`, and the underlying APIs.

Next steps:
* Adopt `DistributedHostBuffer` on the read path.
* Disable "reshaping" path for writing tensor to device. This requires disabling `std::vector<HostBuffer>` based constructor on `MultiDeviceHostStorage`. This requires:
  *  Propagating parameters for making `DistributedHostBuffer` into `aggregate_as_tensor` creation API. In general, re-work the `aggregate_as_tensor` API to accommodate for the new use cases.
  * Migrating legacy serialization code to the new flat buffer based schema.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15612705402)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15612712276)
- [x] New/Existing tests provide coverage for changes