### PR TITLE
Add zero padding for matmul ops - Take 2

### DIFF
--- a/models/demos/mnist/tests/test_perf_mnist.py
+++ b/models/demos/mnist/tests/test_perf_mnist.py
@@ -111,10 +111,7 @@ def test_perf_device_bare_metal(batch_size, reset_seeds):
     subdir = "ttnn_mnist"
     num_iterations = 1
     margin = 0.03
-    if is_grayskull():
-        expected_perf = 402500.0
-    elif is_wormhole_b0():
-        expected_perf = 932965.0
+    expected_perf = 880000.0
 
     command = f"pytest tests/ttnn/integration_tests/mnist/test_mnist.py::test_mnist"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -2229,16 +2229,119 @@ def test_sharded_matmul_with_multiple_out_block_values(device, out_block_h, out_
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)
 
 
+@pytest.mark.parametrize("input_b_value", [2.0])
+@pytest.mark.parametrize("input_a_value", [4.0])
 @pytest.mark.parametrize(
-    "input_a_shape,input_b_shape,input_a_value,input_b_value,input_a_reshape,input_b_reshape",
+    "input_a_shape,input_b_shape,input_a_reshape,input_b_reshape",
     [
-        ((12,), (1, 12, 4, 4), 1.0, 2.0, (12, 1, 1), (12, 1, 16)),
-        ((16,), (1, 16, 2, 2), 1.0, 3.0, (16, 1, 1), (16, 1, 4)),
-        ((8,), (1, 8, 3, 3), 2.0, 1.0, (8, 1, 1), (8, 1, 9)),
+        ((32, 96), (96, 32), (32, 96), (96, 32)),  # No padding introduced
+        ((32, 96), (96, 32), (1, 90), (90, 16)),  # Padding introduced in M,K and N dimensions
     ],
 )
-def test_matmul_with_reshaped_tensors(
-    device, input_a_shape, input_b_shape, input_a_value, input_b_value, input_a_reshape, input_b_reshape
+@pytest.mark.parametrize(
+    "program_config,input_a_memory_config,input_b_memory_config,output_memory_config",
+    [
+        # Uses reader_bmm_tile_layout_in0.cpp
+        (
+            ttnn.MatmulMultiCoreReuseProgramConfig(
+                compute_with_storage_grid_size=(3, 1),
+                in0_block_w=1,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=1,
+                per_core_N=1,
+            ),
+            None,
+            None,
+            None,
+        ),
+        # Uses reader_bmm_tile_layout_in0_sender_padding.cpp
+        (
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(3, 1),
+                in0_block_w=1,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=1,
+                per_core_N=1,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            ),
+            None,
+            None,
+            None,
+        ),
+        # Uses reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+        (
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(3, 1),
+                in0_block_w=1,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=1,
+                per_core_N=1,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))}),
+                    (32, 96),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+            None,
+            None,
+        ),
+        # Uses reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+        (
+            ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+                in0_block_w=1,
+                per_core_M=1,
+                per_core_N=1,
+                fused_activation=None,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))}),
+                    (32, 32),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.DRAM,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))}),
+                    (96, 32),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+            ),
+        ),
+    ],
+)
+def test_matmul_padding(
+    device,
+    input_a_shape,
+    input_b_shape,
+    input_a_value,
+    input_b_value,
+    input_a_reshape,
+    input_b_reshape,
+    program_config,
+    input_a_memory_config,
+    input_b_memory_config,
+    output_memory_config,
 ):
     torch.manual_seed(0)
 
@@ -2246,24 +2349,34 @@ def test_matmul_with_reshaped_tensors(
     input_a = torch.full(input_a_shape, input_a_value, dtype=torch.float32)
     input_b = torch.full(input_b_shape, input_b_value, dtype=torch.float32)
 
-    # Reshape tensors for matmul
-    input_a_reshaped = input_a.reshape(input_a_reshape)
-    input_b_reshaped = input_b.reshape(input_b_reshape)
+    # Reshaped tensors for matmul
+    input_a_torch = torch.full(input_a_reshape, input_a_value, dtype=torch.float32)
+    input_b_torch = torch.full(input_b_reshape, input_b_value, dtype=torch.float32)
 
     # Compute golden output
-    golden_output = torch.matmul(input_a_reshaped, input_b_reshaped)
+    golden_output = torch.matmul(input_a_torch, input_b_torch)
 
     # Convert to ttnn tensors
-    input_a_ttnn = ttnn.from_torch(input_a, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    input_b_ttnn = ttnn.from_torch(input_b, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_a_ttnn = ttnn.from_torch(
+        input_a, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device, memory_config=input_a_memory_config
+    )
+    input_b_ttnn = ttnn.from_torch(
+        input_b, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device, memory_config=input_b_memory_config
+    )
 
     # Reshape ttnn tensors
-    input_a_reshaped_ttnn = ttnn.reshape(input_a_ttnn, input_a_reshape, pad_value=0)
-    input_b_reshaped_ttnn = ttnn.reshape(input_b_ttnn, input_b_reshape, pad_value=0)
+    input_a_reshaped_ttnn = ttnn.reshape(input_a_ttnn, input_a_reshape, padded_shape=input_a_shape)
+    input_b_reshaped_ttnn = ttnn.reshape(input_b_ttnn, input_b_reshape, padded_shape=input_b_shape)
 
     # Compute matmul
-    output_ttnn = ttnn.matmul(input_a_reshaped_ttnn, input_b_reshaped_ttnn)
+    for _ in range(11):
+        output_ttnn = ttnn.matmul(
+            input_a_reshaped_ttnn,
+            input_b_reshaped_ttnn,
+            program_config=program_config,
+            memory_config=output_memory_config,
+        )
     output = ttnn.to_torch(output_ttnn)
 
     # Verify values match with high precision
-    assert_with_pcc(golden_output, output, 0.999)
+    assert torch.allclose(golden_output, output, atol=1e-6)

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -2235,7 +2235,8 @@ def test_sharded_matmul_with_multiple_out_block_values(device, out_block_h, out_
     "input_a_shape,input_b_shape,input_a_reshape,input_b_reshape",
     [
         ((32, 96), (96, 32), (32, 96), (96, 32)),  # No padding introduced
-        ((32, 96), (96, 32), (1, 90), (90, 16)),  # Padding introduced in M,K and N dimensions
+        ((32, 96), (96, 32), (1, 90), (90, 16)),  # Padding introduced in M,K and N dimensions, 1 face padded
+        ((32, 96), (96, 32), (1, 65), (65, 16)),  # Padding introduced in M,K and N dimensions, 2 faces padded
     ],
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/pad_tile.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/pad_tile.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/pad_tile.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/pad_tile.hpp
@@ -8,47 +8,11 @@
 
 using namespace tt::constants;
 
-/*
- * @brief Zero pads a part of a face in a tile, dictated by the number of elements to pad on the right and bottom edges
- * of the face.
- *
- * This function zero pads a part of a face in a tile. It handles both width and height padding
- * by setting the specified number of elements to zero on the right and bottom edges of the face.
- *
- * @tparam T The type of the elements in the tile
- * @param num_elements_padded_w Number of elements to pad on the right edge (width)
- * @param num_elements_padded_h Number of elements to pad on the bottom edge (height)
- * @param tile_ptr Pointer to the start of the face in the tile
- */
-template <typename T>
-void fill_pad_face(uint32_t num_elements_padded_w, uint32_t num_elements_padded_h, T* tile_ptr, T fill_value) {
-    // Right padding (width padding)
-    if (num_elements_padded_w > 0) {
-        for (uint32_t row = 0; row < FACE_HEIGHT; ++row) {
-            auto row_ptr = tile_ptr + row * FACE_WIDTH;
-            for (uint32_t col = FACE_WIDTH - num_elements_padded_w; col < FACE_WIDTH; ++col) {
-                row_ptr[col] = fill_value;
-            }
-        }
-    }
-
-    // Bottom padding (height padding)
-    if (num_elements_padded_h > 0) {
-        for (uint32_t row = FACE_HEIGHT - num_elements_padded_h; row < FACE_HEIGHT; ++row) {
-            auto row_ptr = tile_ptr + row * FACE_WIDTH;
-            for (uint32_t col = 0; col < FACE_WIDTH; ++col) {
-                row_ptr[col] = fill_value;
-            }
-        }
-    }
-}
-
 /**
- * @brief Zero pads a tile by handling padding for each face within the tile.
+ * @brief Pads a face within a tile.
  *
- * This function handles zero padding for a tile by breaking it down into faces and applying
- * padding to each face individually. It calculates the appropriate padding for each face
- * based on the unpadded dimensions and applies the padding using fill_pad_face.
+ * This function handles padding for a face within a tile. It calculates the appropriate
+ * padding for the face based on the unpadded dimensions and applies it.
 
     Case 1: All elements in face are padded (num_elements_unpadded_w <= face_w_offset)
 
@@ -83,58 +47,113 @@ void fill_pad_face(uint32_t num_elements_padded_w, uint32_t num_elements_padded_
                 face_w_offset         face_w_offset + FACE_WIDTH
 
  * @tparam T The type of the elements in the tile
- * @tparam num_faces_w Number of faces in the width dimension (default: TILE_WIDTH / FACE_WIDTH)
- * @tparam num_faces_h Number of faces in the height dimension (default: TILE_HEIGHT / FACE_HEIGHT)
- * @param num_elements_unpadded_w Number of unpadded elements in the width dimension
- * @param num_elements_unpadded_h Number of unpadded elements in the height dimension
- * @param l1_tile_ptr Pointer to the start of the tile
+ * @tparam num_elements_unpadded_w Number of unpadded elements in the width dimension
+ * @tparam num_elements_unpadded_h Number of unpadded elements in the height dimension
+ * @tparam num_faces_w Number of faces in the width dimension
+ * @tparam num_faces_h Number of faces in the height dimension
+ * @tparam face_h The height index of the face
+ * @tparam face_w The width index of the face
+ * @param tile_ptr Pointer to the start of the tile
+ * @param fill_value The value to use for padding
  */
-template <typename T, uint32_t num_faces_w = TILE_WIDTH / FACE_WIDTH, uint32_t num_faces_h = TILE_HEIGHT / FACE_HEIGHT>
-void fill_pad_tile(
-    uint32_t num_elements_unpadded_w, uint32_t num_elements_unpadded_h, uint32_t l1_tile_ptr, uint32_t fill_value) {
-    auto tile_ptr = reinterpret_cast<T*>(l1_tile_ptr);
+template <
+    typename T,
+    uint32_t num_elements_unpadded_w,
+    uint32_t num_elements_unpadded_h,
+    uint32_t num_faces_w,
+    uint32_t num_faces_h,
+    uint32_t face_h,
+    uint32_t face_w>
+void fill_pad_face(T* tile_ptr, uint32_t fill_value) {
+    // Calculate face offset
+    constexpr uint32_t face_offset = (face_h * num_faces_w + face_w) * FACE_HW;
+    auto face_ptr = tile_ptr + face_offset;
 
-    for (uint32_t face_h = 0; face_h < num_faces_h; ++face_h) {
-        for (uint32_t face_w = 0; face_w < num_faces_w; ++face_w) {
-            // Calculate face offset
-            uint32_t face_offset = (face_h * num_faces_w + face_w) * FACE_HW;
-            auto face_ptr = tile_ptr + face_offset;
-            // Calculate padding for this specific face
-            if (num_elements_unpadded_w > 0) {
-                uint32_t face_w_offset = face_w * FACE_WIDTH;
-                uint32_t face_pad_w;
+    // Right padding (width padding)
+    constexpr uint32_t face_w_offset = face_w * FACE_WIDTH;
+    constexpr uint32_t face_pad_w = (num_elements_unpadded_w <= face_w_offset) ? FACE_WIDTH
+                                    : (num_elements_unpadded_w >= face_w_offset + FACE_WIDTH)
+                                        ? 0
+                                        : face_w_offset + FACE_WIDTH - num_elements_unpadded_w;
 
-                if (num_elements_unpadded_w <= face_w_offset) {
-                    // All elements in this face are padded ones
-                    face_pad_w = FACE_WIDTH;
-                } else if (num_elements_unpadded_w >= face_w_offset + FACE_WIDTH) {
-                    // All elements in this face are unpadded ones
-                    face_pad_w = 0;
-                } else {
-                    // Only some elements in this face are padded ones
-                    face_pad_w = face_w_offset + FACE_WIDTH - num_elements_unpadded_w;
-                }
-
-                fill_pad_face<T>(face_pad_w, 0, face_ptr, fill_value);
-            }
-
-            if (num_elements_unpadded_h > 0) {
-                uint32_t face_h_offset = face_h * FACE_HEIGHT;
-                uint32_t face_pad_h;
-
-                if (num_elements_unpadded_h <= face_h_offset) {
-                    // All elements in this face are padded ones
-                    face_pad_h = FACE_HEIGHT;
-                } else if (num_elements_unpadded_h >= face_h_offset + FACE_HEIGHT) {
-                    // All elements in this face are unpadded ones
-                    face_pad_h = 0;
-                } else {
-                    // Only some elements in this face are padded ones
-                    face_pad_h = face_h_offset + FACE_HEIGHT - num_elements_unpadded_h;
-                }
-                fill_pad_face<T>(0, face_pad_h, face_ptr, fill_value);
+    if constexpr (face_pad_w > 0) {
+#pragma unroll
+        for (uint32_t row = 0; row < FACE_HEIGHT; ++row) {
+            auto row_ptr = face_ptr + row * FACE_WIDTH;
+            for (uint32_t col = FACE_WIDTH - face_pad_w; col < FACE_WIDTH; ++col) {
+                row_ptr[col] = fill_value;
             }
         }
+    }
+
+    // Bottom padding (height padding)
+    constexpr uint32_t face_h_offset = face_h * FACE_HEIGHT;
+    constexpr uint32_t face_pad_h = (num_elements_unpadded_h <= face_h_offset) ? FACE_HEIGHT
+                                    : (num_elements_unpadded_h >= face_h_offset + FACE_HEIGHT)
+                                        ? 0
+                                        : face_h_offset + FACE_HEIGHT - num_elements_unpadded_h;
+
+    if constexpr (face_pad_h > 0) {
+#pragma unroll
+        for (uint32_t row = FACE_HEIGHT - face_pad_h; row < FACE_HEIGHT; ++row) {
+            auto row_ptr = face_ptr + row * FACE_WIDTH;
+            for (uint32_t col = 0; col < FACE_WIDTH; ++col) {
+                row_ptr[col] = fill_value;
+            }
+        }
+    }
+}
+
+/**
+ * @brief Fills padding regions in a tile with a specified value.
+ *
+ * This function processes a tile by dividing it into faces and applying padding to each face
+ * based on the unpadded dimensions. The padding is applied to both width and height dimensions
+ * as needed.
+ *
+ * The function uses template metaprogramming to unroll the face processing loops at compile time,
+ * making it efficient for hardware execution. It processes each face in the tile by:
+ * 1. Calculating the face offset in the tile
+ * 2. Determining the padding requirements for width and height
+ * 3. Applying the padding with the specified fill value
+ *
+ * @tparam T The type of the elements in the tile
+ * @tparam num_elements_unpadded_w Number of unpadded elements in the width dimension
+ * @tparam num_elements_unpadded_h Number of unpadded elements in the height dimension
+ * @tparam num_faces_w Number of faces in the width dimension (default: TILE_WIDTH / FACE_WIDTH)
+ * @tparam num_faces_h Number of faces in the height dimension (default: TILE_HEIGHT / FACE_HEIGHT)
+ * @param l1_tile_ptr Pointer to the start of the tile in L1 memory
+ * @param fill_value The value to use for padding
+ */
+template <
+    typename T,
+    uint32_t num_elements_unpadded_w,
+    uint32_t num_elements_unpadded_h,
+    uint32_t num_faces_w = TILE_WIDTH / FACE_WIDTH,
+    uint32_t num_faces_h = TILE_HEIGHT / FACE_HEIGHT>
+void fill_pad_tile(uint32_t l1_tile_ptr, uint32_t fill_value) {
+    auto tile_ptr = reinterpret_cast<T*>(l1_tile_ptr);
+
+    // Face 0, 0
+    fill_pad_face<T, num_elements_unpadded_w, num_elements_unpadded_h, num_faces_w, num_faces_h, 0, 0>(
+        tile_ptr, fill_value);
+
+    // Face 0, 1
+    if constexpr (num_faces_w > 1) {
+        fill_pad_face<T, num_elements_unpadded_w, num_elements_unpadded_h, num_faces_w, num_faces_h, 0, 1>(
+            tile_ptr, fill_value);
+    }
+
+    // Face 1, 0
+    if constexpr (num_faces_h > 1) {
+        fill_pad_face<T, num_elements_unpadded_w, num_elements_unpadded_h, num_faces_w, num_faces_h, 1, 0>(
+            tile_ptr, fill_value);
+    }
+
+    // Face 1, 1
+    if constexpr (num_faces_w > 1 && num_faces_h > 1) {
+        fill_pad_face<T, num_elements_unpadded_w, num_elements_unpadded_h, num_faces_w, num_faces_h, 1, 1>(
+            tile_ptr, fill_value);
     }
 }
 
@@ -146,15 +165,16 @@ void fill_pad_tile(
  * the unpadded width of the last K tile.
  *
  * @tparam in0_data_format The data format of the input tensor (Float32 or Float16_b)
- * @param in0_last_ktile_w The unpadded width of the last K tile
+ * @tparam in0_last_ktile_w The unpadded width of the last K tile
  * @param l1_write_addr_in0 The L1 memory address where the zeros should be written
  */
-
-template <DataFormat in0_data_format>
-void pad_last_ktile(uint32_t in0_last_ktile_w, uint32_t l1_write_addr_in0) {
+template <DataFormat in0_data_format, uint32_t in0_last_ktile_w>
+void pad_last_ktile(uint32_t l1_write_addr_in0) {
     if constexpr (in0_data_format == DataFormat::Float32) {
-        fill_pad_tile<uint32_t>(in0_last_ktile_w, /*num_elements_unpadded_h=*/0, l1_write_addr_in0, /*pad_value=*/0);
+        fill_pad_tile<uint32_t, in0_last_ktile_w, /*num_elements_unpadded_h=*/TILE_HEIGHT>(
+            l1_write_addr_in0, /*pad_value=*/0);
     } else if constexpr (in0_data_format == DataFormat::Float16_b) {
-        fill_pad_tile<uint16_t>(in0_last_ktile_w, /*num_elements_unpadded_h=*/0, l1_write_addr_in0, /*pad_value=*/0);
+        fill_pad_tile<uint16_t, in0_last_ktile_w, /*num_elements_unpadded_h=*/TILE_HEIGHT>(
+            l1_write_addr_in0, /*pad_value=*/0);
     }
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/pad_tile.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/pad_tile.hpp
@@ -1,0 +1,82 @@
+#include <tt-metalium/constants.hpp>
+
+using namespace tt::constants;
+
+/*
+ * @brief Zero pads a part of a face in a tile, dictated by the number of elements to pad on the right and bottom edges
+ * of the face.
+ *
+ * This function zero pads a part of a face in a tile. It handles both width and height padding
+ * by setting the specified number of elements to zero on the right and bottom edges of the face.
+ *
+ * @tparam T The type of the elements in the tile
+ * @param num_elements_padded_w Number of elements to pad on the right edge (width)
+ * @param num_elements_padded_h Number of elements to pad on the bottom edge (height)
+ * @param tile_ptr Pointer to the start of the face in the tile
+ */
+template <typename T>
+void fill_pad_face(uint32_t num_elements_padded_w, uint32_t num_elements_padded_h, T* tile_ptr, T fill_value) {
+    // Right padding (width padding)
+    if (num_elements_padded_w > 0) {
+        for (uint32_t row = 0; row < FACE_HEIGHT; ++row) {
+            auto row_start = tile_ptr + row * FACE_WIDTH + (FACE_WIDTH - num_elements_padded_w);
+            for (uint32_t col = 0; col < num_elements_padded_w; ++col) {
+                row_start[col] = fill_value;
+            }
+        }
+    }
+
+    // Bottom padding (height padding)
+    if (num_elements_padded_h > 0) {
+        for (uint32_t row = FACE_HEIGHT - num_elements_padded_h; row < FACE_HEIGHT; ++row) {
+            auto row_start = tile_ptr + row * FACE_WIDTH;
+            // TODO: Use NOC for faster zero padding - can be done in a single write from MEM_ZERO_ADDR
+            // noc_async_read(zeros_noc_addr, row_start, num_elements_padded_h * sizeof(T));
+            for (uint32_t col = 0; col < FACE_WIDTH; ++col) {
+                row_start[col] = fill_value;
+            }
+        }
+    }
+}
+
+/**
+ * @brief Zero pads a tile by handling padding for each face within the tile.
+ *
+ * This function handles zero padding for a tile by breaking it down into faces and applying
+ * padding to each face individually. It calculates the appropriate padding for each face
+ * based on the unpadded dimensions and applies the padding using fill_pad_face.
+ *
+ * @tparam T The type of the elements in the tile
+ * @tparam num_faces_w Number of faces in the width dimension (default: TILE_WIDTH / FACE_WIDTH)
+ * @tparam num_faces_h Number of faces in the height dimension (default: TILE_HEIGHT / FACE_HEIGHT)
+ * @param num_elements_unpadded_w Number of unpadded elements in the width dimension
+ * @param num_elements_unpadded_h Number of unpadded elements in the height dimension
+ * @param l1_tile_ptr Pointer to the start of the tile
+ */
+template <typename T, uint32_t num_faces_w = TILE_WIDTH / FACE_WIDTH, uint32_t num_faces_h = TILE_HEIGHT / FACE_HEIGHT>
+void fill_pad_tile(
+    uint32_t num_elements_unpadded_w, uint32_t num_elements_unpadded_h, uint32_t l1_tile_ptr, uint32_t fill_value) {
+    auto tile_ptr = reinterpret_cast<T*>(l1_tile_ptr);
+
+    for (uint32_t face_h = 0; face_h < num_faces_h; ++face_h) {
+        for (uint32_t face_w = 0; face_w < num_faces_w; ++face_w) {
+            // Calculate face offset
+            uint32_t face_offset = (face_h * num_faces_w + face_w) * FACE_HW;
+            auto face_ptr = tile_ptr + face_offset;
+            // Calculate padding for this specific face
+            if (num_elements_unpadded_w > 0) {
+                uint32_t face_pad_w = num_elements_unpadded_w < (face_w * FACE_WIDTH)
+                                          ? FACE_WIDTH
+                                          : (FACE_WIDTH - num_elements_unpadded_w % FACE_WIDTH);
+                fill_pad_face<T>(face_pad_w, 0, face_ptr, fill_value);
+            }
+
+            if (num_elements_unpadded_h > 0) {
+                uint32_t face_pad_h = num_elements_unpadded_h < (face_h * FACE_HEIGHT)
+                                          ? FACE_HEIGHT
+                                          : (FACE_HEIGHT - num_elements_unpadded_h % FACE_HEIGHT);
+                fill_pad_face<T>(0, face_pad_h, face_ptr, fill_value);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
@@ -1,11 +1,10 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
 
 #include "dataflow_api.h"
-#include "pad_tile.hpp"
 
 void kernel_main() {
     // same arg indices as in reader_binary_diff_lenghts for compat
@@ -24,7 +23,6 @@ void kernel_main() {
 
     constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
     constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr uint32_t in0_last_ktile_w = get_compile_time_arg_val(2);
 
     // DPRINT << "Mt=" << Mt << " Kt=" << Kt << " Nt=" << Nt << " MtKt=" << MtKt << "KtNt=" << KtNt << ENDL();
     // DPRINT << "src0=" << src0_addr << " src1=" << src1_addr << ENDL();
@@ -62,11 +60,6 @@ void kernel_main() {
                 uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
                 noc_async_read_tile(itileA, s0, l1_write_addr_in0);
                 noc_async_read_barrier();
-                if constexpr (in0_last_ktile_w > 0) {
-                    if (kt == Kt - 1) {
-                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(l1_write_addr_in0);
-                    }
-                }
                 cb_push_back(cb_id_in0, onetile);
             }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
@@ -64,7 +64,7 @@ void kernel_main() {
                 noc_async_read_barrier();
                 if constexpr (in0_last_ktile_w > 0) {
                     if (kt == Kt - 1) {
-                        pad_last_ktile<in0_data_format>(in0_last_ktile_w, l1_write_addr_in0);
+                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(l1_write_addr_in0);
                     }
                 }
                 cb_push_back(cb_id_in0, onetile);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
@@ -1,10 +1,11 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
 
 #include "dataflow_api.h"
+#include "pad_tile.hpp"
 
 void kernel_main() {
     // same arg indices as in reader_binary_diff_lenghts for compat
@@ -23,6 +24,7 @@ void kernel_main() {
 
     constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
     constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr uint32_t in0_last_ktile_w = get_compile_time_arg_val(2);
 
     // DPRINT << "Mt=" << Mt << " Kt=" << Kt << " Nt=" << Nt << " MtKt=" << MtKt << "KtNt=" << KtNt << ENDL();
     // DPRINT << "src0=" << src0_addr << " src1=" << src1_addr << ENDL();
@@ -60,6 +62,11 @@ void kernel_main() {
                 uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
                 noc_async_read_tile(itileA, s0, l1_write_addr_in0);
                 noc_async_read_barrier();
+                if constexpr (in0_last_ktile_w > 0) {
+                    if (kt == Kt - 1) {
+                        pad_last_ktile<in0_data_format>(in0_last_ktile_w, l1_write_addr_in0);
+                    }
+                }
                 cb_push_back(cb_id_in0, onetile);
             }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
@@ -67,7 +67,7 @@ void kernel_main() {
                     if constexpr (last_ktile_w > 0) {
                         if ((block == num_blocks - 1) && (w == in0_block_w - 1)) {
                             noc_async_read_barrier();
-                            pad_last_ktile<in0_data_format>(last_ktile_w, l1_write_addr_in0);
+                            pad_last_ktile<in0_data_format, last_ktile_w>(l1_write_addr_in0);
                         }
                     }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include "dataflow_api.h"
+#include "pad_tile.hpp"
 
 void kernel_main() {
     // in0/in1 common args
@@ -30,6 +31,7 @@ void kernel_main() {
     // COMPILE TIME ARGS
     // interleaved accessor args
     constexpr bool in0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t last_ktile_w = get_compile_time_arg_val(1);
 
     constexpr uint32_t cb_id_in0 = 0;
 
@@ -39,8 +41,8 @@ void kernel_main() {
     cb_push_back(cb_id_in0, in0_num_tiles);
 #else
 
-    const uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
-    const DataFormat in0_data_format = get_dataformat(cb_id_in0);
+    constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
+    constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
     constexpr const uint32_t in0_tile_hw = get_tile_hw(cb_id_in0);
 
     uint32_t l1_write_addr_in0;
@@ -60,6 +62,11 @@ void kernel_main() {
                 uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in0_block_w; ++w) {
                     noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_in0);
+
+                    // Zero out padded regions for the very last tile
+                    if ((block == num_blocks - 1) && (w == in0_block_w - 1) && (last_ktile_w > 0)) {
+                        pad_last_ktile<in0_data_format>(last_ktile_w, l1_write_addr_in0);
+                    }
 
                     l1_write_addr_in0 += in0_single_tile_size_bytes;
                     in0_tensor_tile_id += in0_tensor_stride_w;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
@@ -64,8 +64,11 @@ void kernel_main() {
                     noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_in0);
 
                     // Zero out padded regions for the very last tile
-                    if ((block == num_blocks - 1) && (w == in0_block_w - 1) && (last_ktile_w > 0)) {
-                        pad_last_ktile<in0_data_format>(last_ktile_w, l1_write_addr_in0);
+                    if constexpr (last_ktile_w > 0) {
+                        if ((block == num_blocks - 1) && (w == in0_block_w - 1)) {
+                            noc_async_read_barrier();
+                            pad_last_ktile<in0_data_format>(last_ktile_w, l1_write_addr_in0);
+                        }
                     }
 
                     l1_write_addr_in0 += in0_single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -97,7 +97,6 @@ void kernel_main() {
 
             // Zero out padded regions for the very last tile
             if constexpr (in0_last_ktile_w > 0) {
-                DPRINT << "is_last_ktile_padded: " << (uint32_t)is_last_ktile_padded << ENDL();
                 if (is_last_ktile_padded && (i == num_blocks_per_shard - 1)) {
                     auto in0_last_ktile_ptr = local_read_addr + in0_block_size_bytes - in0_single_tile_size_bytes;
                     pad_last_ktile<in0_data_format, in0_last_ktile_w>(in0_last_ktile_ptr);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -95,7 +95,7 @@ void kernel_main() {
             uint64_t in0_multicast_data_addr = in0_multicast_data_noc | in0_start_address;
 
             // Zero out padded regions for the very last tile
-            if ((i == num_blocks_per_shard - 1) && (in0_last_ktile_w > 0)) {
+            if ((in0_last_ktile_w > 0) && (i == num_blocks_per_shard - 1)) {
                 auto in0_last_ktile_ptr = local_read_addr + in0_block_size_bytes - in0_single_tile_size_bytes;
                 pad_last_ktile<in0_data_format>(in0_last_ktile_w, in0_last_ktile_ptr);
             }
@@ -132,7 +132,7 @@ void kernel_main() {
                 uint64_t in0_multicast_data_addr = in0_multicast_data_noc | in0_start_address;
 
                 // Zero out padded regions for the very last tile
-                if ((block == num_blocks - 1) && (in0_last_ktile_w > 0)) {
+                if ((in0_last_ktile_w > 0) && (block == num_blocks - 1)) {
                     auto in0_last_ktile_ptr = local_read_addr + in0_block_size_bytes - in0_single_tile_size_bytes;
                     pad_last_ktile<in0_data_format>(in0_last_ktile_w, in0_last_ktile_ptr);
                 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -13,22 +13,23 @@ void kernel_main() {
     // in0 block args
     constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(0);
     constexpr uint32_t in0_block_size_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t in0_last_ktile_w = get_compile_time_arg_val(2);
     // in0 mcast args
-    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(2));
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(3));
-    constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(4);
-    constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(5);
+    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(3));
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(4));
+    constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(5);
+    constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(6);
     // block args
-    constexpr uint32_t num_blocks = get_compile_time_arg_val(6);
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(7);
     // in0 mcast args
-    constexpr uint32_t in0_mcast_dest_noc_start_x = get_compile_time_arg_val(7);
-    constexpr uint32_t in0_mcast_dest_noc_start_y = get_compile_time_arg_val(8);
-    constexpr uint32_t in0_mcast_dest_noc_end_x = get_compile_time_arg_val(9);
-    constexpr uint32_t in0_mcast_dest_noc_end_y = get_compile_time_arg_val(10);
+    constexpr uint32_t in0_mcast_dest_noc_start_x = get_compile_time_arg_val(8);
+    constexpr uint32_t in0_mcast_dest_noc_start_y = get_compile_time_arg_val(9);
+    constexpr uint32_t in0_mcast_dest_noc_end_x = get_compile_time_arg_val(10);
+    constexpr uint32_t in0_mcast_dest_noc_end_y = get_compile_time_arg_val(11);
     // in0 semaphore always valid
-    uint32_t in0_mcast_sender_valid_semaphore = get_semaphore(get_compile_time_arg_val(11));
+    uint32_t in0_mcast_sender_valid_semaphore = get_semaphore(get_compile_time_arg_val(12));
 
-    constexpr uint32_t num_blocks_per_shard = get_compile_time_arg_val(12);
+    constexpr uint32_t num_blocks_per_shard = get_compile_time_arg_val(13);
     constexpr uint32_t num_storage_cores = num_blocks / num_blocks_per_shard;
 
     // RUNTIME ARGS
@@ -38,7 +39,7 @@ void kernel_main() {
         return;
     }
     const uint32_t sender_id = get_arg_val<uint32_t>(1);
-    const uint32_t in0_last_ktile_w = get_arg_val<uint32_t>(2);
+    const bool is_last_ktile_padded = static_cast<bool>(get_arg_val<uint32_t>(2));
 
     tt_l1_ptr uint32_t* in0_mcast_sender_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(3));
     tt_l1_ptr uint32_t* in0_mcast_sender_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(3 + num_storage_cores));
@@ -95,9 +96,12 @@ void kernel_main() {
             uint64_t in0_multicast_data_addr = in0_multicast_data_noc | in0_start_address;
 
             // Zero out padded regions for the very last tile
-            if ((in0_last_ktile_w > 0) && (i == num_blocks_per_shard - 1)) {
-                auto in0_last_ktile_ptr = local_read_addr + in0_block_size_bytes - in0_single_tile_size_bytes;
-                pad_last_ktile<in0_data_format>(in0_last_ktile_w, in0_last_ktile_ptr);
+            if constexpr (in0_last_ktile_w > 0) {
+                DPRINT << "is_last_ktile_padded: " << (uint32_t)is_last_ktile_padded << ENDL();
+                if (is_last_ktile_padded && (i == num_blocks_per_shard - 1)) {
+                    auto in0_last_ktile_ptr = local_read_addr + in0_block_size_bytes - in0_single_tile_size_bytes;
+                    pad_last_ktile<in0_data_format, in0_last_ktile_w>(in0_last_ktile_ptr);
+                }
             }
 
 #ifndef SKIP_MCAST
@@ -132,9 +136,11 @@ void kernel_main() {
                 uint64_t in0_multicast_data_addr = in0_multicast_data_noc | in0_start_address;
 
                 // Zero out padded regions for the very last tile
-                if ((in0_last_ktile_w > 0) && (block == num_blocks - 1)) {
-                    auto in0_last_ktile_ptr = local_read_addr + in0_block_size_bytes - in0_single_tile_size_bytes;
-                    pad_last_ktile<in0_data_format>(in0_last_ktile_w, in0_last_ktile_ptr);
+                if constexpr (in0_last_ktile_w > 0) {
+                    if (is_last_ktile_padded && (block == num_blocks - 1)) {
+                        auto in0_last_ktile_ptr = local_read_addr + in0_block_size_bytes - in0_single_tile_size_bytes;
+                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(in0_last_ktile_ptr);
+                    }
                 }
 #ifndef SKIP_MCAST
                 noc_async_write_multicast_loopback_src(

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -6,6 +6,7 @@
 
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include "pad_tile.hpp"
 
 void kernel_main() {
     // COMPILE TIME ARGS
@@ -37,16 +38,18 @@ void kernel_main() {
         return;
     }
     const uint32_t sender_id = get_arg_val<uint32_t>(1);
-    tt_l1_ptr uint32_t* in0_mcast_sender_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
-    tt_l1_ptr uint32_t* in0_mcast_sender_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(2 + num_storage_cores));
+    const uint32_t in0_last_ktile_w = get_arg_val<uint32_t>(2);
+
+    tt_l1_ptr uint32_t* in0_mcast_sender_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(3));
+    tt_l1_ptr uint32_t* in0_mcast_sender_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(3 + num_storage_cores));
 
     const uint32_t sender_block_id = sender_id * num_blocks_per_shard;
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in2 = 2;  // Sharded cb
 
-    const uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
-    const DataFormat in0_data_format = get_dataformat(cb_id_in0);
+    constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
+    constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
 
     uint32_t l1_write_addr_in0;
 
@@ -91,6 +94,12 @@ void kernel_main() {
             // Now we have the block in the CB address, we can mcast to dests!
             uint64_t in0_multicast_data_addr = in0_multicast_data_noc | in0_start_address;
 
+            // Zero out padded regions for the very last tile
+            if ((i == num_blocks_per_shard - 1) && (in0_last_ktile_w > 0)) {
+                auto in0_last_ktile_ptr = local_read_addr + in0_block_size_bytes - in0_single_tile_size_bytes;
+                pad_last_ktile<in0_data_format>(in0_last_ktile_w, in0_last_ktile_ptr);
+            }
+
 #ifndef SKIP_MCAST
             // num_dests must not include source, since we are NOT really doing a local copy!
             noc_async_write_multicast(
@@ -121,6 +130,12 @@ void kernel_main() {
                 noc_semaphore_set(in0_mcast_sender_semaphore_addr_ptr, 0);
 
                 uint64_t in0_multicast_data_addr = in0_multicast_data_noc | in0_start_address;
+
+                // Zero out padded regions for the very last tile
+                if ((block == num_blocks - 1) && (in0_last_ktile_w > 0)) {
+                    auto in0_last_ktile_ptr = local_read_addr + in0_block_size_bytes - in0_single_tile_size_bytes;
+                    pad_last_ktile<in0_data_format>(in0_last_ktile_w, in0_last_ktile_ptr);
+                }
 #ifndef SKIP_MCAST
                 noc_async_write_multicast_loopback_src(
                     local_read_addr, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, true);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -157,7 +157,7 @@ void kernel_main() {
                             if constexpr (in0_last_ktile_w > 0) {
                                 if ((block == num_blocks_inner_dim - 1) && (w == in0_block_w - 1)) {
                                     noc_async_read_barrier();
-                                    pad_last_ktile<in0_data_format>(in0_last_ktile_w, l1_write_addr_in0);
+                                    pad_last_ktile<in0_data_format, in0_last_ktile_w>(l1_write_addr_in0);
                                 }
                             }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -154,9 +154,11 @@ void kernel_main() {
                             }
 
                             // Zero out padded regions for the very last tile
-                            if ((block == num_blocks_inner_dim - 1) && (w == in0_block_w - 1) &&
-                                (in0_last_ktile_w > 0)) {
-                                pad_last_ktile<in0_data_format>(in0_last_ktile_w, l1_write_addr_in0);
+                            if constexpr (in0_last_ktile_w > 0) {
+                                if ((block == num_blocks_inner_dim - 1) && (w == in0_block_w - 1)) {
+                                    noc_async_read_barrier();
+                                    pad_last_ktile<in0_data_format>(in0_last_ktile_w, l1_write_addr_in0);
+                                }
                             }
 
                             l1_write_addr_in0 += in0_single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -173,7 +173,7 @@ void kernel_main() {
                             if constexpr (in0_last_ktile_w > 0) {
                                 if ((block == num_blocks_inner_dim - 1)) {
                                     auto in0_last_ktile_w_ptr = l1_write_extract_shard_in0 - in0_single_tile_size_bytes;
-                                    pad_last_ktile<in0_data_format>(in0_last_ktile_w, in0_last_ktile_w_ptr);
+                                    pad_last_ktile<in0_data_format, in0_last_ktile_w>(in0_last_ktile_w_ptr);
                                 }
                             }
                         } else {
@@ -184,7 +184,7 @@ void kernel_main() {
                                 if ((block == num_blocks_inner_dim - 1)) {
                                     auto in0_last_ktile_w_ptr =
                                         in0_tensor_read_addr + in0_block_size_bytes - in0_single_tile_size_bytes;
-                                    pad_last_ktile<in0_data_format>(in0_last_ktile_w, in0_last_ktile_w_ptr);
+                                    pad_last_ktile<in0_data_format, in0_last_ktile_w>(in0_last_ktile_w_ptr);
                                 }
                             }
                         }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -7,6 +7,7 @@
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
+#include "pad_tile.hpp"
 
 void kernel_main() {
     constexpr bool core_has_output_block_work = (bool)get_compile_time_arg_val(0);
@@ -14,25 +15,27 @@ void kernel_main() {
 
     constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(2);
     constexpr uint32_t in0_block_size_bytes = get_compile_time_arg_val(3);
-    // in0/in1 common args
-    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(4);
-    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(5);
-    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(6);
-    // in0 mcast args
-    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(7));
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(8));
-    constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(9);
-    constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(10);
-    constexpr uint32_t num_x = get_compile_time_arg_val(11);
-    constexpr uint32_t num_y = get_compile_time_arg_val(12);
-    constexpr bool transpose_mcast = (bool)get_compile_time_arg_val(13);
-    constexpr uint32_t shard_width_in_tiles = get_compile_time_arg_val(14);
-    constexpr uint32_t shard_height_in_tiles = get_compile_time_arg_val(15);
-    constexpr uint32_t in0_block_w = get_compile_time_arg_val(16);
-    constexpr uint32_t in0_block_h = get_compile_time_arg_val(17);
+    constexpr uint32_t in0_last_ktile_w = get_compile_time_arg_val(4);
 
-    constexpr uint32_t batch = get_compile_time_arg_val(18);
-    constexpr bool fuse_op = (bool)get_compile_time_arg_val(19);
+    // in0/in1 common args
+    constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(5);
+    constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(6);
+    constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(7);
+    // in0 mcast args
+    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(8));
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(9));
+    constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(10);
+    constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(11);
+    constexpr uint32_t num_x = get_compile_time_arg_val(12);
+    constexpr uint32_t num_y = get_compile_time_arg_val(13);
+    constexpr bool transpose_mcast = (bool)get_compile_time_arg_val(14);
+    constexpr uint32_t shard_width_in_tiles = get_compile_time_arg_val(15);
+    constexpr uint32_t shard_height_in_tiles = get_compile_time_arg_val(16);
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(17);
+    constexpr uint32_t in0_block_h = get_compile_time_arg_val(18);
+
+    constexpr uint32_t batch = get_compile_time_arg_val(19);
+    constexpr bool fuse_op = (bool)get_compile_time_arg_val(20);
 
     uint32_t rt_args_idx = 0;
     const uint32_t sender_id = get_arg_val<uint32_t>(rt_args_idx++);
@@ -166,6 +169,11 @@ void kernel_main() {
                             in0_tensor_current_inner_dim_block_start_addr += shard_read_width;
 
                             noc_async_read_barrier();
+
+                            if ((block == num_blocks_inner_dim - 1) && (in0_last_ktile_w > 0)) {
+                                auto in0_last_ktile_w_ptr = l1_write_extract_shard_in0 - in0_single_tile_size_bytes;
+                                pad_last_ktile<in0_data_format>(in0_last_ktile_w, in0_last_ktile_w_ptr);
+                            }
                         } else {
                             in0_tensor_read_addr = in0_tensor_current_inner_dim_block_start_addr;
                             in0_tensor_current_inner_dim_block_start_addr += in0_block_size_bytes;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -92,7 +92,9 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core(
 
     bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     bool src1_is_dram = src1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_is_dram, (uint32_t)src1_is_dram};
+    uint32_t last_ktile_w = a.get_logical_shape()[-1] % TILE_WIDTH;
+    std::vector<uint32_t> reader_compile_time_args = {
+        (uint32_t)src0_is_dram, (uint32_t)src1_is_dram, (uint32_t)last_ktile_w};
 
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -92,9 +92,7 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core(
 
     bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     bool src1_is_dram = src1_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    uint32_t last_ktile_w = a.get_logical_shape()[-1] % TILE_WIDTH;
-    std::vector<uint32_t> reader_compile_time_args = {
-        (uint32_t)src0_is_dram, (uint32_t)src1_is_dram, (uint32_t)last_ktile_w};
+    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_is_dram, (uint32_t)src1_is_dram};
 
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -277,6 +277,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0(
 
     uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
     uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+    uint32_t in0_last_ktile_w =
+        (a.get_logical_shape()[-1] % in0_tile.get_tile_shape()[1]) * datum_size(in0_data_format);
 
     std::vector<uint32_t> in0_sender_compile_time_args;
     if (in0_is_sharded) {
@@ -286,6 +288,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0(
 
             (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
             (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+            (std::uint32_t)in0_last_ktile_w,
+
             // in0/in1 common args
             (std::uint32_t)num_blocks,        // num_blocks
             (std::uint32_t)out_num_blocks_x,  // num_blocks_x
@@ -320,9 +324,10 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0(
             (std::uint32_t)in0_block_w,          // in0_block_w
             (std::uint32_t)in0_block_h,          // in0_block_h
             (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
-            (std::uint32_t)false,                // extract_shard_sub_blocks (not used for interleaved)
-            (std::uint32_t)0,                    // shard_width_in_tiles (not used for interleaved)
-            (std::uint32_t)0,                    // shard_height_in_tiles (not used for interleaved)
+            (std::uint32_t)in0_last_ktile_w,
+            (std::uint32_t)false,  // extract_shard_sub_blocks (not used for interleaved)
+            (std::uint32_t)0,      // shard_width_in_tiles (not used for interleaved)
+            (std::uint32_t)0,      // shard_height_in_tiles (not used for interleaved)
             // in0/in1 common args
             (std::uint32_t)num_blocks,        // num_blocks
             (std::uint32_t)out_num_blocks_x,  // num_blocks_x
@@ -735,8 +740,6 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0(
     uint32_t last_block_padded_block_tiles_w_skip =
         (out_subblock_w * out_subblock_h) * (out_block_w / out_subblock_w - last_block_num_nonzero_subblocks_w);
 
-    uint32_t last_ktile_w = (a.get_logical_shape()[-1] % in0_tile.get_tile_shape()[1]) * datum_size(in0_data_format);
-
     CoreCoord start_core_noc = top_left_core_physical;
     CoreCoord end_core_noc = bottom_right_core_physical;
     if (in0_noc == tt::tt_metal::NOC::NOC_1) {
@@ -797,8 +800,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0(
                 (std::uint32_t)end_core_noc.y,    // in0_mcast_dest_noc_end_y
 
                 // padding args
-                (std::uint32_t)out_block_h,  // last_block_h
-                (std::uint32_t)last_ktile_w};
+                (std::uint32_t)out_block_h  // last_block_h
+            };
 
             if (fuse_op) {
                 fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
@@ -1047,6 +1050,9 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in1(
     }
     uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
 
+    uint32_t in0_last_ktile_w =
+        (a.get_logical_shape()[-1] % in0_tile.get_tile_shape()[1]) * datum_size(in0_data_format);
+
     bool extract_shard_sub_blocks = false;
     uint32_t in0_shard_height_in_tiles = 0;
     uint32_t in0_shard_width_in_tiles = 0;
@@ -1140,6 +1146,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in1(
         (std::uint32_t)in0_block_w,                // in0_block_w
         (std::uint32_t)in0_block_h,                // in0_block_h
         (std::uint32_t)in0_block_w * in0_block_h,  // in0_block_num_tiles
+        (std::uint32_t)in0_last_ktile_w,
+
         (std::uint32_t)extract_shard_sub_blocks,
         (std::uint32_t)in0_shard_width_in_tiles,
         (std::uint32_t)in0_shard_height_in_tiles,
@@ -1514,8 +1522,6 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in1(
     uint32_t last_block_padded_block_tiles_h_skip =
         (out_block_h / out_subblock_h - last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
 
-    uint32_t last_ktile_w = (a.get_logical_shape()[-1] % in0_tile.get_tile_shape()[1]) * datum_size(in0_data_format);
-
     CoreCoord start_core_noc = bottom_right_core_physical;
     CoreCoord end_core_noc = top_left_core_physical;
     if (in1_noc == tt::tt_metal::NOC::NOC_0) {
@@ -1637,8 +1643,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in1(
             (std::uint32_t)0,  // in0_mcast_dest_noc_end_y
 
             // padding args
-            (std::uint32_t)per_core_M,  // last_block_h
-            (std::uint32_t)last_ktile_w,
+            (std::uint32_t)per_core_M  // last_block_h
         };
         tt_metal::SetRuntimeArgs(program, mm_kernel_in0_sender_id, core, mm_in0_sender_args);  // RISCV_1_default
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -277,8 +277,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0(
 
     uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
     uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
-    uint32_t in0_last_ktile_w =
-        (a.get_logical_shape()[-1] % in0_tile.get_tile_shape()[1]) * datum_size(in0_data_format);
+    uint32_t in0_last_ktile_w = a.get_logical_shape()[-1] % in0_tile.get_tile_shape()[1];
 
     std::vector<uint32_t> in0_sender_compile_time_args;
     if (in0_is_sharded) {
@@ -1050,8 +1049,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in1(
     }
     uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
 
-    uint32_t in0_last_ktile_w =
-        (a.get_logical_shape()[-1] % in0_tile.get_tile_shape()[1]) * datum_size(in0_data_format);
+    uint32_t in0_last_ktile_w = a.get_logical_shape()[-1] % in0_tile.get_tile_shape()[1];
 
     bool extract_shard_sub_blocks = false;
     uint32_t in0_shard_height_in_tiles = 0;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -735,6 +735,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0(
     uint32_t last_block_padded_block_tiles_w_skip =
         (out_subblock_w * out_subblock_h) * (out_block_w / out_subblock_w - last_block_num_nonzero_subblocks_w);
 
+    uint32_t last_ktile_w = (a.get_logical_shape()[-1] % in0_tile.get_tile_shape()[1]) * datum_size(in0_data_format);
+
     CoreCoord start_core_noc = top_left_core_physical;
     CoreCoord end_core_noc = bottom_right_core_physical;
     if (in0_noc == tt::tt_metal::NOC::NOC_1) {
@@ -795,8 +797,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0(
                 (std::uint32_t)end_core_noc.y,    // in0_mcast_dest_noc_end_y
 
                 // padding args
-                (std::uint32_t)out_block_h  // last_block_h
-            };
+                (std::uint32_t)out_block_h,  // last_block_h
+                (std::uint32_t)last_ktile_w};
 
             if (fuse_op) {
                 fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
@@ -968,6 +970,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0(
 }
 
 tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in1(
+    tt::tt_metal::Program& program,
+    const tt::tt_metal::Tensor& a,
     tt_metal::IDevice* device,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -1004,8 +1008,6 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in1(
     bool untilize_out) {
     // currently only support transpose of the full tile
     bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
-
-    tt_metal::Program program{};
 
     bool fuse_op = false;
 
@@ -1512,6 +1514,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in1(
     uint32_t last_block_padded_block_tiles_h_skip =
         (out_block_h / out_subblock_h - last_block_num_nonzero_subblocks_h) * (out_block_w * out_subblock_h);
 
+    uint32_t last_ktile_w = (a.get_logical_shape()[-1] % in0_tile.get_tile_shape()[1]) * datum_size(in0_data_format);
+
     CoreCoord start_core_noc = bottom_right_core_physical;
     CoreCoord end_core_noc = top_left_core_physical;
     if (in1_noc == tt::tt_metal::NOC::NOC_0) {
@@ -1633,7 +1637,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in1(
             (std::uint32_t)0,  // in0_mcast_dest_noc_end_y
 
             // padding args
-            (std::uint32_t)per_core_M  // last_block_h
+            (std::uint32_t)per_core_M,  // last_block_h
+            (std::uint32_t)last_ktile_w,
         };
         tt_metal::SetRuntimeArgs(program, mm_kernel_in0_sender_id, core, mm_in0_sender_args);  // RISCV_1_default
     }
@@ -2579,6 +2584,8 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_o
             fused_op_signaler);
     } else {
         return reuse_mcast_1d_optimized_helpers::create_program_mcast_in1(
+            program,
+            a,
             device,
             math_fidelity,
             fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -335,6 +335,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
 
             (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
             (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+            (std::uint32_t)in0_last_ktile_w,
+
             // in0/in1 common args
             (std::uint32_t)num_blocks,  // num_blocks
             (std::uint32_t)out_num_blocks_x,
@@ -368,7 +370,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
             (std::uint32_t)in0_block_w,          // in0_block_w
             (std::uint32_t)in0_block_h,          // in0_block_h
             (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
-            (std::uint32_t)in0_last_ktile_w,     // in0_last_ktile_w
+            (std::uint32_t)in0_last_ktile_w,
 
             (std::uint32_t)false,                      // extract_shard_sub_blocks (not used for interleaved)
             (std::uint32_t)in0_shard_width_in_tiles,   // shard_width_in_tiles (not used for interleaved)
@@ -1364,8 +1366,7 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_o
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.get_dtype());          // in1
     tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());  // output
 
-    uint32_t in0_last_ktile_w =
-        (a.get_logical_shape()[-1] % in0_tile.get_tile_shape()[1]) * datum_size(in0_data_format);
+    uint32_t in0_last_ktile_w = a.get_logical_shape()[-1] % in0_tile.get_tile_shape()[1];
 
     tt_metal::Buffer* bias_buffer = nullptr;
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -36,6 +36,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     uint32_t K,
     bool bcast_batch,
     uint32_t in0_block_w,
+    uint32_t in0_last_ktile_w,
     uint32_t out_subblock_h,
     uint32_t out_subblock_w,
     uint32_t out_block_h,
@@ -364,9 +365,11 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
             (std::uint32_t)in0_block_w,      // in0_tensor_next_inner_dim_block_stride
             (std::uint32_t)K * in0_block_h,  // in0_tensor_next_h_dim_block_stride
             // in0 block args
-            (std::uint32_t)in0_block_w,                // in0_block_w
-            (std::uint32_t)in0_block_h,                // in0_block_h
-            (std::uint32_t)in0_block_num_tiles,        // in0_block_num_tiles
+            (std::uint32_t)in0_block_w,          // in0_block_w
+            (std::uint32_t)in0_block_h,          // in0_block_h
+            (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+            (std::uint32_t)in0_last_ktile_w,     // in0_last_ktile_w
+
             (std::uint32_t)false,                      // extract_shard_sub_blocks (not used for interleaved)
             (std::uint32_t)in0_shard_width_in_tiles,   // shard_width_in_tiles (not used for interleaved)
             (std::uint32_t)in0_shard_height_in_tiles,  // shard_height_in_tiles (not used for interleaved)
@@ -1361,6 +1364,9 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_o
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.get_dtype());          // in1
     tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());  // output
 
+    uint32_t in0_last_ktile_w =
+        (a.get_logical_shape()[-1] % in0_tile.get_tile_shape()[1]) * datum_size(in0_data_format);
+
     tt_metal::Buffer* bias_buffer = nullptr;
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
     if (bias.has_value()) {
@@ -1455,6 +1461,7 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_o
         Kt,
         bcast_batch,
         in0_block_w,
+        in0_last_ktile_w,
         out_subblock_h,
         out_subblock_w,
         out_block_h,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -975,7 +975,7 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_shard
     uint32_t Mt = get_batch_size(ashape) * ashape[-2] / in0_tile_shape[0];
     uint32_t Kt = ashape[-1] / in0_tile_shape[1];
     uint32_t Nt = bshape[-1] / in1_tile_shape[1];
-    uint32_t in0_last_ktile_w = (a.get_logical_shape()[-1] % in0_tile_shape[1]) * datum_size(in0_data_format);
+    uint32_t in0_last_ktile_w = a.get_logical_shape()[-1] % in0_tile_shape[1];
 
     TT_FATAL(Kt % in0_block_w == 0, "Error");
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -66,6 +66,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
     uint32_t N,
     uint32_t K,
     uint32_t in0_block_w,
+    uint32_t in0_last_ktile_w,
     uint32_t per_core_M,
     uint32_t per_core_N_storage,
     std::optional<UnaryWithParam> fused_activation,
@@ -601,6 +602,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
 
         mm_in0_sender_args.push_back((std::uint32_t)worker_core_type);
         mm_in0_sender_args.push_back((std::uint32_t)sender_id);
+        mm_in0_sender_args.push_back((std::uint32_t)(core == all_storage_cores_vec.back() ? in0_last_ktile_w : 0));
         mm_in0_sender_args.insert(
             mm_in0_sender_args.end(), in0_mcast_sender_noc_x.begin(), in0_mcast_sender_noc_x.end());
         mm_in0_sender_args.insert(
@@ -622,6 +624,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
         uint32_t worker_core_type = 3;
         mm_in0_receiver_args.push_back((std::uint32_t)worker_core_type);
         mm_in0_receiver_args.push_back((std::uint32_t)0);
+        mm_in0_receiver_args.push_back((std::uint32_t)0);  // in0_last_ktile_w
         mm_in0_receiver_args.insert(
             mm_in0_receiver_args.end(), in0_mcast_sender_noc_x.begin(), in0_mcast_sender_noc_x.end());
         mm_in0_receiver_args.insert(
@@ -972,6 +975,7 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_shard
     uint32_t Mt = get_batch_size(ashape) * ashape[-2] / in0_tile_shape[0];
     uint32_t Kt = ashape[-1] / in0_tile_shape[1];
     uint32_t Nt = bshape[-1] / in1_tile_shape[1];
+    uint32_t in0_last_ktile_w = (a.get_logical_shape()[-1] % in0_tile_shape[1]) * datum_size(in0_data_format);
 
     TT_FATAL(Kt % in0_block_w == 0, "Error");
 
@@ -996,6 +1000,7 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_shard
         Nt,
         Kt,
         in0_block_w,
+        in0_last_ktile_w,
         per_core_M,
         per_core_N,
         std::move(fused_activation),

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -307,6 +307,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
     std::vector<uint32_t> in0_sender_compile_time_args = {
         (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
         (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+        (std::uint32_t)in0_last_ktile_w,                            // in0_last_ktile_w
         // in0 mcast args
         (std::uint32_t)in0_mcast_sender_semaphore_id,
         (std::uint32_t)in0_mcast_receiver_semaphore_id,
@@ -602,7 +603,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
 
         mm_in0_sender_args.push_back((std::uint32_t)worker_core_type);
         mm_in0_sender_args.push_back((std::uint32_t)sender_id);
-        mm_in0_sender_args.push_back((std::uint32_t)(core == all_storage_cores_vec.back() ? in0_last_ktile_w : 0));
+        mm_in0_sender_args.push_back(
+            (std::uint32_t)((core == all_storage_cores_vec.back()) and (in0_last_ktile_w > 0)));
         mm_in0_sender_args.insert(
             mm_in0_sender_args.end(), in0_mcast_sender_noc_x.begin(), in0_mcast_sender_noc_x.end());
         mm_in0_sender_args.insert(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -534,7 +534,7 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_
     uint32_t Kt = ashape[-1] / in0_tile_shape[1];
     uint32_t Nt = bshape[-1] / in1_tile_shape[1];
 
-    uint32_t in0_last_ktile_w = a.get_logical_shape()[-1] % in0_tile_shape[1] * datum_size(in0_data_format);
+    uint32_t in0_last_ktile_w = a.get_logical_shape()[-1] % in0_tile_shape[1];
 
     // TODO: Generalize
     TT_FATAL(!fuse_batch, "Only fuse_batch=false is supported for optimized bmm!");

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -31,6 +31,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program(
     uint32_t K,
     bool bcast_batch,
     uint32_t in0_block_w,
+    uint32_t in0_last_ktile_w,
     uint32_t out_subblock_h,
     uint32_t out_subblock_w,
     uint32_t per_core_M,
@@ -163,6 +164,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program(
     std::vector<uint32_t> reader_compile_time_args = {
         // interleaved accessor args
         (std::uint32_t)in0_is_dram,
+        (std::uint32_t)in0_last_ktile_w,
     };
     std::vector<uint32_t> reader_writer_compile_time_args = {// interleaved accessor args
                                                              (std::uint32_t)in1_is_dram,
@@ -532,6 +534,8 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_
     uint32_t Kt = ashape[-1] / in0_tile_shape[1];
     uint32_t Nt = bshape[-1] / in1_tile_shape[1];
 
+    uint32_t in0_last_ktile_w = a.get_logical_shape()[-1] % in0_tile_shape[1] * datum_size(in0_data_format);
+
     // TODO: Generalize
     TT_FATAL(!fuse_batch, "Only fuse_batch=false is supported for optimized bmm!");
 
@@ -566,6 +570,7 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_
         Kt,
         bcast_batch,
         in0_block_w,
+        in0_last_ktile_w,
         out_subblock_h,
         out_subblock_w,
         per_core_M,


### PR DESCRIPTION
This PR is a requeue with a small diff from the previous PR, which was reverted. Please refer to that for complete context.
https://github.com/tenstorrent/tt-metal/pull/22333

### The incremental change from the previous PR
MNIST has three matmuls:
| Reduction dim | Padding | Padding % |
|--------------|---------|-----------|
| 784          | 16      | 2%        |
| 120          | 8       | 6.6%      |
| 84           | 12      | 14.2%     |

There are 3 layers in this MNIST test:
```python
self.fc1 = torch.nn.Linear(784, 120)
self.fc2 = torch.nn.Linear(120, 84)
self.fc3 = torch.nn.Linear(84, 10)
```
Collectively, the the high percentage of padding adds 8-12% extra time. Thus, for these really small inputs that complete in a few microseconds, the padding overhead is high and causes a dip in performance.

Note that without padding, it is not guaranteed that these ops will produce correct results.

We update performance metrics for MNIST tests, reducing the expected performance by 9%.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passing https://github.com/tenstorrent/tt-metal/actions/runs/15423508215
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passing: https://github.com/tenstorrent/tt-metal/actions/runs/15423510891/job/43404980766
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI Passing https://github.com/tenstorrent/tt-metal/actions/runs/15434256620
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passing: https://github.com/tenstorrent/tt-metal/actions/runs/15423518224/job/43405020992
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes
- [x] T300K model perf tests https://github.com/tenstorrent/tt-metal/actions/runs/15425331229