### PR TITLE
#19301: Perform batch allocations when reading device data

### DIFF
--- a/tests/ttnn/benchmark/cpp/CMakeLists.txt
+++ b/tests/ttnn/benchmark/cpp/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(BENCHMARK_SRCS
     "host_tilizer_untilizer/tilizer_untilizer.cpp"
     "padding/pad_rm.cpp"
+    "host_alloc_on_tensor_readback.cpp"
 )
 
 foreach(TEST_SRC ${BENCHMARK_SRCS})

--- a/tests/ttnn/benchmark/cpp/host_alloc_on_tensor_readback.cpp
+++ b/tests/ttnn/benchmark/cpp/host_alloc_on_tensor_readback.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <benchmark/benchmark.h>
+
+#include <ttnn/tensor/tensor.hpp>
+#include "ttnn/tensor/tensor_impl.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/tensor/tensor_spec.hpp"
+#include "ttnn/tensor/layout/tensor_layout.hpp"
+#include "ttnn/distributed/api.hpp"
+
+namespace {
+
+ttnn::distributed::MeshDevice* device = nullptr;
+
+void BM_host_alloc_on_tensor_readback(benchmark::State& state) {
+    const size_t global_tensor_size = state.range(0);
+    tt::tt_metal::Tensor device_tensor = tt::tt_metal::allocate_tensor_on_mesh(
+        tt::tt_metal::TensorSpec(
+            ttnn::Shape({global_tensor_size / sizeof(float) / device->num_devices()}),
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::FLOAT32,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR),
+                tt::tt_metal::MemoryConfig())),
+        device);
+
+    // Note we are reading garbage data from the device, but it is not important for this benchmark.
+    for (auto _ : state) {
+        auto host_tensor = device_tensor.cpu(/*blocking=*/true);
+        benchmark::DoNotOptimize(host_tensor);
+    }
+
+    device_tensor.deallocate(/*force=*/true);
+}
+
+BENCHMARK(BM_host_alloc_on_tensor_readback)
+    ->Unit(benchmark::kMicrosecond)
+    ->Iterations(5)
+    ->Arg(1 << 10)    // 1KB
+    ->Arg(2 << 10)    // 2KB
+    ->Arg(4 << 10)    // 4KB
+    ->Arg(8 << 10)    // 8KB
+    ->Arg(16 << 10)   // 16KB
+    ->Arg(32 << 10)   // 32KB
+    ->Arg(64 << 10)   // 64KB
+    ->Arg(128 << 10)  // 128KB
+    ->Arg(256 << 10)  // 256KB
+    ->Arg(512 << 10)  // 512KB
+    ->Arg(1 << 20)    // 1MB
+    ->Arg(2 << 20)    // 2MB
+    ->Arg(4 << 20)    // 4MB
+    ->Arg(8 << 20)    // 8MB
+    ->Arg(16 << 20)   // 16MB
+    ->Arg(32 << 20)   // 32MB
+    ->Arg(64 << 20)   // 64MB
+    ->Arg(128 << 20)  // 128MB
+    ->Arg(256 << 20)  // 256MB
+    ->Arg(512 << 20)  // 512MB
+    ->Arg(1 << 30);   // 1GB
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    auto mesh_device = ttnn::distributed::open_mesh_device(
+        ttnn::distributed::MeshShape{2, 4},
+        DEFAULT_L1_SMALL_SIZE,
+        DEFAULT_TRACE_REGION_SIZE,
+        1,
+        tt::tt_metal::DispatchCoreConfig{});
+
+    device = mesh_device.get();
+
+    ::benchmark::Initialize(&argc, argv);
+    ::benchmark::RunSpecifiedBenchmarks();
+    ::benchmark::Shutdown();
+
+    return 0;
+}

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -32,7 +32,8 @@ using namespace tt::tt_metal;
 namespace {
 
 // Threshold for switch for mmap-based allocations to regular allocations.
-constexpr size_t kMmapThresholdBytes = 8 << 20;  // 8MB
+// Determined empirically using a microbenchmark; see https://github.com/tenstorrent/tt-metal/pull/22959 for details.
+constexpr size_t kMmapThresholdBytes = 1 << 20;  // 1MB
 
 // Allocates memory on the host in batch; using either mmap for large allocations or std::vector for small allocations.
 std::shared_ptr<void> allocate_host_data(size_t size_bytes) {

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -464,14 +464,7 @@ HostBuffer get_host_buffer_from_tensor(const Tensor& tt_tensor, const bool padde
         }
     };
 
-    auto copy_if_borrowed = [](const HostBuffer& buffer) {
-        if (buffer.is_borrowed()) {
-            return buffer.deep_copy();
-        }
-        return buffer;
-    };
-
-    return copy_if_borrowed(convert_to_logical(std::visit(
+    return convert_to_logical(std::visit(
         tt::stl::overloaded{
             [](const HostStorage& storage) { return storage.buffer; },
             [](const MultiDeviceHostStorage& storage) {
@@ -484,7 +477,7 @@ HostBuffer get_host_buffer_from_tensor(const Tensor& tt_tensor, const bool padde
                     tt::stl::get_active_type_name_in_variant(tt_tensor.get_storage()));
             },
         },
-        tt_tensor.get_storage())));
+        tt_tensor.get_storage()));
 }
 
 py::object convert_tt_tensor_to_torch_tensor(const Tensor& tt_tensor, const bool padded_output = false) {


### PR DESCRIPTION
### Ticket
#19301

### Problem description
Making memory allocations from multiple threads is currently problematic:
* Unnecessarily exposes MeshDevice's thread pool
* Memory blocks will be deallocated in the main thread, which leads to memory allocator cache misbalance.
* Unnecessary thread hops.

### What's changed
Perform a single batch allocation, and use `HostBuffer` borrowing feature to point shards to sub-regions of the batch allocation. When the allocation is greater than 1MB, use `mmap` to bypass memory allocator. Otherwise use a regular allocation path.

Note that mmap is lazy - so in practice, the actual virtual page mapping will be done across multiple threads on page faults.

The first version of this PR didn't use an mmap path - this resulted in regression in model tests, Tracy showed ~50% slower allocations on unet (mean).

### Microbenchmarking 
See the attached microbenchmark.

The main challenge is that running benchmarks for too long makes `std::vector<T>` based allocation (inconsistently) faster, since the allocator learns to cache memory chunks of the relevant sizes. Therefore, I chose to cap the number of iterations to 5, and instead aggressively loop over tensors of varying sizes. The results are summarized below.

`Tensor size` refers to the *global* size, where each device gets an equal portion of the data. The benchmark was run on a T3K machine.

**Old vs new implementation**
Small and large allocations are consistently faster with the new implementation. However, the middle range is noisy and not consistent.

| Tensor Size | Old Impl (µs) | New Impl (µs) | Delta (improvement %) |
|-------------|----------------|----------------|------------------------|
| 1 KB        | 520.0          | 333.0          | 35.96                  |
| 2 KB        | 178.0          | 106.0          | 40.45                  |
| 4 KB        | 167.0          | 104.0          | 37.72                  |
| 8 KB        | 177.0          | 92.9           | 47.51                  |
| 16 KB       | 170.0          | 97.8           | 42.47                  |
| 32 KB       | 173.0          | 102.0          | 41.04                  |
| 64 KB       | 158.0          | 106.0          | 32.91                  |
| 128 KB      | 180.0          | 143.0          | 20.56                  |
| 256 KB      | 180.0          | 144.0          | 20.00                  |
| 512 KB      | 189.0          | 213.0          | -12.70                 |
| 1 MB        | 225.0          | 231.0          | -2.67                  |
| 2 MB        | 276.0          | 591.0          | -114.13                |
| 4 MB        | 686.0          | 459.0          | 49.46                 |
| 8 MB        | 1804.0         | 1439.0         | 20.26                  |
| 16 MB       | 2446.0         | 2724.0         | -11.37                 |
| 32 MB       | 4708.0         | 5321.0         | -13.02                 |
| 64 MB       | 9336.0         | 10138.0        | -8.60                  |
| 128 MB      | 18773.0        | 20688.0        | -10.18                 |
| 256 MB      | 84650.0        | 41198.0        | 51.32                  |
| 512 MB      | 137443.0       | 81550.0        | 40.65                  |
| 1 GB        | 240548.0       | 158562.0       | 34.07                  |

**Determining a threshold for mmap-based allocations**
mmap starts to win in the 1-16MB range.

| Tensor Size     | std::vector<T> (µs) | mmap (µs) | Delta (improvement %) |
|-----------------|----------------|-----------|------------|
| 1 KB            | 345.0          | 313       | 9.28       |
| 2 KB            | 101.0          | 121       | -19.80     |
| 4 KB            | 90.6           | 113       | -24.72     |
| 8 KB            | 95.6           | 111       | -16.11     |
| 16 KB           | 99.7           | 119       | -19.36     |
| 32 KB           | 94.3           | 111       | -17.70     |
| 64 KB           | 105.0          | 116       | -10.48     |
| 128 KB          | 131.0          | 128       | 2.29       |
| 256 KB          | 134.0          | 134       | 0.00       |
| 512 KB          | 180.0          | 175       | 2.78       |
| 1 MB            | 291.0          | 225       | 22.68      |
| 2 MB            | 485.0          | 376       | 22.47      |
| 4 MB            | 894.0          | 862       | 3.58       |
| 8 MB            | 1763.0         | 1387      | 21.34      |
| 16 MB           | 3549.0         | 2687      | 24.31      |
| 32 MB           | 14653.0        | 5147      | 64.86      |
| 64 MB           | 29891.0        | 10273     | 65.65      |
| 128 MB          | 60679.0        | 20636     | 65.99      |
| 256 MB          | 119438.0       | 41286     | 65.44      |
| 512 MB          | 233965.0       | 83534     | 64.32      |
| 1 GB            | 461757.0       | 154789    | 66.48      |

### Model performance - running resent and unet on a T3K machine locally, averaging out over 3 runs:

**UNet**
Test Command:
```bash
WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml \
pytest -sv 'models/experimental/functional_unet/tests/test_unet_trace.py::test_unet_trace_2cq_multi_device[wormhole_b0-1-4-256-device_params0]'
```
Run | Baseline FPS | PR FPS | Improvement (FPS) | Improvement (%)
-- | -- | -- | -- | --
1 | 9715.95 | 10024.19 | +308.24 | +3.17%
2 | 9957.29 | 10034.52 | +77.23 | +0.78%
3 | 9863.48 | 10048.27 | +184.79 | +1.87%
  |   |   |   |  
Average | 9845.57 | 10035.66 | +190.09 | +1.93%


**ResNet-50**
Test Command:

```bash
WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml \
pytest -svv models/demos/tg/resnet50/tests/test_perf_e2e_resnet50.py::test_perf_trace_2cqs
```

Run | Baseline FPS | PR FPS | Improvement (FPS) | Improvement (%)
-- | -- | -- | -- | --
1 | 37768.45 | 37872.18 | +103.73 | +0.27%
2 | 37845.30 | 37825.75 | -19.55 | -0.05%
3 | 37888.39 | 37891.06 | +2.67 | +0.01%
  |   |   |   |  
Average | 37800.71 | 37829.66 | +28.95 | +0.08%

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15475632640) 
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15474274727)
- [X] [Single card tests](https://github.com/tenstorrent/tt-metal/actions/runs/15474300750)
- [X] [TG tests](https://github.com/tenstorrent/tt-metal/actions/runs/15429869702)
- [x] New/Existing tests provide coverage for changes