### PR TITLE
Fix padding for min/max when input is float32

### DIFF
--- a/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
+++ b/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
@@ -36,12 +36,13 @@ parameters = {
             "std",
             "var",
         ],
+        "dtype": [torch.bfloat16, torch.float32],
     }
     for rank in range(5)
 }
 
 
-def run_reduction(device, tensor_shape, dim, keepdim, op) -> list:
+def run_reduction(device, tensor_shape, dim, keepdim, op, dtype) -> list:
     """
     Test the compatibility of the torch and ttnn output for the given operation and different
     tensor shapes, keepdim, and dim values.
@@ -51,7 +52,7 @@ def run_reduction(device, tensor_shape, dim, keepdim, op) -> list:
     """
     rank = len(tensor_shape)
 
-    torch_tensor = torch.randn(*tensor_shape) if rank > 0 else torch.randn(())
+    torch_tensor = torch.randn(*tensor_shape, dtype=dtype) if rank > 0 else torch.randn((), dtype=dtype)
     ttnn_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
     torch_op, ttnn_op = getattr(torch, op), getattr(ttnn, op)
@@ -108,14 +109,17 @@ def test_reduction(
     dim,
     keepdim,
     op,
+    dtype,
 ):
-    run_reduction(
+    result, msg = run_reduction(
         device,
         tensor_shape,
         dim,
         keepdim,
         op,
+        dtype,
     )
+    assert result, msg
 
 
 def run(
@@ -123,6 +127,7 @@ def run(
     dim,
     keepdim,
     op,
+    dtype,
     *,
     device,
 ) -> list:
@@ -132,4 +137,5 @@ def run(
         dim,
         keepdim,
         op,
+        dtype,
     )

--- a/tests/ttnn/unit_tests/operations/test_fill_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_fill_pad.py
@@ -99,8 +99,6 @@ def test_fill_pad_float(
     output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=output_mem_config)
     padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch_with_padded_shape()
 
-    print(padded_torch_tensor)
-    print(padded_torch_output_tensor)
     assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor)
 
 

--- a/tests/ttnn/unit_tests/operations/test_fill_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_fill_pad.py
@@ -54,6 +54,7 @@ ttnn_dtype_to_torch_dtype = {
     ttnn.int32: torch.int32,
     ttnn.bfloat16: torch.float32,
     ttnn.bfloat8_b: torch.bfloat16,
+    ttnn.float32: torch.float32,
 }
 
 
@@ -74,10 +75,10 @@ ttnn_dtype_to_torch_dtype = {
     ],
 )
 @pytest.mark.parametrize("fill_value", [1.5, float("inf"), float("-inf")])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
 @pytest.mark.parametrize("input_mem_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("output_mem_config", [ttnn.DRAM_MEMORY_CONFIG])
-def test_fill_pad_bfloat16(
+def test_fill_pad_float(
     device,
     shape,
     fill_value,
@@ -98,6 +99,8 @@ def test_fill_pad_bfloat16(
     output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=output_mem_config)
     padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch_with_padded_shape()
 
+    print(padded_torch_tensor)
+    print(padded_torch_output_tensor)
     assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor)
 
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -59,11 +59,13 @@ tt::tt_metal::operation::ProgramWithCallbacks fill_pad_multi_core(const Tensor& 
     bool src_is_dram = tens_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
 
     // pack bf16 vals
-    uint32_t packed_fill_value = std::bit_cast<uint32_t>(fill_value);
+    uint32_t packed_fill_value = (std::uint32_t)fill_value;
     if (input_tensor.get_dtype() == DataType::BFLOAT16) {
         packed_fill_value = pack_two_bfloat16_into_uint32({bfloat16(fill_value), bfloat16(fill_value)});
     } else if (input_tensor.get_dtype() == DataType::UINT16) {
         packed_fill_value = pack_two_uint16_into_uint32({fill_value, fill_value});
+    } else if (input_tensor.get_dtype() == DataType::FLOAT32) {
+        packed_fill_value = std::bit_cast<uint32_t>(fill_value);
     }
 
     uint32_t padded_height = tt::div_up(height, tt::constants::TILE_HEIGHT) * tt::constants::TILE_HEIGHT;

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -59,7 +59,7 @@ tt::tt_metal::operation::ProgramWithCallbacks fill_pad_multi_core(const Tensor& 
     bool src_is_dram = tens_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
 
     // pack bf16 vals
-    uint32_t packed_fill_value = (std::uint32_t)fill_value;
+    uint32_t packed_fill_value = std::bit_cast<uint32_t>(fill_value);
     if (input_tensor.get_dtype() == DataType::BFLOAT16) {
         packed_fill_value = pack_two_bfloat16_into_uint32({bfloat16(fill_value), bfloat16(fill_value)});
     } else if (input_tensor.get_dtype() == DataType::UINT16) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19480

### Problem description
When input has padded fields, min/max incorrectly returns 0 as output.

### What's changed
Min/Max currently use fill_implicit_padding to place +/-inf when there are padded locations. This PR fixes an issue with the padding for float32 inputs. It also specifically adds bfloat16 and float32 dtype tests to sweeps.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passing https://github.com/tenstorrent/tt-metal/actions/runs/15427415348
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI fails, but matches main: https://github.com/tenstorrent/tt-metal/actions/runs/15425183923
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI Passing https://github.com/tenstorrent/tt-metal/actions/runs/15434472171
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI Passing: https://github.com/tenstorrent/tt-metal/actions/runs/15425188872
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes

Hat tip to @vsureshTT for finding the fix