### PR TITLE
Update custom mpi deb link to the tenstorrent

### DIFF
--- a/dockerfile/Dockerfile.basic-dev
+++ b/dockerfile/Dockerfile.basic-dev
@@ -24,7 +24,7 @@ RUN set -eux; \
     apt-get install -y -f \
         wget ca-certificates && \
     TMP_DIR="$(mktemp -d)" && \
-    DEB_URL="https://github.com/dmakoviichuk-tt/mpi-ulfm/releases/download/v5.0.7-ulfm/openmpi-ulfm_5.0.7-1_amd64.deb" && \
+    DEB_URL="https://github.com/tenstorrent/ompi/releases/download/v5.0.7/openmpi-ulfm_5.0.7-1_amd64.deb" && \
     wget -qO "$TMP_DIR/ompi.deb" "$DEB_URL" && \
     apt-get install -f -y "$TMP_DIR/ompi.deb" && \
     rm -rf "$TMP_DIR" && \

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -277,7 +277,7 @@ install_mpi_ulfm(){
         return
     fi
 
-    DEB_URL="https://github.com/dmakoviichuk-tt/mpi-ulfm/releases/download/v5.0.7-ulfm/openmpi-ulfm_5.0.7-1_amd64.deb"
+    DEB_URL="https://github.com/tenstorrent/ompi/releases/download/v5.0.7/openmpi-ulfm_5.0.7-1_amd64.deb"
     DEB_FILE="$(basename "$DEB_URL")"
 
     # 1. Create temp workspace


### PR DESCRIPTION
### Problem description
I uploaded deb package with mpi-ulfm to my repo.
We also have created an ompi repo in the tenstorrent org, which will be our main source of OMPI packages going forward.

### What's changed
Update links.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes

APC: 
https://github.com/tenstorrent/tt-metal/actions/runs/15424806214