### PR TITLE
[Fabric] Daemonize test infra for microbenchmark

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -55,7 +55,7 @@ jobs:
             arch: wormhole_b0,
             runs-on: ["arch-wormhole_b0", "pipeline-perf", "config-t3000", "in-service"],
             name: "T3K ubench - Fabric BW",
-            cmd: "pytest -svv tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py",
+            cmd: "TT_FABRIC_DAEMONIZE_TEST=true pytest -svv tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py",
           }, # Sean Nijjar
           {
             arch: wormhole_b0,

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -55,7 +55,7 @@ jobs:
             arch: wormhole_b0,
             runs-on: ["arch-wormhole_b0", "pipeline-perf", "config-t3000", "in-service"],
             name: "T3K ubench - Fabric BW",
-            cmd: "pytest -svv tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py --use_daemon",
+            cmd: "pytest -svv tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py",
           }, # Sean Nijjar
           {
             arch: wormhole_b0,

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -55,7 +55,7 @@ jobs:
             arch: wormhole_b0,
             runs-on: ["arch-wormhole_b0", "pipeline-perf", "config-t3000", "in-service"],
             name: "T3K ubench - Fabric BW",
-            cmd: "TT_FABRIC_DAEMONIZE_TEST=true pytest -svv tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py",
+            cmd: "pytest -svv tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py --use_daemon",
           }, # Sean Nijjar
           {
             arch: wormhole_b0,

--- a/tests/tt_metal/microbenchmarks/ethernet/conftest.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/conftest.py
@@ -8,10 +8,10 @@ import pytest
 def pytest_addoption(parser):
     """Add custom command line options to pytest"""
     parser.addoption(
-        "--use_daemon",
+        "--direct_exec",
         action="store_true",
         default=False,
-        help="Use daemon mode for fabric EDM tests instead of direct execution",
+        help="Use direct execution instead of daemon mode for fabric EDM tests",
     )
 
 

--- a/tests/tt_metal/microbenchmarks/ethernet/conftest.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/conftest.py
@@ -5,6 +5,16 @@
 import pytest
 
 
+def pytest_addoption(parser):
+    """Add custom command line options to pytest"""
+    parser.addoption(
+        "--use_daemon",
+        action="store_true",
+        default=False,
+        help="Use daemon mode for fabric EDM tests instead of direct execution",
+    )
+
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "ubench_quick_tests: quick tests for fast iteration")
     config.addinivalue_line("markers", "sanity_6u: quick subset of 6u applicable tests")

--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -445,10 +445,7 @@ def run_fabric_edm(
 
     enable_persistent_kernel_cache()
 
-    # Try to use daemon mode first
     use_daemon = os.environ.get("TT_FABRIC_DAEMONIZE_TEST", "false").lower() == "true"
-
-    print(f"------------------------- use_daemon {use_daemon}")
     if use_daemon:
         try:
             # Start daemon if not already running

--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -28,6 +28,7 @@ daemon_process = None
 daemon_pipe_path = "/tmp/tt_metal_fabric_edm_daemon"
 daemon_result_pipe_path = "/tmp/tt_metal_fabric_edm_daemon_result"
 daemon_lock = threading.Lock()
+binary_path = os.environ.get("TT_METAL_HOME", "") + "/build/test/ttnn/unit_tests_ttnn_fabric_edm"
 
 # Global daemon mode setting (determined once per test session)
 _daemon_mode_enabled = None
@@ -55,7 +56,7 @@ def start_fabric_edm_daemon():
 
         # Start daemon process
         cmd = [
-            f"{os.environ['TT_METAL_HOME']}/build/test/ttnn/unit_tests_ttnn_fabric_edm",
+            binary_path,
             "daemon_mode",
         ]
 
@@ -479,7 +480,7 @@ def run_fabric_edm(
     else:
         # Fallback to original direct execution
         cmd = f"TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_DEVICE_PROFILER=1 \
-                {os.environ['TT_METAL_HOME']}/build/test/ttnn/unit_tests_ttnn_fabric_edm \
+                    {binary_path} \
                     {test_mode} \
                     {int(is_unicast)} \
                     {noc_message_type} \

--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -25,6 +25,7 @@ machine_type_suffix = None
 
 # Global daemon management variables
 daemon_process = None
+# NOTE: This paths need to be same as the one written in test_fabric_edm.cpp
 daemon_pipe_path = "/tmp/tt_metal_fabric_edm_daemon"
 daemon_result_pipe_path = "/tmp/tt_metal_fabric_edm_daemon_result"
 daemon_lock = threading.Lock()

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
@@ -15,10 +15,8 @@
 #include "tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp"
 
 // Global state for daemon mode
-static bool daemon_mode = false;
 static bool daemon_running = true;
 static std::string daemon_pipe_path = "/tmp/tt_metal_fabric_edm_daemon";
-static FILE* debug_log = nullptr;
 
 // Signal handler for graceful shutdown
 void signal_handler(int signum) { daemon_running = false; }
@@ -316,16 +314,11 @@ static void run_daemon_mode() {
     // Cleanup
     unlink(daemon_pipe_path.c_str());
     unlink((daemon_pipe_path + "_result").c_str());
-    if (debug_log) {
-        fclose(debug_log);
-        debug_log = nullptr;
-    }
     tt::log_info("Daemon shutdown complete");
 }
 
 int main(int argc, char** argv) {
     if (argc > 1 && std::string(argv[1]) == "daemon_mode") {
-        daemon_mode = true;
         run_daemon_mode();
         return 0;
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22979
https://github.com/tenstorrent/tt-metal/issues/22634

### Problem description
Current benchmarking is really slow as it launch test binary for each pytest variants which cause open device, build kernel etc.

### What's changed
Daemonize the binary and communicate between pytest and the binary to avoid extra device open, build kernel.

on T3K, overall test time is
- CI T3K
  - before 29m41s
  - after 2m46s
- local T3K
  - before 20m
  - after 3m

on 6U
- before 27m24s
- after 10m35s

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes