### PR TITLE
Improved GCC version detection to support Ubuntu-based distributions

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -23,7 +23,11 @@ VERSION=`grep '^VERSION_ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
 MAJOR=${VERSION%.*}
 ARCH=`uname -m`
 
-if [[ "$FLAVOR" != "ubuntu" && "$ID_LIKE" != *ubuntu* ]]; then
+is_ubuntu_like() {
+    [[ "$FLAVOR" == "ubuntu" || "$ID_LIKE" == *ubuntu* ]]
+}
+
+if ! is_ubuntu_like; then
     echo "Error: Only Ubuntu and Ubuntu-based distributions are supported"
     exit 1
 fi
@@ -135,8 +139,8 @@ ub_baremetal_packages() {
 
 update_package_list()
 {
-    if [ $FLAVOR == "ubuntu" ]; then
-	case "$mode" in
+    if is_ubuntu_like; then
+        case "$mode" in
             runtime)
                 ub_runtime_packages
                 PKG_LIST=("${UB_RUNTIME_LIST[@]}")
@@ -159,7 +163,7 @@ update_package_list()
 
 validate_packages()
 {
-    if [ $FLAVOR == "ubuntu" ]; then
+    if is_ubuntu_like; then
         dpkg -l "${PKG_LIST[@]}"
     fi
 }
@@ -337,9 +341,9 @@ configure_hugepages() {
 }
 
 install() {
-    if [ $FLAVOR == "ubuntu" ]; then
+    if is_ubuntu_like; then
         echo "Installing packages..."
-	case "$mode" in
+        case "$mode" in
             runtime)
                 prep_ubuntu_runtime
                 install_sfpi
@@ -368,7 +372,7 @@ install() {
 }
 
 cleanup() {
-    if [ $FLAVOR == "ubuntu" ]; then
+    if is_ubuntu_like; then
         rm -rf /var/lib/apt/lists/*
     fi
 }

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -28,7 +28,7 @@ is_ubuntu_like() {
 }
 
 if ! is_ubuntu_like; then
-    echo "Error: Only Ubuntu and Ubuntu-based distributions are supported"
+    echo "Error: Only Ubuntu and Ubuntu-based distributions are currently supported"
     exit 1
 fi
 


### PR DESCRIPTION
### Ticket
#18294 

### Problem description
install_dependencies.sh doesn't detect Linux Mint.
At the case of Mint 22.1 (Ubuntu 24.04 base), It need to install GCC-14, but the default GCC-13 is being used, which causes the build to fail.

### What's changed
Improved the install_gcc() function that determines the GCC version so that it can correctly identify Ubuntu-based distributions (including Linux Mint).

This PR is one of the changes I'm making to #18294.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes