### PR TITLE
[DM] Directly Write to/Read from L1 for Test Preparation and Checking (Test: One To One)

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/dm_common.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dm_common.cpp
@@ -3,7 +3,36 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dm_common.hpp"
+#include "device_fixture.hpp"
+#include <tuple>
 
 namespace tt::tt_metal::unit_tests::dm {
+
 uint32_t runtime_host_id = 0;
+
+// Static function for internal use only
+static uint32_t obtain_page_size_bytes(tt::ARCH arch) { return (arch == tt::ARCH::BLACKHOLE) ? 64 : 32; }
+
+L1AddressInfo get_l1_address_and_size(IDevice* device, const CoreCoord& core_coord) {
+    CoreCoord physical_core = device->worker_core_from_logical_core(core_coord);
+
+    uint64_t core_l1_base_address = device->get_dev_addr(physical_core, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    uint64_t core_l1_size = device->get_dev_size(physical_core, HalL1MemAddrType::DEFAULT_UNRESERVED);
+
+    // return {core_l1_base_address, core_l1_size};
+
+    uint64_t safe_l1_base_address = 1024 * 256;
+
+    return {safe_l1_base_address, core_l1_size + core_l1_base_address - safe_l1_base_address};
 }
+
+std::tuple<uint32_t, uint32_t, uint32_t> compute_physical_constraints(tt::ARCH arch) {
+    uint64_t max_transmittable_bytes =
+        1024 * 1024;  // 1 MB //  ||  //1401888; // L1 Capacity: 1,401,888 Bytes (~= 1.33 MB)
+    uint32_t bytes_per_page = obtain_page_size_bytes(arch);
+    uint32_t max_transmittable_pages = max_transmittable_bytes / bytes_per_page;
+
+    return {bytes_per_page, static_cast<uint32_t>(max_transmittable_bytes), max_transmittable_pages};
+}
+
+}  // namespace tt::tt_metal::unit_tests::dm

--- a/tests/tt_metal/tt_metal/data_movement/dm_common.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dm_common.cpp
@@ -8,27 +8,32 @@
 
 namespace tt::tt_metal::unit_tests::dm {
 
+// Hardcoded constants for L1 memory base address and size
+constexpr uint64_t HARDCODED_L1_MEMORY_BASE_ADDRESS = 1024 * 256;  // 256 KB
+constexpr uint64_t HARDCODED_L1_MEMORY_SIZE_BYTES = 1024 * 1024;   // 1 MB
+
 uint32_t runtime_host_id = 0;
 
 // Static function for internal use only
 static uint32_t obtain_page_size_bytes(tt::ARCH arch) { return (arch == tt::ARCH::BLACKHOLE) ? 64 : 32; }
 
-L1AddressInfo get_l1_address_and_size(IDevice* device, const CoreCoord& core_coord) {
-    CoreCoord physical_core = device->worker_core_from_logical_core(core_coord);
+L1AddressInfo get_l1_address_and_size(const IDevice* device, const CoreCoord& core_coord) {
+    // Obtaining L1 address and size for a specific core //
+
+    /*CoreCoord physical_core = device->worker_core_from_logical_core(core_coord);
 
     uint64_t core_l1_base_address = device->get_dev_addr(physical_core, HalL1MemAddrType::DEFAULT_UNRESERVED);
     uint64_t core_l1_size = device->get_dev_size(physical_core, HalL1MemAddrType::DEFAULT_UNRESERVED);
 
-    // return {core_l1_base_address, core_l1_size};
+    return {core_l1_base_address, core_l1_size};*/
 
-    uint64_t safe_l1_base_address = 1024 * 256;
+    // Obtaining hardcoded values for L1 address and size //
 
-    return {safe_l1_base_address, core_l1_size + core_l1_base_address - safe_l1_base_address};
+    return {HARDCODED_L1_MEMORY_BASE_ADDRESS, HARDCODED_L1_MEMORY_SIZE_BYTES};
 }
 
-std::tuple<uint32_t, uint32_t, uint32_t> compute_physical_constraints(tt::ARCH arch) {
-    uint64_t max_transmittable_bytes =
-        1024 * 1024;  // 1 MB //  ||  //1401888; // L1 Capacity: 1,401,888 Bytes (~= 1.33 MB)
+std::tuple<uint32_t, uint32_t, uint32_t> compute_physical_constraints(const tt::ARCH arch, const IDevice* device) {
+    auto [_, max_transmittable_bytes] = get_l1_address_and_size(device);
     uint32_t bytes_per_page = obtain_page_size_bytes(arch);
     uint32_t max_transmittable_pages = max_transmittable_bytes / bytes_per_page;
 

--- a/tests/tt_metal/tt_metal/data_movement/dm_common.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/dm_common.hpp
@@ -20,10 +20,10 @@ struct L1AddressInfo {
 };
 
 // Function to get L1 address and size
-L1AddressInfo get_l1_address_and_size(IDevice* device, const CoreCoord& core_coord);
+L1AddressInfo get_l1_address_and_size(const IDevice* device, const CoreCoord& core_coord = {0, 0});
 
 // Function to compute physical constraints
-std::tuple<uint32_t, uint32_t, uint32_t> compute_physical_constraints(tt::ARCH arch);
+std::tuple<uint32_t, uint32_t, uint32_t> compute_physical_constraints(const tt::ARCH arch, const IDevice* device);
 
 }  // namespace tt::tt_metal::unit_tests::dm
 

--- a/tests/tt_metal/tt_metal/data_movement/dm_common.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/dm_common.hpp
@@ -6,10 +6,25 @@
 #define DM_COMMON_HPP
 
 #include <cstdint>
-
+#include "device_fixture.hpp"
+#include <tuple>
 namespace tt::tt_metal::unit_tests::dm {
+
 // Unique id for each test run
 extern uint32_t runtime_host_id;
+
+// Struct to hold L1 address information
+struct L1AddressInfo {
+    uint64_t base_address;
+    uint64_t size;
+};
+
+// Function to get L1 address and size
+L1AddressInfo get_l1_address_and_size(IDevice* device, const CoreCoord& core_coord);
+
+// Function to compute physical constraints
+std::tuple<uint32_t, uint32_t, uint32_t> compute_physical_constraints(tt::ARCH arch);
+
 }  // namespace tt::tt_metal::unit_tests::dm
 
 #endif  // DM_COMMON_HPP

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender.cpp
@@ -7,39 +7,38 @@
 
 // L1 to L1 send
 void kernel_main() {
-    uint32_t src_addr = get_compile_time_arg_val(0);
-    uint32_t dst_addr = get_compile_time_arg_val(1);
-    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(2);
-    constexpr uint32_t transaction_num_pages = get_compile_time_arg_val(3);
-    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(4);
-    constexpr uint32_t test_id = get_compile_time_arg_val(5);
+    // Compile-time arguments
+    uint32_t l1_local_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(1);
+    constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(2);
+    constexpr uint32_t test_id = get_compile_time_arg_val(3);
+    constexpr uint32_t sem_id = get_compile_time_arg_val(4);
 
-    uint32_t semaphore = get_semaphore(get_arg_val<uint32_t>(0));
-    uint32_t receiver_x_coord = get_arg_val<uint32_t>(1);
-    uint32_t receiver_y_coord = get_arg_val<uint32_t>(2);
+    // Runtime arguments
+    uint32_t receiver_x_coord = get_arg_val<uint32_t>(0);
+    uint32_t receiver_y_coord = get_arg_val<uint32_t>(1);
 
-    uint64_t sem_addr = get_noc_addr(receiver_x_coord, receiver_y_coord, semaphore);
-
-    constexpr uint32_t transaction_size_bytes = transaction_num_pages * page_size_bytes;
+    // Derivative values
+    uint64_t sem_addr = get_noc_addr(receiver_x_coord, receiver_y_coord, sem_id);
 
     DeviceTimestampedData("Number of transactions", num_of_transactions);
-    DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes);
+    DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction);
     DeviceTimestampedData("Test id", test_id);
 
     {
         DeviceZoneScopedN("RISCV0");
+
         uint64_t dst_base_noc_addr = get_noc_addr(receiver_x_coord, receiver_y_coord, 0);
         for (uint32_t i = 0; i < num_of_transactions; i++) {
             /* The 64-bit NOC addresses consists of a 32-bit local address and a NOC XY coordinate. The local address
              * occupies the lower 32 bits and the NOC XY coordinate occupies the next 12 (unicast) to 24 (multicast)
              * bits. In the get_noc_addr call, we set the local address to 0 to get the base address. Then, we OR it
              * with the local address (dst_addr) in each iteration to get the full NOC address. */
-            uint64_t dst_noc_addr = dst_base_noc_addr | dst_addr;
+            uint64_t dst_noc_addr = dst_base_noc_addr | l1_local_addr;
 
-            noc_async_write(src_addr, dst_noc_addr, transaction_size_bytes);
+            noc_async_write(l1_local_addr, dst_noc_addr, bytes_per_transaction);
 
-            src_addr += transaction_size_bytes;
-            dst_addr += transaction_size_bytes;
+            l1_local_addr += bytes_per_transaction;
         }
         noc_async_write_barrier();
     }

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender.cpp
@@ -23,6 +23,7 @@ void kernel_main() {
 
     DeviceTimestampedData("Number of transactions", num_of_transactions);
     DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction);
+    DeviceTimestampedData("Total bytes transferred", num_of_transactions * bytes_per_transaction);
     DeviceTimestampedData("Test id", test_id);
 
     {

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender.cpp
@@ -19,7 +19,8 @@ void kernel_main() {
     uint32_t receiver_y_coord = get_arg_val<uint32_t>(1);
 
     // Derivative values
-    uint64_t sem_addr = get_noc_addr(receiver_x_coord, receiver_y_coord, sem_id);
+    uint32_t sem_addr = get_semaphore(sem_id);
+    uint64_t sem_noc_addr = get_noc_addr(receiver_x_coord, receiver_y_coord, sem_addr);
 
     DeviceTimestampedData("Number of transactions", num_of_transactions);
     DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction);
@@ -43,5 +44,5 @@ void kernel_main() {
         }
         noc_async_write_barrier();
     }
-    noc_semaphore_inc(sem_addr, 1);
+    noc_semaphore_inc(sem_noc_addr, 1);
 }

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -122,6 +122,7 @@ bool run_dm(IDevice* device, const OneToOneConfig& test_config) {
 
     // Write Input to Master L1
     tt_metal::detail::WriteToDeviceL1(device, test_config.master_core_coord, l1_base_address, packed_input);
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
 
     // LAUNCH THE PROGRAM
     detail::LaunchProgram(device, program);

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -66,7 +66,6 @@ bool run_dm(IDevice* device, const OneToOneConfig& test_config) {
     }
     // Check if the L1 size is sufficient for the test configuration
     if (master_l1_info.size < total_size_bytes) {
-        std::cout << "L1 size: " << master_l1_info.size << ", Total size required: " << total_size_bytes << std::endl;
         log_error("Insufficient L1 size for the test configuration");
         return false;
     }

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -15,14 +15,15 @@ using namespace tt;
 using namespace tt::test_utils;
 
 namespace unit_tests::dm::core_to_core {
+
 // Test config, i.e. test parameters
 struct OneToOneConfig {
     uint32_t test_id = 0;
     CoreCoord master_core_coord = CoreCoord();
     CoreCoord subordinate_core_coord = CoreCoord();
     uint32_t num_of_transactions = 0;
-    uint32_t transaction_size_pages = 0;
-    uint32_t page_size_bytes = 0;
+    uint32_t pages_per_transaction = 0;
+    uint32_t bytes_per_page = 0;
     DataFormat l1_data_format = DataFormat::Invalid;
 
     // TODO: Add the following parameters
@@ -36,61 +37,55 @@ struct OneToOneConfig {
 /// @param test_config - Configuration of the test -- see struct
 /// @return
 bool run_dm(IDevice* device, const OneToOneConfig& test_config) {
+    /* ================ SETUP ================ */
+
     // Program
     Program program = CreateProgram();
 
-    size_t element_size_bytes = bfloat16::SIZEOF;
+    // Buffer Parameters
+    const size_t bytes_per_transaction = test_config.pages_per_transaction * test_config.bytes_per_page;
+    const size_t total_size_bytes = bytes_per_transaction * test_config.num_of_transactions;
 
-    // Sharded L1 buffers
-    const size_t total_size_bytes =
-        test_config.num_of_transactions * test_config.transaction_size_pages * test_config.page_size_bytes;
-    const size_t total_size_pages = test_config.num_of_transactions * test_config.transaction_size_pages;
-
+    // (Logical) Core coordinates and ranges
     CoreRangeSet master_core_set({CoreRange(test_config.master_core_coord)});
     CoreRangeSet subordinate_core_set({CoreRange(test_config.subordinate_core_coord)});
+    CoreRangeSet combined_core_set = master_core_set.merge<CoreRangeSet>(subordinate_core_set);
 
-    auto master_shard_parameters = ShardSpecBuffer(
-        master_core_set,
-        {1, total_size_bytes / element_size_bytes},
-        ShardOrientation::ROW_MAJOR,
-        {1, test_config.page_size_bytes / element_size_bytes},
-        {1, total_size_pages});
-    auto master_l1_buffer = CreateBuffer(ShardedBufferConfig{
-        .device = device,
-        .size = total_size_bytes,
-        .page_size = test_config.page_size_bytes,
-        .buffer_type = BufferType::L1,
-        .buffer_layout = TensorMemoryLayout::WIDTH_SHARDED,
-        .shard_parameters = std::move(master_shard_parameters),
-    });
-    uint32_t master_l1_byte_address = master_l1_buffer->address();
+    // Obtain L1 Address for Storing Data
+    // NOTE: We don't know if the whole block of memory is actually available.
+    //       This is something that could probably be checked
+    L1AddressInfo master_l1_info =
+        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.master_core_coord);
+    L1AddressInfo subordinate_l1_info =
+        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.subordinate_core_coord);
+    // Checks that both master and subordinate cores have the same L1 base address and size
+    if (master_l1_info.base_address != subordinate_l1_info.base_address ||
+        master_l1_info.size != subordinate_l1_info.size) {
+        log_error("Mismatch in L1 address or size between master and subordinate cores");
+        return false;
+    }
+    // Check if the L1 size is sufficient for the test configuration
+    if (master_l1_info.size < total_size_bytes) {
+        std::cout << "L1 size: " << master_l1_info.size << ", Total size required: " << total_size_bytes << std::endl;
+        log_error("Insufficient L1 size for the test configuration");
+        return false;
+    }
+    // Assigns a "safe" L1 local address for the master and subordinate cores
+    uint32_t l1_base_address = master_l1_info.base_address;
 
-    auto subordinate_shard_parameters = ShardSpecBuffer(
-        subordinate_core_set,
-        {1, total_size_bytes / element_size_bytes},
-        ShardOrientation::ROW_MAJOR,
-        {1, test_config.page_size_bytes / element_size_bytes},
-        {1, total_size_pages});
-    auto subordinate_l1_buffer = CreateBuffer(ShardedBufferConfig{
-        .device = device,
-        .size = total_size_bytes,
-        .page_size = test_config.page_size_bytes,
-        .buffer_type = BufferType::L1,
-        .buffer_layout = TensorMemoryLayout::WIDTH_SHARDED,
-        .shard_parameters = std::move(subordinate_shard_parameters),
-    });
-    uint32_t subordinate_l1_byte_address = subordinate_l1_buffer->address();
+    // Semaphores
+    const uint32_t sem_id = CreateSemaphore(program, combined_core_set, 0);
 
     // Compile-time arguments for kernels
     vector<uint32_t> sender_compile_args = {
-        (uint32_t)master_l1_byte_address,
-        (uint32_t)subordinate_l1_byte_address,
+        (uint32_t)l1_base_address,
         (uint32_t)test_config.num_of_transactions,
-        (uint32_t)test_config.transaction_size_pages,
-        (uint32_t)test_config.page_size_bytes,
-        (uint32_t)test_config.test_id};
+        (uint32_t)bytes_per_transaction,
+        (uint32_t)test_config.test_id,
+        (uint32_t)sem_id};
 
     // Kernels
+
     auto sender_kernel = CreateKernel(
         program,
         "tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender.cpp",
@@ -100,33 +95,46 @@ bool run_dm(IDevice* device, const OneToOneConfig& test_config) {
             .noc = NOC::RISCV_0_default,
             .compile_args = sender_compile_args});
 
-    // Semaphores
-    CoreRangeSet sem_core_set = subordinate_core_set.merge<CoreRangeSet>(master_core_set);
-    const uint32_t sem_id = CreateSemaphore(program, sem_core_set, 0);
-    CoreCoord physical_subordinate_core = device->worker_core_from_logical_core(test_config.subordinate_core_coord);
+    // Receiver Kernel
 
     // Runtime Arguments
-    SetRuntimeArgs(program, sender_kernel, master_core_set, {sem_id, physical_subordinate_core.x, physical_subordinate_core.y});
+
+    // Physical Core Coordinates
+    CoreCoord physical_subordinate_core = device->worker_core_from_logical_core(test_config.subordinate_core_coord);
+
+    // Setting the runtime arguments
+    SetRuntimeArgs(program, sender_kernel, master_core_set, {physical_subordinate_core.x, physical_subordinate_core.y});
 
     // Assign unique id
     log_info("Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
     program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
-    // Input
-    vector<uint32_t> packed_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        -100.0f, 100.0f, total_size_bytes / bfloat16::SIZEOF, chrono::system_clock::now().time_since_epoch().count());
+    /* ================ RUNNING THE PROGRAM ================ */
 
-    // Golden output
-    vector<uint32_t> packed_golden = packed_input;
+    // Setup Input
+    // NOTE: The converted vector (uint32_t -> bfloat16) preserves the number of bytes,
+    // but the number of elements is bound to change
+    // l1_data_format is assumed to be bfloat16
+    size_t element_size_bytes = bfloat16::SIZEOF;
+    uint32_t num_elements = total_size_bytes / element_size_bytes;
+    std::vector<uint32_t> packed_input = tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(
+        -100.0f, 100.0f, num_elements, chrono::system_clock::now().time_since_epoch().count());
+    std::vector<uint32_t> packed_golden = packed_input;
 
-    // Launch program and record outputs
-    vector<uint32_t> packed_output;
-    detail::WriteToBuffer(master_l1_buffer, packed_input);
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    // Write Input to Master L1
+    tt_metal::detail::WriteToDeviceL1(device, test_config.master_core_coord, l1_base_address, packed_input);
+    // QUESTION: Safety check needed for L1 write?
+    // MetalContext::instance().get_cluster().l1_barrier(device->id());
+
+    // LAUNCH THE PROGRAM
     detail::LaunchProgram(device, program);
-    detail::ReadFromBuffer(subordinate_l1_buffer, packed_output);
 
-    // Results comparison
+    // Record Output from Subordinate L1
+    std::vector<uint32_t> packed_output;
+    tt_metal::detail::ReadFromDeviceL1(
+        device, test_config.subordinate_core_coord, l1_base_address, total_size_bytes, packed_output);
+
+    // Compare output with golden
     bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
         packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
 
@@ -140,34 +148,42 @@ bool run_dm(IDevice* device, const OneToOneConfig& test_config) {
 
     return pcc;
 }
+
 }  // namespace unit_tests::dm::core_to_core
 
 /* ========== Test case for one to one data movement; Test id = 4 ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneToOnePacketSizes) {
+    // Test ID
+    uint32_t test_id = 4;
+
+    // Physical Constraints
+    auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_);
+
     // Parameters
     uint32_t max_transactions = 256;
-    uint32_t max_transaction_size_pages = 64;
-    uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
+    uint32_t max_pages_per_transaction = 64;
 
     // Cores
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {1, 1};
 
     for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
-        for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
-             transaction_size_pages *= 2) {
-            if (num_of_transactions * transaction_size_pages * page_size_bytes >= 1024 * 1024) {
+        for (uint32_t pages_per_transaction = 1; pages_per_transaction <= max_pages_per_transaction;
+             pages_per_transaction *= 2) {
+            // Check if the total page size is within the limits
+            if (num_of_transactions * pages_per_transaction > max_transmittable_pages) {
                 continue;
             }
 
             // Test config
             unit_tests::dm::core_to_core::OneToOneConfig test_config = {
-                .test_id = 4,
+                .test_id = test_id,
                 .master_core_coord = master_core_coord,
                 .subordinate_core_coord = subordinate_core_coord,
                 .num_of_transactions = num_of_transactions,
-                .transaction_size_pages = transaction_size_pages,
-                .page_size_bytes = page_size_bytes,
+                .pages_per_transaction = pages_per_transaction,
+                .bytes_per_page = bytes_per_page,
                 .l1_data_format = DataFormat::Float16_b,
             };
 
@@ -189,29 +205,17 @@ TEST_F(DeviceFixture, TensixDataMovementOneToOnePacketSizes) {
 */
 
 TEST_F(DeviceFixture, TensixDataMovementOneToOneDirectedIdeal) {
-    uint32_t test_id = 50;  // Arbitrary test ID
+    // Test ID (Arbitrary)
+    uint32_t test_id = 50;
 
-    // Parameters
-    /*
-        L1 Capacity: 1.5 MB (I think, might be wrong)
-        - Max transaction size
-            = 4 * 32 pages
-            = 128 pages * 32 (or 64) bytes/page
-            = 4096 bytes for WH; 8192 bytes for BH
-        - Max total transaction size
-            = 128 transactions * 4096 bytes
-            = 524,288 Bytes
-            < 1.25 MB ~= L1 buffer capacity (.25 MB is allocated for the kernel code and other overheads)
-    */
-    uint32_t page_size_bytes, num_of_transactions;
-    uint32_t transaction_size_pages = 4 * 32;
-    if (arch_ == tt::ARCH::BLACKHOLE) {
-        page_size_bytes = 64;  // (=flit size): 64 bytes for BH
-        num_of_transactions = 64;
-    } else {
-        page_size_bytes = 32;  // (=flit size): 32 bytes for WH
-        num_of_transactions = 128;
-    }
+    // Physical Constraints
+    auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_);
+
+    // Adjustable Parameters
+    // Ideal: Less transactions, more data per transaction
+    uint32_t num_of_transactions = 1;
+    uint32_t pages_per_transaction = max_transmittable_pages / num_of_transactions;
 
     // Cores
     /*
@@ -227,8 +231,8 @@ TEST_F(DeviceFixture, TensixDataMovementOneToOneDirectedIdeal) {
         .master_core_coord = master_core_coord,
         .subordinate_core_coord = subordinate_core_coord,
         .num_of_transactions = num_of_transactions,
-        .transaction_size_pages = transaction_size_pages,
-        .page_size_bytes = page_size_bytes,
+        .pages_per_transaction = pages_per_transaction,
+        .bytes_per_page = bytes_per_page,
         .l1_data_format = DataFormat::Float16_b,
     };
 

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -218,7 +218,7 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 42000, "upper": 44000}, "bandwidth": 34},
         },
         4: {
-            "riscv_0": {"latency": {"lower": 300, "upper": 9200}, "bandwidth": 0.17},
+            "riscv_0": {"latency": {"lower": 200, "upper": 20000}, "bandwidth": 0.17},
         },
         5: {
             "riscv_1": {"latency": {"lower": 300, "upper": 9200}, "bandwidth": 0.17},

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -179,8 +179,7 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 50, "upper": 30000}, "bandwidth": 0.4},
         },
         50: {  # One to One Directed Ideal
-            "riscv_1": {"latency": {"lower": 18000, "upper": 23000}, "bandwidth": 23},  # 21882, 23.9
-            "riscv_0": {"latency": {"lower": 15000, "upper": 19000}, "bandwidth": 29},  # 17705, 29.6
+            "riscv_0": {"latency": {"lower": 28000, "upper": 38000}, "bandwidth": 29},  # 33832
         },
         51: {  # One from One Directed Ideal
             "riscv_1": {"latency": {"lower": 15000, "upper": 20000}, "bandwidth": 28},  # 18596, 28.2
@@ -258,8 +257,7 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 50, "upper": 30000}, "bandwidth": 0.4},
         },
         50: {  # One to One Directed Ideal
-            "riscv_1": {"latency": {"lower": 5000, "upper": 10000}, "bandwidth": 50},  # 9201, 57.0
-            "riscv_0": {"latency": {"lower": 5000, "upper": 9500}, "bandwidth": 59},  # 8725, 60.1
+            "riscv_0": {"latency": {"lower": 12000, "upper": 22000}, "bandwidth": 59},  # 17000
         },
         51: {  # One from One Directed Ideal
             "riscv_1": {"latency": {"lower": 5000, "upper": 10000}, "bandwidth": 59},  # 8730, 60.1

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -179,7 +179,7 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 50, "upper": 30000}, "bandwidth": 0.4},
         },
         50: {  # One to One Directed Ideal
-            "riscv_0": {"latency": {"lower": 28000, "upper": 38000}, "bandwidth": 29},  # 33832
+            "riscv_0": {"latency": {"lower": 28000, "upper": 36000}, "bandwidth": 29},  # 33832
         },
         51: {  # One from One Directed Ideal
             "riscv_1": {"latency": {"lower": 15000, "upper": 20000}, "bandwidth": 28},  # 18596, 28.2
@@ -218,7 +218,7 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 42000, "upper": 44000}, "bandwidth": 34},
         },
         4: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 20000}, "bandwidth": 0.17},
+            "riscv_0": {"latency": {"lower": 200, "upper": 19000}, "bandwidth": 0.17},
         },
         5: {
             "riscv_1": {"latency": {"lower": 300, "upper": 9200}, "bandwidth": 0.17},
@@ -257,7 +257,7 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 50, "upper": 30000}, "bandwidth": 0.4},
         },
         50: {  # One to One Directed Ideal
-            "riscv_0": {"latency": {"lower": 12000, "upper": 22000}, "bandwidth": 59},  # 17000
+            "riscv_0": {"latency": {"lower": 12000, "upper": 19000}, "bandwidth": 59},  # 17000
         },
         51: {  # One from One Directed Ideal
             "riscv_1": {"latency": {"lower": 5000, "upper": 10000}, "bandwidth": 59},  # 8730, 60.1


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22803)

### Problem description
The use of sharded buffers for allocating space on the master and subordinate cores limited the ability of the tests to make use of the entire available L1 spaces on each core. In the case of the One to One tests, this restricted the movement of data amounting to more than half of the available L1 space since a master buffer and a subordinate buffer were each being allocated for all cores, including the master and subordinate cores involved in the transactions.

### What's changed
This has been fixed for the One to One tests. Instead of using sharded buffers, the test now uses the `WriteToDeviceL1()` and `ReadFromDeviceL1()` APIs to set up the master's L1 data and check the subordinate's L1 data respectively.

In addition, at the kernel level, the directed ideal test case now performs a single transaction containing the maximum specified data size, as this is more ideal than performing multiple smaller transactions.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes