### PR TITLE
Revert "#21824: Add uint16 support for eqz and nez"

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -583,82 +583,8 @@ def test_unary_zero_comp_ttnn(input_shapes, low, high, ttnn_function, device):
     golden_tensor = golden_function(in_data)
 
     output_tensor = ttnn.to_torch(output_tensor)
-
-    assert torch.equal(golden_tensor, output_tensor)
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    [
-        torch.Size([1, 1, 32, 32]),
-        torch.Size([1, 1, 320, 384]),
-        torch.Size([1, 3, 320, 384]),
-    ],
-)
-@pytest.mark.parametrize(
-    "low, high",
-    [
-        (0, 2),  # Small range
-        (0, 65535),  # Full uint16 range
-    ],
-)
-@pytest.mark.parametrize(
-    "ttnn_function",
-    [
-        ttnn.eqz,
-        ttnn.nez,
-    ],
-)
-def test_unary_zero_comp_uint16_ttnn(input_shapes, low, high, ttnn_function, device):
-    in_data = torch.randint(low, high, input_shapes, dtype=torch.int32)
-    input_tensor = ttnn.from_torch(in_data, dtype=ttnn.uint16, layout=ttnn.TILE_LAYOUT, device=device)
-
-    cq_id = 0
-    output_tensor = ttnn_function(input_tensor, queue_id=cq_id)
-    golden_function = ttnn.get_golden_function(ttnn_function)
-    golden_tensor = golden_function(in_data)
-
-    output_tensor = ttnn.to_torch(output_tensor)
-
-    assert torch.equal(golden_tensor, output_tensor)
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    [
-        torch.Size([1, 1, 32, 32]),
-        torch.Size([1, 1, 320, 384]),
-    ],
-)
-@pytest.mark.parametrize(
-    "ttnn_function",
-    [
-        ttnn.eqz,
-        ttnn.nez,
-    ],
-)
-def test_unary_zero_comp_with_majority_zeros(input_shapes, ttnn_function, device):
-    rows, cols = input_shapes[-2], input_shapes[-1]
-    total_elements = rows * cols
-    num_zeros = total_elements * 3 // 4
-    num_nonzeros = total_elements - num_zeros
-
-    flat_tensor = torch.zeros(total_elements, dtype=torch.int32)
-    random_ints = torch.randint(0, 100, (num_nonzeros,), dtype=torch.int32)
-    flat_tensor[:num_nonzeros] = random_ints
-    flat_tensor = flat_tensor[torch.randperm(total_elements)]
-
-    in_data = flat_tensor.reshape(input_shapes)
-    input_tensor = ttnn.from_torch(in_data, dtype=ttnn.uint16, layout=ttnn.TILE_LAYOUT, device=device)
-
-    cq_id = 0
-    output_tensor = ttnn_function(input_tensor, queue_id=cq_id)
-    golden_function = ttnn.get_golden_function(ttnn_function)
-    golden_tensor = golden_function(in_data)
-
-    output_tensor = ttnn.to_torch(output_tensor)
-
-    assert torch.equal(golden_tensor, output_tensor)
+    pcc = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
+    assert pcc == 1
 
 
 @pytest.mark.parametrize(
@@ -701,7 +627,8 @@ def test_unary_zero_comp_edge_case(input_shapes, ttnn_function, device):
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert torch.equal(golden_tensor, output_tensor)
+    pcc = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
+    assert pcc == 1
 
 
 @pytest.mark.parametrize(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -120,35 +120,6 @@ inline void calculate_comp_int() {
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp_uint16() {
-    for (int d = 0; d < ITERATIONS; d++) {
-        static_assert(COMP_MODE == SfpuType::equal_zero or COMP_MODE == SfpuType::not_equal_zero);
-        constexpr int check = COMP_MODE == SfpuType::equal_zero ? SFPSETCC_MOD1_LREG_EQ0 : SFPSETCC_MOD1_LREG_NE0;
-
-        // full tile size
-        constexpr int tile_size = 64;
-        // location of conditional value tile
-        constexpr int cond_val_idx = 0 * tile_size;  // tile 0
-        // location of output tile
-        constexpr int output_idx = 0 * tile_size;  // tile 0
-        // load in conditional uint16 value
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, cond_val_idx);
-        // initially put 0 into output
-        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
-        // if (REG0 == 0)
-        TTI_SFPSETCC(0, 0, 0, check);
-        // load in (int) 1
-        TTI_SFPLOADI(p_sfpu::LREG1, 2, 0x0001);
-        // end_if
-        TTI_SFPENCC(0, 0, 0, 0);
-        // store result
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_3, output_idx);
-
-        dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp_unary_int(int scalar) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_comp.h
@@ -26,12 +26,6 @@ inline void llk_math_eltwise_unary_sfpu_eqz_int32(uint dst_index, int vector_mod
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_eqz_uint16(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_comp_uint16<APPROXIMATE, SfpuType::equal_zero>, dst_index, vector_mode);
-}
-
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_eqz_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::equal_zero, APPROXIMATE>();
 }
@@ -47,12 +41,6 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_nez_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_comp_int<APPROXIMATE, SfpuType::not_equal_zero>, dst_index, vector_mode);
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_nez_uint16(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_comp_uint16<APPROXIMATE, SfpuType::not_equal_zero>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -120,35 +120,6 @@ inline void calculate_comp_int() {
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp_uint16() {
-    for (int d = 0; d < ITERATIONS; d++) {
-        static_assert(COMP_MODE == SfpuType::equal_zero or COMP_MODE == SfpuType::not_equal_zero);
-        constexpr int check = COMP_MODE == SfpuType::equal_zero ? SFPSETCC_MOD1_LREG_EQ0 : SFPSETCC_MOD1_LREG_NE0;
-
-        // full tile size
-        constexpr int tile_size = 64;
-        // location of conditional value tile
-        constexpr int cond_val_idx = 0 * tile_size;  // tile 0
-        // location of output tile
-        constexpr int output_idx = 0 * tile_size;  // tile 0
-        // load in conditional uint16 value
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, cond_val_idx);
-        // initially put 0 into output
-        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
-        // if (REG0 == 0)
-        TTI_SFPSETCC(0, 0, 0, check);
-        // load in (int) 1
-        TTI_SFPLOADI(p_sfpu::LREG1, 2, 0x0001);
-        // end_if
-        TTI_SFPENCC(0, 0, 0, 0);
-        // store result
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_3, output_idx);
-
-        dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp_unary_int(int scalar) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_comp.h
@@ -26,12 +26,6 @@ inline void llk_math_eltwise_unary_sfpu_eqz_int32(uint dst_index, int vector_mod
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_eqz_uint16(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_comp_uint16<APPROXIMATE, SfpuType::equal_zero>, dst_index, vector_mode);
-}
-
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_eqz_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::equal_zero, APPROXIMATE>();
 }
@@ -47,12 +41,6 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_nez_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_comp_int<APPROXIMATE, SfpuType::not_equal_zero>, dst_index, vector_mode);
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_nez_uint16(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_comp_uint16<APPROXIMATE, SfpuType::not_equal_zero>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -357,22 +357,6 @@ ALWI void eqz_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_eqz<APPROX
 // clang-format on
 ALWI void eqz_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_eqz_int32<APPROX>(idst))); }
 
-// clang-format off
-/**
- * Will store in the output of the compute core True if each element of a equal to zero.
- * The DST register buffer must be in acquired state via *acquire_dst* call.
- * This call is blocking and is only
- * available on the compute engine.
- *
- * Return value: None
- *
- * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
- * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- */
-// clang-format on
-ALWI void eqz_tile_uint16(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_eqz_uint16<APPROX>(idst))); }
-
 /**
  * Please refer to documentation for any_init.
  */
@@ -504,22 +488,6 @@ ALWI void nez_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_nez<APPROX
  */
 // clang-format on
 ALWI void nez_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_nez_int32<APPROX>(idst))); }
-
-// clang-format off
-/**
- * Will store in the output of the compute core True if each element is not equal to zero.
- * The DST register buffer must be in acquired state via *acquire_dst* call.
- * This call is blocking and is only
- * available on the compute engine.
- *
- * Return value: None
- *
- * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
- * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- */
-// clang-format on
-ALWI void nez_tile_uint16(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_nez_uint16<APPROX>(idst))); }
 
 /**
  * Please refer to documentation for any_init.

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -360,8 +360,6 @@ std::pair<string, string> get_op_init_and_func_default(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype.value() == DataType::INT32) {
                 op_init_and_name = {"eqz_tile_init();", fmt::format("eqz_tile_int32({});", idst)};
-            } else if (input_dtype.value() == DataType::UINT16) {
-                op_init_and_name = {"eqz_tile_init();", fmt::format("eqz_tile_uint16({});", idst)};
             } else {
                 op_init_and_name = {"eqz_tile_init();", fmt::format("eqz_tile({});", idst)};
             }
@@ -371,8 +369,6 @@ std::pair<string, string> get_op_init_and_func_default(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype == DataType::INT32) {
                 op_init_and_name = {"nez_tile_init();", fmt::format("nez_tile_int32({});", idst)};
-            } else if (input_dtype == DataType::UINT16) {
-                op_init_and_name = {"nez_tile_init();", fmt::format("nez_tile_uint16({});", idst)};
             } else {
                 op_init_and_name = {"nez_tile_init();", fmt::format("nez_tile({});", idst)};
             }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -1773,7 +1773,7 @@ void py_module(py::module& module) {
         ttnn::eqz,
         R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor_i\ == 0}}))doc",
         "",
-        R"doc(BFLOAT16, BFLOAT8_B, INT32, UINT16)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
     bind_unary_operation(
         module,
         ttnn::ceil,
@@ -1896,7 +1896,7 @@ void py_module(py::module& module) {
         ttnn::nez,
         R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor_i\ != 0}}))doc",
         "",
-        R"doc(BFLOAT16, BFLOAT8_B, INT32, UINT16)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
 
     bind_unary_operation_overload_complex_return_complex(
         module,


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#22207

Deterministic failures in t3k unit test pipeline
https://github.com/tenstorrent/tt-metal/actions/runs/15372437753

and t3k frequent pipeline
https://github.com/tenstorrent/tt-metal/actions/runs/15372720024