### PR TITLE
[skip ci - DM]: Creating a documentation folder

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/documentation/ideal_performance.md
+++ b/tests/tt_metal/tt_metal/data_movement/documentation/ideal_performance.md
@@ -1,0 +1,12 @@
+# Ideal Performance of Data Movement Primitives
+Below are the results from our directed ideal tests for each data movement primitive.
+
+Units are **Bytes/cycle**.
+
+| Primitive                         | Wormhole B0   | Blackhole |
+| --------------------------------- | --------------| --------- |
+| DRAM Read                         | 22            | 33        |
+| DRAM Write                        | 21            | 34        |
+| One To One                        | 29            | 60        |
+| One From One                      | 28            | 60        |
+| One To All (Multicast + Linked)   | 19            | 34        |

--- a/tests/tt_metal/tt_metal/data_movement/documentation/state_preservation.md
+++ b/tests/tt_metal/tt_metal/data_movement/documentation/state_preservation.md
@@ -1,0 +1,32 @@
+# State Preservation in APIs
+NOC APIs use registers in the command buffers to issue instructions. Some of these registers preserve their value over multiple calls to NOC APIs, unless instructed by the API. Others are modified in each API call. Below is a table of registers that preserve their value over API calls (stateful = preserves value).
+
+## Stateful Registers
+
+| Registers                       | Wormhole B0                                           | Blackhole                                             |
+| --------------------------------| ----------------------------------------------------- | ----------------------------------------------------- |
+| `NOC_TARG_ADDR_LO`              | stateful                                              | stateful                                              |
+| `NOC_TARG_ADDR_MID`             | stateful                                              | stateful                                              |
+| `NOC_TARG_ADDR_HI`              | unused                                                | stateful                                              |
+| `NOC_RET_ADDR_LO`               | stateful                                              | stateful                                              |
+| `NOC_RET_ADDR_MID`              | stateful                                              | stateful                                              |
+| `NOC_RET_ADDR_HI`               | unused                                                | stateful                                              |
+| `NOC_PACKET_TAG`                | stateful                                              | stateful                                              |
+| `NOC_CTRL`                      | stateful                                              | stateful                                              |
+| `NOC_AT_LEN_BE`                 | stateful                                              | stateful                                              |
+| `NOC_AT_LEN_BE_1`               | -                                                     | stateful                                              |
+| `NOC_AT_DATA`                   | stateful                                              | stateful                                              |
+| `NOC_BRCST_EXCLUDE`             | -                                                     | stateful                                              |
+| `NOC_L1_ACC_AT_INSTRN`          | -                                                     | stateful                                              |
+| `NOC_SEC_CTRL`                  | -                                                     | stateful                                              |
+| `NOC_CMD_CTRL`                  | not stateful (control flag for all other registers)   | not stateful (control flag for all other registers)   |
+| `NOC_NODE_ID`                   | not stateful (control flag)                           | not stateful (control flag)                           |
+| `NOC_ENDPOINT_ID`               | not stateful (control flag)                           | not stateful (control flag)                           |
+| `NUM_MEM_PARITY_ERR`            | stateful                                              | stateful                                              |
+| `NUM_HEADER_1B_ERR`             | stateful                                              | stateful                                              |
+| `NUM_HEADER_2B_ERR`             | stateful                                              | stateful                                              |
+| `ECC_CTRL`                      | not stateful (control flag for errors)                | not stateful (control flag for errors)                |
+| `NOC_CLEAR_OUTSTANDING_REQ_CNT` | not stateful (control flag)                           | not stateful (control flag)                           |
+| `RISC_IF_STATUS_OFFSET`         | not stateful (control flag)                           | -                                                     |
+| `CMD_BUF_AVAIL`                 | -                                                     | not stateful (control flag)                           |
+| `CMD_BUF_OVFL`                  | -                                                     | not stateful (control flag)                           |


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22916) #22507


### Problem description
We need a documentation folder where we can place NOC documentation under our data movement suite.


### What's changed
Added stateful vs non-stateful register information table under this folder. Added also a table for our directed ideal test results.