### PR TITLE
#22833: More stringent checking on what gets classified as a T3K cluster

### DIFF
--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -125,8 +125,8 @@ TEST(Cluster, TestMeshFullConnectivity) {
             magic_enum::enum_names<tt::ClusterType>());
         log_info(
             LogTest,
-            "  --min-connections: target minimum number of connections between chips (default depends on system "
-            "type) ");
+            "  --min-connections: target minimum number of connections between connected chips (default depends on "
+            "system type).");
         log_info(
             LogTest,
             "  --system-topology: system topology to check (defaults to no topology check) Valid values: {}",
@@ -209,8 +209,8 @@ TEST(Cluster, TestMeshFullConnectivity) {
             if (*target_system_topology == FabricType::TORUS_2D) {
                 static constexpr std::uint32_t num_expected_chip_connections = 4;
                 EXPECT_EQ(num_connections_to_chip.size(), num_expected_chip_connections)
-                    << chip_ss.str() << " has " << num_connections_to_chip.size()
-                    << " connections to other chips, expected " << num_expected_chip_connections << " for "
+                    << chip_ss.str() << " is connected to " << num_connections_to_chip.size()
+                    << " other chips, expected " << num_expected_chip_connections << " chips for "
                     << magic_enum::enum_name(*target_system_topology) << " topology";
             }
         }

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -157,7 +157,7 @@ TEST(Cluster, TestMeshFullConnectivity) {
         num_expected_chips = 4;
         num_connections_per_side = 4;
     } else {
-        ASSERT_TRUE(false) << "Mesh check not supported for system type " << magic_enum::enum_name(cluster_type);
+        GTEST_SKIP() << "Mesh check not supported for system type " << magic_enum::enum_name(cluster_type);
     }
 
     EXPECT_EQ(eth_connections.size(), num_expected_chips)

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -121,6 +121,26 @@ ClusterType Cluster::get_cluster_type_from_cluster_desc(
         if (board_type == BoardType::N300) {
             if (cluster_desc->get_all_chips().size() == 8) {
                 cluster_type = ClusterType::T3K;
+                // Basic check to determine if the cluster is a T3K cluster
+                // MMIO chips should have 3 connections to other chips, remote chips should have 2 connections to other
+                // chips
+                for (const auto& [chip_id, connections] : cluster_desc->get_ethernet_connections()) {
+                    std::unordered_set<chip_id_t> remote_chips;
+                    for (const auto& [channel, remote_chip_and_channel] : connections) {
+                        remote_chips.insert(std::get<0>(remote_chip_and_channel));
+                    }
+                    if (cluster_desc->is_chip_mmio_capable(chip_id)) {
+                        if (remote_chips.size() != 3) {
+                            cluster_type = ClusterType::N300;
+                            break;
+                        }
+                    } else {
+                        if (remote_chips.size() != 2) {
+                            cluster_type = ClusterType::N300;
+                            break;
+                        }
+                    }
+                }
             } else {
                 cluster_type = ClusterType::N300;
             }


### PR DESCRIPTION
Fall back to N300 if missing all chip connections between chips

### Ticket
https://github.com/tenstorrent/tt-metal/issues/22833

### Problem description
On a system that is configured like a T3K but without QSFP, we determine this cluster type to be a T3K and try to initialize certain objects assuming full connectivity, which then errors out due to the missing links.

### What's changed
Make the T3K determination more stringent to not just be based on number of chips, but also the chip connectivity. Fall back to N300 if connectivity for 8 chips doesn't match T3K.
Note however that this does not play nicely with our system health check script, since on a system we might want to be a T3K if it is missing all links between two chips we will no longer recognize it as a T3K. Add a command line arg to override the detected cluster type in the health check, so that we can error out with more descriptive messaging in this case.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15450701793
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes
T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/15447717996