### PR TITLE
#22984 decrease fps threshold for unet perf

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -61,7 +61,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput",
-    ((1, 4, 256, 30.0, 1271.0),),
+    ((1, 4, 256, 30.0, 1268.0),),
 )
 def test_unet_trace_perf(
     batch: int,


### PR DESCRIPTION
### Ticket
#22984

### Problem description
The fps threshold is too close to the actual performance. This causes flaky failures in perf pipelines.

### What's changed
Decrease the fps threshold to pad with a more reasonable margin.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15446980424) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/15446964607) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes