### PR TITLE
Added DumpMeshDeviceProfileResults function and deleted DumpDeviceProfileResults function which took in a Device and Program as parameters

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -59,6 +59,7 @@ DeviceStorage
 DeviceZoneScopedN
 DstMode
 DumpDeviceProfileResults
+DumpMeshDeviceProfileResults
 ENDL
 ETH
 EltwiseUnary

--- a/docs/source/tt-metalium/tools/device_program_profiler.rst
+++ b/docs/source/tt-metalium/tools/device_program_profiler.rst
@@ -49,7 +49,7 @@ The host code of the ``full_buffer`` example is in ``{$TT_METAL_HOME}/tt_metal/p
 On top of tt_metal's program dispatch API calls, two additional steps specific to this example are taken, which are:
 
 1. Setting ``LOOP_COUNT`` and ``LOOP_SIZE`` defines for the kernels
-2. Calling :ref:`DumpDeviceProfileResults<DumpDeviceProfileResults>` after the call to Finish to collect the device side profiling data
+2. Calling DumpDeviceProfileResults after the call to Finish to collect the device side profiling data
 
 The kernel code for full buffer is in ``{$TT_METAL_HOME}/tt_metal/programming_examples/profiler/test_full_buffer/kernels/full_buffer.cpp`` and demonstrated below:
 

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/profiler/DumpDeviceProfileResults.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/profiler/DumpDeviceProfileResults.rst
@@ -1,6 +1,0 @@
-.. _DumpDeviceProfileResults:
-
-DumpDeviceProfileResults
-========================
-
-.. doxygenfunction:: tt::tt_metal::DumpDeviceProfileResults(IDevice *device, const Program &program);

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/profiler/DumpMeshDeviceProfileResults.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/profiler/DumpMeshDeviceProfileResults.rst
@@ -1,0 +1,6 @@
+.. _DumpMeshDeviceProfileResults:
+
+DumpMeshDeviceProfileResults
+============================
+
+.. doxygenfunction:: tt::tt_metal::DumpMeshDeviceProfileResults

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/profiler/profiler.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/profiler/profiler.rst
@@ -2,4 +2,4 @@ Profiler
 ========
 
 .. toctree::
-  DumpDeviceProfileResults
+  DumpMeshDeviceProfileResults

--- a/tests/sweep_framework/README.md
+++ b/tests/sweep_framework/README.md
@@ -205,8 +205,7 @@ def mesh_device_fixture():
     # TEARDOWN (called after test suite is finished executing)
     print("ADD: Closing device mesh")
 
-    for device in mesh_device.get_devices():
-        ttnn.DumpDeviceProfiler(device)
+    ttnn.DumpDeviceProfiler(mesh_device)
 
     ttnn.close_mesh_device(mesh_device)
     del mesh_device

--- a/tests/tt_metal/microbenchmarks/noc/test_noc_unicast_vs_multicast_to_single_core_latency.py
+++ b/tests/tt_metal/microbenchmarks/noc/test_noc_unicast_vs_multicast_to_single_core_latency.py
@@ -13,7 +13,7 @@ import tt_metal.tools.profiler.device_post_proc_config as device_post_proc_confi
 
 def test_noc_unicast_vs_multicast_to_single_core_latency():
     os.system(
-        f"TT_METAL_SLOW_DISPATCH_MODE=1 TT_METAL_DEVICE_PROFILER=1 {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency"
+        f"TT_METAL_SLOW_DISPATCH_MODE=1 TT_METAL_DEVICE_PROFILER=1 TT_METAL_DEVICE_PROFILER_DISPATCH=1 {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency"
     )
     setup = device_post_proc_config.default_setup()
     setup.timerAnalysis = {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -915,7 +915,7 @@ int main(int argc, char** argv) {
             }
             Finish(device->command_queue());
             for (auto& program : programs) {
-                tt_metal::detail::DumpDeviceProfileResults(device, program);
+                tt_metal::detail::DumpDeviceProfileResults(device);
             }
         }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -915,7 +915,7 @@ int main(int argc, char** argv) {
             }
             Finish(device->command_queue());
             for (auto& program : programs) {
-                tt_metal::DumpDeviceProfileResults(device, program);
+                tt_metal::detail::DumpDeviceProfileResults(device, program);
             }
         }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -908,7 +908,7 @@ int main(int argc, char** argv) {
             }
             Finish(device->command_queue());
             for (auto& program : programs) {
-                tt_metal::DumpDeviceProfileResults(device, program);
+                tt_metal::detail::DumpDeviceProfileResults(device, program);
             }
         }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -908,7 +908,7 @@ int main(int argc, char** argv) {
             }
             Finish(device->command_queue());
             for (auto& program : programs) {
-                tt_metal::detail::DumpDeviceProfileResults(device, program);
+                tt_metal::detail::DumpDeviceProfileResults(device);
             }
         }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -618,7 +618,7 @@ int main(int argc, char** argv) {
                 EnqueueProgram(device->command_queue(), program, false);
                 Finish(device->command_queue());
                 log_debug(LogTest, "EnqueProgram done");
-                tt_metal::detail::DumpDeviceProfileResults(device, program);
+                tt_metal::detail::DumpDeviceProfileResults(device);
 
                 if (single_core) {
                     uint64_t t0_to_any_riscfw_end = get_t0_to_any_riscfw_end_cycle(device, program);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -618,7 +618,7 @@ int main(int argc, char** argv) {
                 EnqueueProgram(device->command_queue(), program, false);
                 Finish(device->command_queue());
                 log_debug(LogTest, "EnqueProgram done");
-                tt_metal::DumpDeviceProfileResults(device, program);
+                tt_metal::detail::DumpDeviceProfileResults(device, program);
 
                 if (single_core) {
                     uint64_t t0_to_any_riscfw_end = get_t0_to_any_riscfw_end_cycle(device, program);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -454,7 +454,7 @@ int main(int argc, char** argv) {
             auto t_begin = std::chrono::steady_clock::now();
             EnqueueProgram(device->command_queue(), program, false);
             Finish(device->command_queue());
-            tt_metal::DumpDeviceProfileResults(device, program);
+            tt_metal::detail::DumpDeviceProfileResults(device, program);
             auto t_end = std::chrono::steady_clock::now();
             auto elapsed_us = duration_cast<microseconds>(t_end - t_begin).count();
             dram_bandwidth.push_back((input_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -454,7 +454,7 @@ int main(int argc, char** argv) {
             auto t_begin = std::chrono::steady_clock::now();
             EnqueueProgram(device->command_queue(), program, false);
             Finish(device->command_queue());
-            tt_metal::detail::DumpDeviceProfileResults(device, program);
+            tt_metal::detail::DumpDeviceProfileResults(device);
             auto t_end = std::chrono::steady_clock::now();
             auto elapsed_us = duration_cast<microseconds>(t_end - t_begin).count();
             dram_bandwidth.push_back((input_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -638,7 +638,7 @@ int main(int argc, char** argv) {
             auto t_begin = std::chrono::steady_clock::now();
             EnqueueProgram(device->command_queue(), program, false);
             Finish(device->command_queue());
-            tt_metal::DumpDeviceProfileResults(device, program);
+            tt_metal::detail::DumpDeviceProfileResults(device, program);
             auto t_end = std::chrono::steady_clock::now();
             auto elapsed_us = duration_cast<microseconds>(t_end - t_begin).count();
             dram_bandwidth.push_back((input_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -638,7 +638,7 @@ int main(int argc, char** argv) {
             auto t_begin = std::chrono::steady_clock::now();
             EnqueueProgram(device->command_queue(), program, false);
             Finish(device->command_queue());
-            tt_metal::detail::DumpDeviceProfileResults(device, program);
+            tt_metal::detail::DumpDeviceProfileResults(device);
             auto t_end = std::chrono::steady_clock::now();
             auto elapsed_us = duration_cast<microseconds>(t_end - t_begin).count();
             dram_bandwidth.push_back((input_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -1113,7 +1113,7 @@ int main(int argc, char** argv) {
         Finish(device->command_queue());
         auto end = std::chrono::high_resolution_clock::now();
         duration = end - start;
-        tt_metal::DumpDeviceProfileResults(device, program);
+        tt_metal::detail::DumpDeviceProfileResults(device, program);
 
         uint64_t num_of_matmul_ops =
             (2 * static_cast<uint64_t>(Kt) * 32 - 1) * (static_cast<uint64_t>(Mt) * static_cast<uint64_t>(Nt) * 1024);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -1113,7 +1113,7 @@ int main(int argc, char** argv) {
         Finish(device->command_queue());
         auto end = std::chrono::high_resolution_clock::now();
         duration = end - start;
-        tt_metal::detail::DumpDeviceProfileResults(device, program);
+        tt_metal::detail::DumpDeviceProfileResults(device);
 
         uint64_t num_of_matmul_ops =
             (2 * static_cast<uint64_t>(Kt) * 32 - 1) * (static_cast<uint64_t>(Mt) * static_cast<uint64_t>(Nt) * 1024);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
@@ -330,7 +330,7 @@ int main(int argc, char** argv) {
         Finish(device->command_queue());
         auto end = std::chrono::high_resolution_clock::now();
         duration = end - start;
-        tt_metal::detail::DumpDeviceProfileResults(device, program);
+        tt_metal::detail::DumpDeviceProfileResults(device);
 
         uint64_t num_of_matmul_ops =
             (2 * static_cast<uint64_t>(Kt) * 32 - 1) * (static_cast<uint64_t>(Mt) * static_cast<uint64_t>(Nt) * 1024);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
@@ -330,7 +330,7 @@ int main(int argc, char** argv) {
         Finish(device->command_queue());
         auto end = std::chrono::high_resolution_clock::now();
         duration = end - start;
-        tt_metal::DumpDeviceProfileResults(device, program);
+        tt_metal::detail::DumpDeviceProfileResults(device, program);
 
         uint64_t num_of_matmul_ops =
             (2 * static_cast<uint64_t>(Kt) * 32 - 1) * (static_cast<uint64_t>(Mt) * static_cast<uint64_t>(Nt) * 1024);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -317,7 +317,7 @@ int main(int argc, char** argv) {
         auto bw = (total_tiles_size_bytes / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
         log_info(LogTest, "Total bytes transfered: {} Bytes", total_tiles_size_bytes);
         log_info(LogTest, "Read global to L1: {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
-        tt_metal::DumpDeviceProfileResults(device, program);
+        tt_metal::detail::DumpDeviceProfileResults(device, program);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -317,7 +317,7 @@ int main(int argc, char** argv) {
         auto bw = (total_tiles_size_bytes / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
         log_info(LogTest, "Total bytes transfered: {} Bytes", total_tiles_size_bytes);
         log_info(LogTest, "Read global to L1: {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
-        tt_metal::detail::DumpDeviceProfileResults(device, program);
+        tt_metal::detail::DumpDeviceProfileResults(device);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
@@ -244,7 +244,7 @@ int main(int argc, char** argv) {
         auto bw = (total_tiles_size_bytes / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
         log_info(LogTest, "Total bytes transfered: {} Bytes", total_tiles_size_bytes);
         log_info(LogTest, "Read local to L1: {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
-        tt_metal::DumpDeviceProfileResults(device, program);
+        tt_metal::detail::DumpDeviceProfileResults(device, program);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
@@ -244,7 +244,7 @@ int main(int argc, char** argv) {
         auto bw = (total_tiles_size_bytes / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
         log_info(LogTest, "Total bytes transfered: {} Bytes", total_tiles_size_bytes);
         log_info(LogTest, "Read local to L1: {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
-        tt_metal::detail::DumpDeviceProfileResults(device, program);
+        tt_metal::detail::DumpDeviceProfileResults(device);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
@@ -466,7 +466,7 @@ inline void RunPersistent1dFabricLatencyTest(
     for (size_t i = 0; i < programs.size(); i++) {
         auto d = devices_with_workers.at(i);
         auto& program = programs.at(i);
-        tt_metal::DumpDeviceProfileResults(d, program);
+        tt_metal::detail::DumpDeviceProfileResults(d, program);
     }
     log_info(tt::LogTest, "Finished");
 }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
@@ -466,7 +466,7 @@ inline void RunPersistent1dFabricLatencyTest(
     for (size_t i = 0; i < programs.size(); i++) {
         auto d = devices_with_workers.at(i);
         auto& program = programs.at(i);
-        tt_metal::detail::DumpDeviceProfileResults(d, program);
+        tt_metal::detail::DumpDeviceProfileResults(d);
     }
     log_info(tt::LogTest, "Finished");
 }

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -80,6 +80,8 @@ target_sources(
             api/tt-metalium/program.hpp
             api/tt-metalium/program_cache.hpp
             api/tt-metalium/program_descriptors.hpp
+            api/tt-metalium/profiler_optional_metadata.hpp
+            api/tt-metalium/profiler_types.hpp
             api/tt-metalium/runtime_args_data.hpp
             api/tt-metalium/semaphore.hpp
             api/tt-metalium/shape.hpp

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -938,13 +938,13 @@ void LoadTrace(IDevice* device, uint8_t cq_id, uint32_t trace_id, const TraceDes
  *
  * | Argument      | Description                                           | Type                     | Valid Range               | Required |
  * |---------------|-------------------------------------------------------|--------------------------|---------------------------|----------|
- * | mesh_device   | The mesh device containing the devices to be profiled | MeshDevice*              |                           | Yes      |
+ * | mesh_device   | The mesh device containing the devices to be profiled | MeshDevice&              |                           | Yes      |
  * | state         | The dump state to use for this profiler dump          | ProfilerDumpState        |                           | No       |
  * | metadata      | Metadata to include in the profiler results           | ProfilerOptionalMetadata |                           | No       |
  * */
 // clang-format on
 void DumpMeshDeviceProfileResults(
-    distributed::MeshDevice* mesh_device,
+    distributed::MeshDevice& mesh_device,
     ProfilerDumpState state = ProfilerDumpState::NORMAL,
     const std::optional<ProfilerOptionalMetadata>& metadata = {});
 

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -14,6 +14,8 @@
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/lightmetal_binary.hpp>
+#include <tt-metalium/profiler_types.hpp>
+#include <tt-metalium/profiler_optional_metadata.hpp>
 
 /** @file */
 
@@ -928,19 +930,23 @@ void LoadTrace(IDevice* device, uint8_t cq_id, uint32_t trace_id, const TraceDes
 
 // clang-format off
 /**
- * Read device side profiler data and dump results into device side CSV log
+ * Read device side profiler data for all devices in the mesh device and dump results into device side CSV log
  *
  * This function only works in PROFILER builds. Please refer to the "Device Program Profiler" section for more information.
  *
  * Return value: void
  *
- * | Argument      | Description                                       | Type            | Valid Range               | Required |
- * |---------------|---------------------------------------------------|-----------------|---------------------------|----------|
- * | device        | The device holding the program being profiled.    | IDevice*        |                           | True     |
- * | program       | The program being profiled.                       | const Program & |                           | True     |
+ * | Argument      | Description                                           | Type                     | Valid Range               | Required |
+ * |---------------|-------------------------------------------------------|--------------------------|---------------------------|----------|
+ * | mesh_device   | The mesh device containing the devices to be profiled | MeshDevice*              |                           | Yes      |
+ * | state         | The dump state to use for this profiler dump          | ProfilerDumpState        |                           | No       |
+ * | metadata      | Metadata to include in the profiler results           | ProfilerOptionalMetadata |                           | No       |
  * */
 // clang-format on
-void DumpDeviceProfileResults(IDevice* device, const Program& program);
+void DumpMeshDeviceProfileResults(
+    distributed::MeshDevice* mesh_device,
+    ProfilerDumpState state = ProfilerDumpState::NORMAL,
+    const std::optional<ProfilerOptionalMetadata>& metadata = {});
 
 // clang-format off
 /**

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -229,22 +229,6 @@ void InitDeviceProfiler(IDevice* device);
  * */
 void ProfilerSync(ProfilerSyncState state);
 
-// clang-format off
-/**
- * Read device side profiler data and dump results into device side CSV log
- *
- * This function only works in PROFILER builds. Please refer to the "Device Program Profiler" section for more information.
- *
- * Return value: void
- *
- * | Argument      | Description                                       | Type            | Valid Range               | Required |
- * |---------------|---------------------------------------------------|-----------------|---------------------------|----------|
- * | device        | The device holding the program being profiled.    | IDevice*        |                           | True     |
- * | program       | The program being profiled.                       | const Program & |                           | True     |
- * */
-// clang-format on
-// void DumpDeviceProfileResults(IDevice* device, const Program& program);
-
 /**
  * Read device side profiler data and dump results into device side CSV log
  *

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -243,7 +243,7 @@ void ProfilerSync(ProfilerSyncState state);
  * | program       | The program being profiled.                       | const Program & |                           | True     |
  * */
 // clang-format on
-void DumpDeviceProfileResults(IDevice* device, const Program& program);
+// void DumpDeviceProfileResults(IDevice* device, const Program& program);
 
 /**
  * Read device side profiler data and dump results into device side CSV log

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <tt-metalium/fabric_types.hpp>
+#include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/profiler_optional_metadata.hpp>
 #include <tt-metalium/profiler_types.hpp>
 #include <umd/device/tt_core_coordinates.h>
@@ -227,6 +228,24 @@ void InitDeviceProfiler(IDevice* device);
  * |---------------|---------------------------------------------------|-----------------|---------------------------|----------|
  * */
 void ProfilerSync(ProfilerSyncState state);
+
+/**
+ * Read device side profiler data for all devices in the mesh device and dump results into device side CSV log
+ *
+ * Return value: void
+ *
+ * | Argument      | Description                                           | Type                     | Valid Range |
+ * Required |
+ * |---------------|-------------------------------------------------------|--------------------------|------------------|----------|
+ * | mesh_device   | The mesh device containing the devices to be profiled | distributed::MeshDevice* | | True     | |
+ * state         | Profiler dump various states                          | ProfilerDumpState        |                  |
+ * False    | | metadata      | Optional metadata to be added to the profiler results | ProfilerOptionalMetadata | |
+ * False    |
+ * */
+void DumpMeshDeviceProfileResults(
+    distributed::MeshDevice* mesh_device,
+    ProfilerDumpState state = ProfilerDumpState::NORMAL,
+    const std::optional<ProfilerOptionalMetadata>& metadata = {});
 
 /**
  * Read device side profiler data and dump results into device side CSV log

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -229,23 +229,21 @@ void InitDeviceProfiler(IDevice* device);
  * */
 void ProfilerSync(ProfilerSyncState state);
 
+// clang-format off
 /**
- * Read device side profiler data for all devices in the mesh device and dump results into device side CSV log
+ * Read device side profiler data and dump results into device side CSV log
+ *
+ * This function only works in PROFILER builds. Please refer to the "Device Program Profiler" section for more information.
  *
  * Return value: void
  *
- * | Argument      | Description                                           | Type                     | Valid Range |
- * Required |
- * |---------------|-------------------------------------------------------|--------------------------|------------------|----------|
- * | mesh_device   | The mesh device containing the devices to be profiled | distributed::MeshDevice* | | True     | |
- * state         | Profiler dump various states                          | ProfilerDumpState        |                  |
- * False    | | metadata      | Optional metadata to be added to the profiler results | ProfilerOptionalMetadata | |
- * False    |
+ * | Argument      | Description                                       | Type            | Valid Range               | Required |
+ * |---------------|---------------------------------------------------|-----------------|---------------------------|----------|
+ * | device        | The device holding the program being profiled.    | IDevice*        |                           | True     |
+ * | program       | The program being profiled.                       | const Program & |                           | True     |
  * */
-void DumpMeshDeviceProfileResults(
-    distributed::MeshDevice* mesh_device,
-    ProfilerDumpState state = ProfilerDumpState::NORMAL,
-    const std::optional<ProfilerOptionalMetadata>& metadata = {});
+// clang-format on
+void DumpDeviceProfileResults(IDevice* device, const Program& program);
 
 /**
  * Read device side profiler data and dump results into device side CSV log

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -688,30 +688,30 @@ void InitDeviceProfiler(IDevice* device) {
 #endif
 }
 
-void DumpDeviceProfileResults(IDevice* device, const Program& program) {
-#if defined(TRACY_ENABLE)
-    std::vector<CoreCoord> worker_cores_in_program;
-    std::vector<CoreCoord> eth_cores_in_program;
+// void DumpDeviceProfileResults(IDevice* device, const Program& program) {
+// #if defined(TRACY_ENABLE)
+//     std::vector<CoreCoord> worker_cores_in_program;
+//     std::vector<CoreCoord> eth_cores_in_program;
 
-    std::vector<std::vector<CoreCoord>> logical_cores = program.logical_cores();
-    const auto& hal = MetalContext::instance().hal();
-    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
-        if (hal.get_core_type(index) == CoreType::WORKER) {
-            worker_cores_in_program = device->worker_cores_from_logical_cores(logical_cores[index]);
-        }
-        if (hal.get_core_type(index) == CoreType::ETH) {
-            eth_cores_in_program = device->ethernet_cores_from_logical_cores(logical_cores[index]);
-        }
-    }
+//     std::vector<std::vector<CoreCoord>> logical_cores = program.logical_cores();
+//     const auto& hal = MetalContext::instance().hal();
+//     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+//         if (hal.get_core_type(index) == CoreType::WORKER) {
+//             worker_cores_in_program = device->worker_cores_from_logical_cores(logical_cores[index]);
+//         }
+//         if (hal.get_core_type(index) == CoreType::ETH) {
+//             eth_cores_in_program = device->ethernet_cores_from_logical_cores(logical_cores[index]);
+//         }
+//     }
 
-    std::vector<CoreCoord> cores_in_program;
-    cores_in_program.reserve(worker_cores_in_program.size() + eth_cores_in_program.size());
-    std::copy(worker_cores_in_program.begin(), worker_cores_in_program.end(), std::back_inserter(cores_in_program));
-    std::copy(eth_cores_in_program.begin(), eth_cores_in_program.end(), std::back_inserter(cores_in_program));
+//     std::vector<CoreCoord> cores_in_program;
+//     cores_in_program.reserve(worker_cores_in_program.size() + eth_cores_in_program.size());
+//     std::copy(worker_cores_in_program.begin(), worker_cores_in_program.end(), std::back_inserter(cores_in_program));
+//     std::copy(eth_cores_in_program.begin(), eth_cores_in_program.end(), std::back_inserter(cores_in_program));
 
-    detail::DumpDeviceProfileResults(device, cores_in_program);
-#endif
-}
+//     detail::DumpDeviceProfileResults(device, cores_in_program);
+// #endif
+// }
 
 void DumpDeviceProfileResults(
     IDevice* device, ProfilerDumpState state, const std::optional<ProfilerOptionalMetadata>& metadata) {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -71,12 +71,12 @@ namespace tt {
 namespace tt_metal {
 
 void DumpMeshDeviceProfileResults(
-    distributed::MeshDevice* mesh_device,
+    distributed::MeshDevice& mesh_device,
     ProfilerDumpState state,
     const std::optional<ProfilerOptionalMetadata>& metadata) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    for (IDevice* device : mesh_device->get_devices()) {
+    for (IDevice* device : mesh_device.get_devices()) {
         detail::DumpDeviceProfileResults(device, state, metadata);
     }
 #endif

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -70,28 +70,15 @@ namespace tt {
 
 namespace tt_metal {
 
-void DumpDeviceProfileResults(IDevice* device, const Program& program) {
+void DumpMeshDeviceProfileResults(
+    distributed::MeshDevice* mesh_device,
+    ProfilerDumpState state,
+    const std::optional<ProfilerOptionalMetadata>& metadata) {
 #if defined(TRACY_ENABLE)
-    std::vector<CoreCoord> worker_cores_in_program;
-    std::vector<CoreCoord> eth_cores_in_program;
-
-    std::vector<std::vector<CoreCoord>> logical_cores = program.logical_cores();
-    const auto& hal = MetalContext::instance().hal();
-    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
-        if (hal.get_core_type(index) == CoreType::WORKER) {
-            worker_cores_in_program = device->worker_cores_from_logical_cores(logical_cores[index]);
-        }
-        if (hal.get_core_type(index) == CoreType::ETH) {
-            eth_cores_in_program = device->ethernet_cores_from_logical_cores(logical_cores[index]);
-        }
+    ZoneScoped;
+    for (IDevice* device : mesh_device->get_devices()) {
+        detail::DumpDeviceProfileResults(device, state, metadata);
     }
-
-    std::vector<CoreCoord> cores_in_program;
-    cores_in_program.reserve(worker_cores_in_program.size() + eth_cores_in_program.size());
-    std::copy(worker_cores_in_program.begin(), worker_cores_in_program.end(), std::back_inserter(cores_in_program));
-    std::copy(eth_cores_in_program.begin(), eth_cores_in_program.end(), std::back_inserter(cores_in_program));
-
-    detail::DumpDeviceProfileResults(device, cores_in_program);
 #endif
 }
 
@@ -701,15 +688,28 @@ void InitDeviceProfiler(IDevice* device) {
 #endif
 }
 
-void DumpMeshDeviceProfileResults(
-    distributed::MeshDevice* mesh_device,
-    ProfilerDumpState state,
-    const std::optional<ProfilerOptionalMetadata>& metadata) {
+void DumpDeviceProfileResults(IDevice* device, const Program& program) {
 #if defined(TRACY_ENABLE)
-    ZoneScoped;
-    for (IDevice* device : mesh_device->get_devices()) {
-        DumpDeviceProfileResults(device, state, metadata);
+    std::vector<CoreCoord> worker_cores_in_program;
+    std::vector<CoreCoord> eth_cores_in_program;
+
+    std::vector<std::vector<CoreCoord>> logical_cores = program.logical_cores();
+    const auto& hal = MetalContext::instance().hal();
+    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+        if (hal.get_core_type(index) == CoreType::WORKER) {
+            worker_cores_in_program = device->worker_cores_from_logical_cores(logical_cores[index]);
+        }
+        if (hal.get_core_type(index) == CoreType::ETH) {
+            eth_cores_in_program = device->ethernet_cores_from_logical_cores(logical_cores[index]);
+        }
     }
+
+    std::vector<CoreCoord> cores_in_program;
+    cores_in_program.reserve(worker_cores_in_program.size() + eth_cores_in_program.size());
+    std::copy(worker_cores_in_program.begin(), worker_cores_in_program.end(), std::back_inserter(cores_in_program));
+    std::copy(eth_cores_in_program.begin(), eth_cores_in_program.end(), std::back_inserter(cores_in_program));
+
+    detail::DumpDeviceProfileResults(device, cores_in_program);
 #endif
 }
 
@@ -730,7 +730,7 @@ void DumpDeviceProfileResults(
         workerCores.push_back(virtualCore);
     }
 
-    DumpDeviceProfileResults(device, workerCores, state, metadata);
+    detail::DumpDeviceProfileResults(device, workerCores, state, metadata);
     if (deviceDeviceTimePair.find(device->id()) != deviceDeviceTimePair.end() and
         state == ProfilerDumpState::CLOSE_DEVICE_SYNC) {
         for (auto& connected_device : deviceDeviceTimePair.at(device->id())) {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -701,6 +701,18 @@ void InitDeviceProfiler(IDevice* device) {
 #endif
 }
 
+void DumpMeshDeviceProfileResults(
+    distributed::MeshDevice* mesh_device,
+    ProfilerDumpState state,
+    const std::optional<ProfilerOptionalMetadata>& metadata) {
+#if defined(TRACY_ENABLE)
+    ZoneScoped;
+    for (IDevice* device : mesh_device->get_devices()) {
+        DumpDeviceProfileResults(device, state, metadata);
+    }
+#endif
+}
+
 void DumpDeviceProfileResults(
     IDevice* device, ProfilerDumpState state, const std::optional<ProfilerOptionalMetadata>& metadata) {
 #if defined(TRACY_ENABLE)

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -688,31 +688,6 @@ void InitDeviceProfiler(IDevice* device) {
 #endif
 }
 
-// void DumpDeviceProfileResults(IDevice* device, const Program& program) {
-// #if defined(TRACY_ENABLE)
-//     std::vector<CoreCoord> worker_cores_in_program;
-//     std::vector<CoreCoord> eth_cores_in_program;
-
-//     std::vector<std::vector<CoreCoord>> logical_cores = program.logical_cores();
-//     const auto& hal = MetalContext::instance().hal();
-//     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
-//         if (hal.get_core_type(index) == CoreType::WORKER) {
-//             worker_cores_in_program = device->worker_cores_from_logical_cores(logical_cores[index]);
-//         }
-//         if (hal.get_core_type(index) == CoreType::ETH) {
-//             eth_cores_in_program = device->ethernet_cores_from_logical_cores(logical_cores[index]);
-//         }
-//     }
-
-//     std::vector<CoreCoord> cores_in_program;
-//     cores_in_program.reserve(worker_cores_in_program.size() + eth_cores_in_program.size());
-//     std::copy(worker_cores_in_program.begin(), worker_cores_in_program.end(), std::back_inserter(cores_in_program));
-//     std::copy(eth_cores_in_program.begin(), eth_cores_in_program.end(), std::back_inserter(cores_in_program));
-
-//     detail::DumpDeviceProfileResults(device, cores_in_program);
-// #endif
-// }
-
 void DumpDeviceProfileResults(
     IDevice* device, ProfilerDumpState state, const std::optional<ProfilerOptionalMetadata>& metadata) {
 #if defined(TRACY_ENABLE)

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
@@ -54,7 +54,7 @@ bool RunCustomCycle(tt_metal::IDevice* device, int loop_count) {
         tt_metal::ComputeConfig{.compile_args = trisc_kernel_args, .defines = kernel_defines});
 
     EnqueueProgram(device->command_queue(), program, false);
-    tt_metal::detail::DumpDeviceProfileResults(device, program);
+    tt_metal::detail::DumpDeviceProfileResults(device);
 
     return pass;
 }

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
@@ -54,7 +54,7 @@ bool RunCustomCycle(tt_metal::IDevice* device, int loop_count) {
         tt_metal::ComputeConfig{.compile_args = trisc_kernel_args, .defines = kernel_defines});
 
     EnqueueProgram(device->command_queue(), program, false);
-    tt_metal::DumpDeviceProfileResults(device, program);
+    tt_metal::detail::DumpDeviceProfileResults(device, program);
 
     return pass;
 }

--- a/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
+++ b/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
@@ -52,7 +52,7 @@ void RunCustomCycle(tt_metal::IDevice* device, int loop_count) {
         tt_metal::ComputeConfig{.compile_args = trisc_kernel_args, .defines = kernel_defines});
 
     EnqueueProgram(device->command_queue(), program, false);
-    tt_metal::DumpDeviceProfileResults(device, program);
+    tt_metal::detail::DumpDeviceProfileResults(device, program);
 }
 
 int main() {

--- a/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
+++ b/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
@@ -52,7 +52,7 @@ void RunCustomCycle(tt_metal::IDevice* device, int loop_count) {
         tt_metal::ComputeConfig{.compile_args = trisc_kernel_args, .defines = kernel_defines});
 
     EnqueueProgram(device->command_queue(), program, false);
-    tt_metal::detail::DumpDeviceProfileResults(device, program);
+    tt_metal::detail::DumpDeviceProfileResults(device);
 }
 
 int main() {

--- a/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
+++ b/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
@@ -4,6 +4,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/bfloat16.hpp>
 
 using namespace tt::tt_metal;
@@ -80,7 +81,7 @@ int main() {
         // It is necessary to explictly dump profile results at the end of the
         // program to get noc traces for standalone tt_metal programs.  For
         // ttnn, this is called _automatically_
-        DumpDeviceProfileResults(device, program);
+        detail::DumpDeviceProfileResults(device, program);
 
         pass &= CloseDevice(device);
 

--- a/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
+++ b/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
@@ -81,7 +81,7 @@ int main() {
         // It is necessary to explictly dump profile results at the end of the
         // program to get noc traces for standalone tt_metal programs.  For
         // ttnn, this is called _automatically_
-        detail::DumpDeviceProfileResults(device, program);
+        detail::DumpDeviceProfileResults(device);
 
         pass &= CloseDevice(device);
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -826,7 +826,7 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
         }
     }  // Profiler scope end
     if (wait_until_cores_done) {
-        DumpDeviceProfileResults(device, program);
+        detail::DumpDeviceProfileResults(device, program);
     }
 }
 
@@ -845,7 +845,7 @@ void WaitProgramDone(IDevice* device, Program& program, bool dump_device_profile
     }
     llrt::internal_::wait_until_cores_done(device_id, RUN_MSG_GO, not_done_cores);
     if (dump_device_profile_results) {
-        DumpDeviceProfileResults(device, program);
+        detail::DumpDeviceProfileResults(device, program);
     }
 }
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -826,7 +826,7 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
         }
     }  // Profiler scope end
     if (wait_until_cores_done) {
-        detail::DumpDeviceProfileResults(device, program);
+        detail::DumpDeviceProfileResults(device);
     }
 }
 
@@ -845,7 +845,7 @@ void WaitProgramDone(IDevice* device, Program& program, bool dump_device_profile
     }
     llrt::internal_::wait_until_cores_done(device_id, RUN_MSG_GO, not_done_cores);
     if (dump_device_profile_results) {
-        detail::DumpDeviceProfileResults(device, program);
+        detail::DumpDeviceProfileResults(device);
     }
 }
 

--- a/ttnn/cpp/ttnn-pybind/device.cpp
+++ b/ttnn/cpp/ttnn-pybind/device.cpp
@@ -33,10 +33,6 @@ namespace py = pybind11;
 using namespace tt::tt_metal;
 
 namespace {
-void DumpMeshDeviceProfiler(distributed::MeshDevice* device) {
-    ProfilerOptionalMetadata prof_metadata(tt::tt_metal::op_profiler::runtime_id_to_opname_.export_map());
-    tt::tt_metal::DumpMeshDeviceProfileResults(*device, ProfilerDumpState::NORMAL, prof_metadata);
-}
 
 void ttnn_device(py::module& module) {
     module.def(
@@ -507,7 +503,10 @@ void device_module(py::module& m_device) {
         py::arg("sub_device_ids") = std::vector<SubDeviceId>());
     m_device.def(
         "DumpDeviceProfiler",
-        [](MeshDevice* device) { DumpMeshDeviceProfiler(device); },
+        [](MeshDevice* device) {
+            ProfilerOptionalMetadata prof_metadata(tt::tt_metal::op_profiler::runtime_id_to_opname_.export_map());
+            tt::tt_metal::DumpMeshDeviceProfileResults(*device, ProfilerDumpState::NORMAL, prof_metadata);
+        },
         py::arg("device"),
         R"doc(
         Dump device side profiling data.

--- a/ttnn/cpp/ttnn-pybind/device.cpp
+++ b/ttnn/cpp/ttnn-pybind/device.cpp
@@ -35,7 +35,7 @@ using namespace tt::tt_metal;
 namespace {
 void DumpMeshDeviceProfiler(distributed::MeshDevice* device) {
     ProfilerOptionalMetadata prof_metadata(tt::tt_metal::op_profiler::runtime_id_to_opname_.export_map());
-    tt::tt_metal::detail::DumpMeshDeviceProfileResults(device, ProfilerDumpState::NORMAL, prof_metadata);
+    tt::tt_metal::DumpMeshDeviceProfileResults(device, ProfilerDumpState::NORMAL, prof_metadata);
 }
 
 void ttnn_device(py::module& module) {

--- a/ttnn/cpp/ttnn-pybind/device.cpp
+++ b/ttnn/cpp/ttnn-pybind/device.cpp
@@ -35,7 +35,7 @@ using namespace tt::tt_metal;
 namespace {
 void DumpMeshDeviceProfiler(distributed::MeshDevice* device) {
     ProfilerOptionalMetadata prof_metadata(tt::tt_metal::op_profiler::runtime_id_to_opname_.export_map());
-    tt::tt_metal::DumpMeshDeviceProfileResults(device, ProfilerDumpState::NORMAL, prof_metadata);
+    tt::tt_metal::DumpMeshDeviceProfileResults(*device, ProfilerDumpState::NORMAL, prof_metadata);
 }
 
 void ttnn_device(py::module& module) {

--- a/ttnn/cpp/ttnn-pybind/device.cpp
+++ b/ttnn/cpp/ttnn-pybind/device.cpp
@@ -33,9 +33,9 @@ namespace py = pybind11;
 using namespace tt::tt_metal;
 
 namespace {
-void DumpDeviceProfiler(IDevice* device) {
+void DumpMeshDeviceProfiler(distributed::MeshDevice* device) {
     ProfilerOptionalMetadata prof_metadata(tt::tt_metal::op_profiler::runtime_id_to_opname_.export_map());
-    tt::tt_metal::detail::DumpDeviceProfileResults(device, ProfilerDumpState::NORMAL, prof_metadata);
+    tt::tt_metal::detail::DumpMeshDeviceProfileResults(device, ProfilerDumpState::NORMAL, prof_metadata);
 }
 
 void ttnn_device(py::module& module) {
@@ -507,11 +507,7 @@ void device_module(py::module& m_device) {
         py::arg("sub_device_ids") = std::vector<SubDeviceId>());
     m_device.def(
         "DumpDeviceProfiler",
-        [](MeshDevice* mesh_device) {
-            for (auto device : mesh_device->get_devices()) {
-                DumpDeviceProfiler(device);
-            }
-        },
+        [](MeshDevice* device) { DumpMeshDeviceProfiler(device); },
         py::arg("device"),
         R"doc(
         Dump device side profiling data.


### PR DESCRIPTION
### Ticket
#22582 

This PR adds a function `DumpMeshDeviceProfileResults` that iterates over the devices contained in the given mesh device, and dumps the device-side profile data for each device. This PR also deletes a version of `DumpDeviceProfileResults` that takes in a `Device` and `Program` as parameters.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15493490699)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/15493493970)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15493504738)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15493499182)
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15493496663)
- [x] [T3K Profiler] (https://github.com/tenstorrent/tt-metal/actions/runs/15493511880)
- [x] [Metal Microbenchmarks] (https://github.com/tenstorrent/tt-metal/actions/runs/15493516080)
- [x] New/Existing tests provide coverage for changes