### PR TITLE
#22840: add perf info to sweeps message for matmul, fused, and reduced

### DIFF
--- a/tests/sweep_framework/sweep_utils/reduction_common.py
+++ b/tests/sweep_framework/sweep_utils/reduction_common.py
@@ -13,6 +13,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -51,13 +52,12 @@ def run_sum(
     )
 
     start_time = start_measuring_time()
-    result = ttnn.sum(input_tensor_a, dim=dim, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(result)
+    op_output_tensor = ttnn.sum(input_tensor_a, dim=dim, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
-
-    pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
-    # print(f"input_shape {input_shape} pcc {pcc}")
-    return [pcc, e2e_perf]
+    expected_pcc = 0.999
+    tensors = [input_tensor_a, op_output_tensor]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
 
 
 def run_prod(
@@ -93,12 +93,11 @@ def run_prod(
     )
 
     start_time = start_measuring_time()
-    result = ttnn.prod(input_tensor_a, dim=dim, keepdim=keepdim, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(result)
+    op_output_tensor = ttnn.prod(input_tensor_a, dim=dim, keepdim=keepdim, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
-
-    pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    expected_pcc = 0.999
+    tensors = [input_tensor_a, op_output_tensor]
     assert len(output_tensor.shape) == len(torch_output_tensor.shape)
     assert output_tensor.shape == torch_output_tensor.shape
-    # print(f"input_shape {input_shape} pcc {pcc}")
-    return [pcc, e2e_perf]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/fused/layer_norm_traces.py
+++ b/tests/sweep_framework/sweeps/fused/layer_norm_traces.py
@@ -10,6 +10,7 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 15
 
@@ -122,11 +123,12 @@ def run_layer_norm(device, params):
     bias_tensor = ttnn.from_torch(torch_bias_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.layer_norm(input_tensor, weight=weight_tensor, bias=bias_tensor, epsilon=eps)
-    output_tensor = ttnn.to_torch(output_tensor)
+    op_output_tensor = ttnn.layer_norm(input_tensor, weight=weight_tensor, bias=bias_tensor, epsilon=eps)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor, weight_tensor, bias_tensor, op_output_tensor]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
 
 
 @pytest.mark.parametrize("params", parameters["default"]["params"])

--- a/tests/sweep_framework/sweeps/fused/softmax_traces.py
+++ b/tests/sweep_framework/sweeps/fused/softmax_traces.py
@@ -10,6 +10,7 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 15
 
@@ -107,11 +108,12 @@ def run_softmax(device, params):
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.softmax(input_tensor, dim)
-    output_tensor = ttnn.to_torch(output_tensor)
+    op_output_tensor = ttnn.softmax(input_tensor, dim)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.989
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor, op_output_tensor]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
 
 
 @pytest.mark.parametrize("params", parameters["default"]["params"])

--- a/tests/sweep_framework/sweeps/matmul/full/matmul_default_block_sharded.py
+++ b/tests/sweep_framework/sweeps/matmul/full/matmul_default_block_sharded.py
@@ -15,7 +15,6 @@ import ttnn
 
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 from tests.ttnn.utils_for_testing import (
-    check_with_pcc,
     get_per_core_size_and_num_cores,
     start_measuring_time,
     stop_measuring_time,

--- a/tests/sweep_framework/sweeps/matmul/full/matmul_default_block_sharded.py
+++ b/tests/sweep_framework/sweeps/matmul/full/matmul_default_block_sharded.py
@@ -21,6 +21,7 @@ from tests.ttnn.utils_for_testing import (
     stop_measuring_time,
 )
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 15
 
@@ -143,18 +144,20 @@ def run_matmul(
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.matmul(
+    op_output_tensor = ttnn.matmul(
         input_tensor_a,
         input_tensor_b,
         memory_config=output_memory_config,
         dtype=output_dtype,
         compute_kernel_config=compute_kernel_config,
     )
-    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 
     expected_pcc = 0.989
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor_a, input_tensor_b, op_output_tensor]
+    flop_counts = list(batch_sizes) + [m_size, n_size, 2, k_size]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))

--- a/tests/sweep_framework/sweeps/matmul/full/matmul_default_interleaved.py
+++ b/tests/sweep_framework/sweeps/matmul/full/matmul_default_interleaved.py
@@ -10,8 +10,9 @@ import torch
 
 import ttnn
 
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
 TIMEOUT = 5
@@ -79,18 +80,20 @@ def run_matmul(
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.matmul(
+    op_output_tensor = ttnn.matmul(
         input_tensor_a,
         input_tensor_b,
         memory_config=output_memory_config,
         dtype=output_dtype,
         compute_kernel_config=compute_kernel_config,
     )
-    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 
     expected_pcc = 0.99
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor_a, input_tensor_b, op_output_tensor]
+    flop_counts = list(batch_sizes) + [m_size, n_size, 2, k_size]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))

--- a/tests/sweep_framework/sweeps/matmul/full/matmul_default_width_sharded.py
+++ b/tests/sweep_framework/sweeps/matmul/full/matmul_default_width_sharded.py
@@ -14,12 +14,12 @@ import ttnn
 
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 from tests.ttnn.utils_for_testing import (
-    check_with_pcc,
     get_per_core_size_and_num_cores,
     start_measuring_time,
     stop_measuring_time,
 )
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 
 TIMEOUT = 5
@@ -117,18 +117,20 @@ def run_matmul(
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.matmul(
+    op_output_tensor = ttnn.matmul(
         input_tensor_a,
         input_tensor_b,
         memory_config=output_memory_config,
         dtype=output_dtype,
         compute_kernel_config=compute_kernel_config,
     )
-    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 
     expected_pcc = 0.99 if k_size < 1024 else 0.98
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor_a, input_tensor_b, op_output_tensor]
+    flop_counts = list(batch_sizes) + [m_size, n_size, 2, k_size]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))

--- a/tests/sweep_framework/sweeps/matmul/generality/linear.py
+++ b/tests/sweep_framework/sweeps/matmul/generality/linear.py
@@ -10,7 +10,9 @@ import ttnn
 from loguru import logger
 
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
-from tests.ttnn.utils_for_testing import check_with_pcc
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -163,46 +165,52 @@ def run_linear(device, shapes, transpose_a, transpose_b) -> tuple:
     # Run ttnn linear with the same operations
     ttnn_errored = False
     ttnn_error_msg = ""
+    start_time = start_measuring_time()
     try:
-        ttnn_result = ttnn.linear(ttnn_a, ttnn_b, bias=ttnn_bias, transpose_a=transpose_a, transpose_b=transpose_b)
+        op_output_tensor = ttnn.linear(ttnn_a, ttnn_b, bias=ttnn_bias, transpose_a=transpose_a, transpose_b=transpose_b)
+        output_tensor = ttnn.to_torch(op_output_tensor)
     except Exception as e:
         ttnn_errored = True
         ttnn_error_msg = str(e)
+    e2e_perf = stop_measuring_time(start_time)
 
     # Compare error behavior
     if torch_errored != ttnn_errored:
-        return (
-            False,
-            f"mismatch in errors raised: torch: {torch_errored} ({torch_error_msg}), ttnn: {ttnn_errored} ({ttnn_error_msg})",
-        )
+        return [
+            (
+                False,
+                f"mismatch in errors raised: torch: {torch_errored} ({torch_error_msg}), ttnn: {ttnn_errored} ({ttnn_error_msg})",
+            ),
+            e2e_perf,
+        ]
 
     # Skip the rest of the test if an exception was raised in both
     if torch_errored:
         logger.warning(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
-        return (True, "")
-
-    # Convert ttnn result to torch for comparison
-    ttnn_result_torch = ttnn.to_torch(ttnn.from_device(ttnn_result))
+        return [(True, ""), e2e_perf]
 
     # Check shape compatibility
-    if ttnn_result_torch.shape != torch_result.shape:
-        return (
-            False,
-            f"shape mismatch: torch: {torch_result.shape}, ttnn: {ttnn_result_torch.shape}",
-        )
-
-    # Check values with PCC
-    pcc_result, msg = check_with_pcc(torch_result, ttnn_result_torch, 0.99)
-    if not pcc_result:
-        return (False, msg)
+    if output_tensor.shape != torch_result.shape:
+        return [
+            (
+                False,
+                f"shape mismatch: torch: {torch_result.shape}, ttnn: {output_tensor.shape}",
+            ),
+            e2e_perf,
+        ]
 
     # Allow some tolerance for numeric differences
     atol = rtol = 0.1
+    allclose = (torch.allclose(torch_result, output_tensor, atol=atol, rtol=rtol, equal_nan=True),)
+    if not allclose:
+        return [(False, f"mismatch in allclose: torch: {torch_result}, ttnn: {output_tensor}"), e2e_perf]
 
-    return (
-        torch.allclose(torch_result, ttnn_result_torch, atol=atol, rtol=rtol, equal_nan=True),
-        f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result_torch}",
-    )
+    expected_pcc = 0.99
+    flop_counts = list(shape_a) + [
+        2,
+        shape_b[-1],
+    ]  # shape_a: all batch dimensions, m, k; shape_b[-1]: n, disregards addition
+    return get_run_return(torch_result, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))

--- a/tests/sweep_framework/sweeps/matmul/generality/linear.py
+++ b/tests/sweep_framework/sweeps/matmul/generality/linear.py
@@ -210,6 +210,9 @@ def run_linear(device, shapes, transpose_a, transpose_b) -> tuple:
         2,
         shape_b[-1],
     ]  # shape_a: all batch dimensions, m, k; shape_b[-1]: n, disregards addition
+    tensors = [ttnn_a, ttnn_b, op_output_tensor]
+    if ttnn_bias:
+        tensors.append(ttnn_bias)
     return get_run_return(torch_result, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts)
 
 

--- a/tests/sweep_framework/sweeps/matmul/generality/matmul.py
+++ b/tests/sweep_framework/sweeps/matmul/generality/matmul.py
@@ -10,7 +10,9 @@ import ttnn
 from loguru import logger
 
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
-from tests.ttnn.utils_for_testing import check_with_pcc
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -211,46 +213,51 @@ def run_matmul(device, shapes, transpose_a, transpose_b) -> tuple:
     # Run ttnn matmul with the same operations
     ttnn_errored = False
     ttnn_error_msg = ""
+    start_time = start_measuring_time()
     try:
-        ttnn_result = ttnn.matmul(ttnn_a, ttnn_b, transpose_a=transpose_a, transpose_b=transpose_b)
+        op_output_tensor = ttnn.matmul(ttnn_a, ttnn_b, transpose_a=transpose_a, transpose_b=transpose_b)
+        output_tensor = ttnn.to_torch(op_output_tensor)
     except Exception as e:
         ttnn_errored = True
         ttnn_error_msg = str(e)
+    e2e_perf = stop_measuring_time(start_time)
 
     # Compare error behavior
     if torch_errored != ttnn_errored:
-        return (
-            False,
-            f"mismatch in errors raised: torch: {torch_errored} ({torch_error_msg}), ttnn: {ttnn_errored} ({ttnn_error_msg})",
-        )
+        return [
+            (
+                False,
+                f"mismatch in errors raised: torch: {torch_errored} ({torch_error_msg}), ttnn: {ttnn_errored} ({ttnn_error_msg})",
+            ),
+            e2e_perf,
+        ]
 
     # Skip the rest of the test if an exception was raised in both
     if torch_errored:
         logger.warning(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
-        return (True, "")
-
-    # Convert ttnn result to torch for comparison
-    ttnn_result_torch = ttnn.to_torch(ttnn.from_device(ttnn_result))
+        return [(True, ""), e2e_perf]
 
     # Check shape compatibility
-    if ttnn_result_torch.shape != torch_result.shape:
-        return (
-            False,
-            f"shape mismatch: torch: {torch_result.shape}, ttnn: {ttnn_result_torch.shape}",
-        )
-
-    # Check values with PCC
-    pcc_result, msg = check_with_pcc(torch_result, ttnn_result_torch, 0.99)
-    if not pcc_result:
-        return (False, msg)
+    if output_tensor.shape != torch_result.shape:
+        return [
+            (
+                False,
+                f"shape mismatch: torch: {torch_result.shape}, ttnn: {output_tensor.shape}",
+            ),
+            e2e_perf,
+        ]
 
     # Allow some tolerance for numeric differences
     atol = rtol = 0.1
+    allclose = (torch.allclose(torch_result, ttnn_result_torch, atol=atol, rtol=rtol, equal_nan=True),)
+    if not allclose:
+        return [(False, f"mismatch in allclose: torch: {torch_result}, ttnn: {output_tensor}"), e2e_perf]
 
-    return (
-        torch.allclose(torch_result, ttnn_result_torch, atol=atol, rtol=rtol, equal_nan=True),
-        f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result_torch}",
-    )
+    expected_pcc = 0.99
+    tensors = [ttnn_a, ttnn_b, op_output_tensor]
+
+    flop_counts = list(shape_a) + [2, shape_b[-1]]  # shape_a: all batch dimensions, m, k; shape_b[-1]: n
+    return get_run_return(torch_result, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))

--- a/tests/sweep_framework/sweeps/matmul/generality/matmul.py
+++ b/tests/sweep_framework/sweeps/matmul/generality/matmul.py
@@ -249,7 +249,7 @@ def run_matmul(device, shapes, transpose_a, transpose_b) -> tuple:
 
     # Allow some tolerance for numeric differences
     atol = rtol = 0.1
-    allclose = (torch.allclose(torch_result, ttnn_result_torch, atol=atol, rtol=rtol, equal_nan=True),)
+    allclose = (torch.allclose(torch_result, output_tensor, atol=atol, rtol=rtol, equal_nan=True),)
     if not allclose:
         return [(False, f"mismatch in allclose: torch: {torch_result}, ttnn: {output_tensor}"), e2e_perf]
 

--- a/tests/sweep_framework/sweeps/matmul/short/matmul.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul.py
@@ -12,6 +12,7 @@ import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 5
 
@@ -77,14 +78,15 @@ def run_matmul(
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.matmul(
+    op_output_tensor = ttnn.matmul(
         input_tensor_a, input_tensor_b, dtype=output_dtype, memory_config=output_memory_config, core_grid=core_grid
     )
-    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.99
-
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor_a, input_tensor_b, op_output_tensor]
+    flop_counts = [m_size, n_size, 2, k_size] + list(batch_sizes)
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))

--- a/tests/sweep_framework/sweeps/matmul/short/matmul_default.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_default.py
@@ -107,7 +107,7 @@ def run_matmul(
 
     expected_pcc = 0.99
     tensors = [input_tensor_a, input_tensor_b, op_output_tensor]
-    flop_counts = list(m_n_sizes) + [2, k_size, batch_sizes[0]]
+    flop_counts = list(m_n_sizes) + [2, k_size] + list(batch_sizes)
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts)
 
 

--- a/tests/sweep_framework/sweeps/matmul/short/matmul_default_sharded.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_default_sharded.py
@@ -13,6 +13,7 @@ import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 
 TIMEOUT = 5
@@ -168,12 +169,16 @@ def run_matmul(
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.matmul(input_tensor_a, input_tensor_b, memory_config=output_memory_config, dtype=output_dtype)
-    output_tensor = ttnn.to_torch(output_tensor)
+    op_output_tensor = ttnn.matmul(
+        input_tensor_a, input_tensor_b, memory_config=output_memory_config, dtype=output_dtype
+    )
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 
     expected_pcc = 0.99
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor_a, input_tensor_b, op_output_tensor]
+    flop_counts = [m_size, n_size, 2, k_size] + list(batch_sizes)
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))

--- a/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config.py
@@ -14,6 +14,7 @@ import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 5
 
@@ -546,7 +547,7 @@ def run_matmul(
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.matmul(
+    op_output_tensor = ttnn.matmul(
         input_tensor_a,
         input_tensor_b,
         memory_config=output_memory_config,
@@ -554,11 +555,13 @@ def run_matmul(
         program_config=program_config,
         compute_kernel_config=compute_kernel_config,
     )
-    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 
     expected_pcc = 0.99
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor_a, input_tensor_b, op_output_tensor]
+    flop_counts = [m_size, n_size, 2, k_size] + list(batch_sizes)
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))

--- a/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py
@@ -14,6 +14,7 @@ import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 5
 
@@ -346,7 +347,7 @@ def run_matmul(
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.matmul(
+    op_output_tensor = ttnn.matmul(
         input_tensor_a,
         input_tensor_b,
         memory_config=output_memory_config,
@@ -354,11 +355,13 @@ def run_matmul(
         program_config=program_config,
         compute_kernel_config=compute_kernel_config,
     )
-    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 
     expected_pcc = 0.99
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor_a, input_tensor_b, op_output_tensor]
+    flop_counts = [m_size, n_size, 2, k_size] + list(batch_sizes)
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))

--- a/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config_mcast_2d.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config_mcast_2d.py
@@ -14,6 +14,7 @@ import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 from tests.ttnn.utils_for_testing import check_with_pcc, assert_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 5
 
@@ -490,7 +491,7 @@ def run_matmul(
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.matmul(
+    op_output_tensor = ttnn.matmul(
         input_tensor_a,
         input_tensor_b,
         memory_config=output_memory_config,
@@ -498,11 +499,13 @@ def run_matmul(
         program_config=program_config,
         compute_kernel_config=compute_kernel_config,
     )
-    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 
     expected_pcc = 0.99
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor_a, input_tensor_b, op_output_tensor]
+    flop_counts = [m_size, n_size, 2, k_size] + list(batch_sizes)
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))

--- a/tests/sweep_framework/sweeps/normalization/batch_norm/batch_norm.py
+++ b/tests/sweep_framework/sweeps/normalization/batch_norm/batch_norm.py
@@ -11,9 +11,10 @@ import itertools
 import ttnn
 import pytest
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
 from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range_batch_norm
@@ -122,34 +123,29 @@ def run_batch_norm(
         momentum=momentum,
     )
 
-    passed = []
-    output_string = ""
-    passed_, output_string_ = check_with_pcc(torch_result, output_tensor, 0.99)
-    passed.append(passed_)
-    output_string += output_string_ + ", "
-
     if training:
         channels = input_shape[1]
         if check_mean:
             tt_updated_mean = ttnn.to_torch(mean_tensor)
             passed_, output_string_ = check_with_pcc(tt_updated_mean, mean_data.view(1, channels, 1, 1), 0.99)
-            passed.append(passed_)
-            output_string += output_string_ + ", "
+            if not passed_:
+                return [(passed_, output_string_), e2e_perf]
         if check_var:
             tt_updated_var = ttnn.to_torch(var_tensor)
             passed_, output_string_ = check_with_pcc(tt_updated_var, var_data.view(1, channels, 1, 1), 0.99)
-            passed.append(passed_)
-            output_string += output_string_ + ", "
+            if not passed_:
+                return [(passed_, output_string_), e2e_perf]
 
-    if all(passed):
-        passed = True
-    else:
-        passed = False
-
-    output_string = output_string[:-2]
-    e2e_perf = stop_measuring_time(start_time)
-
-    return [(passed, output_string), e2e_perf]
+    tensors = [input_tensor, result]
+    if mean_tensor is not None:
+        tensors.append(mean_tensor)
+    if var_tensor is not None:
+        tensors.append(var_tensor)
+    if weight_tensor is not None:
+        tensors.append(weight_tensor)
+    if bias_tensor is not None:
+        tensors.append(bias_tensor)
+    return get_run_return(torch_result, output_tensor, expected_pcc, tensors, e2e_perf)
 
 
 def run(

--- a/tests/sweep_framework/sweeps/normalization/batch_norm/batch_norm.py
+++ b/tests/sweep_framework/sweeps/normalization/batch_norm/batch_norm.py
@@ -14,7 +14,7 @@ from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
 from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range_batch_norm
@@ -123,16 +123,17 @@ def run_batch_norm(
         momentum=momentum,
     )
 
+    expected_pcc = 0.99
     if training:
         channels = input_shape[1]
         if check_mean:
             tt_updated_mean = ttnn.to_torch(mean_tensor)
-            passed_, output_string_ = check_with_pcc(tt_updated_mean, mean_data.view(1, channels, 1, 1), 0.99)
+            passed_, output_string_ = check_with_pcc(tt_updated_mean, mean_data.view(1, channels, 1, 1), expected_pcc)
             if not passed_:
                 return [(passed_, output_string_), e2e_perf]
         if check_var:
             tt_updated_var = ttnn.to_torch(var_tensor)
-            passed_, output_string_ = check_with_pcc(tt_updated_var, var_data.view(1, channels, 1, 1), 0.99)
+            passed_, output_string_ = check_with_pcc(tt_updated_var, var_data.view(1, channels, 1, 1), expected_pcc)
             if not passed_:
                 return [(passed_, output_string_), e2e_perf]
 

--- a/tests/sweep_framework/sweeps/normalization/generality/softmax_fused.py
+++ b/tests/sweep_framework/sweeps/normalization/generality/softmax_fused.py
@@ -10,7 +10,8 @@ import ttnn
 from loguru import logger
 
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
-from tests.ttnn.utils_for_testing import check_with_pcc
+from tests.ttnn.utils_for_testing import start_measuring_time, stop_measuring_time
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -80,8 +81,9 @@ def run_softmax(device, tensor_shape, op) -> list:
 
     ttnn_errored = False
     ttnn_error_msg = ""
+    start_time = start_measuring_time()
     try:
-        ttnn_result = ttnn_op(ttnn_tensor, scale, ttnn_mask) if has_scale_mask else ttnn_op(ttnn_tensor)
+        op_ttnn_result = ttnn_op(ttnn_tensor, scale, ttnn_mask) if has_scale_mask else ttnn_op(ttnn_tensor)
     except RuntimeError as e:
         ttnn_errored = True
         ttnn_error_msg = str(e)
@@ -97,21 +99,20 @@ def run_softmax(device, tensor_shape, op) -> list:
         logger.info(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
         return (True, "")
 
-    ttnn_result = ttnn.to_torch(ttnn.from_device(ttnn_result))
-
-    pcc_result, msg = check_with_pcc(torch_result, ttnn_result, 0.99)
-
-    if not pcc_result:
-        return (False, msg)
+    ttnn_result = ttnn.to_torch(ttnn.from_device(op_ttnn_result))
+    e2e_perf = stop_measuring_time(start_time)
 
     atol = rtol = 0.1
 
-    return (
-        torch.allclose(torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True),
-        f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result}",
-    )
-
+    allclose = (torch.allclose(torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True),)
+    if not allclose:
+        return [(False, f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result}"), e2e_perf]
     # TODO: Verify that the sum of the output tensor is equal to 1.0 over the specified dimension
+    expected_pcc = 0.99
+    tensors = [ttnn_tensor, op_ttnn_result]
+    if has_scale_mask:
+        tensors.append(ttnn_mask)
+    return get_run_return(torch_result, ttnn_result, expected_pcc, tensors, e2e_perf)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))

--- a/tests/sweep_framework/sweeps/normalization/softmax/softmax.py
+++ b/tests/sweep_framework/sweeps/normalization/softmax/softmax.py
@@ -12,6 +12,7 @@ from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 from models.utility_functions import torch_random
 
 # Override the default timeout in seconds for hang detection.
@@ -70,4 +71,6 @@ def run(
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 
-    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]
+    expected_pcc = 0.999
+    tensors = [input_tensor_a, result]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/normalization/softmax/softmax_sharded.py
+++ b/tests/sweep_framework/sweeps/normalization/softmax/softmax_sharded.py
@@ -18,7 +18,7 @@ from tests.sweep_framework.sweep_utils.sharding_utils import (
 )
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time, get_run_return
 from models.utility_functions import torch_random
 
 # Override the default timeout in seconds for hang detection.
@@ -107,5 +107,6 @@ def run(
     e2e_perf = stop_measuring_time(start_time)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
-    return [pcc, e2e_perf]
+    expected_pcc = 0.999
+    tensors = [input_tensor_a, output_tensor]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax_output.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax_output.py
@@ -13,6 +13,7 @@ from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_r
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -104,12 +105,12 @@ def run_argmax(
     )
 
     start_time = start_measuring_time()
-    ttnn.argmax(input_tensor_a, dim=dim, output_tensor=output_tensor)
-    e2e_perf = stop_measuring_time(start_time)
-
+    op_output_tensor = ttnn.argmax(input_tensor_a, dim=dim, output_tensor=output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-
-    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]
+    e2e_perf = stop_measuring_time(start_time)
+    expected_pcc = 0.999
+    tensors = [input_tensor_a, op_output_tensor]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
 
 
 @pytest.mark.parametrize("params", list(permutations(parameters["nightly"])))

--- a/tests/sweep_framework/sweeps/reduction/generality/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/generality/argmax.py
@@ -10,7 +10,8 @@ import ttnn
 from loguru import logger
 
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
-from tests.ttnn.utils_for_testing import check_with_pcc
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -59,43 +60,44 @@ def run_argmax(device, tensor_shape, dim, keepdim, use_multicore) -> list:
 
     ttnn_errored = False
     ttnn_error_msg = ""
+    start_time = start_measuring_time()
     try:
-        ttnn_result = (
+        op_output_tensor = (
             ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim, use_multicore=use_multicore)
             if dim is not None
             else ttnn_op(ttnn_tensor, use_multicore=use_multicore)
         )
+        output_tensor = ttnn.to_torch(ttnn.from_device(op_output_tensor))
     except RuntimeError as e:
         ttnn_errored = True
         ttnn_error_msg = str(e)
+    e2e_perf = stop_measuring_time(start_time)
 
     if torch_errored != ttnn_errored:
-        return (
-            False,
-            f"mismatch in errors raised: torch: {torch_errored} ({torch_error_msg}), ttnn: {ttnn_errored} ({ttnn_error_msg})",
-        )
+        return [
+            (
+                False,
+                f"mismatch in errors raised: torch: {torch_errored} ({torch_error_msg}), ttnn: {ttnn_errored} ({ttnn_error_msg})",
+            ),
+            e2e_perf,
+        ]
 
     # Skip the rest of the test if an exception was raised in both
     if torch_errored:
         logger.warning(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
-        return (True, "")
-
-    ttnn_result = ttnn.to_torch(ttnn.from_device(ttnn_result))
-
-    pcc_result, msg = check_with_pcc(torch_result, ttnn_result, 0.99)
-
-    if not pcc_result:
-        return (False, msg + f"mismatch in pcc: torch: {torch_result}, ttnn: {ttnn_result}")
+        return [(True, ""), e2e_perf]
 
     # Convert torch dtype from uint64 to int32
     # Note: torch does not have uint32
-    torch_result = torch_result.to(torch.int32)
-
+    int32_torch_result = torch_result.to(torch.int32)
     atol = rtol = 0.1
-    return (
-        torch.allclose(torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True),
-        f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result}",
-    )
+    allclose = (torch.allclose(int32_torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True),)
+    if not allclose:
+        return [(False, f"mismatch in allclose: torch: {int32_torch_result}, ttnn: {ttnn_result}"), e2e_perf]
+
+    expected_pcc = 0.99
+    tensors = [ttnn_tensor, op_output_tensor]
+    return get_run_return(torch_result, output_tensor, expected_pcc, tensors, e2e_perf)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))
@@ -106,7 +108,7 @@ def test_argmax(
     keepdim,
     use_multicore,
 ):
-    result, error_msg = run_argmax(
+    result, error_msg, _ = run_argmax(
         device,
         tensor_shape,
         dim,

--- a/tests/sweep_framework/sweeps/reduction/generality/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/generality/argmax.py
@@ -91,9 +91,9 @@ def run_argmax(device, tensor_shape, dim, keepdim, use_multicore) -> list:
     # Note: torch does not have uint32
     int32_torch_result = torch_result.to(torch.int32)
     atol = rtol = 0.1
-    allclose = (torch.allclose(int32_torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True),)
+    allclose = (torch.allclose(int32_torch_result, output_tensor, atol=atol, rtol=rtol, equal_nan=True),)
     if not allclose:
-        return [(False, f"mismatch in allclose: torch: {int32_torch_result}, ttnn: {ttnn_result}"), e2e_perf]
+        return [(False, f"mismatch in allclose: torch: {int32_torch_result}, ttnn: {output_tensor}"), e2e_perf]
 
     expected_pcc = 0.99
     tensors = [ttnn_tensor, op_output_tensor]
@@ -108,7 +108,7 @@ def test_argmax(
     keepdim,
     use_multicore,
 ):
-    result, error_msg, _ = run_argmax(
+    (result, error_msg), e2e_perf = run_argmax(
         device,
         tensor_shape,
         dim,

--- a/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
+++ b/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
@@ -92,9 +92,9 @@ def run_reduction(device, tensor_shape, dim, keepdim, op) -> list:
     elif op == "var":
         atol, rtol = sys.maxsize, 0.1 + 2
 
-    allclose = torch.allclose(torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True)
+    allclose = torch.allclose(torch_result, output_tensor, atol=atol, rtol=rtol, equal_nan=True)
     if not allclose:
-        return [(False, f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result}"), e2e_perf]
+        return [(False, f"mismatch in allclose: torch: {torch_result}, ttnn: {output_tensor}"), e2e_perf]
     expected_pcc = 0.99
     tensors = [ttnn_tensor, op_output_tensor]
     return get_run_return(torch_result, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
+++ b/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
@@ -11,7 +11,8 @@ import torch
 import ttnn
 
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
-from tests.ttnn.utils_for_testing import check_with_pcc
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -64,14 +65,17 @@ def run_reduction(device, tensor_shape, dim, keepdim, op) -> list:
         torch_errored = True
 
     ttnn_errored = False
+    start_time = start_measuring_time()
     try:
-        ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim) if dim is not None else ttnn_op(ttnn_tensor)
+        op_output_tensor = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim) if dim is not None else ttnn_op(ttnn_tensor)
+        output_tensor = ttnn.to_torch(ttnn.from_device(op_output_tensor))
     except RuntimeError:
         ttnn_errored = True
+    e2e_perf = stop_measuring_time(start_time)
 
     # Skip the rest of the test if an exception was raised in both
     if torch_errored:
-        return [True, f"mismatch in errors raised: torch: {torch_errored}, ttnn: {ttnn_errored}"]
+        return [(True, f"mismatch in errors raised: torch: {torch_errored}, ttnn: {ttnn_errored}"), e2e_perf]
 
     # torch's min/max double as argmin/argmax, so we need to extract the values only
     torch_result = (
@@ -79,13 +83,6 @@ def run_reduction(device, tensor_shape, dim, keepdim, op) -> list:
         if isinstance(torch_result, (torch.return_types.min, torch.return_types.max))
         else torch_result
     )
-
-    ttnn_result = ttnn.to_torch(ttnn.from_device(ttnn_result))
-
-    pcc_result, msg = check_with_pcc(torch_result, ttnn_result, 0.99)
-
-    if not pcc_result:
-        return [False, msg]
 
     atol = rtol = 0.1
     # There is a scale factor difference between torch and ttnn for std and var
@@ -95,10 +92,12 @@ def run_reduction(device, tensor_shape, dim, keepdim, op) -> list:
     elif op == "var":
         atol, rtol = sys.maxsize, 0.1 + 2
 
-    return [
-        torch.allclose(torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True),
-        f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result}",
-    ]
+    allclose = torch.allclose(torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True)
+    if not allclose:
+        return [(False, f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result}"), e2e_perf]
+    expected_pcc = 0.99
+    tensors = [ttnn_tensor, op_output_tensor]
+    return get_run_return(torch_result, output_tensor, expected_pcc, tensors, e2e_perf)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))

--- a/tests/sweep_framework/sweeps/reduction/mean/mean.py
+++ b/tests/sweep_framework/sweeps/reduction/mean/mean.py
@@ -14,6 +14,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -121,9 +122,9 @@ def run(
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.mean(input_tensor_a, dim=dim, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(output_tensor)
-
+    op_output_tensor = ttnn.mean(input_tensor_a, dim=dim, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
-
-    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]
+    expected_pcc = 0.999
+    tensors = [input_tensor_a, op_output_tensor]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/reduction/std/std.py
+++ b/tests/sweep_framework/sweeps/reduction/std/std.py
@@ -14,6 +14,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -121,9 +122,9 @@ def run(
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.std(input_tensor_a, dim=dim, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(output_tensor)
-
+    op_output_tensor = ttnn.std(input_tensor_a, dim=dim, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
-
-    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]
+    expected_pcc = 0.999
+    tensors = [input_tensor_a, op_output_tensor]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/reduction/traces/argmax_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/argmax_traces.py
@@ -10,6 +10,7 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 15
 
@@ -31,11 +32,12 @@ def run_argmax(device, height, width, dim, dtype, layout):
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=layout, device=device)
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.argmax(input_tensor, dim=dim)
-    output_tensor = ttnn.to_torch(output_tensor)
+    op_output_tensor = ttnn.argmax(input_tensor, dim=dim)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor, op_output_tensor]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
 
 
 @pytest.mark.parametrize("height", parameters["pytorch"]["height"])

--- a/tests/sweep_framework/sweeps/reduction/traces/max_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/max_traces.py
@@ -10,6 +10,7 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 15
 
@@ -358,11 +359,12 @@ def run_max(device, params, dtype, layout):
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=layout, device=device)
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.max(input_tensor, dim=dim, keepdim=keepdim)
-    output_tensor = ttnn.to_torch(output_tensor)
+    op_output_tensor = ttnn.max(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor, op_output_tensor]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
 
 
 @pytest.mark.parametrize("params", parameters["pytorch"]["params"])

--- a/tests/sweep_framework/sweeps/reduction/traces/mean_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/mean_traces.py
@@ -10,6 +10,7 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 15
 
@@ -116,11 +117,12 @@ def run_mean(device, params):
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=keepdim)
-    output_tensor = ttnn.to_torch(output_tensor)
+    op_output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor, op_output_tensor]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
 
 
 @pytest.mark.parametrize("params", parameters["pytorch"]["params"])

--- a/tests/sweep_framework/sweeps/reduction/traces/topk_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/topk_traces.py
@@ -10,6 +10,7 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 15
 
@@ -33,11 +34,12 @@ def run_topk(device, params):
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.topk(input_tensor, k)
-    output_tensor = ttnn.to_torch(output_tensor)
+    op_output_tensor = ttnn.topk(input_tensor, k)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
-    return [check_with_pcc(torch_output_tensor, output_tensor, expected_pcc), e2e_perf]
+    tensors = [input_tensor, op_output_tensor]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
 
 
 @pytest.mark.parametrize("params", parameters["pytorch"]["params"])

--- a/tests/sweep_framework/sweeps/reduction/var/var.py
+++ b/tests/sweep_framework/sweeps/reduction/var/var.py
@@ -14,6 +14,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -124,9 +125,9 @@ def run(
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.var(input_tensor_a, dim=dim, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(output_tensor)
-
+    op_output_tensor = ttnn.var(input_tensor_a, dim=dim, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(op_output_tensor)
     e2e_perf = stop_measuring_time(start_time)
-
-    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]
+    expected_pcc = 0.999
+    tensors = [input_tensor_a, op_output_tensor]
+    return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)


### PR DESCRIPTION
### Ticket
Link to Github Issue #22840

### Problem description
Need to get more perf info for matmul, fused, and reduced sweeps

### What's changed
- added functionality to generate that info to more sweeps

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes N/A
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) N/A
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). N/A
- [x] New/Existing tests provide coverage for changes