### PR TITLE
Disable the fancy linking while we work on compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,8 @@ endif()
 include(compilers)
 CHECK_COMPILERS()
 
-include(linking)
+# TODO(afuller): Re-enable this after we sort out compatibility with old tools.
+# include(linking)
 
 # We're not currently using C++20 modules, so don't bother scanning for them
 set(CMAKE_CXX_SCAN_FOR_MODULES FALSE)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Some tools default on 22.04 don't understand new fancy things let.  We need to accommodate them, too.

### What's changed
Disabled the fanciness for now.