### PR TITLE
Fix assert in DeviceFixture.TensixDataMovementOneToAll2x2PacketSizes

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender.cpp
@@ -44,4 +44,5 @@ void kernel_main() {
     DeviceTimestampedData("Number of transactions", num_of_transactions);
     DeviceTimestampedData("Transaction size in bytes", total_transaction_size_bytes);
     DeviceTimestampedData("Test id", test_id);
+    noc_async_atomic_barrier();
 }


### PR DESCRIPTION
### Problem description
DeviceFixture.TensixDataMovementOneToAll2x2PacketSizes currents gives this errror:
```
Always | WARNING  | Watcher stopped the device due to tripped assert, see watcher log for more details
Always | WARNING  | Device 0 worker core(x= 0,y= 0) virtual(x= 1,y= 2):  brisc detected an inter-kernel data race due to kernel completing with pending NOC transactions (missing NOC non-posted atomics flushed barrier). Current kernel: tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender.cpp.
```

### What's changed
Add a noc_async_atomic_barrier() to the end of the kernel.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes