### PR TITLE
#0: Add APIs to MeshGraph for multi-host {MeshId, HostRankId} info

### DIFF
--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.yaml
@@ -1,0 +1,27 @@
+ChipSpec: {
+  arch: wormhole_b0,
+  ethernet_ports: {
+    N: 2,
+    E: 2,
+    S: 2,
+    W: 2,
+  }
+}
+
+
+Board: [
+  { name: T3K,
+    type: Mesh,
+    topology: [2, 2]}
+]
+
+Mesh: [
+{
+  id: 0,
+  board: T3K,
+  topology: [1, 2],
+  host_ranks: [[0, 1]]}
+]
+
+Graph: [
+]

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -234,4 +234,58 @@ TEST(MeshGraphValidation, TestT3kDualHostMeshGraph) {
         MeshContainer<chip_id_t>(MeshShape(2, 2), std::vector<chip_id_t>{2, 3, 6, 7}));
 }
 
+TEST(MeshGraphValidation, TestT3k2x2MeshGraph) {
+    const std::filesystem::path t3k_2x2_mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml";
+    auto mesh_graph = std::make_unique<tt_fabric::MeshGraph>(t3k_2x2_mesh_graph_desc_path.string());
+
+    // This configuration has two meshes (id 0 and id 1)
+    EXPECT_THAT(mesh_graph->get_mesh_ids(), ElementsAre(MeshId{0}, MeshId{1}));
+
+    // Check host ranks for mesh 0 - single host rank 0
+    const auto& host_ranks_mesh0 = mesh_graph->get_host_ranks(MeshId{0});
+    EXPECT_EQ(host_ranks_mesh0, MeshContainer<HostRankId>(MeshShape(1, 1), {HostRankId(0)}));
+
+    // Check host ranks for mesh 1 - single host rank 0
+    const auto& host_ranks_mesh1 = mesh_graph->get_host_ranks(MeshId{1});
+    EXPECT_EQ(host_ranks_mesh1, MeshContainer<HostRankId>(MeshShape(1, 1), {HostRankId(0)}));
+
+    // Each mesh has a 2x2 board topology
+    EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{0}), MeshShape(2, 2));
+    EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{1}), MeshShape(2, 2));
+
+    // Since there's only one host rank per mesh, mesh shape should be same
+    EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{0}, HostRankId(0)), MeshShape(2, 2));
+    EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{1}, HostRankId(0)), MeshShape(2, 2));
+
+    // Check coordinate ranges
+    EXPECT_EQ(mesh_graph->get_coord_range(MeshId{0}), MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
+    EXPECT_EQ(mesh_graph->get_coord_range(MeshId{1}), MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
+
+    // Since each mesh has only one host rank, the coord range should be the same
+    EXPECT_EQ(
+        mesh_graph->get_coord_range(MeshId{0}, HostRankId(0)),
+        MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
+    EXPECT_EQ(
+        mesh_graph->get_coord_range(MeshId{1}, HostRankId(0)),
+        MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
+
+    // Check chip IDs - each mesh has 4 chips (2x2)
+    EXPECT_EQ(
+        mesh_graph->get_chip_ids(MeshId{0}),
+        MeshContainer<chip_id_t>(MeshShape(2, 2), std::vector<chip_id_t>{0, 1, 2, 3}));
+    EXPECT_EQ(
+        mesh_graph->get_chip_ids(MeshId{1}),
+        MeshContainer<chip_id_t>(MeshShape(2, 2), std::vector<chip_id_t>{0, 1, 2, 3}));
+
+    // Check chip IDs per host rank
+    EXPECT_EQ(
+        mesh_graph->get_chip_ids(MeshId{0}, HostRankId(0)),
+        MeshContainer<chip_id_t>(MeshShape(2, 2), std::vector<chip_id_t>{0, 1, 2, 3}));
+    EXPECT_EQ(
+        mesh_graph->get_chip_ids(MeshId{1}, HostRankId(0)),
+        MeshContainer<chip_id_t>(MeshShape(2, 2), std::vector<chip_id_t>{0, 1, 2, 3}));
+}
+
 }  // namespace tt::tt_fabric::fabric_router_tests

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -204,7 +204,6 @@ TEST(MeshGraphValidation, TestT3kDualHostMeshGraph) {
     auto mesh_graph = std::make_unique<tt_fabric::MeshGraph>(t3k_dual_host_mesh_graph_desc_path.string());
 
     EXPECT_THAT(mesh_graph->get_mesh_ids(), ElementsAre(MeshId{0}));
-    EXPECT_EQ(mesh_graph->get_mesh_shape(MeshId{0}), MeshShape(2, 4));
 
     // Check host ranks by accessing the values vector
     const auto& host_ranks = mesh_graph->get_host_ranks(MeshId{0});
@@ -233,8 +232,6 @@ TEST(MeshGraphValidation, TestT3kDualHostMeshGraph) {
     EXPECT_EQ(
         mesh_graph->get_chip_ids(MeshId{0}, HostRankId(1)),
         MeshContainer<chip_id_t>(MeshShape(2, 2), std::vector<chip_id_t>{2, 3, 6, 7}));
-
-    mesh_graph->print_connectivity();
 }
 
 }  // namespace tt::tt_fabric::fabric_router_tests

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -152,7 +152,7 @@ public:
 private:
     std::unique_ptr<RoutingTableGenerator> routing_table_generator_;
     // Host rank to sub mesh shape
-    std::unordered_map<uint32_t, std::vector<MeshCoordinate>> host_rank_to_sub_mesh_shape_;
+    std::unordered_map<HostRankId, std::vector<MeshCoordinate>> host_rank_to_sub_mesh_shape_;
     std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane_;
 
     std::string mesh_graph_desc_file_;

--- a/tt_metal/api/tt-metalium/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/fabric_types.hpp
@@ -22,5 +22,6 @@ enum class FabricConfig : uint32_t {
 namespace tt::tt_fabric {
 
 using MeshId = tt::stl::StrongType<uint32_t, struct MeshIdTag>;
+using HostRankId = tt::stl::StrongType<uint32_t, struct HostRankTag>;
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -123,6 +123,9 @@ public:
     const MeshCoordinate& start_coord() const;
     const MeshCoordinate& end_coord() const;
 
+    // Returns the shape of the coordinate range (dimensions).
+    MeshShape shape() const;
+
     // Returns true if the range contains the given coordinate.
     bool contains(const MeshCoordinate& coord) const;
 

--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -86,7 +86,7 @@ public:
 
     // Get the host ranks for a given mesh_id
     // Returned MeshContainer has a shape denoting the shape of how the "board" are arranged
-    const MeshContainer<HostRankId>& get_host_ranks(MeshId mesh_id) const { return mesh_host_ranks_[*mesh_id]; }
+    const MeshContainer<HostRankId>& get_host_ranks(MeshId mesh_id) const;
 
     // Get the shape of the mesh, or the shape of the submesh for a given host rank if provided
     MeshShape get_mesh_shape(MeshId mesh_id, std::optional<HostRankId> host_rank = std::nullopt) const;

--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -104,6 +104,10 @@ public:
     // Get the host rank that owns a given chip in a mesh
     std::optional<HostRankId> get_host_rank_for_chip(MeshId mesh_id, chip_id_t chip_id) const;
 
+    // Translation functions for chip_id and coordinate using RM-convention
+    MeshCoordinate chip_to_coordinate(MeshId mesh_id, chip_id_t chip_id) const;
+    chip_id_t coordinate_to_chip(MeshId mesh_id, MeshCoordinate coordinate) const;
+
 private:
     std::unordered_map<chip_id_t, RouterEdge> get_valid_connections(
         chip_id_t src_chip_id, std::uint32_t row_size, std::uint32_t num_chips_in_mesh, FabricType fabric_type) const;
@@ -117,7 +121,7 @@ private:
         RoutingDirection port_direction);
 
     ChipSpec chip_spec_;
-    std::unordered_map<MeshId, MeshContainer<chip_id_t>> mesh_to_chip_ids_;
+    std::map<MeshId, MeshContainer<chip_id_t>> mesh_to_chip_ids_;
     IntraMeshConnectivity intra_mesh_connectivity_;
     InterMeshConnectivity inter_mesh_connectivity_;
 

--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -17,9 +17,8 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
-#include <vector>
-#include <tt-metalium/fabric_types.hpp>
 
+#include <vector>
 namespace tt {
 enum class ARCH;
 }  // namespace tt

--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -18,6 +18,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <tt-metalium/fabric_types.hpp>
 
 namespace tt {
 enum class ARCH;
@@ -78,22 +79,30 @@ public:
 
     void print_connectivity() const;
 
-    const IntraMeshConnectivity& get_intra_mesh_connectivity() const { return intra_mesh_connectivity_; }
-    const InterMeshConnectivity& get_inter_mesh_connectivity() const { return inter_mesh_connectivity_; }
+    const IntraMeshConnectivity& get_intra_mesh_connectivity() const;
+    const InterMeshConnectivity& get_inter_mesh_connectivity() const;
 
     const ChipSpec& get_chip_spec() const { return chip_spec_; }
 
-    // TODO: remove the ns/ew apis
-    std::uint32_t get_mesh_ns_size(MeshId mesh_id) const { return mesh_shapes_[*mesh_id].first; }
-    std::uint32_t get_mesh_ew_size(MeshId mesh_id) const { return mesh_shapes_[*mesh_id].second; }
-    MeshShape get_mesh_shape(MeshId mesh_id) const {
-        return MeshShape{mesh_shapes_[*mesh_id].first, mesh_shapes_[*mesh_id].second};
-    }
-    const MeshContainer<std::uint32_t>& get_host_ranks(MeshId mesh_id) const { return mesh_host_ranks_[*mesh_id]; }
-    const MeshCoordinateRange& get_host_rank_coord_range(MeshId mesh_id, std::uint32_t host_rank) const {
-        return host_rank_coord_ranges_[*mesh_id][host_rank];
-    }
-    const std::vector<MeshId>& get_mesh_ids() const { return mesh_ids_; }
+    // Get the host ranks for a given mesh_id
+    // Returned MeshContainer has a shape denoting the shape of how the "board" are arranged
+    const MeshContainer<HostRankId>& get_host_ranks(MeshId mesh_id) const { return mesh_host_ranks_[*mesh_id]; }
+
+    // Get the shape of the mesh, or the shape of the submesh for a given host rank if provided
+    MeshShape get_mesh_shape(MeshId mesh_id, std::optional<HostRankId> host_rank = std::nullopt) const;
+
+    // Get the coordinate range of the mesh, or the coordinate range of the submesh for a given host rank if provided
+    MeshCoordinateRange get_coord_range(MeshId mesh_id, std::optional<HostRankId> host_rank = std::nullopt) const;
+
+    std::vector<MeshId> get_mesh_ids() const;
+
+    // Get the chip ids for a given mesh_id
+    // If host_rank is provided, return the chip ids for the submesh for that host rank
+    // Otherwise, return the chip ids for the entire mesh
+    MeshContainer<chip_id_t> get_chip_ids(MeshId mesh_id, std::optional<HostRankId> host_rank = std::nullopt) const;
+
+    // Get the host rank that owns a given chip in a mesh
+    std::optional<HostRankId> get_host_rank_for_chip(MeshId mesh_id, chip_id_t chip_id) const;
 
 private:
     std::unordered_map<chip_id_t, RouterEdge> get_valid_connections(
@@ -108,11 +117,12 @@ private:
         RoutingDirection port_direction);
 
     ChipSpec chip_spec_;
-    std::vector<std::pair<std::uint32_t, std::uint32_t>> mesh_shapes_;
+    std::unordered_map<MeshId, MeshContainer<chip_id_t>> mesh_to_chip_ids_;
     IntraMeshConnectivity intra_mesh_connectivity_;
     InterMeshConnectivity inter_mesh_connectivity_;
-    std::vector<MeshId> mesh_ids_;
-    std::vector<MeshContainer<std::uint32_t>> mesh_host_ranks_;
-    std::vector<std::vector<MeshCoordinateRange>> host_rank_coord_ranges_;
+
+    // For distributed context, bookkeeping of host ranks and their shapes
+    std::vector<MeshContainer<HostRankId>> mesh_host_ranks_;
+    std::unordered_map<std::pair<MeshId, HostRankId>, MeshCoordinateRange, hash_pair> mesh_host_rank_coord_ranges_;
 };
 }  // namespace tt::tt_fabric

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -181,6 +181,14 @@ size_t MeshCoordinateRange::dims() const { return start_.dims(); }
 const MeshCoordinate& MeshCoordinateRange::start_coord() const { return start_; }
 const MeshCoordinate& MeshCoordinateRange::end_coord() const { return end_; }
 
+MeshShape MeshCoordinateRange::shape() const {
+    tt::stl::SmallVector<uint32_t> shape_dims;
+    for (size_t i = 0; i < dims(); ++i) {
+        shape_dims.push_back(end_[i] - start_[i] + 1);
+    }
+    return MeshShape(shape_dims);
+}
+
 bool MeshCoordinateRange::contains(const MeshCoordinate& coord) const {
     TT_FATAL(coord.dims() == dims(), "Coordinate dimensions do not match: {} != {}", coord.dims(), dims());
     for (int i = 0; i < coord.dims(); ++i) {

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -221,11 +221,11 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
             // Resize all variables that loop over mesh_ids
             this->intra_mesh_connectivity_.resize(*mesh_id + 1);
             this->inter_mesh_connectivity_.resize(*mesh_id + 1);
-            this->mesh_shapes_.resize(*mesh_id + 1);
-            this->mesh_host_ranks_.resize(*mesh_id + 1, MeshContainer<std::uint32_t>({}, {}));
-            this->host_rank_coord_ranges_.resize(*mesh_id + 1);
+            // Resize mesh_host_ranks_ by adding empty containers
+            while (this->mesh_host_ranks_.size() <= *mesh_id) {
+                this->mesh_host_ranks_.emplace_back(MeshShape{1, 1}, HostRankId{0});
+            }
             mesh_edge_ports_to_chip_id.resize(*mesh_id + 1);
-            this->mesh_ids_.push_back(mesh_id);
         }
         TT_FATAL(
             board_name_to_topology.find(mesh_board) != board_name_to_topology.end(),
@@ -238,24 +238,27 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
         std::uint32_t mesh_ns_size = mesh_board_ns_size * board_name_to_topology[mesh_board][0];
 
         std::uint32_t mesh_size = mesh_ew_size * mesh_ns_size;
-        this->mesh_shapes_[*mesh_id] = {mesh_ns_size, mesh_ew_size};
+        std::vector<chip_id_t> chip_ids(mesh_size);
+        std::iota(chip_ids.begin(), chip_ids.end(), 0);
+        this->mesh_to_chip_ids_.emplace(
+            *mesh_id, MeshContainer<chip_id_t>(MeshShape(mesh_ns_size, mesh_ew_size), chip_ids));
 
         // Fill in host ranks for Mesh
         TT_FATAL(
             mesh["host_ranks"].IsSequence() and mesh["host_ranks"].size() == mesh_board_ns_size,
             "MeshGraph: Expecting host_ranks to define a 2D array that matches topology");
 
-        std::vector<std::uint32_t> mesh_host_ranks_values;
+        std::vector<HostRankId> mesh_host_ranks_values;
         mesh_host_ranks_values.reserve(mesh_board_ns_size * mesh_board_ew_size);
 
         // Track the start and end coordinates of each host rank
-        std::unordered_map<std::uint32_t, std::pair<MeshCoordinate, MeshCoordinate>> host_rank_submesh_start_end_coords;
+        std::unordered_map<HostRankId, std::pair<MeshCoordinate, MeshCoordinate>> host_rank_submesh_start_end_coords;
         for (std::uint32_t i = 0; i < mesh_board_ns_size; i++) {
             TT_FATAL(
                 mesh["host_ranks"][i].IsSequence() and mesh["host_ranks"][i].size() == mesh_board_ew_size,
                 "MeshGraph: Expecting host_ranks to define a 2D array that matches topology");
             for (std::uint32_t j = 0; j < mesh_board_ew_size; j++) {
-                std::uint32_t host_rank = mesh["host_ranks"][i][j].as<std::uint32_t>();
+                HostRankId host_rank{mesh["host_ranks"][i][j].as<std::uint32_t>()};
                 if (host_rank_submesh_start_end_coords.find(host_rank) == host_rank_submesh_start_end_coords.end()) {
                     host_rank_submesh_start_end_coords.insert(
                         {host_rank, std::make_pair(MeshCoordinate(i, j), MeshCoordinate(i, j))});
@@ -266,18 +269,19 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
             }
         }
         // Fill in all host rank coordinate ranges
-        this->host_rank_coord_ranges_[*mesh_id].resize(mesh_host_ranks_values.size(), MeshCoordinateRange({}));
         for (const auto& [host_rank, coords] : host_rank_submesh_start_end_coords) {
-            this->host_rank_coord_ranges_[*mesh_id][host_rank] = MeshCoordinateRange(
-                MeshCoordinate(
-                    coords.first[0] * board_name_to_topology[mesh_board][0],
-                    coords.first[1] * board_name_to_topology[mesh_board][1]),
-                MeshCoordinate(
-                    (coords.second[0] + 1) * board_name_to_topology[mesh_board][0] - 1,
-                    (coords.second[1] + 1) * board_name_to_topology[mesh_board][1] - 1));
+            this->mesh_host_rank_coord_ranges_.emplace(
+                std::make_pair(*mesh_id, host_rank),
+                MeshCoordinateRange(
+                    MeshCoordinate(
+                        coords.first[0] * board_name_to_topology[mesh_board][0],
+                        coords.first[1] * board_name_to_topology[mesh_board][1]),
+                    MeshCoordinate(
+                        (coords.second[0] + 1) * board_name_to_topology[mesh_board][0] - 1,
+                        (coords.second[1] + 1) * board_name_to_topology[mesh_board][1] - 1)));
         }
         this->mesh_host_ranks_[*mesh_id] =
-            MeshContainer<std::uint32_t>(MeshShape(mesh_board_ns_size, mesh_board_ew_size), mesh_host_ranks_values);
+            MeshContainer<HostRankId>(MeshShape(mesh_board_ns_size, mesh_board_ew_size), mesh_host_ranks_values);
 
         // Fill in connectivity for Mesh
         this->intra_mesh_connectivity_[*mesh_id].resize(mesh_size);
@@ -297,6 +301,22 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
             ss << " " << std::setfill('0') << std::setw(2) << i;
         }
         log_debug(tt::LogFabric, "Mesh Graph: Mesh {} Logical Device Ids {}", *mesh_id, ss.str());
+        for (const auto& [key, coords] : this->mesh_host_rank_coord_ranges_) {
+            const auto& [current_mesh_id, host_rank] = key;
+            if (current_mesh_id == mesh_id) {
+                log_debug(
+                    tt::LogFabric,
+                    "Mesh Graph: Mesh {} Host Rank {} Start: {}, End: {}",
+                    *mesh_id,
+                    *host_rank,
+                    coords.start_coord(),
+                    coords.end_coord());
+                for (auto it = coords.begin(); it != coords.end(); ++it) {
+                    log_debug(
+                        tt::LogFabric, "\t{} -> Chip: {}", *it, this->mesh_to_chip_ids_.at(current_mesh_id).at(*it));
+                }
+            }
+        }
 
         // Get the edge ports of each mesh
         // North, start from NW corner
@@ -348,8 +368,6 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
 }
 
 void MeshGraph::print_connectivity() const {
-    // Print Connectivity
-
     std::stringstream ss;
     ss << " Mesh Graph:  Intra Mesh Connectivity: " << std::endl;
     for (uint32_t mesh_id_val = 0; mesh_id_val < this->intra_mesh_connectivity_.size(); mesh_id_val++) {
@@ -382,6 +400,90 @@ void MeshGraph::print_connectivity() const {
         }
     }
     log_debug(tt::LogFabric, "{}", ss.str());
+}
+
+MeshShape MeshGraph::get_mesh_shape(MeshId mesh_id, std::optional<HostRankId> host_rank) const {
+    if (host_rank.has_value()) {
+        return this->mesh_host_rank_coord_ranges_.at(std::make_pair(mesh_id, *host_rank)).shape();
+    }
+
+    return this->mesh_to_chip_ids_.at(mesh_id).shape();
+}
+
+MeshCoordinateRange MeshGraph::get_coord_range(MeshId mesh_id, std::optional<HostRankId> host_rank) const {
+    if (host_rank.has_value()) {
+        return this->mesh_host_rank_coord_ranges_.at(std::make_pair(mesh_id, *host_rank));
+    }
+    auto mesh_shape = this->mesh_to_chip_ids_.at(mesh_id).shape();
+    return MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(mesh_shape[0] - 1, mesh_shape[1] - 1));
+}
+
+const IntraMeshConnectivity& MeshGraph::get_intra_mesh_connectivity() const { return intra_mesh_connectivity_; }
+const InterMeshConnectivity& MeshGraph::get_inter_mesh_connectivity() const { return inter_mesh_connectivity_; }
+
+std::vector<MeshId> MeshGraph::get_mesh_ids() const {
+    std::vector<MeshId> mesh_ids;
+    mesh_ids.reserve(this->mesh_to_chip_ids_.size());
+    for (const auto& [mesh_id, _] : this->mesh_to_chip_ids_) {
+        mesh_ids.push_back(mesh_id);
+    }
+    return mesh_ids;
+}
+
+MeshContainer<chip_id_t> MeshGraph::get_chip_ids(MeshId mesh_id, std::optional<HostRankId> host_rank) const {
+    auto it = mesh_to_chip_ids_.find(mesh_id);
+    TT_FATAL(it != mesh_to_chip_ids_.end(), "MeshGraph: mesh_id {} not found", mesh_id);
+
+    if (!host_rank.has_value()) {
+        // Return the entire mesh
+        return it->second;
+    }
+
+    // Return submesh for the specific host rank
+    MeshCoordinateRange coord_range = get_coord_range(mesh_id, host_rank);
+    MeshShape submesh_shape(
+        coord_range.end_coord()[0] - coord_range.start_coord()[0] + 1,
+        coord_range.end_coord()[1] - coord_range.start_coord()[1] + 1);
+
+    std::vector<chip_id_t> submesh_chip_ids;
+    submesh_chip_ids.reserve(submesh_shape.mesh_size());
+
+    for (int ns = coord_range.start_coord()[0]; ns <= coord_range.end_coord()[0]; ns++) {
+        for (int ew = coord_range.start_coord()[1]; ew <= coord_range.end_coord()[1]; ew++) {
+            submesh_chip_ids.push_back(it->second.at(MeshCoordinate(ns, ew)));
+        }
+    }
+
+    return MeshContainer<chip_id_t>(submesh_shape, submesh_chip_ids);
+}
+
+std::optional<HostRankId> MeshGraph::get_host_rank_for_chip(MeshId mesh_id, chip_id_t chip_id) const {
+    auto it = mesh_to_chip_ids_.find(mesh_id);
+    if (it == mesh_to_chip_ids_.end()) {
+        return std::nullopt;
+    }
+
+    const auto& mesh_shape = it->second.shape();
+    const auto& host_ranks_container = mesh_host_ranks_[*mesh_id];
+
+    // Convert chip_id to mesh coordinates
+    int ns = chip_id / mesh_shape[1];
+    int ew = chip_id % mesh_shape[1];
+    MeshCoordinate chip_coord(ns, ew);
+
+    // Find which host rank owns this coordinate
+    for (const auto& [key, coord_range] : mesh_host_rank_coord_ranges_) {
+        if (key.first != mesh_id) {
+            continue;
+        }
+
+        if (chip_coord[0] >= coord_range.start_coord()[0] && chip_coord[0] <= coord_range.end_coord()[0] &&
+            chip_coord[1] >= coord_range.start_coord()[1] && chip_coord[1] <= coord_range.end_coord()[1]) {
+            return key.second;
+        }
+    }
+
+    return std::nullopt;
 }
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -478,7 +478,7 @@ std::optional<HostRankId> MeshGraph::get_host_rank_for_chip(MeshId mesh_id, chip
 
     // Find which host rank owns this coordinate
     for (const auto& [mesh_id_host_rank_pair, coord_range] : mesh_host_rank_coord_ranges_) {
-        if (mesh_id_host_rank_pair.first != mesh_id && chip_coord[0] >= coord_range.start_coord()[0] &&
+        if (mesh_id_host_rank_pair.first == mesh_id && chip_coord[0] >= coord_range.start_coord()[0] &&
             chip_coord[0] <= coord_range.end_coord()[0] && chip_coord[1] >= coord_range.start_coord()[1] &&
             chip_coord[1] <= coord_range.end_coord()[1]) {
             return mesh_id_host_rank_pair.second;

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -441,17 +441,13 @@ MeshContainer<chip_id_t> MeshGraph::get_chip_ids(MeshId mesh_id, std::optional<H
 
     // Return submesh for the specific host rank
     MeshCoordinateRange coord_range = get_coord_range(mesh_id, host_rank);
-    MeshShape submesh_shape(
-        coord_range.end_coord()[0] - coord_range.start_coord()[0] + 1,
-        coord_range.end_coord()[1] - coord_range.start_coord()[1] + 1);
+    MeshShape submesh_shape = coord_range.shape();
 
     std::vector<chip_id_t> submesh_chip_ids;
     submesh_chip_ids.reserve(submesh_shape.mesh_size());
 
-    for (int ns = coord_range.start_coord()[0]; ns <= coord_range.end_coord()[0]; ns++) {
-        for (int ew = coord_range.start_coord()[1]; ew <= coord_range.end_coord()[1]; ew++) {
-            submesh_chip_ids.push_back(it->second.at(MeshCoordinate(ns, ew)));
-        }
+    for (const auto& coord : coord_range) {
+        submesh_chip_ids.push_back(it->second.at(coord));
     }
 
     return MeshContainer<chip_id_t>(submesh_shape, submesh_chip_ids);
@@ -485,5 +481,7 @@ std::optional<HostRankId> MeshGraph::get_host_rank_for_chip(MeshId mesh_id, chip
 
     return std::nullopt;
 }
+
+const MeshContainer<HostRankId>& MeshGraph::get_host_ranks(MeshId mesh_id) const { return mesh_host_ranks_[*mesh_id]; }
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -69,7 +69,7 @@ void RoutingTableGenerator::generate_intramesh_routing_table(const IntraMeshConn
         MeshId mesh_id{mesh_id_val};
         for (chip_id_t src_chip_id = 0; src_chip_id < this->intra_mesh_table_[mesh_id_val].size(); src_chip_id++) {
             for (chip_id_t dst_chip_id = 0; dst_chip_id < this->intra_mesh_table_[mesh_id_val].size(); dst_chip_id++) {
-                int row_size = this->mesh_graph->get_mesh_ew_size(mesh_id);
+                int row_size = this->mesh_graph->get_mesh_shape(mesh_id)[1];
                 uint32_t src_x = src_chip_id / row_size;
                 uint32_t src_y = src_chip_id % row_size;
                 uint32_t dst_x = dst_chip_id / row_size;
@@ -182,8 +182,9 @@ void RoutingTableGenerator::generate_intermesh_routing_table(
     for (std::uint32_t src_mesh_id_val = 0; src_mesh_id_val < this->inter_mesh_table_.size(); src_mesh_id_val++) {
         MeshId src_mesh_id{src_mesh_id_val};
         auto paths = get_paths_to_all_meshes(src_mesh_id, inter_mesh_connectivity);
-        std::uint32_t ew_size = this->mesh_graph->get_mesh_ew_size(src_mesh_id);
-        std::uint32_t ns_size = this->mesh_graph->get_mesh_ns_size(src_mesh_id);
+        MeshShape mesh_shape = this->mesh_graph->get_mesh_shape(src_mesh_id);
+        std::uint32_t ns_size = mesh_shape[0];
+        std::uint32_t ew_size = mesh_shape[1];
         for (chip_id_t src_chip_id = 0; src_chip_id < this->inter_mesh_table_[src_mesh_id_val].size(); src_chip_id++) {
             for (std::uint32_t dst_mesh_id_val = 0; dst_mesh_id_val < this->inter_mesh_table_.size(); dst_mesh_id_val++) {
                 MeshId dst_mesh_id{dst_mesh_id_val};


### PR DESCRIPTION
### Ticket
None

### Problem description
- The existing MeshGraph APIs lacked usability support for multi-host mesh descriptors, making it hard to extract information to query which host rank controls specific mesh coordinates or retrieve host rank ranges for a given mesh.

### What's changed
- Introduced `HostRankId` strong type for type-safe host rank identification
- Refactored MeshGraph APIs to support multi-host configurations:
  - Changed `get_host_ranks()` to return `MeshContainer<HostRankId>` instead of `MeshContainer<uint32_t>`
  - Updated `get_mesh_shape()` to optionally return submesh shape for a specific host rank
  - Added `get_coord_range()` to get coordinate ranges for entire mesh or specific host rank
  - Added `get_chip_ids()` to retrieve chip IDs for a mesh or host rank submesh
  - Added `get_host_rank_for_chip()` to find which host rank owns a specific chip
- Removed deprecated `get_mesh_ns_size()` and `get_mesh_ew_size()` APIs
- Introduced `HostRankId` strong type for type-safe host rank identification
- Added dual host T3K mesh graph descriptor as reference implementation

### Checklist
- [x] All post commit: https://github.com/tenstorrent/tt-metal/actions/runs/15438835285, https://github.com/tenstorrent/tt-metal/actions/runs/15502282289
- [x] T3K Unit Tests: https://github.com/tenstorrent/tt-metal/actions/runs/15438841258