### PR TITLE
Llama70b TG - Update 1L perf targets

### DIFF
--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -33,9 +33,9 @@ TSU_PERF_DROP_LIMIT_COUNT = 20
 
 # Constants for TSU thresholds based on the number of layers
 TSU_THRESHOLDS = {
-    "4U": {1: {"min": 530, "max": 555}, 10: {"min": 230, "max": 253}, 80: {"min": 49.5, "max": 54}},
+    "4U": {1: {"min": 540, "max": 565}, 10: {"min": 230, "max": 253}, 80: {"min": 49.5, "max": 54}},
     # TODO: Update thresholds for 6U 10L and 80L based on actual perf when 6U are available and added into CI
-    "6U": {1: {"min": 600, "max": 635}, 10: {"min": 230, "max": 250}, 80: {"min": 49, "max": 53}},
+    "6U": {1: {"min": 625, "max": 655}, 10: {"min": 230, "max": 250}, 80: {"min": 49, "max": 53}},
 }
 
 


### PR DESCRIPTION
Update 1L demo_decode perf targets
4U: [530-555] -> [540-565]
6U: [600-635] -> [625-655]

### Checklist
- [x] [Galaxy Quick](https://github.com/tenstorrent/tt-metal/actions/runs/15439636788)