### PR TITLE
Reduce L1 small by implementing reader indices segments

### DIFF
--- a/models/demos/yolov4/tt/model_preprocessing.py
+++ b/models/demos/yolov4/tt/model_preprocessing.py
@@ -233,7 +233,7 @@ def _create_ds2_model_parameters(conv_args):
     conv_args.c1["enable_split_reader"] = True
     conv_args.c1["enable_act_double_buffer"] = True
     conv_args.c1["deallocate_activation"] = True
-    conv_args.c1["reshard_if_not_optimal"] = False
+    conv_args.c1["reshard_if_not_optimal"] = True
     conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
 
     conv_args.c2["act_block_h"] = None

--- a/models/demos/yolov4/tt/model_preprocessing.py
+++ b/models/demos/yolov4/tt/model_preprocessing.py
@@ -233,7 +233,7 @@ def _create_ds2_model_parameters(conv_args):
     conv_args.c1["enable_split_reader"] = True
     conv_args.c1["enable_act_double_buffer"] = True
     conv_args.c1["deallocate_activation"] = True
-    conv_args.c1["reshard_if_not_optimal"] = True
+    conv_args.c1["reshard_if_not_optimal"] = False
     conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
 
     conv_args.c2["act_block_h"] = None

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -38,7 +38,7 @@ def test_unet_model(batch, groups, device, iterations, use_program_cache, reset_
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1415.0),),
+    ((1, 4, 1425.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_perf.py::test_unet_model"

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -971,7 +971,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
         conv_reader_indices_tensor, parallel_config, is_block_sharded, a.device());
 
-    const DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
+    const optimized_conv_op_utils::DeviceStorage& conv_reader_indices_storage =
+        conv_reader_indices_tensor.device_storage();
 
     log_debug(LogOp, "total_num_cores_per_weight_slice: {}", total_num_cores_per_weight_slice);
     log_debug(LogOp, "num_blocks_act_h_per_core: {}", num_blocks_act_h_per_core);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -31,7 +31,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     const Tensor& b,
     const ttnn::Shape& ashape,
     std::optional<const Tensor> bias,
-    const std::optional<const Tensor>& conv_reader_indices,
     const sliding_window::SlidingWindowConfig& sliding_window_config,
     uint32_t output_channels,
     uint32_t groups,
@@ -674,14 +673,38 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         2 * act_block_w_ntiles,
         act_tile_size);
 
-    auto conv_reader_indices_storage = conv_reader_indices.value().device_storage();
+    ttnn::operations::sliding_window::ParallelConfig parallel_config;
+    parallel_config.grid = a.shard_spec().value().grid;
+    parallel_config.shard_scheme = a.memory_config().memory_layout();
+    parallel_config.shard_orientation = a.shard_spec().value().orientation;
+    auto pad_metadata = ttnn::operations::sliding_window::generate_pad_metadata(sliding_window_config);
+    auto op_trace_metadata = ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
+    auto shard_boundaries =
+        ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config, op_trace_metadata);
+
+    auto conv_sharded_input_top_left_indices = ttnn::operations::sliding_window::generate_sliding_window_op_config(
+        op_trace_metadata, shard_boundaries, stride_w, true, act_block_h_datums, 0);
+
+    // create sharded ttnn config tensors
+    optimized_conv_op_utils::DataType indices_tt_dtype = optimized_conv_op_utils::DataType::UINT16;
+    // For 2d convs, each core in a column or row share the same specs
+    CoreCoord grid_size = parallel_config.grid.bounding_box().grid_size();
+
+    bool is_block_sharded =
+        a.memory_config().memory_layout() == optimized_conv_op_utils::TensorMemoryLayout::BLOCK_SHARDED;
+    auto conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
+        conv_sharded_input_top_left_indices, parallel_config);
+    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
+        conv_reader_indices_tensor, parallel_config, is_block_sharded, a.device());
+
+    auto conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
 
     cb_indices.cb_for_reader_indices = cb_indices.get_next_cb_index();
     tt::tt_metal::create_cb(
         cb_indices.cb_for_reader_indices,
         program,
         all_cores,
-        out_block_h_datums * 2,
+        conv_sharded_input_top_left_indices[0].size(),
         1,
         tt::DataFormat::Float16_b,
         conv_reader_indices_storage.get_buffer());
@@ -793,7 +816,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     };
 
     activation_kernel_compile_args = {
-        (uint32_t)stride_h,
         (uint32_t)stride_w,
         (uint32_t)dilation_h,
         (uint32_t)dilation_w,
@@ -816,7 +838,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         (uint32_t)output_num_cores,
         (uint32_t)all_reader_cores.size(),
         (uint32_t)cb_indices.act_cb,
-        (uint32_t)cb_indices.weight_cb,
         (uint32_t)cb_indices.sharded_act_cb,
         (uint32_t)cb_indices.cb_for_reader_indices,
         (uint32_t)cb_indices.cb_for_l1_array,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -673,11 +673,11 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         2 * act_block_w_ntiles,
         act_tile_size);
 
-    ttnn::operations::sliding_window::ParallelConfig parallel_config;
-    parallel_config.grid = a.shard_spec().value().grid;
-    parallel_config.shard_scheme = a.memory_config().memory_layout();
-    parallel_config.shard_orientation = a.shard_spec().value().orientation;
-    auto pad_metadata = ttnn::operations::sliding_window::generate_pad_metadata(sliding_window_config);
+    ttnn::operations::sliding_window::ParallelConfig parallel_config{
+        .grid = a.shard_spec().value().grid,
+        .shard_scheme = a.memory_config().memory_layout(),
+        .shard_orientation = a.shard_spec().value().orientation};
+
     auto op_trace_metadata = ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
     auto shard_boundaries =
         ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config, op_trace_metadata);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -692,7 +692,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
         conv_reader_indices_tensor, parallel_config, is_block_sharded, a.device());
 
-    const DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
+    const optimized_conv_op_utils::DeviceStorage& conv_reader_indices_storage =
+        conv_reader_indices_tensor.device_storage();
 
     cb_indices.cb_for_reader_indices = cb_indices.get_next_cb_index();
     tt::tt_metal::create_cb(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -10,8 +10,8 @@
 #include "debug/dprint_pages.h"
 #endif
 
-constexpr uint32_t weight_size_h = get_compile_time_arg_val(6);
-constexpr uint32_t weight_size_w = get_compile_time_arg_val(7);
+constexpr uint32_t weight_size_h = get_compile_time_arg_val(5);
+constexpr uint32_t weight_size_w = get_compile_time_arg_val(6);
 // Only a part of the total channel depth (width) is used in one block.
 template <int window_height, int window_width>
 FORCE_INLINE void read_channels(
@@ -40,35 +40,32 @@ FORCE_INLINE void read_channels(
 }
 
 void kernel_main() {
-    constexpr uint32_t stride_h = get_compile_time_arg_val(0);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(1);
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(2);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(3);
-    constexpr uint32_t conv_act_size_w = get_compile_time_arg_val(4);
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(5);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(0);
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(1);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(2);
+    constexpr uint32_t conv_act_size_w = get_compile_time_arg_val(3);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(4);
+    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(7);
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(8);
+    constexpr uint32_t num_input_cores = get_compile_time_arg_val(9);
+    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(10);
+    constexpr uint32_t act_num_blocks_w = get_compile_time_arg_val(11);
+    const uint32_t act_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(12));
+    const uint32_t act_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(13));
+    constexpr uint32_t act_mcast_dest_noc_start_x = get_compile_time_arg_val(14);
+    constexpr uint32_t act_mcast_dest_noc_start_y = get_compile_time_arg_val(15);
+    constexpr uint32_t act_mcast_dest_noc_end_x = get_compile_time_arg_val(16);
+    constexpr uint32_t act_mcast_dest_noc_end_y = get_compile_time_arg_val(17);
+    constexpr uint32_t act_mcast_sender_size_bytes = get_compile_time_arg_val(18);
+    constexpr uint32_t num_output_cores = get_compile_time_arg_val(19);
+    constexpr uint32_t num_reader_cores = get_compile_time_arg_val(20);
 
-    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(8);
-    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(9);
-    constexpr uint32_t num_input_cores = get_compile_time_arg_val(10);
-    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(11);
-    constexpr uint32_t act_num_blocks_w = get_compile_time_arg_val(12);
-    const uint32_t act_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(13));
-    const uint32_t act_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(14));
-    constexpr uint32_t act_mcast_dest_noc_start_x = get_compile_time_arg_val(15);
-    constexpr uint32_t act_mcast_dest_noc_start_y = get_compile_time_arg_val(16);
-    constexpr uint32_t act_mcast_dest_noc_end_x = get_compile_time_arg_val(17);
-    constexpr uint32_t act_mcast_dest_noc_end_y = get_compile_time_arg_val(18);
-    constexpr uint32_t act_mcast_sender_size_bytes = get_compile_time_arg_val(19);
-    constexpr uint32_t num_output_cores = get_compile_time_arg_val(20);
-    constexpr uint32_t num_reader_cores = get_compile_time_arg_val(21);
-
-    constexpr uint32_t cb_id_act = get_compile_time_arg_val(22);
-    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(23);
-    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(24);
-    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(25);
-    constexpr uint32_t cb_l1_array = get_compile_time_arg_val(26);
-    constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(27);
-    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(28);
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(21);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(22);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
+    constexpr uint32_t cb_l1_array = get_compile_time_arg_val(24);
+    constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(25);
+    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(26);
 
     constexpr uint32_t num_mcast_cores = num_input_cores > num_output_cores ? num_input_cores : num_output_cores;
     uint32_t i = 0;  // Runtime arg index
@@ -138,55 +135,64 @@ void kernel_main() {
 
     uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
     noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), conv_act_c_read_bytes);
+    uint32_t reader_idx = 0;
+    uint32_t l1_write_addr_act = 0;
 
     constexpr uint32_t TILE_HEIGHT = 32;
     constexpr uint32_t ntile_height = act_block_h_datums / TILE_HEIGHT;
-    constexpr uint32_t block_width = act_block_num_tiles / ntile_height;
-    constexpr uint32_t act_block_h_datums_per_tile_half = (act_block_h_datums / ntile_height) / 2;
+    constexpr uint32_t ntile_width = act_block_num_tiles / ntile_height;
 
     // Reset reader_idx to finish act_block_h_datums
     for (uint32_t block_h_index = 0; block_h_index < act_num_blocks_h; block_h_index++) {
         act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
+        uint32_t old_reader_idx = reader_idx;
         for (uint32_t block_w_index = 0; block_w_index < act_num_blocks_w; block_w_index++) {
-            uint32_t reader_idx = block_h_index * (act_block_h_datums / 2);
-
+            reader_idx = old_reader_idx;
             if (this_core_id < num_input_cores) {
-                for (uint32_t tile_h_index = 0; tile_h_index < ntile_height; tile_h_index++) {
-                    cb_reserve_back(cb_id_act_row_major_bfloat16, block_width);
-                    uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_row_major_bfloat16);
-                    for (uint32_t bh = 0; bh < act_block_h_datums_per_tile_half; bh++) {
-                        uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
+                uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
+                uint16_t num_elems = two_reader_indices & 0xffff;
+
+                uint16_t remaining_indexes = TILE_HEIGHT;
+                while (num_elems--) {
+                    reader_idx++;
+                    two_reader_indices = packed_reader_indices_ptr[reader_idx];
+                    uint16_t start_ind = two_reader_indices & 0xffff;
+                    uint16_t end_ind = two_reader_indices >> 16;
+                    for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
+                        if (remaining_indexes == TILE_HEIGHT) {
+                            l1_write_addr_act = get_write_ptr(cb_id_act_row_major_bfloat16);
+                            cb_reserve_back(cb_id_act_row_major_bfloat16, ntile_width);
+                        }
                         read_channels<weight_size_h, weight_size_w>(
                             l1_write_addr_act,
                             act_l1_read_addr,
-                            two_reader_indices & 0xffff,
-                            conv_act_c_bytes,
-                            conv_act_c_read_bytes,
-                            stride_h_bytes,
-                            stride_w_bytes);
-                        read_channels<weight_size_h, weight_size_w>(
-                            l1_write_addr_act,
-                            act_l1_read_addr,
-                            two_reader_indices >> 16,
+                            ind,
                             conv_act_c_bytes,
                             conv_act_c_read_bytes,
                             stride_h_bytes,
                             stride_w_bytes);
 
-                        reader_idx++;
+                        if (--remaining_indexes == 0) {
+                            noc_async_read_barrier();
+                            cb_push_back(cb_id_act_row_major_bfloat16, ntile_width);
+                            l1_write_addr_act = get_write_ptr(cb_id_act_row_major_bfloat16);
+                            remaining_indexes = TILE_HEIGHT;
+                        }
                     }
-
-                    noc_async_read_barrier();
-                    cb_push_back(cb_id_act_row_major_bfloat16, block_width);
                 }
+                if (remaining_indexes && remaining_indexes != TILE_HEIGHT) {
+                    noc_async_read_barrier();
+                    cb_push_back(cb_id_act_row_major_bfloat16, ntile_width);
+                }
+                reader_idx++;
 
                 // After reading one block, increment the starting read pointer by the width of the block.
                 // Next read uses the next set of channels.
                 act_l1_read_addr += conv_act_c_read_bytes;
             } else {
                 for (uint32_t tile_h_index = 0; tile_h_index < ntile_height; tile_h_index++) {
-                    cb_reserve_back(cb_id_act_row_major_bfloat16, block_width);
-                    cb_push_back(cb_id_act_row_major_bfloat16, block_width);
+                    cb_reserve_back(cb_id_act_row_major_bfloat16, ntile_width);
+                    cb_push_back(cb_id_act_row_major_bfloat16, ntile_width);
                 }
             }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp
@@ -38,14 +38,12 @@ FORCE_INLINE void read_sticks(
     uint32_t reader_offset,
     uint32_t& l1_write_addr_act,
     uint32_t& reader_idx) {
-    uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
-    uint32_t num_elems = two_reader_indices & 0xffff;
+    uint16_t num_elems = packed_reader_indices_ptr[reader_idx] & 0xffff;
 
     while (num_elems--) {
         reader_idx++;
-        two_reader_indices = packed_reader_indices_ptr[reader_idx];
-        uint16_t start_ind = two_reader_indices & 0xffff;
-        uint16_t end_ind = two_reader_indices >> 16;
+        uint16_t start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
+        uint16_t end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
 
         if constexpr (dilation_w == 1) {
             for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp
@@ -31,44 +31,39 @@ template <
     uint32_t conv_act_c_read_bytes,
     uint32_t act_block_w_extra_align_bytes,
     uint32_t stride_w_bytes,
-    uint32_t weight_size_w>
+    uint32_t weight_size_w,
+    uint32_t stride_w>
 FORCE_INLINE void read_sticks(
-    uint32_t act_block_h_datums_read_curr,
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr,
     uint32_t reader_offset,
     uint32_t& l1_write_addr_act,
     uint32_t& reader_idx) {
-    for (uint32_t bhd = 0; bhd < act_block_h_datums_read_curr; bhd++) {
-        // local read from reader_index + reader_offset;
-        uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
-        uint32_t reader_idx_1 = two_reader_indices & 0xffff;
-        uint32_t reader_idx_2 = two_reader_indices >> 16;
+    uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
+    uint32_t num_elems = two_reader_indices & 0xffff;
+
+    while (num_elems--) {
+        reader_idx++;
+        two_reader_indices = packed_reader_indices_ptr[reader_idx];
+        uint16_t start_ind = two_reader_indices & 0xffff;
+        uint16_t end_ind = two_reader_indices >> 16;
 
         if constexpr (dilation_w == 1) {
-            uint32_t act_l1_offset = reader_offset + (reader_idx_1 * conv_act_c_read_bytes);
-            noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
-            l1_write_addr_act += (coalesced_read_bytes + act_block_w_extra_align_bytes);
-
-            act_l1_offset = reader_offset + (reader_idx_2 * conv_act_c_read_bytes);
-            noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
-            l1_write_addr_act += (coalesced_read_bytes + act_block_w_extra_align_bytes);
+            for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
+                uint32_t act_l1_offset = reader_offset + (ind * conv_act_c_read_bytes);
+                noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
+                l1_write_addr_act += (coalesced_read_bytes + act_block_w_extra_align_bytes);
+            }
         } else {
-            uint32_t act_l1_offset = reader_offset + (reader_idx_1 * conv_act_c_read_bytes);
-            for (uint32_t inner = 0; inner < weight_size_w; inner++) {
-                noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
-                l1_write_addr_act += conv_act_c_read_bytes;
-                act_l1_offset += stride_w_bytes;
+            for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
+                uint32_t act_l1_offset = reader_offset + (ind * conv_act_c_read_bytes);
+                for (uint32_t inner = 0; inner < weight_size_w; inner++) {
+                    noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
+                    l1_write_addr_act += conv_act_c_read_bytes;
+                    act_l1_offset += stride_w_bytes;
+                }
+                l1_write_addr_act += act_block_w_extra_align_bytes;
             }
-            l1_write_addr_act += act_block_w_extra_align_bytes;
-
-            act_l1_offset = reader_offset + (reader_idx_2 * conv_act_c_read_bytes);
-            for (uint32_t inner = 0; inner < weight_size_w; inner++) {
-                noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
-                l1_write_addr_act += conv_act_c_read_bytes;
-                act_l1_offset += stride_w_bytes;
-            }
-            l1_write_addr_act += act_block_w_extra_align_bytes;
         }
-        reader_idx++;
     }
+    reader_idx++;
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -152,13 +152,11 @@ void kernel_main() {
         constexpr uint32_t stride_h_bytes = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
         constexpr uint32_t stride_w_bytes = conv_act_c_read_bytes * dilation_w;
 
-        uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
-        uint16_t num_elems = two_reader_indices & 0xffff;
+        uint16_t num_elems = packed_reader_indices_ptr[reader_idx] & 0xffff;
         while (num_elems--) {
             reader_idx++;
-            two_reader_indices = packed_reader_indices_ptr[reader_idx];
-            uint32_t start_ind = two_reader_indices & 0xffff;
-            uint32_t end_ind = two_reader_indices >> 16;
+            uint16_t start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
+            uint16_t end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
             for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
                 if constexpr (DILATION_W == 1) {
                     read_channels(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -63,9 +63,9 @@ constexpr uint32_t DILATION_W = get_compile_time_arg_val(1);
 void kernel_main() {
     constexpr uint32_t dilation_h = get_compile_time_arg_val(0);
     constexpr uint32_t dilation_w = get_compile_time_arg_val(1);
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(2);
-    constexpr uint32_t window_inner = get_compile_time_arg_val(4);
-    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(5);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(2);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t window_inner = get_compile_time_arg_val(5);
     constexpr uint32_t padded_conv_act_size_w = get_compile_time_arg_val(9);
     constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(10);
     constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(11);
@@ -77,12 +77,12 @@ void kernel_main() {
     const uint32_t act_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(17));
     constexpr uint32_t act_mcast_sender_size_bytes = get_compile_time_arg_val(18);
     constexpr bool transpose_mcast = get_compile_time_arg_val(19) == 1;
-    constexpr uint32_t cb_id_act = get_compile_time_arg_val(23);
-    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(24);
-    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(25);
-    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(26);
-    constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(27);
-    constexpr uint32_t cb_l1_array = get_compile_time_arg_val(28);
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(21);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(22);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
+    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(24);
+    constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(25);
+    constexpr uint32_t cb_l1_array = get_compile_time_arg_val(26);
 
     uint32_t i = 0;
     uint32_t noop = get_arg_val<uint32_t>(i);
@@ -130,7 +130,6 @@ void kernel_main() {
         act_mcast_dest_noc_start_x, act_mcast_dest_noc_start_y, act_mcast_dest_noc_end_x, act_mcast_dest_noc_end_y, 0);
 
     uint64_t act_mcast_receiver_semaphore_noc_addr = act_multicast_noc_addr | act_mcast_receiver_semaphore_addr;
-    constexpr uint32_t num_issued_reads_per_block = act_block_h_datums * window_inner;
 
     // TODO: need to make the read coalescing optimization cleaner
     // currently works for the case of num_coalesced_reads == weight_size_w since these reads are contiguous on both
@@ -153,49 +152,38 @@ void kernel_main() {
         constexpr uint32_t stride_h_bytes = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
         constexpr uint32_t stride_w_bytes = conv_act_c_read_bytes * dilation_w;
 
-        for (uint32_t bh = 0; bh < act_block_h_datums / 2; bh++) {
-            uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
-            if constexpr (DILATION_W == 1) {
-                read_channels(
-                    l1_write_addr_act,
-                    act_l1_read_addr,
-                    two_reader_indices & 0xffff,
-                    conv_act_c_read_bytes,
-                    coalesced_read_bytes,
-                    stride_h_bytes);
-                if constexpr (act_block_w_extra_align_bytes) {
-                    l1_write_addr_act += act_block_w_extra_align_bytes;
-                }
-                read_channels(
-                    l1_write_addr_act,
-                    act_l1_read_addr,
-                    two_reader_indices >> 16,
-                    conv_act_c_read_bytes,
-                    coalesced_read_bytes,
-                    stride_h_bytes);
-                if constexpr (act_block_w_extra_align_bytes) {
-                    l1_write_addr_act += act_block_w_extra_align_bytes;
-                }
-            } else {
-                read_dilated_channels<weight_size_h, weight_size_w>(
-                    l1_write_addr_act,
-                    act_l1_read_addr,
-                    two_reader_indices & 0xffff,
-                    conv_act_c_read_bytes,
-                    stride_h_bytes,
-                    stride_w_bytes);
-                read_dilated_channels<weight_size_h, weight_size_w>(
-                    l1_write_addr_act,
-                    act_l1_read_addr,
-                    two_reader_indices >> 16,
-                    conv_act_c_read_bytes,
-                    stride_h_bytes,
-                    stride_w_bytes);
-            }
+        uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
+        uint16_t num_elems = two_reader_indices & 0xffff;
+        while (num_elems--) {
             reader_idx++;
+            two_reader_indices = packed_reader_indices_ptr[reader_idx];
+            uint32_t start_ind = two_reader_indices & 0xffff;
+            uint32_t end_ind = two_reader_indices >> 16;
+            for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
+                if constexpr (DILATION_W == 1) {
+                    read_channels(
+                        l1_write_addr_act,
+                        act_l1_read_addr,
+                        ind,
+                        conv_act_c_read_bytes,
+                        coalesced_read_bytes,
+                        stride_h_bytes);
+                    if constexpr (act_block_w_extra_align_bytes) {
+                        l1_write_addr_act += act_block_w_extra_align_bytes;
+                    }
+                } else {
+                    read_dilated_channels<weight_size_h, weight_size_w>(
+                        l1_write_addr_act,
+                        act_l1_read_addr,
+                        ind,
+                        conv_act_c_read_bytes,
+                        stride_h_bytes,
+                        stride_w_bytes);
+                }
+            }
         }
-        // incrementing num issued in one shot is actually slower
-        // noc_async_read_inc_num_issued(num_issued_reads_per_block); // "false" on read
+        reader_idx++;
+
         noc_async_read_barrier();
         cb_push_back(cb_id_act_row_major_bfloat16, act_block_num_tiles);
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -4,31 +4,27 @@
 
 #include "dataflow_api.h"
 #include "height_sharded_reader_common.hpp"
+#include "dprint.h"
 
 void kernel_main() {
     constexpr uint32_t dilation_h = get_compile_time_arg_val(0);
     constexpr uint32_t dilation_w = get_compile_time_arg_val(1);
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(2);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(3);
     // need to have these as compile-time, they are inner loop bouds / unroll loops / constexpr conditionals based on
     // them
-    constexpr uint32_t window_outer = get_compile_time_arg_val(3);
-    constexpr uint32_t window_inner = get_compile_time_arg_val(4);
-    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(5);
+    constexpr uint32_t window_outer = get_compile_time_arg_val(4);
+    constexpr uint32_t window_inner = get_compile_time_arg_val(5);
     constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(6);
     constexpr uint32_t weight_size_w = get_compile_time_arg_val(8);
     constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(9);
     constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(10);
     constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(11);
-    constexpr uint32_t act_block_h_datums_last_block = get_compile_time_arg_val(20);
 
-    constexpr uint32_t act_block_h_datums_read_last_block =
-        act_block_h_datums_last_block > act_block_h_datums ? act_block_h_datums / 2 : act_block_h_datums_last_block / 2;
-    constexpr uint32_t act_block_h_datums_second_reader = get_compile_time_arg_val(21);
-    constexpr uint32_t act_block_h_datums_second_reader_read = act_block_h_datums_second_reader / 2;
-    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(22) == 1;
-    constexpr uint32_t cb_id_act = get_compile_time_arg_val(23);
-    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(24);
-    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(25);
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(20) == 1;
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(21);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(22);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
 
     uint32_t i = 0;
     uint32_t noop = get_arg_val<uint32_t>(i);
@@ -43,8 +39,6 @@ void kernel_main() {
     }
 
     constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
-
-    constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 2;  // Extra /2 because of packed uint16 reads
 
     // LOOP TO FILL READER INDICES
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
@@ -76,14 +70,10 @@ void kernel_main() {
     for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
         uint32_t reader_offset = act_l1_read_addr;
         for (uint32_t outer = 0; outer < window_outer; outer++) {
-            // Reset reader_idx to finish act_block_h_datums
             reader_idx = start_reader_idx;
 
             cb_reserve_back(cb_id_act, act_block_num_tiles);
             uint32_t l1_write_addr_act = get_write_ptr(cb_id_act);
-
-            uint32_t act_block_h_datums_read_curr =
-                bh == act_num_blocks_h - 1 ? act_block_h_datums_read_last_block : act_block_h_datums_read;
 
             read_sticks<
                 dilation_w,
@@ -91,8 +81,8 @@ void kernel_main() {
                 conv_act_c_read_bytes,
                 act_block_w_extra_align_bytes,
                 stride_w_bytes,
-                weight_size_w>(
-                act_block_h_datums_read_curr, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+                weight_size_w,
+                stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
 
             noc_async_read_barrier();
 
@@ -103,7 +93,8 @@ void kernel_main() {
 
         start_reader_idx = reader_idx;
 #ifdef SPLIT_READER
-        start_reader_idx += act_block_h_datums_second_reader_read;
+        // Increment reader index for the next number of segments (number of segments for other reader)
+        start_reader_idx += ((uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1);
 #endif
     }
     noc_async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -4,7 +4,6 @@
 
 #include "dataflow_api.h"
 #include "height_sharded_reader_common.hpp"
-#include "dprint.h"
 
 void kernel_main() {
     constexpr uint32_t dilation_h = get_compile_time_arg_val(0);
@@ -94,7 +93,7 @@ void kernel_main() {
         start_reader_idx = reader_idx;
 #ifdef SPLIT_READER
         // Increment reader index for the next number of segments (number of segments for other reader)
-        start_reader_idx += ((uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1);
+        start_reader_idx += (static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1);
 #endif
     }
     noc_async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
@@ -8,24 +8,21 @@
 
 // conv1D reader kernel
 void kernel_main() {
-    constexpr uint32_t LOCAL_PACKED_READER_INDICES_MAX_SIZE = 128;
-    uint32_t local_packed_reader_indices[LOCAL_PACKED_READER_INDICES_MAX_SIZE];
-
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(2);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(3);
     // need to have these as compile-time, they are inner loop bouds / unroll loops / constexpr conditionals based on
     // them
-    constexpr uint32_t window_outer = get_compile_time_arg_val(3);
-    constexpr uint32_t window_inner = get_compile_time_arg_val(4);
-    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(5);
+    constexpr uint32_t window_outer = get_compile_time_arg_val(4);
+    constexpr uint32_t window_inner = get_compile_time_arg_val(5);
     constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(6);
     constexpr uint32_t weight_size_h = get_compile_time_arg_val(7);
     constexpr uint32_t weight_size_w = get_compile_time_arg_val(8);
     constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(9);
     constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(10);
     constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(11);
-    constexpr uint32_t cb_id_act = get_compile_time_arg_val(23);
-    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(24);
-    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(25);
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(21);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(22);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
 
     uint32_t i = 0;
     uint32_t noop = get_arg_val<uint32_t>(i);
@@ -54,22 +51,11 @@ void kernel_main() {
         reader_offset += conv_act_size_w_padded;
     }
 
-#ifdef SPLIT_READER
-    constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 4;  // Extra /2 because of packed uint16 reads
-    constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles / 2;
-#else
-    constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 2;  // packed uint16 reads
-    constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles;
-#endif
-
     // LOOP TO FILL READER INDICES
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
 
     uint32_t reader_idx = 0;
-
-    // Copy packed reader indices to local memory for faster access
-    constexpr bool cache_packed_reader_indices = act_block_h_datums_read <= LOCAL_PACKED_READER_INDICES_MAX_SIZE;
 
     // TODO: need to make the read coalescing optimization cleaner
     // pass coalesce_window_inner_reads as a compile time arg and num_coalesced_reads so we can constexpr the if
@@ -81,147 +67,47 @@ void kernel_main() {
     constexpr uint32_t coalesced_read_bytes = num_coalesced_reads * conv_act_c_read_bytes;
     // the conditional selecting between coalescing and no-colescing must be constexpr to that compiler can optimized
     // the other path away this has shown to be a big perf win
-    static_assert(
-        act_block_h_datums % 2 ==
-        0);  // need to be even to read 2 in the body, due to packing of 2 indices in 1 uint32_t word
-    if constexpr (coalesce_window_inner_reads and window_inner == num_coalesced_reads) {
-        // coalesce reads along weight_size_w
-        reader_offset_idx = 0;
-        uint32_t act_l1_offset = 0;
-        uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
+    reader_offset_idx = 0;
+    uint32_t act_l1_offset = 0;
+    uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
 
-        // static_assert(coalesced_read_bytes <= NOC_MAX_BURST_SIZE);
-        //  set_state uses just x/y from the get_noc_addr, addr is ignored
-        noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
-        uint32_t start_reader_idx = 0;
-        for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
-#ifdef SPLIT_READER
-            if constexpr (cache_packed_reader_indices) {
-                for (uint32_t i = 0; i < act_block_h_datums_read; i++) {
-                    local_packed_reader_indices[i] = packed_reader_indices_ptr[start_reader_idx + i];
-                }
-            }
-#endif
-            for (uint32_t outer = 0; outer < window_outer; outer++) {
-                // Reset reader_idx to finish act_block_h_datums
-                reader_idx = start_reader_idx;
-
-                cb_reserve_back(cb_id_act, act_block_num_tiles_read);
-                uint32_t l1_write_addr_act = get_write_ptr(cb_id_act);
-                uint32_t reader_offset = act_l1_read_addr + (reader_offsets[reader_offset_idx] * conv_act_c_read_bytes);
-                // #pragma GCC unroll 4 // unroll didn't help, but act_block_h_datums (loop bound) being const does help
-                for (uint32_t bhd = 0; bhd < act_block_h_datums_read; bhd++) {
-// local read from reader_index + reader_offset;
-#ifdef SPLIT_READER
-                    uint32_t two_reader_indices = cache_packed_reader_indices ? local_packed_reader_indices[bhd]
-                                                                              : packed_reader_indices_ptr[reader_idx];
-#else  // no split reader
-                    uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
-#endif
-                    uint32_t reader_idx_1 = two_reader_indices & 0xffff;
-                    uint32_t reader_idx_2 = two_reader_indices >> 16;
-
-                    act_l1_offset = reader_offset + (reader_idx_1 * conv_act_c_read_bytes);
-                    // noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
-                    noc_async_read(get_noc_addr(act_l1_offset), l1_write_addr_act, coalesced_read_bytes);
-                    l1_write_addr_act += (coalesced_read_bytes + act_block_w_extra_align_bytes);
-
-                    act_l1_offset = reader_offset + (reader_idx_2 * conv_act_c_read_bytes);
-                    // noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
-                    noc_async_read(get_noc_addr(act_l1_offset), l1_write_addr_act, coalesced_read_bytes);
-                    l1_write_addr_act += (coalesced_read_bytes + act_block_w_extra_align_bytes);
-
-                    reader_idx++;
-                }
-                noc_async_read_barrier();
-                cb_push_back(cb_id_act, act_block_num_tiles_read);
-
-                reader_offset_idx += window_inner;
-            }
-            reader_offset_idx = 0;
-
-            start_reader_idx = reader_idx;
-#ifdef SPLIT_READER
-            start_reader_idx += act_block_h_datums_read;
-#endif
-        }
-
-    } else {
-        // NOTE: This code block expects reader_indices_ptr to be uint32_t (not packed uint16_t)
-        // Inner window dim is usually 3, so reading packed indices is complicated
-        // TODO: We could probably just remove this block is no convs use it
-
-        // no coalescing of reads
-        reader_offset_idx = 0;
-        uint32_t act_l1_offset = 0;
-        uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
-
-        // static_assert(conv_act_c_read_bytes <= NOC_MAX_BURST_SIZE);
-        //  set_state uses just x/y from the get_noc_addr, addr is ignored
-        noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), conv_act_c_read_bytes);
-
-        uint32_t start_reader_idx = 0;
-        for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
+    // static_assert(coalesced_read_bytes <= NOC_MAX_BURST_SIZE);
+    //  set_state uses just x/y from the get_noc_addr, addr is ignored
+    noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+    uint32_t start_reader_idx = 0;
+    for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
+        for (uint32_t outer = 0; outer < window_outer; outer++) {
             // Reset reader_idx to finish act_block_h_datums
             reader_idx = start_reader_idx;
+
             cb_reserve_back(cb_id_act, act_block_num_tiles);
             uint32_t l1_write_addr_act = get_write_ptr(cb_id_act);
-            for (uint32_t bhd = 0; bhd < act_block_h_datums; bhd++) {
-// when no read coalesing, main use case is window_inner == 1,
-// and if window_inner is const this loop should be removed by the compiler
-#ifdef SPLIT_READER
-                uint32_t packed_reader_idx = packed_reader_indices_ptr[reader_idx];
-                if constexpr (cache_packed_reader_indices) {
-                    local_packed_reader_indices[bhd] = packed_reader_idx;
-                }
-#else
-                uint32_t packed_reader_idx = packed_reader_indices_ptr[reader_idx];
-#endif
-                for (uint32_t inner = 0; inner < window_inner; inner++) {
-                    // local read from reader_index + reader_offset;
-                    act_l1_offset =
-                        act_l1_read_addr +
-                        ((packed_reader_idx + reader_offsets[reader_offset_idx + inner]) * conv_act_c_read_bytes);
-                    noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
-                    l1_write_addr_act += conv_act_c_read_bytes;
-                }
+            uint32_t reader_offset = act_l1_read_addr + (reader_offsets[reader_offset_idx] * conv_act_c_read_bytes);
+            // #pragma GCC unroll 4 // unroll didn't help, but act_block_h_datums (loop bound) being const does help
+            uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
+
+            uint16_t num_elems = two_reader_indices & 0xffff;
+
+            while (num_elems--) {
                 reader_idx++;
+                two_reader_indices = packed_reader_indices_ptr[reader_idx];
+
+                uint16_t start_ind = two_reader_indices & 0xffff;
+                uint16_t end_ind = two_reader_indices >> 16;
+
+                for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
+                    act_l1_offset = reader_offset + (ind * conv_act_c_read_bytes);
+                    noc_async_read(get_noc_addr(act_l1_offset), l1_write_addr_act, coalesced_read_bytes);
+                    l1_write_addr_act += (coalesced_read_bytes + act_block_w_extra_align_bytes);
+                }
             }
             noc_async_read_barrier();
             cb_push_back(cb_id_act, act_block_num_tiles);
 
-            reader_offset_idx += 3 * window_inner;
-            for (uint32_t outer = 1; outer < window_outer; outer++) {
-                // Reset reader_idx to finish act_block_h_datums
-                reader_idx = start_reader_idx;
-                cb_reserve_back(cb_id_act, act_block_num_tiles);
-                uint32_t l1_write_addr_act = get_write_ptr(cb_id_act);
-                for (uint32_t bhd = 0; bhd < act_block_h_datums; bhd++) {
-// when no read coalesing, main use case is window_inner == 1,
-// and if window_inner is const this loop should be removed by the compiler
-#ifdef SPLIT_READER
-                    uint32_t packed_reader_idx = cache_packed_reader_indices ? local_packed_reader_indices[bhd]
-                                                                             : packed_reader_indices_ptr[reader_idx];
-#else
-                    uint32_t packed_reader_idx = packed_reader_indices_ptr[reader_idx];
-#endif
-                    for (uint32_t inner = 0; inner < window_inner; inner++) {
-                        // local read from reader_index + reader_offset;
-                        act_l1_offset =
-                            act_l1_read_addr +
-                            ((packed_reader_idx + reader_offsets[reader_offset_idx + inner]) * conv_act_c_read_bytes);
-                        noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
-                        l1_write_addr_act += conv_act_c_read_bytes;
-                    }
-                    reader_idx++;
-                }
-                noc_async_read_barrier();
-                cb_push_back(cb_id_act, act_block_num_tiles);
-
-                reader_offset_idx += 3 * window_inner;
-            }
-            reader_offset_idx = 0;
-            start_reader_idx = reader_idx;
+            reader_offset_idx += window_inner;
         }
+        reader_offset_idx = 0;
+
+        start_reader_idx = reader_idx;
     }
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -22,24 +22,16 @@ void kernel_main() {
     constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(15);
 
     // Split reader args
-    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(17);
-    constexpr uint32_t split_reader = act_block_h_datums != 0;
+    constexpr bool split_reader = get_compile_time_arg_val(17);
     constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(18);
     constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(19);
     constexpr uint32_t weight_size_w = get_compile_time_arg_val(20);
     constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(21);
     constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(22);
-    constexpr uint32_t act_block_h_datums_first_reader = get_compile_time_arg_val(23);
-    constexpr uint32_t act_block_h_datums_last_block = get_compile_time_arg_val(24);
-    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(25) == 1;
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(26);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(27);
-
-    constexpr uint32_t act_block_h_datums_read_last_block =
-        act_block_h_datums_last_block > act_block_h_datums
-            ? (act_block_h_datums_last_block - act_block_h_datums_first_reader) / 2
-            : 0;
-    constexpr uint32_t act_block_h_datums_first_reader_read = act_block_h_datums_first_reader / 2;
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(23) == 1;
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(24);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(25);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(26);
 
     uint32_t i = 0;
     uint32_t noop = get_arg_val<uint32_t>(i++);
@@ -65,8 +57,6 @@ void kernel_main() {
     const uint64_t weights_mcast_sender_semaphore_noc_addr =
         get_noc_addr(weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, weights_mcast_sender_semaphore_addr);
 
-    constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 2;
-
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr;
     uint32_t reader_idx;
     if constexpr (split_reader) {
@@ -88,8 +78,7 @@ void kernel_main() {
     // coalesce reads along weight_size_w
     uint32_t start_reader_idx;
     if constexpr (split_reader) {
-        start_reader_idx = 0;
-        start_reader_idx = act_block_h_datums_first_reader / 2;
+        start_reader_idx = (uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
     }
     for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
         // MCAST RECEIVE WEIGHTS
@@ -105,20 +94,14 @@ void kernel_main() {
                 reader_idx = start_reader_idx;
                 cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
                 uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
-                uint32_t act_block_h_datums_read_curr =
-                    bh == out_num_blocks_h - 1 ? act_block_h_datums_read_last_block : act_block_h_datums_read;
                 read_sticks<
                     dilation_w,
                     coalesced_read_bytes,
                     conv_act_c_read_bytes,
                     act_block_w_extra_align_bytes,
                     stride_w_bytes,
-                    weight_size_w>(
-                    act_block_h_datums_read_curr,
-                    packed_reader_indices_ptr,
-                    reader_offset,
-                    l1_write_addr_act,
-                    reader_idx);
+                    weight_size_w,
+                    stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
 
@@ -161,8 +144,8 @@ void kernel_main() {
 #endif
 
         if constexpr (split_reader) {
-            // Increment reader index for next block in height dim
-            start_reader_idx = reader_idx + act_block_h_datums_first_reader_read;
+            // Increment reader index for the next number of segments (number of segments for other reader)
+            start_reader_idx = reader_idx + (uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
         }
     }  // out_num_blocks_h
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -145,7 +145,7 @@ void kernel_main() {
 
         if constexpr (split_reader) {
             // Increment reader index for the next number of segments (number of segments for other reader)
-            start_reader_idx = reader_idx + (uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+            start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
         }
     }  // out_num_blocks_h
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -29,24 +29,16 @@ void kernel_main() {
     constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(15);
 
     // Split reader args
-    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(17);
-    constexpr uint32_t split_reader = act_block_h_datums != 0;
+    constexpr bool split_reader = get_compile_time_arg_val(17);
     constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(18);
     constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(19);
     constexpr uint32_t weight_size_w = get_compile_time_arg_val(20);
     constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(21);
     constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(22);
-    constexpr uint32_t act_block_h_datums_first_reader = get_compile_time_arg_val(23);
-    constexpr uint32_t act_block_h_datums_last_block = get_compile_time_arg_val(24);
-    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(25) == 1;
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(26);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(27);
-
-    constexpr uint32_t act_block_h_datums_read_last_block =
-        act_block_h_datums_last_block > act_block_h_datums
-            ? (act_block_h_datums_last_block - act_block_h_datums_first_reader) / 2
-            : 0;
-    constexpr uint32_t act_block_h_datums_first_reader_read = act_block_h_datums_first_reader / 2;
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(23) == 1;
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(24);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(25);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(26);
 
     uint32_t i = 0;
     const uint32_t weight_addr_dram_base = get_arg_val<uint32_t>(i++);
@@ -76,8 +68,6 @@ void kernel_main() {
     const uint32_t weights_mcast_num_cores = get_arg_val<uint32_t>(i++);
     const uint32_t weights_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
     const uint32_t weights_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
-
-    constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 2;  // Extra /2 because of packed uint16 reads
 
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr;
     uint32_t reader_idx;
@@ -115,7 +105,6 @@ void kernel_main() {
     bool load_bias = true;
 #endif
     constexpr uint32_t weight_tile_nbytes = get_tile_size(cb_id_weight);
-    constexpr uint32_t tile_mcast_bytes = weight_tile_nbytes * weight_block_num_tiles;
     constexpr DataFormat weight_df = get_dataformat(cb_id_weight);
     const InterleavedAddrGenFast<true> s_weight = {
         .bank_base_address = weight_addr_dram_base, .page_size = weight_tile_nbytes, .data_format = weight_df};
@@ -132,8 +121,7 @@ void kernel_main() {
     // coalesce reads along weight_size_w
     uint32_t start_reader_idx;
     if constexpr (split_reader) {
-        start_reader_idx = 0;
-        start_reader_idx = act_block_h_datums_first_reader / 2;
+        start_reader_idx = (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1;
     }
 
     for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
@@ -153,20 +141,14 @@ void kernel_main() {
                 reader_idx = start_reader_idx;
                 cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
                 uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
-                uint32_t act_block_h_datums_read_curr =
-                    bh == out_num_blocks_h - 1 ? act_block_h_datums_read_last_block : act_block_h_datums_read;
                 read_sticks<
                     dilation_w,
                     coalesced_read_bytes,
                     conv_act_c_read_bytes,
                     act_block_w_extra_align_bytes,
                     stride_w_bytes,
-                    weight_size_w>(
-                    act_block_h_datums_read_curr,
-                    packed_reader_indices_ptr,
-                    reader_offset,
-                    l1_write_addr_act,
-                    reader_idx);
+                    weight_size_w,
+                    stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
 
@@ -302,7 +284,8 @@ void kernel_main() {
         }
 #endif
         if constexpr (split_reader) {
-            start_reader_idx = reader_idx + act_block_h_datums_first_reader_read;
+            // Increment reader index for the next number of segments (number of segments for other reader)
+            start_reader_idx = reader_idx + (uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
         }
     }  // out_num_blocks_h
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -285,7 +285,7 @@ void kernel_main() {
 #endif
         if constexpr (split_reader) {
             // Increment reader index for the next number of segments (number of segments for other reader)
-            start_reader_idx = reader_idx + (uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+            start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
         }
     }  // out_num_blocks_h
 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded.cpp
@@ -13,6 +13,100 @@
 #include "debug/dprint_pages.h"
 #endif
 
+template <
+    bool is_wide_reduction,
+    uint32_t in_nblocks_c,
+    uint32_t in_cb_id,
+    uint32_t npages_to_reserve,
+    uint32_t MAX_BYTES_PER_REDUCTION,
+    bool full_dest_width,
+    uint32_t in_nbytes_leftover,
+    uint32_t clear_value_cb_id,
+    uint32_t leftover_num_tiles,
+    uint32_t window_h,
+    uint32_t window_w,
+    uint32_t in_w_padded,
+    uint32_t in_nbytes_c>
+FORCE_INLINE void read_window_with_top_left_index(
+    uint64_t clear_value_addr, uint64_t in_l1_read_base_addr, uint64_t ind) {
+    if constexpr (is_wide_reduction) {
+        for (uint32_t c_i = 0; c_i < in_nblocks_c; ++c_i) {
+            cb_reserve_back(in_cb_id, npages_to_reserve);
+            uint32_t out_l1_write_addr = get_write_ptr(in_cb_id);
+
+            uint32_t read_bytes = MAX_BYTES_PER_REDUCTION;
+            if constexpr (!full_dest_width) {
+                if (c_i == in_nblocks_c - 1) {
+                    read_bytes = in_nbytes_leftover;
+                    clear_out_tiles<clear_value_cb_id, leftover_num_tiles>(out_l1_write_addr, clear_value_addr);
+                }
+            }
+
+            for (uint32_t h = 0; h < window_h; ++h) {
+                for (uint32_t w = 0; w < window_w; ++w) {
+                    const uint32_t stick_offset = ind + w + h * in_w_padded;
+                    const uint32_t read_offset =
+                        in_l1_read_base_addr + (stick_offset * in_nbytes_c + c_i * MAX_BYTES_PER_REDUCTION);
+                    noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, read_bytes);
+                    out_l1_write_addr += read_bytes;
+                }
+            }
+            noc_async_read_barrier();  // At this line, read is complete.
+
+            cb_push_back(in_cb_id, npages_to_reserve);
+        }
+    } else {
+        cb_reserve_back(in_cb_id, npages_to_reserve);
+        uint32_t out_l1_write_addr = get_write_ptr(in_cb_id);
+        uint32_t h_multiples = 0;
+        for (uint32_t h = 0; h < window_h; ++h, h_multiples += in_w_padded) {
+            const uint32_t stick_offset = ind + h_multiples;
+            const uint32_t read_offset = in_l1_read_base_addr + (stick_offset * in_nbytes_c);
+            noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, in_nbytes_c * window_w);
+            out_l1_write_addr += in_nbytes_c * window_w;
+        }
+        noc_async_read_barrier();
+        cb_push_back(in_cb_id, npages_to_reserve);
+    }
+}
+
+template <
+    bool one_scalar_per_core,
+    uint32_t in_scalar_cb_id,
+    uint32_t reader_nindices,
+    bool split_reader,
+    uint32_t TILE_WIDTH>
+FORCE_INLINE void fill_scalar(
+    uint32_t& scalar_start,
+    uint32_t& scalar_end,
+    uint32_t& scalar_value,
+    uint32_t& scalar_index,
+    uint32_t& counter,
+    volatile uint16_t* config_ptr) {
+    cb_reserve_back(in_scalar_cb_id, 1);
+    while ((counter >= scalar_end) && scalar_end != reader_nindices) {
+        scalar_start = scalar_end;
+        scalar_value = config_ptr[3 * scalar_index + 1];
+        scalar_end = config_ptr[3 * scalar_index + 2];
+        scalar_index++;
+    }
+    // We want to fill the scalar CB at most only the fisrt 2 times since the number of pages is 2, only for the
+    // intervals [x, y) where y >= x + 3 exactly 2 times and when y < x + 3 only once. When split reader is
+    // enabled counter takes even or odd values only depennding on the reader id so if the scalar start is even
+    // and counter is even it will fullfill the first half of the condition counter == scalar_start || counter
+    // == scalar_start + 2. When reader is even and scalar_start is odd or vice versa we will fullfill the
+    // second half of the condition counter == scalar_start + 1 || counter == scalar_start + 3.
+    if (counter < scalar_end && (counter == scalar_start || counter == scalar_start + 1 ||
+                                 (split_reader && (counter == scalar_start + 2 || counter == scalar_start + 3)))) {
+        fill_with_val(get_write_ptr(in_scalar_cb_id), TILE_WIDTH, scalar_value, false);
+    }
+    cb_push_back(in_scalar_cb_id, 1);
+    counter++;
+    if constexpr (split_reader) {
+        counter++;
+    }
+}
+
 /**
  * Pool 2D (Max pool 2D and Avg pool 2D)
  */
@@ -60,6 +154,7 @@ void kernel_main() {
     constexpr uint32_t config_cb_id = get_compile_time_arg_val(27);
     constexpr uint32_t in_scalar_cb_id =
         split_reader && reader_id == 1 && !one_scalar_per_core ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
+    constexpr uint32_t stride_w = get_compile_time_arg_val(31);
 
     constexpr uint32_t in_nbytes_leftover = (in_c % (TILE_WIDTH * MAX_TILES_PER_REDUCTION)) * BYTES_PER_DATUM;
 
@@ -92,10 +187,11 @@ void kernel_main() {
 
     const uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
     uint32_t reader_indices_l1_addr = get_read_ptr(in_reader_indices_cb_id);
-    volatile tt_l1_ptr uint16_t* reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint16_t*>(reader_indices_l1_addr);
+
     uint32_t config_l1_addr;
     volatile tt_l1_ptr uint16_t* config_ptr;
+    volatile tt_l1_ptr uint32_t* reader_indices_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_l1_addr);
 
     constexpr uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
     constexpr uint32_t is_wide_reduction = in_c > MAX_TILES_PER_REDUCTION * TILE_WIDTH;
@@ -110,74 +206,78 @@ void kernel_main() {
     }
 
     constexpr uint32_t npages_to_reserve = 1;
+
+    uint32_t segments_counter = 1;
     uint32_t counter = reader_id;
-    while (counter < reader_nindices) {
-        if constexpr (!one_scalar_per_core) {
-            cb_reserve_back(in_scalar_cb_id, 1);
-            while ((counter >= scalar_end) && scalar_end != reader_nindices) {
-                scalar_start = scalar_end;
-                scalar_value = config_ptr[3 * scalar_index + 1];
-                scalar_end = config_ptr[3 * scalar_index + 2];
-                scalar_index++;
-            }
-            // We want to fill the scalar CB at most only the fisrt 2 times since the number of pages is 2, only for the
-            // intervals [x, y) where y >= x + 3 exactly 2 times and when y < x + 3 only once. When split reader is
-            // enabled counter takes even or odd values only depennding on the reader id so if the scalar start is even
-            // and counter is even it will fullfill the first half of the condition counter == scalar_start || counter
-            // == scalar_start + 2. When reader is even and scalar_start is odd or vice versa we will fullfill the
-            // second half of the condition counter == scalar_start + 1 || counter == scalar_start + 3.
-            if (counter < scalar_end &&
-                (counter == scalar_start || counter == scalar_start + 1 ||
-                 (split_reader && (counter == scalar_start + 2 || counter == scalar_start + 3)))) {
-                fill_with_val(get_write_ptr(in_scalar_cb_id), TILE_WIDTH, scalar_value, false);
-            }
+    uint16_t num_segments = reader_indices_ptr[0] & 0xffff;
+    bool first_row_value = reader_id == 0;
+    uint32_t reader_indices_on_core = 0;
 
-            cb_push_back(in_scalar_cb_id, 1);
-        }
-        if constexpr (is_wide_reduction) {
-            const uint16_t top_left_local_index = reader_indices_ptr[counter++];
-            for (uint32_t c_i = 0; c_i < in_nblocks_c; ++c_i) {
-                cb_reserve_back(in_cb_id, npages_to_reserve);
-                uint32_t out_l1_write_addr = get_write_ptr(in_cb_id);
-
-                uint32_t read_bytes = MAX_BYTES_PER_REDUCTION;
-                if constexpr (!full_dest_width) {
-                    if (c_i == in_nblocks_c - 1) {
-                        read_bytes = in_nbytes_leftover;
-                        clear_out_tiles<clear_value_cb_id, leftover_num_tiles>(out_l1_write_addr, clear_value_addr);
-                    }
-                }
-
-                for (uint32_t h = 0; h < window_h; ++h) {
-                    for (uint32_t w = 0; w < window_w; ++w) {
-                        const uint32_t stick_offset = top_left_local_index + w + h * in_w_padded;
-                        const uint32_t read_offset =
-                            in_l1_read_base_addr + (stick_offset * in_nbytes_c + c_i * MAX_BYTES_PER_REDUCTION);
-                        noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, read_bytes);
-                        out_l1_write_addr += read_bytes;
-                    }
-                }
-                noc_async_read_barrier();  // At this line, read is complete.
-
-                cb_push_back(in_cb_id, npages_to_reserve);
-            }
+    if (split_reader) {
+        if (reader_id == 0) {
+            reader_indices_on_core = (reader_nindices + 1) / 2;
         } else {
-            cb_reserve_back(in_cb_id, npages_to_reserve);
-            uint32_t out_l1_write_addr = get_write_ptr(in_cb_id);
-            uint16_t top_left_local_index = reader_indices_ptr[counter++];
-            uint32_t h_multiples = 0;
-            for (uint32_t h = 0; h < window_h; ++h, h_multiples += in_w_padded) {
-                const uint32_t stick_offset = top_left_local_index + h_multiples;
-                const uint32_t read_offset = in_l1_read_base_addr + (stick_offset * in_nbytes_c);
-                noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, in_nbytes_c * window_w);
-                out_l1_write_addr += in_nbytes_c * window_w;
-            }
-            noc_async_read_barrier();
-            cb_push_back(in_cb_id, npages_to_reserve);
+            reader_indices_on_core = reader_nindices / 2;
+        }
+    } else {
+        reader_indices_on_core = reader_nindices;
+    }
+
+    while (num_segments--) {
+        uint32_t start_end_segment = reader_indices_ptr[segments_counter++];
+        uint16_t start = start_end_segment & 0xffff;
+        uint16_t end = start_end_segment >> 16;
+
+        if (!first_row_value) {
+            start += stride_w;
+            first_row_value = true;
         }
 
-        if constexpr (split_reader) {
-            counter++;  // interleave the indices
+        for (uint16_t ind = start; ind <= end; ind += 2 * stride_w) {
+            if constexpr (!one_scalar_per_core) {
+                fill_scalar<one_scalar_per_core, in_scalar_cb_id, reader_nindices, split_reader, TILE_WIDTH>(
+                    scalar_start, scalar_end, scalar_value, scalar_index, counter, config_ptr);
+            }
+            reader_indices_on_core--;
+            read_window_with_top_left_index<
+                is_wide_reduction,
+                in_nblocks_c,
+                in_cb_id,
+                npages_to_reserve,
+                MAX_BYTES_PER_REDUCTION,
+                full_dest_width,
+                in_nbytes_leftover,
+                clear_value_cb_id,
+                leftover_num_tiles,
+                window_h,
+                window_w,
+                in_w_padded,
+                in_nbytes_c>(clear_value_addr, in_l1_read_base_addr, ind);
+
+            if (split_reader && ind == end) {
+                first_row_value = false;
+            }
         }
+    }
+
+    while (reader_indices_on_core--) {
+        if constexpr (!one_scalar_per_core) {
+            fill_scalar<one_scalar_per_core, in_scalar_cb_id, reader_nindices, split_reader, TILE_WIDTH>(
+                scalar_start, scalar_end, scalar_value, scalar_index, counter, config_ptr);
+        }
+        read_window_with_top_left_index<
+            is_wide_reduction,
+            in_nblocks_c,
+            in_cb_id,
+            npages_to_reserve,
+            MAX_BYTES_PER_REDUCTION,
+            full_dest_width,
+            in_nbytes_leftover,
+            clear_value_cb_id,
+            leftover_num_tiles,
+            window_h,
+            window_w,
+            in_w_padded,
+            in_nbytes_c>(clear_value_addr, in_l1_read_base_addr, 0);
     }
 }  // kernel_main()

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded.cpp
@@ -213,8 +213,8 @@ void kernel_main() {
     bool first_row_value = reader_id == 0;
     uint32_t reader_indices_on_core = 0;
 
-    if (split_reader) {
-        if (reader_id == 0) {
+    if constexpr (split_reader) {
+        if constexpr (reader_id == 0) {
             reader_indices_on_core = (reader_nindices + 1) / 2;
         } else {
             reader_indices_on_core = reader_nindices / 2;
@@ -260,6 +260,7 @@ void kernel_main() {
         }
     }
 
+    // For the case when some core needs to process less indexes - send 0s to compute for the synchronization
     while (reader_indices_on_core--) {
         if constexpr (!one_scalar_per_core) {
             fill_scalar<one_scalar_per_core, in_scalar_cb_id, reader_nindices, split_reader, TILE_WIDTH>(

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_large_kernel_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_large_kernel_v2.cpp
@@ -9,10 +9,108 @@
 
 #define ENABLE_DEBUG_PRINT 0
 
-#if ENABLE_DEBUG_PRINT == 1
+#if ENABLE_DEBUG_PRINT == 0
 #include "debug/dprint.h"
 #include "debug/dprint_pages.h"
 #endif
+
+#define ALWI inline __attribute__((always_inline))
+
+// Fill an L1 buffer with the given val
+// WARNING: Use with caution as there's no memory protection. Make sure size is within limits
+template <
+    uint32_t in_nblocks_c,
+    uint32_t in_cb_id,
+    uint32_t window_h,
+    uint32_t window_w,
+    uint32_t in_w_padded,
+    uint32_t in_nbytes_c,
+    uint32_t MAX_ELE_PER_REDUCTION,
+    uint32_t read_bytes,
+    uint32_t max_rows_for_reduction,
+    uint32_t total_elems_to_reduce,
+    uint32_t remaining_elems,
+    uint32_t in_cb_sz,
+    uint32_t bf16_init_value,
+    bool is_avg_pool,
+    uint32_t clear_value_cb_id,
+    uint32_t in_cb_ntiles>
+FORCE_INLINE void read_window_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base_addr) {
+    for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
+        uint32_t processed_rows = 0;
+        cb_reserve_back(in_cb_id, 1);
+        uint32_t out_l1_write_addr = get_write_ptr(in_cb_id);
+        for (uint32_t h = 0; h < window_h; ++h) {
+            for (uint32_t w = 0; w < window_w; w++) {
+                const uint32_t stick_offset = ind + w + h * in_w_padded;
+                const uint32_t read_offset =
+                    in_l1_read_base_addr + (stick_offset * in_nbytes_c + c_i * MAX_ELE_PER_REDUCTION);
+                noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, read_bytes);
+                out_l1_write_addr += read_bytes;
+                processed_rows++;
+                if ((processed_rows % max_rows_for_reduction) == 0) {
+                    noc_async_read_barrier();
+                    cb_push_back(in_cb_id, 1);
+                    cb_reserve_back(in_cb_id, 1);
+                    out_l1_write_addr = get_write_ptr(in_cb_id);
+                    // If next is last chunk, fill whole buffer with the init_value. note for max pool we do
+                    // not need to fill the CB for the partial chunk since as long as we have N>1 chunks we
+                    // are guaranteed that the junk data remaining from chunk N-1 will fill the entire CB and
+                    // cannot contain values greater than the max value, and if we have N=1 chunks we already
+                    // initialized the entire CB with the init value, but for avg pool we need to fill the
+                    // entire CB with the init value since the junk data will contribute to the average.
+                    if constexpr (is_avg_pool) {
+                        if ((total_elems_to_reduce - processed_rows) < max_rows_for_reduction) {
+                            clear_out_tiles<clear_value_cb_id, in_cb_ntiles>(
+                                get_noc_addr(out_l1_write_addr), get_noc_addr(get_read_ptr(clear_value_cb_id)));
+                            }
+                    }
+                }
+            }
+        }
+        if (remaining_elems) {
+            noc_async_read_barrier();
+            cb_push_back(in_cb_id, 1);
+        }
+    }
+}
+
+template <
+    bool one_scalar_per_core,
+    uint32_t in_scalar_cb_id,
+    uint32_t reader_nindices,
+    bool split_reader,
+    uint32_t TILE_WIDTH>
+FORCE_INLINE void fill_scalar(
+    uint32_t& scalar_start,
+    uint32_t& scalar_end,
+    uint32_t& scalar_value,
+    uint32_t& scalar_index,
+    uint32_t& counter,
+    volatile uint16_t* config_ptr) {
+    cb_reserve_back(in_scalar_cb_id, 1);
+    while ((counter >= scalar_end) && scalar_end != reader_nindices) {
+        scalar_start = scalar_end;
+        scalar_value = config_ptr[3 * scalar_index + 1];
+        scalar_end = config_ptr[3 * scalar_index + 2];
+        scalar_index++;
+    }
+    // We want to fill the scalar CB at most only the fisrt 2 times since the number of pages is 2, only for the
+    // intervals [x, y) where y >= x + 3 exactly 2 times and when y < x + 3 only once. When split reader is
+    // enabled counter takes even or odd values only depennding on the reader id so if the scalar start is even
+    // and counter is even it will fullfill the first half of the condition counter == scalar_start || counter
+    // == scalar_start + 2. When reader is even and scalar_start is odd or vice versa we will fullfill the
+    // second half of the condition counter == scalar_start + 1 || counter == scalar_start + 3.
+    if (counter < scalar_end && (counter == scalar_start || counter == scalar_start + 1 ||
+                                 (split_reader && (counter == scalar_start + 2 || counter == scalar_start + 3)))) {
+        fill_with_val(get_write_ptr(in_scalar_cb_id), TILE_WIDTH, scalar_value, false);
+    }
+    cb_push_back(in_scalar_cb_id, 1);
+    counter++;
+    if constexpr (split_reader) {
+        counter++;
+    }
+}
 
 /**
  * Pool 2D (Max pool 2D and Avg pool 2D)
@@ -65,6 +163,7 @@ void kernel_main() {
 
     constexpr uint32_t in_scalar_cb_id =
         split_reader && reader_id == 1 && !one_scalar_per_core ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
+    constexpr uint32_t stride_w = get_compile_time_arg_val(31);
 
     uint32_t scalar_index = 0;
     uint32_t scalar_start = 0;
@@ -135,13 +234,14 @@ void kernel_main() {
 
     const uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
     uint32_t reader_indices_l1_addr = get_read_ptr(in_reader_indices_cb_id);
-    volatile tt_l1_ptr uint16_t* reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint16_t*>(reader_indices_l1_addr);
+    volatile tt_l1_ptr uint32_t* reader_indices_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_l1_addr);
     uint32_t config_l1_addr;
     volatile tt_l1_ptr uint16_t* config_ptr;
 
     constexpr uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
 
+    uint32_t segments_counter = 1;
     uint32_t counter = reader_id;
     constexpr uint32_t total_elems_to_reduce = window_h * window_w;
     constexpr bool wide_reduction = in_nblocks_c > 1;
@@ -157,70 +257,81 @@ void kernel_main() {
         scalar_index++;
     }
 
-    while (counter < reader_nindices) {
-        if constexpr (!one_scalar_per_core) {
-            cb_reserve_back(in_scalar_cb_id, 1);
-            while ((counter >= scalar_end) && scalar_end != reader_nindices) {
-                scalar_start = scalar_end;
-                scalar_value = config_ptr[3 * scalar_index + 1];
-                scalar_end = config_ptr[3 * scalar_index + 2];
-                scalar_index++;
-            }
-            // We want to fill the scalar CB at most only the fisrt 2 times since the number of pages is 2, only for the
-            // intervals [x, y) where y >= x + 3 exactly 2 times and when y < x + 3 only once. When split reader is
-            // enabled counter takes even or odd values only depennding on the reader id so if the scalar start is even
-            // and counter is even it will fullfill the first half of the condition counter == scalar_start || counter
-            // == scalar_start + 2. When reader is even and scalar_start is odd or vice versa we will fullfill the
-            // second half of the condition counter == scalar_start + 1 || counter == scalar_start + 3.
-            if (counter < scalar_end &&
-                (counter == scalar_start || counter == scalar_start + 1 ||
-                 (split_reader && (counter == scalar_start + 2 || counter == scalar_start + 3)))) {
-                fill_with_val(get_write_ptr(in_scalar_cb_id), TILE_WIDTH, scalar_value, false);
-            }
-            cb_push_back(in_scalar_cb_id, 1);
+    uint16_t num_segments = reader_indices_ptr[0] & 0xffff;
+    bool first_row_value = reader_id == 0;
+
+    uint32_t reader_indices_on_core = 0;
+
+    if (split_reader) {
+        if (reader_id == 0) {
+            reader_indices_on_core = (reader_nindices + 1) / 2;
+        } else {
+            reader_indices_on_core = reader_nindices / 2;
+        }
+    } else {
+        reader_indices_on_core = reader_nindices;
+    }
+
+    while (num_segments--) {
+        uint32_t start_end_segment = reader_indices_ptr[segments_counter++];
+        uint16_t start = start_end_segment & 0xffff;
+        uint16_t end = start_end_segment >> 16;
+
+        if (!first_row_value) {
+            start += stride_w;
+            first_row_value = true;
         }
 
-        for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
-            const uint16_t top_left_local_index = reader_indices_ptr[counter];
-            uint32_t processed_rows = 0;
-            cb_reserve_back(in_cb_id, 1);
-            uint32_t out_l1_write_addr = get_write_ptr(in_cb_id);
-            for (uint32_t h = 0; h < window_h; ++h) {
-                for (uint32_t w = 0; w < window_w; w++) {
-                    const uint32_t stick_offset = top_left_local_index + w + h * in_w_padded;
-                    const uint32_t read_offset =
-                        in_l1_read_base_addr + (stick_offset * in_nbytes_c + c_i * MAX_ELE_PER_REDUCTION);
-                    noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, read_bytes);
-                    out_l1_write_addr += read_bytes;
-                    processed_rows++;
-                    if ((processed_rows % max_rows_for_reduction) == 0) {
-                        noc_async_read_barrier();
-                        cb_push_back(in_cb_id, 1);
-                        cb_reserve_back(in_cb_id, 1);
-                        out_l1_write_addr = get_write_ptr(in_cb_id);
-                        // If next is last chunk, fill whole buffer with the init_value. note for max pool we do
-                        // not need to fill the CB for the partial chunk since as long as we have N>1 chunks we
-                        // are guaranteed that the junk data remaining from chunk N-1 will fill the entire CB and
-                        // cannot contain values greater than the max value, and if we have N=1 chunks we already
-                        // initialized the entire CB with the init value, but for avg pool we need to fill the
-                        // entire CB with the init value since the junk data will contribute to the average.
-                        if constexpr (is_avg_pool) {
-                            if ((total_elems_to_reduce - processed_rows) < max_rows_for_reduction) {
-                                clear_out_tiles<clear_value_cb_id, in_cb_ntiles>(
-                                    get_noc_addr(out_l1_write_addr), get_noc_addr(get_read_ptr(clear_value_cb_id)));
-                            }
-                        }
-                    }
-                }
+        for (uint16_t ind = start; ind <= end; ind += 2 * stride_w) {
+            if constexpr (!one_scalar_per_core) {
+                fill_scalar<one_scalar_per_core, in_scalar_cb_id, reader_nindices, split_reader, TILE_WIDTH>(
+                    scalar_start, scalar_end, scalar_value, scalar_index, counter, config_ptr);
             }
-            if (remaining_elems) {
-                noc_async_read_barrier();
-                cb_push_back(in_cb_id, 1);
+            reader_indices_on_core--;
+            read_window_with_top_left_index<
+                in_nblocks_c,
+                in_cb_id,
+                window_h,
+                window_w,
+                in_w_padded,
+                in_nbytes_c,
+                MAX_ELE_PER_REDUCTION,
+                read_bytes,
+                max_rows_for_reduction,
+                total_elems_to_reduce,
+                remaining_elems,
+                in_cb_sz,
+                bf16_init_value,
+                is_avg_pool,
+                clear_value_cb_id,
+                in_cb_ntiles>(ind, in_l1_read_base_addr);
+            if (split_reader && ind == end) {
+                first_row_value = false;
             }
         }
-        counter++;
-        if constexpr (split_reader) {
-            counter++;  // interleave the indices
+    }
+
+    while (reader_indices_on_core--) {
+        if constexpr (!one_scalar_per_core) {
+            fill_scalar<one_scalar_per_core, in_scalar_cb_id, reader_nindices, split_reader, TILE_WIDTH>(
+                scalar_start, scalar_end, scalar_value, scalar_index, counter, config_ptr);
         }
+        read_window_with_top_left_index<
+            in_nblocks_c,
+            in_cb_id,
+            window_h,
+            window_w,
+            in_w_padded,
+            in_nbytes_c,
+            MAX_ELE_PER_REDUCTION,
+            read_bytes,
+            max_rows_for_reduction,
+            total_elems_to_reduce,
+            remaining_elems,
+            in_cb_sz,
+            bf16_init_value,
+            is_avg_pool,
+            clear_value_cb_id,
+            in_cb_ntiles>(0, in_l1_read_base_addr);
     }
 }  // kernel_main()

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -237,6 +237,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     Program& program,
     const Tensor& input,
     const Tensor& reader_indices,
+    uint32_t reader_indices_size,
     Tensor& output,
     Pool2DType pool_type,
     uint32_t in_n,
@@ -393,7 +394,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     // reader indices
     const uint32_t in_reader_indices_cb_id = next_cb_index++;
     const uint32_t in_reader_indices_cb_pagesize =
-        tt::round_up(out_nhw_per_core * indices_nbytes, 4);  // pagesize needs to be multiple of 4
+        tt::round_up(reader_indices_size, 4);  // pagesize needs to be multiple of 4
     constexpr uint32_t in_reader_indices_cb_npages = 1;
 
     tt::tt_metal::create_cb(
@@ -556,7 +557,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         config_cb_id,
         multi_buffering_factor,
         sync_cb_id1,
-        sync_cb_id2};
+        sync_cb_id2,
+        stride_w};
     std::vector<uint32_t> reader1_ct_args = reader0_ct_args;
     reader1_ct_args[8] = 1;  // split reader id for reader1
 
@@ -711,17 +713,6 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
     uint32_t out_w = output_shape[2];
 
     bool is_block_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
-
-    auto pad_metadata = sliding_window::generate_pad_metadata(sliding_window_config);
-    auto op_trace_metadata = sliding_window::generate_op_trace_metadata(sliding_window_config);
-    auto shard_boundaries = sliding_window::generate_shard_boundaries(sliding_window_config, op_trace_metadata);
-    auto top_left_indices =
-        sliding_window::generate_sliding_window_op_config(op_trace_metadata, shard_boundaries, false, true);
-    auto reader_indices = sliding_window::construct_on_host_config_tensor(top_left_indices, parallel_config);
-    log_debug(tt::LogOp, "reader_indices shape: {}", reader_indices.logical_shape());
-    auto reader_indices_on_device =
-        sliding_window::move_config_tensor_to_device(reader_indices, parallel_config, is_block_sharded, input.device());
-
     auto in_n = sliding_window_config.batch_size;
     auto in_h = sliding_window_config.input_hw.first;
     auto in_w = sliding_window_config.input_hw.second;
@@ -738,10 +729,21 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
     auto dilation_w = sliding_window_config.dilation_hw.second;
     auto num_shards_c = sliding_window_config.num_cores_c;
 
+    auto pad_metadata = sliding_window::generate_pad_metadata(sliding_window_config);
+    auto op_trace_metadata = sliding_window::generate_op_trace_metadata(sliding_window_config);
+    auto shard_boundaries = sliding_window::generate_shard_boundaries(sliding_window_config, op_trace_metadata);
+    auto top_left_indices =
+        sliding_window::generate_sliding_window_op_config(op_trace_metadata, shard_boundaries, stride_w);
+
+    auto reader_indices = sliding_window::construct_on_host_config_tensor(top_left_indices, parallel_config);
+    auto reader_indices_on_device =
+        sliding_window::move_config_tensor_to_device(reader_indices, parallel_config, is_block_sharded, input.device());
+
     return pool2d_multi_core_sharded_with_halo_v2_impl_new(
         program,
         input,
         reader_indices_on_device,
+        top_left_indices[0].size(),
         output_tensor,
         pool_type,
         in_n,

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -729,7 +729,6 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
     auto dilation_w = sliding_window_config.dilation_hw.second;
     auto num_shards_c = sliding_window_config.num_cores_c;
 
-    auto pad_metadata = sliding_window::generate_pad_metadata(sliding_window_config);
     auto op_trace_metadata = sliding_window::generate_op_trace_metadata(sliding_window_config);
     auto shard_boundaries = sliding_window::generate_shard_boundaries(sliding_window_config, op_trace_metadata);
     auto top_left_indices =

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -1085,7 +1085,10 @@ std::tuple<std::vector<std::vector<std::vector<uint16_t>>>, int> generate_inplac
 std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
     const std::vector<uint32_t>& op_trace_metadata,
     const std::vector<ShardBoundary>& shard_boundaries,
-    bool pad_tile,
+    uint32_t stride_w,
+    bool has_act_block,
+    uint32_t reader0_datums,
+    uint32_t reader1_datums,
     bool pad_cores) {
     std::vector<std::vector<uint16_t>> sharded_input_top_left_indices;
     for (const auto& item : shard_boundaries) {
@@ -1098,24 +1101,58 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
             continue;
         }
         TT_ASSERT(input_shard_start == op_trace_metadata[output_shard_start]);
+        uint32_t datums_remaining = 0;
+        uint32_t last_relative_index = 0;
+        uint32_t num_segments = 0;
+        bool start_new_block = true;
+        uint32_t num_segments_ind = 0;
+        bool use_reader0 = true;
+        bool split_reader = reader1_datums > 0;
+
         for (size_t i = output_shard_start; i < output_shard_end + 1; i++) {
-            local_top_left_indices.push_back(op_trace_metadata[i] - op_trace_metadata[output_shard_start]);
+            const uint32_t relative_index = op_trace_metadata[i] - op_trace_metadata[output_shard_start];
+            if (start_new_block) {
+                if (!split_reader) {
+                    datums_remaining = reader0_datums;
+                } else {
+                    datums_remaining = use_reader0 ? reader0_datums : reader1_datums;
+                }
+                local_top_left_indices.push_back(0);  // number of segments, going to be replaced later
+                num_segments_ind = local_top_left_indices.size() - 1;
+                local_top_left_indices.push_back(0);  // empty value, used for 32B alignment
+                local_top_left_indices.push_back(relative_index);
+                start_new_block = false;
+            } else {
+                if (relative_index != last_relative_index + stride_w) {
+                    local_top_left_indices.push_back(last_relative_index);
+                    num_segments++;
+                    local_top_left_indices.push_back(relative_index);
+                }
+            }
+            datums_remaining--;
+            last_relative_index = relative_index;
+
+            if (!datums_remaining || i == output_shard_end) {  // end of block
+                local_top_left_indices.push_back(last_relative_index);
+                num_segments++;
+                local_top_left_indices[num_segments_ind] = num_segments;
+                num_segments = 0;
+                if (has_act_block) {
+                    start_new_block = true;
+                }
+                use_reader0 = !use_reader0;
+            }
         }
         sharded_input_top_left_indices.push_back(local_top_left_indices);
     }
-    if (pad_tile) {
-        // Pad indices to tile-multiple
-        for (size_t i = 0; i < sharded_input_top_left_indices.size(); i++) {
-            uint32_t extend_with_zeroes = (32 - sharded_input_top_left_indices[i].size() % 32) % 32;
-            if (extend_with_zeroes > 0) {
-                std::vector<uint16_t> extend_v(extend_with_zeroes, 0);
-                sharded_input_top_left_indices[i].insert(
-                    sharded_input_top_left_indices[i].end(), extend_v.begin(), extend_v.end());
-            }
+
+    uint32_t indices_length_per_core = sharded_input_top_left_indices[0].size();
+    for (uint32_t core_idx = 1; core_idx < shard_boundaries.size(); core_idx++) {
+        if (sharded_input_top_left_indices[core_idx].size() > indices_length_per_core) {
+            indices_length_per_core = sharded_input_top_left_indices[core_idx].size();
         }
     }
     if (pad_cores) {
-        uint32_t indices_length_per_core = sharded_input_top_left_indices[0].size();
         for (uint32_t core_idx = 0; core_idx < shard_boundaries.size(); core_idx++) {
             // Pad indices for this core if not equal to other cores
             if (sharded_input_top_left_indices.size() == core_idx) {

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -1086,7 +1086,7 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
     const std::vector<uint32_t>& op_trace_metadata,
     const std::vector<ShardBoundary>& shard_boundaries,
     uint32_t stride_w,
-    bool has_act_block,
+    bool is_conv,
     uint32_t reader0_datums,
     uint32_t reader1_datums,
     bool pad_cores) {
@@ -1137,7 +1137,7 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
                 num_segments++;
                 local_top_left_indices[num_segments_ind] = num_segments;
                 num_segments = 0;
-                if (has_act_block) {
+                if (is_conv) {
                     start_new_block = true;
                 }
                 use_reader0 = !use_reader0;

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -1148,12 +1148,22 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
 
     uint32_t indices_length_per_core = sharded_input_top_left_indices[0].size();
     for (uint32_t core_idx = 1; core_idx < shard_boundaries.size(); core_idx++) {
+        const auto& [output_shard_start, output_shard_end] = shard_boundaries[core_idx].output_range;
+        if (output_shard_start >= op_trace_metadata.size()) {
+            // this core has no output
+            continue;
+        }
         if (sharded_input_top_left_indices[core_idx].size() > indices_length_per_core) {
             indices_length_per_core = sharded_input_top_left_indices[core_idx].size();
         }
     }
     if (pad_cores) {
         for (uint32_t core_idx = 0; core_idx < shard_boundaries.size(); core_idx++) {
+            const auto& [output_shard_start, output_shard_end] = shard_boundaries[core_idx].output_range;
+            if (output_shard_start >= op_trace_metadata.size()) {
+                // this core has no output
+                continue;
+            }
             // Pad indices for this core if not equal to other cores
             if (sharded_input_top_left_indices.size() == core_idx) {
                 sharded_input_top_left_indices.push_back(std::vector<uint16_t>());

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -1098,6 +1098,7 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
         // sanity check
         if (output_shard_start >= op_trace_metadata.size()) {
             // this core has no output
+            sharded_input_top_left_indices.push_back(local_top_left_indices);
             continue;
         }
         TT_ASSERT(input_shard_start == op_trace_metadata[output_shard_start]);
@@ -1149,10 +1150,6 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
     uint32_t indices_length_per_core = sharded_input_top_left_indices[0].size();
     for (uint32_t core_idx = 1; core_idx < shard_boundaries.size(); core_idx++) {
         const auto& [output_shard_start, output_shard_end] = shard_boundaries[core_idx].output_range;
-        if (output_shard_start >= op_trace_metadata.size()) {
-            // this core has no output
-            continue;
-        }
         if (sharded_input_top_left_indices[core_idx].size() > indices_length_per_core) {
             indices_length_per_core = sharded_input_top_left_indices[core_idx].size();
         }
@@ -1160,10 +1157,6 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
     if (pad_cores) {
         for (uint32_t core_idx = 0; core_idx < shard_boundaries.size(); core_idx++) {
             const auto& [output_shard_start, output_shard_end] = shard_boundaries[core_idx].output_range;
-            if (output_shard_start >= op_trace_metadata.size()) {
-                // this core has no output
-                continue;
-            }
             // Pad indices for this core if not equal to other cores
             if (sharded_input_top_left_indices.size() == core_idx) {
                 sharded_input_top_left_indices.push_back(std::vector<uint16_t>());

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -148,8 +148,11 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
 std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
     const std::vector<uint32_t>& op_trace_metadata,
     const std::vector<ShardBoundary>& shard_boundaries,
-    bool pad_tile = false,
-    bool pad_cores = false);
+    uint32_t stride_w,
+    bool has_act_block = false,
+    uint32_t reader0_datums = 0,
+    uint32_t reader1_datums = 0,
+    bool pad_cores = true);
 
 std::vector<uint16_t> flatten(const std::vector<std::vector<uint16_t>>& input, uint32_t extend_with_zeroes = 0);
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -149,7 +149,8 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
     const std::vector<uint32_t>& op_trace_metadata,
     const std::vector<ShardBoundary>& shard_boundaries,
     uint32_t stride_w,
-    bool has_act_block = false,
+    bool is_conv =
+        false,  // In convs, we have the concept of dividing the act block (act_block_h_override and split reader)
     uint32_t reader0_datums = 0,
     uint32_t reader1_datums = 0,
     bool pad_cores = true);


### PR DESCRIPTION
### Ticket
#22017

### Problem description
The L1 small configuration is causing OOM issues in SDXL. Profiling revealed that the reader indices tensor is the primary contributor to memory usage.

### What's changed
The previous reader index format stored every single index explicitly, which led to a large memory footprint:
`ind0`, `ind1`, `ind2`, `ind3`, `ind4`, ... 

Switched to a compressed segment-based format for reader indices:
`num_segments`, `seg0_start`, `seg0_end`, `seg1_start`, `seg1_end`, ... (this reduces memory usage by storing ranges of contiguous indices instead of individual values)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15681743577)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15681770336) 
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/15681780876) - the pipeline is unstable; encountering the same error as on main branch
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15700407331) 
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15681807641) 
- [x] [Nightly tt-metal L2 tests WH](https://github.com/tenstorrent/tt-metal/actions/runs/15681817934)