### PR TITLE
Add operation accuracy measurement alternatives to `assert_with_pcc()`

### DIFF
--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -559,6 +559,46 @@ def comp_pcc(golden, calculated, pcc=0.99):
     return cal_pcc >= pcc, cal_pcc
 
 
+def ulp(x):
+    "Return Unit of Least Precision for each element of a given tensor"
+    max_value = torch.full(x.size(), torch.finfo(x.dtype).max, dtype=x.dtype)
+
+    # Notes:
+    # - This should be identical to the definition of ULP by Goldberg
+    #   "What every computer scientist should know about floating-point arithmetic"
+    #   https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
+    # - We use torch.abs(x) to ensure symmetry ULP(-x) == ULP(x)
+    # - For x powers of 2, x + ULP(x) is not closest number but second closest (previous number is 2x closer)
+    #   However, this avoids rounding-to-nearest-tie-to-even issues on addition (i.e. x + ULP(x) != x)
+    abs_x = torch.abs(x)
+    next = torch.nextafter(abs_x, max_value)  # 1 ULP ~ Difference between two consecutive floating point numbers
+    ulp_value = next - abs_x
+
+    return ulp_value
+
+
+def comp_ulp(golden, calculated, ulp_threshold):
+    """
+    Compute absolute error between two tensors in Units of Least Precision (ULP)
+    """
+
+    # ULP is measured according to the golden tensor
+    # In most cases, data type of golden tensor should be the same as calculated tensor.
+    # However, in some cases, we may want to measure < 1 ULP differences, which requires golden tensor
+    # to have higher precision than calculated tensor.
+    # If we passed golden tensor to ulp() as is, we would get ULP of higher precision.
+    # e.g. ulp of float32 rather bfloat16 calculation, which would give us a wrong value.
+    ulp_value = ulp(golden.type(calculated.dtype))
+
+    if golden.dtype != calculated.dtype:  # Note: assumes that golden has higher precision than calculated tensor
+        calculated = calculated.type(golden.dtype)
+        ulp_value = ulp_value.type(golden.dtype)  # Convert ULP to higher precision (for sub-1 ULP measurements)
+
+    ulp_delta = torch.max(torch.abs(calculated - golden) / ulp_value)
+
+    return (ulp_delta <= ulp_threshold, f"Max ULP Delta: {ulp_delta}")
+
+
 def comp_allclose_and_pcc(golden, calculated, rtol=1e-05, atol=1e-08, pcc=0.99):
     if golden.dtype != calculated.dtype:
         calculated = calculated.type(golden.dtype)

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -85,7 +85,7 @@ def assert_allclose(expected_pytorch_result, actual_pytorch_result, rtol=1e-05, 
 
      Two tensors are considered close if
      ``
-     |actual - expected| \leq atol \cdot rtol . |expected|
+     |actual - expected| \leq atol + rtol \cdot |expected|
      ``
 
     Args:
@@ -115,15 +115,26 @@ def assert_with_ulp(expected_pytorch_result, actual_pytorch_result, ulp_threshol
     """
     Assert that two PyTorch tensors are similar within a given distance expressed in Units of Least Precision (ULP)
 
+    The error is measured using the following formula:
+    ``
+        | expected - actual | / ULP(expected)
+    ``
+
+    Where ULP(expected) returns, for each element, the length of a single Unit of Least Precision (ULP).
+
+
     Args:
         expected_pytorch_result (torch.Tensor): The expected reference tensor
         actual_pytorch_result (torch.Tensor): The actual tensor to compare against the reference
         ulp_threshold (float, optional): Maximum tolerated ULP distance. Defaults to 10.
 
+    Note:
+        The length of a single ULP is measured using the difference between two consecutive floating point numbers.
+
     Returns:
         tuple: A tuple containing:
-            - allclose_passed (bool): True if ulp check passed, False otherwise
-            - allclose_message (str): A message describing comparison result
+            - ulp_passed (bool): True if ulp check passed, False otherwise
+            - ulp_message (str): A message describing comparison result
 
     Raises:
         AssertionError: If the tensor shapes don't match or if tensor difference is greater than ulp_threshold.


### PR DESCRIPTION
### Ticket
#22994 


### Problem description

Right now, `assert_with_pcc()` is inadequate for measuring operation accuracy and fails to detect several inaccurate functions. 
We would like to add alternatives to it, and thus improve our testing methodology.

### What's changed

This PR adds two alternatives to `assert_with_pcc()` for operation accuracy measurement:

- `assert_allclose()`: raise exception if `|golden - x| > atol + rtol * |golden|`
- `assert_with_ulp(golden, actual, ulp_threshold)`: raise exception if absolute difference expressed in [Units of Least Precision](https://en.wikipedia.org/wiki/Unit_in_the_last_place) is greater than `ulp_threshold`

On top of it, it adds the following helper functions:

- `ulp(tensor)`: compute ULP for each element
- `comp_ulp_error()`: ULP equivalent of other `comp_X` functions

(Note: `comp_allclose()` is already available)

Our definition ULP should be similar to the one proposed by Goldberge in "What every computer scientist should know about floating-point arithmetic".

It is not the only scheme ([other definitions of ULP exist](https://inria.hal.science/inria-00070503/en/)), but:
- it maintains symmetry (i.e. ULP(x) = ULP(-x))
- it's somewhat more mistake-proof: x + ULP(x) != x (ULP(x) keeps same data type as x). 
It does add a few edge cases on powers of 2: `for x = 2**n, x > 0, ULP(x) = |next(x) - x| = 2 * | prev(x) - x|` (i.e. x is closer to `prev(x)` than of `next(x)` )

ULP is meant to be used in cases where we want high precision (e.g. at most several ULPs of error), I picked a default tolerance value of 10 ULPs for `assert_with_ulp()`. 
For `assert_allclose()`, the default value is the same as `comp_allclose()`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes