### PR TITLE
#22442: Add int32 support for logical_not 

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ],
+)
+@pytest.mark.parametrize(
+    "low_a, high_a",
+    [
+        (-100, 100),
+        (-300, 300),
+        (-500, 500),
+        (-1000, 1000),
+        (-1e4, 1e4),
+        (2e9, 2077000000),  # large positive input
+        (-2147483647, -2e9),  # large negative input
+    ],
+)
+@pytest.mark.parametrize(
+    "logical_op",
+    [
+        ttnn.logical_not,
+    ],
+)
+def test_unary_logical_int32(input_shapes, low_a, high_a, logical_op, device):
+    num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
+    torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
+    torch_input_tensor_a[::5] = 0  # every 5th element is zero
+    torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(input_shapes).nan_to_num(0.0)
+
+    golden_function = ttnn.get_golden_function(logical_op)
+    torch_output_tensor = golden_function(torch_input_tensor_a, device=device)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    output_tensor = logical_op(input_tensor_a)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert torch.equal(output_tensor, torch_output_tensor)
+
+
+@pytest.mark.parametrize(
+    "logical_op",
+    [
+        ttnn.logical_not,
+    ],
+)
+def test_unary_logical_int32_edge_cases(logical_op, device):
+    torch_input_tensor_a = torch.tensor([0, 1, -1, 2147483647, -2147483647])
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(logical_op)
+    torch_output_tensor = golden_function(torch_input_tensor_a, device=device)
+
+    output_tensor = logical_op(input_tensor_a)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert torch.equal(output_tensor, torch_output_tensor)
+
+
+height_sharded_memory_config = ttnn.create_sharded_memory_config(
+    [128, 160],
+    core_grid=ttnn.CoreRangeSet({ttnn.CoreRange((1, 0), (1, 6)), ttnn.CoreRange((3, 0), (3, 6))}),
+    strategy=ttnn.ShardStrategy.HEIGHT,
+    orientation=ttnn.ShardOrientation.COL_MAJOR,
+    use_height_and_width_as_shard_shape=True,
+)
+
+width_sharded_memory_config = ttnn.create_sharded_memory_config(
+    [2240, 32],
+    core_grid=ttnn.CoreRangeSet({ttnn.CoreRange((2, 2), (2, 3)), ttnn.CoreRange((0, 0), (0, 1))}),
+    strategy=ttnn.ShardStrategy.WIDTH,
+    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    use_height_and_width_as_shard_shape=True,
+)
+
+block_sharded_memory_config = ttnn.create_sharded_memory_config(
+    [320, 32],
+    core_grid=ttnn.CoreRangeSet({ttnn.CoreRange((1, 0), (4, 6))}),
+    strategy=ttnn.ShardStrategy.BLOCK,
+    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    use_height_and_width_as_shard_shape=True,
+)
+
+
+@pytest.mark.parametrize(
+    "a_shape",
+    [(torch.Size([5, 7, 64, 128]))],
+)
+@pytest.mark.parametrize(
+    "sharded_config",
+    [
+        height_sharded_memory_config,
+        width_sharded_memory_config,
+        block_sharded_memory_config,
+    ],
+)
+@pytest.mark.parametrize(
+    "logical_op",
+    [
+        "logical_not",
+    ],
+)
+def test_unary_logical_int32_sharded(a_shape, sharded_config, logical_op, device):
+    ttnn_op = getattr(ttnn, logical_op)
+    num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
+    torch_input_tensor_a = torch.linspace(-100, 100, num_elements, dtype=torch.int32)
+    torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape).nan_to_num(0.0)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=sharded_config,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_op)
+    torch_output_tensor = golden_function(torch_input_tensor_a, device=device)
+
+    output_tensor = ttnn_op(input_tensor_a, memory_config=sharded_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert torch.equal(output_tensor, torch_output_tensor)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
@@ -13,18 +13,21 @@ import ttnn
         (torch.Size([1, 1, 32, 32])),
         (torch.Size([1, 1, 320, 384])),
         (torch.Size([1, 3, 320, 384])),
+        (torch.Size([1, 1, 1024, 1024])),
+        (torch.Size([1, 3, 1024, 1024])),
     ],
 )
 @pytest.mark.parametrize(
     "low_a, high_a",
     [
-        (-100, 100),
-        (-300, 300),
-        (-500, 500),
         (-1000, 1000),
         (-1e4, 1e4),
-        (2e9, 2077000000),  # large positive input
+        (-1e6, 1e6),
+        (-2147483647, 0),  # max negative to zero
+        (0, 2147483647),  # zero to max positive
+        (2e9, 2147483647),  # large positive input
         (-2147483647, -2e9),  # large negative input
+        (-2147483647, 2147483647),  # whole range
     ],
 )
 @pytest.mark.parametrize(
@@ -63,6 +66,8 @@ def test_unary_logical_int32(input_shapes, low_a, high_a, logical_op, device):
     ],
 )
 def test_unary_logical_int32_edge_cases(logical_op, device):
+    # Note: torch.logical_not(-2147483648) returns False, whereas ttnn.logical_not(-2147483648) returns True.
+    # This discrepancy occurs because, in Wormhole, the value -2147483648 wraps around to 0 due to integer overflow.
     torch_input_tensor_a = torch.tensor([0, 1, -1, 2147483647, -2147483647])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not_noti.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not_noti.h
@@ -11,25 +11,13 @@
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE>
+template <typename V, typename T>
 inline void calculate_logical_not_unary() {
 #pragma GCC unroll 0
     for (int d = 0; d < 8; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v == 0) { sfpi::dst_reg[0] = 1.0f; }
-        v_else { sfpi::dst_reg[0] = 0.0f; }
-        v_endif;
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE>
-inline void calculate_logical_not_unary_int32() {
-#pragma GCC unroll 0
-    for (int d = 0; d < 8; d++) {
-        sfpi::vInt v = sfpi::dst_reg[0];
-        v_if(v == 0) { sfpi::dst_reg[0] = 1; }
-        v_else { sfpi::dst_reg[0] = 0; }
+        V v = sfpi::dst_reg[0];
+        v_if(v == 0) { sfpi::dst_reg[0] = T(1); }
+        v_else { sfpi::dst_reg[0] = T(0); }
         v_endif;
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not_noti.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not_noti.h
@@ -7,7 +7,6 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
-using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
@@ -16,11 +15,23 @@ template <bool APPROXIMATION_MODE>
 inline void calculate_logical_not_unary() {
 #pragma GCC unroll 0
     for (int d = 0; d < 8; d++) {
-        vFloat v = dst_reg[0];
-        v_if(v == 0) { dst_reg[0] = 1.0f; }
-        v_else { dst_reg[0] = 0.0f; }
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        v_if(v == 0) { sfpi::dst_reg[0] = 1.0f; }
+        v_else { sfpi::dst_reg[0] = 0.0f; }
         v_endif;
-        dst_reg++;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void calculate_logical_not_unary_int32() {
+#pragma GCC unroll 0
+    for (int d = 0; d < 8; d++) {
+        sfpi::vInt v = sfpi::dst_reg[0];
+        v_if(v == 0) { sfpi::dst_reg[0] = 1; }
+        v_else { sfpi::dst_reg[0] = 0; }
+        v_endif;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_logical_not_noti.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_logical_not_noti.h
@@ -20,13 +20,13 @@ inline void llk_math_eltwise_unary_sfpu_logical_not_unary_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_logical_not_unary_op(uint dst_index) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_logical_not_unary<APPROXIMATE>, dst_index, (int)VectorMode::RC);
+        ckernel::sfpu::calculate_logical_not_unary<sfpi::vFloat, float>, dst_index, static_cast<int>(VectorMode::RC));
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_logical_not_unary_op_int32(uint dst_index) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_logical_not_unary_int32<APPROXIMATE>, dst_index, (int)VectorMode::RC);
+        ckernel::sfpu::calculate_logical_not_unary<sfpi::vInt, int16_t>, dst_index, static_cast<int>(VectorMode::RC));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_logical_not_noti.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_logical_not_noti.h
@@ -23,4 +23,10 @@ inline void llk_math_eltwise_unary_sfpu_logical_not_unary_op(uint dst_index) {
         ckernel::sfpu::calculate_logical_not_unary<APPROXIMATE>, dst_index, (int)VectorMode::RC);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_logical_not_unary_op_int32(uint dst_index) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_logical_not_unary_int32<APPROXIMATE>, dst_index, (int)VectorMode::RC);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not_noti.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not_noti.h
@@ -9,7 +9,6 @@
 #include "noc_nonblocking_api.h"
 
 #include "sfpi.h"
-using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
@@ -18,11 +17,23 @@ template <bool APPROXIMATION_MODE>
 inline void calculate_logical_not_unary() {
 #pragma GCC unroll 0
     for (int d = 0; d < 8; d++) {
-        vFloat v = dst_reg[0];
-        v_if(v == 0) { dst_reg[0] = 1.0f; }
-        v_else { dst_reg[0] = 0.0f; }
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        v_if(v == 0) { sfpi::dst_reg[0] = 1.0f; }
+        v_else { sfpi::dst_reg[0] = 0.0f; }
         v_endif;
-        dst_reg++;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void calculate_logical_not_unary_int32() {
+#pragma GCC unroll 0
+    for (int d = 0; d < 8; d++) {
+        sfpi::vInt v = sfpi::dst_reg[0];
+        v_if(v == 0) { sfpi::dst_reg[0] = 1; }
+        v_else { sfpi::dst_reg[0] = 0; }
+        v_endif;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not_noti.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not_noti.h
@@ -13,25 +13,13 @@
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE>
+template <typename V, typename T>
 inline void calculate_logical_not_unary() {
 #pragma GCC unroll 0
     for (int d = 0; d < 8; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v == 0) { sfpi::dst_reg[0] = 1.0f; }
-        v_else { sfpi::dst_reg[0] = 0.0f; }
-        v_endif;
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE>
-inline void calculate_logical_not_unary_int32() {
-#pragma GCC unroll 0
-    for (int d = 0; d < 8; d++) {
-        sfpi::vInt v = sfpi::dst_reg[0];
-        v_if(v == 0) { sfpi::dst_reg[0] = 1; }
-        v_else { sfpi::dst_reg[0] = 0; }
+        V v = sfpi::dst_reg[0];
+        v_if(v == 0) { sfpi::dst_reg[0] = T(1); }
+        v_else { sfpi::dst_reg[0] = T(0); }
         v_endif;
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_logical_not_noti.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_logical_not_noti.h
@@ -13,6 +13,12 @@ namespace ckernel {
 // New LLK SFPU APIs
 
 template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_logical_not_unary_op_int32(uint dst_index) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_logical_not_unary_int32<APPROXIMATE>, dst_index, (int)VectorMode::RC);
+}
+
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_logical_not_unary_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::logical_not_unary, APPROXIMATE>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_logical_not_noti.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_logical_not_noti.h
@@ -13,20 +13,19 @@ namespace ckernel {
 // New LLK SFPU APIs
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_logical_not_unary_op_int32(uint dst_index) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_logical_not_unary_int32<APPROXIMATE>, dst_index, (int)VectorMode::RC);
-}
-
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_logical_not_unary_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::logical_not_unary, APPROXIMATE>();
 }
-
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_logical_not_unary_op(uint dst_index) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_logical_not_unary<APPROXIMATE>, dst_index, (int)VectorMode::RC);
+        ckernel::sfpu::calculate_logical_not_unary<sfpi::vFloat, float>, dst_index, static_cast<int>(VectorMode::RC));
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_logical_not_unary_op_int32(uint dst_index) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_logical_not_unary<sfpi::vInt, int16_t>, dst_index, static_cast<int>(VectorMode::RC));
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/logical_not_noti.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/logical_not_noti.h
@@ -32,8 +32,27 @@ ALWI void logical_not_unary_tile(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_logical_not_unary_op<APPROX>(idst)));
 }
 
+// clang-format off
+/**
+ * Performs element-wise computation of the logical not unary operation for int32 dtype on each element of a tile
+ * in DST register at index tile_index. The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void logical_not_unary_tile_int32(uint32_t idst) {
+    MATH((llk_math_eltwise_unary_sfpu_logical_not_unary_op_int32<APPROX>(idst)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
 ALWI void logical_not_unary_tile_init() { MATH((llk_math_eltwise_unary_sfpu_logical_not_unary_init<APPROX>())); }
+
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -336,7 +336,12 @@ std::pair<string, string> get_op_init_and_func_default(
             break;
         case UnaryOpType::ISNAN: op_init_and_name = {"isnan_tile_init();", fmt::format("isnan_tile({});", idst)}; break;
         case UnaryOpType::LOGICAL_NOT_UNARY:
-            op_init_and_name = {"logical_not_unary_tile_init();", fmt::format("logical_not_unary_tile({});", idst)};
+            if (input_dtype == DataType::INT32) {
+                op_init_and_name = {
+                    "logical_not_unary_tile_init();", fmt::format("logical_not_unary_tile_int32({});", idst)};
+            } else {
+                op_init_and_name = {"logical_not_unary_tile_init();", fmt::format("logical_not_unary_tile({});", idst)};
+            }
             break;
         case UnaryOpType::I0: op_init_and_name = {"i0_tile_init();", fmt::format("i0_tile({});", idst)}; break;
         case UnaryOpType::I1: op_init_and_name = {"i1_tile_init();", fmt::format("i1_tile({});", idst)}; break;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -1878,7 +1878,7 @@ void py_module(py::module& module) {
         ttnn::logical_not,
         R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{!input\_tensor_i}})doc",
         "",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
     bind_unary_operation(
         module,
         ttnn::ltz,
@@ -2198,7 +2198,7 @@ void py_module(py::module& module) {
         ttnn::logical_not_,
         R"doc(Performs logical_not inplace function on :attr:`input_tensor`.)doc",
         "",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
     bind_unary_composite(
         module,
         ttnn::normalize_global,


### PR DESCRIPTION
### Ticket
#22442 

### Problem description
Provide int32 support for ttnn.logical_not with LLK implementation

### What's changed
- Added WH_B0 and BH LLK implementations for ttnn.logical_not to support int32 datatype.
- Added support in unary infra.

### BH Results
<img width="1297" alt="BH tests passed" src="https://github.com/user-attachments/assets/73227636-0f65-4ff4-8592-33dbd1492a58" />

### Doc update
<img width="1154" alt="logical_not_landing_pg" src="https://github.com/user-attachments/assets/3bf8d8dc-c27c-414d-a3a7-9d8775c9122e" />


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15550756394)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15550813681) 
- [x] New/Existing tests provide coverage for changes