### PR TITLE
 #22722: Implement binary relational ops as SFPU ops

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_relational.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_relational.py
@@ -309,13 +309,19 @@ def test_isclose(device, h, w, atol, rtol):
     "use_legacy",
     [False, True],
 )
-def test_binary_relational_ttnn(input_shapes, ttnn_function, range1, range2, use_legacy, device):
+@pytest.mark.parametrize(
+    "ttnn_dtype, torch_dtype",
+    [(ttnn.int32, torch.int32), (ttnn.bfloat16, torch.bfloat16), (ttnn.float32, torch.float32)],
+)
+def test_binary_relational_ttnn(
+    input_shapes, ttnn_function, range1, range2, use_legacy, device, ttnn_dtype, torch_dtype
+):
     low1, high1 = range1
     low2, high2 = range2
-    in_data1 = torch.randint(low1, high1, input_shapes, dtype=torch.int32)
-    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
-    in_data2 = torch.randint(low2, high2, input_shapes, dtype=torch.int32)
-    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    in_data1 = torch.randint(low1, high1, input_shapes, dtype=torch_dtype)
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    in_data2 = torch.randint(low2, high2, input_shapes, dtype=torch_dtype)
+    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn_function(input_tensor1, input_tensor2, use_legacy=use_legacy)
     golden_function = ttnn.get_golden_function(ttnn_function)
     golden_tensor = golden_function(in_data1, in_data2)

--- a/tt_metal/include/compute_kernel_api/eltwise_binary_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_binary_sfpu.h
@@ -29,10 +29,10 @@ namespace ckernel {
  *
  * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
  * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void add_binary_tile(uint32_t idst0, uint32_t idst1) {
     MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::sfpu::BinaryOp::ADD>(idst0, idst1)));
 }
@@ -55,6 +55,30 @@ ALWI void rsub_binary_tile(uint32_t idst0, uint32_t idst1) {
 
 ALWI void power_binary_tile(uint32_t idst0, uint32_t idst1) {
     MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::sfpu::BinaryOp::POW>(idst0, idst1)));
+}
+
+ALWI void eq_binary_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::sfpu::BinaryOp::EQ>(idst0, idst1)));
+}
+
+ALWI void ne_binary_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::sfpu::BinaryOp::NE>(idst0, idst1)));
+}
+
+ALWI void lt_binary_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::sfpu::BinaryOp::LT>(idst0, idst1)));
+}
+
+ALWI void le_binary_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::sfpu::BinaryOp::LE>(idst0, idst1)));
+}
+
+ALWI void gt_binary_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::sfpu::BinaryOp::GT>(idst0, idst1)));
+}
+
+ALWI void ge_binary_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_binop<APPROX, ckernel::sfpu::BinaryOp::GE>(idst0, idst1)));
 }
 
 /**
@@ -82,6 +106,30 @@ ALWI void rsub_binary_tile_init() {
 
 ALWI void power_binary_tile_init() {
     MATH((llk_math_eltwise_binary_sfpu_binop_init<APPROX, ckernel::sfpu::BinaryOp::POW>()));
+}
+
+ALWI void eq_binary_tile_init() {
+    MATH((llk_math_eltwise_binary_sfpu_binop_init<APPROX, ckernel::sfpu::BinaryOp::EQ>()));
+}
+
+ALWI void ne_binary_tile_init() {
+    MATH((llk_math_eltwise_binary_sfpu_binop_init<APPROX, ckernel::sfpu::BinaryOp::NE>()));
+}
+
+ALWI void lt_binary_tile_init() {
+    MATH((llk_math_eltwise_binary_sfpu_binop_init<APPROX, ckernel::sfpu::BinaryOp::LT>()));
+}
+
+ALWI void le_binary_tile_init() {
+    MATH((llk_math_eltwise_binary_sfpu_binop_init<APPROX, ckernel::sfpu::BinaryOp::LE>()));
+}
+
+ALWI void gt_binary_tile_init() {
+    MATH((llk_math_eltwise_binary_sfpu_binop_init<APPROX, ckernel::sfpu::BinaryOp::GT>()));
+}
+
+ALWI void ge_binary_tile_init() {
+    MATH((llk_math_eltwise_binary_sfpu_binop_init<APPROX, ckernel::sfpu::BinaryOp::GE>()));
 }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -28,13 +28,14 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
         case LOGICAL_AND:
         case BIAS_GELU: return (a == FLOAT32 && b == FLOAT32);
         case LOGICAL_OR:
-        case LOGICAL_XOR:
+        case LOGICAL_XOR: return ((a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32));
         case GT:
         case LT:
         case GTE:
         case LTE:
         case EQ:
-        case NE: return ((a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32));
+        case NE:
+            return ((a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32) || (a == BFLOAT16 && b == BFLOAT16));
         case LCM:
         case GCD:
         case LEFT_SHIFT:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -471,8 +471,8 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
 
     auto op_type = operation_attributes.binary_op_type;
 
-    const auto op_config = is_sfpu_op ? OpConfig(op_type, std::in_place_type<OpConfig::SfpuBinaryOp>)
-                                      : OpConfig(op_type, std::in_place_type<OpConfig::FpuBinaryOp>);
+    const auto op_config = is_sfpu_op ? OpConfig(op_type, std::in_place_type<OpConfig::SfpuBinaryOp>, a_dtype)
+                                      : OpConfig(op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype);
 
     auto compute_kernel_defines = op_config.as_defines(a_dtype);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -63,11 +63,17 @@ struct OpConfig {
         REQUANT,
         DEQUANT,
         MAXIMUM,
-        MINIMUM
+        MINIMUM,
+        EQ,
+        NE,
+        LT,
+        LTE,
+        GT,
+        GTE,
     };
 
     template <class EnumT>
-    OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>);
+    OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, DataType dtype = DataType::BFLOAT16);
 
     std::map<std::string, std::string> as_defines(DataType dtype) const;
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #22722 

### Problem description
Relational ops are currently implemented using a combination of sub-SFPU and zero-comparison operations.



### What's changed
Refactored and updated the implementation to use dedicated SFPU code for relational operations.

LLK changes: https://github.com/tenstorrent/tt-llk/pull/301

### Checklist
- [x] [All post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/15462132016)