### PR TITLE
Set MEM_ETH_SIZE on BH to be full L1 including syseng reserved space since host will need to read/write to it

### DIFF
--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -33,8 +33,8 @@
 #define MEM_L1_SIZE (1536 * 1024)
 
 #define MEM_ETH_BASE 0x0
-// Top 64K is reserved for syseng
-#define MEM_ETH_SIZE (512 * 1024 - 64 * 1024)
+// Top 64K is reserved for syseng but host reads/writes from that region
+#define MEM_ETH_SIZE (512 * 1024)
 
 #define MEM_DRAM_SIZE (4177920 * 1024U)
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`Cluster.ReportSystemHealth` was failing with Watcher enabled because it was flagging a read from syseng reserved space as being out of bounds.

### What's changed
Size BH eth L1 to be all of L1. Host will read/write from syseng reserved region (to read out link stats, enable second risc, etc)  

FYI @williamlyTT 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15448488717) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15448495573) CI with demo tests passes (if applicable)