### PR TITLE
Make event validation assert use wrapping compare to support long running workloads

### DIFF
--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -32,6 +32,16 @@ enum class CoreType;
 
 namespace tt::tt_metal {
 
+namespace {
+
+bool wrap_ge(uint32_t a, uint32_t b) {
+    // SIgned Diff uses 2's Complement to handle wrap
+    // Works as long as a and b are 2^31 apart
+    int32_t diff = a - b;
+    return diff >= 0;
+}
+}  // namespace
+
 SystemMemoryManager::SystemMemoryManager(chip_id_t device_id, uint8_t num_hw_cqs) :
     device_id(device_id),
     num_hw_cqs(num_hw_cqs),
@@ -152,7 +162,7 @@ void SystemMemoryManager::increment_event_id(const uint8_t cq_id, const uint32_t
 
 void SystemMemoryManager::set_last_completed_event(const uint8_t cq_id, const uint32_t event_id) {
     TT_ASSERT(
-        event_id >= this->cq_to_last_completed_event[cq_id],
+        wrap_ge(event_id, this->cq_to_last_completed_event[cq_id]),
         "Event ID is expected to increase. Wrapping not supported for sync. Completed event {} but last recorded "
         "completed event is {}",
         event_id,

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -93,8 +93,8 @@ private:
     std::vector<SystemMemoryCQInterface> cq_interfaces;
     uint32_t cq_size = 0;
     uint32_t channel_offset = 0;
-    std::vector<int> cq_to_event;
-    std::vector<int> cq_to_last_completed_event;
+    std::vector<uint32_t> cq_to_event;
+    std::vector<uint32_t> cq_to_last_completed_event;
     std::vector<std::mutex> cq_to_event_locks;
     std::vector<tt_cxy_pair> prefetcher_cores;
     std::vector<tt::Writer> prefetch_q_writers;


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
Assert validating event id in `SystemMemoryManager::set_last_completed_event` did not account for IDs wrapping at uint32_t boundary. The assert could thus incorrectly trigger for long running workloads.
Relevant thread: https://tenstorrent.slack.com/archives/C03N2GED3PS/p1748984950696649

### What's changed
- Use wrapping compare instead of `>=`.
- Make `cq_to_event` and `cq_to_last_completed_event` store `uint32_t` since events are always positive (this is also needed for the wrapping compare).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes