### PR TITLE
Initial Changes for Multi Host Sockets: (De)Serialization Functionality

### DIFF
--- a/cmake/flatbuffers.cmake
+++ b/cmake/flatbuffers.cmake
@@ -1,17 +1,41 @@
-# Function to generate FlatBuffers C++ headers from schema files
 function(GENERATE_FBS_HEADER FBS_FILE)
+    # Optional Arguments:
+    # - TARGET: Target to associate the generated header with (used for include directories)
+    # - OUTPUT_DIR: Directory to place the generated header file (CMAKE_CURRENT_BINARY_DIR/flatbuffers by default)
+    set(oneValueArgs
+        TARGET
+        OUTPUT_DIR
+    )
+    cmake_parse_arguments(FBS_ARGS "" "${oneValueArgs}" "" "${ARGN}")
+
     get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME_WE)
-    set(FBS_GENERATED_HEADER_DIR "${CMAKE_CURRENT_BINARY_DIR}/flatbuffers")
+
+    # Set default output directory if not specified
+    if(FBS_ARGS_OUTPUT_DIR)
+        set(FBS_GENERATED_HEADER_DIR "${FBS_ARGS_OUTPUT_DIR}")
+    else()
+        set(FBS_GENERATED_HEADER_DIR "${CMAKE_CURRENT_BINARY_DIR}/flatbuffers")
+    endif()
+
     set(FBS_GENERATED_HEADER_FILE "${FBS_GENERATED_HEADER_DIR}/${FBS_FILE_NAME}_generated.h")
+
+    set(incdirs "${CMAKE_CURRENT_SOURCE_DIR}")
+    if(FBS_ARGS_TARGET)
+        set(incdirs "$<TARGET_PROPERTY:${FBS_ARGS_TARGET},INCLUDE_DIRECTORIES>")
+    endif()
+
     add_custom_command(
         OUTPUT
             ${FBS_GENERATED_HEADER_FILE}
         COMMAND
-            flatc --cpp --scoped-enums -I ${CMAKE_CURRENT_SOURCE_DIR} -o "${FBS_GENERATED_HEADER_DIR}" ${FBS_FILE}
+            flatc --keep-prefix --cpp --scoped-enums "$<$<BOOL:${incdirs}>:-I;$<JOIN:${incdirs},;-I;>>" -o
+            "${FBS_GENERATED_HEADER_DIR}" ${FBS_FILE}
         DEPENDS
             flatc
             ${FBS_FILE}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMENT "Building C++ header for ${FBS_FILE}"
+        COMMAND_EXPAND_LISTS
     )
     set(FBS_GENERATED_HEADER_FILE ${FBS_GENERATED_HEADER_FILE} PARENT_SCOPE)
 endfunction()

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -16,6 +16,8 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/hw/inc/socket.h"
 #include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/distributed/mesh_socket_utils.hpp"
+#include "tt_metal/distributed/mesh_socket_serialization.hpp"
 #include <tt-metalium/system_mesh.hpp>
 
 namespace tt::tt_metal::distributed {
@@ -2179,6 +2181,23 @@ TEST_F(MeshSocketTest, AssertOnDuplicateCores) {
     EXPECT_NO_THROW(MeshSocket::create_sockets(md0, md0, socket_config_2));
 }
 
+void verify_socket_configs_match(const SocketConfig& config_a, const SocketConfig& config_b) {
+    EXPECT_EQ(config_a.socket_connection_config.size(), config_b.socket_connection_config.size());
+
+    // Make sure connections match
+    for (size_t i = 0; i < config_a.socket_connection_config.size(); ++i) {
+        const auto& local_conn = config_a.socket_connection_config[i];
+        const auto& peer_conn = config_b.socket_connection_config[i];
+        EXPECT_EQ(local_conn.sender_core, peer_conn.sender_core);
+        EXPECT_EQ(local_conn.receiver_core, peer_conn.receiver_core);
+    }
+    // make sure socket memory config matches
+    EXPECT_EQ(config_a.socket_mem_config.socket_storage_type, config_b.socket_mem_config.socket_storage_type);
+    EXPECT_EQ(config_a.socket_mem_config.fifo_size, config_b.socket_mem_config.fifo_size);
+    EXPECT_EQ(config_a.socket_mem_config.sender_sub_device, config_b.socket_mem_config.sender_sub_device);
+    EXPECT_EQ(config_a.socket_mem_config.receiver_sub_device, config_b.socket_mem_config.receiver_sub_device);
+}
+
 // ========= Single Device Data Movement Tests =========
 
 TEST_F(MeshSocketTest, SingleConnectionSingleDeviceSocket) {
@@ -2318,6 +2337,105 @@ TEST_F(MeshSocketTest2DFabric, MultiSenderSingleRecvSplitReducer) { run_multi_se
 
 TEST_F(MeshSocketTest2DFabric, MultiConnectionMultiDeviceDataCopy) {
     run_multi_connection_multi_device_data_copy(this);
+}
+
+// ================== (De)Serialization Tests ==================
+
+// Verify that serialization and deserialization of socket peer descriptors works correctly (this is needed for
+// Multi-Host Sockets)
+TEST(SocketSerializationTest, PeerDesc) {
+    std::size_t socket_fifo_size = 1024;
+    const auto worker_grid = CoreCoord(8, 8);
+
+    std::vector<CoreCoord> sender_logical_coords;
+    std::vector<CoreCoord> recv_logical_coords;
+    std::vector<uint32_t> sender_chip_ids;
+    std::vector<uint32_t> recv_chip_ids;
+    std::vector<MeshCoordinate> sender_device_coords;
+    std::vector<MeshCoordinate> recv_device_coords;
+    uint32_t core_idx = 0;
+    for (std::size_t x = 0; x < worker_grid.x; x++) {
+        for (std::size_t y = 0; y < worker_grid.y; y++) {
+            sender_logical_coords.push_back(CoreCoord(x, y));
+            recv_logical_coords.push_back(CoreCoord(x, y));
+            sender_chip_ids.push_back(core_idx % 4);
+            recv_chip_ids.push_back(4 + core_idx % 4);
+            sender_device_coords.push_back(MeshCoordinate(0, core_idx % 4));
+            recv_device_coords.push_back(MeshCoordinate(1, core_idx % 4));
+            core_idx++;
+        }
+    }
+
+    // Shuffle core coordinates to randomize the connections
+    std::random_device rd;
+    std::mt19937 generator(rd());
+    std::shuffle(sender_logical_coords.begin(), sender_logical_coords.end(), generator);
+    std::shuffle(recv_logical_coords.begin(), recv_logical_coords.end(), generator);
+    std::shuffle(sender_chip_ids.begin(), sender_chip_ids.end(), generator);
+    std::shuffle(recv_chip_ids.begin(), recv_chip_ids.end(), generator);
+    std::shuffle(sender_device_coords.begin(), sender_device_coords.end(), generator);
+    std::shuffle(recv_device_coords.begin(), recv_device_coords.end(), generator);
+    std::vector<SocketConnection> socket_connections;
+
+    for (std::size_t coord_idx = 0; coord_idx < sender_logical_coords.size(); coord_idx++) {
+        SocketConnection socket_connection = {
+            .sender_core = {sender_device_coords[coord_idx], sender_logical_coords[coord_idx]},
+            .receiver_core = {recv_device_coords[coord_idx], recv_logical_coords[coord_idx]}};
+        socket_connections.push_back(socket_connection);
+    }
+
+    SocketConfig socket_config_l1 = {
+        .socket_connection_config = socket_connections,
+        .socket_mem_config =
+            {
+                .socket_storage_type = BufferType::L1,
+                .fifo_size = socket_fifo_size,
+
+            },
+        .sender_rank = 0,
+        .receiver_rank = 1,
+    };
+
+    // Populate sender size peer descriptor based on config, addresses and device coordinates
+    SocketPeerDescriptor send_socket_peer_desc_l1 = SocketPeerDescriptor{
+        .config = socket_config_l1,
+        .config_buffer_address = 1 << 20,  // Assuming a dummy address for the config buffer at 1 MB
+        .data_buffer_address = 0,          /* Sender Endpoint has no data buffer allocated. */
+    };
+
+    for (const auto& id : sender_chip_ids) {
+        send_socket_peer_desc_l1.mesh_ids.push_back(0);
+        send_socket_peer_desc_l1.chip_ids.push_back(id);
+    }
+
+    // Populate receiver size peer descriptor based on config, addresses and device coordinates
+    SocketPeerDescriptor recv_socket_peer_desc_l1 = SocketPeerDescriptor{
+        .config = socket_config_l1,
+        .config_buffer_address = 1 << 21,  // Assuming a dummy address for the config buffer at 2 MB
+        .data_buffer_address = 1 << 22,    // Assuming a dummy address for the data buffer at 4 MB
+    };
+    for (const auto& id : recv_chip_ids) {
+        recv_socket_peer_desc_l1.mesh_ids.push_back(1);
+        recv_socket_peer_desc_l1.chip_ids.push_back(id);
+    }
+    // Serialize and deserialize the socket peer descriptors
+    auto serialized_send_socket_desc = serialize_to_bytes(send_socket_peer_desc_l1);
+    SocketPeerDescriptor deserialized_send_socket_desc = deserialize_from_bytes(serialized_send_socket_desc);
+    auto serialized_recv_socket_desc = serialize_to_bytes(recv_socket_peer_desc_l1);
+    SocketPeerDescriptor deserialized_recv_socket_desc = deserialize_from_bytes(serialized_recv_socket_desc);
+    // Validate configs are preserved after serialization
+    verify_socket_configs_match(deserialized_send_socket_desc.config, send_socket_peer_desc_l1.config);
+    verify_socket_configs_match(deserialized_recv_socket_desc.config, recv_socket_peer_desc_l1.config);
+    verify_socket_configs_match(deserialized_send_socket_desc.config, deserialized_recv_socket_desc.config);
+    // Validate that all other attributes of the peer descriptors are preserved
+    EXPECT_EQ(deserialized_send_socket_desc.config_buffer_address, send_socket_peer_desc_l1.config_buffer_address);
+    EXPECT_EQ(deserialized_recv_socket_desc.config_buffer_address, recv_socket_peer_desc_l1.config_buffer_address);
+    EXPECT_EQ(deserialized_send_socket_desc.data_buffer_address, send_socket_peer_desc_l1.data_buffer_address);
+    EXPECT_EQ(deserialized_recv_socket_desc.data_buffer_address, recv_socket_peer_desc_l1.data_buffer_address);
+    EXPECT_EQ(deserialized_send_socket_desc.mesh_ids, send_socket_peer_desc_l1.mesh_ids);
+    EXPECT_EQ(deserialized_recv_socket_desc.mesh_ids, recv_socket_peer_desc_l1.mesh_ids);
+    EXPECT_EQ(deserialized_send_socket_desc.chip_ids, send_socket_peer_desc_l1.chip_ids);
+    EXPECT_EQ(deserialized_recv_socket_desc.chip_ids, recv_socket_peer_desc_l1.chip_ids);
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -15,12 +15,28 @@ set_target_properties(
             Metalium
 )
 
+include(flatbuffers)
+GENERATE_FBS_HEADER(
+    api/tt-metalium/serialized_descriptors/mesh_coordinate.fbs
+    TARGET TT::Metalium
+    OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/api/tt-metalium/serialized_descriptors/
+)
+set(API_GENERATED_HEADERS ${FBS_GENERATED_HEADER_FILE})
+
+add_custom_target(
+    metalium_GeneratedHeaders
+    DEPENDS
+        ${API_GENERATED_HEADERS}
+    COMMENT "Generating all FlatBuffer headers"
+)
+
 target_sources(
     tt_metal
     PRIVATE
         tt_metal.cpp
         graph/graph_tracking.cpp
         hal.cpp
+        ${API_GENERATED_HEADERS}
 )
 
 target_sources(
@@ -28,7 +44,7 @@ target_sources(
     PUBLIC
         FILE_SET api
         TYPE HEADERS
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/api
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/api ${CMAKE_CURRENT_BINARY_DIR}/api
         FILES
             api/tt-metalium/allocator.hpp
             api/tt-metalium/allocator_types.hpp
@@ -387,6 +403,7 @@ target_include_directories(
     tt_metal
     PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/api>"
     PRIVATE
         api/tt-metalium # FIXME: Re-home the tests and remove this
 )
@@ -411,6 +428,7 @@ endif()
 include_directories(
     api
     api/tt-metalium
+    ${CMAKE_CURRENT_BINARY_DIR}/api
 )
 
 add_subdirectory(logging)

--- a/tt_metal/api/tt-metalium/mesh_socket.hpp
+++ b/tt_metal/api/tt-metalium/mesh_socket.hpp
@@ -12,6 +12,9 @@ namespace tt::tt_metal::distributed {
 struct MeshCoreCoord {
     MeshCoordinate device_coord;
     CoreCoord core_coord;
+    bool operator==(const MeshCoreCoord& other) const {
+        return device_coord == other.device_coord && core_coord == other.core_coord;
+    }
 };
 
 // Specifies how sender cores on a Virtual Mesh connect to receiver cores on the same or another Virtual Mesh.
@@ -41,6 +44,10 @@ struct SocketMemoryConfig {
 struct SocketConfig {
     std::vector<SocketConnection> socket_connection_config;
     SocketMemoryConfig socket_mem_config;
+    // Specifies the ranks of the sender and receiver hosts in a multi-host context.
+    // Used for inital handshaking and validation of the socket configs.
+    uint32_t sender_rank = 0;
+    uint32_t receiver_rank = 0;
 };
 
 // Socket Handle exposed to the user.

--- a/tt_metal/api/tt-metalium/serialized_descriptors/mesh_coordinate.fbs
+++ b/tt_metal/api/tt-metalium/serialized_descriptors/mesh_coordinate.fbs
@@ -1,4 +1,4 @@
-namespace ttnn.flatbuffer;
+namespace tt.tt_metal.distributed.flatbuffer;
 
 table MeshCoordinate {
     // The coordinate values in each dimension

--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -10,6 +10,7 @@ set(DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/mesh_event.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mesh_socket.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mesh_socket_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mesh_socket_serialization.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mesh_trace.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mesh_workload.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mesh_workload_utils.cpp
@@ -17,6 +18,11 @@ set(DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/distributed_host_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/multihost/distributed_context.cpp
 )
+
+# Include helper functions and generate headers from flatbuffer schemas
+include(flatbuffers)
+
+set(FLATBUFFER_SCHEMAS ${CMAKE_CURRENT_SOURCE_DIR}/flatbuffer/socket_peer_descriptor.fbs)
 
 # Check if distributed compute is enabled
 if(NOT DEFINED ENABLE_DISTRIBUTED)
@@ -71,6 +77,11 @@ endif()
 
 add_library(distributed OBJECT ${DISTRIBUTED_SRC})
 
+foreach(FBS_FILE ${FLATBUFFER_SCHEMAS})
+    GENERATE_FBS_HEADER(${FBS_FILE} TARGET distributed)
+    target_sources(distributed PRIVATE ${FBS_GENERATED_HEADER_FILE})
+endforeach()
+
 target_link_libraries(
     distributed
     PUBLIC
@@ -79,9 +90,13 @@ target_link_libraries(
         Metalium::Metal::Impl
         Metalium::Metal::LLRT
         TT::Metalium::HostDevCommon
+        FlatBuffers::FlatBuffers
 )
+add_dependencies(distributed metalium_GeneratedHeaders)
 
 if(USE_MPI)
     target_link_libraries(distributed PRIVATE OpenMPI::MPI)
     target_compile_definitions(distributed PRIVATE OPEN_MPI="1")
 endif()
+
+target_include_directories(distributed SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers)

--- a/tt_metal/distributed/flatbuffer/socket_peer_descriptor.fbs
+++ b/tt_metal/distributed/flatbuffer/socket_peer_descriptor.fbs
@@ -1,0 +1,42 @@
+include "tt-metalium/serialized_descriptors/mesh_coordinate.fbs";
+
+namespace tt.tt_metal.distributed.flatbuffer;
+
+table CoreCoord {
+    x: uint32;
+    y: uint32;
+}
+
+table MeshCoreCoord {
+    device_coord: MeshCoordinate;
+    core_coord: CoreCoord;
+}
+
+table SocketConnection {
+    sender_core: MeshCoreCoord;
+    receiver_core: MeshCoreCoord;
+}
+
+table SocketMemoryConfig {
+    socket_storage_type: uint32;  // enum as uint32
+    fifo_size: uint32;
+    sender_sub_device: uint32 = null;
+    receiver_sub_device: uint32 = null;
+}
+
+table SocketConfig {
+    socket_connections: [SocketConnection];
+    socket_mem_config: SocketMemoryConfig;
+    sender_rank: uint32;
+    receiver_rank: uint32;
+}
+
+table SocketPeerDescriptor {
+    config: SocketConfig;
+    config_buffer_address: uint64;
+    data_buffer_address: uint64;
+    mesh_ids: [uint32];
+    chip_ids: [uint32];
+}
+
+root_type SocketPeerDescriptor;

--- a/tt_metal/distributed/mesh_socket_serialization.cpp
+++ b/tt_metal/distributed/mesh_socket_serialization.cpp
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/distributed/mesh_socket_serialization.hpp"
+#include "socket_peer_descriptor_generated.h"
+
+namespace tt::tt_metal::distributed {
+namespace {
+
+flatbuffers::Offset<distributed::flatbuffer::CoreCoord> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const CoreCoord& coord) {
+    return distributed::flatbuffer::CreateCoreCoord(builder, coord.x, coord.y);
+}
+
+flatbuffers::Offset<distributed::flatbuffer::MeshCoordinate> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const MeshCoordinate& mesh_coord) {
+    auto values_vector = builder.CreateVector(mesh_coord.coords().data(), mesh_coord.coords().size());
+    return distributed::flatbuffer::CreateMeshCoordinate(builder, values_vector);
+}
+
+flatbuffers::Offset<distributed::flatbuffer::MeshCoreCoord> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const MeshCoreCoord& mesh_core_coord) {
+    auto device_coord = to_flatbuffer(builder, mesh_core_coord.device_coord);
+    auto core_coord = to_flatbuffer(builder, mesh_core_coord.core_coord);
+    return distributed::flatbuffer::CreateMeshCoreCoord(builder, device_coord, core_coord);
+}
+
+flatbuffers::Offset<distributed::flatbuffer::SocketConnection> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const SocketConnection& socket_connection) {
+    auto sender_core = to_flatbuffer(builder, socket_connection.sender_core);
+    auto receiver_core = to_flatbuffer(builder, socket_connection.receiver_core);
+    return distributed::flatbuffer::CreateSocketConnection(builder, sender_core, receiver_core);
+}
+
+flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<distributed::flatbuffer::SocketConnection>>> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const std::vector<SocketConnection>& socket_connections) {
+    std::vector<flatbuffers::Offset<distributed::flatbuffer::SocketConnection>> fb_connections;
+    fb_connections.reserve(socket_connections.size());
+    for (const auto& conn : socket_connections) {
+        fb_connections.push_back(to_flatbuffer(builder, conn));
+    }
+    return builder.CreateVector(fb_connections);
+}
+
+flatbuffers::Offset<distributed::flatbuffer::SocketMemoryConfig> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const SocketMemoryConfig& socket_mem_config) {
+    std::optional<uint32_t> sender_sub_device = std::nullopt;
+    if (socket_mem_config.sender_sub_device.has_value()) {
+        sender_sub_device = *(socket_mem_config.sender_sub_device.value());
+    }
+
+    std::optional<uint32_t> receiver_sub_device = std::nullopt;
+    if (socket_mem_config.receiver_sub_device.has_value()) {
+        receiver_sub_device = *(socket_mem_config.receiver_sub_device.value());
+    }
+
+    return distributed::flatbuffer::CreateSocketMemoryConfig(
+        builder,
+        static_cast<uint32_t>(socket_mem_config.socket_storage_type),
+        socket_mem_config.fifo_size,
+        sender_sub_device,
+        receiver_sub_device);
+}
+
+CoreCoord from_flatbuffer(const distributed::flatbuffer::CoreCoord* fb_core_coord) {
+    return CoreCoord(fb_core_coord->x(), fb_core_coord->y());
+}
+
+MeshCoordinate from_flatbuffer(const distributed::flatbuffer::MeshCoordinate* fb_mesh_coord) {
+    return MeshCoordinate(*(fb_mesh_coord->values()));
+}
+
+MeshCoreCoord from_flatbuffer(const distributed::flatbuffer::MeshCoreCoord* fb_mesh_core_coord) {
+    TT_FATAL(
+        fb_mesh_core_coord->device_coord(),
+        "Internal Error: Device coord is not present in MeshCoreCoord during deserialization");
+    TT_FATAL(
+        fb_mesh_core_coord->core_coord(),
+        "Internal Error: Core coord is not present in MeshCoreCoord during deserialization");
+
+    return MeshCoreCoord{
+        from_flatbuffer(fb_mesh_core_coord->device_coord()), from_flatbuffer(fb_mesh_core_coord->core_coord())};
+}
+
+SocketConnection from_flatbuffer(const distributed::flatbuffer::SocketConnection* fb_socket_connection) {
+    TT_FATAL(
+        fb_socket_connection->sender_core(),
+        "Internal Error: Sender core is not present in the socket connection during deserialization");
+    TT_FATAL(
+        fb_socket_connection->receiver_core(),
+        "Internal Error: Receiver core is not present in the socket connection during deserialization");
+
+    return SocketConnection{
+        .sender_core = from_flatbuffer(fb_socket_connection->sender_core()),
+        .receiver_core = from_flatbuffer(fb_socket_connection->receiver_core())};
+}
+
+std::vector<SocketConnection> from_flatbuffer(
+    const flatbuffers::Vector<flatbuffers::Offset<distributed::flatbuffer::SocketConnection>>* fb_socket_connections) {
+    std::vector<SocketConnection> socket_connections;
+    if (fb_socket_connections) {
+        socket_connections.reserve(fb_socket_connections->size());
+        for (const auto* fb_conn : *fb_socket_connections) {
+            socket_connections.push_back(from_flatbuffer(fb_conn));
+        }
+    }
+    return socket_connections;
+}
+
+SocketMemoryConfig from_flatbuffer(const distributed::flatbuffer::SocketMemoryConfig* fb_socket_mem_config) {
+    SocketMemoryConfig socket_mem_config;
+    if (fb_socket_mem_config) {
+        socket_mem_config.socket_storage_type = static_cast<BufferType>(fb_socket_mem_config->socket_storage_type());
+        socket_mem_config.fifo_size = fb_socket_mem_config->fifo_size();
+
+        // Handle optional fields
+        if (fb_socket_mem_config->sender_sub_device().has_value()) {
+            socket_mem_config.sender_sub_device = SubDeviceId(fb_socket_mem_config->sender_sub_device().value());
+        }
+        if (fb_socket_mem_config->receiver_sub_device().has_value()) {
+            socket_mem_config.receiver_sub_device = SubDeviceId(fb_socket_mem_config->receiver_sub_device().value());
+        }
+    }
+    return socket_mem_config;
+}
+
+}  // namespace
+
+std::vector<uint8_t> serialize_to_bytes(const SocketPeerDescriptor& socket_peer_desc) {
+    flatbuffers::FlatBufferBuilder builder;
+    auto& socket_config = socket_peer_desc.config;
+    // Build the connections FlatBuffer
+    auto connections_vector_fb = to_flatbuffer(builder, socket_config.socket_connection_config);
+    // Build the memory config FlatBuffer`
+    auto mem_config_fb = to_flatbuffer(builder, socket_config.socket_mem_config);
+    // Create the SocketConfig FlatBuffer
+    auto socket_config_fb = distributed::flatbuffer::CreateSocketConfig(
+        builder, connections_vector_fb, mem_config_fb, socket_config.sender_rank, socket_config.receiver_rank);
+    // Build the SocketPeerDescriptor FlatBuffer (root object)
+    auto socket_peer_desc_fb = distributed::flatbuffer::CreateSocketPeerDescriptor(
+        builder,
+        socket_config_fb,
+        socket_peer_desc.config_buffer_address,
+        socket_peer_desc.data_buffer_address,
+        builder.CreateVector(socket_peer_desc.mesh_ids),
+        builder.CreateVector(socket_peer_desc.chip_ids));
+
+    builder.Finish(socket_peer_desc_fb);
+    // Extract the FlatBuffer data as a vector of bytes
+    // Note: FlatBufferBuilder's GetBufferPointer returns a pointer to the internal buffer, which is not std::byte.
+    std::vector<uint8_t> byte_vector(builder.GetBufferPointer(), builder.GetBufferPointer() + builder.GetSize());
+    return byte_vector;
+}
+
+SocketPeerDescriptor deserialize_from_bytes(const std::vector<uint8_t>& data) {
+    // Verify the buffer: FlatBuffer Verifier requires a uint8_t pointer
+    auto verifier = flatbuffers::Verifier(data.data(), data.size());
+    TT_FATAL(
+        distributed::flatbuffer::VerifySocketPeerDescriptorBuffer(verifier),
+        "Invalid FlatBuffer data of distributed socket metadata");
+
+    auto socket_peer_desc_fb = distributed::flatbuffer::GetSocketPeerDescriptor(data.data());
+    auto socket_config_fb = socket_peer_desc_fb->config();
+
+    SocketPeerDescriptor socket_peer_desc;
+    // Populate the SocketPeerDescriptor from the FlatBuffer (connections, memory config, ranks, peer address, Mesh IDs,
+    // Chip IDs)
+    socket_peer_desc.config.socket_connection_config = from_flatbuffer(socket_config_fb->socket_connections());
+    socket_peer_desc.config.socket_mem_config = from_flatbuffer(socket_config_fb->socket_mem_config());
+    socket_peer_desc.config.sender_rank = socket_config_fb->sender_rank();
+    socket_peer_desc.config.receiver_rank = socket_config_fb->receiver_rank();
+    socket_peer_desc.config_buffer_address = socket_peer_desc_fb->config_buffer_address();
+    socket_peer_desc.data_buffer_address = socket_peer_desc_fb->data_buffer_address();
+    if (socket_peer_desc_fb->mesh_ids()) {
+        socket_peer_desc.mesh_ids.assign(
+            socket_peer_desc_fb->mesh_ids()->begin(), socket_peer_desc_fb->mesh_ids()->end());
+    }
+    if (socket_peer_desc_fb->chip_ids()) {
+        socket_peer_desc.chip_ids.assign(
+            socket_peer_desc_fb->chip_ids()->begin(), socket_peer_desc_fb->chip_ids()->end());
+    }
+    return socket_peer_desc;
+}
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_socket_serialization.hpp
+++ b/tt_metal/distributed/mesh_socket_serialization.hpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/distributed.hpp>
+#include "tt_metal/distributed/mesh_socket_utils.hpp"
+
+namespace tt::tt_metal::distributed {
+// Utility functions to serialize and deserialize SocketPeerDescriptor to/from bytes.
+std::vector<uint8_t> serialize_to_bytes(const SocketPeerDescriptor& socket_md);
+SocketPeerDescriptor deserialize_from_bytes(const std::vector<uint8_t>& data);
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_socket_utils.hpp
+++ b/tt_metal/distributed/mesh_socket_utils.hpp
@@ -6,10 +6,28 @@
 
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/fabric_types.hpp>
+#include <tt-metalium/mesh_socket.hpp>
 
 namespace tt::tt_metal::distributed {
 
 enum class SocketEndpoint : uint8_t { SENDER, RECEIVER };
+
+// Utiity struct used for Sender and Receiver Hanshaking.
+// Each endpoint (sender/receiver) needs to know the following about its peer:
+// 1. The socket config used to create the connection (this is used for validation to ensure that both endpoints
+// correspond to the same socket config)
+// 2. Addresses of the peer's socket config and data buffers
+// 3. The Mesh and Chip IDs corresponding to the peer endpoint (to compute the fabric encoding)
+
+// For single-host sockets, this struct can be directly used when writing the socket config to the MeshDevice.
+// For multi-host sockets, this struct is serialized to a FlatBuffer and sent over the network to the peer endpoint.
+struct SocketPeerDescriptor {
+    SocketConfig config;
+    DeviceAddr config_buffer_address = 0;
+    DeviceAddr data_buffer_address = 0;
+    std::vector<uint32_t> mesh_ids;
+    std::vector<uint32_t> chip_ids;
+};
 
 // Create send/receive socket config buffers
 std::shared_ptr<MeshBuffer> create_socket_config_buffer(

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -97,11 +97,13 @@ set(FLATBUFFER_SCHEMAS
     ${CMAKE_CURRENT_SOURCE_DIR}/flatbuffer/program_types.fbs
 )
 
+set(GENERATED_HEADERS)
 foreach(FBS_FILE ${FLATBUFFER_SCHEMAS})
     GENERATE_FBS_HEADER(${FBS_FILE})
-    list(APPEND IMPL_SRC ${FBS_GENERATED_HEADER_FILE})
+    list(APPEND GENERATED_HEADERS ${FBS_GENERATED_HEADER_FILE})
 endforeach()
 
+list(APPEND IMPL_SRC ${GENERATED_HEADERS})
 add_library(impl OBJECT ${IMPL_SRC})
 add_library(Metalium::Metal::Impl ALIAS impl)
 

--- a/tt_metal/impl/flatbuffer/buffer_types.fbs
+++ b/tt_metal/impl/flatbuffer/buffer_types.fbs
@@ -1,5 +1,5 @@
-include "flatbuffer/base_types.fbs";
-include "flatbuffer/program_types.fbs"; // For CoreRangeSet
+include "base_types.fbs";
+include "program_types.fbs"; // For CoreRangeSet
 
 namespace tt.tt_metal.flatbuffer;
 

--- a/tt_metal/impl/flatbuffer/command.fbs
+++ b/tt_metal/impl/flatbuffer/command.fbs
@@ -1,7 +1,7 @@
 // Define schema for tracing host API calls, called Commands in this context.
-include "flatbuffer/buffer_types.fbs";
-include "flatbuffer/program_types.fbs";
-include "flatbuffer/base_types.fbs";
+include "buffer_types.fbs";
+include "program_types.fbs";
+include "base_types.fbs";
 
 namespace tt.tt_metal.flatbuffer;
 

--- a/tt_metal/impl/flatbuffer/light_metal_binary.fbs
+++ b/tt_metal/impl/flatbuffer/light_metal_binary.fbs
@@ -1,4 +1,4 @@
-include "flatbuffer/command.fbs";
+include "command.fbs";
 
 namespace tt.tt_metal.flatbuffer;
 

--- a/tt_metal/impl/flatbuffer/program_types.fbs
+++ b/tt_metal/impl/flatbuffer/program_types.fbs
@@ -1,4 +1,4 @@
-include "flatbuffer/base_types.fbs";
+include "base_types.fbs";
 
 namespace tt.tt_metal.flatbuffer;
 

--- a/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.cpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "flatbuffer/program_types_from_flatbuffer.hpp"
-#include "flatbuffer/base_types_from_flatbuffer.hpp"
+#include "program_types_from_flatbuffer.hpp"
+#include "base_types_from_flatbuffer.hpp"
 
 namespace tt::tt_metal {
 

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -26,7 +26,6 @@ target_compile_definitions(ttnn_core PUBLIC "$<$<CXX_COMPILER_ID:GNU>:DISABLE_NA
 target_precompile_headers(ttnn_core REUSE_FROM TT::CommonPCH)
 
 set(TENSOR_FLATBUFFER_SCHEMAS
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/tensor/flatbuffer/mesh_coordinate.fbs
     ${CMAKE_CURRENT_SOURCE_DIR}/core/tensor/flatbuffer/mesh_shape.fbs
     ${CMAKE_CURRENT_SOURCE_DIR}/core/tensor/flatbuffer/tensor_spec.fbs
     ${CMAKE_CURRENT_SOURCE_DIR}/core/tensor/flatbuffer/tensor.fbs
@@ -34,7 +33,7 @@ set(TENSOR_FLATBUFFER_SCHEMAS
 
 set(TENSOR_FLATBUFFER_GENERATED_HEADERS)
 foreach(FBS_FILE ${TENSOR_FLATBUFFER_SCHEMAS})
-    GENERATE_FBS_HEADER(${FBS_FILE})
+    GENERATE_FBS_HEADER(${FBS_FILE} TARGET TTNN::Core)
     list(APPEND TENSOR_FLATBUFFER_GENERATED_HEADERS ${FBS_GENERATED_HEADER_FILE})
 endforeach()
 

--- a/ttnn/core/tensor/flatbuffer/tensor.fbs
+++ b/ttnn/core/tensor/flatbuffer/tensor.fbs
@@ -1,6 +1,6 @@
 include "tensor_spec.fbs";
 include "mesh_shape.fbs";
-include "mesh_coordinate.fbs";
+include "tt-metalium/serialized_descriptors/mesh_coordinate.fbs";
 
 namespace ttnn.flatbuffer;
 
@@ -17,7 +17,7 @@ struct InlineFileStorage {
 
 table TensorShard {
     buffer: TensorBuffer;
-    mesh_coordinate: MeshCoordinate;
+    mesh_coordinate: tt.tt_metal.distributed.flatbuffer.MeshCoordinate;
 }
 
 union TensorType {

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -19,7 +19,7 @@
 #include "ttnn/tensor/tensor_utils.hpp"
 
 #include "mesh_shape_generated.h"
-#include "mesh_coordinate_generated.h"
+#include <tt-metalium/serialized_descriptors/mesh_coordinate_generated.h>
 #include "tensor_generated.h"
 
 #include <vector>
@@ -27,13 +27,14 @@
 namespace ttnn {
 namespace {
 
-flatbuffers::Offset<flatbuffer::MeshCoordinate> to_flatbuffer(
+flatbuffers::Offset<tt::tt_metal::distributed::flatbuffer::MeshCoordinate> to_flatbuffer(
     const tt::tt_metal::distributed::MeshCoordinate& coord, flatbuffers::FlatBufferBuilder& builder) {
     auto values_vector = builder.CreateVector(std::vector<uint32_t>(coord.coords().begin(), coord.coords().end()));
-    return flatbuffer::CreateMeshCoordinate(builder, values_vector);
+    return tt::tt_metal::distributed::flatbuffer::CreateMeshCoordinate(builder, values_vector);
 }
 
-tt::tt_metal::distributed::MeshCoordinate from_flatbuffer(const flatbuffer::MeshCoordinate* coord) {
+tt::tt_metal::distributed::MeshCoordinate from_flatbuffer(
+    const tt::tt_metal::distributed::flatbuffer::MeshCoordinate* coord) {
     return tt::tt_metal::distributed::MeshCoordinate(
         std::vector<uint32_t>(coord->values()->begin(), coord->values()->end()));
 }


### PR DESCRIPTION
### Ticket
No TIcket.

### Problem description
Multi-Host sockets require the ability to (de)serialize socket configs and metadata. This feature will be used during sender receiver host handshaking, address exchange and socket setup.

### What's changed
  - Add `MeshSocket` serialization tests and functionality. Current serialization schema relies on FlatBuffers
  - Add `SocketPeerDescriptor` struct encapsulating runtime dependent endpoint state
    - This includes the socket config and data buffer addresses + chip IDs (needed for computing fabric encodings
    - This data structure will be used for Multi-Host Socket Handshaking
  - Add `sender_rank` and `receiver_rank` fields to `SocketConfig` (0 by default)
  - Move` mesh_coordinate.fbs` out of `ttnn/` and into `distributed/ `since its used by the `MeshSocket` FB schema. Update namespaces and build flow to account for this

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes