### PR TITLE
chore: uplift tt-llk, June 4th

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -153,20 +153,27 @@ target_sources(
             soc_descriptors/blackhole_140_arch.yaml
             soc_descriptors/wormhole_b0_80_arch.yaml
             third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel.h
+            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_addr_map.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_addrmod.h
+            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_debug.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_defs.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_globals.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_gpr_map.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_include.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_instr_params.h
+            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_main.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_ops.h
+            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_pcbuf.h
+            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_sfpi.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_sfpu.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_structs.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_template.h
+            third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel_xmov.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/cmath_common.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/cpack_common.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/cunpack_common.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_abs.h
+            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_activations.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_add_int32.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -187,7 +194,6 @@ target_sources(
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_power.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_quant.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
-            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_recip.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_shift.h
@@ -204,9 +210,13 @@ target_sources(
             third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_defs.h
             third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_common.h
             third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
+            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary_sfpu.h
             third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpi.h
             third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_sfpu.h
             third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
+            third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
             third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_pack.h
             third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
             third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h
@@ -218,6 +228,7 @@ target_sources(
             third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
             third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel.h
+            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_addr_map.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_addrmod.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_debug.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
@@ -225,14 +236,19 @@ target_sources(
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_gpr_map.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_include.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_instr_params.h
+            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_main.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_ops.h
+            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_pcbuf.h
+            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_sfpi.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_sfpu.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_structs.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_template.h
+            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel_xmov.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_abs.h
+            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_activations.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_add_int32.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_binary_bitwise.h
@@ -252,7 +268,6 @@ target_sources(
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_max_int32.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_power.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_quant.h
-            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_relu.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reshuffle_rows.h

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -18,6 +18,7 @@ namespace sfpu {
 static const float PI = 3.1415927f;
 static const float PI_2 = 1.5707964f;
 static const float PI_4 = 0.7853982f;
+static const float FRAC_1_PI = 0.31830987f;
 
 static sfpi_inline vFloat sfpu_tan_large(vFloat x) {
     const vFloat r = 4.0f * sfpi::abs(x) - 5.0f;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -18,7 +18,6 @@ namespace sfpu {
 static const float PI = 3.1415927f;
 static const float PI_2 = 1.5707964f;
 static const float PI_4 = 0.7853982f;
-static const float FRAC_1_PI = 0.31830987f;
 
 static sfpi_inline vFloat sfpu_tan_large(vFloat x) {
     const vFloat r = 4.0f * sfpi::abs(x) - 5.0f;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -19,6 +19,7 @@ namespace sfpu {
 static const float PI = 3.1415927f;
 static const float PI_2 = 1.5707964f;
 static const float PI_4 = 0.7853982f;
+static const float FRAC_1_PI = 0.31830987f;
 
 static sfpi_inline vFloat sfpu_tan_large(vFloat x) {
     const vFloat r = 4.0f * sfpi::abs(x) - 5.0f;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -19,7 +19,6 @@ namespace sfpu {
 static const float PI = 3.1415927f;
 static const float PI_2 = 1.5707964f;
 static const float PI_4 = 0.7853982f;
-static const float FRAC_1_PI = 0.31830987f;
 
 static sfpi_inline vFloat sfpu_tan_large(vFloat x) {
     const vFloat r = 4.0f * sfpi::abs(x) - 5.0f;


### PR DESCRIPTION
### Ticket
None

### Problem description
This is the uplift of tt-llk containing changes from May 21st to June 5th. Only relevant changes are listed here. The rest are part of the effort to bootstrap testing infrastructure in llk repo and do not affect metal.

- Conditionally call disable/enable_gathering based on compile option (https://github.com/tenstorrent/tt-llk/pull/227)
- Move llk_unpack_tilizeA_B_* from tt-metal to tt-llk, Blackhole edition. (https://github.com/tenstorrent/tt-llk/pull/256)
- Add trunc and frac to LLK (https://github.com/tenstorrent/tt-llk/pull/263)
- Fix SETADCZW macro parameter names. (https://github.com/tenstorrent/tt-llk/pull/247)
- Fix pack_untilize for block_ct_dim != full_ct_dim (https://github.com/tenstorrent/tt-llk/pull/236)
- Improve gathering asms (https://github.com/tenstorrent/tt-llk/pull/271)
- Copy Blackhole unpack_tilizeA_B changes from latest tt-metal. (https://github.com/tenstorrent/tt-llk/pull/264)
- Add 32-bit support for transpose_of_faces to A2D datacopy. (https://github.com/tenstorrent/tt-llk/pull/250)
- TT_REPLAY -> TTI_REPLAY (https://github.com/tenstorrent/tt-llk/pull/292)
- Add comp ops to llk (https://github.com/tenstorrent/tt-llk/pull/228)

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15459640342) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15459642570) CI with demo tests passes (if applicable)