### PR TITLE
Remove tunneling reservation logic and add fabric connection args when fabric is enabled

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -597,6 +597,10 @@ int main(int argc, char** argv) {
             host_completion_queue_wr_ptr,
             dev_completion_queue_wr_ptr,
             dev_completion_queue_rd_ptr,
+            MetalContext::instance().dispatch_mem_map(CoreType::WORKER).get_dispatch_stream_index(0),
+            0,  // unused for single device - used to "virtualize" the number of eth cores across devices
+            0,  // unused for single device - used to "virtualize" the number of eth cores across devices
+            0,  // unused for single device - used to "virtualize" the number of eth cores across devices
             0,
             0,
             0,
@@ -605,9 +609,17 @@ int main(int argc, char** argv) {
             0,
             0,
             0,
-            0,     // unused for single device - used to "virtualize" the number of eth cores across devices
-            0,     // unused for single device - used to "virtualize" the number of eth cores across devices
-            0,     // unused for single device - used to "virtualize" the number of eth cores across devices
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
             true,  // is_dram_variant
             true,  // is_host_variant
         };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2058,14 +2058,26 @@ void configure_for_single_chip(
         0,                                           // unused: for prefetch_hd <--> dispatch_hd
         0,                                           // unused: for prefetch_hd <--> dispatch_hd
         0,                                           // unused: for prefetch_hd <--> dispatch_hd
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
         scratch_db_size_g,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
     };
 
     constexpr NOC my_noc_index = NOC::NOC_0;
@@ -2351,17 +2363,29 @@ void configure_for_single_chip(
         host_completion_queue_wr_ptr,
         dev_completion_queue_wr_ptr,
         dev_completion_queue_rd_ptr,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
         MetalContext::instance().dispatch_mem_map(DISPATCH_CORE_TYPE).get_dispatch_stream_index(0),
         0,  // unused for single device - used to "virtualize" the number of eth cores across devices
         0,  // unused for single device - used to "virtualize" the number of eth cores across devices
         0,  // unused for single device - used to "virtualize" the number of eth cores across devices
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
     };
 
     CoreCoord phys_upstream_from_dispatch_core = split_prefetcher_g ? phys_prefetch_d_core : phys_prefetch_core_g;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -865,7 +865,9 @@ void Device::clear_dram_state() {
 
 void Device::compile_command_queue_programs() {
     ZoneScoped;
-    if (this->is_mmio_capable()) {
+    // If the active ethernet core is not reserved a fabric will
+    // be created on it
+    if (this->is_mmio_capable() && !tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
         auto command_queue_program_ptr = create_and_compile_cq_program(this);
         this->command_queue_programs_.push_back(std::move(command_queue_program_ptr));
         // Since devices could be set up in any order, on mmio device do a pass and populate cores for tunnelers.

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -865,8 +865,6 @@ void Device::clear_dram_state() {
 
 void Device::compile_command_queue_programs() {
     ZoneScoped;
-    // If the active ethernet core is not reserved a fabric will
-    // be created on it
     if (this->is_mmio_capable() && !tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
         auto command_queue_program_ptr = create_and_compile_cq_program(this);
         this->command_queue_programs_.push_back(std::move(command_queue_program_ptr));

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -237,16 +237,6 @@ void DevicePool::initialize(
     tt::tt_metal::MetalContext::instance().initialize(
         dispatch_core_config, num_hw_cqs, {l1_bank_remap.begin(), l1_bank_remap.end()});
 
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
-        // Automatically initialize 1D fabric for dispatch
-        FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
-        if (fabric_config == FabricConfig::DISABLED) {
-            tt::tt_metal::detail::InitializeFabricConfig(FabricConfig::FABRIC_1D);
-        } else if (fabric_config != FabricConfig::FABRIC_1D) {
-            TT_THROW("Fast Dispatch only supports 1D Fabric. Mixed Fabric config is not supported.");
-        }
-    }
-
     if (_inst == nullptr) {
         static DevicePool device_pool{};
         _inst = &device_pool;

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -239,7 +239,7 @@ void DevicePool::initialize(
 
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
         // Automatically initialize 1D fabric for dispatch
-        FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
+        FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
         if (fabric_config == FabricConfig::DISABLED) {
             tt::tt_metal::detail::InitializeFabricConfig(FabricConfig::FABRIC_1D);
         } else if (fabric_config != FabricConfig::FABRIC_1D) {

--- a/tt_metal/impl/dispatch/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/command_queue_common.hpp
@@ -21,8 +21,9 @@ enum class CommandQueueDeviceAddrType : uint8_t {
     COMPLETION_Q0_LAST_EVENT = 4,
     COMPLETION_Q1_LAST_EVENT = 5,
     DISPATCH_S_SYNC_SEM = 6,
-    FABRIC_INTERFACE = 7,
-    UNRESERVED = 8
+    FABRIC_HEADER_RB = 7,
+    FABRIC_SYNC_STATUS = 8,
+    UNRESERVED = 9,
 };
 
 // likely only used in impl

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -140,9 +140,8 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
             device_cq_addr_sizes_[dev_addr_idx] = settings.dispatch_s_sync_sem_;
         } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_HEADER_RB) {
             if (tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
-                const auto& control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
-                TT_ASSERT(control_plane, "Fabric config not initialized yet. Call InitializeFabricConfig");
-                const auto& fabric_context = control_plane->get_fabric_context();
+                const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+                const auto& fabric_context = control_plane.get_fabric_context();
                 device_cq_addr_sizes_[dev_addr_idx] = tt::tt_metal::DispatchSettings::FABRIC_HEADER_RB_ENTRIES *
                                                       fabric_context.get_fabric_packet_header_size_bytes();
             } else {

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -139,20 +139,13 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
         } else if (dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM) {
             device_cq_addr_sizes_[dev_addr_idx] = settings.dispatch_s_sync_sem_;
         } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_HEADER_RB) {
-            if (tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
-                const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-                const auto& fabric_context = control_plane.get_fabric_context();
-                device_cq_addr_sizes_[dev_addr_idx] = tt::tt_metal::DispatchSettings::FABRIC_HEADER_RB_ENTRIES *
-                                                      fabric_context.get_fabric_packet_header_size_bytes();
-            } else {
-                device_cq_addr_sizes_[dev_addr_idx] = 0;
-            }
+            // At this point fabric context is not initialized yet
+            // Hardcode to 64B (more than enough space) for now
+            // const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+            // const auto& fabric_context = control_plane.get_fabric_context();
+            device_cq_addr_sizes_[dev_addr_idx] = tt::tt_metal::DispatchSettings::FABRIC_HEADER_RB_ENTRIES * 64;
         } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_SYNC_STATUS) {
-            if (tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
-                device_cq_addr_sizes_[dev_addr_idx] = sizeof(uint32_t);
-            } else {
-                device_cq_addr_sizes_[dev_addr_idx] = 0;
-            }
+            device_cq_addr_sizes_[dev_addr_idx] = sizeof(uint32_t);
         } else {
             device_cq_addr_sizes_[dev_addr_idx] = settings.other_ptrs_size;
         }

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -3,14 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <magic_enum/magic_enum.hpp>
-#include <tt-metalium/fabric_host_interface.h>
+#include <tt-metalium/fabric_edm_packet_header.hpp>
 #include <tt-metalium/tt_align.hpp>
-#include <optional>
 
 #include "dispatch_mem_map.hpp"
 #include "assert.hpp"
 #include "command_queue_common.hpp"
+#include "control_plane.hpp"
 #include "dispatch_settings.hpp"
+#include "fabric/fabric_context.hpp"
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include "utils.hpp"
@@ -126,7 +127,7 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
         DispatchSettings::DISPATCH_MESSAGE_ENTRIES <= DispatchSettings::DISPATCH_MESSAGES_MAX_OFFSET / l1_alignment + 1,
         "Number of dispatch message entries exceeds max representable offset");
 
-    uint8_t num_dev_cq_addrs = magic_enum::enum_count<CommandQueueDeviceAddrType>();
+    constexpr uint8_t num_dev_cq_addrs = magic_enum::enum_count<CommandQueueDeviceAddrType>();
     std::vector<uint32_t> device_cq_addr_sizes_(num_dev_cq_addrs, 0);
     for (auto dev_addr_idx = 0; dev_addr_idx < num_dev_cq_addrs; dev_addr_idx++) {
         CommandQueueDeviceAddrType dev_addr_type =
@@ -137,9 +138,19 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
             device_cq_addr_sizes_[dev_addr_idx] = settings.prefetch_q_pcie_rd_ptr_size_;
         } else if (dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM) {
             device_cq_addr_sizes_[dev_addr_idx] = settings.dispatch_s_sync_sem_;
-        } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_INTERFACE) {
+        } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_HEADER_RB) {
             if (tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
-                device_cq_addr_sizes_[dev_addr_idx] = tt_fabric::PACKET_HEADER_SIZE_BYTES;
+                const auto& control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+                TT_ASSERT(control_plane, "Fabric config not initialized yet. Call InitializeFabricConfig");
+                const auto& fabric_context = control_plane->get_fabric_context();
+                device_cq_addr_sizes_[dev_addr_idx] = tt::tt_metal::DispatchSettings::FABRIC_HEADER_RB_ENTRIES *
+                                                      fabric_context.get_fabric_packet_header_size_bytes();
+            } else {
+                device_cq_addr_sizes_[dev_addr_idx] = 0;
+            }
+        } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_SYNC_STATUS) {
+            if (tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
+                device_cq_addr_sizes_[dev_addr_idx] = sizeof(uint32_t);
             } else {
                 device_cq_addr_sizes_[dev_addr_idx] = 0;
             }
@@ -155,7 +166,9 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
         CommandQueueDeviceAddrType dev_addr_type = magic_enum::enum_value<CommandQueueDeviceAddrType>(dev_addr_idx);
         if (dev_addr_type == CommandQueueDeviceAddrType::UNRESERVED) {
             device_cq_addrs_[dev_addr_idx] = align(device_cq_addrs_[dev_addr_idx], pcie_alignment);
-        } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_INTERFACE) {
+        } else if (
+            dev_addr_type == CommandQueueDeviceAddrType::FABRIC_HEADER_RB ||
+            dev_addr_type == CommandQueueDeviceAddrType::FABRIC_SYNC_STATUS) {
             device_cq_addrs_[dev_addr_idx] = align(device_cq_addrs_[dev_addr_idx], l1_alignment);
         }
     }

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -142,6 +142,9 @@ public:
     static constexpr uint32_t MAX_DEV_CHANNEL_SIZE = 1 << 28;                                      // 256 MB;
     static constexpr uint32_t DEVICES_PER_UMD_CHANNEL = MAX_HUGEPAGE_SIZE / MAX_DEV_CHANNEL_SIZE;  // 256 MB;
 
+    // Number of entries in the fabric header ring buffer
+    static constexpr uint32_t FABRIC_HEADER_RB_ENTRIES = 1;
+
     //
     // Configurable Settings
     //

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -386,6 +386,7 @@ void DispatchKernel::GenerateDependentConfigs() {
                     tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
                 tt::tt_metal::assemble_fabric_mux_client_config_args(
                     node_id_, ch_type, relay_mux, dependent_config_.fabric_mux_client_config);
+            } else {
                 TT_FATAL(false, "Unexpected downstream kernel for dispatch_d");
             }
         }

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,6 +9,7 @@
 
 #include "assert.hpp"
 #include "core_coord.hpp"
+#include "dispatch/kernel_config/relay_mux.hpp"
 #include "fd_kernel.hpp"
 #include "mesh_graph.hpp"
 #include "impl/context/metal_context.hpp"
@@ -47,11 +48,12 @@ struct dispatch_static_config_t {
     std::optional<uint32_t> dev_completion_q_wr_ptr;
     std::optional<uint32_t> dev_completion_q_rd_ptr;
 
+    std::optional<uint32_t> fabric_header_rb_base;
+    std::optional<uint32_t> fabric_header_rb_entries;
+    std::optional<uint32_t> my_fabric_sync_status_addr;
+
     std::optional<bool> is_d_variant;
     std::optional<bool> is_h_variant;
-
-    // Populated if fabric is being used to talk to downstream
-    std::optional<uint32_t> client_interface_addr;
 };
 
 struct dispatch_dependent_config_t {
@@ -71,13 +73,9 @@ struct dispatch_dependent_config_t {
     std::optional<uint32_t> prefetch_h_noc_xy;                     // Dependent. Used if split_prefetch is true
     std::optional<uint32_t> prefetch_h_local_downstream_sem_addr;  // Dependent. Used if split_prefetch is true
 
-    // Populated if fabric is being used to talk to downstream
-    std::optional<uint32_t> fabric_router_noc_xy;
-    std::optional<uint32_t> upstream_mesh_id;
-    std::optional<uint32_t> upstream_dev_id;
-    std::optional<uint32_t> downstream_mesh_id;
-    std::optional<uint32_t> downstream_dev_id;
-    std::optional<uint32_t> outbound_eth_chan;
+    std::optional<uint32_t> num_hops;
+
+    tt::tt_metal::relay_mux_client_config fabric_mux_client_config;
 };
 
 class DispatchKernel : public FDKernel {
@@ -122,14 +120,6 @@ public:
 
     void ConfigureCore() override;
 
-    void UpdateArgsForFabric(
-        const CoreCoord& fabric_router,
-        uint32_t outbound_eth_chan,
-        tt::tt_fabric::MeshId src_mesh_id,
-        chip_id_t src_chip_id,
-        tt::tt_fabric::MeshId dst_mesh_id,
-        chip_id_t dst_chip_id) override;
-
     uint32_t GetDispatchBufferSize() const {
         return (1 << static_config_.dispatch_cb_log_page_size.value()) * static_config_.dispatch_cb_pages.value();
     }
@@ -138,6 +128,7 @@ public:
 private:
     dispatch_static_config_t static_config_;
     dispatch_dependent_config_t dependent_config_;
+    FDKernelEdmConnectionAttributes edm_connection_attributes_;
 };
 
 }  // namespace tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -167,9 +167,6 @@ KernelHandle FDKernel::configure_kernel_variant(
     if (rt_options.watcher_dispatch_disabled()) {
         defines["FORCE_WATCHER_OFF"] = "1";
     }
-    if (rt_options.get_fd_fabric()) {
-        defines["FABRIC_RELAY"] = "1";
-    }
     if (!DPrintServerReadsDispatchCores(device_->id())) {
         defines["FORCE_DPRINT_OFF"] = "1";
     }

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -170,9 +170,6 @@ KernelHandle FDKernel::configure_kernel_variant(
     if (rt_options.get_fd_fabric()) {
         defines["FABRIC_RELAY"] = "1";
     }
-    if (tt::tt_metal::MetalContext::instance().get_fabric_config() != FabricConfig::FABRIC_2D) {
-        defines["FVC_MODE_PULL"] = "1";
-    }
     if (!DPrintServerReadsDispatchCores(device_->id())) {
         defines["FORCE_DPRINT_OFF"] = "1";
     }

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -167,6 +167,9 @@ KernelHandle FDKernel::configure_kernel_variant(
     if (rt_options.watcher_dispatch_disabled()) {
         defines["FORCE_WATCHER_OFF"] = "1";
     }
+    if (rt_options.get_fd_fabric()) {
+        defines["FABRIC_RELAY"] = "1";
+    }
     if (tt::tt_metal::MetalContext::instance().get_fabric_config() != FabricConfig::FABRIC_2D) {
         defines["FVC_MODE_PULL"] = "1";
     }
@@ -199,4 +202,10 @@ KernelHandle FDKernel::configure_kernel_variant(
                 .defines = defines,
                 .opt_level = opt_level});
     }
+}
+
+void FDKernel::create_edm_connection_sems(FDKernelEdmConnectionAttributes& attributes) {
+    attributes.worker_flow_control_sem = tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+    attributes.worker_buffer_index_sem = tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+    attributes.worker_teardown_sem = tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
 }

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -1,6 +1,7 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <tt-metalium/program.hpp>
@@ -102,16 +103,6 @@ public:
     // after above functions and before FD kernels are launched.
     virtual void ConfigureCore() {}
 
-    // Override for specific kernels that can be configured for fabric. Will be called by the FABRIC_ROUTER_VC, which is
-    // an intermediary FDKernel for indicating a fabric router path needs to be found.
-    virtual void UpdateArgsForFabric(
-        const CoreCoord& fabric_router_virtual,
-        uint32_t outbound_eth_chan,
-        tt::tt_fabric::MeshId upstream_mesh_id,
-        chip_id_t upstream_chip_id,
-        tt::tt_fabric::MeshId downstream_mesh_id,
-        chip_id_t downstream_chip_id) {}
-
     // Generator function to create a kernel of a given type. New kernels need to be added here.
     static FDKernel* Generate(
         int node_id,
@@ -155,6 +146,13 @@ public:
     void AddProgram(tt::tt_metal::Program* program) { program_ = program; }
 
 protected:
+    // Attributes for an EDM client to connect to the router
+    struct FDKernelEdmConnectionAttributes {
+        size_t worker_flow_control_sem;
+        size_t worker_teardown_sem;
+        size_t worker_buffer_index_sem;
+    };
+
     [[maybe_unused]] KernelHandle configure_kernel_variant(
         const string& path,
         const std::vector<uint32_t>& compile_args,
@@ -179,7 +177,8 @@ protected:
     static chip_id_t GetDownstreamDeviceId(chip_id_t device_id, int tunnel = -1);
     // Helper function to get the tunnel stop index of current device
     static uint32_t GetTunnelStop(chip_id_t device_id);
-
+    // Create and populate semaphores for the EDM connection
+    void create_edm_connection_sems(FDKernelEdmConnectionAttributes& attributes);
     tt::tt_metal::IDevice* device_ = nullptr;  // Set at configuration time by AddDeviceAndProgram()
     tt::tt_metal::Program* program_ = nullptr;
     tt_cxy_pair logical_core_;

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -1,6 +1,7 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #include "prefetch.hpp"
 
 #include <host_api.hpp>
@@ -8,7 +9,6 @@
 #include <array>
 #include <map>
 #include <string>
-#include <utility>
 #include <variant>
 #include <vector>
 
@@ -18,10 +18,10 @@
 #include "dispatch.hpp"
 #include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch/dispatch_settings.hpp"
+#include "dispatch/kernel_config/relay_mux.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch_s.hpp"
 #include "eth_router.hpp"
-#include "hal.hpp"
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
@@ -36,6 +36,13 @@ void PrefetchKernel::GenerateStaticConfigs() {
         tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
     uint8_t cq_id_ = this->cq_id_;
     auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
+
+    // May be zero if not using dispatch on fabric
+    static_config_.fabric_header_rb_base =
+        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_HEADER_RB);
+    static_config_.fabric_header_rb_entries = tt::tt_metal::DispatchSettings::FABRIC_HEADER_RB_ENTRIES;
+    static_config_.my_fabric_sync_status_addr =
+        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_SYNC_STATUS);
 
     if (static_config_.is_h_variant.value() && this->static_config_.is_d_variant.value()) {
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
@@ -126,14 +133,15 @@ void PrefetchKernel::GenerateStaticConfigs() {
         // Workaround for now. Need downstream to initialize my semaphore. Can't defer creating semaphore yet
         {
             uint32_t downstream_cb_pages;
-            if (tt::tt_metal::MetalContext::instance()
-                    .get_cluster()
-                    .is_galaxy_cluster()) {  // TODO: whys is this hard-coded for galaxy?
+            if (tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
+                downstream_cb_pages = my_dispatch_constants.prefetch_d_buffer_pages();
+            } else if (tt::tt_metal::MetalContext::instance()
+                           .get_cluster()
+                           .is_galaxy_cluster()) {  // TODO: whys is this hard-coded for galaxy?
                 downstream_cb_pages = my_dispatch_constants.mux_buffer_pages(1);
             } else {
                 downstream_cb_pages = my_dispatch_constants.mux_buffer_pages(device_->num_hw_cqs());
             }
-
             static_config_.my_downstream_cb_sem_id =
                 tt::tt_metal::CreateSemaphore(*program_, logical_core_, downstream_cb_pages, GetCoreType());
         }
@@ -200,6 +208,11 @@ void PrefetchKernel::GenerateStaticConfigs() {
     } else {
         TT_FATAL(false, "PrefetchKernel must be one of (or both) H and D variants");
     }
+
+    if ((static_config_.is_h_variant.value() ^ static_config_.is_d_variant.value()) &&
+        tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
+        create_edm_connection_sems(edm_connection_attributes_);
+    }
 }
 
 void PrefetchKernel::GenerateDependentConfigs() {
@@ -249,53 +262,68 @@ void PrefetchKernel::GenerateDependentConfigs() {
             dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
             dependent_config_.downstream_dispatch_s_cb_sem_id = UNUSED_SEM_ID;
         }
+        dependent_config_.num_hops = 0;
     } else if (static_config_.is_h_variant.value()) {
         // Upstream, just host so no dispatch core
         TT_ASSERT(upstream_kernels_.size() == 0);
         dependent_config_.upstream_logical_core = UNUSED_LOGICAL_CORE;
         dependent_config_.upstream_cb_sem_id = 0;  // Used in prefetch_d only
+        // May be updated below
+        dependent_config_.num_hops = 0;
 
-        // Downstream
-        // one ROUTER or direct connection to PREFETCH_D if using fabric
-        TT_ASSERT(downstream_kernels_.size() == 1);
-        if (auto router_kernel = dynamic_cast<EthRouterKernel*>(downstream_kernels_[0])) {
-            dependent_config_.downstream_logical_core = router_kernel->GetLogicalCore();
-            dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
-            uint32_t router_idx =
-                router_kernel->GetUpstreamPort(this);  // Need the port that this connects to downstream
-            auto downstream_buffer_size = router_kernel->GetStaticConfig().rx_queue_size_words.value() << 4;
-            dependent_config_.downstream_cb_base =
-                (router_kernel->GetStaticConfig().rx_queue_start_addr_words.value() << 4) +
-                downstream_buffer_size * router_idx;
-            dependent_config_.downstream_cb_sem_id =
-                router_kernel->GetStaticConfig().input_packetize_local_sem[router_idx];
-            dependent_config_.downstream_dispatch_s_cb_sem_id = 0;  // No downstream DISPATCH_S in this case
+        // Process downstream
+        // ROUTER ||
+        // PREFETCH_D ||
+        // FABRIC_MUX
+        for (FDKernel* ds_kernel : downstream_kernels_) {
+            if (auto router_kernel = dynamic_cast<EthRouterKernel*>(ds_kernel)) {
+                dependent_config_.downstream_logical_core = router_kernel->GetLogicalCore();
+                dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
+                uint32_t router_idx =
+                    router_kernel->GetUpstreamPort(this);  // Need the port that this connects to downstream
+                auto downstream_buffer_size = router_kernel->GetStaticConfig().rx_queue_size_words.value() << 4;
+                dependent_config_.downstream_cb_base =
+                    (router_kernel->GetStaticConfig().rx_queue_start_addr_words.value() << 4) +
+                    downstream_buffer_size * router_idx;
+                dependent_config_.downstream_cb_sem_id =
+                    router_kernel->GetStaticConfig().input_packetize_local_sem[router_idx];
+                dependent_config_.downstream_dispatch_s_cb_sem_id = 0;  // No downstream DISPATCH_S in this case
 
-            dependent_config_.downstream_cb_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
-            dependent_config_.downstream_cb_pages =
-                downstream_buffer_size / (1 << DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
-        } else if (auto prefetch_d = dynamic_cast<PrefetchKernel*>(downstream_kernels_[0])) {
-            TT_ASSERT(
-                prefetch_d->GetStaticConfig().is_d_variant.value() &&
-                !prefetch_d->GetStaticConfig().is_h_variant.value());
+                dependent_config_.downstream_cb_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
+                dependent_config_.downstream_cb_pages =
+                    downstream_buffer_size / (1 << DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
+            } else if (auto prefetch_d = dynamic_cast<PrefetchKernel*>(ds_kernel)) {
+                TT_ASSERT(
+                    prefetch_d->GetStaticConfig().is_d_variant.value() &&
+                    !prefetch_d->GetStaticConfig().is_h_variant.value());
 
-            dependent_config_.downstream_logical_core = prefetch_d->GetLogicalCore();
-            dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
-            dependent_config_.downstream_cb_base = prefetch_d->GetStaticConfig().cmddat_q_base.value();
-            dependent_config_.downstream_cb_sem_id = prefetch_d->GetStaticConfig().my_upstream_cb_sem_id.value();
-            dependent_config_.downstream_dispatch_s_cb_sem_id = 0;
+                dependent_config_.downstream_logical_core = prefetch_d->GetLogicalCore();
+                dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
+                dependent_config_.downstream_cb_base = prefetch_d->GetStaticConfig().cmddat_q_base.value();
+                dependent_config_.downstream_cb_sem_id = prefetch_d->GetStaticConfig().my_upstream_cb_sem_id.value();
+                dependent_config_.downstream_dispatch_s_cb_sem_id = 0;
 
-            static_assert(
-                DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE == DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE);
-            dependent_config_.downstream_cb_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
-            dependent_config_.downstream_cb_pages = prefetch_d->GetStaticConfig().cmddat_q_pages.value();
-        } else {
-            TT_FATAL(false, "Path not implemented");
+                static_assert(
+                    DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE ==
+                    DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE);
+                dependent_config_.downstream_cb_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
+                dependent_config_.downstream_cb_pages = prefetch_d->GetStaticConfig().cmddat_q_pages.value();
+                dependent_config_.num_hops = tt::tt_metal::get_num_hops(device_id_, prefetch_d->GetDeviceId());
+            } else if (auto fabric_mux = dynamic_cast<tt::tt_metal::RelayMux*>(ds_kernel)) {
+                constexpr tt::tt_fabric::FabricMuxChannelType ch_type =
+                    tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
+                tt::tt_metal::assemble_fabric_mux_client_config_args(
+                    node_id_, ch_type, fabric_mux, dependent_config_.fabric_mux_client_config);
+            } else {
+                TT_FATAL(false, "PREFETCH_H Downstream - Unimplemented path");
+            }
         }
     } else if (static_config_.is_d_variant.value()) {
         // Upstream
         // One ROUTER or direct connection to PREFETCH_H if using fabric
         TT_ASSERT(upstream_kernels_.size() == 1);
+        // May be updated below
+        dependent_config_.num_hops = 0;
         if (auto router_kernel = dynamic_cast<EthRouterKernel*>(upstream_kernels_[0])) {
             dependent_config_.upstream_logical_core = router_kernel->GetLogicalCore();
             int router_idx = router_kernel->GetDownstreamPort(this);
@@ -304,6 +332,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
         } else if (auto prefetch_h = dynamic_cast<PrefetchKernel*>(upstream_kernels_[0])) {
             dependent_config_.upstream_logical_core = prefetch_h->GetLogicalCore();
             dependent_config_.upstream_cb_sem_id = prefetch_h->GetStaticConfig().my_downstream_cb_sem_id.value();
+            dependent_config_.num_hops = tt::tt_metal::get_num_hops(prefetch_h->GetDeviceId(), device_id_);
         } else {
             TT_FATAL(false, "Path not implemented");
         }
@@ -317,6 +346,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
         }
         bool found_dispatch = false;
         bool found_dispatch_s = false;
+        bool found_relay_mux = false;
         for (FDKernel* k : downstream_kernels_) {
             if (auto dispatch_kernel = dynamic_cast<DispatchKernel*>(k)) {
                 TT_ASSERT(!found_dispatch, "PREFETCH kernel has multiple downstream DISPATCH kernels.");
@@ -336,10 +366,19 @@ void PrefetchKernel::GenerateDependentConfigs() {
                 dependent_config_.downstream_s_logical_core = dispatch_s_kernel->GetLogicalCore();
                 dependent_config_.downstream_dispatch_s_cb_sem_id =
                     dispatch_s_kernel->GetStaticConfig().my_dispatch_cb_sem_id;
+            } else if (auto relay_mux = dynamic_cast<tt::tt_metal::RelayMux*>(k)) {
+                TT_ASSERT(!found_relay_mux, "PREFETCH_D kernel has multiple downstream RELAY_MUX kernels.");
+                found_relay_mux = true;
+                constexpr tt::tt_fabric::FabricMuxChannelType ch_type =
+                    tt::tt_fabric::FabricMuxChannelType::HEADER_ONLY_CHANNEL;
+                tt::tt_metal::assemble_fabric_mux_client_config_args(
+                    node_id_, ch_type, relay_mux, dependent_config_.fabric_mux_client_config);
             } else {
                 TT_FATAL(false, "Unrecognized downstream kernel.");
             }
         }
+        // No check needed for found relay mux. A direct connection to PREFETCH_H on the same core
+        // is possible (used in test prefetcher) and does not need tunneling.
         if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
             // Should have found dispatch_s in the downstream kernels
             TT_ASSERT(found_dispatch && found_dispatch_s);
@@ -385,18 +424,35 @@ void PrefetchKernel::CreateKernel() {
         dependent_config_.downstream_dispatch_s_cb_sem_id.value(),
         static_config_.dispatch_s_buffer_size.value(),
         static_config_.dispatch_s_cb_log_page_size.value(),
-        dependent_config_.downstream_mesh_id.value_or(0),
-        dependent_config_.downstream_dev_id.value_or(0),
-        dependent_config_.upstream_mesh_id.value_or(0),
-        dependent_config_.upstream_dev_id.value_or(0),
-        dependent_config_.fabric_router_noc_xy.value_or(0),
-        dependent_config_.outbound_eth_chan.value_or(0),
-        static_config_.client_interface_addr.value_or(0),
         static_config_.ringbuffer_size.value(),
+
+        static_config_.fabric_header_rb_base.value(),
+        static_config_.fabric_header_rb_entries.value(),
+        static_config_.my_fabric_sync_status_addr.value(),
+
+        dependent_config_.fabric_mux_client_config.virtual_x.value_or(0),
+        dependent_config_.fabric_mux_client_config.virtual_y.value_or(0),
+        dependent_config_.fabric_mux_client_config.num_buffers_per_channel.value_or(0),
+        dependent_config_.fabric_mux_client_config.channel_buffer_size_bytes.value_or(0),
+        dependent_config_.fabric_mux_client_config.channel_base_address.value_or(0),
+        dependent_config_.fabric_mux_client_config.connection_info_address.value_or(0),
+        dependent_config_.fabric_mux_client_config.connection_handshake_address.value_or(0),
+        dependent_config_.fabric_mux_client_config.flow_control_address.value_or(0),
+        dependent_config_.fabric_mux_client_config.buffer_index_address.value_or(0),
+        dependent_config_.fabric_mux_client_config.status_address.value_or(0),
+        dependent_config_.fabric_mux_client_config.termination_signal_address.value_or(0),
+        dependent_config_.fabric_mux_client_config.worker_credits_stream_id.value_or(0),
+
+        edm_connection_attributes_.worker_flow_control_sem,
+        edm_connection_attributes_.worker_teardown_sem,
+        edm_connection_attributes_.worker_buffer_index_sem,
+
+        dependent_config_.num_hops.value(),
+
         static_config_.is_d_variant.value(),
         static_config_.is_h_variant.value(),
     };
-    TT_ASSERT(compile_args.size() == 36);
+
     auto my_virtual_core = get_virtual_core_coord(logical_core_, GetCoreType());
     auto upstream_virtual_core = get_virtual_core_coord(dependent_config_.upstream_logical_core.value(), GetCoreType());
     auto downstream_virtual_core =
@@ -471,24 +527,4 @@ void PrefetchKernel::ConfigureCore() {
             device_, logical_core_, prefetch_q_pcie_rd_ptr, prefetch_q_pcie_rd_ptr_addr_data, GetCoreType());
         detail::WriteToDeviceL1(device_, logical_core_, prefetch_q_base, prefetch_q, GetCoreType());
     }
-}
-
-void PrefetchKernel::UpdateArgsForFabric(
-    const CoreCoord& fabric_router_virtual,
-    uint32_t outbound_eth_chan,
-    tt::tt_fabric::MeshId upstream_mesh_id,
-    chip_id_t upstream_dev_id,
-    tt::tt_fabric::MeshId downstream_mesh_id,
-    chip_id_t downstream_dev_id) {
-    dependent_config_.fabric_router_noc_xy =
-        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(fabric_router_virtual.x, fabric_router_virtual.y);
-    dependent_config_.upstream_mesh_id = *upstream_mesh_id;
-    dependent_config_.upstream_dev_id = upstream_dev_id;
-    dependent_config_.downstream_mesh_id = *downstream_mesh_id;
-    dependent_config_.downstream_dev_id = downstream_dev_id;
-    dependent_config_.outbound_eth_chan = outbound_eth_chan;
-
-    auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
-    static_config_.client_interface_addr =
-        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_INTERFACE);
 }

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -337,13 +337,8 @@ void PrefetchKernel::GenerateDependentConfigs() {
             TT_FATAL(false, "Path not implemented");
         }
 
-        // Downstream, expect a DISPATCH_D and s DISPATCH_S
-        // Prefetch_d will always be local with dispatch_d
-        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
-            TT_ASSERT(downstream_kernels_.size() == 2);
-        } else {
-            TT_ASSERT(downstream_kernels_.size() == 1);
-        }
+        // Downstream
+        // DISPATCH_D || DISPATCH_S || FABRIC_MUX
         bool found_dispatch = false;
         bool found_dispatch_s = false;
         bool found_relay_mux = false;

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -268,7 +268,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
         TT_ASSERT(upstream_kernels_.size() == 0);
         dependent_config_.upstream_logical_core = UNUSED_LOGICAL_CORE;
         dependent_config_.upstream_cb_sem_id = 0;  // Used in prefetch_d only
-        // May be updated below
+        // May be overwritten below
         dependent_config_.num_hops = 0;
 
         // Process downstream
@@ -322,7 +322,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
         // Upstream
         // One ROUTER or direct connection to PREFETCH_H if using fabric
         TT_ASSERT(upstream_kernels_.size() == 1);
-        // May be updated below
+        // May be overwritten below
         dependent_config_.num_hops = 0;
         if (auto router_kernel = dynamic_cast<EthRouterKernel*>(upstream_kernels_[0])) {
             dependent_config_.upstream_logical_core = router_kernel->GetLogicalCore();

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,6 +13,7 @@
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.h>
+#include "dispatch/kernel_config/relay_mux.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -48,11 +49,12 @@ struct prefetch_static_config_t {
     std::optional<uint32_t> dispatch_s_buffer_size;
     std::optional<uint32_t> dispatch_s_cb_log_page_size;
 
+    std::optional<uint32_t> fabric_header_rb_base;
+    std::optional<uint32_t> fabric_header_rb_entries;
+    std::optional<uint32_t> my_fabric_sync_status_addr;
+
     std::optional<bool> is_d_variant;
     std::optional<bool> is_h_variant;
-
-    // Populated if fabric is being used to talk to downstream
-    std::optional<uint32_t> client_interface_addr;
 };
 
 struct prefetch_dependent_config_t {
@@ -69,13 +71,9 @@ struct prefetch_dependent_config_t {
 
     std::optional<uint32_t> downstream_dispatch_s_cb_sem_id;
 
-    // Populated if fabric is being used to talk to downstream
-    std::optional<uint32_t> fabric_router_noc_xy;
-    std::optional<uint32_t> upstream_mesh_id;
-    std::optional<uint32_t> upstream_dev_id;
-    std::optional<uint32_t> downstream_mesh_id;
-    std::optional<uint32_t> downstream_dev_id;
-    std::optional<uint32_t> outbound_eth_chan;
+    std::optional<uint32_t> num_hops;
+
+    tt::tt_metal::relay_mux_client_config fabric_mux_client_config;
 };
 
 class PrefetchKernel : public FDKernel {
@@ -106,22 +104,21 @@ public:
         }
         this->kernel_type_ = FDKernelType::DISPATCH;
     }
+
     void CreateKernel() override;
+
     void GenerateStaticConfigs() override;
+
     void GenerateDependentConfigs() override;
+
     void ConfigureCore() override;
-    void UpdateArgsForFabric(
-        const CoreCoord& fabric_router,
-        uint32_t outbound_eth_chan,
-        tt::tt_fabric::MeshId src_mesh_id,
-        chip_id_t src_chip_id,
-        tt::tt_fabric::MeshId dst_mesh_id,
-        chip_id_t dst_chip_id) override;
+
     const prefetch_static_config_t& GetStaticConfig() { return static_config_; }
 
 private:
     prefetch_static_config_t static_config_;
     prefetch_dependent_config_t dependent_config_;
+    FDKernelEdmConnectionAttributes edm_connection_attributes_;
 };
 
 }  // namespace tt_metal

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -10,6 +10,7 @@
 //  - # blocks must evenly divide the dispatch buffer size
 //  - dispatch buffer base must be page size aligned
 
+#include "dataflow_api.h"
 #include "debug/assert.h"
 #include "debug/dprint.h"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
@@ -58,8 +59,32 @@ constexpr uint32_t virtualize_unicast_cores = get_compile_time_arg_val(30);
 constexpr uint32_t num_virtual_unicast_cores = get_compile_time_arg_val(31);
 constexpr uint32_t num_physical_unicast_cores = get_compile_time_arg_val(32);
 
-constexpr uint32_t is_d_variant = get_compile_time_arg_val(33);
-constexpr uint32_t is_h_variant = get_compile_time_arg_val(34);
+// fabric mux connection
+constexpr uint32_t fabric_header_rb_base = get_compile_time_arg_val(33);
+constexpr uint32_t fabric_header_rb_entries = get_compile_time_arg_val(34);
+constexpr uint32_t my_fabric_sync_status_addr = get_compile_time_arg_val(35);
+
+constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(36);
+constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(37);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(38);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(39);
+constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(40);
+constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(41);
+constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(42);
+constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(43);
+constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(44);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(45);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(46);
+constexpr size_t worker_credits_stream_id = get_compile_time_arg_val(47);
+
+constexpr size_t fabric_worker_flow_control_sem = get_compile_time_arg_val(48);
+constexpr size_t fabric_worker_teardown_sem = get_compile_time_arg_val(49);
+constexpr size_t fabric_worker_buffer_index_sem = get_compile_time_arg_val(50);
+
+constexpr uint32_t num_hops = get_compile_time_arg_val(51);
+
+constexpr uint32_t is_d_variant = get_compile_time_arg_val(52);
+constexpr uint32_t is_h_variant = get_compile_time_arg_val(53);
 
 constexpr uint8_t upstream_noc_index = UPSTREAM_NOC_INDEX;
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -52,23 +52,14 @@ constexpr uint32_t host_completion_q_wr_ptr = get_compile_time_arg_val(26);
 constexpr uint32_t dev_completion_q_wr_ptr = get_compile_time_arg_val(27);
 constexpr uint32_t dev_completion_q_rd_ptr = get_compile_time_arg_val(28);
 
-// used for fd on fabric
-constexpr uint32_t downstream_mesh_id = get_compile_time_arg_val(29);
-constexpr uint32_t downstream_dev_id = get_compile_time_arg_val(30);
-constexpr uint32_t upstream_mesh_id = get_compile_time_arg_val(31);
-constexpr uint32_t upstream_dev_id = get_compile_time_arg_val(32);
-constexpr uint32_t fabric_router_noc_xy = get_compile_time_arg_val(33);
-constexpr uint32_t outbound_eth_chan = get_compile_time_arg_val(34);
-constexpr uint32_t client_interface_addr = get_compile_time_arg_val(35);
+constexpr uint32_t first_stream_used = get_compile_time_arg_val(29);
 
-constexpr uint32_t first_stream_used = get_compile_time_arg_val(36);
+constexpr uint32_t virtualize_unicast_cores = get_compile_time_arg_val(30);
+constexpr uint32_t num_virtual_unicast_cores = get_compile_time_arg_val(31);
+constexpr uint32_t num_physical_unicast_cores = get_compile_time_arg_val(32);
 
-constexpr uint32_t virtualize_unicast_cores = get_compile_time_arg_val(37);
-constexpr uint32_t num_virtual_unicast_cores = get_compile_time_arg_val(38);
-constexpr uint32_t num_physical_unicast_cores = get_compile_time_arg_val(39);
-
-constexpr uint32_t is_d_variant = get_compile_time_arg_val(40);
-constexpr uint32_t is_h_variant = get_compile_time_arg_val(41);
+constexpr uint32_t is_d_variant = get_compile_time_arg_val(33);
+constexpr uint32_t is_h_variant = get_compile_time_arg_val(34);
 
 constexpr uint8_t upstream_noc_index = UPSTREAM_NOC_INDEX;
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -70,19 +70,10 @@ constexpr uint32_t downstream_dispatch_s_cb_sem_id = get_compile_time_arg_val(23
 constexpr uint32_t dispatch_s_buffer_size = get_compile_time_arg_val(24);
 constexpr uint32_t dispatch_s_cb_log_page_size = get_compile_time_arg_val(25);
 
-// used for fd on fabric
-constexpr uint32_t downstream_mesh_id = get_compile_time_arg_val(26);
-constexpr uint32_t downstream_dev_id = get_compile_time_arg_val(27);
-constexpr uint32_t upstream_mesh_id = get_compile_time_arg_val(28);
-constexpr uint32_t upstream_dev_id = get_compile_time_arg_val(29);
-constexpr uint32_t fabric_router_noc_xy = get_compile_time_arg_val(30);
-constexpr uint32_t outbound_eth_chan = get_compile_time_arg_val(31);
-constexpr uint32_t client_interface_addr = get_compile_time_arg_val(32);
+constexpr uint32_t ringbuffer_size = get_compile_time_arg_val(26);
 
-constexpr uint32_t ringbuffer_size = get_compile_time_arg_val(33);
-
-constexpr uint32_t is_d_variant = get_compile_time_arg_val(34);
-constexpr uint32_t is_h_variant = get_compile_time_arg_val(35);
+constexpr uint32_t is_d_variant = get_compile_time_arg_val(27);
+constexpr uint32_t is_h_variant = get_compile_time_arg_val(28);
 
 constexpr uint32_t prefetch_q_end = prefetch_q_base + prefetch_q_size;
 constexpr uint32_t cmddat_q_end = cmddat_q_base + cmddat_q_size;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -17,6 +17,7 @@
 //
 
 #include "dataflow_api.h"
+#include "dataflow_api_addrgen.h"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_common.hpp"
 #include "debug/dprint.h"
@@ -72,8 +73,32 @@ constexpr uint32_t dispatch_s_cb_log_page_size = get_compile_time_arg_val(25);
 
 constexpr uint32_t ringbuffer_size = get_compile_time_arg_val(26);
 
-constexpr uint32_t is_d_variant = get_compile_time_arg_val(27);
-constexpr uint32_t is_h_variant = get_compile_time_arg_val(28);
+// fabric mux connection
+constexpr uint32_t fabric_header_rb_base = get_compile_time_arg_val(27);
+constexpr uint32_t fabric_header_rb_entries = get_compile_time_arg_val(28);
+constexpr uint32_t my_fabric_sync_status_addr = get_compile_time_arg_val(29);
+
+constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(30);
+constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(31);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(32);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(33);
+constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(34);
+constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(35);
+constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(36);
+constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(37);
+constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(38);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(39);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(40);
+constexpr size_t worker_credits_stream_id = get_compile_time_arg_val(41);
+
+constexpr size_t fabric_worker_flow_control_sem = get_compile_time_arg_val(42);
+constexpr size_t fabric_worker_teardown_sem = get_compile_time_arg_val(43);
+constexpr size_t fabric_worker_buffer_index_sem = get_compile_time_arg_val(44);
+
+constexpr uint32_t num_hops = get_compile_time_arg_val(45);
+
+constexpr uint32_t is_d_variant = get_compile_time_arg_val(46);
+constexpr uint32_t is_h_variant = get_compile_time_arg_val(47);
 
 constexpr uint32_t prefetch_q_end = prefetch_q_base + prefetch_q_size;
 constexpr uint32_t cmddat_q_end = cmddat_q_base + cmddat_q_size;

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -806,10 +806,17 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
         }
     } else {
         // Need to handle N300/T3000 separately from TG/TGG since they have different templates/tunnel depths
+        // If using fabric, upstream would have already initalized to the proper config for dispatch
+        const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
         if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
             // For Galaxy, we always init all remote devices associated with an mmio device.
-            const std::vector<DispatchKernelNode>* nodes_for_one_mmio =
-                (num_hw_cqs == 1) ? &galaxy_nine_chip_arch_1cq : &galaxy_nine_chip_arch_2cq;
+            std::vector<DispatchKernelNode> nodes_for_one_mmio;
+            if (rtoptions.get_fd_fabric()) {
+                nodes_for_one_mmio =
+                    (num_hw_cqs == 1) ? galaxy_nine_chip_arch_1cq_fabric : galaxy_nine_chip_arch_2cq_fabric;
+            } else {
+                nodes_for_one_mmio = (num_hw_cqs == 1) ? galaxy_nine_chip_arch_1cq : galaxy_nine_chip_arch_2cq;
+            }
             uint32_t index_offset = 0;
             for (auto mmio_device_id : mmio_devices) {
                 // Need a mapping from templated device id (1-8) to actual device id (from the tunnel)
@@ -827,7 +834,7 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
                 }
 
                 // Pull nodes from the template, updating their index and device id
-                for (DispatchKernelNode node : *nodes_for_one_mmio) {
+                for (DispatchKernelNode node : nodes_for_one_mmio) {
                     int32_t num_devices = template_id_to_device_id.size();
                     TT_ASSERT(
                         node.device_id < num_devices,
@@ -844,7 +851,7 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
                     increment_node_ids(node, index_offset);
                     nodes.push_back(node);
                 }
-                index_offset += nodes_for_one_mmio->size();
+                index_offset += nodes_for_one_mmio.size();
             }
         } else {
             // Should be paired mmio/remote devices
@@ -852,7 +859,11 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
                 mmio_devices.size() == remote_devices.size() or remote_devices.empty(),
                 "N300/T3K expects devices in mmio/remote pairs.");
             std::vector<DispatchKernelNode> nodes_for_one_mmio;
-            nodes_for_one_mmio = (num_hw_cqs == 1) ? two_chip_arch_1cq : two_chip_arch_2cq;
+            if (rtoptions.get_fd_fabric()) {
+                nodes_for_one_mmio = (num_hw_cqs == 1) ? two_chip_arch_1cq_fabric : two_chip_arch_2cq_fabric;
+            } else {
+                nodes_for_one_mmio = (num_hw_cqs == 1) ? two_chip_arch_1cq : two_chip_arch_2cq;
+            }
 
             uint32_t index_offset = 0;
             for (auto mmio_device_id : mmio_devices) {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1010,7 +1010,7 @@ void Cluster::reserve_ethernet_cores_for_tunneling() {
         }
         std::map<std::tuple<chip_id_t, chip_id_t>, bool> reserved_chip_connections = {};
         for (const auto &chip_id : devices) {
-            if (TT_METAL_SLOW_DISPATCH_MODE == nullptr and arch_ == ARCH::WORMHOLE_B0) {
+            if (!TT_METAL_SLOW_DISPATCH_MODE && arch_ == ARCH::WORMHOLE_B0 && !rtoptions_.get_fd_fabric()) {
                 for (const auto &[connected_chip_id, active_eth_cores] :
                      this->get_ethernet_cores_grouped_by_connected_chips(chip_id)) {
                     for (const auto &eth_core : active_eth_cores) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18726

### Problem description
- For Fast dispatch on fabric, we connect the prefetch/dispatchers directly as upstream and downstream kernels and tunneling reservation logic needs to be removed so a fabric router can be created on the active ethernet core
- Additional compile args are needed for prefetch/dispatch to connect to fabric
- Follow up PR will be made for device changes to fully enable fabric

### What's changed
- Update Dispatch and Prefetch kernels to accept a `RelayMux` as a downstream kernel
- Disable tunneling / active ethernet core reservation logic when FD Fabric is enabled. This will cause a fabric router to be created on the free active eth core
- Pass in additional compile time args required for prefetch and dispatch to connect to the fabric mux (`RelayMux`)
- Automatically initialize the fabric config to be 1D fabric when FD Fabric is enabled. Mixed Fabric config is not supported and will throw an error
- The `TT_METAL_FD_FABRIC` variable will be removed when dispatch on fabric is fully enabled

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15499620045
BH
https://github.com/tenstorrent/tt-metal/actions/runs/15473720663
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/15474208392