### PR TITLE
[skip ci] easier ability to run tests with sanitizers

### DIFF
--- a/.github/workflows/build-and-unit-tests-wrapper.yaml
+++ b/.github/workflows/build-and-unit-tests-wrapper.yaml
@@ -2,6 +2,17 @@ name: "[post-commit] Slow Dispatch unit tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      build-type:
+        required: false
+        type: choice
+        options:
+          - Release
+          - Debug
+          - RelWithDebInfo
+          - ASan
+          - TSan
+        default: "Release"
 
 jobs:
   build-artifact:
@@ -10,6 +21,7 @@ jobs:
       packages: write
     secrets: inherit
     with:
+      build-type: ${{ inputs.build-type }}
       build-wheel: true
   sd-unit-tests:
     needs: build-artifact

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
@@ -63,14 +63,7 @@ foreach(TEST_SRC ${PERF_MICROBENCH_TESTS_SRCS})
     string(REPLACE "wormhole" "wormhole_b0" TEST_TARGET ${TEST_TARGET})
 
     add_executable(${TEST_TARGET} ${TEST_SRC})
-    target_link_libraries(
-        ${TEST_TARGET}
-        PUBLIC
-            test_metal_common_libs
-        PRIVATE
-            yaml-cpp::yaml-cpp
-            fabric
-    )
+    target_link_libraries(${TEST_TARGET} PRIVATE test_metal_common_libs)
     if(${TEST_SRC} STREQUAL "dispatch/test_pgm_dispatch.cpp")
         target_link_libraries(${TEST_TARGET} PRIVATE benchmark::benchmark)
     endif()


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Running all of APC is overkill when tackling ASan (or TSan) issues in certain tests.  And this workflow didn't ask what type of build to run.

### What's changed
Ask what type of build to run.
Fixed an ODR while I was there.