### PR TITLE
Refactored Paged Attention usage

### DIFF
--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -205,7 +205,10 @@ def run_llama3_demo(
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper, per_device_group=True)
 
-        paged_attention_config = PagedAttentionConfig(**page_params)
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
 
         logger.info("Page table tensor done")
 

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -16,9 +16,7 @@ import hashlib
 
 is_RING_6U = os.environ.get("RING_6U", "0") == "1"
 
-from models.demos.llama3_subdevices.tt.llama_common import (
-    PagedAttentionConfig,
-)
+from models.demos.llama3_subdevices.tt.llama_common import PagedAttentionConfig, PagedAttention
 from models.demos.llama3_subdevices.tt.llama_model import TtTransformer
 from models.demos.llama3_subdevices.tt.llama_embedding import TtLlamaEmbedding
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
@@ -186,6 +184,7 @@ def run_llama3_demo(
     profiler.end("weight_loading")
 
     page_table_tt = None
+
     if paged_attention:
         paged_cache_max_seq_len = (
             paged_attention_config.block_size
@@ -198,21 +197,16 @@ def run_llama3_demo(
         assert_msg = f"Either stress test with start_pos ({start_pos}) <= paged_cache_max_seq_len ({paged_cache_max_seq_len}) or max_generated_tokens ({max_generated_tokens}) + start_pos ({start_pos}) <= paged_cache_max_seq_len ({paged_cache_max_seq_len})"
         assert is_valid_token_position, assert_msg
 
-        # Implied shuffling of blocks
-        permutation = torch.randperm(paged_attention_config.max_num_blocks)
-        # Page table which maps virtual blocks to physical
-        reverse_permutation = torch.argsort(permutation)
-        page_table = reverse_permutation.reshape(
-            model_args.batch_size_per_device_group,
-            paged_attention_config.max_num_blocks // model_args.batch_size_per_device_group,
+        mesh_mapper = ttnn.ShardTensor2dMesh(
+            mesh_device,
+            dims=(None, -2) if batch_size > 1 else (None, None),
+            mesh_shape=model_args.cluster_shape,
         )
-        page_table_tt = ttnn.from_torch(
-            page_table,
-            device=mesh_device,
-            dtype=ttnn.int32,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, None), mesh_shape=model_args.cluster_shape),
-        )
+
+        paged_attn = PagedAttention(config=paged_attention_config, model_args=model_args)
+
+        page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper, per_device_group=True)
+
         logger.info("Page table tensor done")
 
     # Load TTNN Llama3.1 model

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -199,7 +199,7 @@ def run_llama3_demo(
 
         mesh_mapper = ttnn.ShardTensor2dMesh(
             mesh_device,
-            dims=(None, -2) if batch_size > 1 else (None, None),
+            dims=(None, None),
             mesh_shape=model_args.cluster_shape,
         )
 

--- a/models/demos/llama3_subdevices/demo/demo_performance.py
+++ b/models/demos/llama3_subdevices/demo/demo_performance.py
@@ -119,8 +119,10 @@ def run_llama3_decode_performance(
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper)
 
-        paged_attention_config = PagedAttentionConfig(**page_params)
-
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
         logger.info("Page table tensor done")
 
     # Load TTNN Llama3.1 model
@@ -449,14 +451,6 @@ def test_llama_decode_performance(
     # TODO: Remove this once all batch sizes are supported on TG
     if os.environ.get("FAKE_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("TG only supports batch 1 and 32")
-
-    if paged_attention:
-        paged_attention_config = PagedAttentionConfig(
-            block_size=page_params["page_block_size"],
-            max_num_blocks=page_params["page_max_num_blocks"],
-        )
-    else:
-        paged_attention_config = None
 
     return run_llama3_decode_performance(
         user_input=input_prompts,

--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -121,12 +121,9 @@ def create_tt_model(
         permutation = torch.randperm(paged_attention_config.max_num_blocks)
         # Page table which maps virtual blocks to physical
         reverse_permutation = torch.argsort(permutation)
+
         page_table = reverse_permutation.reshape(
             tt_model_args.max_batch_size, paged_attention_config.max_num_blocks // tt_model_args.max_batch_size
-        )
-        paged_attention_config = PagedAttentionConfig(
-            block_size=page_params["page_block_size"],
-            max_num_blocks=page_params["page_max_num_blocks"],
         )
 
     model = TtTransformer(

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -9,9 +9,6 @@ import ttnn
 import json
 import pandas as pd
 from collections import defaultdict
-from models.demos.llama3_subdevices.tt.llama_common import (
-    PagedAttentionConfig,
-)
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from models.perf.device_perf_utils import run_device_perf
 from tt_metal.tools.profiler.process_model_log import (
@@ -111,14 +108,6 @@ def test_llama_demo(
     if os.environ.get("FAKE_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("TG only supports batch 1 and 32")
 
-    if paged_attention:
-        paged_attention_config = PagedAttentionConfig(
-            block_size=page_params["page_block_size"],
-            max_num_blocks=page_params["page_max_num_blocks"],
-        )
-    else:
-        paged_attention_config = None
-
     return run_llama3_demo(
         user_input=input_prompts,
         mesh_device=mesh_device,
@@ -126,7 +115,7 @@ def test_llama_demo(
         batch_size=batch_size,
         num_batches=repeat_batches,
         paged_attention=paged_attention,
-        paged_attention_config=paged_attention_config,
+        page_params=page_params,
         max_generated_tokens=max_generated_tokens,
         optimizations=optimizations,
         sampling_params=sampling_params,

--- a/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
@@ -6,10 +6,7 @@ import pytest
 from loguru import logger
 import os
 import ttnn
-from models.demos.llama3_subdevices.tt.llama_common import (
-    HostEmbedding,
-    PagedAttentionConfig,
-)
+from models.demos.llama3_subdevices.tt.llama_common import HostEmbedding, PagedAttentionConfig, PagedAttention
 from models.demos.llama3_subdevices.tt.llama_model import TtTransformer
 from models.demos.llama3_subdevices.tt.sampling import TTSampling
 from models.demos.llama3_subdevices.tt.model_config import TtModelArgs, LlamaOptimizations
@@ -154,24 +151,16 @@ def test_tt_model_acc(
             block_size=page_params["page_block_size"],
             max_num_blocks=page_params["page_max_num_blocks"],
         )
-        # Implied shuffling of blocks
-        permutation = torch.randperm(paged_attention_config.max_num_blocks)
-        # Page table which maps virtual blocks to physical
-        reverse_permutation = torch.argsort(permutation)
-        page_table = reverse_permutation.reshape(
-            model_args.max_batch_size, paged_attention_config.max_num_blocks // model_args.max_batch_size
+
+        mesh_mapper = ttnn.ShardTensor2dMesh(
+            mesh_device,
+            dims=(None, -2) if batch_size > 1 else (None, None),
+            mesh_shape=model_args.cluster_shape,
         )
-        page_table_tt = ttnn.from_torch(
-            page_table,
-            device=mesh_device,
-            dtype=ttnn.int32,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_device,
-                dims=(None, -2) if batch_size > 1 else (None, None),
-                mesh_shape=model_args.cluster_shape,
-            ),
-        )
+
+        paged_attn = PagedAttention(paged_attention_config, model_args)
+
+        page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper)
 
     # Initialize TT model
     tt_model = TtTransformer(

--- a/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
@@ -147,20 +147,17 @@ def test_tt_model_acc(
     paged_attention_config = None
 
     if paged_attention:
-        paged_attention_config = PagedAttentionConfig(
-            block_size=page_params["page_block_size"],
-            max_num_blocks=page_params["page_max_num_blocks"],
-        )
-
         mesh_mapper = ttnn.ShardTensor2dMesh(
             mesh_device,
             dims=(None, -2) if batch_size > 1 else (None, None),
             mesh_shape=model_args.cluster_shape,
         )
 
-        paged_attn = PagedAttention(paged_attention_config, model_args)
+        paged_attn = PagedAttention(page_params, model_args)
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper)
+
+        paged_attention_config = PagedAttentionConfig(**page_params)
 
     # Initialize TT model
     tt_model = TtTransformer(

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder.py
@@ -123,20 +123,17 @@ def test_llama_decoder_inference(
     paged_attention_config = None
 
     if paged_attention:
-        paged_attention_config = PagedAttentionConfig(
-            block_size=page_params["page_block_size"],
-            max_num_blocks=page_params["page_max_num_blocks"],
-        )
-
         mesh_mapper = ttnn.ShardTensor2dMesh(
             mesh_device,
             dims=(None, None),
             mesh_shape=model_args.cluster_shape,
         )
 
-        paged_attn = PagedAttention(paged_attention_config, model_args)
+        paged_attn = PagedAttention(page_params, model_args)
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper, per_device_group=True)
+
+        paged_attention_config = PagedAttentionConfig(**page_params)
 
     # Initialize TT model
     tt_model = TtTransformerBlock(

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder.py
@@ -133,7 +133,10 @@ def test_llama_decoder_inference(
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper, per_device_group=True)
 
-        paged_attention_config = PagedAttentionConfig(**page_params)
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
 
     # Initialize TT model
     tt_model = TtTransformerBlock(

--- a/models/demos/llama3_subdevices/tests/test_llama_model.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_model.py
@@ -198,8 +198,10 @@ def test_llama_model_inference(
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper, per_device_group=True)
 
-        paged_attention_config = PagedAttentionConfig(**page_params)
-
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
     # Load TTNN model
     tt_model = TtTransformer(
         args=model_args,

--- a/models/demos/llama3_subdevices/tests/test_llama_model.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_model.py
@@ -10,6 +10,7 @@ from models.demos.llama3_subdevices.tt.llama_common import (
     sample_host,
     HostEmbedding,
     PagedAttentionConfig,
+    PagedAttention,
 )
 from models.demos.llama3_subdevices.tt.model_config import TtModelArgs, LlamaOptimizations
 from models.demos.llama3_subdevices.tt.llama_model import TtTransformer
@@ -191,25 +192,16 @@ def test_llama_model_inference(
             block_size=page_params["page_block_size"],
             max_num_blocks=page_params["page_max_num_blocks"],
         )
-        # Implied shuffling of blocks
-        permutation = torch.randperm(paged_attention_config.max_num_blocks)
-        # Page table which maps virtual blocks to physical
-        reverse_permutation = torch.argsort(permutation)
-        page_table = reverse_permutation.reshape(
-            model_args.batch_size_per_device_group,
-            paged_attention_config.max_num_blocks // model_args.batch_size_per_device_group,
+
+        mesh_mapper = ttnn.ShardTensor2dMesh(
+            mesh_device,
+            dims=(None, None),
+            mesh_shape=model_args.cluster_shape,
         )
-        page_table_tt = ttnn.from_torch(
-            page_table,
-            device=mesh_device,
-            dtype=ttnn.int32,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_device,
-                dims=(None, None),
-                mesh_shape=model_args.cluster_shape,
-            ),
-        )
+
+        paged_attn = PagedAttention(paged_attention_config, model_args)
+
+        page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper, per_device_group=True)
 
     # Load TTNN model
     tt_model = TtTransformer(
@@ -383,7 +375,9 @@ def test_llama_model_inference(
                                             dims=(1, 3) if model_args.is_galaxy else (0, 1),
                                             mesh_shape=model_args.cluster_shape,
                                         ),
-                                    )[reverse_permutation][:, : model_args.n_kv_heads, :, : model_args.head_dim]
+                                    )[paged_attn.reverse_permutation][
+                                        :, : model_args.n_kv_heads, :, : model_args.head_dim
+                                    ]
                                     .reshape(
                                         model_args.max_batch_size,
                                         paged_attention_config.max_num_blocks // model_args.max_batch_size,

--- a/models/demos/llama3_subdevices/tests/test_llama_model.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_model.py
@@ -188,20 +188,17 @@ def test_llama_model_inference(
 
     # Prepare page table for paged attention
     if paged_attention:
-        paged_attention_config = PagedAttentionConfig(
-            block_size=page_params["page_block_size"],
-            max_num_blocks=page_params["page_max_num_blocks"],
-        )
-
         mesh_mapper = ttnn.ShardTensor2dMesh(
             mesh_device,
             dims=(None, None),
             mesh_shape=model_args.cluster_shape,
         )
 
-        paged_attn = PagedAttention(paged_attention_config, model_args)
+        paged_attn = PagedAttention(page_params, model_args)
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper, per_device_group=True)
+
+        paged_attention_config = PagedAttentionConfig(**page_params)
 
     # Load TTNN model
     tt_model = TtTransformer(

--- a/models/demos/llama3_subdevices/tests/test_llama_model_nd.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_model_nd.py
@@ -127,12 +127,14 @@ def test_llama_model_inference(
             mesh_shape=model_args.cluster_shape,
         )
 
-        paged_attn = PagedAttention(paged_attention_config, model_args)
+        paged_attn = PagedAttention(page_params, model_args)
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper, per_device_group=True)
 
-        paged_attention_config = PagedAttentionConfig(**page_params)
-
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
     # Load TTNN model
     tt_model = TtTransformer(
         args=model_args,

--- a/models/demos/llama3_subdevices/tests/test_llama_model_nd.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_model_nd.py
@@ -121,11 +121,6 @@ def test_llama_model_inference(
 
     # Prepare page table for paged attention
     if paged_attention:
-        paged_attention_config = PagedAttentionConfig(
-            block_size=page_params["page_block_size"],
-            max_num_blocks=page_params["page_max_num_blocks"],
-        )
-
         mesh_mapper = ttnn.ShardTensor2dMesh(
             mesh_device,
             dims=(None, None),
@@ -135,6 +130,8 @@ def test_llama_model_inference(
         paged_attn = PagedAttention(paged_attention_config, model_args)
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper, per_device_group=True)
+
+        paged_attention_config = PagedAttentionConfig(**page_params)
 
     # Load TTNN model
     tt_model = TtTransformer(

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
@@ -121,11 +121,14 @@ def test_llama_attention_inference(
             mesh_shape=model_args.cluster_shape,
         )
 
-        paged_attn = PagedAttention(paged_attention_config, model_args)
+        paged_attn = PagedAttention(page_params, model_args)
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper, per_device_group=True)
 
-        paged_attention_config = PagedAttentionConfig(**page_params)
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
 
     prefetcher_setup = TtLlamaPrefetcherSetup(
         mesh_device,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
@@ -115,11 +115,6 @@ def test_llama_attention_inference(
     paged_attention_config = None
 
     if paged_attention:
-        paged_attention_config = PagedAttentionConfig(
-            block_size=page_params["page_block_size"],
-            max_num_blocks=page_params["page_max_num_blocks"],
-        )
-
         mesh_mapper = ttnn.ShardTensor2dMesh(
             mesh_device,
             dims=(None, None),
@@ -129,6 +124,8 @@ def test_llama_attention_inference(
         paged_attn = PagedAttention(paged_attention_config, model_args)
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper, per_device_group=True)
+
+        paged_attention_config = PagedAttentionConfig(**page_params)
 
     prefetcher_setup = TtLlamaPrefetcherSetup(
         mesh_device,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
@@ -9,7 +9,7 @@ import ttnn
 from models.demos.llama3_subdevices.tt.llama_attention import TtLlamaAttention
 from models.demos.llama3_subdevices.tt.llama_rope import TtLlamaRotarySetup
 from models.demos.llama3_subdevices.tt.model_config import TtModelArgs
-from models.demos.llama3_subdevices.tt.llama_common import precompute_freqs, PagedAttentionConfig, PageAttention
+from models.demos.llama3_subdevices.tt.llama_common import precompute_freqs, PagedAttentionConfig, PagedAttention
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.model import Attention
 from models.utility_functions import (
     comp_pcc,
@@ -126,9 +126,9 @@ def test_llama_attention_inference(
             mesh_shape=model_args.cluster_shape,
         )
 
-        paged_attn = PageAttention(paged_attention_config, model_args)
+        paged_attn = PagedAttention(paged_attention_config, model_args)
 
-        page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper)
+        page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper, per_device_group=True)
 
     prefetcher_setup = TtLlamaPrefetcherSetup(
         mesh_device,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention_prefill.py
@@ -12,6 +12,7 @@ from models.demos.llama3_subdevices.tt.llama_common import (
     get_prefill_rot_mat,
     get_rot_transformation_mat,
     PagedAttentionConfig,
+    PagedAttention,
 )
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.model import Attention, precompute_freqs_cis
 from models.utility_functions import (
@@ -121,20 +122,13 @@ def test_llama_attention_inference(
             block_size=page_params["page_block_size"],
             max_num_blocks=page_params["page_max_num_blocks"],
         )
-        # Implied shuffling of blocks
-        permutation = torch.randperm(paged_attention_config.max_num_blocks)
-        # Page table which maps virtual blocks to physical
-        reverse_permutation = torch.argsort(permutation)
-        page_table = reverse_permutation.reshape(
-            model_args.max_batch_size, paged_attention_config.max_num_blocks // model_args.max_batch_size
-        )
-        page_table_tt = ttnn.from_torch(
-            page_table,
-            device=mesh_device,
-            dtype=ttnn.int32,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-        )
+
+        paged_attn = PagedAttention(paged_attention_config, model_args)
+
+        mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+
+        page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper)
+
     prefetcher_setup = TtLlamaPrefetcherSetup(mesh_device, n_tensors=0, n_layers=1, mode="prefill")
     mesh_device.set_sub_device_stall_group([prefetcher_setup.worker_sub_device_id])
     tt_ccl = TT_CCL(mesh_device, model_args, prefetcher_setup.worker_sub_device_id, mode="prefill")
@@ -214,7 +208,7 @@ def test_llama_attention_inference(
                             dims=(1, 3) if model_args.is_galaxy else (0, 1),
                             mesh_shape=model_args.cluster_shape,
                         ),
-                    )[reverse_permutation][:, : model_args.n_kv_heads, :, : model_args.head_dim]
+                    )[paged_attn.reverse_permutation][:, : model_args.n_kv_heads, :, : model_args.head_dim]
                     .reshape(
                         model_args.max_batch_size,
                         paged_attention_config.max_num_blocks // model_args.max_batch_size,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention_prefill.py
@@ -124,7 +124,10 @@ def test_llama_attention_inference(
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper)
 
-        paged_attention_config = PagedAttentionConfig(**page_params)
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
 
     prefetcher_setup = TtLlamaPrefetcherSetup(mesh_device, n_tensors=0, n_layers=1, mode="prefill")
     mesh_device.set_sub_device_stall_group([prefetcher_setup.worker_sub_device_id])

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention_prefill.py
@@ -118,16 +118,13 @@ def test_llama_attention_inference(
     paged_attention_config = None
 
     if paged_attention:
-        paged_attention_config = PagedAttentionConfig(
-            block_size=page_params["page_block_size"],
-            max_num_blocks=page_params["page_max_num_blocks"],
-        )
-
-        paged_attn = PagedAttention(paged_attention_config, model_args)
+        paged_attn = PagedAttention(page_params, model_args)
 
         mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper)
+
+        paged_attention_config = PagedAttentionConfig(**page_params)
 
     prefetcher_setup = TtLlamaPrefetcherSetup(mesh_device, n_tensors=0, n_layers=1, mode="prefill")
     mesh_device.set_sub_device_stall_group([prefetcher_setup.worker_sub_device_id])

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_decoder_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_decoder_prefill.py
@@ -118,16 +118,13 @@ def test_llama_decoder_inference(
     paged_attention_config = None
 
     if paged_attention:
-        paged_attention_config = PagedAttentionConfig(
-            block_size=page_params["page_block_size"],
-            max_num_blocks=page_params["page_max_num_blocks"],
-        )
-
         mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
 
         paged_attn = PagedAttention(paged_attention_config, model_args)
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper)
+
+        paged_attention_config = PagedAttentionConfig(**page_params)
 
     prefetcher_setup = TtLlamaPrefetcherSetup(mesh_device, n_tensors=0, n_layers=1, mode="prefill")
     mesh_device.set_sub_device_stall_group([prefetcher_setup.worker_sub_device_id])

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_decoder_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_decoder_prefill.py
@@ -120,11 +120,14 @@ def test_llama_decoder_inference(
     if paged_attention:
         mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
 
-        paged_attn = PagedAttention(paged_attention_config, model_args)
+        paged_attn = PagedAttention(page_params, model_args)
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper)
 
-        paged_attention_config = PagedAttentionConfig(**page_params)
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
 
     prefetcher_setup = TtLlamaPrefetcherSetup(mesh_device, n_tensors=0, n_layers=1, mode="prefill")
     mesh_device.set_sub_device_stall_group([prefetcher_setup.worker_sub_device_id])

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
@@ -158,8 +158,10 @@ def test_llama_model_inference(
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper)
 
-        paged_attention_config = PagedAttentionConfig(**page_params)
-
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks"],
+        )
     # Load TTNN model
     tt_model = TtTransformer(
         args=model_args,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
@@ -152,16 +152,13 @@ def test_llama_model_inference(
     paged_attention_config = None
 
     if paged_attention:
-        paged_attention_config = PagedAttentionConfig(
-            block_size=page_params["page_block_size"],
-            max_num_blocks=page_params["page_max_num_blocks"],
-        )
-
         mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
 
-        paged_attn = PagedAttention(paged_attention_config, model_args)
+        paged_attn = PagedAttention(page_params, model_args)
 
         page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper)
+
+        paged_attention_config = PagedAttentionConfig(**page_params)
 
     # Load TTNN model
     tt_model = TtTransformer(

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
@@ -12,6 +12,7 @@ from models.demos.llama3_subdevices.tt.llama_common import (
     HostEmbedding,
     encode_prompt_llama_instruct,
     PagedAttentionConfig,
+    PagedAttention,
 )
 from models.demos.llama3_subdevices.tt.llama_model import TtTransformer
 from models.demos.llama3_subdevices.tt.model_config import TtModelArgs, LlamaOptimizations
@@ -155,20 +156,12 @@ def test_llama_model_inference(
             block_size=page_params["page_block_size"],
             max_num_blocks=page_params["page_max_num_blocks"],
         )
-        # Implied shuffling of blocks
-        permutation = torch.randperm(paged_attention_config.max_num_blocks)
-        # Page table which maps virtual blocks to physical
-        reverse_permutation = torch.argsort(permutation)
-        page_table = reverse_permutation.reshape(
-            model_args.max_batch_size, paged_attention_config.max_num_blocks // model_args.max_batch_size
-        )
-        page_table_tt = ttnn.from_torch(
-            page_table,
-            device=mesh_device,
-            dtype=ttnn.int32,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-        )
+
+        mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+
+        paged_attn = PagedAttention(paged_attention_config, model_args)
+
+        page_table_tt = paged_attn.create_page_table(mesh_device, mesh_mapper)
 
     # Load TTNN model
     tt_model = TtTransformer(
@@ -256,7 +249,7 @@ def test_llama_model_inference(
                                         dims=(1, 3) if model_args.is_galaxy else (0, 1),
                                         mesh_shape=model_args.cluster_shape,
                                     ),
-                                )[reverse_permutation][:, : model_args.n_kv_heads, :, : model_args.head_dim]
+                                )[paged_attn.reverse_permutation][:, : model_args.n_kv_heads, :, : model_args.head_dim]
                                 .reshape(
                                     model_args.max_batch_size,
                                     paged_attention_config.max_num_blocks // model_args.max_batch_size,
@@ -278,7 +271,7 @@ def test_llama_model_inference(
                                         dims=(1, 0) if model_args.is_galaxy else (0, 1),
                                         mesh_shape=model_args.cluster_shape,
                                     ),
-                                )[reverse_permutation]
+                                )[paged_attn.reverse_permutation]
                                 .reshape(
                                     model_args.max_batch_size,
                                     paged_attention_config.max_num_blocks // model_args.max_batch_size,

--- a/models/demos/llama3_subdevices/tt/llama_common.py
+++ b/models/demos/llama3_subdevices/tt/llama_common.py
@@ -32,9 +32,7 @@ class PagedAttention:
         self.page_table_tt = None
 
     def create_page_table(self, device, mesh_mapper=None, per_device_group=False):
-        batch_size = (
-            self.model_args.max_batch_size if not per_device_group else self.model_args.batch_size_per_device_group
-        )
+        batch_size = self.model_args.batch_size_per_device_group if per_device_group else self.model_args.max_batch_size
         permutation = torch.randperm(self.config.max_num_blocks)
         self.reverse_permutation = torch.argsort(permutation)
         assert self.config.max_num_blocks % batch_size == 0, "max_num_blocks must be divisible by max_batch_size"

--- a/models/demos/llama3_subdevices/tt/llama_common.py
+++ b/models/demos/llama3_subdevices/tt/llama_common.py
@@ -18,9 +18,9 @@ class HostEmbedding(torch.nn.Module):
 
 # Default configuration for Paged Attention
 class PagedAttentionConfig:
-    def __init__(self, page_block_size=32, page_max_num_blocks=1024):
-        self.page_block_size = page_block_size
-        self.page_max_num_blocks = page_max_num_blocks
+    def __init__(self, block_size=32, max_num_blocks=1024):
+        self.block_size = block_size
+        self.max_num_blocks = max_num_blocks
 
 
 # Helper class for Page Attention, uses above PagedAttentionConfig


### PR DESCRIPTION
### Problem description
There was over reusage of repeated large chunks of code for page attention in our llama tg unit tests. This PR performs a refactor to improve code readability and maintainability on this.

### What's changed
- Added an additional helper class `PagedAttention` under `llama_common.py`, allows for creating the page table from the class method `create_page_table(mesh_device, mesh_mapper,per_device_group)`
- if `per_device_group` is enabled the reshape utilizes `batch_size_per_device_group`, it uses `max_batch_size` by default
- replaced all instances of paged attention usage with instantiation of this class

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes