### PR TITLE
[skip ci] Fix workflows that lost write permission

### DIFF
--- a/.github/workflows/release-cleanup.yaml
+++ b/.github/workflows/release-cleanup.yaml
@@ -1,5 +1,8 @@
 name: Release Cleanup
 
+permissions:
+  contents: write
+
 on:
   schedule:
     - cron: "0 7 * * *"  # Runs daily at midnight UTC

--- a/.github/workflows/remove-stale-branches.yaml
+++ b/.github/workflows/remove-stale-branches.yaml
@@ -1,5 +1,8 @@
 name: "[internal] Remove Stale Branches"
 
+permissions:
+  contents: write
+
 on:
   schedule:
     - cron: "0 0,12 * * *"   # Runs at midnight (0:00) and noon (12:00)
@@ -10,7 +13,7 @@ jobs:
     if: github.repository == 'tenstorrent/tt-metal'
     runs-on: ubuntu-latest
     steps:
-      - uses: blozano-tt/remove-stale-branches@379c5b1430ca2951a1365427e7eb6574cfc4c7dd
+      - uses: fpicalausa/remove-stale-branches@68ab5e762e74b8c055007c62e5e85afdf0ec54be
         with:
           dry-run: false
           days-before-branch-stale: 180 # Branches stale for ~6 months


### PR DESCRIPTION
### What's changed
These workflows lost write permission after some GH -> GHE migration?
Also, stop using blozano's fork of some open source action, because my changes were upstreamed.