### PR TITLE
Make active mesh device use FD for reading/writing profiler buffers

### DIFF
--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -53,22 +53,14 @@ std::vector<uint32_t> read_control_buffer_from_core(
         MetalContext::instance().hal().get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
     if (state != ProfilerDumpState::FORCE_UMD_READ && tt::DevicePool::instance().is_dispatch_firmware_active()) {
         if (auto mesh_device = device->get_mesh_device()) {
-            if (core_type == HalProgrammableCoreType::TENSIX) {
-                distributed::FDMeshCommandQueue& mesh_cq =
-                    dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-                const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
-                const distributed::DeviceMemoryAddress address = {
-                    device_coord, core, reinterpret_cast<DeviceAddr>(profiler_msg->control_vector)};
-                control_buffer.resize(kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE);
-                mesh_cq.enqueue_read_shard_from_core(
-                    address, control_buffer.data(), kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE, true);
-            } else {
-                control_buffer = tt::llrt::read_hex_vec_from_core(
-                    device->id(),
-                    core,
-                    reinterpret_cast<DeviceAddr>(profiler_msg->control_vector),
-                    kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE);
-            }
+            distributed::FDMeshCommandQueue& mesh_cq =
+                dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
+            const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
+            const distributed::DeviceMemoryAddress address = {
+                device_coord, core, reinterpret_cast<DeviceAddr>(profiler_msg->control_vector)};
+            control_buffer.resize(kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE);
+            mesh_cq.enqueue_read_shard_from_core(
+                address, control_buffer.data(), kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE, true);
         } else {
             control_buffer.resize(kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE);
             dynamic_cast<HWCommandQueue&>(device->command_queue())
@@ -100,18 +92,13 @@ void write_control_buffer_to_core(
         MetalContext::instance().hal().get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
     if (state != ProfilerDumpState::FORCE_UMD_READ && tt::DevicePool::instance().is_dispatch_firmware_active()) {
         if (auto mesh_device = device->get_mesh_device()) {
-            if (core_type == HalProgrammableCoreType::TENSIX) {
-                distributed::FDMeshCommandQueue& mesh_cq =
-                    dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-                const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
-                const distributed::DeviceMemoryAddress address = {
-                    device_coord, core, reinterpret_cast<DeviceAddr>(profiler_msg->control_vector)};
-                mesh_cq.enqueue_write_shard_to_core(
-                    address, control_buffer.data(), kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE, true);
-            } else {
-                tt::llrt::write_hex_vec_to_core(
-                    device->id(), core, control_buffer, reinterpret_cast<DeviceAddr>(profiler_msg->control_vector));
-            }
+            distributed::FDMeshCommandQueue& mesh_cq =
+                dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
+            const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
+            const distributed::DeviceMemoryAddress address = {
+                device_coord, core, reinterpret_cast<DeviceAddr>(profiler_msg->control_vector)};
+            mesh_cq.enqueue_write_shard_to_core(
+                address, control_buffer.data(), kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE, true);
         } else {
             dynamic_cast<HWCommandQueue&>(device->command_queue())
                 .enqueue_write_to_core(

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -110,8 +110,6 @@ tt_metal::HalProgrammableCoreType get_core_type(chip_id_t chip_id, const CoreCoo
             active_eth_cores.find(logical_core_from_ethernet_core(chip_id, virtual_core)) != active_eth_cores.end();
         is_inactive_eth_core =
             inactive_eth_cores.find(logical_core_from_ethernet_core(chip_id, virtual_core)) != inactive_eth_cores.end();
-        // we should not be operating on any reserved cores here.
-        TT_ASSERT(is_active_eth_core or is_inactive_eth_core);
     }
 
     return is_active_eth_core     ? tt_metal::HalProgrammableCoreType::ACTIVE_ETH

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -110,6 +110,8 @@ tt_metal::HalProgrammableCoreType get_core_type(chip_id_t chip_id, const CoreCoo
             active_eth_cores.find(logical_core_from_ethernet_core(chip_id, virtual_core)) != active_eth_cores.end();
         is_inactive_eth_core =
             inactive_eth_cores.find(logical_core_from_ethernet_core(chip_id, virtual_core)) != inactive_eth_cores.end();
+        // we should not be operating on any reserved cores here.
+        TT_ASSERT(is_active_eth_core or is_inactive_eth_core);
     }
 
     return is_active_eth_core     ? tt_metal::HalProgrammableCoreType::ACTIVE_ETH


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22072

https://github.com/tenstorrent/tt-metal/issues/22950

### Problem description
- Writing to remote devices was hanging during init on some TG tests when the combination of TTNN + Mesh Device + Profiler were being used

### What's changed
- Switch active Mesh device to use FD for reading/writing profiler control buffer. UMD/slow dispatch reads/writes get backed up easily because the tunneler has a high context switch interval and the fabric router does not context switch at all. 
- Prerequisite: https://github.com/tenstorrent/tt-metal/commit/f42758777c3e4174ffaa3f7088fecd368afa9bbe

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15455198956
BH
https://github.com/tenstorrent/tt-metal/actions/runs/15455199582
TG
https://github.com/tenstorrent/tt-metal/actions/runs/15455203416
TG Model Perf
https://github.com/tenstorrent/tt-metal/actions/runs/15455207804
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/15455205910