### PR TITLE
[skip ci] Shift load over to N300 to balance things out

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -87,7 +87,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "N150",
+          "N300",
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
@@ -121,7 +121,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "N150",
+          "N300",
         ]
     uses: ./.github/workflows/sdk-examples.yaml
     with:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
N150's get bogged down in CIv2.  Shift some load over to N300 which now has more available in the pool.

### What's changed
N150 -> N300 in PR Gate