### PR TITLE
#23093: Classify chan 15 on WH as an active eth core on mmio chips even when it is unconnected

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -381,7 +381,7 @@ def test_timestamped_events():
     OP_COUNT = 2
     RISC_COUNT = 5
     ZONE_COUNT = 100
-    WH_ERISC_COUNTS = [0, 1, 5]
+    WH_ERISC_COUNTS = [0, 2, 5]  # N150, N300, T3K
     WH_TENSIX_COUNTS = [72, 64, 56]
     BH_ERISC_COUNTS = [0, 1, 6, 8]
     BH_TENSIX_COUNTS = [130, 120, 110]

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
@@ -46,6 +46,9 @@ TEST_F(WatcherFixture, ActiveEthTestWatcherEthLinkCheck) {
     uint32_t retrain_force_addr = tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
         tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::RETRAIN_FORCE);
     for (const CoreCoord &eth_core : device->get_active_ethernet_cores()) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device->id(), eth_core)) {
+            continue;
+        }
         // Only force a retrain on odd-numbered eth cores
         if (eth_core.y % 2) {
             CoreCoord virtual_core = device->ethernet_core_from_logical_core(eth_core);
@@ -57,6 +60,9 @@ TEST_F(WatcherFixture, ActiveEthTestWatcherEthLinkCheck) {
     std::this_thread::sleep_for(std::chrono::seconds(5));
     vector<string> expected_strings;
     for (const CoreCoord &eth_core : device->get_active_ethernet_cores()) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device->id(), eth_core)) {
+            continue;
+        }
         CoreCoord virtual_core = device->ethernet_core_from_logical_core(eth_core);
         expected_strings.push_back(fmt::format(
             "\tDevice {} Ethernet Core {} retraining events: {}",

--- a/tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp
@@ -36,10 +36,10 @@ TEST_F(N300DeviceFixture, EthValidateEthernetConnectivity) {
     const auto& device_0_active_eth_cores = device_0->get_active_ethernet_cores();
     const auto& device_1_active_eth_cores = device_1->get_active_ethernet_cores();
 
-    ASSERT_TRUE(device_0_active_eth_cores.size() == 2);
+    // mmio device (0) has 2 ports (8, 9) reserved for umd non-mmio access which are also active links.
+    // mmio device (0) port 15 is reserved for syseng tools and is active without any remote connections.
+    ASSERT_TRUE(device_0_active_eth_cores.size() == 3);
     ASSERT_TRUE(device_1_active_eth_cores.size() == 2);
-    // mmio device (0) has 2 ports (8, 9) reserved for umd non-mmio access.
-    // mmio device (0) port 15 is reserved for syseng tools.
     ASSERT_TRUE(device_0->get_inactive_ethernet_cores().size() == 13);
     ASSERT_TRUE(device_1->get_inactive_ethernet_cores().size() == 14);
 

--- a/tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp
@@ -44,11 +44,17 @@ TEST_F(N300DeviceFixture, EthValidateEthernetConnectivity) {
     ASSERT_TRUE(device_1->get_inactive_ethernet_cores().size() == 14);
 
     for (const auto& core : device_0_active_eth_cores) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_0->id(), core)) {
+            continue;
+        }
         std::tuple<chip_id_t, CoreCoord> core_on_chip_1 = device_0->get_connected_ethernet_core(core);
         ASSERT_TRUE(std::get<0>(core_on_chip_1) == 1);
         ASSERT_TRUE(device_1_active_eth_cores.find(std::get<1>(core_on_chip_1)) != device_1_active_eth_cores.end());
     }
     for (const auto& core : device_1_active_eth_cores) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_0->id(), core)) {
+            continue;
+        }
         std::tuple<chip_id_t, CoreCoord> core_on_chip_0 = device_1->get_connected_ethernet_core(core);
         ASSERT_TRUE(std::get<0>(core_on_chip_0) == 0);
         ASSERT_TRUE(device_0_active_eth_cores.find(std::get<1>(core_on_chip_0)) != device_0_active_eth_cores.end());

--- a/tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp
@@ -61,7 +61,7 @@ TEST_F(N300DeviceFixture, EthValidateEthernetConnectivity) {
     }
 
     // Check conversion to noc coords
-    std::vector<CoreCoord> chip_0_eth_noc_coords_expected = {CoreCoord(25, 17), CoreCoord(18, 17)};
+    std::vector<CoreCoord> chip_0_eth_noc_coords_expected = {CoreCoord(25, 17), CoreCoord(18, 17), CoreCoord(21, 17)};
 
     std::vector<CoreCoord> chip_0_eth_logical_coords;
     std::copy(

--- a/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
@@ -45,6 +45,9 @@ std::unordered_set<chip_id_t> get_ethernet_connected_device_ids(const chip_id_t 
     const std::unordered_set<CoreCoord>& active_ethernet_cores =
         tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id);
     for (const CoreCoord& ethernet_core : active_ethernet_cores) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_id, ethernet_core)) {
+            continue;
+        }
         const auto& [connected_device_id, _] =
             tt::tt_metal::MetalContext::instance().get_cluster().get_connected_ethernet_core(
                 {device_id, ethernet_core});
@@ -67,6 +70,10 @@ TEST_F(TGFixture, ActiveEthValidateNumLinksBetweenAdjacentGalaxyChips) {
             const std::unordered_set<CoreCoord>& active_ethernet_cores =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id);
             for (const CoreCoord& ethernet_core : active_ethernet_cores) {
+                if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                        device_id, ethernet_core)) {
+                    continue;
+                }
                 const auto& [connected_device_id, _] =
                     tt::tt_metal::MetalContext::instance().get_cluster().get_connected_ethernet_core(
                         {device_id, ethernet_core});

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -452,6 +452,9 @@ TEST_F(N300DeviceFixture, ActiveEthKernelsDirectSendChip0ToChip1) {
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
 
     for (const auto& sender_core : device_0->get_active_ethernet_cores(true)) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_0->id(), sender_core)) {
+            continue;
+        }
         auto [device_id, receiver_core] = device_0->get_connected_ethernet_core(sender_core);
         if (device_1->id() != device_id) {
             continue;
@@ -507,6 +510,9 @@ TEST_F(N300DeviceFixture, ActiveEthKernelsDirectSendChip1ToChip0) {
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
 
     for (const auto& sender_core : device_1->get_active_ethernet_cores(true)) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_1->id(), sender_core)) {
+            continue;
+        }
         auto [device_id, receiver_core] = device_1->get_connected_ethernet_core(sender_core);
         if (device_0->id() != device_id) {
             continue;

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -771,10 +771,16 @@ TEST_F(TwoDeviceFixture, ActiveEthKernelsRandomDirectSendTests) {
 
     std::map<std::tuple<int, CoreCoord>, std::tuple<int, CoreCoord>> connectivity = {};
     for (const auto& sender_core : device_0->get_active_ethernet_cores(true)) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_0->id(), sender_core)) {
+            continue;
+        }
         const auto& receiver_core = device_0->get_connected_ethernet_core(sender_core);
         connectivity.insert({{0, sender_core}, receiver_core});
     }
     for (const auto& sender_core : device_1->get_active_ethernet_cores(true)) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_1->id(), sender_core)) {
+            continue;
+        }
         const auto& receiver_core = device_1->get_connected_ethernet_core(sender_core);
         connectivity.insert({{1, sender_core}, receiver_core});
     }

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -130,6 +130,10 @@ std::vector<std::tuple<tt_metal::IDevice*, tt_metal::IDevice*, CoreCoord, CoreCo
         const auto& second_device = device_ring[1];
         uint32_t i = 0;
         for (const auto& first_eth_core : first_device->get_active_ethernet_cores(true)) {
+            if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                    first_device->id(), first_eth_core)) {
+                continue;
+            }
             auto [device_id, second_eth_core] = first_device->get_connected_ethernet_core(first_eth_core);
             if (second_device->id() == device_id) {
                 tt_metal::IDevice *sender_device, *receiver_device;

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -164,6 +164,10 @@ std::vector<std::tuple<tt_metal::IDevice*, tt_metal::IDevice*, CoreCoord, CoreCo
             const auto& sender_device = device_ring[i];
             const auto& receiver_device = device_ring[i + 1];
             for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
+                if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                        sender_device->id(), sender_eth_core)) {
+                    continue;
+                }
                 auto [device_id, receiver_eth_core] = sender_device->get_connected_ethernet_core(sender_eth_core);
                 if (receiver_device->id() == device_id) {
                     sender_receivers.push_back({sender_device, receiver_device, sender_eth_core, receiver_eth_core});

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1221,13 +1221,13 @@ bool Cluster::is_ethernet_link_up(chip_id_t chip_id, const CoreCoord& logical_co
 std::tuple<chip_id_t, CoreCoord> Cluster::get_connected_ethernet_core(std::tuple<chip_id_t, CoreCoord> eth_core) const {
     const auto &soc_desc = get_soc_desc(std::get<0>(eth_core));
     ethernet_channel_t eth_chan = soc_desc.logical_eth_core_to_chan_map.at(std::get<1>(eth_core));
-    TT_ASSERT(
+    TT_FATAL(
         this->is_ethernet_link_up(std::get<0>(eth_core), std::get<1>(eth_core)),
         "Logical eth core {} is not an active eth core on chip {}.",
         std::get<1>(eth_core).str(),
         std::get<0>(eth_core));
     const auto& ethernet_connections_within_cluster = this->get_ethernet_connections();
-    TT_ASSERT(
+    TT_FATAL(
         (ethernet_connections_within_cluster.find(std::get<0>(eth_core)) !=
          ethernet_connections_within_cluster.end()) and
             (ethernet_connections_within_cluster.at(std::get<0>(eth_core)).find(eth_chan) !=
@@ -1247,7 +1247,7 @@ std::tuple<uint64_t, CoreCoord> Cluster::get_connected_ethernet_core_to_remote_m
     std::tuple<chip_id_t, CoreCoord> eth_core) const {
     const auto& soc_desc = get_soc_desc(std::get<0>(eth_core));
     ethernet_channel_t eth_chan = soc_desc.logical_eth_core_to_chan_map.at(std::get<1>(eth_core));
-    TT_ASSERT(
+    TT_FATAL(
         this->is_ethernet_link_up(std::get<0>(eth_core), std::get<1>(eth_core)),
         "Logical eth core {} is not an active eth core on chip {}.",
         std::get<1>(eth_core).str(),
@@ -1255,7 +1255,7 @@ std::tuple<uint64_t, CoreCoord> Cluster::get_connected_ethernet_core_to_remote_m
     const auto& ethernet_connections_to_remote_cluster = this->get_ethernet_connections_to_remote_mmio_devices();
     const auto& local_chip_id = std::get<0>(eth_core);
     const auto& local_eth_core = std::get<1>(eth_core);
-    TT_ASSERT(
+    TT_FATAL(
         (ethernet_connections_to_remote_cluster.find(local_chip_id) != ethernet_connections_to_remote_cluster.end()) and
             (ethernet_connections_to_remote_cluster.at(local_chip_id).find(eth_chan) !=
              ethernet_connections_to_remote_cluster.at(local_chip_id).end()),

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -863,7 +863,7 @@ void Cluster::set_tunnels_from_mmio_device() {
             const auto &other_chip_id = std::get<0>(connected_chip_chan);
             if (device_ids.find(other_chip_id) != device_ids.end()) {
                 // mmio chip is connected to a remote chip in its mmio group.
-                // erase from the pool so multiple ethenret connections to same remote device do not
+                // erase from the pool so multiple ethernet connections to same remote device do not
                 // pollute the counts.
                 device_ids.erase(other_chip_id);
                 std::vector<chip_id_t> first_stop = {other_chip_id};
@@ -920,7 +920,7 @@ void Cluster::set_tunnels_from_mmio_device() {
                 "All tunnels from mmio device must have same depth. Found {}. Expected {}.",
                 dev_vec.size(),
                 tunnel_depth);
-            // Now that all remotete chips have been added to respective tunnels,
+            // Now that all remote chips have been added to respective tunnels,
             // add mmio device at start of each of the tunnels.
             if (dev_vec.size() > MAX_TUNNEL_DEPTH) {
                 dev_vec.resize(dev_vec.size() - (dev_vec.size() - MAX_TUNNEL_DEPTH));
@@ -1113,11 +1113,11 @@ std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
 
             active_ethernet_cores.insert(eth_core);
         }
-        if (this->arch_ == tt::ARCH::WORMHOLE_B0) {
-            // channel 15 is used by syseng tools and must always be active for mmio chips
+        // channel 15 is used by syseng tools and must always be active for WH mmio chips with remote connections
+        if (this->arch_ == tt::ARCH::WORMHOLE_B0 && this->cluster_desc_->is_chip_mmio_capable(chip_id) &&
+            this->get_tunnels_from_mmio_device(chip_id).size() > 0) {
             constexpr uint32_t syseng_eth_channel = 15;
-            if (this->cluster_desc_->is_chip_mmio_capable(chip_id) &&
-                logical_active_eth_channels.find(syseng_eth_channel) == logical_active_eth_channels.end()) {
+            if (logical_active_eth_channels.find(syseng_eth_channel) == logical_active_eth_channels.end()) {
                 tt::umd::CoreCoord eth_core =
                     soc_desc.get_eth_core_for_channel(syseng_eth_channel, CoordSystem::LOGICAL);
                 active_ethernet_cores.insert(eth_core);

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1113,23 +1113,14 @@ std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
 
             active_ethernet_cores.insert(eth_core);
         }
-        // WH has a special case where mmio chips with remote connections must always have certain channels active
+        // channel 15 is used by syseng tools and must always be active for WH mmio chips with remote connections
         if (this->arch_ == tt::ARCH::WORMHOLE_B0 && this->cluster_desc_->is_chip_mmio_capable(chip_id) &&
             this->get_tunnels_from_mmio_device(chip_id).size() > 0) {
-            // UMD routing FW uses these cores for base routing
-            // channel 15 is used by syseng tools
-            std::unordered_set<int> channels_to_skip = {};
-            if (this->is_galaxy_cluster()) {
-                // TODO: This may need to change, if we need additional eth cores for dispatch on Galaxy
-                channels_to_skip = {0, 1, 2, 3, 15};
-            } else {
-                channels_to_skip = {15};
-            }
-            for (const auto& eth_channel : channels_to_skip) {
-                if (logical_active_eth_channels.find(eth_channel) == logical_active_eth_channels.end()) {
-                    tt::umd::CoreCoord eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
-                    active_ethernet_cores.insert(eth_core);
-                }
+            constexpr uint32_t syseng_eth_channel = 15;
+            if (logical_active_eth_channels.find(syseng_eth_channel) == logical_active_eth_channels.end()) {
+                tt::umd::CoreCoord eth_core =
+                    soc_desc.get_eth_core_for_channel(syseng_eth_channel, CoordSystem::LOGICAL);
+                active_ethernet_cores.insert(eth_core);
             }
         }
     }
@@ -1202,7 +1193,18 @@ std::vector<CoreCoord> Cluster::get_fabric_ethernet_routers_between_src_and_dest
 std::unordered_set<CoreCoord> Cluster::get_inactive_ethernet_cores(chip_id_t chip_id) const {
     std::unordered_set<CoreCoord> active_ethernet_cores = this->get_active_ethernet_cores(chip_id);
     std::unordered_set<CoreCoord> inactive_ethernet_cores;
+    std::unordered_set<int> channels_to_skip = {};
+    // UMD routing FW uses these cores for base routing
+    // We don't mark these channels as active as this could affect slow dispatch performance of read/writeon Galaxy
+    if (this->is_galaxy_cluster()) {
+        // TODO: This may need to change, if we need additional eth cores for dispatch on Galaxy
+        channels_to_skip = {0, 1, 2, 3};
+    }
     for (const auto& [eth_core, chan] : get_soc_desc(chip_id).logical_eth_core_to_chan_map) {
+        if (this->cluster_desc_->is_chip_mmio_capable(chip_id) and
+            (channels_to_skip.find(chan) != channels_to_skip.end())) {
+            continue;
+        }
         if (active_ethernet_cores.find(eth_core) == active_ethernet_cores.end()) {
             inactive_ethernet_cores.insert(eth_core);
         }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1342,14 +1342,14 @@ void Cluster::set_internal_routing_info_for_ethernet_cores(bool enable_internal_
             .dst_acked_valid_cmd = 0,
         };
         for (const auto &chip_id : non_mmio_devices) {
-            for (const auto &[eth_core, routing_info] : this->device_eth_routing_info_.at(chip_id)) {
+            for (const auto& eth_core : this->get_active_ethernet_cores(chip_id, false)) {
                 tt_cxy_pair virtual_eth_core(chip_id, get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
                 // Enable internal ethernet routing for non-mmio devices
                 write_core((void*)&routing_info_enabled, sizeof(routing_info_t), virtual_eth_core, routing_info_addr_);
             }
         }
         for (const auto &chip_id : mmio_devices) {
-            for (const auto &[eth_core, routing_info] : this->device_eth_routing_info_.at(chip_id)) {
+            for (const auto& eth_core : this->get_active_ethernet_cores(chip_id, false)) {
                 tt_cxy_pair virtual_eth_core(chip_id, get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
                 // Enable internal ethernet routing for mmio devices
                 write_core((void*)&routing_info_enabled, sizeof(routing_info_t), virtual_eth_core, routing_info_addr_);
@@ -1362,14 +1362,14 @@ void Cluster::set_internal_routing_info_for_ethernet_cores(bool enable_internal_
             .dst_acked_valid_cmd = 0,
         };
         for (const auto &chip_id : mmio_devices) {
-            for (const auto &[eth_core, routing_info] : this->device_eth_routing_info_.at(chip_id)) {
+            for (const auto& eth_core : this->get_active_ethernet_cores(chip_id, false)) {
                 tt_cxy_pair virtual_eth_core(chip_id, get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
                 // Disable internal ethernet routing for mmio devices
                 write_core((void*)&routing_info_disabled, sizeof(routing_info_t), virtual_eth_core, routing_info_addr_);
             }
         }
         for (const auto &chip_id : non_mmio_devices) {
-            for (const auto &[eth_core, routing_info] : this->device_eth_routing_info_.at(chip_id)) {
+            for (const auto& eth_core : this->get_active_ethernet_cores(chip_id, false)) {
                 tt_cxy_pair virtual_eth_core(chip_id, get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
                 // Disable internal ethernet routing for non-mmio devices
                 write_core((void*)&routing_info_disabled, sizeof(routing_info_t), virtual_eth_core, routing_info_addr_);

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1113,14 +1113,23 @@ std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
 
             active_ethernet_cores.insert(eth_core);
         }
-        // channel 15 is used by syseng tools and must always be active for WH mmio chips with remote connections
+        // WH has a special case where mmio chips with remote connections must always have certain channels active
         if (this->arch_ == tt::ARCH::WORMHOLE_B0 && this->cluster_desc_->is_chip_mmio_capable(chip_id) &&
             this->get_tunnels_from_mmio_device(chip_id).size() > 0) {
-            constexpr uint32_t syseng_eth_channel = 15;
-            if (logical_active_eth_channels.find(syseng_eth_channel) == logical_active_eth_channels.end()) {
-                tt::umd::CoreCoord eth_core =
-                    soc_desc.get_eth_core_for_channel(syseng_eth_channel, CoordSystem::LOGICAL);
-                active_ethernet_cores.insert(eth_core);
+            // UMD routing FW uses these cores for base routing
+            // channel 15 is used by syseng tools
+            std::unordered_set<int> channels_to_skip = {};
+            if (this->is_galaxy_cluster()) {
+                // TODO: This may need to change, if we need additional eth cores for dispatch on Galaxy
+                channels_to_skip = {0, 1, 2, 3, 15};
+            } else {
+                channels_to_skip = {15};
+            }
+            for (const auto& eth_channel : channels_to_skip) {
+                if (logical_active_eth_channels.find(eth_channel) == logical_active_eth_channels.end()) {
+                    tt::umd::CoreCoord eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
+                    active_ethernet_cores.insert(eth_core);
+                }
             }
         }
     }
@@ -1193,16 +1202,7 @@ std::vector<CoreCoord> Cluster::get_fabric_ethernet_routers_between_src_and_dest
 std::unordered_set<CoreCoord> Cluster::get_inactive_ethernet_cores(chip_id_t chip_id) const {
     std::unordered_set<CoreCoord> active_ethernet_cores = this->get_active_ethernet_cores(chip_id);
     std::unordered_set<CoreCoord> inactive_ethernet_cores;
-    std::unordered_set<int> channels_to_skip = {};
-    // UMD routing FW uses these cores for base routing
-    if (this->is_galaxy_cluster()) {
-        // TODO: This may need to change, if we need additional eth cores for dispatch on Galaxy
-        channels_to_skip = {0, 1, 2, 3};
-    }
-    for (const auto &[eth_core, chan] : get_soc_desc(chip_id).logical_eth_core_to_chan_map) {
-        if (this->cluster_desc_->is_chip_mmio_capable(chip_id) and (channels_to_skip.find(chan) != channels_to_skip.end())) {
-            continue;
-        }
+    for (const auto& [eth_core, chan] : get_soc_desc(chip_id).logical_eth_core_to_chan_map) {
         if (active_ethernet_cores.find(eth_core) == active_ethernet_cores.end()) {
             inactive_ethernet_cores.insert(eth_core);
         }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1114,9 +1114,10 @@ std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
             active_ethernet_cores.insert(eth_core);
         }
         if (this->arch_ == tt::ARCH::WORMHOLE_B0) {
-            // channel 15 is used by syseng tools and must always be active
+            // channel 15 is used by syseng tools and must always be active for mmio chips
             constexpr uint32_t syseng_eth_channel = 15;
-            if (logical_active_eth_channels.find(syseng_eth_channel) == logical_active_eth_channels.end()) {
+            if (this->cluster_desc_->is_chip_mmio_capable(chip_id) &&
+                logical_active_eth_channels.find(syseng_eth_channel) == logical_active_eth_channels.end()) {
                 tt::umd::CoreCoord eth_core =
                     soc_desc.get_eth_core_for_channel(syseng_eth_channel, CoordSystem::LOGICAL);
                 active_ethernet_cores.insert(eth_core);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23093

### Problem description
Channel 15 on WH is skipped from ever being added to the inactive eth core list because it is reserved for syseng on mmio chips. This is okay when channel 15 is an eth core with an active link, but if it is not then we have an eth core that is not classified as active or idle, which can cause issues with core type queries.

### What's changed
Always mark channel 15 as an active eth core for WH mmio chips that service remote chips. Change the loop to set routing to be over active eth cores, instead of `device_eth_routing_info_`, which is only populated with eth cores with active connections.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15470087491
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/15458693804
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes
APC Debug: https://github.com/tenstorrent/tt-metal/actions/runs/15470093489
T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/15470098372
T3K Profiler: https://github.com/tenstorrent/tt-metal/actions/runs/15458590750