### PR TITLE
Assert non-mcast transactions aren't submitted if NOC_CMD_VC_LINKED is set

### DIFF
--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -132,6 +132,26 @@ inline __attribute__((always_inline)) bool noc_cmd_buf_ready(uint32_t noc, uint3
     return (NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CMD_CTRL) == NOC_CTRL_STATUS_READY);
 }
 
+#if WATCHER_ASSERT_ENABLED
+void validate_no_linked_transactions(uint32_t noc) {
+    // Submitting a non-mcast transaction if there's a linked transaction on any cmd_buf will cause a deadlock.
+    ASSERT(
+        !(NOC_CMD_BUF_READ_REG(noc, 0, NOC_CMD_CTRL) & NOC_CMD_VC_LINKED),
+        DebugAssertNCriscNOCLinked0TransactionTripped);
+    ASSERT(
+        !(NOC_CMD_BUF_READ_REG(noc, 1, NOC_CMD_CTRL) & NOC_CMD_VC_LINKED),
+        DebugAssertNCriscNOCLinked1TransactionTripped);
+    ASSERT(
+        !(NOC_CMD_BUF_READ_REG(noc, 2, NOC_CMD_CTRL) & NOC_CMD_VC_LINKED),
+        DebugAssertNCriscNOCLinked2TransactionTripped);
+    ASSERT(
+        !(NOC_CMD_BUF_READ_REG(noc, 3, NOC_CMD_CTRL) & NOC_CMD_VC_LINKED),
+        DebugAssertNCriscNOCLinked3TransactionTripped);
+}
+#else
+inline void validate_no_linked_transactions(uint32_t noc) {}
+#endif  // WATCHER_ASSERT_ENABLED
+
 inline __attribute__((always_inline)) uint32_t noc_get_interim_inline_value_addr(uint32_t noc, uint64_t dst_noc_addr) {
     // On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
     // time. If one port on the receipient has no back-pressure then the transaction will hang because there is no
@@ -149,6 +169,7 @@ inline __attribute__((always_inline)) uint32_t noc_get_interim_inline_value_addr
 template <uint8_t noc_mode = DM_DEDICATED_NOC>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_read(
     uint32_t noc, uint32_t cmd_buf, uint64_t src_addr, uint32_t dest_addr, uint32_t len_bytes) {
+    validate_no_linked_transactions(noc);
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, 1);
     }
@@ -199,6 +220,9 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write(
     bool multicast_path_reserve,
     bool posted = false,
     uint32_t trid = 0) {
+    if (!mcast) {
+        validate_no_linked_transactions(noc);
+    }
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         if (posted) {
             inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
@@ -248,6 +272,9 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
     bool linked,
     uint32_t num_dests,
     bool multicast_path_reserve) {
+    if (!mcast) {
+        validate_no_linked_transactions(noc);
+    }
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
         inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, num_dests);
@@ -285,6 +312,9 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_exclude_region(
     uint32_t num_dests,
     bool multicast_path_reserve,
     uint32_t exclude_region) {
+    if (!mcast) {
+        validate_no_linked_transactions(noc);
+    }
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
         inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, num_dests);
@@ -655,6 +685,9 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline(
     uint32_t static_vc,
     bool mcast,
     bool posted = false) {
+    if (!mcast) {
+        validate_no_linked_transactions(noc);
+    }
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         if (posted) {
             inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
@@ -704,6 +737,7 @@ inline __attribute__((always_inline)) void noc_fast_atomic_increment(
     bool linked,
     bool posted = false,
     uint32_t atomic_ret_val = 0) {
+    validate_no_linked_transactions(noc);
     // On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
     // time. If one port on the receipient has no back-pressure then the transaction will hang because there is no
     // mechanism to allow one memory port to move ahead of another. To workaround this hang, we emulate force atomics to
@@ -750,6 +784,7 @@ inline __attribute__((always_inline)) void noc_fast_atomic_increment(
 template <uint8_t noc_mode = DM_DEDICATED_NOC, bool skip_ptr_update = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_read_with_transaction_id(
     uint32_t noc, uint32_t cmd_buf, uint32_t src_base_addr, uint32_t src_addr, uint32_t dest_addr, uint32_t trid) {
+    validate_no_linked_transactions(noc);
     if constexpr (noc_mode == DM_DYNAMIC_NOC && !skip_ptr_update) {
         inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, 1);
     }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -466,6 +466,7 @@ void cb_wait_front(int32_t operand, int32_t num_pages) {
 FORCE_INLINE
 void noc_async_read_one_packet(
     std::uint64_t src_noc_addr, std::uint32_t dst_local_l1_addr, std::uint32_t size, uint8_t noc = noc_index) {
+    validate_no_linked_transactions(noc);
     /*
         Read requests - use static VC
         Read responses - assigned VCs dynamically
@@ -585,6 +586,7 @@ void noc_async_read_one_packet_set_state(std::uint64_t src_noc_addr, std::uint32
 template <bool inc_num_issued = true>
 FORCE_INLINE void noc_async_read_one_packet_with_state(
     std::uint32_t src_noc_addr, std::uint32_t dst_local_l1_addr, uint8_t noc = noc_index) {
+    validate_no_linked_transactions(noc);
     /*
         Read requests - use static VC
         Read responses - assigned VCs dynamically
@@ -655,6 +657,7 @@ void noc_async_read_set_state(std::uint64_t src_noc_addr, uint8_t noc = noc_inde
 template <bool inc_num_issued = true>
 FORCE_INLINE void noc_async_read_with_state(
     std::uint32_t src_noc_addr, std::uint32_t dst_local_l1_addr, std::uint32_t size, uint8_t noc = noc_index) {
+    validate_no_linked_transactions(noc);
     /*
         Read requests - use static VC
         Read responses - assigned VCs dynamically
@@ -727,6 +730,7 @@ void noc_async_read_inc_num_issued(std::uint32_t num_issued_reads_inc, uint8_t n
 FORCE_INLINE
 void noc_async_write_one_packet(
     std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size, uint8_t noc = noc_index) {
+    validate_no_linked_transactions(noc);
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_,dst_noc_addr,size,NOC_UNICAST_WRITE_VC);
 
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
@@ -844,6 +848,7 @@ FORCE_INLINE void noc_async_write_one_packet_set_state(
 template <bool non_posted = true>
 FORCE_INLINE void noc_async_write_one_packet_with_state(
     std::uint32_t src_local_l1_addr, std::uint32_t dst_noc_addr, uint8_t noc = noc_index) {
+    validate_no_linked_transactions(noc);
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, 0ull, 0, -1);
 
     if constexpr (non_posted) {
@@ -894,6 +899,7 @@ FORCE_INLINE void noc_async_read_tile(
     std::uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
+    validate_no_linked_transactions(noc);
     /*
         Read requests - use static VC
         Read responses - assigned VCs dynamically
@@ -1013,6 +1019,7 @@ FORCE_INLINE void noc_async_read_partial_page(
     const uint32_t size,
     const uint32_t offset,
     uint8_t noc = noc_index) {
+    validate_no_linked_transactions(noc);
     // Note: This is not used anywhere in tt-metal
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, 1);
@@ -1050,6 +1057,7 @@ FORCE_INLINE void noc_async_write_page(
     const uint32_t write_size_bytes,
     const uint32_t offset = 0,
     uint8_t noc = noc_index) {
+    validate_no_linked_transactions(noc);
     // Note: This is not used anywhere in tt-metal
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
@@ -1695,6 +1703,7 @@ FORCE_INLINE void noc_inline_dw_write_with_state(
     uint32_t val, uint32_t addr = 0, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {
     // only either hi or lo address should be getting updated
     static_assert("Error: Only High or Low address update is supported" && (update_addr_lo && update_addr_hi) == 0);
+    validate_no_linked_transactions(noc);
 
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         if constexpr (update_counter) {
@@ -1813,6 +1822,7 @@ FORCE_INLINE uint32_t noc_async_read_tile_dram_sharded_set_state(
 FORCE_INLINE
 void noc_async_read_tile_dram_sharded_with_state(
     uint32_t src_base_addr, uint32_t src_addr, uint32_t dest_addr, uint32_t trid = 0, uint8_t noc = noc_index) {
+    validate_no_linked_transactions(noc);
     RECORD_NOC_EVENT(NocEventType::READ_DRAM_SHARDED_WITH_STATE);
 
     uint32_t src_addr_;
@@ -1896,6 +1906,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
     std::uint32_t trid,
     uint8_t cmd_buf = write_cmd_buf,
     uint8_t noc = noc_index) {
+    validate_no_linked_transactions(noc);
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         if constexpr (update_counter) {
             if constexpr (posted) {
@@ -1939,6 +1950,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid(
     uint8_t cmd_buf = write_cmd_buf,
     uint8_t noc = noc_index,
     uint8_t vc = NOC_UNICAST_WRITE_VC) {
+    validate_no_linked_transactions(noc);
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         if constexpr (update_counter) {
             if constexpr (posted) {

--- a/tt_metal/hw/inc/dataflow_internal.h
+++ b/tt_metal/hw/inc/dataflow_internal.h
@@ -32,6 +32,7 @@ void noc_fast_read_set_len(uint32_t len_bytes) {
 
 FORCE_INLINE
 void noc_fast_read(uint32_t src_addr, uint32_t dest_addr) {
+    validate_no_linked_transactions(noc);
     WAYPOINT("NFRW");
     DEBUG_SANITIZE_NOC_READ_TRANSACTION(
         noc_index,
@@ -85,6 +86,7 @@ void noc_fast_write_set_len(uint32_t len_bytes) {
 // a fast write that assumes a single-dest (ie unicast)
 FORCE_INLINE
 void noc_fast_write(uint32_t src_addr, uint64_t dest_addr) {
+    validate_no_linked_transactions(noc);
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(
         noc_index,
         dest_addr | (uint64_t)NOC_CMD_BUF_READ_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_COORDINATE) << 32,

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -247,7 +247,11 @@ enum debug_assert_type_t {
     DebugAssertNCriscNOCReadsFlushedTripped = 4,
     DebugAssertNCriscNOCNonpostedWritesSentTripped = 5,
     DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped = 6,
-    DebugAssertNCriscNOCPostedWritesSentTripped = 7
+    DebugAssertNCriscNOCPostedWritesSentTripped = 7,
+    DebugAssertNCriscNOCLinked0TransactionTripped = 8,
+    DebugAssertNCriscNOCLinked1TransactionTripped = 9,
+    DebugAssertNCriscNOCLinked2TransactionTripped = 10,
+    DebugAssertNCriscNOCLinked3TransactionTripped = 11,
 };
 
 // XXXX TODO(PGK): why why why do we not have this standardized

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -686,6 +686,22 @@ void WatcherDeviceReader::DumpAssertStatus(CoreDescriptor& core, const string& c
             this->DumpAssertTrippedDetails(core, error_msg, mbox_data);
             break;
         }
+        case DebugAssertNCriscNOCLinked0TransactionTripped:
+        case DebugAssertNCriscNOCLinked1TransactionTripped:
+        case DebugAssertNCriscNOCLinked2TransactionTripped:
+        case DebugAssertNCriscNOCLinked3TransactionTripped: {
+            uint32_t cmd_buf_index = assert_status->tripped - DebugAssertNCriscNOCLinked0TransactionTripped;
+            const string error_msg = fmt::format(
+                "{}: {} detected an attempt to send a non-mcast transaction while command buffer {} is linked. "
+                "Current kernel: {}.",
+                core_str,
+                get_riscv_name(core.coord, assert_status->which),
+                cmd_buf_index,
+                GetKernelName(core, launch_msg, assert_status->which).c_str());
+            this->DumpAssertTrippedDetails(core, error_msg, mbox_data);
+            break;
+        }
+
         case DebugAssertOK: {
             if (assert_status->line_num != DEBUG_SANITIZE_NOC_SENTINEL_OK_16 ||
                 assert_status->which != DEBUG_SANITIZE_NOC_SENTINEL_OK_8) {


### PR DESCRIPTION
### Problem description
If NOC_CMD_VC_LINKED is set on any command buffer, the next transaction must be an mcast on the same VC. If not, the NOC will completely fail to initiate any new transactions.

### What's changed
Add function to assert that no command buffers have NOC_CMD_VC_LINKED set, and call it at all the appropriate times.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes