### PR TITLE
Fix TSAN error in DprintServer

### DIFF
--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -149,7 +149,7 @@ struct HartKeyComparator {
 struct DebugPrintServerContext {
     // only one instance is allowed at the moment
     static DebugPrintServerContext* inst;
-    static bool ProfilerIsRunning;
+    static std::atomic<bool> ProfilerIsRunning;
 
     // Constructor/destructor, reads dprint options from RTOptions.
     DebugPrintServerContext();
@@ -1313,7 +1313,7 @@ ostream* DebugPrintServerContext::GetOutputStream(const HartKey& risc_key) {
 }  // GetOutputStream
 
 DebugPrintServerContext* DebugPrintServerContext::inst = nullptr;
-bool DebugPrintServerContext::ProfilerIsRunning = false;
+std::atomic<bool> DebugPrintServerContext::ProfilerIsRunning = false;
 
 }  // namespace
 


### PR DESCRIPTION
### Problem description
We're hitting a TSAN error in DprintServerSetProfilerState because multiple threads are setting the same state.

### What's changed
All threads are getting the state from the same location and setting the same value, so we can just make ProfilerIsRunning an atomic to prevent the error.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes