### PR TITLE
#21194: Add int32 support for Tensor-scalar version of max

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
@@ -7,14 +7,11 @@ import pytest
 import ttnn
 from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import compare_equal
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import torch_random, is_wormhole_b0
 
 
 @pytest.mark.parametrize("scalar", [-1, -2, -3, -4, -5, 3, 0, 1, 100, 10, 5, 2147483, -2147483, -16777216, 16777216])
-# @pytest.mark.parametrize("scalar", [-214748360]) # Failing due to integer to float conversion
 def test_unary_max_int32_test(scalar, device):
     num_elements = torch.prod(torch.tensor(torch.Size([1, 1, 32, 32]))).item()
-    # torch_input = torch.linspace(-(2**31)+1, (2**31)-1, num_elements, dtype=torch.int32)
     torch_input = torch.linspace(-10, 10, num_elements, dtype=torch.int32)
     torch_input = torch_input[:num_elements].reshape(torch.Size([1, 1, 32, 32]))
 
@@ -29,7 +26,6 @@ def test_unary_max_int32_test(scalar, device):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     tt_result = ttnn.maximum(tt_in, scalar)
-    print(tt_result)
     comp_pass = compare_equal([tt_result], [golden])
     assert comp_pass
 
@@ -55,7 +51,7 @@ def test_unary_max_int32_test(scalar, device):
         (-(2**31) + 1, (2**31) - 1),
     ],
 )
-@pytest.mark.parametrize("scalar", [-1, -2, -3, -4, -5, 3, 21474836, 0, 1, 100, 10, 5, 2147483, -2147483])
+@pytest.mark.parametrize("scalar", [-1, -2, -3, -4, -5, 3, 0, 1, 100, 10, 5, -16777216, 16777216, -16777215, 16777215])
 def test_unary_max_int32(input_shapes, low, high, scalar, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.int32)
@@ -88,7 +84,6 @@ def test_unary_max_int32(input_shapes, low, high, scalar, device):
         (1, 0),
         (0, 0),
         (1, 1),
-        (21474836, -1),
         (11, 53),
     ],
 )

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
@@ -7,6 +7,110 @@ import pytest
 import ttnn
 from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import compare_equal
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import torch_random, is_wormhole_b0
+
+
+@pytest.mark.parametrize("scalar", [-1, -2, -3, -4, -5, 3, 0, 1, 100, 10, 5, 2147483, -2147483, -16777216, 16777216])
+# @pytest.mark.parametrize("scalar", [-214748360]) # Failing due to integer to float conversion
+def test_unary_max_int32_test(scalar, device):
+    num_elements = torch.prod(torch.tensor(torch.Size([1, 1, 32, 32]))).item()
+    # torch_input = torch.linspace(-(2**31)+1, (2**31)-1, num_elements, dtype=torch.int32)
+    torch_input = torch.linspace(-10, 10, num_elements, dtype=torch.int32)
+    torch_input = torch_input[:num_elements].reshape(torch.Size([1, 1, 32, 32]))
+
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    golden = golden_function(torch_input, torch.full(torch.Size([1, 1, 32, 32]), scalar), device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_result = ttnn.maximum(tt_in, scalar)
+    print(tt_result)
+    comp_pass = compare_equal([tt_result], [golden])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 2, 64, 120])),
+        (torch.Size([1, 3, 320, 320])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low, high",
+    [
+        (-5, 5),
+        (-100, 100),
+        (-21474, 21474),
+        (-2147483600, 2147483600),
+        (-21474836, 21474836),
+        (-214748364, 214748364),
+        (-2147483647, 2147483647),
+        (-(2**31) + 1, (2**31) - 1),
+    ],
+)
+@pytest.mark.parametrize("scalar", [-1, -2, -3, -4, -5, 3, 21474836, 0, 1, 100, 10, 5, 2147483, -2147483])
+def test_unary_max_int32(input_shapes, low, high, scalar, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input = torch.linspace(high, low, num_elements, dtype=torch.int32)
+    torch_input = torch_input[:num_elements].reshape(input_shapes)
+
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    golden = golden_function(torch_input, torch.full(input_shapes, scalar), device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.maximum(tt_in, scalar)
+    comp_pass = compare_equal([tt_result], [golden])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@pytest.mark.parametrize(
+    "input_val, scalar",
+    [
+        (-1, 1),
+        (1, 0),
+        (0, 0),
+        (1, 1),
+        (21474836, -1),
+        (11, 53),
+    ],
+)
+def test_unary_max_fill_val_int32(input_shapes, input_val, scalar, device):
+    torch_input = torch.ones(input_shapes, dtype=torch.int32) * input_val
+
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    golden = golden_function(torch_input, torch.full(input_shapes, scalar), device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.maximum(tt_in, scalar)
+    result = ttnn.to_torch(tt_result)
+
+    comp_pass = compare_equal([tt_result], [golden])
+    assert comp_pass
 
 
 @pytest.mark.parametrize(
@@ -19,14 +123,14 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         (0.36719, 0.5),
         (0, 0.06719),
         (0, 0.002),
-        (3.4 * 10**38, 1),
+        (3.4 * 10**38, 1.0),
         (-1, -3.4 * 10**38),
         (3.4 * 10**38, -3.4 * 10**38),
-        (float("inf"), 1),
+        (float("inf"), 1.0),
         (1, -float("inf")),
         (3.4 * 10**38, float("inf")),
         (-3.4 * 10**38, -float("inf")),
-        (11, 1),
+        (11, 1.0),
     ],
 )
 def test_unary_max_fill_val_fp32(input_shapes, input_val, scalar, device):
@@ -61,14 +165,14 @@ def test_unary_max_fill_val_fp32(input_shapes, input_val, scalar, device):
         (0.0034, 0.0023),
         (0, 0.06719),
         (0, 0.002),
-        (3.4 * 10**38, 1),
+        (3.4 * 10**38, 1.0),
         (-1, -3.4 * 10**38),
         (3.4 * 10**38, -3.4 * 10**38),
-        (float("inf"), 1),
+        (float("inf"), 1.0),
         (1, -float("inf")),
         (3.4 * 10**38, float("inf")),
         (-3.4 * 10**38, -float("inf")),
-        (11, 1),
+        (11, 1.0),
     ],
 )
 def test_unary_max_fill_val_bf16(input_shapes, input_val, scalar, device):
@@ -101,11 +205,11 @@ def test_unary_max_fill_val_bf16(input_shapes, input_val, scalar, device):
 @pytest.mark.parametrize(
     "low, high",
     [
-        (-100.0, 100.0),
+        (-100, 100),
         (-3.3 * 10**38, 3.3 * 10**38),
     ],
 )
-@pytest.mark.parametrize("scalar", [0.5, 0, 20, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")])
+@pytest.mark.parametrize("scalar", [0.5, 0.0, 20.0, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")])
 def test_unary_max_bf16(input_shapes, low, high, scalar, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
@@ -142,7 +246,9 @@ def test_unary_max_bf16(input_shapes, low, high, scalar, device):
         (-1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-@pytest.mark.parametrize("scalar", [0.5, 0.1, 0, 1, 10, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")])
+@pytest.mark.parametrize(
+    "scalar", [0.5, 0.1, 0.0, 1.0, 10.0, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")]
+)
 def test_unary_max_fp32(input_shapes, low, high, scalar, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.float32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
@@ -36,6 +36,7 @@ def test_unary_max_int32_test(scalar, device):
         (torch.Size([1, 1, 32, 32])),
         (torch.Size([1, 2, 64, 120])),
         (torch.Size([1, 3, 320, 320])),
+        (torch.Size([1, 3, 1024, 1024])),
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
@@ -17,16 +17,16 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "input_val, scalar",
     [
         (0.36719, 0.5),
-        (0, 0.06719),
-        (0, 0.002),
-        (3.4 * 10**38, 1),
-        (-1, -3.4 * 10**38),
+        (0.0, 0.06719),
+        (0.0, 0.002),
+        (3.4 * 10**38, 1.0),
+        (-1.0, -3.4 * 10**38),
         (3.4 * 10**38, -3.4 * 10**38),
-        (float("inf"), 1),
+        (float("inf"), 1.0),
         (1, -float("inf")),
         (3.4 * 10**38, float("inf")),
         (-3.4 * 10**38, -float("inf")),
-        (11, 1),
+        (11.0, 1.0),
     ],
 )
 def test_unary_min_fill_val_fp32(input_shapes, input_val, scalar, device):
@@ -58,16 +58,16 @@ def test_unary_min_fill_val_fp32(input_shapes, input_val, scalar, device):
     [
         (0.36719, 0.5),
         (0.0034, 0.0023),
-        (0, 0.06719),
-        (0, 0.002),
-        (3.4 * 10**38, 1),
-        (-1, -3.4 * 10**38),
+        (0.0, 0.06719),
+        (0.0, 0.002),
+        (3.4 * 10**38, 1.0),
+        (-1.0, -3.4 * 10**38),
         (3.4 * 10**38, -3.4 * 10**38),
-        (float("inf"), 1),
-        (1, -float("inf")),
+        (float("inf"), 1.0),
+        (1.0, -float("inf")),
         (3.4 * 10**38, float("inf")),
         (-3.4 * 10**38, -float("inf")),
-        (11, 1),
+        (11.0, 1.0),
     ],
 )
 def test_unary_min_fill_val_bf16(input_shapes, input_val, scalar, device):
@@ -104,7 +104,7 @@ def test_unary_min_fill_val_bf16(input_shapes, input_val, scalar, device):
         (-3.3 * 10**38, 3.3 * 10**38),
     ],
 )
-@pytest.mark.parametrize("scalar", [0.5, 0, 20, 3.4 * 10**38, -3.4 * 10**38])
+@pytest.mark.parametrize("scalar", [0.5, 0.0, 20.0, 3.4 * 10**38, -3.4 * 10**38])
 def test_unary_min_bf16(input_shapes, low, high, scalar, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
@@ -137,11 +137,13 @@ def test_unary_min_bf16(input_shapes, low, high, scalar, device):
 @pytest.mark.parametrize(
     "low, high",
     [
-        (-100, 100),
+        (-10.0, 100.0),
         (-1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-@pytest.mark.parametrize("scalar", [0.5, 0.1, 0, 1, 10, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")])
+@pytest.mark.parametrize(
+    "scalar", [0.5, 0.1, 0.0, 1.0, 10.0, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")]
+)
 def test_unary_min_fp32(input_shapes, low, high, scalar, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.float32)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -14,7 +14,6 @@ namespace sfpu {
 
 template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_unary_max_min(uint value) {
-
     // Load value param to lreg2
     TT_SFPLOADI(p_sfpu::LREG2, 10, value & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG2, 8, value >> 16);
@@ -42,28 +41,28 @@ inline void calculate_unary_max_min(uint value) {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_unary_max_int32(uint value) {
-   // Load value param to lreg2 --> sign + magnitude
-   _sfpu_load_imm32_(p_sfpu::LREG2, value);
-   TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG3, 2); // InstrModCast::INT32_2S_COMP_TO_INT_SIGN_MAGN;
-   TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG2, 0);
+    // Load value param to lreg2 and cast to sign + magnitude format
+    _sfpu_load_imm32_(p_sfpu::LREG2, value);
+    TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG3, 2);
+    TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG2, 0);
 
 #pragma GCC unroll 0
    for (int d = 0; d < ITERATIONS; d++) {
        // Load input to lreg0
        TTI_SFPLOAD(p_sfpu::LREG0, 12, ADDR_MOD_3, 0);
-       TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG3, 2); // InstrModCast::INT32_2S_COMP_TO_INT_SIGN_MAGN;
+       TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG3, 2);
        TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);
 
        // Copy value param to lreg1
        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
 
-       // Swap and store maximum in lreg1 (sign + magnitude format)
+       // Swap and store maximum in lreg1
        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
 
-       TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG3, 3); // InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP;
+       TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG3, 3);
        TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG1, 0);
        TTI_SFPSTORE(p_sfpu::LREG3, 12, ADDR_MOD_3, 0);
-       
+
        dst_reg++;
    }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -40,5 +40,33 @@ inline void calculate_unary_max_min(uint value) {
     }
 }
 
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_unary_max_int32(uint value) {
+   // Load value param to lreg2 --> sign + magnitude
+   _sfpu_load_imm32_(p_sfpu::LREG2, value);
+   TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG3, 2); // InstrModCast::INT32_2S_COMP_TO_INT_SIGN_MAGN;
+   TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG2, 0);
+
+#pragma GCC unroll 0
+   for (int d = 0; d < ITERATIONS; d++) {
+       // Load input to lreg0
+       TTI_SFPLOAD(p_sfpu::LREG0, 12, ADDR_MOD_3, 0);
+       TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG3, 2); // InstrModCast::INT32_2S_COMP_TO_INT_SIGN_MAGN;
+       TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);
+
+       // Copy value param to lreg1
+       TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+
+       // Swap and store maximum in lreg1 (sign + magnitude format)
+       TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+
+       TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG3, 3); // InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP;
+       TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG1, 0);
+       TTI_SFPSTORE(p_sfpu::LREG3, 12, ADDR_MOD_3, 0);
+       
+       dst_reg++;
+   }
+}
+
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -41,7 +41,7 @@ inline void calculate_unary_max_min(uint value) {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_unary_max_int32(uint value) {
-    // Load value param to lreg2 and cast to sign + magnitude format
+    // Load value param to lreg2 and cast 2's complement to sign + magnitude format
     _sfpu_load_imm32_(p_sfpu::LREG2, value);
     TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG3, 2);
     TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG2, 0);
@@ -49,7 +49,7 @@ inline void calculate_unary_max_int32(uint value) {
 #pragma GCC unroll 0
    for (int d = 0; d < ITERATIONS; d++) {
        // Load input to lreg0
-       TTI_SFPLOAD(p_sfpu::LREG0, 12, ADDR_MOD_3, 0);
+       TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG3, 2);
        TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);
 
@@ -61,7 +61,7 @@ inline void calculate_unary_max_int32(uint value) {
 
        TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG3, 3);
        TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG1, 0);
-       TTI_SFPSTORE(p_sfpu::LREG3, 12, ADDR_MOD_3, 0);
+       TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
 
        dst_reg++;
    }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
@@ -24,6 +24,13 @@ inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, i
         ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_max_int32<APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
 // Unary minimum
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_init() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -55,7 +55,7 @@ inline void calculate_unary_max_int32(uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         // Load input tensor to lreg0
-        TTI_SFPLOAD(p_sfpu::LREG0, 12, ADDR_MOD_3, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
 
         // Copy value param to lreg2 to lreg1
         TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
@@ -64,7 +64,7 @@ inline void calculate_unary_max_int32(uint value) {
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
 
         // Store the result
-        TTI_SFPSTORE(p_sfpu::LREG1, 12, ADDR_MOD_3, 0);
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -42,15 +42,15 @@ inline void calculate_unary_max_min(uint value) {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_unary_max_int32(uint value) {
-    int inp = value;
-    if (inp < 0) {  // To convert from 2's complement to sign+magnitude
-        inp = -inp;
-        int res = 0x80000000 | (inp & 0x7FFFFFFF);
-        inp = res;
+    int scalar = value;
+    if (scalar < 0) {  // To convert from 2's complement to sign+magnitude
+        scalar = -scalar;
+        int res = 0x80000000 | (scalar & 0x7FFFFFFF);
+        scalar = res;
     }
 
     // Load value param to lreg2
-    _sfpu_load_imm32_(p_sfpu::LREG2, inp);
+    _sfpu_load_imm32_(p_sfpu::LREG2, scalar);
 
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
@@ -24,6 +24,13 @@ inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, i
         ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_max_int32<APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
 // Unary minimum
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_init() {

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -997,6 +997,26 @@ ALWI void dbg_read_dest_acc_row(int row_addr, uint32_t* rd_data) {
  * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
  */
 // clang-format on
+ALWI void unary_max_int32_tile(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_max_int32<APPROX>(idst, param0)));
+}
+
+// unary_max : if x > value --> x, else value
+// clang-format off
+/**
+ * Performs element-wise computation of:  result = x if x > value , where x is each element of a tile
+ * in DST register at index tile_index. The value is provided as const param0 The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
+ */
+// clang-format on
 ALWI void unary_max_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_max<APPROX>(idst, param0)));
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -310,7 +310,7 @@ struct ExecuteMaximum {
     static Tensor invoke(
         QueueId queue_id,
         const Tensor& input_a,
-        const std::variant<int, float> value,
+        const std::variant<int32_t, float> value,
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
@@ -336,7 +336,7 @@ struct ExecuteMinimum {
     static Tensor invoke(
         QueueId queue_id,
         const Tensor& input_a,
-        const std::variant<int, float> value,
+        const std::variant<int32_t, float> value,
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -310,7 +310,7 @@ struct ExecuteMaximum {
     static Tensor invoke(
         QueueId queue_id,
         const Tensor& input_a,
-        const float value,
+        const std::variant<int, float> value,
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
@@ -336,7 +336,7 @@ struct ExecuteMinimum {
     static Tensor invoke(
         QueueId queue_id,
         const Tensor& input_a,
-        const float value,
+        const std::variant<int, float> value,
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -331,8 +331,8 @@ void bind_binary_unary_max_operation(
     py::module& module,
     const binary_operation_t& operation,
     const std::string& description,
-    const std::string& supported_dtype = "BFLOAT16, FLOAT32, INT32",
-    const std::string& note = " ") {
+    const std::string& note = " ",
+    const std::string& supported_dtype = "BFLOAT16, FLOAT32, INT32") {
     auto doc = fmt::format(
         R"doc(
         {2}
@@ -2207,7 +2207,8 @@ void py_module(py::module& module) {
     detail::bind_binary_unary_max_operation(
         module,
         ttnn::maximum,
-        R"doc(Computes maximum for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc");
+        R"doc(Computes maximum for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(Supported range for :attr:`input_tensor_b` when its of scalar type is [-16777216, 16777216])doc");
 
     detail::bind_prelu(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -386,7 +386,7 @@ void bind_binary_unary_max_operation(
         ttnn::pybind_overload_t{
             [](const binary_operation_t& self,
                const ttnn::Tensor& input_tensor_a,
-               const std::variant<int, float> scalar,
+               const std::variant<int32_t, float> scalar,
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -386,7 +386,7 @@ void bind_binary_unary_max_operation(
         ttnn::pybind_overload_t{
             [](const binary_operation_t& self,
                const ttnn::Tensor& input_tensor_a,
-               const float scalar,
+               const std::variant<int, float> scalar,
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -143,17 +143,10 @@ Tensor ExecuteMinimum::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
-    return std::visit(
-        [&](auto input_b) -> Tensor {
-            if constexpr (std::is_same_v<decltype(input_b), float>) {
-                return ttnn::operations::unary::
-                    ExecuteUnaryWithVariantFloatIntParameter<ttnn::operations::unary::UnaryOpType::MINIMUM>::invoke(
-                        queue_id, input_a, input_b, memory_config, optional_output_tensor);
-            } else {
-                TT_FATAL(false, "int32 minimum not yet supported");
-            }
-        },
-        value);
+    TT_FATAL(std::holds_alternative<float>(value), "int32 minimum not yet supported");
+    return ttnn::operations::unary::
+        ExecuteUnaryWithVariantFloatIntParameter<ttnn::operations::unary::UnaryOpType::MINIMUM>::invoke(
+            queue_id, input_a, std::get<float>(value), memory_config, optional_output_tensor);
 }
 
 Tensor ExecuteMaximum::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -135,7 +135,7 @@ Tensor ExecuteMinimum::invoke(
 Tensor ExecuteMinimum::invoke(
     QueueId queue_id,
     const Tensor& input_a,
-    const std::variant<int, float> value,
+    const std::variant<int32_t, float> value,
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
@@ -183,7 +183,7 @@ Tensor ExecuteMaximum::invoke(
 Tensor ExecuteMaximum::invoke(
     QueueId queue_id,
     const Tensor& input_a,
-    const std::variant<int, float> value,
+    const std::variant<int32_t, float> value,
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -7,7 +7,6 @@
 #include <utility>
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
-#include <iomanip>
 #include "ttnn/types.hpp"
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/hal.hpp>
@@ -186,14 +185,10 @@ Tensor ExecuteMaximum::invoke(
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (value.index() == 0) {  // int
-        std::cout << "In composite file --> param0 : " << std::fixed << std::setprecision(15) << std::get<int>(value)
-                  << std::endl;
         return ttnn::operations::unary::
             ExecuteUnaryWithVariantFloatIntParameter<ttnn::operations::unary::UnaryOpType::MAXIMUM, int>::invoke(
                 queue_id, input_a, std::get<int>(value), memory_config, optional_output_tensor);
     }
-    std::cout << "In composite file in float--> param0 : " << std::fixed << std::setprecision(15)
-              << std::get<float>(value) << std::endl;
     return ttnn::operations::unary::
         ExecuteUnaryWithVariantFloatIntParameter<ttnn::operations::unary::UnaryOpType::MAXIMUM, float>::invoke(
             queue_id, input_a, std::get<float>(value), memory_config, optional_output_tensor);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -493,8 +493,6 @@ BinaryNgDeviceOperation::invoke(
     DataType dtype_a = input_tensor_a.dtype();
     bool is_sfpu_op = (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_a));
     bool is_quant_op = utils::is_quant_op(binary_op_type);
-    std::cout << " Inside ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp :" << scalar
-              << std::endl;
     return {
         operation_attributes_t{
             binary_op_type,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -493,6 +493,8 @@ BinaryNgDeviceOperation::invoke(
     DataType dtype_a = input_tensor_a.dtype();
     bool is_sfpu_op = (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_a));
     bool is_quant_op = utils::is_quant_op(binary_op_type);
+    std::cout << " Inside ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp :" << scalar
+              << std::endl;
     return {
         operation_attributes_t{
             binary_op_type,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -6,6 +6,8 @@
 
 #include <tt-metalium/assert.hpp>
 #include "ttnn/tensor/types.hpp"
+#include <sstream>
+#include <iomanip>
 
 using namespace tt::tt_metal;
 
@@ -222,7 +224,8 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype == DataType::INT32 || input_dtype == DataType::UINT32) {
-                op_init_and_name = {"unary_ne_tile_init();", fmt::format("unary_ne_tile_int32({}, {});", idst, param0)};
+                op_init_and_name = {
+                    "unary_ne_tile_init();", fmt::format("unary_ne_tile_int32({}, {}u);", idst, (uint)param0)};
             } else {
                 op_init_and_name = {
                     "unary_ne_tile_init();",
@@ -233,7 +236,8 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype == DataType::INT32 || input_dtype == DataType::UINT32) {
-                op_init_and_name = {"unary_eq_tile_init();", fmt::format("unary_eq_tile_int32({}, {});", idst, param0)};
+                op_init_and_name = {
+                    "unary_eq_tile_init();", fmt::format("unary_eq_tile_int32({}, {}u);", idst, (uint)param0)};
             } else {
                 op_init_and_name = {
                     "unary_eq_tile_init();",
@@ -291,9 +295,28 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                     (uint32_t)datatype_to_dataformat_converter((DataType)params[1]))};
             break;
         case UnaryOpType::MAXIMUM:
-            op_init_and_name = {
-                "unary_max_tile_init();",
-                fmt::format("unary_max_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+            TT_FATAL(
+                input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
+            if (input_dtype == DataType::INT32) {
+                // unsigned int uparam0 = static_cast<unsigned int>(param0);
+                // std::stringstream ss;
+                // ss << "0x" << std::hex << uparam0;
+                // std::string hexStr = ss.str();
+                // op_init_and_name = {
+                //     "unary_max_tile_init();", fmt::format("unary_max_int32_tile({}, {});", idst, hexStr)};
+                std::cout << "in utils file --> param0 : " << std::fixed << std::setprecision(15) << param0
+                          << std::endl;
+                std::cout << "in utils file --> param0 : " << (uint)param0 << std::endl;
+                // int32_t scalar = -214748360;
+
+                op_init_and_name = {
+                    "unary_max_tile_init();", fmt::format("unary_max_int32_tile({}, {}u);", idst, (uint)param0)};
+
+            } else {
+                op_init_and_name = {
+                    "unary_max_tile_init();",
+                    fmt::format("unary_max_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+            }
             break;
         case UnaryOpType::MINIMUM:
             op_init_and_name = {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -6,8 +6,6 @@
 
 #include <tt-metalium/assert.hpp>
 #include "ttnn/tensor/types.hpp"
-#include <sstream>
-#include <iomanip>
 
 using namespace tt::tt_metal;
 
@@ -298,20 +296,8 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype == DataType::INT32) {
-                // unsigned int uparam0 = static_cast<unsigned int>(param0);
-                // std::stringstream ss;
-                // ss << "0x" << std::hex << uparam0;
-                // std::string hexStr = ss.str();
-                // op_init_and_name = {
-                //     "unary_max_tile_init();", fmt::format("unary_max_int32_tile({}, {});", idst, hexStr)};
-                std::cout << "in utils file --> param0 : " << std::fixed << std::setprecision(15) << param0
-                          << std::endl;
-                std::cout << "in utils file --> param0 : " << (uint)param0 << std::endl;
-                // int32_t scalar = -214748360;
-
                 op_init_and_name = {
                     "unary_max_tile_init();", fmt::format("unary_max_int32_tile({}, {}u);", idst, (uint)param0)};
-
             } else {
                 op_init_and_name = {
                     "unary_max_tile_init();",

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -210,7 +210,7 @@ template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MAXIMUM>::
     QueueId, const Tensor&, const float, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
 
 template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MAXIMUM>::invoke<int32_t>(
-    QueueId, const Tensor&, const int, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
+    QueueId, const Tensor&, const int32_t, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
 
 Tensor Sigmoid_accurate::invoke(
     QueueId queue_id,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -13,6 +13,7 @@
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "ttnn/operations/eltwise/ternary/where.hpp"
 #include "ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.hpp"
+#include <typeinfo>
 
 namespace ttnn::operations::unary {
 
@@ -173,6 +174,30 @@ Tensor ExecuteUnaryWithFloatParameter<unary_op_type>::invoke(
         optional_output_tensor);
 }
 
+template <UnaryOpType unary_op_type, typename T>
+Tensor ExecuteUnaryWithVariantFloatIntParameter<unary_op_type, T>::invoke(
+    QueueId queue_id,
+    const Tensor& input_tensor,
+    T parameter,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    std::cout << "In unary.cpp --> param0 : " << std::fixed << std::setprecision(15) << static_cast<T>(parameter)
+              << std::endl;
+    std::cout << "In unary.cpp --> param0 : " << std::fixed << std::setprecision(15)
+              << std::bit_cast<uint32_t>(parameter) << std::endl;
+    std::cout << "In unary.cpp --> param0 : " << std::fixed << std::setprecision(15) << std::bit_cast<float>(parameter)
+              << std::endl;
+    std::cout << "In unary.cpp --> param0 : " << std::fixed << std::setprecision(15) << static_cast<double>(parameter)
+              << std::endl;
+
+    return detail::unary_impl(
+        queue_id,
+        input_tensor,
+        {UnaryWithParam{unary_op_type, static_cast<T>(parameter)}},
+        memory_config,
+        optional_output_tensor);
+}
+
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::ELU>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::RSUB>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::HEAVISIDE>;
@@ -186,8 +211,9 @@ template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_GT>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_LT>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_NE>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_EQ>;
-template struct ExecuteUnaryWithFloatParameter<UnaryOpType::MAXIMUM>;
-template struct ExecuteUnaryWithFloatParameter<UnaryOpType::MINIMUM>;
+template struct ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MAXIMUM, int32_t>;
+template struct ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MAXIMUM, float>;
+template struct ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MINIMUM, float>;
 
 Tensor Sigmoid_accurate::invoke(
     QueueId queue_id,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -13,7 +13,6 @@
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "ttnn/operations/eltwise/ternary/where.hpp"
 #include "ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.hpp"
-#include <typeinfo>
 
 namespace ttnn::operations::unary {
 
@@ -181,15 +180,6 @@ Tensor ExecuteUnaryWithVariantFloatIntParameter<unary_op_type, T>::invoke(
     T parameter,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
-    std::cout << "In unary.cpp --> param0 : " << std::fixed << std::setprecision(15) << static_cast<T>(parameter)
-              << std::endl;
-    std::cout << "In unary.cpp --> param0 : " << std::fixed << std::setprecision(15)
-              << std::bit_cast<uint32_t>(parameter) << std::endl;
-    std::cout << "In unary.cpp --> param0 : " << std::fixed << std::setprecision(15) << std::bit_cast<float>(parameter)
-              << std::endl;
-    std::cout << "In unary.cpp --> param0 : " << std::fixed << std::setprecision(15) << static_cast<double>(parameter)
-              << std::endl;
-
     return detail::unary_impl(
         queue_id,
         input_tensor,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -173,11 +173,12 @@ Tensor ExecuteUnaryWithFloatParameter<unary_op_type>::invoke(
         optional_output_tensor);
 }
 
-template <UnaryOpType unary_op_type, typename T>
-Tensor ExecuteUnaryWithVariantFloatIntParameter<unary_op_type, T>::invoke(
+template <UnaryOpType unary_op_type>
+template <typename T>
+Tensor ExecuteUnaryWithVariantFloatIntParameter<unary_op_type>::invoke(
     QueueId queue_id,
     const Tensor& input_tensor,
-    T parameter,
+    const T parameter,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
@@ -201,9 +202,15 @@ template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_GT>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_LT>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_NE>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_EQ>;
-template struct ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MAXIMUM, int32_t>;
-template struct ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MAXIMUM, float>;
-template struct ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MINIMUM, float>;
+
+template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MINIMUM>::invoke<float>(
+    QueueId, const Tensor&, const float, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
+
+template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MAXIMUM>::invoke<float>(
+    QueueId, const Tensor&, const float, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
+
+template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MAXIMUM>::invoke<int32_t>(
+    QueueId, const Tensor&, const int, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
 
 Tensor Sigmoid_accurate::invoke(
     QueueId queue_id,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -63,6 +63,16 @@ struct ExecuteUnaryWithFloatParameter {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
+template <UnaryOpType unary_op_type, typename T>
+struct ExecuteUnaryWithVariantFloatIntParameter {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input_tensor,
+        const T parameter,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
 struct LogSigmoid {
     static Tensor invoke(
         QueueId queue_id,
@@ -285,6 +295,13 @@ struct Tanh {
         "ttnn::" #operation_name,                                                     \
         ttnn::operations::unary::ExecuteUnaryWithFloatParameter<                      \
             ttnn::operations::unary::UnaryOpType::operation_type>>();
+
+#define REGISTER_UNARY_OPERATION_WITH_VARIANT_INT_FLOAT_PARAMETER(operation_name, operation_type, data_type) \
+    constexpr auto operation_name = ttnn::register_operation<                                                \
+        "ttnn::" #operation_name,                                                                            \
+        ttnn::operations::unary::ExecuteUnaryWithVariantFloatIntParameter<                                   \
+            ttnn::operations::unary::UnaryOpType::operation_type,                                            \
+            data_type>>();
 
 #define REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(operation_name, operation_type, data_type) \
     constexpr auto operation_name = ttnn::register_operation<                                      \

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -63,8 +63,9 @@ struct ExecuteUnaryWithFloatParameter {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
-template <UnaryOpType unary_op_type, typename T>
+template <UnaryOpType unary_op_type>
 struct ExecuteUnaryWithVariantFloatIntParameter {
+    template <typename T>
     static Tensor invoke(
         QueueId queue_id,
         const Tensor& input_tensor,
@@ -295,13 +296,6 @@ struct Tanh {
         "ttnn::" #operation_name,                                                     \
         ttnn::operations::unary::ExecuteUnaryWithFloatParameter<                      \
             ttnn::operations::unary::UnaryOpType::operation_type>>();
-
-#define REGISTER_UNARY_OPERATION_WITH_VARIANT_INT_FLOAT_PARAMETER(operation_name, operation_type, data_type) \
-    constexpr auto operation_name = ttnn::register_operation<                                                \
-        "ttnn::" #operation_name,                                                                            \
-        ttnn::operations::unary::ExecuteUnaryWithVariantFloatIntParameter<                                   \
-            ttnn::operations::unary::UnaryOpType::operation_type,                                            \
-            data_type>>();
 
 #define REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(operation_name, operation_type, data_type) \
     constexpr auto operation_name = ttnn::register_operation<                                      \


### PR DESCRIPTION
### Ticket
#21194

### Problem description
Int32 support required for unary version of max

### What's changed
Provided int32 support for Tensor - scalar version of maximum
Range constraint : https://github.com/tenstorrent/tt-metal/issues/21194#issuecomment-2942827295
<img width="881" alt="Screenshot 2025-06-06 at 10 50 26 AM" src="https://github.com/user-attachments/assets/81a3fbc7-2b54-461c-a6ff-97893c6f336a" />
Regarding the difference in WH, BH implementation is that for WH the SFPCAST instruction cant do INT32_2S_COMP_TO_INT_SIGN_MAGN, it only does int<->fp32. Hence have used another formula through which I can perform casting


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15709438060) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15709441805) CI passes as in main
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/15709443694) CI passes as in main
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15673809378) CI passes
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/15711673026) CI passes as in main
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15673812794) CI passes
- [x] New/Existing tests provide coverage for changes