### PR TITLE
Choose a branch for vLLM test

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -12,6 +12,10 @@ on:
       build-artifact-name:
         required: true
         type: string
+      vllm-commit:
+        description: "The branch or SHA of vLLM to test"
+        required: false
+        default: dev
 
 jobs:
   vllm-tests:
@@ -84,7 +88,7 @@ jobs:
         with:
           repository: tenstorrent/vllm
           path: docker-job/vllm
-          ref: dev
+          ref: ${{ inputs.vllm-commit }}
           fetch-depth: 1
 
       - name: 📀 Install vLLM

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -13,9 +13,10 @@ on:
         required: true
         type: string
       vllm-commit:
-        description: "The branch or SHA of vLLM to test"
+        description: "vLLM branch or sha"
         required: false
         default: dev
+        type: string
 
 jobs:
   vllm-tests:

--- a/.github/workflows/vllm-nightly-tests.yaml
+++ b/.github/workflows/vllm-nightly-tests.yaml
@@ -2,6 +2,11 @@ name: "vLLM nightly tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      vllm-commit:
+        description: "The branch or SHA of vLLM to test"
+        required: false
+        default: dev
   schedule:
     - cron: '0 0 * * *' # This cron schedule runs the workflow every day at 12am UTC
 
@@ -22,3 +27,4 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      vllm-commit: ${{ inputs.vllm-commit }}

--- a/.github/workflows/vllm-nightly-tests.yaml
+++ b/.github/workflows/vllm-nightly-tests.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       vllm-commit:
-        description: "The branch or SHA of vLLM to test"
+        description: "vLLM branch or sha"
         required: false
         default: dev
   schedule:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23102

### Problem description
To test changes on vLLM side we need to be able to choose a branch in tt-metal test

### What's changed
Expose the vLLM branch/sha as an input for the workflow

### Checklist
I tried vLLM nightly test with another branch and it successfully checked it out and installed vLLM
The branch isn't ready for testing, so the overall test failed, but I don't see that as an issue for this change.
https://github.com/tenstorrent/tt-metal/actions/runs/15462748704/job/43528010634#step:5:67