### PR TITLE
Update galaxy-demo to run every night

### DIFF
--- a/.github/workflows/galaxy-demo-tests.yaml
+++ b/.github/workflows/galaxy-demo-tests.yaml
@@ -3,9 +3,7 @@ name: "Galaxy demo tests"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 6'  # Runs every Saturday at 12am UTC
-    - cron: '0 0 * * 0'  # Runs every Sunday at 12am UTC
-
+    - cron: '0 3 * * *'  # Every day at 3:00 UTC
 jobs:
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml


### PR DESCRIPTION
Set Galaxy demo to nightly UTC3 AM (night in US East 11PM and US West 8PM and early morning in Europe CEST 5AM)

### Problem description
Currently we are not running 6U demo for Llama and other models due to shortage of 6Us. Monitoring Llama demo started being a problem to always run manually. 

### What's changed
So I decided to increase frequency of Galaxy demo from twice a week on weekends to every night and put it to nightly (actual night time across US/Can/EU timezones).