### PR TITLE
Update Llama70b 6U tsu range

### DIFF
--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -35,7 +35,7 @@ TSU_PERF_DROP_LIMIT_COUNT = 20
 TSU_THRESHOLDS = {
     "4U": {1: {"min": 540, "max": 565}, 10: {"min": 230, "max": 253}, 80: {"min": 49.5, "max": 54}},
     # TODO: Update thresholds for 6U 10L and 80L based on actual perf when 6U are available and added into CI
-    "6U": {1: {"min": 625, "max": 655}, 10: {"min": 230, "max": 250}, 80: {"min": 49, "max": 53}},
+    "6U": {1: {"min": 625, "max": 655}, 10: {"min": 230, "max": 250}, 80: {"min": 53, "max": 58}},
 }
 
 


### PR DESCRIPTION
Update tsu range to relevant since lot of improvements went in

### Problem description
Llama70b on 6U full demo was not executing often and tsu range is out of date
### What's changed
tsu range [49,53] -> [53,58] due to lot if improvements in the meantime
### Checklist
- [ ] [Failing run on main for reference of current tsu range](https://github.com/tenstorrent/tt-metal/actions/runs/15443553448/job/43467532347#step:5:758) 
- [ ] [Run on branch](https://github.com/tenstorrent/tt-metal/actions/runs/15466750644)