### PR TITLE
Conv2d WS act and weight db options

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -794,6 +794,14 @@ def test_conv_dram(
     "output_dtype",
     [ttnn.bfloat16, ttnn.bfloat8_b],
 )
+@pytest.mark.parametrize(
+    "enable_act_double_buffer",
+    [True, False],
+)
+@pytest.mark.parametrize(
+    "enable_weights_double_buffer",
+    [True, False],
+)
 @pytest.mark.parametrize("auto_shard", [True, False], ids=["auto_shard", "no_auto_shard"])
 @pytest.mark.parametrize("tilized_input", [True, False], ids=["tilized", "row_major"])
 def test_conv_ws(
@@ -816,6 +824,8 @@ def test_conv_ws(
     output_dtype,
     auto_shard,
     tilized_input,
+    enable_act_double_buffer,
+    enable_weights_double_buffer,
 ):
     if device.core_grid.y != 8 and is_wormhole_b0():
         pytest.skip("Needs 8x8 grid for wormhole_b0")
@@ -872,7 +882,8 @@ def test_conv_ws(
         weights_dtype=weights_dtype,
         shard_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED if not auto_shard else None,
         deallocate_activation=deallocate_activation,
-        enable_act_double_buffer=False,
+        enable_act_double_buffer=enable_act_double_buffer,
+        enable_weights_double_buffer=enable_weights_double_buffer,
         enable_split_reader=False,
         enable_subblock_padding=False,
         reshard_if_not_optimal=True,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1060,6 +1060,9 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
         uint32_t weight_block_w_ntiles = per_core_out_matrix_width_ntiles;
         uint32_t weight_block_num_tiles =
             weight_block_w_ntiles * act_block_w_ntiles;  // act_block_w_ntiles == weight_block_h_ntiles
+        if (conv_config.enable_weights_double_buffer) {
+            weight_block_num_tiles *= 2;
+        }
         uint32_t weight_block_num_bytes = weight_block_num_tiles * weights_tile_size;
 
         uint32_t bias_block_num_bytes = per_core_out_matrix_width_ntiles * bias_tile_size;
@@ -1079,6 +1082,9 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
 
         // ACT CB
         uint32_t act_cb_size = tilized_act_block_num_bytes;
+        if (conv_config.enable_act_double_buffer) {
+            act_cb_size *= 2;
+        }
         tt::log_debug(tt::LogOp, "Act CB Size: {}", act_cb_size);
 
         // WEIGHTS CB

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -74,7 +74,8 @@ struct Conv2dConfig {
     // Increased perf, but increased L1 usage.
     bool enable_act_double_buffer = false;
 
-    // Used on for height and block sharded convolutions
+    // Doubles the size of the CBs for weights.
+    // Increased perf, but increased L1 usage.
     bool enable_weights_double_buffer = false;
 
     // Only for height sharding.

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -44,6 +44,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     Tensor& output,
     DeviceComputeKernelConfig compute_kernel_config,
     bool enable_act_double_buffer,
+    bool enable_weights_double_buffer,
     bool enable_split_reader,
     bool enable_subblock_padding);
 
@@ -1816,6 +1817,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             output,
             compute_kernel_config.value(),
             enable_act_double_buffer,
+            enable_weights_double_buffer,
             enable_split_reader,
             enable_subblock_padding);
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -44,6 +44,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     Tensor& output,
     DeviceComputeKernelConfig compute_kernel_config,
     bool enable_act_double_buffer,
+    bool enable_weights_double_buffer,
     bool enable_split_reader,
     bool enable_subblock_padding) {
     using tt::tt_metal::CBHandle;
@@ -98,9 +99,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     uint32_t max_subblock_h = fp32_dest_acc_en ? 4 : 8;
     uint32_t act_block_h_ntiles_padded = act_block_h_ntiles;
     uint32_t out_subblock_h_ntiles_padded = out_subblock_h_ntiles;
-    // bool enable_subblock_padding = false;
-    // bool enable_split_reader = false;
-    // enable_act_double_buffer = false;
     if (enable_subblock_padding) {
         TT_FATAL(
             act_block_h_ntiles == out_block_h_ntiles, "to pad subblock, the number of blocks on height dim must be 1");
@@ -630,14 +628,12 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         a.buffer());
 
     cb_indices.act_cb = cb_indices.get_next_cb_index();
+    const uint32_t act_cb_num_tiles =
+        enable_act_double_buffer ? act_block_num_tiles_split * 2 : act_block_num_tiles_split;
     tt::tt_metal::create_cb(
-        cb_indices.act_cb, program, all_cores, tilized_act_tile_size, act_block_num_tiles_split, tilized_act_df);
+        cb_indices.act_cb, program, all_cores, tilized_act_tile_size, act_cb_num_tiles, tilized_act_df);
     log_debug(
-        LogOp,
-        "Act CB: {}, npages: {}, pagesize: {}",
-        cb_indices.act_cb,
-        act_block_num_tiles_split,
-        tilized_act_tile_size);
+        LogOp, "Act CB: {}, npages: {}, pagesize: {}", cb_indices.act_cb, act_cb_num_tiles, tilized_act_tile_size);
 
     // Used for placing tilized activations
     cb_indices.tilize_mode_tilized_act_cb = cb_indices.get_next_cb_index();
@@ -657,13 +653,15 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         tilized_act_tile_size);
 
     cb_indices.weight_cb = cb_indices.get_next_cb_index();
+    const uint32_t weights_cb_num_tiles =
+        enable_weights_double_buffer ? weight_block_num_tiles * 2 : weight_block_num_tiles;
     tt::tt_metal::create_cb(
-        cb_indices.weight_cb, program, all_cores, weight_tile_size, weight_block_num_tiles, weight_df);
+        cb_indices.weight_cb, program, all_cores, weight_tile_size, weights_cb_num_tiles, weight_df);
     log_debug(
         LogOp,
         "Weight CB: {}, npages: {}, pagesize: {}, ",
         cb_indices.weight_cb,
-        weight_block_num_tiles,
+        weights_cb_num_tiles,
         weight_tile_size);
 
     cb_indices.act_cb_row_major_bfloat16 = cb_indices.get_next_cb_index();


### PR DESCRIPTION
Issue ##21428

Add option to enable weights and activations double buffer for width sharded conv2d operations.

This can have a significant impact on performance.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/21428)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15454129610)
- [x] [Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/15454144252) 
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15454133413)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/15454140359)