### PR TITLE
[skip ci] Add infra team + Paul as CODEOWNERS of CMakeLists.txt in hw folder, per his request

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@ tt_metal/hw/inc/ethernet/ @aliuTT @ubcheema
 tt_metal/hw/inc/wormhole/eth_l1_address_map.h @aliuTT @ubcheema
 tt_metal/hw/firmware/ @abhullar-tt @jbaumanTT @pgkeller @nathan-TT
 tt_metal/hw/toolchain/ @jbaumanTT @pgkeller @nathan-TT
+tt_metal/hw/**/CMakeLists.txt @tenstorrent/metalium-developers-infra @pgkeller
 tt_metal/impl/allocator/ @abhullar-tt @tt-aho
 tt_metal/impl/buffers/ @abhullar-tt @jbaumanTT
 tt_metal/impl/context/ @tt-dma @jbaumanTT @aliuTT

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,7 +46,7 @@ tt_metal/hw/inc/ethernet/ @aliuTT @ubcheema
 tt_metal/hw/inc/wormhole/eth_l1_address_map.h @aliuTT @ubcheema
 tt_metal/hw/firmware/ @abhullar-tt @jbaumanTT @pgkeller @nathan-TT
 tt_metal/hw/toolchain/ @jbaumanTT @pgkeller @nathan-TT
-tt_metal/hw/**/CMakeLists.txt @tenstorrent/metalium-developers-infra @pgkeller
+tt_metal/hw/**/CMakeLists.txt @tenstorrent/metalium-developers-infra @jbaumanTT @pgkeller @nathan-TT
 tt_metal/impl/allocator/ @abhullar-tt @tt-aho
 tt_metal/impl/buffers/ @abhullar-tt @jbaumanTT
 tt_metal/impl/context/ @tt-dma @jbaumanTT @aliuTT


### PR DESCRIPTION
### Ticket

Quick request from @pgkeller 

### Problem description

CMake, from runtime POV, is a bit of a black box.

### What's changed

Let's help them out.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes