### PR TITLE
WS conv2d overlap I2C and tilize

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1054,7 +1054,6 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
         uint32_t output_size_per_core_in_bytes = per_core_out_matrix_width_ntiles * per_core_out_matrix_height_ntiles *
                                                  tt::tile_size(datatype_to_dataformat_converter(conv_config.dtype));
 
-        uint32_t act_block_num_bytes = act_block_num_tiles * input_tile_size;
         uint32_t tilized_act_block_num_bytes = act_block_num_tiles * output_tile_size;
 
         uint32_t weight_block_w_ntiles = per_core_out_matrix_width_ntiles;
@@ -1100,7 +1099,7 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
         tt::log_debug(tt::LogOp, "L1 CB Size: {}", l1_scratchpad_cb_size);
 
         // ACT ROW MAJOR CB
-        uint32_t row_major_act_cb_size = act_block_num_bytes;
+        uint32_t row_major_act_cb_size = act_block_w_ntiles * input_tile_size * 2;
         tt::log_debug(tt::LogOp, "Act row major CB Size: {}", row_major_act_cb_size);
 
         // MATMUL PARTIALs CB

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -666,12 +666,12 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
 
     cb_indices.act_cb_row_major_bfloat16 = cb_indices.get_next_cb_index();
     tt::tt_metal::create_cb(
-        cb_indices.act_cb_row_major_bfloat16, program, all_cores, act_tile_size, act_block_num_tiles_split, act_df);
+        cb_indices.act_cb_row_major_bfloat16, program, all_cores, act_tile_size, 2 * act_block_w_ntiles, act_df);
     log_debug(
         LogOp,
         "Act Row Major CB: {}, npages: {}, pagesize: {}",
         cb_indices.act_cb_row_major_bfloat16,
-        act_block_num_tiles_split,
+        2 * act_block_w_ntiles,
         act_tile_size);
 
     auto conv_reader_indices_storage = conv_reader_indices.value().device_storage();

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -139,43 +139,56 @@ void kernel_main() {
     uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
     noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), conv_act_c_read_bytes);
 
+    constexpr uint32_t TILE_HEIGHT = 32;
+    constexpr uint32_t ntile_height = act_block_h_datums / TILE_HEIGHT;
+    constexpr uint32_t block_width = act_block_num_tiles / ntile_height;
+    constexpr uint32_t act_block_h_datums_per_tile_half = (act_block_h_datums / ntile_height) / 2;
+
     // Reset reader_idx to finish act_block_h_datums
     for (uint32_t block_h_index = 0; block_h_index < act_num_blocks_h; block_h_index++) {
         act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
         for (uint32_t block_w_index = 0; block_w_index < act_num_blocks_w; block_w_index++) {
             uint32_t reader_idx = block_h_index * (act_block_h_datums / 2);
-            cb_reserve_back(cb_id_act_row_major_bfloat16, act_block_num_tiles);
-            if (this_core_id < num_input_cores) {
-                uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_row_major_bfloat16);
-                for (uint32_t bh = 0; bh < act_block_h_datums / 2; bh++) {
-                    uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
-                    read_channels<weight_size_h, weight_size_w>(
-                        l1_write_addr_act,
-                        act_l1_read_addr,
-                        two_reader_indices & 0xffff,
-                        conv_act_c_bytes,
-                        conv_act_c_read_bytes,
-                        stride_h_bytes,
-                        stride_w_bytes);
-                    read_channels<weight_size_h, weight_size_w>(
-                        l1_write_addr_act,
-                        act_l1_read_addr,
-                        two_reader_indices >> 16,
-                        conv_act_c_bytes,
-                        conv_act_c_read_bytes,
-                        stride_h_bytes,
-                        stride_w_bytes);
 
-                    reader_idx++;
+            if (this_core_id < num_input_cores) {
+                for (uint32_t tile_h_index = 0; tile_h_index < ntile_height; tile_h_index++) {
+                    cb_reserve_back(cb_id_act_row_major_bfloat16, block_width);
+                    uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_row_major_bfloat16);
+                    for (uint32_t bh = 0; bh < act_block_h_datums_per_tile_half; bh++) {
+                        uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
+                        read_channels<weight_size_h, weight_size_w>(
+                            l1_write_addr_act,
+                            act_l1_read_addr,
+                            two_reader_indices & 0xffff,
+                            conv_act_c_bytes,
+                            conv_act_c_read_bytes,
+                            stride_h_bytes,
+                            stride_w_bytes);
+                        read_channels<weight_size_h, weight_size_w>(
+                            l1_write_addr_act,
+                            act_l1_read_addr,
+                            two_reader_indices >> 16,
+                            conv_act_c_bytes,
+                            conv_act_c_read_bytes,
+                            stride_h_bytes,
+                            stride_w_bytes);
+
+                        reader_idx++;
+                    }
+
+                    noc_async_read_barrier();
+                    cb_push_back(cb_id_act_row_major_bfloat16, block_width);
                 }
 
                 // After reading one block, increment the starting read pointer by the width of the block.
                 // Next read uses the next set of channels.
                 act_l1_read_addr += conv_act_c_read_bytes;
-
-                noc_async_read_barrier();
+            } else {
+                for (uint32_t tile_h_index = 0; tile_h_index < ntile_height; tile_h_index++) {
+                    cb_reserve_back(cb_id_act_row_major_bfloat16, block_width);
+                    cb_push_back(cb_id_act_row_major_bfloat16, block_width);
+                }
             }
-            cb_push_back(cb_id_act_row_major_bfloat16, act_block_num_tiles);
 
             // Round robin self-mcast and receive tilized act matrix in cb_id_act
             // Compute should function like regular mm
@@ -198,13 +211,13 @@ void kernel_main() {
 
                     noc_semaphore_set(act_mcast_receiver_semaphore_addr_ptr, INVALID);
 
-                    // // compute tilizes and pops cb_id_act and pushes to tilized_in0_cb_id
+                    // compute tilizes and pops cb_id_act and pushes to tilized_in0_cb_id
                     cb_wait_front(tilized_in0_cb_id, act_block_num_tiles);
 
-                    // // Now we have the block in the CB address, we can mcast to dests!
+                    // Now we have the block in the CB address, we can mcast to dests!
                     uint32_t tilized_act_start_address = get_read_ptr(tilized_in0_cb_id);
 
-                    // // num_dests will source, since we are copying to a different local CB as well
+                    // num_dests will source, since we are copying to a different local CB as well
                     uint64_t act_multicast_data_addr = act_multicast_noc_addr | get_write_ptr(cb_id_act);
 
                     noc_async_write_multicast_loopback_src(
@@ -223,15 +236,13 @@ void kernel_main() {
                     // not be sent in order they are issued
                     noc_async_writes_flushed();
 #endif
-                    // // We should also multicast VALID flag to destinations for receiver semaphore
+                    // We should also multicast VALID flag to destinations for receiver semaphore
                     noc_semaphore_set_multicast_loopback_src(
                         act_mcast_sender_semaphore_valid_addr,
                         act_mcast_receiver_semaphore_noc_addr,
                         num_reader_cores,
                         false);
-
                     noc_semaphore_wait(act_mcast_receiver_semaphore_addr_ptr, VALID);
-
                 } else {
                     // MCAST RECEIVER: receive entire tilized input from sender core
                     // Set act semaphore value to INVALID


### PR DESCRIPTION
Issue #21428

In Conv2d reader kernel currently Image2Column
algorithm prepares whole activatino matrix before
tilize on compute kernel can start working on it.

This change changes this so that I2C pushes work
to tilize when it produces single row of activation matrix per core. This allows to overlap I2C and tilize. Also this allows us no to buffer whole activation
matrix for I2C and reduces L1 memory usage for
width sharded conv2d.
Now for I2C we will buffer two rows of activation matrix, to allow for double buffering scheme between I2C and tilize.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/21428)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15447521429)
- [x] [ Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/15453283776) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15453279404) 
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15453275813)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/15447542156)