### PR TITLE
Fix reading data-parallel decode output

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -603,13 +603,14 @@ class Generator:
         """
         Input is ttnn device tensor of logits if is_tokens=False, otherwise tokens. Output is the corresponding torch tensor.
         """
-        batch_per_dp = unpadded_batch // self.data_parallel
         logits = []
         for i in range(self.data_parallel):
-            logits_i = self.model[i].process_output_decode(tt_out[i], B=batch_per_dp, S=1, is_tokens=is_tokens)
+            logits_i = self.model[i].process_output_decode(
+                tt_out[i], B=self.model_args[i].max_batch_size, S=1, is_tokens=is_tokens
+            )
             logits.append(logits_i)
         logits = torch.cat(logits, 0)
-        return logits
+        return logits[:unpadded_batch]
 
     def _decode_forward_no_trace(
         self,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23042

### Problem description
Fixing incorrect formula for reading unpadded batch of decode results. `unpadded_batch` is not necessarily a proper multiple of `data_parallel` so we need to adjust the algorithm accordingly.
Continuing the effort of another closed PR https://github.com/tenstorrent/tt-metal/pull/22789

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15472387251) CI passes
- [x] [TG demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/15554702115)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes