### PR TITLE
Update IdleEthTestInvalidReadWriteAddressL1 to target invalid eth addr on BH

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_device/test_enqueue_read_write_core.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_device/test_enqueue_read_write_core.cpp
@@ -288,7 +288,7 @@ TEST_F(CommandQueueSingleCardFixture, IdleEthTestInvalidReadWriteAddressL1) {
 
     const DeviceAddr l1_end_address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED) +
-        MetalContext::instance().hal().get_dev_size(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);
+        MetalContext::instance().hal().get_dev_size(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::BASE);
     const DeviceAddr l1_end_address_offset = 256;
     const DeviceAddr address = l1_end_address + l1_end_address_offset;
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
BH smoke test was failing. This test meant to target invalid eth address but it was just hitting syseng reserved region. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15473871076) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15478062112) CI 