### PR TITLE
[DM] Directly Write to/Read from L1 for Test Preparation and Checking (Test: One From One)

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between two Tensix cores.
 
 ## Test Flow
-Sharded L1 buffers are created on two Tensix cores: one requestor and one responder core. Data is written into the L1 buffer on the responder core. The requestor kernel issues read NOC transactions to request a transfer of this data from the L1 buffer of the responder core to the L1 buffer of its core. A read barrier is placed after these transactions in order to ensure data validity.
+Data is written directly into the L1 memory on the responder core. The requestor kernel issues read NOC transactions to request a transfer of this data from the L1 address of the responder core to the L1 address of its core. A read barrier is placed after these transactions in order to ensure data validity.
 
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
@@ -27,4 +27,4 @@ Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B fo
 Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
 
 1. One From One Packet Sizes: Tests different number of transactions and transaction sizes by varying the num_of_transactions and transaction_size_pages parameters. Sweeps values that are multiples of 2 (including 1) in the range [1, 64] for both parameters.
-2. One From One Directed Ideal: Tests the most optimal data movement setup between two cores that maximizes the transaction size and performs enough transactions to amortize initialization overhead. This test is performed between neigbouring cores on a torus to minimize latency.
+2. One From One Directed Ideal: Tests the most optimal data movement setup between two cores that reduces the number of transactions while maximizing transaction size to minimize the effects of initialization overhead. This test is performed between neigbouring cores on a torus to minimize latency.

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -54,12 +54,12 @@ bool run_dm(IDevice* device, const OneFromOneConfig& test_config) {
     // Checks that both master and subordinate cores have the same L1 base address and size
     if (master_l1_info.base_address != subordinate_l1_info.base_address ||
         master_l1_info.size != subordinate_l1_info.size) {
-        log_error("Mismatch in L1 address or size between master and subordinate cores");
+        log_error(tt::LogTest, "Mismatch in L1 address or size between master and subordinate cores");
         return false;
     }
     // Check if the L1 size is sufficient for the test configuration
     if (master_l1_info.size < total_size_bytes) {
-        log_error("Insufficient L1 size for the test configuration");
+        log_error(tt::LogTest, "Insufficient L1 size for the test configuration");
         return false;
     }
     // Assigns a "safe" L1 local address for the master and subordinate cores
@@ -125,7 +125,7 @@ bool run_dm(IDevice* device, const OneFromOneConfig& test_config) {
 TEST_F(DeviceFixture, TensixDataMovementOneFromOnePacketSizes) {
     // Physical Constrains
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
 
     // Parameters
     uint32_t max_transactions = 256;
@@ -166,7 +166,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromOneDirectedIdeal) {
     uint32_t test_id = 51;  // Arbitrary test ID
 
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
-        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_);
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
     // Adjustable Parameters
     // Ideal: Less transactions, more data per transaction
     uint32_t num_of_transactions = 1;

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -38,53 +38,38 @@ bool run_dm(IDevice* device, const OneFromOneConfig& test_config) {
     // Program
     Program program = CreateProgram();
 
-    // Sharded L1 buffers
-    const size_t total_size_bytes =
-        test_config.num_of_transactions * test_config.transaction_size_pages * test_config.page_size_bytes;
-    const size_t total_size_pages = test_config.num_of_transactions * test_config.transaction_size_pages;
+    const size_t transaction_size_bytes = test_config.transaction_size_pages * test_config.page_size_bytes;
+    const size_t total_size_bytes = transaction_size_bytes * test_config.num_of_transactions;
 
+    // (Logical) Core Coordinates and ranges
     CoreRangeSet master_core_set({CoreRange(test_config.master_core_coord)});
-    CoreRangeSet subordinate_core_set({CoreRange(test_config.subordinate_core_coord)});
 
-    auto master_shard_parameters = ShardSpecBuffer(
-        master_core_set,
-        {1, total_size_bytes / 2},
-        ShardOrientation::ROW_MAJOR,
-        {1, test_config.page_size_bytes / 2},
-        {1, total_size_pages});
-    auto master_l1_buffer = CreateBuffer(ShardedBufferConfig{
-        .device = device,
-        .size = total_size_bytes,
-        .page_size = test_config.page_size_bytes,
-        .buffer_type = BufferType::L1,
-        .buffer_layout = TensorMemoryLayout::WIDTH_SHARDED,
-        .shard_parameters = std::move(master_shard_parameters),
-    });
-    uint32_t master_l1_byte_address = master_l1_buffer->address();
-
-    auto subordinate_shard_parameters = ShardSpecBuffer(
-        subordinate_core_set,
-        {1, total_size_bytes / 2},
-        ShardOrientation::ROW_MAJOR,
-        {1, test_config.page_size_bytes / 2},
-        {1, total_size_pages});
-    auto subordinate_l1_buffer = CreateBuffer(ShardedBufferConfig{
-        .device = device,
-        .size = total_size_bytes,
-        .page_size = test_config.page_size_bytes,
-        .buffer_type = BufferType::L1,
-        .buffer_layout = TensorMemoryLayout::WIDTH_SHARDED,
-        .shard_parameters = std::move(subordinate_shard_parameters),
-    });
-    uint32_t subordinate_l1_byte_address = subordinate_l1_buffer->address();
+    // Obtain L1 Address for Storing Data
+    // NOTE: We don't know if the whole block of memory is actually available.
+    //       This is something that could probably be checked
+    L1AddressInfo master_l1_info =
+        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.master_core_coord);
+    L1AddressInfo subordinate_l1_info =
+        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.subordinate_core_coord);
+    // Checks that both master and subordinate cores have the same L1 base address and size
+    if (master_l1_info.base_address != subordinate_l1_info.base_address ||
+        master_l1_info.size != subordinate_l1_info.size) {
+        log_error("Mismatch in L1 address or size between master and subordinate cores");
+        return false;
+    }
+    // Check if the L1 size is sufficient for the test configuration
+    if (master_l1_info.size < total_size_bytes) {
+        log_error("Insufficient L1 size for the test configuration");
+        return false;
+    }
+    // Assigns a "safe" L1 local address for the master and subordinate cores
+    uint32_t l1_base_address = master_l1_info.base_address;
 
     // Compile-time arguments for kernels
     vector<uint32_t> requestor_compile_args = {
-        (uint32_t)subordinate_l1_byte_address,
-        (uint32_t)master_l1_byte_address,
+        (uint32_t)l1_base_address,
         (uint32_t)test_config.num_of_transactions,
-        (uint32_t)test_config.transaction_size_pages,
-        (uint32_t)test_config.page_size_bytes,
+        (uint32_t)transaction_size_bytes,
         (uint32_t)test_config.test_id};
 
     // Kernels
@@ -114,11 +99,11 @@ bool run_dm(IDevice* device, const OneFromOneConfig& test_config) {
     vector<uint32_t> packed_golden = packed_input;
 
     // Launch program and record outputs
-    vector<uint32_t> packed_output;
-    detail::WriteToBuffer(subordinate_l1_buffer, packed_input);
+    detail::WriteToDeviceL1(device, test_config.subordinate_core_coord, l1_base_address, packed_input);
     MetalContext::instance().get_cluster().l1_barrier(device->id());
     detail::LaunchProgram(device, program);
-    detail::ReadFromBuffer(master_l1_buffer, packed_output);
+    vector<uint32_t> packed_output;
+    detail::ReadFromDeviceL1(device, test_config.master_core_coord, l1_base_address, total_size_bytes, packed_output);
 
     // Results comparison
     bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
@@ -138,10 +123,13 @@ bool run_dm(IDevice* device, const OneFromOneConfig& test_config) {
 
 /* ========== Test case for one from one data movement; Test id = 5 ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneFromOnePacketSizes) {
+    // Physical Constrains
+    auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_);
+
     // Parameters
     uint32_t max_transactions = 256;
     uint32_t max_transaction_size_pages = 64;
-    uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
 
     // Cores
     CoreCoord master_core_coord = {0, 0};
@@ -150,7 +138,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromOnePacketSizes) {
     for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
         for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
              transaction_size_pages *= 2) {
-            if (num_of_transactions * transaction_size_pages * page_size_bytes >= 1024 * 1024) {
+            if (num_of_transactions * transaction_size_pages > max_transmittable_pages) {
                 continue;
             }
 
@@ -177,28 +165,12 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromOnePacketSizes) {
 TEST_F(DeviceFixture, TensixDataMovementOneFromOneDirectedIdeal) {
     uint32_t test_id = 51;  // Arbitrary test ID
 
-    // Parameters
-    /*
-        L1 Capacity: 1.5 MB (I think, might be wrong)
-        - Max transaction size
-            = 4 * 32 pages
-            = 128 pages * 32 (or 64) bytes/page
-            = 4096 bytes for WH; 8192 bytes for BH
-        - Max total transaction size
-            = 128 transactions * 4096 bytes
-            = 524,288 Bytes
-            < 1.25 MB ~= L1 buffer capacity (.25 MB is allocated for the kernel code and other overheads)
-    */
-    uint32_t page_size_bytes, num_of_transactions;
-    uint32_t transaction_size_pages = 4 * 32;
-    if (arch_ == tt::ARCH::BLACKHOLE) {
-        page_size_bytes = 64;  // (=flit size): 64 bytes for BH
-        num_of_transactions = 64;
-    } else {
-        page_size_bytes = 32;  // (=flit size): 32 bytes for WH
-        num_of_transactions = 128;
-    }
-
+    auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_);
+    // Adjustable Parameters
+    // Ideal: Less transactions, more data per transaction
+    uint32_t num_of_transactions = 1;
+    uint32_t transaction_size_pages = max_transmittable_pages / num_of_transactions;
     // Cores
     /*
         Any two cores that are next to each other on the torus

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -248,7 +248,7 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 200, "upper": 19000}, "bandwidth": 0.17},
         },
         5: {
-            "riscv_1": {"latency": {"lower": 300, "upper": 9200}, "bandwidth": 0.17},
+            "riscv_1": {"latency": {"lower": 300, "upper": 18000}, "bandwidth": 0.17},
         },
         6: {
             "riscv_0": {"latency": {"lower": 400, "upper": 70000}, "bandwidth": 0.5},

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -200,7 +200,7 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 28000, "upper": 36000}, "bandwidth": 29},  # 33832
         },
         51: {  # One from One Directed Ideal
-            "riscv_1": {"latency": {"lower": 15000, "upper": 20000}, "bandwidth": 28},  # 18596, 28.2
+            "riscv_1": {"latency": {"lower": 32700, "upper": 37500}, "bandwidth": 28},  # 18596, 28.2
         },
         52: {  # One to All Directed Ideal
             "riscv_0": {"latency": {"lower": 24000, "upper": 28000}, "bandwidth": 19},  # 26966, 19.4
@@ -288,7 +288,7 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 12000, "upper": 19000}, "bandwidth": 59},  # 17000
         },
         51: {  # One from One Directed Ideal
-            "riscv_1": {"latency": {"lower": 5000, "upper": 10000}, "bandwidth": 59},  # 8730, 60.1
+            "riscv_1": {"latency": {"lower": 16000, "upper": 17800}, "bandwidth": 59},  # 8730, 60.1
         },
         52: {  # One to All Directed Ideal
             "riscv_0": {"latency": {"lower": 10000, "upper": 17000}, "bandwidth": 30},  # 15322, 34.2


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22803)
### Problem description
The use of sharded buffers for allocating space on the master and subordinate cores limited the ability of the tests to make use of the entire available L1 spaces on each core. In the case of the One from One tests, this restricted the movement of data amounting to more than half of the available L1 space since a master buffer and a subordinate buffer were each being allocated for all cores, including the master and subordinate cores involved in the transactions.

### What's changed
This has been fixed for the One from One tests. Instead of using sharded buffers, the test now uses the `WriteToDeviceL1()` and `ReadFromDeviceL1()` APIs to set up the subordinate's L1 data and check the master's L1 data respectively.

In addition, at the kernel level, the directed ideal test case now performs a single transaction containing the maximum specified data size, as this is more ideal than performing multiple smaller transactions.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes