### PR TITLE
[DM]: Removing basic `one_packet` APIs

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/bw_and_latency.cpp
@@ -37,7 +37,7 @@ void kernel_main() {
             uint64_t noc_write_addr = NOC_XY_ADDR(NOC_X(NOC_ADDR_X), NOC_Y(NOC_ADDR_Y), write_ptr);
             noc_async_write(NOC_MEM_ADDR, noc_write_addr, page_size);
 #elif READ_ONE_PACKET
-            noc_async_read_one_packet(noc_addr, read_ptr, page_size);
+            noc_async_read<1 /* max_page_size */>(noc_addr, read_ptr, page_size);
 #else
             noc_async_read(noc_addr, read_ptr, page_size);
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -76,7 +76,7 @@ void kernel_main() {
 
         // Test write
         noc_async_write(l1_read_addr, noc_addr, page_size, noc);
-        noc_async_write_one_packet(l1_read_addr, noc_addr, page_size, noc);
+        noc_async_write<page_size>(l1_read_addr, noc_addr, page_size, noc);
         // interleaved write
         noc_async_write_tile(i % 1024, s0, l1_read_addr, noc);
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -83,7 +83,7 @@ void kernel_main() {
         // Test mcast
         if (mcast) {
             // write mcast
-            noc_async_write_multicast_one_packet(
+            noc_async_write_multicast<page_size>(
                 l1_read_addr, mcast_addr_self_noc, page_size, num_dests - 1, false, noc);
             noc_async_write_multicast(l1_read_addr, mcast_addr_self_noc, page_size, num_dests - 1, false, noc);
             noc_async_write_multicast_loopback_src(l1_read_addr, mcast_addr_self_noc, page_size, num_dests, false, noc);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -65,7 +65,7 @@ void kernel_main() {
         uint64_t noc_addr = get_noc_addr(noc_x, noc_y, l1_read_addr, noc);
 
         // Test read
-        noc_async_read_one_packet(noc_addr, l1_read_addr, page_size, noc);
+        noc_async_read<page_size>(noc_addr, l1_read_addr, page_size, noc);
         noc_async_read(noc_addr, l1_read_addr, page_size, noc);
         // interleaved read
         noc_async_read_tile(i % 1024, s0, l1_read_addr, 0, noc);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -77,7 +77,7 @@ void kernel_main() {
         uint64_t noc_addr = get_noc_addr(noc_x, noc_y, l1_read_addr, noc);
 
         // Test read
-        noc_async_read_one_packet(noc_addr, l1_read_addr, page_size, noc);
+        noc_async_read<page_size>(noc_addr, l1_read_addr, page_size, noc);
         noc_async_read(noc_addr, l1_read_addr, page_size, noc);
         // interleaved read
         noc_async_read_tile(i % 1024, s0, l1_read_addr, 0, noc);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -88,7 +88,7 @@ void kernel_main() {
 
         // Test write
         noc_async_write(l1_read_addr, noc_addr, page_size, noc);
-        noc_async_write_one_packet(l1_read_addr, noc_addr, page_size, noc);
+        noc_async_write<page_size>(l1_read_addr, noc_addr, page_size, noc);
         // interleaved write
         noc_async_write_tile(i % 1024, s0, l1_read_addr, noc);
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -95,7 +95,7 @@ void kernel_main() {
         // Test mcast
         if (mcast) {
             // write mcast
-            noc_async_write_multicast_one_packet(
+            noc_async_write_multicast<page_size>(
                 l1_read_addr,
                 noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc,
                 page_size,

--- a/tt_metal/fabric/hw/inc/tt_fabric.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric.h
@@ -2022,7 +2022,7 @@ struct fvcc_inbound_state_t {
         uint32_t wrptr = fvcc_buf->wrptr.ptr;
         noc_addr = dest_addr + offsetof(ctrl_chan_msg_buf, rdptr);
         while (1) {
-            noc_async_read_one_packet(noc_addr, (uint32_t)(&fvcc_buf->rdptr.ptr), 4);
+            noc_async_read<4>(noc_addr, (uint32_t)(&fvcc_buf->rdptr.ptr), 4);
             noc_async_read_barrier();
             if (!fvcc_buf_ptrs_full(wrptr, fvcc_buf->rdptr.ptr)) {
                 break;
@@ -2453,7 +2453,7 @@ template <bool blocking_mode = false>
 inline bool tt_fabric_check_pull_request_slot(uint64_t dest_addr, volatile local_pull_request_t* local_pull_request, uint32_t wrptr) {
     uint64_t noc_addr = dest_addr + offsetof(chan_req_buf, rdptr);
     do {
-        noc_async_read_one_packet(noc_addr, (uint32_t)(&local_pull_request->rdptr.ptr), 4);
+        noc_async_read<4>(noc_addr, (uint32_t)(&local_pull_request->rdptr.ptr), 4);
         noc_async_read_barrier();
         if (!req_buf_ptrs_full(wrptr, local_pull_request->rdptr.ptr)) {
             return true;

--- a/tt_metal/fabric/hw/inc/tt_fabric_api.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_api.h
@@ -139,7 +139,7 @@ inline void fabric_send_pull_request(
         tt_fabric_check_pull_request_slot<true>(router_addr, pull_request, header_wrptr);
         uint32_t header_wr_index = header_wrptr & CHAN_REQ_BUF_SIZE_MASK;
         uint64_t noc_addr = router_addr + offsetof(chan_req_buf, chan_req) + header_wr_index * sizeof(pull_request_t);
-        noc_async_write_one_packet((uint32_t)header, noc_addr, sizeof(pull_request_t), noc_index);
+        noc_async_write<sizeof(pull_request_t)>((uint32_t)header, noc_addr, sizeof(pull_request_t), noc_index);
     } else {
         tt_fabric_check_pull_request_slot<true>(router_addr, pull_request, wrptr);
     }
@@ -610,11 +610,12 @@ inline void fabric_async_write_push_data(
         (client_interface->buffer_start + (client_interface->wr_ptr * FABRIC_ROUTER_BUF_SLOT_SIZE)));
     if constexpr (data_mode == ClientDataMode::RAW_DATA) {
         // In raw mode, pick up the header from header buffer in client interface.
-        noc_async_write_one_packet((uint32_t)header, buffer_wr_addr, PACKET_HEADER_SIZE_BYTES, noc_index);
+        noc_async_write<PACKET_HEADER_SIZE_BYTES>(
+            (uint32_t)header, buffer_wr_addr, PACKET_HEADER_SIZE_BYTES, noc_index);
         buffer_wr_addr += PACKET_HEADER_SIZE_BYTES;
         size -= PACKET_HEADER_SIZE_BYTES;
     }
-    noc_async_write_one_packet(src_addr, buffer_wr_addr, size, noc_index);
+    noc_async_write<1>(src_addr, buffer_wr_addr, size, noc_index);
     noc_inline_dw_write(push_addr, 1 << REMOTE_DEST_BUF_WORDS_FREE_INC);
     client_interface->wr_ptr++;
     *(volatile uint32_t*)client_interface->update_router_space = (-1) << REMOTE_DEST_BUF_WORDS_FREE_INC;

--- a/tt_metal/fabric/hw/inc/tt_fabric_api.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_api.h
@@ -536,7 +536,7 @@ inline void fabric_client_connect(
     uint64_t curr_client_idx_addr = client_q_addr + offsetof(fabric_push_client_queue_t, curr_client_idx);
     // wait until the client ahead in the queue disconnects
     while (true) {
-        noc_async_read_one_packet(curr_client_idx_addr, (uint32_t)&(local_req_entry->remote_curr_client_idx.ptr), 4);
+        noc_async_read<4>(curr_client_idx_addr, (uint32_t)&(local_req_entry->remote_curr_client_idx.ptr), 4);
         noc_async_read_barrier();
         if (local_req_entry->my_client_idx.ptr == local_req_entry->remote_curr_client_idx.ptr) {
             break;
@@ -544,7 +544,7 @@ inline void fabric_client_connect(
     }
 
     uint64_t router_wr_ptr_addr = client_q_addr + offsetof(fabric_push_client_queue_t, router_wr_ptr);
-    noc_async_read_one_packet(router_wr_ptr_addr, (uint32_t)&(local_req_entry->remote_router_wr_ptr.ptr), 4);
+    noc_async_read<4>(router_wr_ptr_addr, (uint32_t)&(local_req_entry->remote_router_wr_ptr.ptr), 4);
     noc_async_read_barrier();
 
     uint64_t router_addr = get_noc_addr_helper(router_addr_h, FABRIC_ROUTER_REQ_QUEUE_START);
@@ -1066,7 +1066,8 @@ inline void fabric_endpoint_init(tt_l1_ptr ClientInterfaceType client_interface,
         // read routing table
         uint64_t dest_addr = get_noc_addr_helper(
             eth_chan_to_noc_xy[noc_index][outbound_eth_chan], eth_l1_mem::address_map::FABRIC_ROUTER_CONFIG_BASE);
-        noc_async_read_one_packet(dest_addr, routing_tables_offset, sizeof(fabric_router_l1_config_t));
+        noc_async_read<sizeof(fabric_router_l1_config_t)>(
+            dest_addr, routing_tables_offset, sizeof(fabric_router_l1_config_t));
         noc_async_read_barrier();
     }
 }

--- a/tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp
+++ b/tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp
@@ -65,7 +65,7 @@ FORCE_INLINE void wait_for_fabric_endpoint_ready(
 
     local_fabric_ep_status_ptr[0] = tt::tt_fabric::FabricEndpointStatus::TERMINATED;
     while (local_fabric_ep_status_ptr[0] != tt::tt_fabric::FabricEndpointStatus::READY_FOR_TRAFFIC) {
-        noc_async_read_one_packet(noc_addr, local_fabric_ep_status_address, 4);
+        noc_async_read<4>(noc_addr, local_fabric_ep_status_address, 4);
         noc_async_read_barrier();
     }
 }

--- a/tt_metal/fabric/impl/kernels/tt_fabric_gatekeeper.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_gatekeeper.cpp
@@ -65,7 +65,7 @@ inline void get_routing_tables() {
             if (temp_mask & 0x1) {
                 uint64_t router_config_addr = ((uint64_t)eth_chan_to_noc_xy[noc_index][channel] << 32) |
                                               eth_l1_mem::address_map::FABRIC_ROUTER_CONFIG_BASE;
-                noc_async_read_one_packet(
+                noc_async_read<sizeof(tt::tt_fabric::fabric_router_l1_config_t)>(
                     router_config_addr,
                     (uint32_t)&routing_table[routing_plane],
                     sizeof(tt::tt_fabric::fabric_router_l1_config_t));
@@ -328,7 +328,7 @@ inline bool send_gk_message(uint64_t dest_addr, packet_header_t* packet) {
     uint32_t wrptr = socket_info->wrptr.ptr;
     noc_addr = dest_addr + offsetof(ctrl_chan_msg_buf, rdptr);
 
-    noc_async_read_one_packet(noc_addr, (uint32_t)(&socket_info->rdptr.ptr), 4);
+    noc_async_read<4>(noc_addr, (uint32_t)(&socket_info->rdptr.ptr), 4);
     noc_async_read_barrier();
     if (fvcc_buf_ptrs_full(wrptr, socket_info->rdptr.ptr)) {
         return false;
@@ -344,7 +344,7 @@ inline bool retry_gk_message(uint64_t dest_addr, packet_header_t* packet) {
     uint32_t wrptr = socket_info->wrptr.ptr;
     uint64_t noc_addr = dest_addr + offsetof(ctrl_chan_msg_buf, rdptr);
 
-    noc_async_read_one_packet(noc_addr, (uint32_t)(&socket_info->rdptr.ptr), 4);
+    noc_async_read<4>(noc_addr, (uint32_t)(&socket_info->rdptr.ptr), 4);
     noc_async_read_barrier();
     if (fvcc_buf_ptrs_full(wrptr, socket_info->rdptr.ptr)) {
         return false;

--- a/tt_metal/fabric/impl/kernels/tt_fabric_gatekeeper.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_gatekeeper.cpp
@@ -157,7 +157,7 @@ inline socket_handle_t* socket_receiver_available(packet_header_t* packet) {
 inline void set_socket_active(socket_handle_t* handle) {
     handle->socket_state = SocketState::ACTIVE;
     // send socket connection state to send socket opener.
-    noc_async_write_one_packet(
+    noc_async_write<sizeof(socket_handle_t)>(
         (uint32_t)(handle), handle->status_notification_addr, sizeof(socket_handle_t), noc_index);
 }
 
@@ -336,7 +336,7 @@ inline bool send_gk_message(uint64_t dest_addr, packet_header_t* packet) {
 
     uint32_t dest_wr_index = wrptr & FVCC_SIZE_MASK;
     noc_addr = dest_addr + offsetof(ctrl_chan_msg_buf, msg_buf) + dest_wr_index * sizeof(packet_header_t);
-    noc_async_write_one_packet((uint32_t)(packet), noc_addr, sizeof(packet_header_t), noc_index);
+    noc_async_write<sizeof(packet_header_t)>((uint32_t)(packet), noc_addr, sizeof(packet_header_t), noc_index);
     return true;
 }
 
@@ -352,7 +352,7 @@ inline bool retry_gk_message(uint64_t dest_addr, packet_header_t* packet) {
 
     uint32_t dest_wr_index = wrptr & FVCC_SIZE_MASK;
     noc_addr = dest_addr + offsetof(ctrl_chan_msg_buf, msg_buf) + dest_wr_index * sizeof(packet_header_t);
-    noc_async_write_one_packet((uint32_t)(packet), noc_addr, sizeof(packet_header_t), noc_index);
+    noc_async_write<sizeof(packet_header_t)>((uint32_t)(packet), noc_addr, sizeof(packet_header_t), noc_index);
     gk_message_pending = 0;
     return true;
 }

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -546,15 +546,17 @@ inline __attribute__((always_inline)) void ncrisc_noc_full_sync() {
     }
 }
 
-template <uint8_t noc_mode = DM_DEDICATED_NOC>
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool one_packet = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_read_any_len(
     uint32_t noc, uint32_t cmd_buf, uint64_t src_addr, uint32_t dest_addr, uint32_t len_bytes) {
-    while (len_bytes > NOC_MAX_BURST_SIZE) {
-        while (!noc_cmd_buf_ready(noc, cmd_buf));
-        ncrisc_noc_fast_read<noc_mode>(noc, cmd_buf, src_addr, dest_addr, NOC_MAX_BURST_SIZE);
-        src_addr += NOC_MAX_BURST_SIZE;
-        dest_addr += NOC_MAX_BURST_SIZE;
-        len_bytes -= NOC_MAX_BURST_SIZE;
+    if constexpr (!one_packet) {
+        while (len_bytes > NOC_MAX_BURST_SIZE) {
+            while (!noc_cmd_buf_ready(noc, cmd_buf));
+            ncrisc_noc_fast_read<noc_mode>(noc, cmd_buf, src_addr, dest_addr, NOC_MAX_BURST_SIZE);
+            src_addr += NOC_MAX_BURST_SIZE;
+            dest_addr += NOC_MAX_BURST_SIZE;
+            len_bytes -= NOC_MAX_BURST_SIZE;
+        }
     }
     while (!noc_cmd_buf_ready(noc, cmd_buf));
     ncrisc_noc_fast_read<noc_mode>(noc, cmd_buf, src_addr, dest_addr, len_bytes);

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -463,29 +463,6 @@ void cb_wait_front(int32_t operand, int32_t num_pages) {
 
 // clang-format off
 /**
- * Initiates an asynchronous read for a single packet with size <= NOC_MAX_BURST_SIZE (i.e. maximum packet size).
- * Refer to \a noc_async_read for more details.
- */
-// clang-format on
-FORCE_INLINE
-void noc_async_read_one_packet(
-    std::uint64_t src_noc_addr, std::uint32_t dst_local_l1_addr, std::uint32_t size, uint8_t noc = noc_index) {
-    /*
-        Read requests - use static VC
-        Read responses - assigned VCs dynamically
-    */
-    WAYPOINT("RP2W");
-    while (!noc_cmd_buf_ready(noc, read_cmd_buf));
-    WAYPOINT("RP2D");
-
-    WAYPOINT("NAOW");
-    DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc, src_noc_addr, dst_local_l1_addr, size);
-    ncrisc_noc_fast_read<noc_mode>(noc, read_cmd_buf, src_noc_addr, dst_local_l1_addr, size);
-    WAYPOINT("NAOD");
-}
-
-// clang-format off
-/**
  * Initiates an asynchronous read from a specified source node located at NOC
  * coordinates (x,y) at a local address (encoded as a uint64_t using \a
  * get_noc_addr function). The destination is in L1 memory on the Tensix core

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -512,15 +512,10 @@ inline void noc_async_read(
         Read responses - assigned VCs dynamically
     */
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ,src_noc_addr,size, -1);
+    DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc, src_noc_addr, dst_local_l1_addr, size);
 
-    if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
-        noc_async_read_one_packet(src_noc_addr, dst_local_l1_addr, size, noc);
-    } else {
-        WAYPOINT("NARW");
-        DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc, src_noc_addr, dst_local_l1_addr, size);
-        ncrisc_noc_fast_read_any_len<noc_mode>(noc, read_cmd_buf, src_noc_addr, dst_local_l1_addr, size);
-        WAYPOINT("NARD");
-    }
+    ncrisc_noc_fast_read_any_len<noc_mode, max_page_size <= NOC_MAX_BURST_SIZE>(
+        noc, read_cmd_buf, src_noc_addr, dst_local_l1_addr, size);
 }
 
 // TODO: write docs

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -469,15 +469,17 @@ inline __attribute__((always_inline)) void ncrisc_noc_full_sync() {
     }
 }
 
-template <uint8_t noc_mode = DM_DEDICATED_NOC>
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool one_packet = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_read_any_len(
     uint32_t noc, uint32_t cmd_buf, uint64_t src_addr, uint32_t dest_addr, uint32_t len_bytes) {
-    while (len_bytes > NOC_MAX_BURST_SIZE) {
-        while (!noc_cmd_buf_ready(noc, cmd_buf));
-        ncrisc_noc_fast_read<noc_mode>(noc, cmd_buf, src_addr, dest_addr, NOC_MAX_BURST_SIZE);
-        src_addr += NOC_MAX_BURST_SIZE;
-        dest_addr += NOC_MAX_BURST_SIZE;
-        len_bytes -= NOC_MAX_BURST_SIZE;
+    if constexpr (!one_packet) {
+        while (len_bytes > NOC_MAX_BURST_SIZE) {
+            while (!noc_cmd_buf_ready(noc, cmd_buf));
+            ncrisc_noc_fast_read<noc_mode>(noc, cmd_buf, src_addr, dest_addr, NOC_MAX_BURST_SIZE);
+            src_addr += NOC_MAX_BURST_SIZE;
+            dest_addr += NOC_MAX_BURST_SIZE;
+            len_bytes -= NOC_MAX_BURST_SIZE;
+        }
     }
     while (!noc_cmd_buf_ready(noc, cmd_buf));
     ncrisc_noc_fast_read<noc_mode>(noc, cmd_buf, src_addr, dest_addr, len_bytes);

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1024,7 +1024,7 @@ void process_go_signal_mcast_cmd() {
 
     for (uint32_t i = 0; i < num_unicasts; ++i) {
         uint64_t dst = get_noc_addr_helper(go_signal_noc_data[go_signal_noc_data_idx++], unicast_go_signal_addr);
-        noc_async_write_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t));
+        noc_async_write<sizeof(uint32_t)>((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t));
     }
 
     cmd_ptr += sizeof(CQDispatchCmd);

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -263,7 +263,7 @@ void process_go_signal_mcast_cmd() {
 
     for (uint32_t i = 0; i < num_unicasts; ++i) {
         uint64_t dst = get_noc_addr_helper(go_signal_noc_data[go_signal_noc_data_idx++], unicast_go_signal_addr);
-        noc_async_write_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t));
+        noc_async_write<sizeof(uint32_t)>((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t));
     }
 
     update_worker_completion_count_on_dispatch_d();

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -37,7 +37,7 @@ FORCE_INLINE void enhanced_noc_async_write(
     // If you do not know the max_transfer_size at compile time write 0 to it.
     // only writes is true if we ONLY use noc_async_read and all calls to tt_memmove have use_read_datamover as False
     if constexpr (only_writes && max_transfer_size <= NOC_MAX_BURST_SIZE) {
-        noc_async_write_one_packet(src_l1_addr, dst_noc_addr, bytes);
+        noc_async_write<max_transfer_size>(src_l1_addr, dst_noc_addr, bytes);
     } else {
         noc_async_write<max_transfer_size == 0 ? NOC_MAX_BURST_SIZE + 1 : max_transfer_size>(
             src_l1_addr, dst_noc_addr, bytes);

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -24,7 +24,7 @@ FORCE_INLINE void enhanced_noc_async_read(
     // If you do not know the max_transfer_size at compile time write 0 to it.
     // only reads is true if we ONLY use noc_async_read and all calls to tt_memmove have use_read_datamover as True
     if constexpr (only_reads && max_transfer_size <= NOC_MAX_BURST_SIZE) {
-        noc_async_read_one_packet(src_noc_addr, dst_l1_addr, bytes);
+        noc_async_read<max_transfer_size>(src_noc_addr, dst_l1_addr, bytes);
     } else {
         noc_async_read<max_transfer_size == 0 ? NOC_MAX_BURST_SIZE + 1 : max_transfer_size>(
             src_noc_addr, dst_l1_addr, bytes);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_sharded_rm.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
             uint64_t noc_read_addr = get_noc_addr(noc_coord_x[core], noc_coord_y[core], l1_read_addr);
             uint32_t l1_write_addr = get_write_ptr(cb_out0) + l1_write_offset + dst_write_stick_offset;
             for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
-                noc_async_read_one_packet(noc_read_addr, l1_write_addr, stick_size_bytes);
+                noc_async_read<stick_size_bytes>(noc_read_addr, l1_write_addr, stick_size_bytes);
                 noc_read_addr += read_stick_stride;
                 l1_write_addr += write_stick_stride;
             }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_receiver_reader.cpp
@@ -118,7 +118,7 @@ void kernel_main() {
             uint64_t noc_addr_ex_par =
                 remote_noc_addrs_first_stage[block] | (l1_read_addr_ex_par);  // Updating read address for reading
                                                                               // SUm(X) and Sum(X2) per core
-            noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
+            noc_async_read<single_tile_size_bytes>(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
             l1_write_addr_external += single_tile_size_bytes;
         }
         l1_read_addr_ex_par += single_tile_size_bytes;
@@ -133,7 +133,7 @@ void kernel_main() {
                 // read data from other cores - second stage reduce
                 for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
                     uint64_t noc_addr_ex = remote_noc_addrs_second_stage[block + 1] | l1_read_addr_ex;
-                    noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
+                    noc_async_read<single_tile_size_bytes>(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
                     l1_write_addr_external += single_tile_size_bytes;
                 }
                 l1_read_addr_ex += single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_sender_reader.cpp
@@ -92,7 +92,7 @@ void kernel_main() {
         uint32_t l1_write_addr_external = get_write_ptr(cb_external);
         for (uint32_t block = 0; block < num_blocks_first_stage; ++block) {
             uint64_t noc_addr_ex_par = remote_noc_addrs[block] | (l1_read_addr_ex_par);
-            noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
+            noc_async_read<single_tile_size_bytes>(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
             l1_write_addr_external += single_tile_size_bytes;
         }
         l1_read_addr_ex_par += single_tile_size_bytes;
@@ -109,7 +109,7 @@ void kernel_main() {
             uint32_t curr_block_index = block_index_stride;
             for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
                 uint64_t noc_addr_ex = remote_noc_addrs[curr_block_index] | (l1_read_addr_ex);
-                noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
+                noc_async_read<single_tile_size_bytes>(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
                 l1_write_addr_external += single_tile_size_bytes;
                 curr_block_index += block_index_stride;
             }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
@@ -340,7 +340,7 @@ void kernel_main() {
                             uint32_t read_size = (cb_ex_external_bytes_written % single_tile_size_bytes > 0)
                                                      ? num_bytes_read
                                                      : single_tile_size_bytes;
-                            noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, read_size);
+                            noc_async_read<1>(noc_addr_ex_par, l1_write_addr_external, read_size);
                             l1_write_addr_external += 16;
                             cb_ex_external_bytes_written += 16;
                             noc_async_read_barrier();
@@ -354,7 +354,7 @@ void kernel_main() {
                                 for (uint32_t i = 0; i < num_mcast_cores - 1; ++i) {
                                     uint64_t noc_addr_ex_par =
                                         get_noc_addr(noc_coord_x[i + 1], noc_coord_y[i + 1], l1_read_addr_ex_par);
-                                    noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, num_bytes_read);
+                                    noc_async_read<1>(noc_addr_ex_par, l1_write_addr_external, num_bytes_read);
                                     l1_write_addr_external += 16;
                                     cb_ex_external_bytes_written += 16;
                                     noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -188,7 +188,7 @@ void kernel_main() {
                 uint32_t l1_read_addr_ex_par = get_read_ptr(cb_ex_partial);
                 uint32_t l1_write_addr_external = get_write_ptr(cb_ex_external);
                 uint64_t noc_addr_ex_par = get_noc_addr(noc_coord_x[0], noc_coord_y[0], l1_read_addr_ex_par);
-                noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
+                noc_async_read<1>(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
                 l1_write_addr_external += 16;
                 noc_async_read_barrier();
 
@@ -201,7 +201,7 @@ void kernel_main() {
                 for (uint32_t i = 0; i < num_mcast_cores - 1; ++i) {
                     uint64_t noc_addr_ex_par =
                         get_noc_addr(noc_coord_x[i + 1], noc_coord_y[i + 1], l1_read_addr_ex_par);
-                    noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, num_bytes_read);
+                    noc_async_read<1>(noc_addr_ex_par, l1_write_addr_external, num_bytes_read);
                     l1_write_addr_external += 16;
                     noc_async_read_barrier();
                 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
@@ -156,7 +156,7 @@ void kernel_main() {
                 uint32_t l1_write_addr_external = get_write_ptr(cb_external);
                 for (uint32_t block = 0; block < num_blocks_first_stage; block++) {
                     uint64_t noc_addr_ex_par = remote_noc_addrs_first_stage[block] | l1_read_addr_ex_par;
-                    noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
+                    noc_async_read<1>(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
                     l1_write_addr_external += single_tile_size_bytes;
                 }
                 l1_read_addr_ex_par += single_tile_size_bytes;
@@ -175,7 +175,7 @@ void kernel_main() {
                         cb_reserve_back(cb_external, num_blocks_second_stage - 1);
                         for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
                             uint64_t noc_addr_ex = remote_noc_addrs_second_stage[block + 1] | l1_read_addr_ex;
-                            noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
+                            noc_async_read<1>(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
                             l1_write_addr_external += single_tile_size_bytes;
                         }
                         l1_read_addr_ex += single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
@@ -159,7 +159,7 @@ void kernel_main() {
                             (l1_read_addr_ex_par +
                              tile_idx * single_tile_size_bytes);  // Updating read address for reading SUm(X) and
                                                                   // Sum(X2) per core
-                        noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
+                        noc_async_read<1>(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
                         l1_write_addr_external += single_tile_size_bytes;
                     }
                 }
@@ -177,7 +177,7 @@ void kernel_main() {
                         // read data from other cores - second stage reduce
                         for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
                             uint64_t noc_addr_ex = remote_noc_addrs_second_stage[block + 1] | l1_read_addr_ex;
-                            noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
+                            noc_async_read<1>(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
                             l1_write_addr_external += single_tile_size_bytes;
                         }
                         l1_read_addr_ex += single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -123,7 +123,7 @@ void kernel_main() {
             uint32_t l1_write_addr_external = get_write_ptr(cb_external);
             for (uint32_t block = 0; block < num_blocks_first_stage; ++block) {
                 uint64_t noc_addr_ex_par = remote_noc_addrs[block] | l1_read_addr_ex_par;
-                noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
+                noc_async_read<1>(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
                 l1_write_addr_external += single_tile_size_bytes;
             }
             l1_read_addr_ex_par += single_tile_size_bytes;
@@ -141,7 +141,7 @@ void kernel_main() {
                 cb_reserve_back(cb_external, num_blocks_second_stage - 1);
                 for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
                     uint64_t noc_addr_ex = remote_noc_addrs[curr_block_index] | l1_read_addr_ex;
-                    noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
+                    noc_async_read<1>(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
                     curr_block_index += block_index_stride;
                     l1_write_addr_external += single_tile_size_bytes;
                 }
@@ -168,7 +168,7 @@ void kernel_main() {
             uint32_t num_tiles_bytes = block == num_all_to_all_workers_first_stage - 1 ? num_tiles_per_worker_last_bytes
                                                                                        : num_tiles_per_worker_bytes;
             if constexpr (num_tiles_per_worker_bytes <= NOC_MAX_BURST_SIZE) {
-                noc_async_read_one_packet(noc_addr_ex, l1_write_addr_ex_global, num_tiles_bytes);
+                noc_async_read<1>(noc_addr_ex, l1_write_addr_ex_global, num_tiles_bytes);
             } else {
                 noc_async_read(noc_addr_ex, l1_write_addr_ex_global, num_tiles_bytes);
             }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
@@ -124,7 +124,7 @@ void kernel_main() {
                 for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; ++tile_idx) {
                     uint64_t noc_addr_ex_par =
                         remote_noc_addrs[block] | (l1_read_addr_ex_par + tile_idx * single_tile_size_bytes);
-                    noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
+                    noc_async_read<1>(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
                     l1_write_addr_external += single_tile_size_bytes;
                 }
             }
@@ -144,7 +144,7 @@ void kernel_main() {
                     for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; ++tile_idx) {
                         uint64_t noc_addr_ex =
                             remote_noc_addrs[curr_block_index] | (l1_read_addr_ex + tile_idx * single_tile_size_bytes);
-                        noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
+                        noc_async_read<1>(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
                         l1_write_addr_external += single_tile_size_bytes;
                     }
                     curr_block_index += block_index_stride;

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded.cpp
@@ -179,7 +179,7 @@ void kernel_main() {
                         const uint32_t stick_offset = top_left_local_index + w + h * in_w_padded;
                         const uint32_t read_offset =
                             in_l1_read_base_addr + (stick_offset * in_nbytes_c + c_i * MAX_BYTES_PER_REDUCTION);
-                        noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, read_bytes);
+                        noc_async_read<1>(get_noc_addr(read_offset), out_l1_write_addr, read_bytes);
                         out_l1_write_addr += read_bytes;
                     }
                 }
@@ -195,7 +195,8 @@ void kernel_main() {
             for (uint32_t h = 0; h < window_h; ++h, h_multiples += in_w_padded) {
                 const uint32_t stick_offset = top_left_local_index + h_multiples;
                 const uint32_t read_offset = in_l1_read_base_addr + (stick_offset * in_nbytes_c);
-                noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, in_nbytes_c * window_w);
+                noc_async_read<in_nbytes_c * window_w>(
+                    get_noc_addr(read_offset), out_l1_write_addr, in_nbytes_c * window_w);
                 out_l1_write_addr += in_nbytes_c * window_w;
             }
             noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_large_kernel_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_large_kernel_v2.cpp
@@ -137,7 +137,7 @@ void kernel_main() {
                     const uint32_t stick_offset = top_left_local_index + w + h * in_w_padded;
                     const uint32_t read_offset =
                         in_l1_read_base_addr + (stick_offset * in_nbytes_c + c_i * MAX_ELE_PER_REDUCTION);
-                    noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, read_bytes);
+                    noc_async_read<read_bytes>(get_noc_addr(read_offset), out_l1_write_addr, read_bytes);
                     out_l1_write_addr += read_bytes;
                     processed_rows++;
                     if ((processed_rows % max_rows_for_reduction) == 0) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22962)

### Problem description
For some basic APIs, the breaking down of data into packets and the specific case for one packet are handled in `noc_nonblocking_api`. We should be able to remove the logic that checks if a transaction requires one packet or more from `dataflow_api.h`. This means that we can remove the `one_packet` versions of NOC APIs. 

### What's changed
Removed the `one_packet` alternatives of some basic NOC APIs and moved the logic that handles data size breakdown into `noc_nonblocking_api`. Implemented a template parameter called `one_packet` for these api in `noc_nonblocking_api` that will determine if one packet transactions will be issued in compile time. Callstacks have also been updated for these APIs. Full list of removed APIs:

- `noc_async_read_one_packet`
- `noc_async_write_one_packet`
- `noc_async_write_multicast_one_packet`

**Note:** The `NOC_TRACE_QUICK_PUSH_IF_LINKED` used in linked multicast transactions for [BH profiler hang](https://github.com/tenstorrent/tt-metal/issues/22578) was removed in https://github.com/tenstorrent/tt-metal/pull/23076. This is reintroduced in this PR.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15587982708) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15587986759) CI with demo tests passes (known failure on main)
- [x] [Single card perf pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/15587991365) (known failure on main)
- [x] [T3K perf pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/15587996256)
- [x] [TG perf pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/15588001494)