### PR TITLE
Slightly increase trace region size in TT-Transformers demo for Llama70B on BH

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -435,7 +435,7 @@ def prepare_generator_args(
     ],
     ids=["performance", "accuracy"],
 )
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 23887872, "num_command_queues": 1}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 25000000, "num_command_queues": 1}], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",
     [


### PR DESCRIPTION
### Ticket
#22632

### Problem description
- Trace region size in demo is too small for Llama70B on BH 4xP150

### What's changed
- Slightly increased trace region size (by ~1MB). Didn't consider the increase large enough to create separate trace region sizes per model/device but maybe that should be done in the future.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes