### PR TITLE
[skip ci] Remove redundant `void` arguments

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -152,7 +152,6 @@ Checks: >
   -modernize-loop-convert,
   -modernize-macro-to-enum,
   -modernize-pass-by-value,
-  -modernize-redundant-void-arg,
   -modernize-return-braced-init-list,
   -modernize-type-traits,
   -modernize-use-auto,

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -61,7 +61,7 @@ protected:
     size_t num_devices_;
 
 public:
-    std::pair<unsigned, unsigned> worker_grid_minimum_dims(void) {
+    std::pair<unsigned, unsigned> worker_grid_minimum_dims() {
         constexpr size_t UMAX = std::numeric_limits<unsigned>::max();
         std::pair<size_t, size_t> min_dims = {UMAX, UMAX};
         for (auto device : devices_) {

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -55,7 +55,7 @@ static string noc_address(CoreCoord core, uint64_t a, uint32_t l) {
     return ss.str();
 }
 
-static void print_stack_trace(void) {
+static void print_stack_trace() {
     void* array[15];
 
     int size = backtrace(array, 15);


### PR DESCRIPTION
### Ticket
#23157

### Problem description
Redundancy reduces S:R.  Simplicity is best.

### What's changed
rm -rf