### PR TITLE
Introduce new query APIs for inter-mesh ethernet links

### DIFF
--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(UNIT_TESTS_FABRIC_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/common/utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_routing_tables.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_intermesh_apis.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_fabric_apis.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_1d_fabric.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_fabric_mux.cpp

--- a/tests/tt_metal/tt_fabric/fabric_router/test_intermesh_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_intermesh_apis.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include "impl/context/metal_context.hpp"
+#include <iomanip>
+#include <sstream>
+#include <set>
+
+namespace tt::tt_fabric {
+namespace intermesh_api_tests {
+
+TEST(IntermeshAPIs, BasicQueries) {
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+
+    // Test that cluster supports intermesh links
+    bool supports_intermesh = cluster.contains_intermesh_links();
+
+    // Get all intermesh links
+    auto all_links = cluster.get_all_intermesh_eth_links();
+
+    // Test per-chip queries
+    for (const auto& chip_id : cluster.user_exposed_chip_ids()) {
+        bool has_links = cluster.has_intermesh_links(chip_id);
+        auto chip_links = cluster.get_intermesh_eth_links(chip_id);
+
+        // Verify consistency
+        if (has_links) {
+            EXPECT_GT(chip_links.size(), 0) << "Chip " << chip_id << " reports having links but returned empty vector";
+        } else {
+            EXPECT_EQ(chip_links.size(), 0) << "Chip " << chip_id << " reports no links but returned non-empty vector";
+        }
+
+        // Test is_intermesh_eth_link for each link
+        for (const auto& [eth_core, channel] : chip_links) {
+            bool is_intermesh = cluster.is_intermesh_eth_link(chip_id, eth_core);
+            EXPECT_TRUE(is_intermesh) << "Eth core " << eth_core.str() << " on chip " << chip_id
+                                     << " was returned by get_intermesh_eth_links but is_intermesh_eth_link returned false";
+        }
+    }
+
+    // If cluster supports intermesh, at least one chip should have links
+    if (supports_intermesh) {
+        EXPECT_GT(all_links.size(), 0) << "Cluster reports supporting intermesh but no chips have links";
+    }
+}
+
+TEST(IntermeshAPIs, ConsistencyChecks) {
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+
+    // Get all links via get_all_intermesh_eth_links
+    auto all_links = cluster.get_all_intermesh_eth_links();
+
+    // Verify it matches individual chip queries
+    for (const auto& [chip_id, expected_links] : all_links) {
+        auto actual_links = cluster.get_intermesh_eth_links(chip_id);
+
+        EXPECT_EQ(expected_links.size(), actual_links.size())
+            << "Mismatch in link count for chip " << chip_id;
+
+        // Compare link contents (assuming order might differ)
+        std::set<std::pair<CoreCoord, uint32_t>> expected_set(expected_links.begin(), expected_links.end());
+        std::set<std::pair<CoreCoord, uint32_t>> actual_set(actual_links.begin(), actual_links.end());
+
+        EXPECT_EQ(expected_set, actual_set)
+            << "Link content mismatch for chip " << chip_id;
+    }
+}
+
+TEST(IntermeshAPIs, IntermeshLinksAreDistinctFromEthernetLinks) {
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+
+    if (!cluster.contains_intermesh_links()) {
+        GTEST_SKIP() << "Cluster does not support intermesh links";
+    }
+
+    log_info(tt::LogTest, "=== Verifying Intermesh Links are Distinct from Ethernet Links ===");
+
+    // This test documents that intermesh links are a distinct category from regular ethernet links
+    auto all_intermesh_links = cluster.get_all_intermesh_eth_links();
+
+    for (const auto& [chip_id, intermesh_links] : all_intermesh_links) {
+        auto active_eth_cores = cluster.get_active_ethernet_cores(chip_id);
+        auto inactive_eth_cores = cluster.get_inactive_ethernet_cores(chip_id);
+
+        // Verify no overlap between intermesh links and active ethernet cores
+        for (const auto& [eth_core, channel] : intermesh_links) {
+            EXPECT_TRUE(active_eth_cores.find(eth_core) == active_eth_cores.end())
+                << "Intermesh link at " << eth_core.str() << " on chip " << chip_id
+                << " should not be in active ethernet cores";
+
+            // Intermesh links appear in inactive ethernet cores
+            EXPECT_TRUE(inactive_eth_cores.find(eth_core) != inactive_eth_cores.end())
+                << "Intermesh link at " << eth_core.str() << " on chip " << chip_id
+                << " should be in inactive ethernet cores";
+        }
+
+        log_info(tt::LogTest, "Chip {}: {} intermesh links are distinct from {} active ethernet cores",
+                 chip_id, intermesh_links.size(), active_eth_cores.size());
+    }
+}
+
+}  // namespace intermesh_api_tests
+}  // namespace tt::tt_fabric

--- a/tests/tt_metal/tt_fabric/fabric_router/test_intermesh_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_intermesh_apis.cpp
@@ -17,7 +17,7 @@ TEST(IntermeshAPIs, BasicQueries) {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Test that cluster supports intermesh links
-    bool supports_intermesh = control_plane.contains_intermesh_links();
+    bool supports_intermesh = control_plane.system_has_intermesh_links();
 
     // Get all intermesh links
     auto all_links = control_plane.get_all_intermesh_eth_links();
@@ -75,7 +75,7 @@ TEST(IntermeshAPIs, IntermeshLinksAreDistinctFromEthernetLinks) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
-    if (!control_plane.contains_intermesh_links()) {
+    if (!control_plane.system_has_intermesh_links()) {
         GTEST_SKIP() << "Cluster does not support intermesh links";
     }
 

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -5,6 +5,7 @@
 #include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <magic_enum/magic_enum.hpp>
+#include <iomanip>
 #include <map>
 #include <tuple>
 #include <unordered_map>
@@ -65,6 +66,45 @@ bool is_chip_on_corner_of_mesh(chip_id_t physical_chip_id, tt::ClusterType clust
             "is_chip_on_corner_of_mesh not implemented for {} cluster type",
             magic_enum::enum_name(cluster_type));
         return false;
+    }
+}
+
+
+TEST(Cluster, ReportIntermeshLinks) {
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+
+    // Check if cluster supports intermesh links
+    if (!cluster.contains_intermesh_links()) {
+        log_info(tt::LogTest, "Cluster does not support intermesh links");
+        return;
+    }
+
+    log_info(tt::LogTest, "Intermesh Link Configuration Report");
+    log_info(tt::LogTest, "===================================");
+
+    // Get all intermesh links in the system
+    auto all_intermesh_links = cluster.get_all_intermesh_eth_links();
+
+    // Summary
+    size_t total_links = 0;
+    for (const auto& [chip_id, links] : all_intermesh_links) {
+        total_links += links.size();
+    }
+
+    log_info(tt::LogTest, "Total chips with intermesh links: {}", all_intermesh_links.size());
+    log_info(tt::LogTest, "Total intermesh links: {}", total_links);
+    log_info(tt::LogTest, "");
+
+    // Detailed information per chip
+    for (const auto& chip_id : cluster.user_exposed_chip_ids()) {
+        if (cluster.has_intermesh_links(chip_id)) {
+            auto links = cluster.get_intermesh_eth_links(chip_id);
+            log_info(tt::LogTest, "Chip {}: {} inter-mesh ethernet links", chip_id, links.size());
+
+            for (const auto& [eth_core, channel] : links) {
+                log_info(tt::LogTest, "  Channel {} at {}", channel, eth_core.str());
+            }
+        }
     }
 }
 

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/control_plane.hpp>
 #include <tt-metalium/mesh_graph.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tests/tt_metal/test_utils/test_common.hpp"
@@ -72,9 +73,10 @@ bool is_chip_on_corner_of_mesh(chip_id_t physical_chip_id, tt::ClusterType clust
 
 TEST(Cluster, ReportIntermeshLinks) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Check if cluster supports intermesh links
-    if (!cluster.contains_intermesh_links()) {
+    if (!control_plane.contains_intermesh_links()) {
         log_info(tt::LogTest, "Cluster does not support intermesh links");
         return;
     }
@@ -83,7 +85,7 @@ TEST(Cluster, ReportIntermeshLinks) {
     log_info(tt::LogTest, "===================================");
 
     // Get all intermesh links in the system
-    auto all_intermesh_links = cluster.get_all_intermesh_eth_links();
+    auto all_intermesh_links = control_plane.get_all_intermesh_eth_links();
 
     // Summary
     size_t total_links = 0;
@@ -97,8 +99,8 @@ TEST(Cluster, ReportIntermeshLinks) {
 
     // Detailed information per chip
     for (const auto& chip_id : cluster.user_exposed_chip_ids()) {
-        if (cluster.has_intermesh_links(chip_id)) {
-            auto links = cluster.get_intermesh_eth_links(chip_id);
+        if (control_plane.has_intermesh_links(chip_id)) {
+            auto links = control_plane.get_intermesh_eth_links(chip_id);
             log_info(tt::LogTest, "Chip {}: {} inter-mesh ethernet links", chip_id, links.size());
 
             for (const auto& [eth_core, channel] : links) {

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -76,7 +76,7 @@ TEST(Cluster, ReportIntermeshLinks) {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Check if cluster supports intermesh links
-    if (!control_plane.contains_intermesh_links()) {
+    if (!control_plane.system_has_intermesh_links()) {
         log_info(tt::LogTest, "Cluster does not support intermesh links");
         return;
     }

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -86,6 +86,27 @@ public:
 
     void clear_fabric_context();
 
+    // Check if ANY managed chip supports intermesh links
+    bool contains_intermesh_links() const;
+
+    // Check if a specific chip has intermesh links configured
+    bool has_intermesh_links(chip_id_t chip_id) const;
+
+    // Get intermesh ethernet links for a specific chip
+    // Returns: vector of (eth_core, channel)
+    const std::vector<std::pair<CoreCoord, uint32_t>>& get_intermesh_eth_links(chip_id_t chip_id) const;
+
+    // Get all intermesh ethernet links in the system
+    // Returns: map of chip_id -> vector of (eth_core, channel)
+    const std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, uint32_t>>>& get_all_intermesh_eth_links()
+        const;
+
+    // Check if a specific ethernet core is an intermesh link
+    bool is_intermesh_eth_link(chip_id_t chip_id, CoreCoord eth_core) const;
+
+    // If the ethernet core is an intermesh link, probe to see if it is trained
+    bool is_intermesh_eth_link_trained(chip_id_t chip_id, CoreCoord eth_core) const;
+
 private:
     uint16_t routing_mode_ = 0;  // ROUTING_MODE_UNDEFINED
     // TODO: remove this from local node control plane. Can get it from the global control plane
@@ -100,6 +121,8 @@ private:
         intra_mesh_routing_tables_;  // table that will be written to each ethernet core
     std::map<FabricNodeId, std::vector<std::vector<chan_id_t>>>
         inter_mesh_routing_tables_;  // table that will be written to each ethernet core
+    // map[phys_chip_id] has a vector of (eth_core, channel) pairs used for intermesh routing
+    std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, uint32_t>>> intermesh_eth_links_;
 
     // custom logic to order eth channels
     void order_ethernet_channels();
@@ -133,6 +156,12 @@ private:
     void convert_fabric_routing_table_to_chip_routing_table();
 
     void write_routing_tables_to_chip(MeshId mesh_id, chip_id_t chip_id) const;
+
+    // Initialize internal map of physical chip_id to intermesh ethernet links
+    void initialize_intermesh_eth_links();
+
+    // Check if intermesh links are available by reading SPI ROM config from first chip
+    bool is_intermesh_enabled() const;
 
     std::unique_ptr<FabricContext> fabric_context_;
 };

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -87,18 +87,18 @@ public:
     void clear_fabric_context();
 
     // Check if ANY managed chip supports intermesh links
-    bool contains_intermesh_links() const;
+    bool system_has_intermesh_links() const;
 
     // Check if a specific chip has intermesh links configured
     bool has_intermesh_links(chip_id_t chip_id) const;
 
     // Get intermesh ethernet links for a specific chip
     // Returns: vector of (eth_core, channel)
-    const std::vector<std::pair<CoreCoord, uint32_t>>& get_intermesh_eth_links(chip_id_t chip_id) const;
+    const std::vector<std::pair<CoreCoord, chan_id_t>>& get_intermesh_eth_links(chip_id_t chip_id) const;
 
     // Get all intermesh ethernet links in the system
     // Returns: map of chip_id -> vector of (eth_core, channel)
-    const std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, uint32_t>>>& get_all_intermesh_eth_links()
+    const std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, chan_id_t>>>& get_all_intermesh_eth_links()
         const;
 
     // Check if a specific ethernet core is an intermesh link
@@ -122,7 +122,7 @@ private:
     std::map<FabricNodeId, std::vector<std::vector<chan_id_t>>>
         inter_mesh_routing_tables_;  // table that will be written to each ethernet core
     // map[phys_chip_id] has a vector of (eth_core, channel) pairs used for intermesh routing
-    std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, uint32_t>>> intermesh_eth_links_;
+    std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, chan_id_t>>> intermesh_eth_links_;
 
     // custom logic to order eth channels
     void order_ethernet_channels();

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -81,29 +81,6 @@ inline std::string get_soc_description_file(
     path += file;
     return path;
 }
-
-// Constants for multi-mesh configuration
-constexpr uint32_t MULTI_MESH_CONFIG_ADDR = 0x104C;
-constexpr uint32_t MULTI_MESH_LINK_STATUS_ADDR = 0x1104;
-constexpr uint32_t MULTI_MESH_ENABLED_VALUE = 0x2;
-constexpr uint32_t LINK_CONNECTED_VALUE = 0x1;
-constexpr uint32_t MULTI_MESH_MODE_MASK = 0xFF;
-constexpr uint32_t INTERMESH_ETH_LINK_BITS_SHIFT = 8;
-constexpr uint32_t INTERMESH_ETH_LINK_BITS_MASK = 0xFFFF;
-constexpr uint32_t MAX_ETH_LINKS = 16;
-
-// Helper to extract intermesh ports from config value
-std::vector<uint32_t> extract_intermesh_eth_links(uint32_t config_value) {
-    std::vector<uint32_t> intermesh_eth_links;
-    uint32_t intermesh_eth_links_bits = (config_value >> INTERMESH_ETH_LINK_BITS_SHIFT) & INTERMESH_ETH_LINK_BITS_MASK;
-    for (uint32_t link = 0; link < MAX_ETH_LINKS; ++link) {
-        if (intermesh_eth_links_bits & (1 << link)) {
-            intermesh_eth_links.push_back(link);
-        }
-    }
-    return intermesh_eth_links;
-}
-
 }  // namespace
 namespace tt {
 
@@ -211,8 +188,6 @@ Cluster::Cluster(const llrt::RunTimeOptions& rtoptions, const tt_metal::Hal& hal
     this->reserve_ethernet_cores_for_tunneling();
 
     this->initialize_ethernet_sockets();
-
-    this->initialize_intermesh_eth_links();
 
     this->set_tunnels_from_mmio_device();
 
@@ -993,45 +968,6 @@ void Cluster::initialize_ethernet_sockets() {
     }
 }
 
-void Cluster::initialize_intermesh_eth_links() {
-    // If intermesh is not enabled, set all intermesh_eth_links to empty
-    if (not this->is_intermesh_enabled()) {
-        for (const auto& chip_id : this->all_chip_ids()) {
-            this->intermesh_eth_links_[chip_id] = {};
-        }
-        return;
-    }
-
-    // Iterate over all chips in the cluster and populate the intermesh_eth_links
-    for (const auto& chip_id : this->all_chip_ids()) {
-        const auto& soc_desc = this->get_soc_desc(chip_id);
-        if (soc_desc.logical_eth_core_to_chan_map.empty()) {
-            this->intermesh_eth_links_[chip_id] = {};
-            continue;
-        }
-
-        // Read multi-mesh configuration from the first available eth core
-        auto first_eth_core = soc_desc.logical_eth_core_to_chan_map.begin()->first;
-        tt_cxy_pair virtual_eth_core(
-            chip_id, this->get_virtual_coordinate_from_logical_coordinates(chip_id, first_eth_core, CoreType::ETH));
-
-        std::vector<uint32_t> config_data(1, 0);
-        this->read_core(config_data, sizeof(uint32_t), virtual_eth_core, MULTI_MESH_CONFIG_ADDR);
-        std::vector<std::pair<CoreCoord, uint32_t>> intermesh_eth_links;
-        for (auto link : extract_intermesh_eth_links(config_data[0])) {
-            // Find the CoreCoord for this channel
-            for (const auto& [core_coord, channel] : soc_desc.logical_eth_core_to_chan_map) {
-                if (channel == link) {
-                    intermesh_eth_links.push_back({core_coord, link});
-                    break;
-                }
-            }
-        }
-
-        this->intermesh_eth_links_[chip_id] = intermesh_eth_links;
-    }
-}
-
 void Cluster::disable_ethernet_cores_with_retrain() {
     std::vector<uint32_t> read_vec;
     const auto& chips = this->driver_->get_target_device_ids();
@@ -1565,57 +1501,6 @@ bool Cluster::is_external_cable(chip_id_t physical_chip_id, CoreCoord eth_core) 
         }
     }
     return is_external_cable;
-}
-
-bool Cluster::is_intermesh_enabled() const {
-    std::vector<uint32_t> config_data(1, 0);
-    auto first_chip_id = *this->driver_->get_target_mmio_device_ids().begin();
-    auto first_eth_core = this->get_soc_desc(first_chip_id).logical_eth_core_to_chan_map.begin()->first;
-    tt_cxy_pair virtual_eth_core(
-        first_chip_id, this->get_virtual_coordinate_from_logical_coordinates(first_chip_id, first_eth_core, CoreType::ETH));
-    this->read_core(config_data, sizeof(uint32_t), virtual_eth_core, MULTI_MESH_CONFIG_ADDR);
-    bool intermesh_enabled = (config_data[0] & MULTI_MESH_MODE_MASK) == MULTI_MESH_ENABLED_VALUE;
-    return intermesh_enabled;
-}
-
-bool Cluster::contains_intermesh_links() const {
-    return !this->get_all_intermesh_eth_links().empty();
-}
-
-bool Cluster::has_intermesh_links(chip_id_t chip_id) const {
-    return !this->get_intermesh_eth_links(chip_id).empty();
-}
-
-const std::vector<std::pair<CoreCoord, uint32_t>>& Cluster::get_intermesh_eth_links(chip_id_t chip_id) const {
-    return this->intermesh_eth_links_.at(chip_id);
-}
-
-const std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, uint32_t>>>& Cluster::get_all_intermesh_eth_links() const {
-    return this->intermesh_eth_links_;
-}
-
-bool Cluster::is_intermesh_eth_link(chip_id_t chip_id, CoreCoord eth_core) const {
-    for (const auto& [link_eth_core, channel] : this->get_intermesh_eth_links(chip_id)) {
-        if (link_eth_core == eth_core) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool Cluster::is_intermesh_eth_link_trained(chip_id_t chip_id, CoreCoord eth_core) const {
-    if (!this->is_intermesh_eth_link(chip_id, eth_core)) {
-        return false;
-    }
-
-    // Read the link status from designated L1 address
-    tt_cxy_pair virtual_eth_core(
-        chip_id, this->get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
-    std::vector<uint32_t> status_data(1, 0);
-    this->read_core(status_data, sizeof(uint32_t), virtual_eth_core, MULTI_MESH_LINK_STATUS_ADDR);
-
-    // Check if the link is trained
-    return (status_data[0] & LINK_CONNECTED_VALUE) == LINK_CONNECTED_VALUE;
 }
 
 }  // namespace tt

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -338,6 +338,26 @@ public:
     // return enum for connection type, Internal, QSFP, Other, Unknown
     bool is_external_cable(chip_id_t physical_chip_id, CoreCoord eth_core) const;
 
+    // Check if ANY chip in the cluster supports intermesh links
+    bool contains_intermesh_links() const;
+
+    // Check if a specific chip has intermesh links configured
+    bool has_intermesh_links(chip_id_t chip_id) const;
+
+    // Get intermesh ethernet links for a specific chip
+    // Returns: vector of (eth_core, channel)
+    const std::vector<std::pair<CoreCoord, uint32_t>>& get_intermesh_eth_links(chip_id_t chip_id) const;
+
+    // Get all intermesh ethernet links in the system
+    // Returns: map of chip_id -> vector of (eth_core, channel)
+    const std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, uint32_t>>>& get_all_intermesh_eth_links() const;
+
+    // Check if a specific ethernet core is an intermesh link
+    bool is_intermesh_eth_link(chip_id_t chip_id, CoreCoord eth_core) const;
+
+    // If the ethernet core is an intermesh link, probe to see if it is trained
+    bool is_intermesh_eth_link_trained(chip_id_t chip_id, CoreCoord eth_core) const;
+
 private:
     void detect_arch_and_target();
     void generate_cluster_descriptor();
@@ -357,6 +377,12 @@ private:
     void reserve_ethernet_cores_for_tunneling();
 
     void initialize_ethernet_sockets();
+
+    // Initialize internal map of chip_id to intermesh ethernet links
+    void initialize_intermesh_eth_links();
+
+    // Check if intermesh is enabled by reading SPI ROM config from first chip
+    bool is_intermesh_enabled() const;
 
     // Disable ethernet cores that retrain
     // This should be removed when we handle retraining or dropped links in control plane properly
@@ -392,6 +418,7 @@ private:
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> virtual_pcie_cores_;
     std::unordered_map<BoardType, std::unordered_map<CoreCoord, int32_t>> virtual_routing_to_profiler_flat_id_;
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> frequent_retrain_cores_;
+    std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, uint32_t>>> intermesh_eth_links_;
     // Flag to tell whether we are on a TG type of system.
     // If any device has to board type of GALAXY, we are on a TG cluster.
     ClusterType cluster_type_ = ClusterType::INVALID;

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -111,6 +111,8 @@ public:
 
     size_t number_of_pci_devices() const { return this->driver_->get_target_mmio_device_ids().size(); }
 
+    std::set<chip_id_t> all_pci_chip_ids() const { return this->driver_->get_target_mmio_device_ids(); }
+
     // TODO: UMD will eventually consolidate ethernet coordinates and unique ids, we can remove the ethernet coord
     // getter after that change is in
     const std::unordered_map<chip_id_t, uint64_t>& get_unique_chip_ids() const {
@@ -338,26 +340,6 @@ public:
     // return enum for connection type, Internal, QSFP, Other, Unknown
     bool is_external_cable(chip_id_t physical_chip_id, CoreCoord eth_core) const;
 
-    // Check if ANY chip in the cluster supports intermesh links
-    bool contains_intermesh_links() const;
-
-    // Check if a specific chip has intermesh links configured
-    bool has_intermesh_links(chip_id_t chip_id) const;
-
-    // Get intermesh ethernet links for a specific chip
-    // Returns: vector of (eth_core, channel)
-    const std::vector<std::pair<CoreCoord, uint32_t>>& get_intermesh_eth_links(chip_id_t chip_id) const;
-
-    // Get all intermesh ethernet links in the system
-    // Returns: map of chip_id -> vector of (eth_core, channel)
-    const std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, uint32_t>>>& get_all_intermesh_eth_links() const;
-
-    // Check if a specific ethernet core is an intermesh link
-    bool is_intermesh_eth_link(chip_id_t chip_id, CoreCoord eth_core) const;
-
-    // If the ethernet core is an intermesh link, probe to see if it is trained
-    bool is_intermesh_eth_link_trained(chip_id_t chip_id, CoreCoord eth_core) const;
-
 private:
     void detect_arch_and_target();
     void generate_cluster_descriptor();
@@ -377,12 +359,6 @@ private:
     void reserve_ethernet_cores_for_tunneling();
 
     void initialize_ethernet_sockets();
-
-    // Initialize internal map of chip_id to intermesh ethernet links
-    void initialize_intermesh_eth_links();
-
-    // Check if intermesh is enabled by reading SPI ROM config from first chip
-    bool is_intermesh_enabled() const;
 
     // Disable ethernet cores that retrain
     // This should be removed when we handle retraining or dropped links in control plane properly
@@ -418,7 +394,6 @@ private:
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> virtual_pcie_cores_;
     std::unordered_map<BoardType, std::unordered_map<CoreCoord, int32_t>> virtual_routing_to_profiler_flat_id_;
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> frequent_retrain_cores_;
-    std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, uint32_t>>> intermesh_eth_links_;
     // Flag to tell whether we are on a TG type of system.
     // If any device has to board type of GALAXY, we are on a TG cluster.
     ClusterType cluster_type_ = ClusterType::INVALID;


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We now have the ability to program SPI ROM to tag ethernet links as "inter-mesh" ethernet links. This denotes special connectivity between two meshes. These links can be used to connect devices onto a big mesh across multiple host systems. 

### What's changed
This commit introduces new APIs to query inter-mesh ethernet links in multi-mesh TT-Metal clusters. The intermesh links are specialized ethernet connections that bridge between different mesh networks in the cluster.

These inter-mesh ethernet links can be used to form a "big-mesh" across multiple host systems or mesh-to-mesh connectivity.

New APIs added to tt_Cluster:
- supports_intermesh_links(): Check if cluster has intermesh capability
- has_intermesh_links(chip_id): Check if specific chip has intermesh links
- get_intermesh_eth_links(chip_id): Get intermesh links for a chip
- get_all_intermesh_eth_links(): Get all intermesh links in the system
- is_intermesh_eth_link(chip_id, eth_core): Check if ethernet core is intermesh

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] T3K Unit Tests: