### PR TITLE
Track which CQ owns a subdevice

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -487,4 +487,63 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceProgramReuseRtas) {
     }
 }
 
+TEST_F(MultiCommandQueueSingleDeviceFixture, TensixTestSubDeviceCQOwnership) {
+    constexpr uint32_t k_num_iters = 5;
+    auto* device = device_;
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
+    SubDevice sub_device_2(std::array{CoreRangeSet(CoreRange({3, 3}, {3, 3}))});
+    // Sub device IDs are swapped between the two sub device managers.
+    auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, k_local_l1_size);
+    device->load_sub_device_manager(sub_device_manager);
+
+    tt_metal::Program program_1 = tt_metal::CreateProgram();
+    tt_metal::Program program_2 = tt_metal::CreateProgram();
+    // On sub device 1.
+    tt_metal::CreateKernel(
+        program_1,
+        "tt_metal/kernels/dataflow/blank.cpp",
+        CoreRangeSet(CoreRange({0, 0}, {2, 2})),
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+    // On sub device 2.
+    tt_metal::CreateKernel(
+        program_2,
+        "tt_metal/kernels/dataflow/blank.cpp",
+        CoreRangeSet(CoreRange({3, 3}, {3, 3})),
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+    EnqueueProgram(device->command_queue(0), program_1, false);
+    auto early_event = std::make_shared<Event>();
+    EnqueueRecordEvent(device->command_queue(1), early_event);
+    EnqueueProgram(device->command_queue(1), program_2, false);
+
+    // CQ 0 owns sub device 1, CQ 1 owns sub device 2.
+    EXPECT_THROW(EnqueueProgram(device->command_queue(1), program_1, false), std::exception);
+
+    // Finish allows transfering ownership of sub device 1.
+    Finish(device->command_queue(0));
+    EnqueueProgram(device->command_queue(1), program_1, false);
+
+    // CQ 1 owns sub devices 1 and 2.
+    EXPECT_THROW(EnqueueProgram(device->command_queue(0), program_2, false), std::exception);
+
+    // Waiting on an event before the last program was queued does not allow transferring ownership of sub device 2.
+    EnqueueWaitForEvent(device->command_queue(0), early_event);
+    EXPECT_THROW(EnqueueProgram(device->command_queue(0), program_2, false), std::exception);
+
+    // Later event allows transferring ownership of sub device 2 to CQ 0
+    auto event1 = std::make_shared<Event>();
+    auto event2 = std::make_shared<Event>();
+    EnqueueRecordEvent(device->command_queue(1), event1);
+    EnqueueRecordEvent(device->command_queue(1), event2);
+    EnqueueWaitForEvent(device->command_queue(0), event2);
+    EnqueueProgram(device->command_queue(0), program_2, false);
+
+    Synchronize(device);
+    // Synchronize allows transferring ownership of either subdevice.
+    EnqueueProgram(device->command_queue(0), program_1, false);
+    EnqueueProgram(device->command_queue(1), program_2, false);
+    Synchronize(device);
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -72,11 +72,10 @@ FDMeshCommandQueue::FDMeshCommandQueue(
     uint32_t id,
     std::shared_ptr<ThreadPool>& dispatch_thread_pool,
     std::shared_ptr<ThreadPool>& reader_thread_pool,
-    std::shared_ptr<DispatchArray<LaunchMessageRingBufferState>>& worker_launch_message_buffer_state) :
+    std::shared_ptr<CQSharedState>& cq_shared_state) :
     MeshCommandQueueBase(mesh_device, id, dispatch_thread_pool),
     reader_thread_pool_(reader_thread_pool),
-    worker_launch_message_buffer_state_(worker_launch_message_buffer_state)  //
-{
+    cq_shared_state_(cq_shared_state) {
     program_dispatch::reset_config_buf_mgrs_and_expected_workers(
         config_buffer_mgr_,
         expected_num_workers_completed_,
@@ -199,6 +198,11 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     auto& sysmem_manager = this->reference_sysmem_manager();
     auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
+    if (!sysmem_manager.get_bypass_mode()) {
+        auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
+        auto& sub_device = sub_device_cq_owner[*sub_device_id];
+        sub_device.TakeOwnership(sub_device_id, this->id_);
+    }
 
     TT_FATAL(
         mesh_workload.impl().get_program_binary_status(mesh_device_id) != ProgramBinaryStatus::NotSent,
@@ -248,8 +252,8 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         program_dispatch::update_program_dispatch_commands(
             program.impl(),
             program_cmd_seq,
-            (*worker_launch_message_buffer_state_)[*sub_device_id].get_mcast_wptr(),
-            (*worker_launch_message_buffer_state_)[*sub_device_id].get_unicast_wptr(),
+            cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].get_mcast_wptr(),
+            cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].get_unicast_wptr(),
             expected_num_workers_completed,
             this->virtual_program_dispatch_core(),
             dispatch_core_type,
@@ -295,10 +299,10 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     }
     // Increment Launch Message Buffer Write Pointers
     if (mcast_go_signals) {
-        (*worker_launch_message_buffer_state_)[*sub_device_id].inc_mcast_wptr(1);
+        cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].inc_mcast_wptr(1);
     }
     if (unicast_go_signals) {
-        (*worker_launch_message_buffer_state_)[*sub_device_id].inc_unicast_wptr(1);
+        cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].inc_unicast_wptr(1);
     }
 
     if (sysmem_manager.get_bypass_mode()) {
@@ -392,6 +396,10 @@ void FDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids)
 
     std::unique_lock<std::mutex> lock(reads_processed_cv_mutex_);
     reads_processed_cv_.wait(lock, [this] { return num_outstanding_reads_.load() == 0; });
+    auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
+    for (auto& sub_device_id : buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids)) {
+        sub_device_cq_owner[*sub_device_id].Finished(this->id_);
+    }
 }
 
 void FDMeshCommandQueue::write_shard_to_device(
@@ -574,7 +582,14 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_helper(
 
 MeshEvent FDMeshCommandQueue::enqueue_record_event(
     tt::stl::Span<const SubDeviceId> sub_device_ids, const std::optional<MeshCoordinateRange>& device_range) {
-    return this->enqueue_record_event_helper(sub_device_ids, /*notify_host=*/false, device_range);
+    auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
+
+    MeshEvent event = this->enqueue_record_event_helper(sub_device_ids, /*notify_host=*/false, device_range);
+    for (const auto& sub_device_id : sub_device_ids) {
+        auto& sub_device_entry = sub_device_cq_owner[*sub_device_id];
+        sub_device_entry.RecordedEvent(event.id(), event.mesh_cq_id());
+    }
+    return event;
 }
 
 MeshEvent FDMeshCommandQueue::enqueue_record_event_to_host(
@@ -583,6 +598,11 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_to_host(
     completion_queue_reads_.push(std::make_shared<MeshCompletionReaderVariant>(
         std::in_place_type<MeshReadEventDescriptor>, ReadEventDescriptor(event.id()), event.device_range()));
     this->increment_num_entries_in_completion_queue();
+    auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
+    for (const auto& sub_device_id : sub_device_ids) {
+        auto& sub_device_entry = sub_device_cq_owner[*sub_device_id];
+        sub_device_entry.RecordedEvent(event.id(), event.mesh_cq_id());
+    }
     return event;
 }
 
@@ -592,6 +612,10 @@ void FDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent& sync_event) {
     for (const auto& coord : sync_event.device_range()) {
         event_dispatch::issue_wait_for_event_commands(
             id_, sync_event.mesh_cq_id(), mesh_device_->get_device(coord)->sysmem_manager(), sync_event.id());
+    }
+    auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
+    for (auto& sub_device_entry : sub_device_cq_owner) {
+        sub_device_entry.WaitedForEvent(sync_event.id(), sync_event.mesh_cq_id(), this->id_);
     }
 }
 
@@ -705,6 +729,9 @@ void FDMeshCommandQueue::read_l1_data_from_completion_queue(MeshCoreDataReadDesc
 
 void FDMeshCommandQueue::reset_worker_state(
     bool reset_launch_msg_state, uint32_t num_sub_devices, const vector_aligned<uint32_t>& go_signal_noc_data) {
+    auto& sysmem_manager = this->reference_sysmem_manager();
+    cq_shared_state_->sub_device_cq_owner.clear();
+    cq_shared_state_->sub_device_cq_owner.resize(num_sub_devices);
     in_use_ = true;
     for (auto device : mesh_device_->get_devices()) {
         program_dispatch::reset_worker_dispatch_state_on_device(
@@ -725,8 +752,8 @@ void FDMeshCommandQueue::reset_worker_state(
         mesh_device_->allocator()->get_config().l1_unreserved_base);
     if (reset_launch_msg_state) {
         std::for_each(
-            this->worker_launch_message_buffer_state_->begin(),
-            this->worker_launch_message_buffer_state_->begin() + num_sub_devices,
+            this->cq_shared_state_->worker_launch_message_buffer_state.begin(),
+            this->cq_shared_state_->worker_launch_message_buffer_state.begin() + num_sub_devices,
             std::mem_fn(&LaunchMessageRingBufferState::reset));
     }
 }
@@ -850,6 +877,11 @@ void FDMeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blockin
     auto descriptor = trace_inst->desc;
     auto buffer = trace_inst->mesh_buffer;
     uint32_t num_sub_devices = descriptor->sub_device_ids.size();
+    auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
+    for (auto sub_device_id : descriptor->sub_device_ids) {
+        auto& sub_device = sub_device_cq_owner[*sub_device_id];
+        sub_device.TakeOwnership(sub_device_id, this->id_);
+    }
 
     auto cmd_sequence_sizeB = trace_dispatch::compute_trace_cmd_size(num_sub_devices);
 
@@ -867,7 +899,7 @@ void FDMeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blockin
     }
     trace_dispatch::update_worker_state_post_trace_execution(
         trace_inst->desc->descriptors,
-        *worker_launch_message_buffer_state_,
+        cq_shared_state_->worker_launch_message_buffer_state,
         config_buffer_mgr_,
         expected_num_workers_completed_);
 
@@ -879,7 +911,7 @@ void FDMeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blockin
 void FDMeshCommandQueue::record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) {
     trace_dispatch::reset_host_dispatch_state_for_trace(
         mesh_device_->num_sub_devices(),
-        *worker_launch_message_buffer_state_,
+        cq_shared_state_->worker_launch_message_buffer_state,
         expected_num_workers_completed_,
         config_buffer_mgr_,
         worker_launch_message_buffer_state_reset_,
@@ -900,7 +932,7 @@ void FDMeshCommandQueue::record_end() {
 
     trace_dispatch::load_host_dispatch_state(
         mesh_device_->num_sub_devices(),
-        *worker_launch_message_buffer_state_,
+        cq_shared_state_->worker_launch_message_buffer_state,
         expected_num_workers_completed_,
         config_buffer_mgr_,
         worker_launch_message_buffer_state_reset_,

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/command_queue.hpp>
 
 #include "tt_metal/common/multi_producer_single_consumer_queue.hpp"
+#include "dispatch/cq_shared_state.hpp"
 #include "dispatch/dispatch_settings.hpp"
 #include "dispatch/launch_message_ring_buffer_state.hpp"
 #include "dispatch/worker_config_buffer.hpp"
@@ -104,7 +105,7 @@ private:
         tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
     // Shared across all MeshCommandQueue instances for a MeshDevice.
-    std::shared_ptr<DispatchArray<LaunchMessageRingBufferState>> worker_launch_message_buffer_state_;
+    std::shared_ptr<CQSharedState> cq_shared_state_;
 
     DispatchArray<uint32_t> expected_num_workers_completed_;
     DispatchArray<tt::tt_metal::WorkerConfigBufferMgr> config_buffer_mgr_;
@@ -174,7 +175,7 @@ public:
         uint32_t id,
         std::shared_ptr<ThreadPool>& dispatch_thread_pool,
         std::shared_ptr<ThreadPool>& reader_thread_pool,
-        std::shared_ptr<DispatchArray<LaunchMessageRingBufferState>>& worker_launch_message_buffer_state);
+        std::shared_ptr<CQSharedState>& cq_shared_state);
 
     ~FDMeshCommandQueue() override;
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -789,7 +789,8 @@ bool MeshDevice::initialize(
         SubDevice(std::array{CoreRangeSet(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}))})};
 
     // Resource shared across mesh command queues.
-    auto worker_launch_message_buffer_state = std::make_shared<DispatchArray<LaunchMessageRingBufferState>>();
+    auto cq_shared_state = std::make_shared<CQSharedState>();
+    cq_shared_state->sub_device_cq_owner.resize(1);
 
     const auto& allocator = reference_device()->allocator();
     sub_device_manager_tracker_ = std::make_unique<SubDeviceManagerTracker>(
@@ -801,12 +802,7 @@ bool MeshDevice::initialize(
     if (this->using_fast_dispatch()) {
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
             mesh_command_queues_.push_back(std::make_unique<FDMeshCommandQueue>(
-                this,
-                cq_id,
-                dispatch_thread_pool_,
-                reader_thread_pool_,
-                worker_launch_message_buffer_state  //
-                ));
+                this, cq_id, dispatch_thread_pool_, reader_thread_pool_, cq_shared_state));
         }
     } else {
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -34,6 +34,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/program/program_device_map.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/profiler/profiler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/profiler/tt_metal_profiler.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/cq_shared_state.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/debug_tools.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/device_command.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/host_runtime_commands.cpp

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -955,11 +955,13 @@ void Device::configure_command_queue_programs() {
 void Device::init_command_queue_host() {
     using_fast_dispatch_ = true;
     sysmem_manager_ = std::make_unique<SystemMemoryManager>(this->id_, this->num_hw_cqs());
-    auto worker_launch_message_buffer_state = std::make_shared<DispatchArray<LaunchMessageRingBufferState>>();
+
+    auto cq_shared_state = std::make_shared<CQSharedState>();
+    cq_shared_state->sub_device_cq_owner.resize(1);
     command_queues_.reserve(num_hw_cqs());
     for (size_t cq_id = 0; cq_id < num_hw_cqs(); cq_id++) {
         command_queues_.push_back(std::make_unique<HWCommandQueue>(
-            this, worker_launch_message_buffer_state, cq_id, k_dispatch_downstream_noc, completion_queue_reader_core_));
+            this, cq_shared_state, cq_id, k_dispatch_downstream_noc, completion_queue_reader_core_));
     }
 }
 

--- a/tt_metal/impl/dispatch/cq_shared_state.cpp
+++ b/tt_metal/impl/dispatch/cq_shared_state.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "cq_shared_state.hpp"
+
+namespace tt::tt_metal {
+void CQOwnerState::take_ownership(SubDeviceId id, uint32_t cq_id) {
+    if (cq_id_ != std::nullopt && cq_id_ != cq_id) {
+        TT_FATAL(
+            cq_id_ == cq_id,
+            "Sub device id {} currently in use by cq {}. Can't enqueue program from cq {}. Finish or wait "
+            "for an event to transfer ownership.",
+            *id,
+            *cq_id_,
+            cq_id);
+    }
+    cq_id_ = cq_id;
+    ownership_event_id_ = std::nullopt;
+}
+
+void CQOwnerState::finished(uint32_t cq_id) {
+    if (cq_id_.has_value() && cq_id_ == cq_id) {
+        cq_id_ = std::nullopt;
+        ownership_event_id_ = std::nullopt;
+    }
+}
+
+void CQOwnerState::recorded_event(uint32_t event_id, uint32_t event_cq) {
+    if (cq_id_.has_value() && cq_id_ == event_cq) {
+        if (ownership_event_id_.has_value()) {
+            TT_ASSERT(*ownership_event_id_ < event_id, "Ownership event ID must be less than the current event ID");
+        } else {
+            ownership_event_id_ = event_id;
+        }
+    }
+}
+
+void CQOwnerState::waited_for_event(uint32_t event_id, uint32_t event_cq, uint32_t cq_id) {
+    if (cq_id_.has_value() && event_cq == cq_id_ && cq_id_ != cq_id && ownership_event_id_.has_value() &&
+        ownership_event_id_ <= event_id) {
+        cq_id_ = std::nullopt;
+        ownership_event_id_ = std::nullopt;
+    }
+}
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/cq_shared_state.hpp
+++ b/tt_metal/impl/dispatch/cq_shared_state.hpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+#include <optional>
+#include <api/tt-metalium/event.hpp>
+#include <api/tt-metalium/sub_device_types.hpp>
+
+#include "assert.hpp"
+#include "launch_message_ring_buffer_state.hpp"
+#include "dispatch_settings.hpp"
+
+namespace tt::tt_metal {
+
+// Keeps track of the ownership state of a sub-device's workers.
+class CQOwnerState {
+public:
+    void TakeOwnership(SubDeviceId id, uint32_t cq_id) {
+        if (this->cq_id != std::nullopt && this->cq_id != cq_id) {
+            TT_FATAL(
+                this->cq_id == cq_id,
+                "Sub device id {} currently in use by cq {}. Can't enqueue program from cq {}. Finish or wait "
+                "for an event to transfer ownership.",
+                *id,
+                *this->cq_id,
+                cq_id);
+        }
+        this->cq_id = cq_id;
+        ownership_event_id = std::nullopt;
+    }
+
+    void Finished(uint32_t cq_id) {
+        if (this->cq_id.has_value() && this->cq_id == cq_id) {
+            this->cq_id = std::nullopt;
+            this->ownership_event_id = std::nullopt;
+        }
+    }
+
+    void RecordedEvent(uint32_t event_id, uint32_t event_cq) {
+        if (cq_id.has_value() && cq_id == event_cq) {
+            if (ownership_event_id.has_value()) {
+                TT_ASSERT(*ownership_event_id < event_id, "Ownership event ID must be less than the current event ID");
+            } else {
+                ownership_event_id = event_id;
+            }
+        }
+    }
+
+    void WaitedForEvent(uint32_t event_id, uint32_t event_cq, uint32_t cq_id) {
+        if (this->cq_id.has_value() && event_cq == this->cq_id && this->cq_id != cq_id &&
+            ownership_event_id.has_value() && ownership_event_id <= event_id) {
+            this->cq_id = std::nullopt;
+            ownership_event_id = std::nullopt;
+        }
+    }
+
+private:
+    std::optional<uint32_t> cq_id;               // The command queue ID that owns this sub-device.
+    std::optional<uint32_t> ownership_event_id;  // The first event ID to wait on to grant ownership.
+};
+
+// State that is shared across all command queues for a device.
+struct CQSharedState {
+    DispatchArray<LaunchMessageRingBufferState> worker_launch_message_buffer_state;
+
+    std::vector<CQOwnerState> sub_device_cq_owner;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/cq_shared_state.hpp
+++ b/tt_metal/impl/dispatch/cq_shared_state.hpp
@@ -18,54 +18,23 @@ namespace tt::tt_metal {
 // Keeps track of the ownership state of a sub-device's workers.
 class CQOwnerState {
 public:
-    void TakeOwnership(SubDeviceId id, uint32_t cq_id) {
-        if (this->cq_id != std::nullopt && this->cq_id != cq_id) {
-            TT_FATAL(
-                this->cq_id == cq_id,
-                "Sub device id {} currently in use by cq {}. Can't enqueue program from cq {}. Finish or wait "
-                "for an event to transfer ownership.",
-                *id,
-                *this->cq_id,
-                cq_id);
-        }
-        this->cq_id = cq_id;
-        ownership_event_id = std::nullopt;
-    }
+    // Raises an exception if the sub-device is already owned by a different command queue.
+    void take_ownership(SubDeviceId id, uint32_t cq_id);
 
-    void Finished(uint32_t cq_id) {
-        if (this->cq_id.has_value() && this->cq_id == cq_id) {
-            this->cq_id = std::nullopt;
-            this->ownership_event_id = std::nullopt;
-        }
-    }
-
-    void RecordedEvent(uint32_t event_id, uint32_t event_cq) {
-        if (cq_id.has_value() && cq_id == event_cq) {
-            if (ownership_event_id.has_value()) {
-                TT_ASSERT(*ownership_event_id < event_id, "Ownership event ID must be less than the current event ID");
-            } else {
-                ownership_event_id = event_id;
-            }
-        }
-    }
-
-    void WaitedForEvent(uint32_t event_id, uint32_t event_cq, uint32_t cq_id) {
-        if (this->cq_id.has_value() && event_cq == this->cq_id && this->cq_id != cq_id &&
-            ownership_event_id.has_value() && ownership_event_id <= event_id) {
-            this->cq_id = std::nullopt;
-            ownership_event_id = std::nullopt;
-        }
-    }
+    void finished(uint32_t cq_id);
+    void recorded_event(uint32_t event_id, uint32_t event_cq);
+    void waited_for_event(uint32_t event_id, uint32_t event_cq, uint32_t cq_id);
 
 private:
-    std::optional<uint32_t> cq_id;               // The command queue ID that owns this sub-device.
-    std::optional<uint32_t> ownership_event_id;  // The first event ID to wait on to grant ownership.
+    std::optional<uint32_t> cq_id_;               // The command queue ID that owns this sub-device.
+    std::optional<uint32_t> ownership_event_id_;  // The first event ID to wait on to grant ownership.
 };
 
 // State that is shared across all command queues for a device.
 struct CQSharedState {
     DispatchArray<LaunchMessageRingBufferState> worker_launch_message_buffer_state;
 
+    // One entry per sub-device.
     std::vector<CQOwnerState> sub_device_cq_owner;
 };
 

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -22,6 +22,7 @@
 
 #include "assert.hpp"
 #include "buffers/dispatch.hpp"
+#include "cq_shared_state.hpp"
 #include "device/dispatch.hpp"
 #include "dispatch/device_command.hpp"
 #include "dispatch_settings.hpp"
@@ -75,7 +76,7 @@ void set_device_thread_affinity(std::thread& thread_, int cpu_core_for_worker) {
 
 HWCommandQueue::HWCommandQueue(
     IDevice* device,
-    std::shared_ptr<DispatchArray<LaunchMessageRingBufferState>>& worker_launch_message_buffer_state,
+    std::shared_ptr<CQSharedState> cq_shared_state,
     uint32_t id,
     NOC noc_index,
     uint32_t completion_queue_reader_core) :
@@ -84,7 +85,7 @@ HWCommandQueue::HWCommandQueue(
     completion_queue_reader_core_(completion_queue_reader_core) {
     ZoneScopedN("CommandQueue_constructor");
     this->device_ = device;
-    this->worker_launch_message_buffer_state_ = worker_launch_message_buffer_state;
+    this->cq_shared_state_ = std::move(cq_shared_state);
     this->id_ = id;
     this->noc_index_ = noc_index;
     this->num_entries_in_completion_q_ = 0;
@@ -147,6 +148,8 @@ SystemMemoryManager& HWCommandQueue::sysmem_manager() { return this->manager_; }
 void HWCommandQueue::reset_worker_state(
     bool reset_launch_msg_state, uint32_t num_sub_devices, const vector_aligned<uint32_t>& go_signal_noc_data) {
     TT_FATAL(!this->manager_.get_bypass_mode(), "Cannot reset worker state during trace capture");
+    cq_shared_state_->sub_device_cq_owner.clear();
+    cq_shared_state_->sub_device_cq_owner.resize(num_sub_devices);
     // TODO: This could be further optimized by combining all of these into a single prefetch entry
     // Currently each one will be pushed into its own prefetch entry
     program_dispatch::reset_worker_dispatch_state_on_device(
@@ -168,8 +171,8 @@ void HWCommandQueue::reset_worker_state(
         device_->allocator()->get_config().l1_unreserved_base);
     if (reset_launch_msg_state) {
         std::for_each(
-            this->worker_launch_message_buffer_state_->begin(),
-            this->worker_launch_message_buffer_state_->begin() + num_sub_devices,
+            this->cq_shared_state_->worker_launch_message_buffer_state.begin(),
+            this->cq_shared_state_->worker_launch_message_buffer_state.begin() + num_sub_devices,
             std::mem_fn(&LaunchMessageRingBufferState::reset));
     }
 }
@@ -427,6 +430,13 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
     ZoneScopedN("HWCommandQueue_enqueue_program");
     std::vector<SubDeviceId> sub_device_ids = {program.determine_sub_device_ids(device_)};
     TT_FATAL(sub_device_ids.size() == 1, "Programs must be executed on a single sub-device");
+
+    if (!this->manager_.get_bypass_mode()) {
+        auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
+        auto& sub_device = sub_device_cq_owner[*sub_device_ids[0]];
+        sub_device.TakeOwnership(sub_device_ids[0], this->id_);
+    }
+
     // Finalize Program: Compute relative offsets for data structures (semaphores, kernel binaries, etc) in L1
     program.finalize_offsets(device_);
 
@@ -481,7 +491,8 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
             device_->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id);
     }
 
-    auto& worker_launch_message_buffer_state = (*this->worker_launch_message_buffer_state_)[*sub_device_id];
+    auto& worker_launch_message_buffer_state =
+        this->cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id];
     auto command = EnqueueProgramCommand(
         this->id_,
         this->device_,
@@ -552,11 +563,21 @@ void HWCommandQueue::enqueue_record_event(
     this->issued_completion_q_reads_.push(
         std::make_shared<CompletionReaderVariant>(std::in_place_type<ReadEventDescriptor>, event->event_id));
     this->increment_num_entries_in_completion_q();
+
+    auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
+    for (const auto& sub_device_id : sub_device_ids) {
+        auto& sub_device_entry = sub_device_cq_owner[*sub_device_id];
+        sub_device_entry.RecordedEvent(event->event_id, event->cq_id);
+    }
 }
 
 void HWCommandQueue::enqueue_wait_for_event(const std::shared_ptr<Event>& sync_event) {
     ZoneScopedN("HWCommandQueue_enqueue_wait_for_event");
     event_dispatch::issue_wait_for_event_commands(id_, sync_event->cq_id, this->manager_, sync_event->event_id);
+    auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
+    for (auto& sub_device : sub_device_cq_owner) {
+        sub_device.WaitedForEvent(sync_event->event_id, sync_event->cq_id, this->id_);
+    }
 }
 
 void HWCommandQueue::enqueue_trace(const uint32_t trace_id, bool blocking) {
@@ -566,6 +587,12 @@ void HWCommandQueue::enqueue_trace(const uint32_t trace_id, bool blocking) {
     auto descriptor = trace_inst->desc;
     auto buffer = trace_inst->buffer;
     uint32_t num_sub_devices = descriptor->sub_device_ids.size();
+
+    auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
+    for (auto sub_device_id : descriptor->sub_device_ids) {
+        auto& sub_device = sub_device_cq_owner[*sub_device_id];
+        sub_device.TakeOwnership(sub_device_id, this->id_);
+    }
 
     auto cmd_sequence_sizeB = trace_dispatch::compute_trace_cmd_size(num_sub_devices);
 
@@ -587,7 +614,7 @@ void HWCommandQueue::enqueue_trace(const uint32_t trace_id, bool blocking) {
 
     trace_dispatch::update_worker_state_post_trace_execution(
         trace_inst->desc->descriptors,
-        *this->worker_launch_message_buffer_state_,
+        this->cq_shared_state_->worker_launch_message_buffer_state,
         this->config_buffer_mgr_,
         this->expected_num_workers_completed_);
 
@@ -689,6 +716,11 @@ void HWCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids) {
         this->reads_processed_cv_.wait(
             lock, [this] { return this->num_entries_in_completion_q_ == this->num_completed_completion_q_reads_; });
     }
+    auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
+    for (const auto& sub_device_id : buffer_dispatch::select_sub_device_ids(this->device_, sub_device_ids)) {
+        auto& sub_device_entry = sub_device_cq_owner[*sub_device_id];
+        sub_device_entry.Finished(this->id_);
+    }
 }
 
 const CoreCoord& HWCommandQueue::virtual_enqueue_program_dispatch_core() const {
@@ -700,7 +732,7 @@ void HWCommandQueue::record_begin(const uint32_t tid, const std::shared_ptr<Trac
     // worker_config_buffer, etc.
     trace_dispatch::reset_host_dispatch_state_for_trace(
         device_->num_sub_devices(),
-        *this->worker_launch_message_buffer_state_,
+        this->cq_shared_state_->worker_launch_message_buffer_state,
         this->expected_num_workers_completed_,
         this->config_buffer_mgr_,
         this->worker_launch_message_buffer_state_reset_,
@@ -779,7 +811,8 @@ void HWCommandQueue::record_end() {
         // Access the program dispatch-command cache
         uint64_t command_hash = *device_->get_active_sub_device_manager_id();
         auto& cached_program_command_sequence = program.get_trace_cached_program_command_sequences().at(command_hash);
-        auto& worker_launch_message_buffer_state = (*this->worker_launch_message_buffer_state_)[*sub_device_id];
+        auto& worker_launch_message_buffer_state =
+            this->cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id];
         // Update the generated dispatch commands based on the state of the CQ and the ring buffer
         program_dispatch::update_traced_program_dispatch_commands(
             node,
@@ -836,7 +869,7 @@ void HWCommandQueue::record_end() {
     // host, even though device doesn't run any programs.
     trace_dispatch::load_host_dispatch_state(
         device_->num_sub_devices(),
-        *this->worker_launch_message_buffer_state_,
+        this->cq_shared_state_->worker_launch_message_buffer_state,
         this->expected_num_workers_completed_,
         this->config_buffer_mgr_,
         this->worker_launch_message_buffer_state_reset_,

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -434,7 +434,7 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
     if (!this->manager_.get_bypass_mode()) {
         auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
         auto& sub_device = sub_device_cq_owner[*sub_device_ids[0]];
-        sub_device.TakeOwnership(sub_device_ids[0], this->id_);
+        sub_device.take_ownership(sub_device_ids[0], this->id_);
     }
 
     // Finalize Program: Compute relative offsets for data structures (semaphores, kernel binaries, etc) in L1
@@ -567,7 +567,7 @@ void HWCommandQueue::enqueue_record_event(
     auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
     for (const auto& sub_device_id : sub_device_ids) {
         auto& sub_device_entry = sub_device_cq_owner[*sub_device_id];
-        sub_device_entry.RecordedEvent(event->event_id, event->cq_id);
+        sub_device_entry.recorded_event(event->event_id, event->cq_id);
     }
 }
 
@@ -576,7 +576,7 @@ void HWCommandQueue::enqueue_wait_for_event(const std::shared_ptr<Event>& sync_e
     event_dispatch::issue_wait_for_event_commands(id_, sync_event->cq_id, this->manager_, sync_event->event_id);
     auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
     for (auto& sub_device : sub_device_cq_owner) {
-        sub_device.WaitedForEvent(sync_event->event_id, sync_event->cq_id, this->id_);
+        sub_device.waited_for_event(sync_event->event_id, sync_event->cq_id, this->id_);
     }
 }
 
@@ -591,7 +591,7 @@ void HWCommandQueue::enqueue_trace(const uint32_t trace_id, bool blocking) {
     auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
     for (auto sub_device_id : descriptor->sub_device_ids) {
         auto& sub_device = sub_device_cq_owner[*sub_device_id];
-        sub_device.TakeOwnership(sub_device_id, this->id_);
+        sub_device.take_ownership(sub_device_id, this->id_);
     }
 
     auto cmd_sequence_sizeB = trace_dispatch::compute_trace_cmd_size(num_sub_devices);
@@ -719,7 +719,7 @@ void HWCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids) {
     auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
     for (const auto& sub_device_id : buffer_dispatch::select_sub_device_ids(this->device_, sub_device_ids)) {
         auto& sub_device_entry = sub_device_cq_owner[*sub_device_id];
-        sub_device_entry.Finished(this->id_);
+        sub_device_entry.finished(this->id_);
     }
 }
 

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -15,6 +15,7 @@
 #include <variant>
 
 #include "buffer.hpp"
+#include "cq_shared_state.hpp"
 #include "command_queue.hpp"
 #include "command_queue_interface.hpp"
 #include "core_coord.hpp"
@@ -48,7 +49,7 @@ class HWCommandQueue : public CommandQueue {
 public:
     HWCommandQueue(
         IDevice* device,
-        std::shared_ptr<DispatchArray<LaunchMessageRingBufferState>>& worker_launch_message_buffer_state,
+        std::shared_ptr<CQSharedState> cq_shared_state,
         uint32_t id,
         NOC noc_index,
         uint32_t completion_queue_reader_core = 0);
@@ -130,7 +131,7 @@ private:
     std::vector<TraceNode> trace_nodes_;
 
     // Shared across all CommandQueue instances for a Device.
-    std::shared_ptr<DispatchArray<LaunchMessageRingBufferState>> worker_launch_message_buffer_state_;
+    std::shared_ptr<CQSharedState> cq_shared_state_;
 
     DispatchArray<tt::tt_metal::WorkerConfigBufferMgr> config_buffer_mgr_;
     // Expected value of DISPATCH_MESSAGE_ADDR in dispatch core L1


### PR DESCRIPTION

### Ticket
#20802 

### Problem description
If programs are simultaneously queued on multiple CQs, they'll each try to write their data, launch messages, and GO messages to workers at the same time, potentially stomping over work by the other.

### What's changed
Keep track of ownership of each subdevice by CQ. Ownership can only change on finish (when the current ownership is dropped, allowing either CQ to pick it up) or after waiting on an event, which can drop ownership if the event was after all programs enqueued on the other CQ.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes