### PR TITLE
Add padding support for row major tensor for fold operation.

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
+++ b/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
@@ -49,18 +49,27 @@ def pad_and_fold_conv_activation_for_unity_stride(activation_pyt_nchw_tensor, pa
     return activation_pyt_padded_folded
 
 
-def fold_torch(input_tensor, stride_h, stride_w, pad_h=0, pad_w=0, pad_c=0):
+def fold_torch(input_tensor, stride_h, stride_w, padding=None):
     N, H, W, C = input_tensor.shape
 
-    # Apply padding if needed
-    if pad_h != 0 or pad_w != 0 or pad_c != 0:
-        import torch.nn.functional as F
+    # Handle padding specification
+    if padding is not None:
+        if len(padding) == 2:
+            # Symmetric padding: [pad_h, pad_w]
+            pad_top = pad_bottom = padding[0]
+            pad_left = pad_right = padding[1]
+        elif len(padding) == 4:
+            # Asymmetric padding: [top, bottom, left, right]
+            pad_top, pad_bottom, pad_left, pad_right = padding
+        else:
+            raise ValueError(f"Padding must be length 2 or 4, got {len(padding)}")
 
-        # For NHWC tensor format, F.pad works from last dim to first:
-        # input_tensor shape is (N, H, W, C), so padding order is:
-        # (pad_c_left, pad_c_right, pad_w_left, pad_w_right, pad_h_top, pad_h_bottom)
-        input_tensor = F.pad(input_tensor, (pad_c, pad_c, pad_w, pad_w, pad_h, pad_h), value=0.0)
-        N, H, W, C = input_tensor.shape
+        # Apply padding if needed
+        if pad_top != 0 or pad_bottom != 0 or pad_left != 0 or pad_right != 0:
+            import torch.nn.functional as F
+
+            input_tensor = F.pad(input_tensor, (0, 0, pad_left, pad_right, pad_top, pad_bottom), value=0.0)
+            N, H, W, C = input_tensor.shape
 
     reshaped = input_tensor.reshape(N, H // stride_h, stride_h, W // stride_w, stride_w, C)
     transposed = reshaped.permute(0, 1, 3, 2, 4, 5)
@@ -70,17 +79,29 @@ def fold_torch(input_tensor, stride_h, stride_w, pad_h=0, pad_w=0, pad_c=0):
 @pytest.mark.parametrize("nhw", [(3, 64, 64), (1, 224, 224), (1, 384, 512), (1, 512, 672)])
 @pytest.mark.parametrize("channels", [3, 32, 320])
 @pytest.mark.parametrize("stride", [(16, 16), (32, 32)])
-@pytest.mark.parametrize("pad_h, pad_w", [(0, 0), (8, 8)])
+@pytest.mark.parametrize("padding", [(0, 0), (8, 8), (4, 12, 2, 6)])
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
-def test_fold_with_permute_for_dram_tensor(device, nhw, channels, stride, pad_h, pad_w, input_layout):
+def test_fold_with_permute_for_dram_tensor(device, nhw, channels, stride, padding, input_layout):
     batch_size, height, width = nhw
     stride_h, stride_w = stride
 
+    # Handle both symmetric and asymmetric padding
+    if len(padding) == 2:
+        # Symmetric padding: [pad_h, pad_w]
+        padded_h = height + 2 * padding[0]
+        padded_w = width + 2 * padding[1]
+        has_padding = padding[0] > 0 or padding[1] > 0
+    elif len(padding) == 4:
+        # Asymmetric padding: [top, bottom, left, right]
+        padded_h = height + padding[0] + padding[1]
+        padded_w = width + padding[2] + padding[3]
+        has_padding = any(p > 0 for p in padding)
+    else:
+        pytest.skip(f"Invalid padding format: {padding}")
+
     # Skip invalid combinations where padding makes dimensions not divisible by stride
-    padded_h = height + 2 * pad_h
-    padded_w = width + 2 * pad_w
-    if (pad_h > 0 or pad_w > 0) and input_layout == ttnn.TILE_LAYOUT:
-        pytest.skip("Tile layout does not support padding")
+    if has_padding and input_layout == ttnn.TILE_LAYOUT:
+        pytest.skip("ttnn::pad with tile layout does not support front padding yet")
     if padded_h % stride_h != 0 or padded_w % stride_w != 0:
         pytest.skip(
             f"Skipping invalid padding combination: padded_h={padded_h}, padded_w={padded_w}, stride_h={stride_h}, stride_w={stride_w}"
@@ -91,17 +112,16 @@ def test_fold_with_permute_for_dram_tensor(device, nhw, channels, stride, pad_h,
     torch_input_tensor_nhwc = torch.permute(torch_input_tensor, (0, 2, 3, 1))
 
     # Use the fold_torch function which handles padding
-    torch_output_tensor = fold_torch(torch_input_tensor_nhwc, stride_h, stride_w, pad_h, pad_w, 0)
+    torch_output_tensor = fold_torch(torch_input_tensor_nhwc, stride_h, stride_w, padding=padding)
     input_memory_config = ttnn.DRAM_MEMORY_CONFIG
     tt_input_tensor = ttnn.from_torch(
         torch_input_tensor_nhwc, layout=input_layout, device=device, memory_config=input_memory_config
     )
     tt_output_tensor = ttnn.fold(
         tt_input_tensor,
-        pad_h=pad_h,
-        pad_w=pad_w,
         stride_h=stride_h,
         stride_w=stride_w,
+        padding=list(padding),
     )
     tt_output_tensor = ttnn.to_torch(tt_output_tensor)
     isequal = torch.equal(torch_output_tensor, tt_output_tensor)
@@ -299,8 +319,7 @@ def test_fold_with_permute_reshape_on_device_sharded(device, n, c, h, w, pad_h, 
         stride_w,
         use_transpose_as_fold=True,
         pad_c=_nearest_y(c, 4) - c,
-        pad_h=pad_h,
-        pad_w=pad_w,
+        padding=[pad_h, pad_w],
         grid_size=grid_size,
     )
     tt_output_tensor = ttnn.to_torch(tt_output_tensor)
@@ -340,8 +359,7 @@ def test_fold_with_permute_reshape_on_device(device, n, c, h, w, pad_h, pad_w, s
         use_transpose_as_fold=True,
         output_shape=(n, padded_h // stride_h, padded_w // stride_w, C * (stride_h * stride_w)),
         pad_c=C - c,
-        pad_h=0,
-        pad_w=0,
+        padding=[0, 0],
     )
     tt_output_tensor = ttnn.to_torch(tt_output_tensor)
     assert_with_pcc(torch_output_tensor, tt_output_tensor, 1)
@@ -378,25 +396,29 @@ def test_fold(act_shape, stride_h, stride_w, device):
     tt_out = ttnn.fold(tt_input, stride_h, stride_w)
     actual = tt2torch_tensor(tt_out)
 
-    torch.testing.assert_allclose(actual, expected)
+    torch.testing.assert_close(actual, expected)
 
 
 @pytest.mark.parametrize(
-    "act_shape,stride_h,stride_w, pad_h, pad_w",
+    "act_shape,stride_h,stride_w,padding",
     [
-        ((1, 16, 16, 8), 2, 2, 0, 0),
-        ((16, 42, 42, 64), 6, 6, 0, 0),
-        ((1, 16, 16, 8), 2, 2, 2, 2),
-        ((4, 64, 64, 24), 2, 2, 0, 0),
-        ((4, 62, 62, 24), 2, 2, 1, 1),
-        ((4, 14, 14, 256), 2, 2, 1, 1),
-        ((1, 20, 20, 16), 4, 4, 2, 2),
-        ((8, 18, 12, 8), 3, 2, 3, 2),
-        ((2, 30, 30, 32), 5, 5, 0, 0),
-        ((1, 24, 32, 16), 3, 4, 3, 0),
+        ((8, 224, 14, 8), 16, 1, (0, 0)),
+        ((16, 224, 224, 16), 2, 2, (0, 0)),
+        ((1, 16, 16, 8), 2, 2, (0, 0)),
+        ((16, 42, 42, 64), 6, 6, (0, 0)),
+        ((1, 16, 16, 8), 2, 2, (2, 2)),
+        ((4, 64, 64, 24), 2, 2, (0, 0)),
+        ((4, 62, 62, 24), 2, 2, (1, 1)),
+        ((4, 14, 14, 256), 2, 2, (1, 1)),
+        ((1, 20, 20, 16), 4, 4, (2, 2)),
+        ((8, 18, 12, 8), 3, 2, (3, 2)),
+        ((2, 30, 30, 32), 5, 5, (0, 0)),
+        ((1, 24, 32, 16), 3, 4, (3, 0)),
+        ((1, 20, 20, 8), 2, 2, (1, 3, 0, 2)),
+        ((2, 16, 16, 16), 4, 4, (2, 2, 1, 3)),
     ],
 )
-def test_fold_sharded(device, act_shape, stride_h, stride_w, pad_h, pad_w):
+def test_fold_sharded(device, act_shape, stride_h, stride_w, padding):
     torch.manual_seed(0)
 
     N, H, W, C = act_shape
@@ -404,7 +426,7 @@ def test_fold_sharded(device, act_shape, stride_h, stride_w, pad_h, pad_w):
     for run in range(2):
         torch_input = torch.randn(shape, dtype=torch.bfloat16)
 
-        expected = fold_torch(torch_input, stride_h, stride_w, pad_h, pad_w)
+        expected = fold_torch(torch_input, stride_h, stride_w, padding=padding)
         expected = expected.reshape(1, 1, -1, expected.shape[-1])
 
         # Simple sharding: always try for maximum cores for best performance
@@ -432,9 +454,9 @@ def test_fold_sharded(device, act_shape, stride_h, stride_w, pad_h, pad_w):
             ttnn.ROW_MAJOR_LAYOUT,
             tt_memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec),
         )
-        tt_out = ttnn.fold(tt_input, pad_h=pad_h, pad_w=pad_w, stride_h=stride_h, stride_w=stride_w)
+        tt_out = ttnn.fold(tt_input, stride_h=stride_h, stride_w=stride_w, padding=list(padding))
         actual = tt2torch_tensor(tt_out)
 
-        torch.testing.assert_allclose(actual, expected)
+        torch.testing.assert_close(actual, expected)
         tt_input.deallocate()
         tt_out.deallocate()

--- a/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
+++ b/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
@@ -49,8 +49,18 @@ def pad_and_fold_conv_activation_for_unity_stride(activation_pyt_nchw_tensor, pa
     return activation_pyt_padded_folded
 
 
-def fold_torch(input_tensor, stride_h, stride_w):
+def fold_torch(input_tensor, stride_h, stride_w, pad_h=0, pad_w=0, pad_c=0):
     N, H, W, C = input_tensor.shape
+
+    # Apply padding if needed
+    if pad_h != 0 or pad_w != 0 or pad_c != 0:
+        import torch.nn.functional as F
+
+        # For NHWC tensor format, F.pad works from last dim to first:
+        # input_tensor shape is (N, H, W, C), so padding order is:
+        # (pad_c_left, pad_c_right, pad_w_left, pad_w_right, pad_h_top, pad_h_bottom)
+        input_tensor = F.pad(input_tensor, (pad_c, pad_c, pad_w, pad_w, pad_h, pad_h), value=0.0)
+        N, H, W, C = input_tensor.shape
 
     reshaped = input_tensor.reshape(N, H // stride_h, stride_h, W // stride_w, stride_w, C)
     transposed = reshaped.permute(0, 1, 3, 2, 4, 5)
@@ -60,27 +70,38 @@ def fold_torch(input_tensor, stride_h, stride_w):
 @pytest.mark.parametrize("nhw", [(3, 64, 64), (1, 224, 224), (1, 384, 512), (1, 512, 672)])
 @pytest.mark.parametrize("channels", [3, 32, 320])
 @pytest.mark.parametrize("stride", [(16, 16), (32, 32)])
+@pytest.mark.parametrize("pad_h, pad_w", [(0, 0), (8, 8)])
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
-def test_fold_with_permute_for_dram_tensor(device, nhw, channels, stride, input_layout):
+def test_fold_with_permute_for_dram_tensor(device, nhw, channels, stride, pad_h, pad_w, input_layout):
     batch_size, height, width = nhw
     stride_h, stride_w = stride
-    torch_input_tensor = torch.rand((batch_size, channels, height, width), dtype=torch.bfloat16)
+
+    # Skip invalid combinations where padding makes dimensions not divisible by stride
+    padded_h = height + 2 * pad_h
+    padded_w = width + 2 * pad_w
+    if (pad_h > 0 or pad_w > 0) and input_layout == ttnn.TILE_LAYOUT:
+        pytest.skip("Tile layout does not support padding")
+    if padded_h % stride_h != 0 or padded_w % stride_w != 0:
+        pytest.skip(
+            f"Skipping invalid padding combination: padded_h={padded_h}, padded_w={padded_w}, stride_h={stride_h}, stride_w={stride_w}"
+        )
+
+    # torch_input_tensor = torch.rand((batch_size, channels, height, width), dtype=torch.bfloat16)
+    torch_input_tensor = torch.ones((batch_size, channels, height, width), dtype=torch.bfloat16)
     torch_input_tensor_nhwc = torch.permute(torch_input_tensor, (0, 2, 3, 1))
-    torch_output_tensor = torch.reshape(
-        torch_input_tensor_nhwc, (batch_size, height // stride_h, stride_h, width // stride_w, stride_w, channels)
-    )
-    torch_output_tensor = torch.permute(torch_output_tensor, (0, 1, 3, 2, 4, 5))
-    torch_output_tensor = torch.reshape(
-        torch_output_tensor, (batch_size, height // stride_h, width // stride_w, channels * stride_h * stride_w)
-    )
+
+    # Use the fold_torch function which handles padding
+    torch_output_tensor = fold_torch(torch_input_tensor_nhwc, stride_h, stride_w, pad_h, pad_w, 0)
     input_memory_config = ttnn.DRAM_MEMORY_CONFIG
     tt_input_tensor = ttnn.from_torch(
         torch_input_tensor_nhwc, layout=input_layout, device=device, memory_config=input_memory_config
     )
     tt_output_tensor = ttnn.fold(
         tt_input_tensor,
-        stride_h,
-        stride_w,
+        pad_h=pad_h,
+        pad_w=pad_w,
+        stride_h=stride_h,
+        stride_w=stride_w,
     )
     tt_output_tensor = ttnn.to_torch(tt_output_tensor)
     isequal = torch.equal(torch_output_tensor, tt_output_tensor)
@@ -361,21 +382,21 @@ def test_fold(act_shape, stride_h, stride_w, device):
 
 
 @pytest.mark.parametrize(
-    "act_shape,stride_h,stride_w",
+    "act_shape,stride_h,stride_w, pad_h, pad_w",
     [
-        ((8, 224, 14, 8), 16, 1),
-        ((16, 224, 224, 16), 2, 2),
-        ((1, 16, 16, 8), 2, 2),
-        ((4, 64, 64, 24), 2, 2),
-        ((1, 21, 21, 16), 3, 7),
-        ((4, 21, 21, 16), 3, 7),
-        ((16, 42, 42, 64), 6, 6),
-        ((1, 8, 8, 16), 8, 8),
-        ((4, 14, 14, 256), 2, 2),
-        ((1, 33, 33, 16), 3, 11),
+        ((1, 16, 16, 8), 2, 2, 0, 0),
+        ((16, 42, 42, 64), 6, 6, 0, 0),
+        ((1, 16, 16, 8), 2, 2, 2, 2),
+        ((4, 64, 64, 24), 2, 2, 0, 0),
+        ((4, 62, 62, 24), 2, 2, 1, 1),
+        ((4, 14, 14, 256), 2, 2, 1, 1),
+        ((1, 20, 20, 16), 4, 4, 2, 2),
+        ((8, 18, 12, 8), 3, 2, 3, 2),
+        ((2, 30, 30, 32), 5, 5, 0, 0),
+        ((1, 24, 32, 16), 3, 4, 3, 0),
     ],
 )
-def test_fold_sharded(device, act_shape, stride_h, stride_w):
+def test_fold_sharded(device, act_shape, stride_h, stride_w, pad_h, pad_w):
     torch.manual_seed(0)
 
     N, H, W, C = act_shape
@@ -383,7 +404,7 @@ def test_fold_sharded(device, act_shape, stride_h, stride_w):
     for run in range(2):
         torch_input = torch.randn(shape, dtype=torch.bfloat16)
 
-        expected = fold_torch(torch_input, stride_h, stride_w)
+        expected = fold_torch(torch_input, stride_h, stride_w, pad_h, pad_w)
         expected = expected.reshape(1, 1, -1, expected.shape[-1])
 
         # Simple sharding: always try for maximum cores for best performance
@@ -411,7 +432,7 @@ def test_fold_sharded(device, act_shape, stride_h, stride_w):
             ttnn.ROW_MAJOR_LAYOUT,
             tt_memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec),
         )
-        tt_out = ttnn.fold(tt_input, stride_h, stride_w)
+        tt_out = ttnn.fold(tt_input, pad_h=pad_h, pad_w=pad_w, stride_h=stride_h, stride_w=stride_w)
         actual = tt2torch_tensor(tt_out)
 
         torch.testing.assert_allclose(actual, expected)

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1583,6 +1583,7 @@ Tensor fold_input_tensor_if_required(
         in_channels = folding_result.in_channels;
         stride = folding_result.stride;
         kernel_size = folding_result.kernel_size;
+        padding_n4 = folding_result.padding_n4;  // Padding is zero after folding
         mm_conv = folding_result.mm_conv;
         return folded_input_tensor;
     } else {
@@ -1601,9 +1602,6 @@ ttnn::Tensor fold_tensor(
         !tensor.memory_config().is_l1(),
         "Conv2D kernel stride folding: Input tensor must not be in L1 memory for folding");
     TT_FATAL(
-        padding_n4[0] == 0 && padding_n4[1] == 0 && padding_n4[2] == 0 && padding_n4[3] == 0,
-        "Conv2D kernel stride folding: Padding must be 0 for folding");
-    TT_FATAL(
         tensor.dtype() != tt::tt_metal::DataType::BFLOAT8_B,
         "Conv2D kernel stride folding: Currently doesn't support BFLOAT8_B");
     TT_FATAL(
@@ -1617,7 +1615,7 @@ ttnn::Tensor fold_tensor(
     }
 
     // Core folding operation
-    tensor_on_device = ttnn::fold(tensor_on_device, stride[0], stride[1], false, std::nullopt, 0, 0, 0);
+    tensor_on_device = ttnn::fold(tensor_on_device, stride[0], stride[1], false, std::nullopt, 0, padding_n4);
 
     return tensor_on_device;
 }
@@ -1630,23 +1628,36 @@ KernelStrideFoldingResult compute_kernel_stride_folding_params(
     std::array<uint32_t, 2> stride,
     std::array<uint32_t, 4> padding_n4,
     const Conv2dConfig& conv_config) {
-    TT_FATAL(input_height % stride[0] == 0, "Input height must be divisible by stride for kernel stride folding.");
-    TT_FATAL(input_width % stride[1] == 0, "Input width must be divisible by stride for kernel stride folding.");
+    // Calculate padded dimensions first - this is what the folding operation will see
+    uint32_t padded_height = input_height + padding_n4[0] + padding_n4[1];
+    uint32_t padded_width = input_width + padding_n4[2] + padding_n4[3];
 
-    // Update dimensions for folded operation
-    input_height = input_height / stride[0];
-    input_width = input_width / stride[1];
-    in_channels = in_channels * stride[0] * stride[1];
+    TT_FATAL(
+        padded_height % stride[0] == 0,
+        "Padded input height ({}) must be divisible by stride ({}) for kernel stride folding.",
+        padded_height,
+        stride[0]);
+    TT_FATAL(
+        padded_width % stride[1] == 0,
+        "Padded input width ({}) must be divisible by stride ({}) for kernel stride folding.",
+        padded_width,
+        stride[1]);
+
+    // Update dimensions for folded operation based on padded dimensions
+    uint32_t folded_height = padded_height / stride[0];
+    uint32_t folded_width = padded_width / stride[1];
+    uint32_t folded_channels = in_channels * stride[0] * stride[1];
 
     auto kernel_h = tt::div_up(kernel_size[0], stride[0]);
     auto kernel_w = tt::div_up(kernel_size[1], stride[1]);
 
     return KernelStrideFoldingResult{
-        .input_height = input_height,
-        .input_width = input_width,
-        .in_channels = in_channels,
+        .input_height = folded_height,
+        .input_width = folded_width,
+        .in_channels = folded_channels,
         .stride = {1, 1},
         .kernel_size = {kernel_h, kernel_w},
+        .padding_n4 = {0, 0, 0, 0},  // Padding is zero after folding
         .mm_conv = (kernel_size[0] == stride[0] && kernel_size[1] == stride[1])};
 }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -217,6 +217,7 @@ struct KernelStrideFoldingResult {
     uint32_t in_channels;
     std::array<uint32_t, 2> stride;
     std::array<uint32_t, 2> kernel_size;
+    std::array<uint32_t, 4> padding_n4;
     bool mm_conv;
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -30,7 +30,7 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
     auto device = input_tensor.device();
     auto program = tt::tt_metal::CreateProgram();
 
-    const uint32_t input_width = input_tensor.logical_shape()[2];
+    const uint32_t input_width = input_tensor.padded_shape()[2];
 
     // Get compute grid size and buffer pointers
     Buffer* src0_buffer = input_tensor.buffer();

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <array>
+#include <variant>
+
 #include "ttnn/core.hpp"
 #include "ttnn/types.hpp"
 #include "ttnn/run_operation.hpp"
@@ -25,8 +28,7 @@ struct FoldOperation {
         bool use_transpose_as_fold = false,
         const std::optional<const ttnn::Shape>& output_shape = std::nullopt,
         uint32_t pad_c = 0,
-        uint32_t pad_h = 0,
-        uint32_t pad_w = 0,
+        std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding = std::array<uint32_t, 2>{0, 0},
         const std::optional<CoreRangeSet>& core_grid = std::nullopt,
         const std::optional<MemoryConfig>& override_memory_config = std::nullopt);
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold_pybind.cpp
@@ -5,6 +5,8 @@
 #include "ttnn/operations/data_movement/fold/fold.hpp"
 #include "ttnn/operations/data_movement/fold/fold_pybind.hpp"
 
+#include <array>
+#include <variant>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -35,8 +37,7 @@ void bind_fold_operation(py::module& module) {
                bool use_transpose_as_fold,
                std::optional<ttnn::Shape> output_shape,
                uint32_t pad_c,
-               uint32_t pad_h,
-               uint32_t pad_w,
+               std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
                std::optional<CoreRangeSet> grid_size,
                std::optional<MemoryConfig> override_memory_config) -> ttnn::Tensor {
                 return op(
@@ -46,8 +47,7 @@ void bind_fold_operation(py::module& module) {
                     use_transpose_as_fold,
                     output_shape,
                     pad_c,
-                    pad_h,
-                    pad_w,
+                    padding,
                     grid_size,
                     override_memory_config);
             },
@@ -57,8 +57,7 @@ void bind_fold_operation(py::module& module) {
             py::arg("use_transpose_as_fold") = false,
             py::arg("output_shape") = std::nullopt,
             py::arg("pad_c") = 0,
-            py::arg("pad_h") = 0,
-            py::arg("pad_w") = 0,
+            py::arg("padding") = std::array<uint32_t, 2>{0, 0},
             py::arg("grid_size") = std::nullopt,
             py::arg("override_memory_config") = std::nullopt});
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22378

### Problem description
The weights of conv2d operations are often stored in row major layout. When stride > 1 and enable_kernel_stride_fold is used, weight tensors may require padding to align dimensions properly. For example, with stride = (2,2) and kernel = (7,7), the resultant kernel (4,4) needs to be transformed to (8,8) with zero padding on the last height and width dimensions before folding by 2. The existing fold operation lacked support for this zero padding requirement, limiting the usability of kernel stride folding with non-aligned dimensions.

### What's changed
This change adds padding support for row major tensor in the fold operation. Key modifications include:
- Extended the fold operation API to accept padding parameters (pad_h, pad_w, pad_c) for DRAM tensors with row-major layout.
- Add unit test cases for same.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes