### PR TITLE
#0: [skip ci] Fix permissions for mirror fork branch workflow

### DIFF
--- a/.github/workflows/mirror-fork-branch.yaml
+++ b/.github/workflows/mirror-fork-branch.yaml
@@ -26,6 +26,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   mirror-fork-branch:

--- a/.github/workflows/mirror-fork-branch.yaml
+++ b/.github/workflows/mirror-fork-branch.yaml
@@ -24,6 +24,9 @@ on:
           `mirror/<fork_owner>/<branch>`.
         required: false
 
+permissions:
+  contents: write
+
 jobs:
   mirror-fork-branch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Ticket
None

### Problem description
Mirror fork branch workflow missing perms

### What's changed
Add perms:
contents: to create branches
pull-requests: to fix step in the workflow that adds a comment to the external PR

### Checklist
- [x] Rerun of mirror fork job on branch: https://github.com/tenstorrent/tt-metal/actions/runs/15492357418/job/43620687187