### PR TITLE
[skip ci] Update description on TG CYO pipeline

### DIFF
--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -41,11 +41,12 @@ on:
         type: boolean
         default: false
       tg-model-perf:
-        description: "TG model perf tests (requires tracy build)"
+        description: "tg-model-perf (Requires tracy build)"
         required: false
         type: boolean
         default: false
       tg-nightly:
+        description: "tg-nightly (Warning: Long running test! Do not choose this unless there is a specific need. Requires tracy build)"
         required: false
         type: boolean
         default: false


### PR DESCRIPTION
### Ticket


### Problem description
TG queue times are long partially due to people queueing up more CYO tests than necessary.

### What's changed
Add a warning to TG nightly option in CYO pipeline

### Checklist