### PR TITLE
Diagnostic message fix: Buffer size should be divisible by the page size

### DIFF
--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -88,7 +88,7 @@ void validate_buffer_parameters(
         TT_FATAL(
             size % page_size == 0,
             "For valid non-interleaved buffers page size {} must equal buffer size {}. For interleaved-buffers, "
-            "buffer size should be divisble by the page size "
+            "buffer size should be divisble by the page size ",
             page_size,
             size);
     }

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -87,9 +87,8 @@ void validate_buffer_parameters(
     } else {
         TT_FATAL(
             size % page_size == 0,
-            "For valid non-interleaved buffers page size {} must equal buffer size {}. For interleaved-buffers page "
-            "size "
-            "should be divisible by buffer size",
+            "For valid non-interleaved buffers page size {} must equal buffer size {}. For interleaved-buffers, "
+            "buffer size should be divisble by the page size "
             page_size,
             size);
     }

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -88,7 +88,7 @@ void validate_buffer_parameters(
         TT_FATAL(
             size % page_size == 0,
             "For valid non-interleaved buffers page size {} must equal buffer size {}. For interleaved-buffers, "
-            "buffer size should be divisble by the page size ",
+            "buffer size should be divisble by the page size",
             page_size,
             size);
     }


### PR DESCRIPTION
### Ticket
Github issue: https://github.com/tenstorrent/tt-metal/issues/23183

### Problem description
In the following code (inside `buffer.cpp` file), the diagnostic message for invalid page size is incorrect:
```cpp
void validate_buffer_parameters(

    ...

    if (size == 0) {
        return;
    }

    if (buffer_layout == TensorMemoryLayout::SINGLE_BANK) {
        TT_FATAL(page_size == size, "Contiguous buffer must be one contiguous page");
    } else {
        TT_FATAL(
            size % page_size == 0,
            "For valid non-interleaved buffers page size {} must equal buffer size {}. For interleaved-buffers page "
            "size "
            "should be divisible by buffer size",
            page_size,
            size);
    }
}
```

The diagnostic message  **"For interleaved-buffers page size should be divisible by buffer size"** is incorrect as the divisor is `page_size` and dividend is `size` (total buffer size), so the message should be **"For interleaved-buffers buffer size should be divisible by page size"**

### What's changed
Changed the diagnostic message to **"For interleaved-buffers, buffer size should be divisible by the page size"**