### PR TITLE
Adjust minimum stack sizes

### DIFF
--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -124,12 +124,14 @@
 
 /////////////
 // Stack info
-// Increasing the stack size comes at the expense of less local memory for globals
-#define MEM_BRISC_STACK_MIN_SIZE 896
-#define MEM_NCRISC_STACK_MIN_SIZE 1040
-#define MEM_TRISC0_STACK_MIN_SIZE 640
-#define MEM_TRISC1_STACK_MIN_SIZE 512
-#define MEM_TRISC2_STACK_MIN_SIZE 768
+// Stack and globals share the same piece of memory, one grows at the
+// expense of the other.
+#define MEM_BRISC_STACK_MIN_SIZE 256
+#define MEM_NCRISC_STACK_MIN_SIZE 256
+#define MEM_TRISC0_STACK_MIN_SIZE 192
+#define MEM_TRISC1_STACK_MIN_SIZE 192
+#define MEM_TRISC2_STACK_MIN_SIZE 256
+#define MEM_ERISC_STACK_MIN_SIZE 192
 
 #define MEM_SYSENG_RESERVED_SIZE (64 * 1024)
 // This Barrier is not the same as the metal L1 barrier (MEM_L1_BARRIER)
@@ -163,7 +165,6 @@
 #define MEM_ERISC_FIRMWARE_SIZE (24 * 1024)
 #define MEM_SUBORDINATE_ERISC_FIRMWARE_SIZE (24 * 1024)
 #define MEM_ERISC_KERNEL_SIZE (24 * 1024)
-#define MEM_ERISC_STACK_MIN_SIZE 1024
 #define MEM_ERISC_RESERVED1 0
 #define MEM_ERISC_RESERVED1_SIZE 1024
 

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -121,12 +121,14 @@
 
 /////////////
 // Stack info
-// Increasing the stack size comes at the expense of less local memory for globals
-#define MEM_BRISC_STACK_MIN_SIZE 1040
-#define MEM_NCRISC_STACK_MIN_SIZE 1040
-#define MEM_TRISC0_STACK_MIN_SIZE 320
-#define MEM_TRISC1_STACK_MIN_SIZE 256
-#define MEM_TRISC2_STACK_MIN_SIZE 720
+// Stack and globals share the same piece of memory, one grows at the
+// expense of the other.
+#define MEM_BRISC_STACK_MIN_SIZE 256
+#define MEM_NCRISC_STACK_MIN_SIZE 256
+#define MEM_TRISC0_STACK_MIN_SIZE 192
+#define MEM_TRISC1_STACK_MIN_SIZE 192
+#define MEM_TRISC2_STACK_MIN_SIZE 256
+#define MEM_IERISC_STACK_MIN_SIZE 128
 
 /////////////
 // IERISC memory map
@@ -145,11 +147,9 @@
 #define MEM_IERISC_MAP_END (MEM_IERISC_FIRMWARE_BASE + MEM_IERISC_FIRMWARE_SIZE)
 #define MEM_IERISC_KERNEL_SIZE (24 * 1024)
 #define MEM_IERISC_INIT_LOCAL_L1_BASE_SCRATCH MEM_IERISC_MAP_END
-#define MEM_IERISC_STACK_MIN_SIZE 1024
 
 #define MEM_IERISC_BANK_TO_NOC_SCRATCH (MEM_IERISC_INIT_LOCAL_L1_BASE_SCRATCH + MEM_IERISC_LOCAL_SIZE)
 #define MEM_IERISC_BANK_TO_NOC_SIZE (MEM_BANK_TO_NOC_XY_SIZE + MEM_BANK_OFFSET_SIZE)
-
 
 /////////////
 // Padding/alignment restriction needed in linker scripts for erisc


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19983

### Problem description
Now that the stack limit is dynamically determined (by the data size), it's time to reduce the minimum stack sizes.

### What's changed
I measured the stack used with a null kernel on both WH & BH.  Here are the results in `n/m` form -- `n` is the stack used and `m` is the current min stack size (originally just the stack size).  The `-> n` or `-> w:b` shows the new minima.  `n` is the same value for both WH and BH, and `w:b` is the WH and BH respectively, when different.
```
          WH       BH
brisc   112/1040 128/896  -> 256
ncrisc   96/1040  80/1040 -> 256
trisc0  112/320  112/640  -> 192
trisc1   96/256   96/512  -> 192
trisc2  128/720  128/768  -> 256
ierisc   64/1024 112/1024 -> 128:192
```


### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes