### PR TITLE
Mount MLPerf as readonly for vLLM test

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -70,7 +70,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf
+        - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -90,7 +90,7 @@ jobs:
           repository: tenstorrent/vllm
           path: docker-job/vllm
           ref: ${{ inputs.vllm-commit }}
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: 📀 Install vLLM
         run: |


### PR DESCRIPTION
### Ticket
n/a

### Problem description
MLPerf is being mounted without readonly, allowing the CI to change the content

### What's changed
Added :ro flag

### Checklist
- [ ✅ ] [vLLM nightly test](https://github.com/tenstorrent/tt-metal/actions/runs/15490982069)