### PR TITLE
#22045: Parallelize host-side multi device shards using OpenMP parallel for

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,10 @@ add_library(TT::CommonPCH ALIAS metal_common_pch)
 file(GENERATE OUTPUT metal_common_pch.cpp CONTENT "/*dummy pch file*/\n")
 target_sources(metal_common_pch PRIVATE metal_common_pch.cpp)
 
+# TODO: re-enable after figuring out OpenMP version mismatch.
+set(CMAKE_DISABLE_PRECOMPILE_HEADERS ON)
+find_package(OpenMP REQUIRED)
+
 target_precompile_headers(
     metal_common_pch
     PUBLIC

--- a/tests/ttnn/benchmark/cpp/CMakeLists.txt
+++ b/tests/ttnn/benchmark/cpp/CMakeLists.txt
@@ -2,6 +2,7 @@ set(BENCHMARK_SRCS
     "host_tilizer_untilizer/tilizer_untilizer.cpp"
     "padding/pad_rm.cpp"
     "host_alloc_on_tensor_readback.cpp"
+    "multi_device/multi_device_parallel.cpp"
 )
 
 foreach(TEST_SRC ${BENCHMARK_SRCS})
@@ -17,6 +18,7 @@ foreach(TEST_SRC ${BENCHMARK_SRCS})
             test_common_libs
             benchmark::benchmark
             Python3::Python
+            OpenMP::OpenMP_CXX
     )
     target_include_directories(
         ${TEST_TARGET}

--- a/tests/ttnn/benchmark/cpp/multi_device/multi_device_parallel.cpp
+++ b/tests/ttnn/benchmark/cpp/multi_device/multi_device_parallel.cpp
@@ -1,0 +1,57 @@
+// SPDX - FileCopyrightText : © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <benchmark/benchmark.h>
+#include <cstdint>
+#include <random>
+#include <thread>
+#include <vector>
+#include <omp.h>
+
+#include <tt_stl/span.hpp>
+#include <ttnn/tensor/storage.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <ttnn/tensor/host_buffer/functions.hpp>
+#include <tt-metalium/host_buffer.hpp>
+#include "ttnn/distributed/api.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+
+namespace tt::tt_metal {
+namespace {
+
+void BM_parallel_to_layout(benchmark::State& state) {
+    static std::mt19937 gen(42);
+    const int num_shards = state.range(0);
+
+    std::vector<Tensor> tensor_shards;
+    for (int i = 0; i < num_shards; ++i) {
+        ttnn::Shape shape({1, 1, 1024, 1024});
+        std::uniform_real_distribution<float> dist(-100.0f, 100.0f);
+        std::vector<float> input_data;
+        input_data.reserve(shape.volume());
+        for (size_t i = 0; i < shape.volume(); ++i) {
+            input_data.push_back(dist(gen));
+        }
+
+        tensor_shards.push_back(Tensor(HostBuffer{std::move(input_data)}, shape, DataType::FLOAT32, Layout::ROW_MAJOR));
+    }
+
+    auto mult_device_tensor = ttnn::distributed::aggregate_as_tensor(tensor_shards, tt::tt_metal::AllGatherTensor{});
+
+    for (auto _ : state) {
+        auto out = tt::tt_metal::transform(
+            mult_device_tensor,
+            [](const auto& shard) { return shard.to_layout(Layout::TILE); },
+            DeviceShardExecutionPolicy::PARALLEL);
+        benchmark::DoNotOptimize(out);
+        benchmark::ClobberMemory();
+    }
+}
+
+BENCHMARK(BM_parallel_to_layout)->Unit(benchmark::kMillisecond)->Arg(1)->Arg(2)->Arg(4)->Arg(8)->Arg(16)->Arg(32);
+
+}  // namespace
+}  // namespace tt::tt_metal
+
+BENCHMARK_MAIN();

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -96,6 +96,7 @@ target_link_libraries(
         xtensor
         FlatBuffers::FlatBuffers
         Boost::algorithm
+        OpenMP::OpenMP_CXX
 )
 install(TARGETS ttnn_core LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/ttnn/api/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_ops.hpp
@@ -27,8 +27,6 @@ Tensor tensor_to_device(
 
 Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, IDevice* worker);
 
-Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distributed::MeshDevice* mesh_device);
-
 Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, QueueId cq_id);
 
 void tensor_print(const Tensor& input_tensor);

--- a/ttnn/api/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_utils.hpp
@@ -43,12 +43,24 @@ bool is_multi_device_host_tensor(const Tensor& tensor);
 // Returns true if tensor is on device.
 bool is_device_tensor(const Tensor& tensor);
 
+// Specifies execution policy for host-side operations on multi-device host tensors.
+enum class DeviceShardExecutionPolicy {
+    SEQUENTIAL,
+    PARALLEL,
+};
+
 // Given a multi-device host tensor and a function that transforms a tensor, applies the function to all per-device
 // tensors.
-Tensor transform(const Tensor& tensor, const std::function<Tensor(const Tensor&)>& transform_func);
+Tensor transform(
+    const Tensor& tensor,
+    const std::function<Tensor(const Tensor&)>& transform_func,
+    DeviceShardExecutionPolicy policy = DeviceShardExecutionPolicy::PARALLEL);
 
 // Given a multi-device host tensor and a callable, applies the function to all per-device tensors.
-void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& callable);
+void apply(
+    const Tensor& tensor,
+    const std::function<void(const Tensor&)>& callable,
+    DeviceShardExecutionPolicy policy = DeviceShardExecutionPolicy::PARALLEL);
 
 template <class T>
 uint32_t get_batch_size(const T& shape) {

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -159,8 +159,8 @@ private:
         // for each one, copy its value to all other shards along the axes.
         if (!replicate_dims.empty()) {
             for (const auto& [coord, xtensor_view] : sharded_xtensor_views) {
-                const bool replication_source =
-                    std::all_of(replicate_dims.begin(), replicate_dims.end(), [&](size_t replicate_mesh_dim) {
+                const bool replication_source = std::all_of(
+                    replicate_dims.begin(), replicate_dims.end(), [&coord = coord](size_t replicate_mesh_dim) {
                         return coord[replicate_mesh_dim] == 0;
                     });
                 if (xtensor_view.has_value() && replication_source) {
@@ -184,7 +184,7 @@ private:
             tt::tt_metal::DistributedHostBuffer::create(shape_, shape_, MeshCoordinate::zero_coordinate(shape_.dims()));
         for (const auto& [coord, xtensor_view] : sharded_xtensor_views) {
             if (xtensor_view.has_value()) {
-                distributed_buffer.emplace_shard(coord, [&xtensor_view, &shard_spec, &coord]() {
+                distributed_buffer.emplace_shard(coord, [&xtensor_view = xtensor_view, &shard_spec, &coord = coord]() {
                     xt::xarray<T> data(xtensor_view->get());
                     auto shard_tensor = experimental::xtensor::from_xtensor<T>(data, shard_spec);
                     return tt::tt_metal::host_buffer::get_host_buffer(shard_tensor);

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -475,11 +475,14 @@ std::string to_string(
                 const auto& coords = storage.coords;
                 auto coords_it = coords.begin();
                 std::stringstream ss;
-                apply(cpu_tensor, [&](const Tensor& device_shard) {
-                    const distributed::MeshCoordinate coord = *coords_it++;
-                    ss << "device_id: " << mesh_device->get_device(coord)->id() << ", " << coord << std::endl;
-                    ss << to_string<T>(device_shard) << std::endl;
-                });
+                apply(
+                    cpu_tensor,
+                    [&](const Tensor& device_shard) {
+                        const distributed::MeshCoordinate coord = *coords_it++;
+                        ss << "device_id: " << mesh_device->get_device(coord)->id() << ", " << coord << std::endl;
+                        ss << to_string<T>(device_shard) << std::endl;
+                    },
+                    DeviceShardExecutionPolicy::SEQUENTIAL);
                 return ss.str();
             },
             [&](const MultiDeviceHostStorage& storage) -> std::string {

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -80,54 +80,10 @@ Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, QueueId cq_id) {
 }
 
 Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, IDevice* worker) {
-    ZoneScoped;
+    ZoneScopedN("HostToLayout");
     GraphTracker::instance().track_function_start("Tensor::to_layout", input_tensor, target_layout, worker);
     TT_ASSERT(
         input_tensor.storage_type() != StorageType::DEVICE, "Bring tensor to host before converting to target layout");
-    Tensor output = tensor_impl::to_layout_wrapper(input_tensor, target_layout);
-    output = tt::tt_metal::set_tensor_id(output);
-    GraphTracker::instance().track_function_end(output);
-    return output;
-}
-
-Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distributed::MeshDevice* mesh_device) {
-    ZoneScoped;
-    TT_FATAL(
-        is_cpu_tensor(input_tensor) || is_multi_device_host_tensor(input_tensor),
-        "to(layout) must be called on host tensors with MULTI_DEVICE_HOST_STORAGE when multiple "
-        "workers "
-        "are specified");
-
-    GraphTracker::instance().track_function_start("Tensor::to_layout", input_tensor, target_layout, mesh_device);
-    if (mesh_device) {
-        // Mesh Device provided - have a handle to the thread-pool
-        Tensor tensor_modified_layout = std::visit(
-            tt::stl::overloaded{
-                [&](const HostStorage& s) { return tensor_impl::to_layout_wrapper(input_tensor, target_layout); },
-                [&](const MultiDeviceHostStorage& s) {
-                    // TODO: #22045 - Move to `transform` and use OMP parallel for.
-                    std::vector<Tensor> shards(s.num_buffers());
-                    for (std::size_t shard_idx = 0; shard_idx < s.num_buffers(); ++shard_idx) {
-                        // Multi-Thread Host tilization of shards.
-                        mesh_device->enqueue_to_thread_pool([shard_idx, &s, &shards, target_layout, &input_tensor]() {
-                            ZoneScopedN("HostTilize");
-                            Tensor shard(s.get_buffer(shard_idx), input_tensor.get_tensor_spec());
-                            shards[shard_idx] = tensor_impl::to_layout_wrapper(shard, target_layout);
-                        });
-                    }
-                    mesh_device->wait_for_thread_pool();
-                    return ttnn::distributed::aggregate_as_tensor(shards, input_tensor.get_distributed_tensor_config());
-                },
-                [&](const DeviceStorage& s) -> Tensor { TT_THROW("Unexpected storage type"); },
-            },
-            input_tensor.get_storage());
-
-        tensor_modified_layout = tt::tt_metal::set_tensor_id(tensor_modified_layout);
-        GraphTracker::instance().track_function_end(tensor_modified_layout);
-        return tensor_modified_layout;
-    }
-
-    // Running without worker threads (non-async)
     auto output = tensor_impl::to_layout_wrapper(input_tensor, target_layout);
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);


### PR DESCRIPTION
### Ticket
#22045

### Problem description
To avoid exposing Metal's thread pool, OMP parallel for allows to parallelize processing of multi-device shards on host in a generalize way.

### What's changed
Integrate OMP, use it in TTNN's `transform` and `apply` functions.

Added benchmark to confirm parallelization works:
* `N` in `BM_parallel_to_layout/N` refers to the number of device shards being processed. 
* Each tensor shard is hardcoded to 1MB.

With OMP disabled:
```
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
BM_parallel_to_layout/1       0.326 ms        0.326 ms         1819
BM_parallel_to_layout/2        1.05 ms         1.05 ms          656
BM_parallel_to_layout/4        2.42 ms         2.42 ms          293
BM_parallel_to_layout/8        9.52 ms         9.52 ms          105
BM_parallel_to_layout/16       10.2 ms         10.2 ms           69
BM_parallel_to_layout/32       45.8 ms         45.8 ms           13
```

With OMP enabled with 32 threads:
```
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
BM_parallel_to_layout/1       0.443 ms        0.443 ms         1591
BM_parallel_to_layout/2       0.673 ms        0.673 ms         1064
BM_parallel_to_layout/4       0.941 ms        0.940 ms          749
BM_parallel_to_layout/8        1.50 ms         1.50 ms          468
BM_parallel_to_layout/16       1.91 ms         1.91 ms          368
BM_parallel_to_layout/32       2.77 ms         2.77 ms          252
```

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes