### PR TITLE
#23146: Add support for disjointed meshes in control plane

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -26,9 +26,14 @@ class ControlPlaneFixture : public ::testing::Test {
                    "Control plane test suite can only be run with slow dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
                GTEST_SKIP();
            }
+           tt::tt_metal::MetalContext::instance().get_cluster().configure_ethernet_cores_for_fabric_routers(
+               tt::tt_metal::FabricConfig::FABRIC_2D);
        }
 
-       void TearDown() override {}
+       void TearDown() override {
+           tt::tt_metal::MetalContext::instance().get_cluster().configure_ethernet_cores_for_fabric_routers(
+               tt::tt_metal::FabricConfig::DISABLED);
+       }
 };
 
 class BaseFabricFixture : public ::testing::Test {

--- a/tests/tt_metal/tt_fabric/common/t3k_mesh_descriptor_chip_mappings.hpp
+++ b/tests/tt_metal/tt_fabric/common/t3k_mesh_descriptor_chip_mappings.hpp
@@ -58,6 +58,15 @@ static const std::array<std::tuple<std::string, std::vector<std::vector<eth_coor
                 {{0, 2, 1, 0, 0}},
                 {{0, 3, 1, 0, 0}}}}};
 
+static const std::array<std::tuple<std::string, std::vector<std::vector<eth_coord_t>>>, 1>
+    t3k_disjoint_mesh_descriptor_chip_mappings = {
+        std::tuple{
+            "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_disjoint_mesh_graph_descriptor.yaml",
+            std::vector<std::vector<eth_coord_t>>{
+                {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}},
+                {{0, 2, 0, 0, 0}, {0, 3, 0, 0, 0}, {0, 2, 1, 0, 0}, {0, 3, 1, 0, 0}}}},
+};
+
 }  // namespace fabric_router_tests
 
 }  // namespace tt::tt_fabric

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_disjoint_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_disjoint_mesh_graph_descriptor.yaml
@@ -1,0 +1,32 @@
+ChipSpec: {
+  arch: wormhole_b0,
+  ethernet_ports: {
+    N: 2,
+    E: 2,
+    S: 2,
+    W: 2,
+  }
+}
+
+
+Board: [
+  { name: 2x2,
+    type: Mesh,
+    topology: [2, 2]}
+]
+
+Mesh: [
+{
+  id: 0,
+  board: 2x2,
+  topology: [1, 1],
+  host_ranks: [[0]]},
+{
+  id: 1,
+  board: 2x2,
+  topology: [1, 1],
+  host_ranks: [[0]]}
+]
+
+Graph: [
+]

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -118,6 +118,7 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kControlPlaneInit) {
 }
 
 TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
+    std::srand(std::time(nullptr));  // Seed the RNG
     auto [mesh_graph_desc_path, mesh_graph_eth_coords] = GetParam();
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
@@ -125,23 +126,19 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
         t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
     auto& control_plane = global_control_plane->get_local_node_control_plane();
     control_plane.configure_routing_tables_for_fabric_ethernet_channels();
-    // TODO: Query this
-    constexpr uint32_t num_routing_planes = 2;
     for (const auto& src_mesh : control_plane.get_user_physical_mesh_ids()) {
         for (const auto& dst_mesh : control_plane.get_user_physical_mesh_ids()) {
             auto src_mesh_shape = control_plane.get_physical_mesh_shape(src_mesh);
-            auto src_mesh_size = src_mesh_shape[0] * src_mesh_shape[1];
+            auto src_mesh_size = src_mesh_shape.mesh_size();
             auto dst_mesh_shape = control_plane.get_physical_mesh_shape(dst_mesh);
-            auto dst_mesh_size = dst_mesh_shape[0] * dst_mesh_shape[1];
-            auto valid_chans = control_plane.get_valid_eth_chans_on_routing_plane(
-                FabricNodeId(src_mesh, std::rand() % src_mesh_size), std::rand() % num_routing_planes);
-            EXPECT_GT(valid_chans.size(), 0);
-            for (auto chan : valid_chans) {
-                auto path = control_plane.get_fabric_route(
-                    FabricNodeId(src_mesh, std::rand() % src_mesh_size),
-                    FabricNodeId(dst_mesh, std::rand() % dst_mesh_size),
-                    chan);
-                EXPECT_EQ(path.size() > 0, true);
+            auto dst_mesh_size = dst_mesh_shape.mesh_size();
+            auto src_fabric_node_id = FabricNodeId(src_mesh, std::rand() % src_mesh_size);
+            auto active_fabric_eth_channels = control_plane.get_active_fabric_eth_channels(src_fabric_node_id);
+            EXPECT_GT(active_fabric_eth_channels.size(), 0);
+            for (auto [chan, direction] : active_fabric_eth_channels) {
+                auto dst_fabric_node_id = FabricNodeId(dst_mesh, std::rand() % dst_mesh_size);
+                auto path = control_plane.get_fabric_route(src_fabric_node_id, dst_fabric_node_id, chan);
+                EXPECT_EQ(src_fabric_node_id == dst_fabric_node_id ? path.size() == 0 : path.size() > 0, true);
             }
         }
     }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -53,7 +53,7 @@ TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(tg_mesh_graph_desc_path.string());
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();
-    auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 3);
+    auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 1);
     EXPECT_GT(valid_chans.size(), 0);
     for (auto chan : valid_chans) {
         auto path = control_plane->get_fabric_route(FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{4}, 31), chan);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -54,6 +54,7 @@ TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
     auto control_plane = std::make_unique<ControlPlane>(tg_mesh_graph_desc_path.string());
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 3);
+    EXPECT_GT(valid_chans.size(), 0);
     for (auto chan : valid_chans) {
         auto path = control_plane->get_fabric_route(FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{4}, 31), chan);
         EXPECT_EQ(path.size() > 0, true);
@@ -82,11 +83,13 @@ TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
     auto control_plane = std::make_unique<ControlPlane>(t3k_mesh_graph_desc_path.string());
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 0);
+    EXPECT_GT(valid_chans.size(), 0);
     for (auto chan : valid_chans) {
         auto path = control_plane->get_fabric_route(FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 7), chan);
         EXPECT_EQ(path.size() > 0, true);
     }
     valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 1);
+    EXPECT_GT(valid_chans.size(), 0);
     for (auto chan : valid_chans) {
         auto path = control_plane->get_fabric_route(FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 7), chan);
         EXPECT_EQ(path.size() > 0, true);
@@ -132,6 +135,7 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
             auto dst_mesh_size = dst_mesh_shape[0] * dst_mesh_shape[1];
             auto valid_chans = control_plane.get_valid_eth_chans_on_routing_plane(
                 FabricNodeId(src_mesh, std::rand() % src_mesh_size), std::rand() % num_routing_planes);
+            EXPECT_GT(valid_chans.size(), 0);
             for (auto chan : valid_chans) {
                 auto path = control_plane.get_fabric_route(
                     FabricNodeId(src_mesh, std::rand() % src_mesh_size),
@@ -140,6 +144,36 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
                 EXPECT_EQ(path.size() > 0, true);
             }
         }
+    }
+}
+
+TEST_F(ControlPlaneFixture, TestT3kDisjointFabricRoutes) {
+    auto [mesh_graph_desc_path, mesh_graph_eth_coords] = t3k_disjoint_mesh_descriptor_chip_mappings[0];
+    const std::filesystem::path t3k_mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
+    auto global_control_plane = std::make_unique<GlobalControlPlane>(
+        t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
+    auto& control_plane = global_control_plane->get_local_node_control_plane();
+    control_plane.configure_routing_tables_for_fabric_ethernet_channels();
+    auto valid_chans = control_plane.get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 0);
+    EXPECT_GT(valid_chans.size(), 0);
+    for (auto chan : valid_chans) {
+        auto path = control_plane.get_fabric_route(FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 3), chan);
+        EXPECT_EQ(path.size() > 0, true);
+    }
+    valid_chans = control_plane.get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{1}, 0), 0);
+    EXPECT_GT(valid_chans.size(), 0);
+    for (auto chan : valid_chans) {
+        auto path = control_plane.get_fabric_route(FabricNodeId(MeshId{1}, 0), FabricNodeId(MeshId{1}, 3), chan);
+        EXPECT_EQ(path.size() > 0, true);
+    }
+    valid_chans = control_plane.get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 0);
+    EXPECT_GT(valid_chans.size(), 0);
+    for (auto chan : valid_chans) {
+        auto path = control_plane.get_fabric_route(FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{1}, 3), chan);
+        EXPECT_EQ(path.size() == 0, true);
+        auto direction = control_plane.get_forwarding_direction(FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{1}, 3));
+        EXPECT_EQ(direction.has_value(), false);
     }
 }
 

--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -47,7 +47,8 @@ enum class RoutingDirection {
     E = 2,
     S = 4,
     W = 8,
-    C = 16,  // Centre, means that destination is same as source
+    C = 16,     // Centre, means that destination is same as source
+    NONE = 32,  // No direction, means that destination is not reachable
 };
 
 struct RouterEdge {

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -917,10 +917,6 @@ std::optional<RoutingDirection> ControlPlane::get_forwarding_direction(
                 // Intra-mesh routing
                 next_chan_id = this->intra_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_chip_id];
             }
-            if (next_chan_id == eth_chan_magic_values::INVALID_DIRECTION) {
-                // The complete route b/w src and dst not found, probably some eth cores are reserved along the path
-                return std::nullopt;
-            }
             if (src_chan_id != next_chan_id) {
                 continue;
             }

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -195,7 +195,10 @@ void RoutingTableGenerator::generate_intermesh_routing_table(
                 auto& candidate_paths = paths[dst_mesh_id_val];
                 std::uint32_t min_load = std::numeric_limits<std::uint32_t>::max();
                 std::uint32_t min_distance = std::numeric_limits<std::uint32_t>::max();
-                TT_ASSERT(candidate_paths.size() > 0, "Expecting at least one path to target mesh");
+                if (candidate_paths.size() == 0) {
+                    this->inter_mesh_table_[src_mesh_id_val][src_chip_id][dst_mesh_id_val] = RoutingDirection::NONE;
+                    continue;
+                }
                 // TODO: This exit_chip_id doesn't make sense since it is always chip 0
                 chip_id_t exit_chip_id = candidate_paths[0][1].first;
                 MeshId next_mesh_id = candidate_paths[0][1].second;


### PR DESCRIPTION
Fix routing tests (needed to reserve fabric links)

### Ticket
https://github.com/tenstorrent/tt-metal/issues/23146

### Problem description
We want to support having disjointed meshes. We used to assert that there is always at least one path between meshes when generating routing tables.

### What's changed
Add support for disconnected meshes.
Fix routing tests which weren't getting any routes because we weren't reserving eth cores for fabric to always reserve in the fixture and add checks to confirm we had at least one eth chan to use.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15503368330
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes
T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/15500452331
TG Unit: https://github.com/tenstorrent/tt-metal/actions/runs/15503368330