### PR TITLE
 22888: Update the installation instructions for Docker Release images.

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -178,7 +178,7 @@ docker run -it --rm -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstor
 
 - For more information on the Docker Release Images, visit our [Docker registry page](https://github.com/orgs/tenstorrent/packages?q=tt-metalium-ubuntu&tab=packages&q=tt-metalium-ubuntu-22.04-release-amd64).
 
-- Continue to [You Are All Set!](#you-are-all-set)
+- You are all set! Try some [TT-NN Basic Examples](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/usage.html#basic-examples) next.
 
 ---
 
@@ -215,7 +215,7 @@ To try our pre-built models in `models/`, you must:
 
 ### You are All Set!
 
-#### To verify your installation, try executing a programming example:
+#### To verify your installation (for source or wheel installation only), try executing a programming example:
 
 - First, set the following environment variables:
 

--- a/docs/source/ttnn/ttnn/usage.rst
+++ b/docs/source/ttnn/ttnn/usage.rst
@@ -6,7 +6,7 @@ Using TT-NN
 .. note::
    These basic snippets currently work on Grayskull only. We are working on
    updating the API for other architectures, like Wormhole.
-   
+
 .. note::
    If you are using a wheel or a Docker Release Image,
    you will need to install Pytorch for these examples to work.

--- a/docs/source/ttnn/ttnn/usage.rst
+++ b/docs/source/ttnn/ttnn/usage.rst
@@ -6,6 +6,13 @@ Using TT-NN
 .. note::
    These basic snippets currently work on Grayskull only. We are working on
    updating the API for other architectures, like Wormhole.
+   
+.. note::
+   If you are using a wheel or a Docker Release Image,
+   you will need to install Pytorch for these examples to work.
+   ```sh
+   pip install torch
+   ```
 
 Basic Examples
 **************


### PR DESCRIPTION

### Ticket
#22888 

### Problem description
The users are told to use ttnn.examples that are not included as part of the wheel and therefore not available.

### What's changed

Clarify the documentation

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes