### PR TITLE
Fix non-portable LTO issues and reenable LTO.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,7 @@ endif()
 include(compilers)
 CHECK_COMPILERS()
 
-# TODO(afuller): Re-enable this after we sort out compatibility with old tools.
-# include(linking)
+include(linking)
 
 # We're not currently using C++20 modules, so don't bother scanning for them
 set(CMAKE_CXX_SCAN_FOR_MODULES FALSE)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -385,6 +385,12 @@ list(
 # Build the libraries!
 ##################################################
 
+if(TT_LTO_ENABLED)
+    set(TTNN_CPP_BUILD_TYPE STATIC)
+else()
+    set(TTNN_CPP_BUILD_TYPE SHARED)
+endif()
+
 #there are two ways to build TTNN
 # 1) Without Python bindings
 #        ttnncpp will be a dynamic library that can be linked to any project
@@ -395,9 +401,13 @@ list(
 # Most of the use cases will link to ttnn without caring a lot about the backend, but
 # for those who need this second use case, now it is officially supported
 
-add_library(ttnncpp SHARED)
+add_library(ttnncpp ${TTNN_CPP_BUILD_TYPE})
 add_library(TTNN::CPP ALIAS ttnncpp)
 add_library(Metalium::TTNNCPP ALIAS ttnncpp) # backwards compatibility. FIXME: remove
+
+#if(TT_LTO_ENABLED)
+#    set_target_properties(ttnncpp PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+#endif()
 
 target_compile_definitions(ttnncpp PUBLIC "$<$<CXX_COMPILER_ID:GNU>:DISABLE_NAMESPACE_STATIC_ASSERT>")
 target_precompile_headers(ttnncpp REUSE_FROM TT::CommonPCH)
@@ -540,9 +550,14 @@ if(TT_INSTALL)
 endif()
 
 if(WITH_PYTHON_BINDINGS)
-    add_library(ttnn SHARED)
+    add_library(ttnn ${TTNN_CPP_BUILD_TYPE})
     add_library(TTNN::PYTHON ALIAS ttnn)
     add_library(Metalium::TTNN ALIAS ttnn) # backwards compatibility. FIXME: remove
+
+    #if(TT_LTO_ENABLED)
+    #    set_target_properties(ttnn PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+    #endif()
+
     target_compile_definitions(ttnn PUBLIC "$<$<CXX_COMPILER_ID:GNU>:DISABLE_NAMESPACE_STATIC_ASSERT>")
     TT_ENABLE_UNITY_BUILD(ttnn)
 


### PR DESCRIPTION
### Ticket
#23208
LTO Round 2 (Link-time-boogaloo)

### Problem description
I tried making linking fancy and it wasn't portable enough the first time.

### What's changed
* Leave compressed debug sections commented out for now.
* Add checks for mold version.
* Only enable LTO with pure Release builds (no LTO in relwithdebinfo) for now

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes