### PR TITLE
#23029: Remove memory_config() from DeviceStorage

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_morehdot.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_morehdot.cpp
@@ -44,9 +44,7 @@ TEST_F(TestGraphCaptureArgumentsMorehDot, MorehDot) {
     EXPECT_EQ(operation0.arguments.size(), 6);
     EXPECT_EQ(
         operation0.arguments[0],
-        "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_"
-        "type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)),tensor_"
-        "spec=TensorSpec(logical_shape=Shape([1, 1, 1, "
+        "Tensor(storage=DeviceStorage(),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, "
         "32]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile="
         "Tile(tile_shape={32, 32},face_shape={16, "
         "16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type="
@@ -54,9 +52,7 @@ TEST_F(TestGraphCaptureArgumentsMorehDot, MorehDot) {
         "Alignment([32, 32]))))");
     EXPECT_EQ(
         operation0.arguments[1],
-        "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_"
-        "type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)),tensor_"
-        "spec=TensorSpec(logical_shape=Shape([1, 1, 1, "
+        "Tensor(storage=DeviceStorage(),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, "
         "32]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile="
         "Tile(tile_shape={32, 32},face_shape={16, "
         "16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type="
@@ -72,9 +68,7 @@ TEST_F(TestGraphCaptureArgumentsMorehDot, MorehDot) {
     EXPECT_EQ(operation1.arguments.size(), 6);
     EXPECT_EQ(
         operation1.arguments[0],
-        "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_"
-        "type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)),tensor_"
-        "spec=TensorSpec(logical_shape=Shape([1, 1, 1, "
+        "Tensor(storage=DeviceStorage(),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, "
         "32]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile="
         "Tile(tile_shape={32, 32},face_shape={16, "
         "16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type="
@@ -82,9 +76,7 @@ TEST_F(TestGraphCaptureArgumentsMorehDot, MorehDot) {
         "Alignment([32, 32]))))");
     EXPECT_EQ(
         operation1.arguments[1],
-        "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_"
-        "type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)),tensor_"
-        "spec=TensorSpec(logical_shape=Shape([1, 1, 1, "
+        "Tensor(storage=DeviceStorage(),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, "
         "32]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile="
         "Tile(tile_shape={32, 32},face_shape={16, "
         "16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type="

--- a/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_transpose.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_transpose.cpp
@@ -43,9 +43,7 @@ TEST_F(TestGraphCaptureArgumentsTranspose, Transpose) {
     EXPECT_EQ(operation0.arguments.size(), 3);
     EXPECT_EQ(
         operation0.arguments[0],
-        "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_"
-        "type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)),tensor_"
-        "spec=TensorSpec(logical_shape=Shape([1, 1, 2048, "
+        "Tensor(storage=DeviceStorage(),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 2048, "
         "512]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=RowMajorPageConfig("
         "tile=Tile(tile_shape={32, 32},face_shape={16, "
         "16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type="
@@ -59,9 +57,7 @@ TEST_F(TestGraphCaptureArgumentsTranspose, Transpose) {
     EXPECT_EQ(operation1.arguments.size(), 5);
     EXPECT_EQ(
         operation1.arguments[0],
-        "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_"
-        "type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)),tensor_"
-        "spec=TensorSpec(logical_shape=Shape([1, 1, 2048, "
+        "Tensor(storage=DeviceStorage(),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 2048, "
         "512]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=RowMajorPageConfig("
         "tile=Tile(tile_shape={32, 32},face_shape={16, "
         "16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type="

--- a/tests/ttnn/unit_tests/test_graph_capture.py
+++ b/tests/ttnn/unit_tests/test_graph_capture.py
@@ -58,7 +58,7 @@ def test_graph_capture_with_all_parameters(device):
     assert node1[0] == "\x00"
     assert (
         node1[1]
-        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)),tensor_spec=TensorSpec(logical_shape=Shape([1, 2048, 4, 128]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=RowMajorPageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([1]))))"
+        == "Tensor(storage=DeviceStorage(),tensor_spec=TensorSpec(logical_shape=Shape([1, 2048, 4, 128]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=RowMajorPageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([1]))))"
     )
     assert node1[2] == "1"
     assert node1[3] == "2"
@@ -69,7 +69,7 @@ def test_graph_capture_with_all_parameters(device):
     node4 = captured_graph[4]["arguments"]
     assert (
         node4[0]
-        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)),tensor_spec=TensorSpec(logical_shape=Shape([1, 2048, 4, 128]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=RowMajorPageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([1]))))"
+        == "Tensor(storage=DeviceStorage(),tensor_spec=TensorSpec(logical_shape=Shape([1, 2048, 4, 128]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=RowMajorPageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([1]))))"
     )
     assert node4[1] == "SmallVector([0, 2, 1, 3])"
     assert (
@@ -130,11 +130,11 @@ def test_graph_capture_without_memory_config(device):
     node1 = captured_graph[1]["arguments"]
     assert (
         node1[0]
-        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([32, 32]))))"
+        == "Tensor(storage=DeviceStorage(),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([32, 32]))))"
     )
     assert (
         node1[1]
-        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([32, 32]))))"
+        == "Tensor(storage=DeviceStorage(),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([32, 32]))))"
     )
     assert node1[2] == "nullopt"
     assert node1[3] == "DataType::BFLOAT16"
@@ -145,11 +145,11 @@ def test_graph_capture_without_memory_config(device):
     node6 = captured_graph[6]["arguments"]
     assert (
         node6[0]
-        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([32, 32]))))"
+        == "Tensor(storage=DeviceStorage(),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([32, 32]))))"
     )
     assert (
         node6[1]
-        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([32, 32]))))"
+        == "Tensor(storage=DeviceStorage(),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=DataType::BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([32, 32]))))"
     )
     assert node6[2] == "nullopt"
     assert node6[3] == "DataType::BFLOAT16"
@@ -190,7 +190,7 @@ def test_graph_capture_without_dtype(device):
     node1 = captured_graph[1]["arguments"]
     assert (
         node1[0]
-        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)),tensor_spec=TensorSpec(logical_shape=Shape([32, 32]),tensor_layout=TensorLayout(dtype=DataType::INT32,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([32, 32]))))"
+        == "Tensor(storage=DeviceStorage(),tensor_spec=TensorSpec(logical_shape=Shape([32, 32]),tensor_layout=TensorLayout(dtype=DataType::INT32,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([32, 32]))))"
     )
     assert node1[1] == "3"
     assert node1[2] == "nullopt"
@@ -201,7 +201,7 @@ def test_graph_capture_without_dtype(device):
     node4 = captured_graph[4]["arguments"]
     assert (
         node4[0]
-        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)),tensor_spec=TensorSpec(logical_shape=Shape([32, 32]),tensor_layout=TensorLayout(dtype=DataType::INT32,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([32, 32]))))"
+        == "Tensor(storage=DeviceStorage(),tensor_spec=TensorSpec(logical_shape=Shape([32, 32]),tensor_layout=TensorLayout(dtype=DataType::INT32,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([32, 32]))))"
     )
     assert node4[1] == "3"
     assert node4[2] == "nullopt"
@@ -265,10 +265,6 @@ def test_graph_capture_with_all_parameters_json_output(device):
     # arg1
     arg1 = item0["arguments"][1]["arg1"]
     tensor = arg1["Tensor"]
-    mem_config_storage = tensor["storage"]["memory_config"]
-    assert mem_config_storage["memory_layout"] == "TensorMemoryLayout::INTERLEAVED"
-    assert mem_config_storage["buffer_type"] == "BufferType::L1"
-    assert mem_config_storage["shard_spec"] == "std::nullopt"
 
     tspec = tensor["tensor_spec"]
     assert tspec["logical_shape"] == [1, 2048, 4, 128]
@@ -294,13 +290,6 @@ def test_graph_capture_with_all_parameters_json_output(device):
     item1 = data["content"][1]
     assert item1["operation"] == "ttnn::prim::permute"
     assert len(item1["arguments"]) == 5
-
-    arg0_item1 = item1["arguments"][0]["arg0"]
-    mem_config_item1 = arg0_item1["Tensor"]["storage"]["memory_config"]
-    assert mem_config_item1["memory_layout"] == "TensorMemoryLayout::INTERLEAVED"
-    assert mem_config_item1["buffer_type"] == "BufferType::L1"
-    assert mem_config_item1["shard_spec"] == "std::nullopt"
-    assert item1["arguments"][1]["arg1"]["SmallVector"] == [0, 2, 1, 3]
 
     arg2_item1 = item1["arguments"][2]["arg2"]["MemoryConfig"]
     assert arg2_item1["memory_layout"] == "TensorMemoryLayout::INTERLEAVED"
@@ -377,10 +366,6 @@ def test_graph_capture_without_memory_config_json_output(device):
     # arg0
     arg0_item0 = item0["arguments"][0]["arg0"]
     tensor0 = arg0_item0["Tensor"]
-    mem_config_storage0 = tensor0["storage"]["memory_config"]
-    assert mem_config_storage0["memory_layout"] == "TensorMemoryLayout::INTERLEAVED"
-    assert mem_config_storage0["buffer_type"] == "BufferType::DRAM"
-    assert mem_config_storage0["shard_spec"] == "std::nullopt"
 
     tspec0 = tensor0["tensor_spec"]
     assert tspec0["logical_shape"] == [1, 1, 1, 32]
@@ -399,10 +384,6 @@ def test_graph_capture_without_memory_config_json_output(device):
     # arg1
     arg1_item0 = item0["arguments"][1]["arg1"]
     tensor1 = arg1_item0["Tensor"]
-    mem_config_storage1 = tensor1["storage"]["memory_config"]
-    assert mem_config_storage1["memory_layout"] == "TensorMemoryLayout::INTERLEAVED"
-    assert mem_config_storage1["buffer_type"] == "BufferType::DRAM"
-    assert mem_config_storage1["shard_spec"] == "std::nullopt"
 
     tspec1 = tensor1["tensor_spec"]
     assert tspec1["logical_shape"] == [1, 1, 1, 32]
@@ -432,10 +413,6 @@ def test_graph_capture_without_memory_config_json_output(device):
     # arg0
     arg0_item1 = item1["arguments"][0]["arg0"]
     tensor0_item1 = arg0_item1["Tensor"]
-    mem_config_storage0_item1 = tensor0_item1["storage"]["memory_config"]
-    assert mem_config_storage0_item1["memory_layout"] == "TensorMemoryLayout::INTERLEAVED"
-    assert mem_config_storage0_item1["buffer_type"] == "BufferType::DRAM"
-    assert mem_config_storage0_item1["shard_spec"] == "std::nullopt"
 
     tspec0_item1 = tensor0_item1["tensor_spec"]
     assert tspec0_item1["logical_shape"] == [1, 1, 1, 32]
@@ -454,10 +431,6 @@ def test_graph_capture_without_memory_config_json_output(device):
     # arg1
     arg1_item1 = item1["arguments"][1]["arg1"]
     tensor1_item1 = arg1_item1["Tensor"]
-    mem_config_storage1_item1 = tensor1_item1["storage"]["memory_config"]
-    assert mem_config_storage1_item1["memory_layout"] == "TensorMemoryLayout::INTERLEAVED"
-    assert mem_config_storage1_item1["buffer_type"] == "BufferType::DRAM"
-    assert mem_config_storage1_item1["shard_spec"] == "std::nullopt"
 
     tspec1_item1 = tensor1_item1["tensor_spec"]
     assert tspec1_item1["logical_shape"] == [1, 1, 1, 32]
@@ -533,12 +506,6 @@ def test_graph_capture_without_dtype_json_output(device):
     arg0_item0 = item0["arguments"][0]["arg0"]
     tensor0 = arg0_item0["Tensor"]
 
-    # Check storage.memory_config
-    mem_config_storage0 = tensor0["storage"]["memory_config"]
-    assert mem_config_storage0["memory_layout"] == "TensorMemoryLayout::INTERLEAVED"
-    assert mem_config_storage0["buffer_type"] == "BufferType::DRAM"
-    assert mem_config_storage0["shard_spec"] == "std::nullopt"
-
     # Check tensor_spec
     tspec0 = tensor0["tensor_spec"]
     assert tspec0["logical_shape"] == [32, 32]
@@ -570,11 +537,6 @@ def test_graph_capture_without_dtype_json_output(device):
     # arg0: Check the Tensor structure in arg0 for item1
     arg0_item1 = item1["arguments"][0]["arg0"]
     tensor1 = arg0_item1["Tensor"]
-
-    mem_config_storage1 = tensor1["storage"]["memory_config"]
-    assert mem_config_storage1["memory_layout"] == "TensorMemoryLayout::INTERLEAVED"
-    assert mem_config_storage1["buffer_type"] == "BufferType::DRAM"
-    assert mem_config_storage1["shard_spec"] == "std::nullopt"
 
     tspec1 = tensor1["tensor_spec"]
     assert tspec1["logical_shape"] == [32, 32]

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -34,12 +34,11 @@ struct DeviceStorage {
     DeviceStorage(
         std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords_);
 
-    MemoryConfig memory_config() const;
     Buffer* get_buffer() const;
     std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer() const;
 
-    static constexpr auto attribute_names = std::forward_as_tuple("memory_config");
-    auto attribute_values() const { return std::make_tuple(this->memory_config()); }
+    static constexpr auto attribute_names = std::forward_as_tuple();
+    auto attribute_values() const { return std::forward_as_tuple(); }
 
     bool is_allocated() const;
 

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -12,21 +12,6 @@ namespace tt::tt_metal {
 
 DeviceStorage::DeviceStorage(std::shared_ptr<Buffer> buffer_) { buffer = std::move(buffer_); }
 
-MemoryConfig DeviceStorage::memory_config() const {
-    auto* buffer_to_use = get_buffer();
-
-    std::optional<ShardSpec> shard_spec = std::nullopt;
-
-    if (is_sharded(buffer_to_use->buffer_layout())) {
-        shard_spec = buffer_to_use->shard_spec().tensor_shard_spec;
-    }
-    return MemoryConfig{
-        buffer_to_use->buffer_layout(),
-        buffer_to_use->buffer_type(),
-        shard_spec,
-    };
-}
-
 DeviceStorage::DeviceStorage(
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords_) :
     coords(std::move(coords_)), mesh_buffer(std::move(mesh_buffer_)) {}

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.cpp
@@ -118,11 +118,7 @@ tt::stl::hash::hash_t TypecastDeviceOperation::compute_program_hash(
 
     auto program_factory = select_program_factory(args, tensor_args);
     operation::Hash hash = operation::hash_operation<TypecastDeviceOperation>(
-        args,
-        program_factory.index(),
-        input_tensor.dtype(),
-        std::get<DeviceStorage>(input_tensor.storage()).memory_config(),
-        input_shape.volume());
+        args, program_factory.index(), input_tensor.dtype(), input_tensor.memory_config(), input_shape.volume());
 
     return hash;
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -200,9 +200,9 @@ operation::Hash EltwiseBinaryBroadcast::compute_program_hash(const std::vector<T
     return operation::hash_operation<EltwiseBinaryBroadcast>(
         *this,
         parallelization_strategy,
-        std::get<DeviceStorage>(input_tensors.at(0).storage()).memory_config(),
+        input_tensors.at(0).memory_config(),
         input_tensors.at(0).dtype(),
-        std::get<DeviceStorage>(input_tensors.at(1).storage()).memory_config(),
+        input_tensors.at(1).memory_config(),
         input_tensors.at(1).dtype(),
         bcast_scalar,
         this->in_place);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -305,16 +305,16 @@ tt::stl::hash::hash_t BinaryDeviceOperation::compute_program_hash(
             attributes,
             program_factory.index(),
             input_tensor_a.dtype(),
-            std::get<DeviceStorage>(input_tensor_a.storage()).memory_config(),
+            input_tensor_a.memory_config(),
             input_tensor_b->dtype(),
-            std::get<DeviceStorage>(input_tensor_b->storage()).memory_config());
+            input_tensor_b->memory_config());
     }
 
     return operation::hash_operation<BinaryDeviceOperation>(
         attributes,
         program_factory.index(),
         input_tensor_a.dtype(),
-        std::get<DeviceStorage>(input_tensor_a.storage()).memory_config());
+        input_tensor_a.memory_config());
 }
 
 operation::OpPerformanceModelGeneral<BinaryDeviceOperation::tensor_return_value_t> BinaryDeviceOperation::create_op_performance_model(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -423,13 +423,13 @@ tt::stl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
         return operation::hash_operation<BinaryNgDeviceOperation>(
             attributes,
             input_tensor_a.dtype(),
-            std::get<DeviceStorage>(input_tensor_a.storage()).memory_config(),
+            input_tensor_a.memory_config(),
             input_tensor_b->dtype(),
-            std::get<DeviceStorage>(input_tensor_b->storage()).memory_config());
+            input_tensor_b->memory_config());
     }
 
     return operation::hash_operation<BinaryNgDeviceOperation>(
-        attributes, input_tensor_a.dtype(), std::get<DeviceStorage>(input_tensor_a.storage()).memory_config());
+        attributes, input_tensor_a.dtype(), input_tensor_a.memory_config());
 }
 
 bool BinaryNgDeviceOperation::skip_launch(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -162,7 +162,7 @@ tt::stl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
         args,
         program_factory.index(),
         input_tensor.dtype(),
-        std::get<DeviceStorage>(input_tensor.storage()).memory_config(),
+        input_tensor.memory_config(),
         input_shape.volume());
 
     return hash;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.cpp
@@ -111,11 +111,7 @@ tt::stl::hash::hash_t TanhAccurateDeviceOperation::compute_program_hash(
 
     auto program_factory = select_program_factory(args, tensor_args);
     operation::Hash hash = operation::hash_operation<TanhAccurateDeviceOperation>(
-        args,
-        program_factory.index(),
-        input_tensor.dtype(),
-        std::get<DeviceStorage>(input_tensor.storage()).memory_config(),
-        input_shape.volume());
+        args, program_factory.index(), input_tensor.dtype(), input_tensor.memory_config(), input_shape.volume());
 
     return hash;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
@@ -124,7 +124,7 @@ tt::stl::hash::hash_t DropoutDeviceOperation::compute_program_hash(
         args_without_seed,
         program_factory.index(),
         input_tensor.dtype(),
-        std::get<DeviceStorage>(input_tensor.storage()).memory_config(),
+        input_tensor.memory_config(),
         input_shape.volume());
 
     return hash;

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
@@ -121,9 +121,9 @@ operation::Hash AttnMatmulDeviceOperation::compute_program_hash(const std::vecto
         this->transpose_hw,
         this->output_mem_config,
         this->output_dtype,
-        std::get<DeviceStorage>(input_tensors.at(0).storage()).memory_config(),
+        input_tensors.at(0).memory_config(),
         input_tensors.at(0).dtype(),
-        std::get<DeviceStorage>(input_tensors.at(1).storage()).memory_config(),
+        input_tensors.at(1).memory_config(),
         input_tensors.at(1).dtype());
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
@@ -199,12 +199,12 @@ operation::Hash GroupAttnMatmulDeviceOperation::compute_program_hash(const std::
         this->output_mem_config.buffer_type(),
         this->output_dtype,
         this->row_major,
-        std::get<DeviceStorage>(input_tensor_a.storage()).memory_config().memory_layout(),
-        std::get<DeviceStorage>(input_tensor_a.storage()).memory_config().buffer_type(),
+        input_tensor_a.memory_config().memory_layout(),
+        input_tensor_a.memory_config().buffer_type(),
         input_tensor_a.dtype(),
         input_tensor_a.device()->id(),
-        std::get<DeviceStorage>(input_tensor_b.storage()).memory_config().memory_layout(),
-        std::get<DeviceStorage>(input_tensor_b.storage()).memory_config().buffer_type(),
+        input_tensor_b.memory_config().memory_layout(),
+        input_tensor_b.memory_config().buffer_type(),
         input_tensor_b.dtype(),
         input_tensor_b.device()->id());
 }

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.cpp
@@ -125,9 +125,9 @@ tt::stl::hash::hash_t GeluBackwardDeviceOperation::compute_program_hash(
         args,
         program_factory.index(),
         input_tensor.dtype(),
-        std::get<DeviceStorage>(input_tensor.storage()).memory_config(),
+        input_tensor.memory_config(),
         grad_output.dtype(),
-        std::get<DeviceStorage>(grad_output.storage()).memory_config(),
+        grad_output.memory_config(),
         input_shape.volume());
 
     return hash;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -135,8 +135,7 @@ tt::stl::hash::hash_t BatchNormOperation::compute_program_hash(
         tt::stl::get_active_type_name_in_variant(input.get_storage()));
 
     // For input tensor
-    auto base_tuple = std::make_tuple(
-        attributes, input.dtype(), std::get<tt::tt_metal::DeviceStorage>(input.storage()).memory_config());
+    auto base_tuple = std::make_tuple(attributes, input.dtype(), input.memory_config());
 
     // To extract (optional<DataType>, optional<MemoryConfig>) from optional tensors
     auto get_optional_tensor_info = [](const std::optional<const Tensor>& tensor_opt)
@@ -146,9 +145,7 @@ tt::stl::hash::hash_t BatchNormOperation::compute_program_hash(
         }
 
         const auto& tensor = tensor_opt.value();
-        return std::make_tuple(
-            std::optional{tensor.dtype()},
-            std::optional{std::get<tt::tt_metal::DeviceStorage>(tensor.storage()).memory_config()});
+        return std::make_tuple(std::optional{tensor.dtype()}, std::optional{tensor.memory_config()});
     };
 
     auto args_tuple = std::tuple_cat(

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.cpp
@@ -181,12 +181,10 @@ tt::tt_metal::operation::Hash Softmax::compute_program_hash(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
     return tt::tt_metal::operation::hash_operation<Softmax>(
-        std::get<tt::tt_metal::DeviceStorage>(input_tensors.at(0).storage()).memory_config(),
+        input_tensors.at(0).memory_config(),
         input_tensors.at(0).dtype(),
-        optional_input_tensors.at(0).has_value()
-            ? std::optional{std::get<tt::tt_metal::DeviceStorage>(optional_input_tensors.at(0).value().storage())
-                                .memory_config()}
-            : std::nullopt,
+        optional_input_tensors.at(0).has_value() ? std::optional{optional_input_tensors.at(0).value().memory_config()}
+                                                 : std::nullopt,
         optional_input_tensors.at(0).has_value() ? std::optional{optional_input_tensors.at(0).value().dtype()}
                                                  : std::nullopt,
         this->output_mem_config);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23029

### Problem description
Currently calculating a hash of ND sharded tensor fails, because it tries to calculate a hash of DeviceStorage, which in turns calls `memory_config()` method. This is unnecessary, because Tensor already hashes TensorSpec which contains full and correct MemoryConfig, without the need of trying to recover it from Buffer.

### What's changed
Removed `memory_config()` method from DeviceStorage
DeviceStorage hash is now consistent with how we calculate hash of HostStorage and MultiDeviceStorage
Removed all usages of DeviceStorage::memory_config() in favor of just asking the Tensor for its memory config

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/15501362695)
- [x] New/Existing tests provide coverage for changes