### PR TITLE
[skip ci] Use std::forward rather than std::move

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,7 +17,6 @@ Checks: >
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-integer-division,
   -bugprone-macro-parentheses,
-  -bugprone-move-forwarding-reference,
   -bugprone-narrowing-conversions,
   -bugprone-parent-virtual-call,
   -bugprone-reserved-identifier,

--- a/tt_stl/tt_stl/unique_any.hpp
+++ b/tt_stl/tt_stl/unique_any.hpp
@@ -17,7 +17,7 @@ struct unique_any final {
 
     template <typename Type, typename BaseType = std::decay_t<Type>>
     unique_any(Type&& object) :
-        pointer{new(&type_erased_storage) BaseType{std::move(object)}},
+        pointer{new(&type_erased_storage) BaseType{std::forward<Type>(object)}},
         delete_storage{[](storage_t& self) { reinterpret_cast<BaseType*>(&self)->~BaseType(); }},
         move_storage{[](storage_t& self, void* other) -> void* {
             if constexpr (std::is_move_constructible_v<BaseType>) {


### PR DESCRIPTION
### Ticket
Fixes #23222

### Problem description
In certain cases we should be using `std::forward` rather than `std::move`.  More details here: https://clang.llvm.org/extra/clang-tidy/checks/bugprone/move-forwarding-reference.html

### What's changed
* Enabled the check.
* Fixed the diagnosed code.