### PR TITLE
Add Relay interface to dispatch kernels

### DIFF
--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <umd/device/types/arch.h>
 #include "gtest/gtest.h"
 #include "dispatch_fixture.hpp"
 #include "hostdevcommon/common_values.hpp"
@@ -188,5 +189,21 @@ protected:
 class CommandQueueMultiDeviceProgramFixture : public CommandQueueMultiDeviceFixture {};
 
 class CommandQueueMultiDeviceBufferFixture : public CommandQueueMultiDeviceFixture {};
+
+class CommandQueueOnFabricMultiDeviceFixture : public CommandQueueMultiDeviceFixture {
+protected:
+    void SetUp() override {
+        if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
+            GTEST_SKIP() << "Dispatch on Fabric tests only applicable on Wormhole B0";
+        }
+        tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(true);
+        CommandQueueMultiDeviceFixture::SetUp();
+    }
+
+    void TearDown() override {
+        CommandQueueMultiDeviceFixture::TearDown();
+        tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(false);
+    }
+};
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -164,4 +164,20 @@ class MultiCommandQueueMultiDeviceBufferFixture : public MultiCommandQueueMultiD
 
 class MultiCommandQueueMultiDeviceEventFixture : public MultiCommandQueueMultiDeviceFixture {};
 
+class MultiCommandQueueOnFabricMultiDeviceFixture : public MultiCommandQueueMultiDeviceFixture {
+protected:
+    void SetUp() override {
+        if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
+            GTEST_SKIP() << "Dispatch on Fabric tests only applicable on Wormhole B0";
+        }
+        tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(true);
+        MultiCommandQueueMultiDeviceFixture::SetUp();
+    }
+
+    void TearDown() override {
+        MultiCommandQueueMultiDeviceFixture::TearDown();
+        tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(false);
+    }
+};
+
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -622,6 +622,11 @@ int main(int argc, char** argv) {
             0,
             0,
             0,
+            0,
+            0,
+            0,
+            0,
+            0,
             true,  // is_dram_variant
             true,  // is_host_variant
         };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2079,6 +2079,11 @@ void configure_for_single_chip(
         0,
         0,
         0,
+        0,
+        0,
+        0,
+        0,
+        0,
     };
 
     constexpr NOC my_noc_index = NOC::NOC_0;
@@ -2368,6 +2373,11 @@ void configure_for_single_chip(
         0,  // unused for single device - used to "virtualize" the number of eth cores across devices
         0,  // unused for single device - used to "virtualize" the number of eth cores across devices
         0,  // unused for single device - used to "virtualize" the number of eth cores across devices
+        0,
+        0,
+        0,
+        0,
+        0,
         0,
         0,
         0,

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -126,6 +126,7 @@ target_sources(
             api/tt-metalium/circular_buffer_constants.h
             api/tt-metalium/fabric_host_interface.h
             api/tt-metalium/fabric_edm_packet_header.hpp
+            api/tt-metalium/fabric_edm_types.hpp
             core_descriptors/blackhole_140_arch.yaml
             core_descriptors/wormhole_b0_80_arch.yaml
             core_descriptors/wormhole_b0_80_arch_eth_dispatch.yaml
@@ -140,8 +141,11 @@ target_sources(
             fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml
             fabric/hw/inc/fabric_routing_mode.h
             fabric/hw/inc/noc_addr.h
+            fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp
+            fabric/hw/inc/edm_fabric/named_types.hpp
             impl/dispatch/kernels/cq_commands.hpp
             impl/dispatch/kernels/cq_common.hpp
+            impl/dispatch/kernels/cq_relay.hpp
             impl/dispatch/kernels/cq_helpers.hpp
             impl/dispatch/kernels/packet_queue.hpp
             impl/dispatch/kernels/packet_queue_ctrl.hpp

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -56,7 +56,7 @@ static CoreDescriptorSet GetDispatchCores(chip_id_t device_id) {
     const auto& dispatch_core_config =
         tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
-    log_warning(tt::LogAlways, "Dispatch Core Type = {}", dispatch_core_type);
+    log_debug(tt::LogAlways, "Dispatch Core Type = {}", dispatch_core_type);
     for (auto logical_core : tt::get_logical_dispatch_cores(device_id, num_cqs, dispatch_core_config)) {
         dispatch_cores.insert({logical_core, dispatch_core_type});
     }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -870,30 +870,8 @@ void Device::clear_dram_state() {
 
 void Device::compile_command_queue_programs() {
     ZoneScoped;
-    if (this->is_mmio_capable() && !tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
-        auto command_queue_program_ptr = create_and_compile_cq_program(this);
-        this->command_queue_programs_.push_back(std::move(command_queue_program_ptr));
-        // Since devices could be set up in any order, on mmio device do a pass and populate cores for tunnelers.
-        if (tt::tt_metal::MetalContext::instance().get_cluster().get_mmio_device_tunnel_count(this->id_) > 0) {
-            tunnels_from_mmio_ =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(this->id_);
-            for (auto& tunnel : tunnels_from_mmio_) {
-                for (uint32_t tunnel_stop = 0; tunnel_stop < tunnel.size() - 1; tunnel_stop++) {
-                    chip_id_t device_id = tunnel[tunnel_stop];
-                    chip_id_t ds_device_id = tunnel[tunnel_stop + 1];
-                    uint16_t channel =
-                        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(
-                            ds_device_id);
-                    // Only one tunneler per connection, use CQ ID 0
-                    MetalContext::instance().get_dispatch_core_manager().tunneler_core(
-                        device_id, ds_device_id, channel, 0);
-                }
-            }
-        }
-    } else {
-        auto command_queue_program_ptr = create_and_compile_cq_program(this);
-        this->command_queue_programs_.push_back(std::move(command_queue_program_ptr));
-    }
+    auto command_queue_program_ptr = create_and_compile_cq_program(this);
+    this->command_queue_programs_.push_back(std::move(command_queue_program_ptr));
 }
 
 // Writes issue and completion queue pointers to device and in sysmem and loads fast dispatch program onto dispatch cores

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -185,8 +185,7 @@ std::tuple<chip_id_t, CoreCoord> Device::get_connected_ethernet_core(CoreCoord e
 }
 
 std::vector<CoreCoord> Device::get_ethernet_sockets(chip_id_t connected_chip_id) const {
-    if (tt::tt_metal::MetalContext::instance().get_fabric_config() !=
-        tt::tt_metal::FabricConfig::DISABLED) {
+    if (tt::tt_metal::MetalContext::instance().get_fabric_config() != tt::tt_metal::FabricConfig::DISABLED) {
         return tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_routers_between_src_and_dest(
             this->id_, connected_chip_id);
     } else {

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -8,11 +8,13 @@
 #include <sched.h>
 #include <tracy/Tracy.hpp>
 #include <tt_metal.hpp>
+#include <umd/device/types/arch.h>
 #include <unistd.h>  // Warning Linux Only, needed for _SC_NPROCESSORS_ONLN
 #include <algorithm>
 #include <cstdlib>
 #include <future>
 #include <set>
+#include <unordered_map>
 #include <utility>
 
 #include "assert.hpp"
@@ -278,7 +280,62 @@ void DevicePool::initialize(
     // Need to reserve eth cores for fabric before we initialize individual devices to maintain consistent state
     // while initializing default sub device state.
     // This call will be a no-op if fabric is disabled.
+    // May be called again below
     tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+
+    // Try to enable FD on Fabric if dispatching to remote devices. Fabric can only be enabled if all devices are open.
+    // If not, then fallback to tunneling.
+    // First check if all devices are enabled and if there any any remote devices. Then set the appropriate mode.
+    std::unordered_set<chip_id_t> device_ids_set{device_ids.begin(), device_ids.end()};
+    bool all_devices_open = true;
+    bool any_remote_devices = false;
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
+        for (int dev_id = 0; dev_id < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices();
+             ++dev_id) {
+            if (!device_ids_set.contains(dev_id)) {
+                all_devices_open = false;
+                break;
+            }
+            any_remote_devices =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev_id) != dev_id;
+        }
+
+        const auto fallback_to_tunneling = [&]() {
+            tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(false);
+            // Need to reinitialize because FD Fabric setting has changed
+            tt::tt_metal::MetalContext::instance().initialize(
+                dispatch_core_config, num_hw_cqs, {l1_bank_remap.begin(), l1_bank_remap.end()});
+        };
+
+        if (all_devices_open && any_remote_devices) {
+            FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+            if (tt::tt_fabric::is_2d_fabric_config(fabric_config) || hal::get_arch() == tt::ARCH::BLACKHOLE) {
+                // 2D Fabric config or Blackhole
+                fallback_to_tunneling();
+                log_debug(
+                    tt::LogMetal, "Cannot launch Dispatch on Fabric on unsupported configuration. Using tunneling.");
+            } else if (fabric_config == FabricConfig::DISABLED) {
+                tt::tt_metal::detail::SetFabricConfig(
+                    FabricConfig::FABRIC_1D, tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
+                // Previously disabled. Need to init
+                if (fabric_config == FabricConfig::DISABLED) {
+                    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+                }
+                fabric_config = FabricConfig::FABRIC_1D;
+                log_info(tt::LogMetal, "Dispatch on 1D Fabric");
+            } else {
+                // Use the same 1D mode
+                tt::tt_metal::detail::SetFabricConfig(
+                    fabric_config, tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
+                log_info(tt::LogMetal, "Dispatch on 1D Fabric");
+            }
+        } else {
+            fallback_to_tunneling();
+            log_debug(
+                tt::LogMetal,
+                "Cannot launch Dispatch on Fabric without all physical devices activated. Using tunneling.");
+        }
+    }
 
     _inst->skip_remote_devices = skip;
     _inst->use_max_eth_core_count_on_all_devices_ = use_max_eth_core_count_on_all_devices;
@@ -509,7 +566,9 @@ std::size_t DevicePool::get_max_num_eth_cores_across_all_devices() const {
 }
 
 void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
+    this->using_fast_dispatch = (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr);
     std::set<chip_id_t> devices_to_activate;
+
     if (this->skip_remote_devices) {
         for (const auto& device_id : device_ids) {
             const auto& mmio_device_id =
@@ -536,8 +595,8 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
         }
     }
 
-    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     // Only can launch Fabric if all devices are active
+    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (tt_fabric::is_tt_fabric_config(fabric_config)) {
         for (int i = 0; i < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices(); i++) {
             if (not _inst->is_device_active(i)) {
@@ -547,7 +606,6 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
         }
     }
 
-    this->using_fast_dispatch = (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr);
     if (this->using_fast_dispatch) {
         populate_fd_kernels(devices_to_activate, this->num_hw_cqs);
     }
@@ -845,6 +903,10 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
     for (const auto& dev_id : devices_to_close) {
         auto dev = tt::DevicePool::instance().get_active_device(dev_id);
         pass &= dev->close();
+    }
+
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
+        tt::tt_metal::detail::SetFabricConfig(FabricConfig::DISABLED);
     }
 
     return pass;

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -102,4 +102,12 @@ inline uint32_t get_cq_completion_rd_ptr(chip_id_t chip_id, uint8_t cq_id, uint3
 template uint32_t get_cq_completion_rd_ptr<true>(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
 template uint32_t get_cq_completion_rd_ptr<false>(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
 
+uint32_t calculate_expected_workers_to_finish(const tt::tt_metal::IDevice* device, const SubDeviceId& sub_device_id, tt::tt_metal::HalProgrammableCoreType core_type) {
+    // Sub Device manager state must be correct (from device init)
+    // If core type is active ethernet, it does not include fabric routers which were created using slow dispatch
+    // Not managed by fast dispatch
+    const auto num_workers = device->num_worker_cores(core_type, sub_device_id);
+    return num_workers;
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/command_queue_common.hpp
@@ -7,6 +7,8 @@
 #include <stdint.h>
 
 #include <umd/device/types/cluster_descriptor_types.h>
+#include "device.hpp"
+#include "sub_device_types.hpp"
 
 namespace tt::tt_metal {
 
@@ -68,5 +70,8 @@ uint32_t get_cq_completion_wr_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_
 
 template <bool addr_16B>
 uint32_t get_cq_completion_rd_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size);
+
+// Return the expected number of workers to be in the finished state
+uint32_t calculate_expected_workers_to_finish(const tt::tt_metal::IDevice* device, const SubDeviceId& sub_device_id, tt::tt_metal::HalProgrammableCoreType core_type);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -140,10 +140,10 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
             device_cq_addr_sizes_[dev_addr_idx] = settings.dispatch_s_sync_sem_;
         } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_HEADER_RB) {
             // At this point fabric context is not initialized yet
-            // Hardcode to 64B (more than enough space) for now
+            // Hardcode to 128B (more than enough space) for now
             // const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
             // const auto& fabric_context = control_plane.get_fabric_context();
-            device_cq_addr_sizes_[dev_addr_idx] = tt::tt_metal::DispatchSettings::FABRIC_HEADER_RB_ENTRIES * 64;
+            device_cq_addr_sizes_[dev_addr_idx] = tt::tt_metal::DispatchSettings::FABRIC_HEADER_RB_ENTRIES * 128;
         } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_SYNC_STATUS) {
             device_cq_addr_sizes_[dev_addr_idx] = sizeof(uint32_t);
         } else {

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -120,10 +120,10 @@ void EnqueueProgramCommand::process() {
     // Compute the total number of workers this program uses
     uint32_t num_workers = 0;
     if (program.runs_on_noc_multicast_only_cores()) {
-        num_workers += device->num_worker_cores(HalProgrammableCoreType::TENSIX, this->sub_device_id);
+        num_workers += calculate_expected_workers_to_finish(device, sub_device_id, HalProgrammableCoreType::TENSIX);
     }
     if (program.runs_on_noc_unicast_only_cores()) {
-        num_workers += device->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, this->sub_device_id);
+        num_workers += calculate_expected_workers_to_finish(device, sub_device_id, HalProgrammableCoreType::ACTIVE_ETH);
     }
     // Reserve space for this program in the kernel config ring buffer
     program_dispatch::reserve_space_in_kernel_config_buffer(

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -209,8 +209,7 @@ void DispatchKernel::GenerateStaticConfigs() {
         TT_FATAL(false, "DispatchKernel must be one of (or both) H and D variants");
     }
 
-    if ((static_config_.is_h_variant.value() ^ static_config_.is_d_variant.value()) &&
-        tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
+    if (!is_hd() && tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
         create_edm_connection_sems(edm_connection_attributes_);
     }
 }
@@ -517,6 +516,9 @@ void DispatchKernel::CreateKernel() {
         {"DOWNSTREAM_SUBORDINATE_NOC_X", std::to_string(downstream_s_virtual_noc_coords.x)},
         {"DOWNSTREAM_SUBORDINATE_NOC_Y", std::to_string(downstream_s_virtual_noc_coords.y)},
     };
+    if (!is_hd() && tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
+        defines["FABRIC_RELAY"] = "1";
+    }
     // Compile at Os on IERISC to fit in code region.
     auto optimization_level = (GetCoreType() == CoreType::WORKER) ? KernelBuildOptLevel::O2 : KernelBuildOptLevel::Os;
     configure_kernel_variant(

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -211,6 +211,11 @@ void DispatchKernel::GenerateStaticConfigs() {
 
     if (!is_hd() && tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
         create_edm_connection_sems(edm_connection_attributes_);
+        static_config_.is_2d_fabric =
+            tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context().get_fabric_topology() ==
+            tt_fabric::Topology::Mesh;
+    } else {
+        static_config_.is_2d_fabric = false;
     }
 }
 
@@ -273,6 +278,7 @@ void DispatchKernel::GenerateDependentConfigs() {
                 dispatch_d->GetStaticConfig().my_downstream_cb_sem_id.value();
             dependent_config_.upstream_sync_sem = 0;  // Unused
             dependent_config_.num_hops = tt::tt_metal::get_num_hops(device_id_, dispatch_d->GetDeviceId());
+            assemble_2d_fabric_packet_header_args(this->dependent_config_, GetDeviceId(), dispatch_d->GetDeviceId());
         } else {
             TT_FATAL(false, "Unimplemented path");
         }
@@ -376,6 +382,8 @@ void DispatchKernel::GenerateDependentConfigs() {
                 dependent_config_.downstream_cb_sem_id =
                     dispatch_h_kernel->GetStaticConfig().my_dispatch_cb_sem_id.value();
                 dependent_config_.num_hops = tt::tt_metal::get_num_hops(dispatch_h_kernel->GetDeviceId(), device_id_);
+                assemble_2d_fabric_packet_header_args(
+                    this->dependent_config_, GetDeviceId(), dispatch_h_kernel->GetDeviceId());
                 found_dispatch_h = true;
             } else if (auto relay_mux = dynamic_cast<tt::tt_metal::RelayMux*>(ds_kernel)) {
                 TT_ASSERT(!found_relay_mux, "DISPATCH_D has multiple downstream RELAY_MUX kernels.");
@@ -486,6 +494,12 @@ void DispatchKernel::CreateKernel() {
 
         dependent_config_.num_hops.value(),
 
+        dependent_config_.my_dev_id.value_or(0),
+        dependent_config_.ew_dim.value_or(0),
+        dependent_config_.to_mesh_id.value_or(0),
+        dependent_config_.to_dev_id.value_or(0),
+        dependent_config_.router_direction.value_or(0),
+
         static_config_.is_d_variant.value(),
         static_config_.is_h_variant.value(),
     };
@@ -518,6 +532,9 @@ void DispatchKernel::CreateKernel() {
     };
     if (!is_hd() && tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
         defines["FABRIC_RELAY"] = "1";
+        if (static_config_.is_2d_fabric.value_or(false)) {
+            defines["FABRIC_2D"] = "1";
+        }
     }
     // Compile at Os on IERISC to fit in code region.
     auto optimization_level = (GetCoreType() == CoreType::WORKER) ? KernelBuildOptLevel::O2 : KernelBuildOptLevel::Os;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -51,6 +51,7 @@ struct dispatch_static_config_t {
     std::optional<uint32_t> fabric_header_rb_base;
     std::optional<uint32_t> fabric_header_rb_entries;
     std::optional<uint32_t> my_fabric_sync_status_addr;
+    std::optional<bool> is_2d_fabric;
 
     std::optional<bool> is_d_variant;
     std::optional<bool> is_h_variant;
@@ -76,6 +77,12 @@ struct dispatch_dependent_config_t {
     std::optional<uint32_t> num_hops;
 
     tt::tt_metal::relay_mux_client_config fabric_mux_client_config;
+
+    std::optional<uint32_t> my_dev_id;
+    std::optional<uint32_t> ew_dim;
+    std::optional<uint32_t> to_mesh_id;
+    std::optional<uint32_t> to_dev_id;
+    std::optional<uint32_t> router_direction;
 };
 
 class DispatchKernel : public FDKernel {

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -129,6 +129,8 @@ private:
     dispatch_static_config_t static_config_;
     dispatch_dependent_config_t dependent_config_;
     FDKernelEdmConnectionAttributes edm_connection_attributes_;
+
+    bool is_hd() const { return static_config_.is_h_variant.value() && static_config_.is_d_variant.value(); }
 };
 
 }  // namespace tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -167,9 +167,9 @@ KernelHandle FDKernel::configure_kernel_variant(
     if (rt_options.watcher_dispatch_disabled()) {
         defines["FORCE_WATCHER_OFF"] = "1";
     }
-    if (!DPrintServerReadsDispatchCores(device_->id())) {
-        defines["FORCE_DPRINT_OFF"] = "1";
-    }
+    // if (!DPrintServerReadsDispatchCores(device_->id())) {
+    //     defines["FORCE_DPRINT_OFF"] = "1";
+    // }
     defines.insert(defines_in.begin(), defines_in.end());
 
     if (GetCoreType() == CoreType::WORKER) {

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -167,9 +167,9 @@ KernelHandle FDKernel::configure_kernel_variant(
     if (rt_options.watcher_dispatch_disabled()) {
         defines["FORCE_WATCHER_OFF"] = "1";
     }
-    // if (!DPrintServerReadsDispatchCores(device_->id())) {
-    //     defines["FORCE_DPRINT_OFF"] = "1";
-    // }
+    if (!DPrintServerReadsDispatchCores(device_->id())) {
+        defines["FORCE_DPRINT_OFF"] = "1";
+    }
     defines.insert(defines_in.begin(), defines_in.end());
 
     if (GetCoreType() == CoreType::WORKER) {

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -22,6 +22,7 @@
 #include "dispatch_core_common.hpp"
 #include "dispatch_s.hpp"
 #include "eth_router.hpp"
+#include "fabric_edm_types.hpp"
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
@@ -219,6 +220,11 @@ void PrefetchKernel::GenerateStaticConfigs() {
 
     if (!is_hd() && tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
         create_edm_connection_sems(edm_connection_attributes_);
+        static_config_.is_2d_fabric =
+            tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context().get_fabric_topology() ==
+            tt_fabric::Topology::Mesh;
+    } else {
+        static_config_.is_2d_fabric = false;
     }
 }
 
@@ -316,6 +322,8 @@ void PrefetchKernel::GenerateDependentConfigs() {
                 dependent_config_.downstream_cb_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
                 dependent_config_.downstream_cb_pages = prefetch_d->GetStaticConfig().cmddat_q_pages.value();
                 dependent_config_.num_hops = tt::tt_metal::get_num_hops(device_id_, prefetch_d->GetDeviceId());
+                assemble_2d_fabric_packet_header_args(
+                    this->dependent_config_, GetDeviceId(), prefetch_d->GetDeviceId());
             } else if (auto fabric_mux = dynamic_cast<tt::tt_metal::RelayMux*>(ds_kernel)) {
                 constexpr tt::tt_fabric::FabricMuxChannelType ch_type =
                     tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
@@ -340,6 +348,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
             dependent_config_.upstream_logical_core = prefetch_h->GetLogicalCore();
             dependent_config_.upstream_cb_sem_id = prefetch_h->GetStaticConfig().my_downstream_cb_sem_id.value();
             dependent_config_.num_hops = tt::tt_metal::get_num_hops(prefetch_h->GetDeviceId(), device_id_);
+            assemble_2d_fabric_packet_header_args(this->dependent_config_, GetDeviceId(), prefetch_h->GetDeviceId());
         } else {
             TT_FATAL(false, "Path not implemented");
         }
@@ -451,6 +460,12 @@ void PrefetchKernel::CreateKernel() {
 
         dependent_config_.num_hops.value(),
 
+        dependent_config_.my_dev_id.value_or(0),
+        dependent_config_.ew_dim.value_or(0),
+        dependent_config_.to_mesh_id.value_or(0),
+        dependent_config_.to_dev_id.value_or(0),
+        dependent_config_.router_direction.value_or(0),
+
         static_config_.is_d_variant.value(),
         static_config_.is_h_variant.value(),
     };
@@ -484,6 +499,9 @@ void PrefetchKernel::CreateKernel() {
 
     if (!is_hd() && tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
         defines["FABRIC_RELAY"] = "1";
+        if (static_config_.is_2d_fabric.value_or(false)) {
+            defines["FABRIC_2D"] = "1";
+        }
     }
     // Compile at Os on IERISC to fit in code region.
     auto optimization_level = (GetCoreType() == CoreType::WORKER) ? KernelBuildOptLevel::O2 : KernelBuildOptLevel::Os;

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -217,8 +217,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
         ringbuffer_size,
         l1_size);
 
-    if ((static_config_.is_h_variant.value() ^ static_config_.is_d_variant.value()) &&
-        tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
+    if (!is_hd() && tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
         create_edm_connection_sems(edm_connection_attributes_);
     }
 }
@@ -482,6 +481,10 @@ void PrefetchKernel::CreateKernel() {
         {"DOWNSTREAM_SUBORDINATE_NOC_X", std::to_string(downstream_s_virtual_noc_coords.x)},
         {"DOWNSTREAM_SUBORDINATE_NOC_Y", std::to_string(downstream_s_virtual_noc_coords.y)},
     };
+
+    if (!is_hd() && tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
+        defines["FABRIC_RELAY"] = "1";
+    }
     // Compile at Os on IERISC to fit in code region.
     auto optimization_level = (GetCoreType() == CoreType::WORKER) ? KernelBuildOptLevel::O2 : KernelBuildOptLevel::Os;
     configure_kernel_variant(

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -119,6 +119,8 @@ private:
     prefetch_static_config_t static_config_;
     prefetch_dependent_config_t dependent_config_;
     FDKernelEdmConnectionAttributes edm_connection_attributes_;
+
+    bool is_hd() const { return static_config_.is_h_variant.value() && static_config_.is_d_variant.value(); }
 };
 
 }  // namespace tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -53,6 +53,8 @@ struct prefetch_static_config_t {
     std::optional<uint32_t> fabric_header_rb_entries;
     std::optional<uint32_t> my_fabric_sync_status_addr;
 
+    std::optional<bool> is_2d_fabric;
+
     std::optional<bool> is_d_variant;
     std::optional<bool> is_h_variant;
 };
@@ -74,6 +76,12 @@ struct prefetch_dependent_config_t {
     std::optional<uint32_t> num_hops;
 
     tt::tt_metal::relay_mux_client_config fabric_mux_client_config;
+
+    std::optional<uint32_t> my_dev_id;
+    std::optional<uint32_t> ew_dim;
+    std::optional<uint32_t> to_mesh_id;
+    std::optional<uint32_t> to_dev_id;
+    std::optional<uint32_t> router_direction;
 };
 
 class PrefetchKernel : public FDKernel {

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
@@ -74,7 +74,7 @@ void RelayMux::GenerateStaticConfigs() {
         mux_config_core);
     mux_ct_args_ = mux_kernel_config_->get_fabric_mux_compile_time_args();
 
-    log_debug(
+    log_info(
         tt::LogMetal,
         "RelayMux Device:{}, HeaderCh:{}, FullCh:{}, FullB:{}, Logical:{}, Virtual: {}, D2H: {}",
         device_->id(),

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
@@ -74,7 +74,7 @@ void RelayMux::GenerateStaticConfigs() {
         mux_config_core);
     mux_ct_args_ = mux_kernel_config_->get_fabric_mux_compile_time_args();
 
-    log_info(
+    log_debug(
         tt::LogMetal,
         "RelayMux Device:{}, HeaderCh:{}, FullCh:{}, FullB:{}, Logical:{}, Virtual: {}, D2H: {}",
         device_->id(),

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.hpp
@@ -128,8 +128,9 @@ void assemble_2d_fabric_packet_header_args(Configuration& config, int my_device_
     config.to_dev_id = dst_fabric_node_id.chip_id;
     config.router_direction = router_direction;
 
-    log_info(
-        "Src {} -> Dst {}: Src Chip {}, Mesh Shape {}, Dst Mesh Id {}, Dst Chip Id {} Router Direction {}",
+    log_debug(
+        "assemble_2d_fabric_packet_header_args: Src {} -> Dst {}: Src Chip {}, Mesh Shape {}, Dst Mesh Id {}, Dst Chip "
+        "Id {} Router Direction {}",
         my_device_id,
         destination_device_id,
         src_fabric_node_id.chip_id,

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.hpp
@@ -127,17 +127,6 @@ void assemble_2d_fabric_packet_header_args(Configuration& config, int my_device_
     config.to_mesh_id = dst_fabric_node_id.mesh_id.get();
     config.to_dev_id = dst_fabric_node_id.chip_id;
     config.router_direction = router_direction;
-
-    log_debug(
-        "assemble_2d_fabric_packet_header_args: Src {} -> Dst {}: Src Chip {}, Mesh Shape {}, Dst Mesh Id {}, Dst Chip "
-        "Id {} Router Direction {}",
-        my_device_id,
-        destination_device_id,
-        src_fabric_node_id.chip_id,
-        mesh_shape[1],
-        dst_fabric_node_id.mesh_id.get(),
-        dst_fabric_node_id.chip_id,
-        router_direction);
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -431,13 +431,13 @@ FORCE_INLINE void cb_block_release_pages(uint32_t& block_noc_writes_to_clear, ui
     block_noc_writes_to_clear = noc_nonposted_writes_num_issued[noc];
 }
 
-template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id, uint32_t cb_pages_per_block, uint32_t num_hops, typename T>
+template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id, uint32_t cb_pages_per_block, typename T>
 FORCE_INLINE void cb_block_release_pages_remote(
     T& relay_client, uint32_t& block_noc_writes_to_clear, uint8_t noc = noc_index) {
     if (cb_block_released_prev_block) {
         WAYPOINT("CBRW");
         while (!wrap_ge(NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT), block_noc_writes_to_clear));
-        relay_client.template release_pages<noc_idx, noc_xy, sem_id, num_hops>(cb_pages_per_block);
+        relay_client.template release_pages<noc_idx, noc_xy, sem_id>(cb_pages_per_block);
         WAYPOINT("CBRD");
     } else {
         cb_block_released_prev_block = true;
@@ -465,11 +465,10 @@ template <
     uint32_t sem_id,
     uint32_t cb_pages_per_block,
     uint32_t cb_blocks,
-    uint32_t num_hops,
     typename T>
 FORCE_INLINE void move_rd_to_next_block_and_release_pages_remote(
     T& relay_client, uint32_t& block_noc_writes_to_clear, uint32_t& rd_block_idx, uint8_t noc = noc_index) {
-    cb_block_release_pages_remote<noc_idx, noc_xy, sem_id, cb_pages_per_block, num_hops>(
+    cb_block_release_pages_remote<noc_idx, noc_xy, sem_id, cb_pages_per_block>(
         relay_client, block_noc_writes_to_clear, noc);
     move_rd_to_next_block<cb_blocks>(rd_block_idx);
 }
@@ -522,7 +521,6 @@ template <
     uint32_t upstream_noc_xy,
     uint32_t upstream_cb_sem,
     uint32_t cb_pages_per_block,
-    uint32_t num_hops,
     typename T>
 FORCE_INLINE uint32_t get_cb_page_and_release_pages_remote(
     T& relay_client,
@@ -544,8 +542,7 @@ FORCE_INLINE uint32_t get_cb_page_and_release_pages_remote(
             upstream_noc_xy,
             upstream_cb_sem,
             cb_pages_per_block,
-            cb_blocks,
-            num_hops>(relay_client, block_noc_writes_to_clear, rd_block_idx, noc);
+            cb_blocks>(relay_client, block_noc_writes_to_clear, rd_block_idx, noc);
     }
 
     // Wait for dispatcher to supply a page

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -229,6 +229,14 @@ FORCE_INLINE void cq_noc_async_write_init_state(
 template <enum CQNocInlineFlags flags, enum CQNocWait wait = CQ_NOC_WAIT, enum CQNocSend send = CQ_NOC_SEND>
 FORCE_INLINE void cq_noc_inline_dw_write_with_state(
     uint64_t dst_addr, uint32_t val = 0, uint8_t be = 0xF, uint8_t noc = noc_index) {
+#if defined(ARCH_BLACKHOLE)
+    uint32_t inline_l1_src_addr = noc_get_interim_inline_value_addr(noc, dst_addr);
+    volatile tt_l1_ptr uint32_t* inline_l1_src_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inline_l1_src_addr);
+    *inline_l1_src_addr_ptr = val;
+    cq_noc_async_write_with_state<CQ_NOC_SnDL, CQ_NOC_WAIT, CQ_NOC_SEND, NCRISC_WR_REG_CMD_BUF>(
+        inline_l1_src_addr, dst_addr, 4);
+#else
     if constexpr (wait) {
         WAYPOINT("NISW");
         while (!noc_cmd_buf_ready(noc, NCRISC_WR_REG_CMD_BUF));
@@ -261,14 +269,22 @@ FORCE_INLINE void cq_noc_inline_dw_write_with_state(
         DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc, NCRISC_WR_REG_CMD_BUF);
         NOC_CMD_BUF_WRITE_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     }
+#endif
 }
 
 // TODO: noc_inline_dw_write currently hardcodes most of these parameters, which we copied here
 // If needed, add templates for setting these
-// TODO: uplift for BH to not do inline write
 template <enum CQNocInlineFlags flags>
 FORCE_INLINE void cq_noc_inline_dw_write_init_state(
     uint64_t dst_addr, uint32_t val = 0, uint8_t be = 0xF, uint8_t noc = noc_index) {
+#if defined(ARCH_BLACKHOLE)
+    // On Blackhole inline writes are disabled so use cq_noc_async_write_init_state with inline write cmd buf
+    // See comment in `noc_inline_dw_write` for more details
+    uint32_t inline_l1_src_addr = noc_get_interim_inline_value_addr(noc, dst_addr);
+    volatile tt_l1_ptr uint32_t* inline_l1_src_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inline_l1_src_addr);
+    cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, NCRISC_WR_REG_CMD_BUF>(0, dst_addr, 0);
+#else
     WAYPOINT("NIIW");
     uint32_t heartbeat = 0;
     while (!noc_cmd_buf_ready(noc, NCRISC_WR_REG_CMD_BUF)) {
@@ -289,6 +305,7 @@ FORCE_INLINE void cq_noc_inline_dw_write_init_state(
     NOC_CMD_BUF_WRITE_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_CTRL, noc_cmd_field);
 
     cq_noc_inline_dw_write_with_state<flags, CQ_NOC_wait, CQ_NOC_send>(dst_addr, val, be);
+#endif
 }
 
 template <uint32_t sem_id>
@@ -396,19 +413,34 @@ cb_acquire_pages(uint32_t cb_fence, uint32_t block_next_start_addr[], uint32_t r
     return usable;
 }
 
+// Do not release pages on the first call to the cb block release pages functions below
+// This is because the first call means we don't have a previous block to release
+static bool cb_block_released_prev_block = false;
+
 template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id, uint32_t cb_pages_per_block>
 FORCE_INLINE void cb_block_release_pages(uint32_t& block_noc_writes_to_clear, uint8_t noc = noc_index) {
-    // Do not release pages on the first call to this function
-    // This is because the first call means we don't have a previous block to release
-    static bool prev_block = false;
-    if (prev_block) {
+    if (cb_block_released_prev_block) {
         WAYPOINT("CBRW");
         uint32_t sem_addr = get_semaphore<fd_core_type>(sem_id);
         while (!wrap_ge(NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT), block_noc_writes_to_clear));
         noc_semaphore_inc(get_noc_addr_helper(noc_xy, sem_addr), cb_pages_per_block, noc_idx);
         WAYPOINT("CBRD");
     } else {
-        prev_block = true;
+        cb_block_released_prev_block = true;
+    }
+    block_noc_writes_to_clear = noc_nonposted_writes_num_issued[noc];
+}
+
+template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id, uint32_t cb_pages_per_block, uint32_t num_hops, typename T>
+FORCE_INLINE void cb_block_release_pages_remote(
+    T& relay_client, uint32_t& block_noc_writes_to_clear, uint8_t noc = noc_index) {
+    if (cb_block_released_prev_block) {
+        WAYPOINT("CBRW");
+        while (!wrap_ge(NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT), block_noc_writes_to_clear));
+        relay_client.template release_pages<noc_idx, noc_xy, sem_id, num_hops>(cb_pages_per_block);
+        WAYPOINT("CBRD");
+    } else {
+        cb_block_released_prev_block = true;
     }
     block_noc_writes_to_clear = noc_nonposted_writes_num_issued[noc];
 }
@@ -424,6 +456,21 @@ template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id, uint32_t cb_pages_p
 FORCE_INLINE void move_rd_to_next_block_and_release_pages(
     uint32_t& block_noc_writes_to_clear, uint32_t& rd_block_idx, uint8_t noc = noc_index) {
     cb_block_release_pages<noc_idx, noc_xy, sem_id, cb_pages_per_block>(block_noc_writes_to_clear, noc);
+    move_rd_to_next_block<cb_blocks>(rd_block_idx);
+}
+
+template <
+    uint8_t noc_idx,
+    uint32_t noc_xy,
+    uint32_t sem_id,
+    uint32_t cb_pages_per_block,
+    uint32_t cb_blocks,
+    uint32_t num_hops,
+    typename T>
+FORCE_INLINE void move_rd_to_next_block_and_release_pages_remote(
+    T& relay_client, uint32_t& block_noc_writes_to_clear, uint32_t& rd_block_idx, uint8_t noc = noc_index) {
+    cb_block_release_pages_remote<noc_idx, noc_xy, sem_id, cb_pages_per_block, num_hops>(
+        relay_client, block_noc_writes_to_clear, noc);
     move_rd_to_next_block<cb_blocks>(rd_block_idx);
 }
 
@@ -456,6 +503,49 @@ FORCE_INLINE uint32_t get_cb_page_and_release_pages(
             upstream_cb_sem,
             cb_pages_per_block,
             cb_blocks>(block_noc_writes_to_clear, rd_block_idx, noc);
+    }
+
+    // Wait for dispatcher to supply a page
+    uint32_t n_pages =
+        cb_acquire_pages<local_cb_sem, cb_log_page_size>(cb_fence, block_next_start_addr, rd_block_idx, local_count);
+    cb_fence += n_pages << cb_log_page_size;
+
+    return n_pages;
+}
+
+template <
+    uint32_t cb_base,
+    uint32_t cb_blocks,
+    uint32_t cb_log_page_size,
+    uint32_t local_cb_sem,
+    uint8_t upstream_noc_idx,
+    uint32_t upstream_noc_xy,
+    uint32_t upstream_cb_sem,
+    uint32_t cb_pages_per_block,
+    uint32_t num_hops,
+    typename T>
+FORCE_INLINE uint32_t get_cb_page_and_release_pages_remote(
+    T& relay_client,
+    uint32_t& cmd_ptr,
+    uint32_t& cb_fence,
+    uint32_t& block_noc_writes_to_clear,
+    uint32_t block_next_start_addr[],
+    uint32_t& rd_block_idx,
+    uint32_t& local_count,
+    uint8_t noc = noc_index) {
+    // Strided past the data that has arrived, get the next page
+    if (cb_fence == block_next_start_addr[rd_block_idx]) {
+        if (rd_block_idx == cb_blocks - 1) {
+            cmd_ptr = cb_base;
+            cb_fence = cb_base;
+        }
+        move_rd_to_next_block_and_release_pages_remote<
+            upstream_noc_idx,
+            upstream_noc_xy,
+            upstream_cb_sem,
+            cb_pages_per_block,
+            cb_blocks,
+            num_hops>(relay_client, block_noc_writes_to_clear, rd_block_idx, noc);
     }
 
     // Wait for dispatcher to supply a page

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -230,6 +230,7 @@ template <enum CQNocInlineFlags flags, enum CQNocWait wait = CQ_NOC_WAIT, enum C
 FORCE_INLINE void cq_noc_inline_dw_write_with_state(
     uint64_t dst_addr, uint32_t val = 0, uint8_t be = 0xF, uint8_t noc = noc_index) {
 #if defined(ARCH_BLACKHOLE)
+    noc_async_writes_flushed();  // ensure inline_l1_src_addr is not overwritten
     uint32_t inline_l1_src_addr = noc_get_interim_inline_value_addr(noc, dst_addr);
     volatile tt_l1_ptr uint32_t* inline_l1_src_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inline_l1_src_addr);

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -235,7 +235,7 @@ void process_write_host_h(uint32_t& block_noc_writes_to_clear, uint32_t block_ne
     // We will send the cmd back in the first X bytes, this makes the logic of reserving/pushing completion queue
     // pages much simpler since we are always sending writing full pages (except for last page)
     uint32_t length = cmd->write_linear_host.length;
-    DPRINT << "process_write_host_h: " << length << ENDL();
+    // DPRINT << "process_write_host_h: " << length << ENDL();
     uint32_t data_ptr = cmd_ptr;
 #if !defined(FABRIC_RELAY)
     cq_noc_async_write_init_state<CQ_NOC_sNdl>(0, pcie_noc_xy, 0);

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -11,10 +11,12 @@
 //  - dispatch buffer base must be page size aligned
 
 #include "dataflow_api.h"
+#include "dataflow_api_addrgen.h"
 #include "debug/assert.h"
 #include "debug/dprint.h"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_common.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_relay.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 
 // The command queue write interface controls writes to the completion region, host owns the completion region read
@@ -122,6 +124,9 @@ static uint32_t write_offset[CQ_DISPATCH_MAX_WRITE_OFFSETS];  // added to write 
 
 static uint32_t upstream_total_acquired_page_count;
 
+CQRelayClient<fabric_mux_num_buffers_per_channel, fabric_mux_channel_buffer_size_bytes, fabric_header_rb_base>
+    relay_client;
+
 constexpr uint32_t packed_write_max_multicast_sub_cmds =
     get_packed_write_max_multicast_sub_cmds(packed_write_max_unicast_sub_cmds);
 constexpr uint32_t max_write_packed_large_cmd =
@@ -191,7 +196,11 @@ void notify_host_of_completion_queue_write_pointer() {
         cq_write_interface.completion_fifo_wr_ptr | (cq_write_interface.completion_fifo_wr_toggle << 31);
     volatile tt_l1_ptr uint32_t* completion_wr_ptr_addr = get_cq_completion_write_ptr();
     completion_wr_ptr_addr[0] = completion_wr_ptr_and_toggle;
+#if defined(FABRIC_RELAY)
+    noc_async_write(dev_completion_q_wr_ptr, pcie_noc_xy | completion_queue_write_ptr_addr, 4);
+#else
     cq_noc_async_write_with_state<CQ_NOC_SnDL>(dev_completion_q_wr_ptr, completion_queue_write_ptr_addr, 4);
+#endif
 }
 
 FORCE_INLINE
@@ -220,7 +229,9 @@ void process_write_host_h(uint32_t& block_noc_writes_to_clear, uint32_t block_ne
     uint32_t length = cmd->write_linear_host.length;
     // DPRINT << "process_write_host_h: " << length << ENDL();
     uint32_t data_ptr = cmd_ptr;
+#if !defined(FABRIC_RELAY)
     cq_noc_async_write_init_state<CQ_NOC_sNdl>(0, pcie_noc_xy, 0);
+#endif
     while (length != 0) {
         // Get a page if needed
         if (cb_fence == data_ptr) {
@@ -231,12 +242,22 @@ void process_write_host_h(uint32_t& block_noc_writes_to_clear, uint32_t block_ne
                     cb_fence = dispatch_cb_base;
                     data_ptr = dispatch_cb_base;
                 }
-                move_rd_to_next_block_and_release_pages<
-                    upstream_noc_index,
-                    upstream_noc_xy,
-                    upstream_dispatch_cb_sem_id,
-                    dispatch_cb_pages_per_block,
-                    dispatch_cb_blocks>(block_noc_writes_to_clear, rd_block_idx);
+                if constexpr (is_h_variant && is_d_variant) {
+                    move_rd_to_next_block_and_release_pages<
+                        upstream_noc_index,
+                        upstream_noc_xy,
+                        upstream_dispatch_cb_sem_id,
+                        dispatch_cb_pages_per_block,
+                        dispatch_cb_blocks>(block_noc_writes_to_clear, rd_block_idx);
+                } else {
+                    move_rd_to_next_block_and_release_pages_remote<
+                        upstream_noc_index,
+                        upstream_noc_xy,
+                        upstream_dispatch_cb_sem_id,
+                        dispatch_cb_pages_per_block,
+                        dispatch_cb_blocks,
+                        num_hops>(relay_client, block_noc_writes_to_clear, rd_block_idx);
+                }
             }
             // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
             uint32_t n_pages = cb_acquire_pages<my_dispatch_cb_sem_id, dispatch_cb_log_page_size>(
@@ -254,24 +275,32 @@ void process_write_host_h(uint32_t& block_noc_writes_to_clear, uint32_t block_ne
         // transactions
         if (completion_queue_write_addr + xfer_size > completion_queue_end_addr) {
             uint32_t last_chunk_size = completion_queue_end_addr - completion_queue_write_addr;
+#if defined(FABRIC_RELAY)
+            noc_async_write(data_ptr, pcie_noc_xy | completion_queue_write_addr, last_chunk_size);
+#else
             cq_noc_async_write_with_state_any_len(data_ptr, completion_queue_write_addr, last_chunk_size);
+            uint32_t num_noc_packets_written = div_up(last_chunk_size, NOC_MAX_BURST_SIZE);
+            noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
+            noc_nonposted_writes_acked[noc_index] += num_noc_packets_written;
+#endif
             completion_queue_write_addr = completion_queue_base_addr;
             data_ptr += last_chunk_size;
             length -= last_chunk_size;
             xfer_size -= last_chunk_size;
-            uint32_t num_noc_packets_written = div_up(last_chunk_size, NOC_MAX_BURST_SIZE);
-            noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
-            noc_nonposted_writes_acked[noc_index] += num_noc_packets_written;
         }
+#if defined(FABRIC_RELAY)
+        noc_async_write(data_ptr, pcie_noc_xy | completion_queue_write_addr, xfer_size);
+#else
         cq_noc_async_write_with_state_any_len(data_ptr, completion_queue_write_addr, xfer_size);
+        // completion_queue_push_back below will do a write to host, so we add 1 to the number of data packets written
+        uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE) + 1;
+        noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
+        noc_nonposted_writes_acked[noc_index] += num_noc_packets_written;
+#endif
 
         // This will update the write ptr on device and host
         // We flush to ensure the ptr has been read out of l1 before we update it again
         completion_queue_push_back(npages);
-        // completion_queue_push_back will do a write to host, so we add 1 to the number of data packets written
-        uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE) + 1;
-        noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
-        noc_nonposted_writes_acked[noc_index] += num_noc_packets_written;
 
         length -= xfer_size;
         data_ptr += xfer_size;
@@ -281,7 +310,7 @@ void process_write_host_h(uint32_t& block_noc_writes_to_clear, uint32_t block_ne
 }
 
 void process_exec_buf_end_h() {
-    if (split_prefetch) {
+    if constexpr (split_prefetch) {
         invalidate_l1_cache();
         volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
             get_semaphore<fd_core_type>(prefetch_h_local_downstream_sem_addr));
@@ -313,18 +342,8 @@ void relay_to_next_cb(
     // regular write, inline writes, and atomic writes use different cmd bufs, so we can init state for each
     // TODO: Add support for stateful atomics. We can preserve state once cb_acquire_pages is changed to a free running
     // counter so we would only need to inc atomics downstream
-    uint64_t dst = get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr);
-    cq_noc_async_write_init_state<CQ_NOC_sNdl>(0, dst, 0);
-#ifdef ARCH_BLACKHOLE
-    // On Blackhole inline writes are disabled so use cq_noc_async_write_init_state with inline write cmd buf
-    // See comment in `noc_inline_dw_write` for more details
-    uint32_t inline_l1_src_addr = noc_get_interim_inline_value_addr(noc_index, dst);
-    volatile tt_l1_ptr uint32_t* inline_l1_src_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(inline_l1_src_addr);
-    cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, NCRISC_WR_REG_CMD_BUF>(0, dst, 0);
-#else
-    cq_noc_inline_dw_write_init_state<CQ_NOC_INLINE_Ndvb>(dst);
-#endif
+    relay_client.init_write_state_only<my_noc_index, NCRISC_WR_CMD_BUF>(get_noc_addr_helper(downstream_noc_xy, 0));
+    relay_client.init_inline_write_state_only<my_noc_index>(get_noc_addr_helper(downstream_noc_xy, 0));
 
     while (length > 0) {
         ASSERT(downstream_cb_end > downstream_cb_data_ptr);
@@ -343,16 +362,9 @@ void relay_to_next_cb(
 
         if constexpr (preamble_size > 0) {
             uint32_t flag;
-#ifdef ARCH_BLACKHOLE
-            *inline_l1_src_addr_ptr = xfer_size + preamble_size + not_end_of_cmd;
-            cq_noc_async_write_with_state<CQ_NOC_SnDL, CQ_NOC_WAIT, CQ_NOC_SEND, NCRISC_WR_REG_CMD_BUF>(
-                inline_l1_src_addr, downstream_cb_data_ptr, 4);
-#else
-            cq_noc_inline_dw_write_with_state<CQ_NOC_INLINE_nDVB>(
-                downstream_cb_data_ptr, xfer_size + preamble_size + not_end_of_cmd);
-#endif
-            noc_nonposted_writes_num_issued[noc_index]++;
-            noc_nonposted_writes_acked[noc_index]++;
+            relay_client.write_inline<my_noc_index, num_hops>(
+                get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr),
+                xfer_size + preamble_size + not_end_of_cmd);
             downstream_cb_data_ptr += preamble_size;
             ASSERT(downstream_cb_data_ptr < downstream_cb_end);
         }
@@ -367,9 +379,8 @@ void relay_to_next_cb(
                 if (rd_block_idx == dispatch_cb_blocks - 1) {
                     ASSERT(cb_fence == dispatch_cb_end);
                     if (orphan_size != 0) {
-                        cq_noc_async_write_with_state<CQ_NOC_SnDL>(data_ptr, downstream_cb_data_ptr, orphan_size);
-                        noc_nonposted_writes_num_issued[noc_index]++;
-                        noc_nonposted_writes_acked[noc_index]++;
+                        relay_client.write<my_noc_index, num_hops, true, NCRISC_WR_CMD_BUF>(
+                            data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr), orphan_size);
                         length -= orphan_size;
                         xfer_size -= orphan_size;
                         downstream_cb_data_ptr += orphan_size;
@@ -397,10 +408,13 @@ void relay_to_next_cb(
             cb_fence += n_pages * dispatch_cb_page_size;
         }
 
-        cq_noc_async_write_with_state<CQ_NOC_SnDL>(data_ptr, downstream_cb_data_ptr, xfer_size);
-        noc_nonposted_writes_num_issued[noc_index]++;
-        noc_nonposted_writes_acked[noc_index]++;
-        cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(1);
+        relay_client.write_atomic_inc_any_len<
+            my_noc_index,
+            downstream_noc_xy,
+            downstream_cb_sem_id,
+            num_hops,
+            true,
+            NCRISC_WR_CMD_BUF>(data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr), xfer_size, 1);
 
         length -= xfer_size;
         data_ptr += xfer_size;
@@ -472,12 +486,26 @@ void process_write_linear(
                     cb_fence = dispatch_cb_base;
                     data_ptr = dispatch_cb_base;
                 }
-                move_rd_to_next_block_and_release_pages<
-                    upstream_noc_index,
-                    upstream_noc_xy,
-                    upstream_dispatch_cb_sem_id,
-                    dispatch_cb_pages_per_block,
-                    dispatch_cb_blocks>(block_noc_writes_to_clear, rd_block_idx);
+                if constexpr (is_d_variant) {
+                    // Dispatch HD/D upstream is local
+                    move_rd_to_next_block_and_release_pages<
+                        upstream_noc_index,
+                        upstream_noc_xy,
+                        upstream_dispatch_cb_sem_id,
+                        dispatch_cb_pages_per_block,
+                        dispatch_cb_blocks>(block_noc_writes_to_clear, rd_block_idx);
+                } else {
+                    // Dispatch H upstream is local
+                    // Dispatch upstream is using NOC1 so init_noc_state again is not needed because this function
+                    // uses non_dispatch_noc which is NOC0
+                    move_rd_to_next_block_and_release_pages_remote<
+                        upstream_noc_index,
+                        upstream_noc_xy,
+                        upstream_dispatch_cb_sem_id,
+                        dispatch_cb_pages_per_block,
+                        dispatch_cb_blocks,
+                        num_hops>(relay_client, block_noc_writes_to_clear, rd_block_idx);
+                }
             }
             // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
             uint32_t n_pages = cb_acquire_pages<my_dispatch_cb_sem_id, dispatch_cb_log_page_size>(
@@ -1322,21 +1350,41 @@ void kernel_main() {
     uint32_t heartbeat = 0;
     while (!done) {
         if (cmd_ptr == cb_fence) {
-            get_cb_page_and_release_pages<
-                dispatch_cb_base,
-                dispatch_cb_blocks,
-                dispatch_cb_log_page_size,
-                my_dispatch_cb_sem_id,
-                upstream_noc_index,
-                upstream_noc_xy,
-                upstream_dispatch_cb_sem_id,
-                dispatch_cb_pages_per_block>(
-                cmd_ptr,
-                cb_fence,
-                block_noc_writes_to_clear,
-                block_next_start_addr,
-                rd_block_idx,
-                upstream_total_acquired_page_count);
+            if constexpr (is_h_variant && !is_d_variant) {
+                get_cb_page_and_release_pages_remote<
+                    dispatch_cb_base,
+                    dispatch_cb_blocks,
+                    dispatch_cb_log_page_size,
+                    my_dispatch_cb_sem_id,
+                    upstream_noc_index,
+                    upstream_noc_xy,
+                    upstream_dispatch_cb_sem_id,
+                    dispatch_cb_pages_per_block,
+                    num_hops>(
+                    relay_client,
+                    cmd_ptr,
+                    cb_fence,
+                    block_noc_writes_to_clear,
+                    block_next_start_addr,
+                    rd_block_idx,
+                    upstream_total_acquired_page_count);
+            } else {
+                get_cb_page_and_release_pages<
+                    dispatch_cb_base,
+                    dispatch_cb_blocks,
+                    dispatch_cb_log_page_size,
+                    my_dispatch_cb_sem_id,
+                    upstream_noc_index,
+                    upstream_noc_xy,
+                    upstream_dispatch_cb_sem_id,
+                    dispatch_cb_pages_per_block>(
+                    cmd_ptr,
+                    cb_fence,
+                    block_noc_writes_to_clear,
+                    block_next_start_addr,
+                    rd_block_idx,
+                    upstream_total_acquired_page_count);
+            }
         }
 
         DeviceZoneScopedN("CQ-DISPATCH");
@@ -1349,35 +1397,40 @@ void kernel_main() {
         cmd_ptr = round_up_pow2(cmd_ptr, dispatch_cb_page_size);
     }
 
-    noc_async_write_barrier();
-
-    if (is_h_variant && !is_d_variant) {
-        // Set upstream semaphore MSB to signal completion and path teardown
-        // in case dispatch_h is connected to a depacketizing stage.
-        // TODO: This should be replaced with a signal similar to what packetized
-        // components use.
-        noc_semaphore_inc(
-            get_noc_addr_helper(upstream_noc_xy, get_semaphore<fd_core_type>(upstream_dispatch_cb_sem_id)),
-            0x80000000,
-            upstream_noc_index);
-    }
-
     // Release any held pages from the previous block
-    cb_block_release_pages<
-        upstream_noc_index,
-        upstream_noc_xy,
-        upstream_dispatch_cb_sem_id,
-        dispatch_cb_pages_per_block>(block_noc_writes_to_clear);
+    if (is_h_variant && !is_d_variant) {
+        cb_block_release_pages_remote<
+            upstream_noc_index,
+            upstream_noc_xy,
+            upstream_dispatch_cb_sem_id,
+            dispatch_cb_pages_per_block,
+            num_hops>(relay_client, block_noc_writes_to_clear);
+    } else {
+        cb_block_release_pages<
+            upstream_noc_index,
+            upstream_noc_xy,
+            upstream_dispatch_cb_sem_id,
+            dispatch_cb_pages_per_block>(block_noc_writes_to_clear);
+    }
 
     // Release any held pages from the current block
     uint32_t npages =
         dispatch_cb_pages_per_block - ((block_next_start_addr[rd_block_idx] - cmd_ptr) >> dispatch_cb_log_page_size);
-    cb_release_pages<upstream_noc_index, upstream_noc_xy, upstream_dispatch_cb_sem_id>(npages);
+    if (is_h_variant && !is_d_variant) {
+        relay_client.release_pages<upstream_noc_index, upstream_noc_xy, upstream_dispatch_cb_sem_id, num_hops>(npages);
+    } else {
+        cb_release_pages<upstream_noc_index, upstream_noc_xy, upstream_dispatch_cb_sem_id>(npages);
+    }
+
+    noc_async_write_barrier();
 
     // Confirm expected number of pages, spinning here is a leak
     cb_wait_all_pages<my_dispatch_cb_sem_id>(upstream_total_acquired_page_count);
 
     noc_async_full_barrier();
 
+    if (is_h_variant && !is_d_variant) {
+        relay_client.template teardown<upstream_noc_index, upstream_noc_xy, upstream_dispatch_cb_sem_id>();
+    }
     // DPRINT << "dispatch_" << is_h_variant << is_d_variant << ": out" << ENDL();
 }

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -16,7 +16,6 @@
 //  Using the normal NoC APIs for writes and/or inline_dw_writes are not allowed on this kernel.
 //
 
-#include "compile_time_args.h"
 #include "dataflow_api.h"
 #include "dataflow_api_addrgen.h"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1670,7 +1670,24 @@ void kernel_main_d() {
     uint32_t l1_cache[l1_cache_elements_rounded];
 
     // Cmdbuf allocation is not defined yet for fabric so we can't use stateful APIs on Dispatch D
-#if !defined(FABRIC_RELAY)
+#if defined(FABRIC_RELAY)
+    relay_client.init<
+        my_noc_index,
+        fabric_mux_x,
+        fabric_mux_y,
+        worker_credits_stream_id,
+        fabric_mux_channel_base_address,
+        fabric_mux_flow_control_address,
+        fabric_mux_connection_handshake_address,
+        fabric_mux_connection_info_address,
+        fabric_mux_buffer_index_address,
+        fabric_worker_flow_control_sem,
+        fabric_worker_teardown_sem,
+        fabric_worker_buffer_index_sem,
+        fabric_mux_status_address,
+        my_fabric_sync_status_addr,
+        NCRISC_WR_CMD_BUF>(get_noc_addr_helper(downstream_noc_xy, 0));
+#else
     cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchRelayInlineState::downstream_write_cmd_buf>(
         0, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), 0, my_noc_index);
     cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchSRelayInlineState::downstream_write_cmd_buf>(
@@ -1747,7 +1764,11 @@ void kernel_main_hd() {
 }
 
 void kernel_main() {
+#if defined(FABRIC_RELAY)
+    DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start (fabric relay)" << ENDL();
+#else
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start" << ENDL();
+#endif
 
     if (is_h_variant and is_d_variant) {
         kernel_main_hd();

--- a/tt_metal/impl/dispatch/kernels/cq_relay.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_relay.hpp
@@ -8,6 +8,7 @@
 #include "dataflow_api.h"
 #include "cq_common.hpp"
 #include "fabric/hw/inc/tt_fabric_mux.hpp"
+#include "fabric/hw/inc/tt_fabric_mux_interface.hpp"
 #include "risc_attribs.h"
 #include "debug/waypoint.h"
 #include "noc/noc_parameters.h"

--- a/tt_metal/impl/dispatch/kernels/cq_relay.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_relay.hpp
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "dataflow_api.h"
+#include "cq_common.hpp"
+#include "fabric/hw/inc/tt_fabric_mux.hpp"
+#include "risc_attribs.h"
+#include "debug/waypoint.h"
+#include "noc/noc_parameters.h"
+
+#if !defined(FD_CORE_TYPE)
+#define FD_CORE_TYPE 0
+#endif
+
+template <uint32_t mux_num_buffers_per_channel, uint32_t mux_channel_buffer_size_bytes, uint32_t header_rb>
+class CQRelayClient {
+private:
+    constexpr static ProgrammableCoreType fd_core_type = static_cast<ProgrammableCoreType>(FD_CORE_TYPE);
+
+    tt::tt_fabric::WorkerToFabricMuxSender<mux_num_buffers_per_channel> edm;
+
+public:
+    CQRelayClient() = default;
+
+    template <
+        uint8_t noc_index,
+        uint32_t mux_x,
+        uint32_t mux_y,
+        uint32_t mux_worker_credits_stream_id,
+        uint32_t mux_channel_base_address,
+        uint32_t mux_flow_control_address,
+        uint32_t mux_connection_handshake_address,
+        uint32_t mux_connection_info_address,
+        uint32_t mux_buffer_index_address,
+        uint32_t worker_flow_control_sem,
+        uint32_t worker_teardown_sem,
+        uint32_t worker_buffer_index_sem,
+        uint32_t mux_status_address,
+        uint32_t local_mux_status_address,
+        uint8_t downstream_cmd_buf>
+    FORCE_INLINE void init(uint64_t downstream_noc_addr) {
+        WAYPOINT("FMCW");
+#if defined(FABRIC_RELAY)
+        edm.template init<fd_core_type>(
+            true /*connected_to_persistent_fabric*/,
+            0, /* ignored, direction */
+            mux_x,
+            mux_y,
+            mux_channel_base_address,
+            mux_num_buffers_per_channel,
+            mux_flow_control_address,
+            mux_connection_handshake_address,
+            mux_connection_info_address,
+            mux_channel_buffer_size_bytes,
+            mux_buffer_index_address,
+            (volatile uint32_t* const)get_semaphore<fd_core_type>(worker_flow_control_sem),
+            (volatile uint32_t* const)get_semaphore<fd_core_type>(worker_teardown_sem),
+            get_semaphore<fd_core_type>(worker_buffer_index_sem),
+            mux_worker_credits_stream_id,
+            StreamId{0}  // my stream id -- As a sender I currently do NOT get acks over stream regs
+        );
+
+        tt::tt_fabric::wait_for_fabric_endpoint_ready(mux_x, mux_y, mux_status_address, local_mux_status_address);
+        tt::tt_fabric::fabric_client_connect<mux_num_buffers_per_channel>(edm);
+#else
+        init_write_state_only<noc_index, downstream_cmd_buf>(downstream_noc_addr);
+#endif
+        WAYPOINT("FMCD");
+    }
+
+    template <uint8_t noc_index, uint8_t downstream_cmd_buf>
+    FORCE_INLINE void init_write_state_only(uint64_t downstream_noc_addr) {
+#if !defined(FABRIC_RELAY)
+        cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, downstream_cmd_buf>(
+            0, downstream_noc_addr, 0, noc_index);
+#endif
+    }
+
+    template <uint8_t noc_index>
+    FORCE_INLINE void init_inline_write_state_only(uint64_t downstream_noc_addr) {
+#if !defined(FABRIC_RELAY)
+        cq_noc_inline_dw_write_init_state<CQ_NOC_INLINE_Ndvb>(downstream_noc_addr);
+#endif
+    }
+
+    template <uint8_t noc_index, uint64_t noc_xy, uint32_t sem_id>
+    FORCE_INLINE void teardown() {
+#if defined(FABRIC_RELAY)
+        tt::tt_fabric::fabric_client_disconnect<mux_num_buffers_per_channel>(edm);
+#else
+        constexpr uint32_t k_PacketQueueTeardownFlag = 0x80000000;
+        noc_semaphore_inc(
+            get_noc_addr_helper(noc_xy, get_semaphore<fd_core_type>(sem_id)), k_PacketQueueTeardownFlag, noc_index);
+#endif
+    }
+
+    template <uint8_t noc_idx, uint8_t num_hops, bool count = true>
+    FORCE_INLINE void write_inline(uint64_t dst, uint32_t val) {
+#if defined(FABRIC_RELAY)
+        auto packet_header = reinterpret_cast<tt_l1_ptr PACKET_HEADER_TYPE*>(header_rb);
+        packet_header->to_chip_unicast(static_cast<uint8_t>(num_hops));
+        packet_header->to_noc_unicast_inline_write(
+            tt::tt_fabric::NocUnicastInlineWriteCommandHeader{.noc_address = dst, .value = val});
+        // Use the fabric_atomic_inc helper to send the header
+        tt::tt_fabric::fabric_atomic_inc<mux_num_buffers_per_channel>(edm, packet_header);
+#else
+        cq_noc_inline_dw_write_with_state<CQ_NOC_INLINE_nDVB>(dst, val, 0xF, noc_idx);
+        if constexpr (count) {
+            noc_nonposted_writes_num_issued[noc_idx]++;
+            noc_nonposted_writes_acked[noc_idx]++;
+        }
+#endif
+    }
+
+    template <uint8_t noc_idx, uint8_t num_hops, bool wait, uint8_t downstream_cmd_buf, bool count = true>
+    FORCE_INLINE void write_any_len(uint32_t data_ptr, uint64_t dst_ptr, uint32_t length) {
+#if defined(FABRIC_RELAY)
+        // Writing to a HEADER only buffer is wrong. This function requires a FULL SIZE buffer
+        ASSERT(mux_channel_buffer_size_bytes > sizeof(PACKET_HEADER_TYPE));
+        constexpr uint32_t k_FabricMaxBurstSize = mux_channel_buffer_size_bytes - sizeof(PACKET_HEADER_TYPE);
+
+        auto packet_header = reinterpret_cast<tt_l1_ptr PACKET_HEADER_TYPE*>(header_rb);
+        packet_header->to_chip_unicast(static_cast<uint8_t>(num_hops));
+        while (length > k_FabricMaxBurstSize) {
+            packet_header->to_noc_unicast_write(tt::tt_fabric::NocUnicastCommandHeader{dst_ptr}, k_FabricMaxBurstSize);
+
+            tt::tt_fabric::fabric_async_write<mux_num_buffers_per_channel>(
+                edm, packet_header, data_ptr, k_FabricMaxBurstSize);
+
+            dst_ptr += k_FabricMaxBurstSize;
+            data_ptr += k_FabricMaxBurstSize;
+            length -= k_FabricMaxBurstSize;
+        }
+
+        packet_header->to_noc_unicast_write(tt::tt_fabric::NocUnicastCommandHeader{dst_ptr}, length);
+
+        tt::tt_fabric::fabric_async_write<mux_num_buffers_per_channel>(edm, packet_header, data_ptr, length);
+#else
+        if constexpr (wait) {
+            cq_noc_async_write_with_state_any_len<true, count, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
+                data_ptr, dst_ptr, length, 1, noc_idx);
+        } else {
+            cq_noc_async_write_with_state_any_len<true, count, CQNocWait::CQ_NOC_wait, downstream_cmd_buf>(
+                data_ptr, dst_ptr, length, 1, noc_idx);
+        }
+#endif
+    }
+
+    template <uint8_t noc_idx, uint8_t num_hops, bool wait, uint8_t downstream_cmd_buf, bool count = true>
+    FORCE_INLINE void write(uint32_t data_ptr, uint64_t dst_ptr, uint32_t length) {
+#if defined(FABRIC_RELAY)
+        write_any_len<noc_idx, num_hops, wait, downstream_cmd_buf, count>(data_ptr, dst_ptr, length);
+#else
+        if constexpr (wait) {
+            cq_noc_async_write_with_state<
+                CQ_NOC_SnDL,
+                CQNocWait::CQ_NOC_WAIT,
+                CQNocSend::CQ_NOC_SEND,
+                downstream_cmd_buf>(data_ptr, dst_ptr, length, 1, noc_idx);
+        } else {
+            cq_noc_async_write_with_state<
+                CQ_NOC_SnDL,
+                CQNocWait::CQ_NOC_wait,
+                CQNocSend::CQ_NOC_SEND,
+                downstream_cmd_buf>(data_ptr, dst_ptr, length, 1, noc_idx);
+        }
+        if (count) {
+            noc_nonposted_writes_num_issued[noc_idx]++;
+            noc_nonposted_writes_acked[noc_idx]++;
+        }
+#endif
+    }
+
+    template <uint8_t noc_idx, uint32_t dest_noc_xy, uint32_t dest_sem_id, uint8_t num_hops>
+    FORCE_INLINE void release_pages(uint16_t n) {
+#if defined(FABRIC_RELAY)
+        auto sem_addr = get_semaphore<fd_core_type>(dest_sem_id);
+        uint64_t noc_dest_addr = get_noc_addr_helper(dest_noc_xy, sem_addr);
+
+        auto packet_header = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(header_rb);
+        packet_header->to_chip_unicast(static_cast<uint8_t>(num_hops));
+        packet_header->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+            noc_dest_addr,
+            n,
+            std::numeric_limits<uint16_t>::max(),
+        });
+        tt::tt_fabric::fabric_atomic_inc<mux_num_buffers_per_channel>(edm, packet_header);
+#else
+        noc_semaphore_inc(get_noc_addr_helper(dest_noc_xy, get_semaphore<fd_core_type>(dest_sem_id)), n, noc_idx);
+#endif
+    }
+
+    template <
+        uint32_t downstream_noc_idx,
+        uint32_t downstream_noc_xy,
+        uint32_t downstream_sem_id,
+        uint8_t num_hops,
+        bool wait,
+        uint8_t downstream_cmd_buf>
+    FORCE_INLINE void write_atomic_inc_any_len(uint32_t data_ptr, uint64_t dst_ptr, uint32_t length, uint16_t n) {
+#if defined(FABRIC_RELAY)
+        // Writing to a HEADER only buffer is wrong. This function requires a FULL SIZE buffer
+        ASSERT(mux_channel_buffer_size_bytes > sizeof(PACKET_HEADER_TYPE));
+        constexpr uint32_t k_FabricMaxBurstSize = mux_channel_buffer_size_bytes - sizeof(PACKET_HEADER_TYPE);
+
+        auto packet_header = reinterpret_cast<tt_l1_ptr PACKET_HEADER_TYPE*>(header_rb);
+        packet_header->to_chip_unicast(static_cast<uint8_t>(num_hops));
+        while (length > k_FabricMaxBurstSize) {
+            packet_header->to_noc_unicast_write(tt::tt_fabric::NocUnicastCommandHeader{dst_ptr}, k_FabricMaxBurstSize);
+
+            tt::tt_fabric::fabric_async_write<mux_num_buffers_per_channel>(
+                edm, packet_header, data_ptr, k_FabricMaxBurstSize);
+
+            dst_ptr += k_FabricMaxBurstSize;
+            data_ptr += k_FabricMaxBurstSize;
+            length -= k_FabricMaxBurstSize;
+        }
+
+        packet_header->to_noc_fused_unicast_write_atomic_inc(
+            tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{
+                dst_ptr,
+                get_noc_addr_helper(downstream_noc_xy, get_semaphore<fd_core_type>(downstream_sem_id)),
+                n,
+                std::numeric_limits<uint16_t>::max()},
+            length);
+
+        tt::tt_fabric::fabric_async_write<mux_num_buffers_per_channel>(edm, packet_header, data_ptr, length);
+#else
+        write_any_len<downstream_noc_idx, num_hops, wait, downstream_cmd_buf>(data_ptr, dst_ptr, length);
+        release_pages<downstream_noc_idx, downstream_noc_xy, downstream_sem_id, num_hops>(n);
+#endif
+    }
+};

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -170,8 +170,8 @@ RunTimeOptions::RunTimeOptions() {
         }
     }
 
-    const char* fb_fabric = getenv(TT_METAL_FD_FABRIC_DEMO);
-    fb_fabric_en = fb_fabric != nullptr;
+    using_slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
+    fd_fabric_en = getenv(TT_METAL_FD_FABRIC_DEMO) != nullptr;
 
     const char* dispatch_data_collection_str = std::getenv("TT_METAL_DISPATCH_DATA_COLLECTION");
     if (dispatch_data_collection_str != nullptr) {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -145,7 +145,8 @@ class RunTimeOptions {
     bool validate_kernel_binaries = false;
     unsigned num_hw_cqs = 1;
 
-    bool fb_fabric_en = false;
+    bool fd_fabric_en = false;
+    bool using_slow_dispatch = false;
 
     bool enable_dispatch_data_collection = false;
 
@@ -377,7 +378,8 @@ public:
     inline unsigned get_num_hw_cqs() const { return num_hw_cqs; }
     inline void set_num_hw_cqs(unsigned num) { num_hw_cqs = num; }
 
-    inline bool get_fd_fabric() const { return fb_fabric_en; }
+    inline bool get_fd_fabric() const { return fd_fabric_en && !using_slow_dispatch; }
+    inline void set_fd_fabric(bool enable) { fd_fabric_en = enable; }
 
     inline uint32_t get_watcher_debug_delay() const { return watcher_debug_delay; }
     inline void set_watcher_debug_delay(uint32_t delay) { watcher_debug_delay = delay; }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1021,7 +1021,7 @@ void Cluster::disable_ethernet_cores_with_retrain() {
 }
 
 void Cluster::reserve_ethernet_cores_for_tunneling() {
-    const char *TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     for (const auto& [assoc_mmio_device, devices] : this->cluster_desc_->get_chips_grouped_by_closest_mmio()) {
         for (const auto &chip_id : devices) {
             if (this->device_eth_routing_info_.find(chip_id) == this->device_eth_routing_info_.end()) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18726

### Problem description
- Upgrade dispatch kernels to use TT-Fabric for relaying remote data and semaphores

### What's changed
- Dispatch on Fabric can be enabled by using the environment variable `TT_METAL_FD_FABRIC=true`. This variable will be removed when the packet queue can be fully removed.
- Add remote functions to `cq_common.hpp` intended for split prefetch/dispatch use
  - `cb_block_release_pages_remote`
  - `move_rd_to_next_block_and_release_pages_remote`
  - `get_cb_page_and_release_pages_remote`
- Add a relay interface `CQRelayClient`
  - Interfaces with a ERISC Data Mover (Fabric) to send data, do atomic increments, etc. to the downstream dispatch core
  - Uses regular NoC APIs when packet queue is being used
- Init/topology changes to ensure `static_args_` are populated first
  - Note: If any remote device is being used then all devices must be initialized (Fabric requirement)
- Added basic 1CQ and 2CQ dispatch on fabric tests

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15725421591

T3K
https://github.com/tenstorrent/tt-metal/actions/runs/15797885984
https://github.com/tenstorrent/tt-metal/actions/runs/15791173204

TG
https://github.com/tenstorrent/tt-metal/actions/runs/15785790305

BH
https://github.com/tenstorrent/tt-metal/actions/runs/15793390184