### PR TITLE
#23103: Add EventQuery API for MeshEvent

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -334,5 +334,20 @@ TEST_F(MeshEventsTestSuite, MultiCQNonBlockingReads) {
     }
 }
 
+TEST_F(MeshEventsTestSuite, EventQuery) {
+    uint32_t NUM_ITERS = 500;
+    // Stress EventQuery API and ensure that an event is marked as completed post synchronization.
+    for (auto i = 0; i < NUM_ITERS; i++) {
+        auto event = EnqueueRecordEventToHost(mesh_device_->mesh_command_queue(0));
+        if (i % 10 == 0) {
+            EventSynchronize(event);
+            EXPECT_TRUE(EventQuery(event));
+        }
+    }
+    // Create a dummy event from the future that has not been issued yet.
+    auto event = MeshEvent(0xffff, mesh_device_.get(), 0, MeshCoordinateRange(mesh_device_->shape()));
+    EXPECT_FALSE(EventQuery(event));  // Querying an event that has not been issued should return false.
+}
+
 }  // namespace
 }  // namespace tt::tt_metal::distributed::test

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -96,19 +96,32 @@ void EnqueueReadMeshBuffer(
     mesh_cq.enqueue_read_mesh_buffer(dst.data(), mesh_buffer, blocking);
 }
 
+// Make the specified MeshCommandQueue record an event.
+// Host is not notified when this event completes.
+// Can be used for CQ to CQ synchronization.
 MeshEvent EnqueueRecordEvent(
     MeshCommandQueue& mesh_cq,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {},
     const std::optional<MeshCoordinateRange>& device_range = std::nullopt);
 
+// Make the specified MeshCommandQueue record an event and notify the host when it completes.
+// Can be used for CQ to CQ and host to CQ synchronization.
 MeshEvent EnqueueRecordEventToHost(
     MeshCommandQueue& mesh_cq,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {},
     const std::optional<MeshCoordinateRange>& device_range = std::nullopt);
 
+// Make the specified MeshCommandQueue wait for the completion of an event.
+// This operation is non-blocking on host, however the specified command queue
+// will stall until the event is recorded.
 void EnqueueWaitForEvent(MeshCommandQueue& mesh_cq, const MeshEvent& event);
 
+// Make the current thread block until the event is recorded by the associated MeshCommandQueue.
 void EventSynchronize(const MeshEvent& event);
+
+// Query the status of an event tied to a MeshCommandQueue.
+// Returns true if the CQ has completed recording the event, false otherwise.
+bool EventQuery(const MeshEvent& event);
 
 MeshTraceId BeginTraceCapture(MeshDevice* device, uint8_t cq_id);
 

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -55,6 +55,14 @@ void EventSynchronize(const MeshEvent& event) {
     }
 }
 
+bool EventQuery(const MeshEvent& event) {
+    const auto& mesh_device = event.device();
+    const auto& device_range = event.device_range();
+    auto& sysmem_manager = mesh_device->get_device(*(device_range.begin()))->sysmem_manager();
+    bool event_completed = sysmem_manager.get_last_completed_event(event.mesh_cq_id()) >= event.id();
+    return event_completed;
+}
+
 MeshTraceId BeginTraceCapture(MeshDevice* device, uint8_t cq_id) {
     auto trace_id = MeshTrace::next_id();
     device->begin_mesh_trace(cq_id, trace_id);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23103

### Problem description
TT-Mesh API surface is missing the `EventQuery` API on main. Users have no way of checking if an event has been recorded or not.

### What's changed
Add missing API and tests.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes