### PR TITLE
Close SubMeshes before closing Parent Mesh

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -428,6 +428,9 @@ def mesh_device(request, silicon_arch_name, device_params):
 
     ttnn.DumpDeviceProfiler(mesh_device)
 
+    for submesh in mesh_device.get_submeshes():
+        ttnn.close_mesh_device(submesh)
+
     ttnn.close_mesh_device(mesh_device)
     reset_fabric(fabric_config)
     del mesh_device
@@ -493,6 +496,9 @@ def pcie_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
 
     ttnn.DumpDeviceProfiler(mesh_device)
 
+    for submesh in mesh_device.get_submeshes():
+        ttnn.close_mesh_device(submesh)
+
     ttnn.close_mesh_device(mesh_device)
     reset_fabric(fabric_config)
     del mesh_device
@@ -517,6 +523,9 @@ def n300_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
     yield mesh_device
 
     ttnn.DumpDeviceProfiler(mesh_device)
+
+    for submesh in mesh_device.get_submeshes():
+        ttnn.close_mesh_device(submesh)
 
     ttnn.close_mesh_device(mesh_device)
     reset_fabric(fabric_config)
@@ -543,6 +552,9 @@ def t3k_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device
     yield mesh_device
 
     ttnn.DumpDeviceProfiler(mesh_device)
+
+    for submesh in mesh_device.get_submeshes():
+        ttnn.close_mesh_device(submesh)
 
     ttnn.close_mesh_device(mesh_device)
     reset_fabric(fabric_config)

--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -752,3 +752,10 @@ def test_heterogenous_operation_dispatch():
     assert_with_pcc(
         ttnn.to_torch(ttnn_silu, mesh_composer=ttnn.ConcatMeshToTensor(submesh_1, dim=-1)), torch_silu, pcc=0.9999
     )
+
+
+# Verify that submeshes can be created on a mesh device with fabric enabled
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+def test_fabric_with_submeshes(t3k_mesh_device):
+    logger.info("Spawning 2 1x4 submeshes on a 2x4 mesh device with fabric enabled")
+    submeshes = t3k_mesh_device.create_submeshes(ttnn.MeshShape(1, 4))

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -194,6 +194,15 @@ void py_module(py::module& module) {
             py::arg("submesh_shape"),
             py::keep_alive<1, 0>())  // Keep MeshDevice alive as long as SubmeshDevices are alive
         .def(
+            "get_submeshes",
+            &MeshDevice::get_submeshes,
+            R"doc(
+              Get the submeshes created on this MeshDevice.
+
+                Returns:
+                    List[MeshDevice]: The submeshes created on this MeshDevice.
+        )doc")
+        .def(
             "compute_with_storage_grid_size",
             &MeshDevice::compute_with_storage_grid_size,
             R"doc(


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
SubMeshes with Fabric are broken on main (for pytests) for the following reason:
 - Creating a SubMesh requires a handle to `ScopedDevices`
 - SubMeshes are not closed/cleared by default when the parent mesh is closed
 - When a pytest exits, it closes the Parent Mesh and disables fabric config. The devices are not closed at this point, since the SubMeshes still maintain handles to them
 - If fabric was previously enabled, it will not be disabled when the SubMeshes are destroyed, since the fabric config was disabled
 - This causes the subsequent run to hang

### What's changed
 - Close SubMeshes in all conftest teardown functions before closing the parent mesh or calling `reset_fabric`. This ensures that the parent mesh closes devices and tears down fabric before setting `FabricConfig::DISABLED`.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes