### PR TITLE
#21096: Remove distributed namespace and import directly into tt::tt_…

### DIFF
--- a/tests/tt_eager/integration_tests/test_bert.cpp
+++ b/tests/tt_eager/integration_tests/test_bert.cpp
@@ -231,7 +231,7 @@ void test_bert() {
     using tt::tt_metal::Tensor;
 
     int device_id = 0;
-    auto device_owner = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+    auto device_owner = tt::tt_metal::MeshDevice::create_unit_mesh(device_id);
     auto device = device_owner.get();
     CoreCoord compute_grid_size = device->compute_with_storage_grid_size();
 

--- a/tests/tt_eager/ops/test_bcast_op.cpp
+++ b/tests/tt_eager/ops/test_bcast_op.cpp
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
         //                      Device Setup
         ////////////////////////////////////////////////////////////////////////////
         int device_id = 0;
-        auto device_owner = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+        auto device_owner = tt_metal::MeshDevice::create_unit_mesh(device_id);
         auto device = device_owner.get();
         ////////////////////////////////////////////////////////////////////////////
         //                      Application Setup

--- a/tests/tt_eager/ops/test_bmm_op.cpp
+++ b/tests/tt_eager/ops/test_bmm_op.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
         //                      Device Setup
         ////////////////////////////////////////////////////////////////////////////
         int device_id = 0;
-        auto device_owner = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+        auto device_owner = tt_metal::MeshDevice::create_unit_mesh(device_id);
         auto device = device_owner.get();
 
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_eager/ops/test_eltwise_binary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_binary_op.cpp
@@ -23,8 +23,8 @@
 
 using tt::tt_metal::DataType;
 using tt::tt_metal::Layout;
+using tt::tt_metal::MeshDevice;
 using tt::tt_metal::Tensor;
-using tt::tt_metal::distributed::MeshDevice;
 
 template <typename BinaryFunction>
 Tensor host_function(const Tensor& input_tensor_a, const Tensor& input_tensor_b) {

--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -32,7 +32,7 @@
 #include "ttnn/tensor/types.hpp"
 
 using tt::tt_metal::DataType;
-using tt::tt_metal::distributed::MeshDevice;
+using tt::tt_metal::MeshDevice;
 
 using tt::tt_metal::Layout;
 using tt::tt_metal::Tensor;
@@ -122,7 +122,7 @@ void test_operation_infrastructure() {
     using ttnn::operations::unary::UnaryWithParam;
 
     int device_id = 0;
-    auto device_owner = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+    auto device_owner = tt::tt_metal::MeshDevice::create_unit_mesh(device_id);
     auto device = device_owner.get();
 
     auto shape = ttnn::Shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
@@ -144,7 +144,7 @@ void test_shape_padding() {
     using ttnn::operations::unary::UnaryWithParam;
 
     int device_id = 0;
-    auto device_owner = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+    auto device_owner = tt::tt_metal::MeshDevice::create_unit_mesh(device_id);
     auto device = device_owner.get();
     ttnn::operations::experimental::auto_format::AutoFormat::SetDefaultDevice(device);
 
@@ -183,7 +183,7 @@ void test_numerically() {
     using ttnn::operations::unary::UnaryWithParam;
 
     int device_id = 0;
-    auto device_owner = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+    auto device_owner = tt::tt_metal::MeshDevice::create_unit_mesh(device_id);
     auto device = device_owner.get();
 
     ttnn::Shape shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
@@ -239,7 +239,7 @@ void test_program_cache() {
     using ttnn::operations::unary::UnaryWithParam;
 
     int device_id = 0;
-    auto device_owner = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+    auto device_owner = tt::tt_metal::MeshDevice::create_unit_mesh(device_id);
     auto device = device_owner.get();
 
     auto run_tests = [&]() {

--- a/tests/tt_eager/ops/test_layernorm_op.cpp
+++ b/tests/tt_eager/ops/test_layernorm_op.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
         //                      Device Setup
         ////////////////////////////////////////////////////////////////////////////
         int device_id = 0;
-        auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+        auto device = tt_metal::MeshDevice::create_unit_mesh(device_id);
         ttnn::Shape shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
         Tensor a = ttnn::random::random(shape).to_layout(Layout::TILE).to_device(device.get());
         Tensor c = ttnn::layer_norm(a, 1e-4f);

--- a/tests/tt_eager/ops/test_softmax_op.cpp
+++ b/tests/tt_eager/ops/test_softmax_op.cpp
@@ -26,7 +26,7 @@ using namespace tt;
 using namespace tt::tt_metal;
 using namespace constants;
 
-void run_softmax(distributed::MeshDevice* device, const ttnn::Shape& shape) {
+void run_softmax(MeshDevice* device, const ttnn::Shape& shape) {
     Tensor input_tensor = ttnn::random::random(shape).to_layout(Layout::TILE).to_device(device);
     Tensor device_output_tensor = ttnn::softmax_in_place(input_tensor);
     Tensor output_tensor = device_output_tensor.cpu();
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     int device_id = 0;
-    auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+    auto device = tt_metal::MeshDevice::create_unit_mesh(device_id);
 
     run_softmax(device.get(), Shape({1, 1, TILE_HEIGHT, TILE_WIDTH}));
     run_softmax(device.get(), Shape({1, 1, TILE_HEIGHT * 2, TILE_WIDTH * 2}));

--- a/tests/tt_eager/tensors/test_copy_and_move.cpp
+++ b/tests/tt_eager/tensors/test_copy_and_move.cpp
@@ -39,7 +39,7 @@ using namespace tt;
 using namespace tt_metal;
 using namespace constants;
 
-void test_tensor_copy_semantics(distributed::MeshDevice* device) {
+void test_tensor_copy_semantics(MeshDevice* device) {
     ttnn::Shape single_tile_shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
 
     // host tensor to host tensor copy constructor
@@ -97,7 +97,7 @@ void test_tensor_copy_semantics(distributed::MeshDevice* device) {
     TT_FATAL(std::equal(dev_b_data.begin(), dev_b_data.end(), dev_b_copy_data.begin()), "Test Failed");
 }
 
-void test_tensor_move_semantics(distributed::MeshDevice* device) {
+void test_tensor_move_semantics(MeshDevice* device) {
     ttnn::Shape single_tile_shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
 
     auto random_tensor = ttnn::random::uniform(bfloat16(-1.0f), bfloat16(1.0f), single_tile_shape);
@@ -170,7 +170,7 @@ void test_tensor_move_semantics(distributed::MeshDevice* device) {
     TT_FATAL(std::equal(dev_b_copy_data.begin(), dev_b_copy_data.end(), bfloat_data_five.begin()), "Test Failed");
 }
 
-void test_tensor_deallocate_semantics(distributed::MeshDevice* device) {
+void test_tensor_deallocate_semantics(MeshDevice* device) {
     ttnn::Shape single_tile_shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
 
     MemoryConfig dram_mem_config =
@@ -209,7 +209,7 @@ void test_tensor_deallocate_semantics(distributed::MeshDevice* device) {
     TT_FATAL(address_f == address_h, "Test Failed");
 }
 
-void test_tensor_deallocate_and_close_device(distributed::MeshDevice* device) {
+void test_tensor_deallocate_and_close_device(MeshDevice* device) {
     ttnn::Shape single_tile_shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
 
     MemoryConfig dram_mem_config =
@@ -232,7 +232,7 @@ int main(int argc, char** argv) {
         //                      Device Setup
         ////////////////////////////////////////////////////////////////////////////
         int device_id = 0;
-        auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+        auto device = tt_metal::MeshDevice::create_unit_mesh(device_id);
 
         test_tensor_copy_semantics(device.get());
 

--- a/tests/tt_eager/tensors/test_host_device_loopback.cpp
+++ b/tests/tt_eager/tensors/test_host_device_loopback.cpp
@@ -29,7 +29,7 @@ using namespace tt;
 using namespace tt_metal;
 using namespace constants;
 
-bool test_single_tile_single_dram_bank_loopback(distributed::MeshDevice* device) {
+bool test_single_tile_single_dram_bank_loopback(MeshDevice* device) {
     bool pass = true;
     ttnn::Shape single_tile_shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
 
@@ -43,7 +43,7 @@ bool test_single_tile_single_dram_bank_loopback(distributed::MeshDevice* device)
     return pass;
 }
 
-bool test_multi_tile_multi_dram_bank_loopback(distributed::MeshDevice* device) {
+bool test_multi_tile_multi_dram_bank_loopback(MeshDevice* device) {
     bool pass = true;
     ttnn::Shape multi_tile_shape({1, 1, 4 * TILE_HEIGHT, 3 * TILE_WIDTH});
 
@@ -64,7 +64,7 @@ int main(int argc, char** argv) {
         //                      Device Setup
         ////////////////////////////////////////////////////////////////////////////
         int device_id = 0;
-        auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+        auto device = tt_metal::MeshDevice::create_unit_mesh(device_id);
 
         pass &= test_single_tile_single_dram_bank_loopback(device.get());
 

--- a/tests/tt_eager/tensors/test_ranks.cpp
+++ b/tests/tt_eager/tensors/test_ranks.cpp
@@ -18,7 +18,7 @@ using namespace tt;
 using namespace tt_metal;
 using namespace constants;
 
-bool test_2d_tensor(distributed::MeshDevice* device) {
+bool test_2d_tensor(MeshDevice* device) {
     bool pass = true;
 
     ttnn::Shape shape({30, 30});
@@ -31,7 +31,7 @@ bool test_2d_tensor(distributed::MeshDevice* device) {
     return pass;
 }
 
-bool test_3d_tensor(distributed::MeshDevice* device) {
+bool test_3d_tensor(MeshDevice* device) {
     bool pass = true;
 
     ttnn::Shape shape({3, 30, 30});
@@ -44,7 +44,7 @@ bool test_3d_tensor(distributed::MeshDevice* device) {
     return pass;
 }
 
-bool test_4d_tensor(distributed::MeshDevice* device) {
+bool test_4d_tensor(MeshDevice* device) {
     bool pass = true;
 
     ttnn::Shape shape({2, 3, 30, 30});
@@ -57,7 +57,7 @@ bool test_4d_tensor(distributed::MeshDevice* device) {
     return pass;
 }
 
-bool test_5d_tensor(distributed::MeshDevice* device) {
+bool test_5d_tensor(MeshDevice* device) {
     bool pass = true;
 
     ttnn::Shape shape({2, 2, 3, 30, 30});
@@ -70,7 +70,7 @@ bool test_5d_tensor(distributed::MeshDevice* device) {
     return pass;
 }
 
-bool test_6d_tensor(distributed::MeshDevice* device) {
+bool test_6d_tensor(MeshDevice* device) {
     bool pass = true;
 
     ttnn::Shape shape({2, 2, 2, 3, 30, 30});
@@ -83,7 +83,7 @@ bool test_6d_tensor(distributed::MeshDevice* device) {
     return pass;
 }
 
-bool test_7d_tensor(distributed::MeshDevice* device) {
+bool test_7d_tensor(MeshDevice* device) {
     bool pass = true;
 
     ttnn::Shape shape({2, 2, 2, 2, 3, 30, 30});
@@ -96,7 +96,7 @@ bool test_7d_tensor(distributed::MeshDevice* device) {
     return pass;
 }
 
-bool test_8d_tensor(distributed::MeshDevice* device) {
+bool test_8d_tensor(MeshDevice* device) {
     bool pass = true;
 
     ttnn::Shape shape({2, 2, 2, 2, 2, 3, 30, 30});
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
         //                      Device Setup
         ////////////////////////////////////////////////////////////////////////////
         int device_id = 0;
-        auto device_owner = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+        auto device_owner = tt_metal::MeshDevice::create_unit_mesh(device_id);
         auto device = device_owner.get();
 
         pass &= test_2d_tensor(device);

--- a/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
+++ b/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
@@ -71,7 +71,7 @@ void test_raw_host_memory_pointer() {
     using tt::tt_metal::Tensor;
 
     int device_id = 0;
-    auto device = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+    auto device = tt::tt_metal::MeshDevice::create_unit_mesh(device_id);
 
     ttnn::Shape shape({1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH});
 

--- a/tests/tt_metal/distributed/test_distributed_host_buffer.cpp
+++ b/tests/tt_metal/distributed/test_distributed_host_buffer.cpp
@@ -22,123 +22,123 @@ using ::testing::SizeIs;
 using ::testing::UnorderedElementsAre;
 
 TEST(DistributedHostBufferTest, WithInvalidLocalShape) {
-    distributed::MeshShape global_shape(2, 3);
-    distributed::MeshShape local_shape(2, 4);  // 2x4 > 2x3
-    distributed::MeshCoordinate local_offset(0, 0);
+    MeshShape global_shape(2, 3);
+    MeshShape local_shape(2, 4);  // 2x4 > 2x3
+    MeshCoordinate local_offset(0, 0);
 
     EXPECT_ANY_THROW(DistributedHostBuffer::create(global_shape, local_shape, local_offset));
 }
 
 TEST(DistributedHostBufferTest, WithInvalidLocalOffset) {
-    distributed::MeshShape global_shape(2, 3);
-    distributed::MeshShape local_shape(1, 2);
-    distributed::MeshCoordinate local_offset(2, 0);  // Offset 2 in first dimension exceeds global shape
+    MeshShape global_shape(2, 3);
+    MeshShape local_shape(1, 2);
+    MeshCoordinate local_offset(2, 0);  // Offset 2 in first dimension exceeds global shape
 
     EXPECT_ANY_THROW(DistributedHostBuffer::create(global_shape, local_shape, local_offset));
 }
 
 TEST(DistributedHostBufferTest, WithInvalidCombination) {
-    distributed::MeshShape global_shape(2, 3);
-    distributed::MeshShape local_shape(1, 2);
-    distributed::MeshCoordinate local_offset(1, 2);  // Offset + shape exceeds global shape
+    MeshShape global_shape(2, 3);
+    MeshShape local_shape(1, 2);
+    MeshCoordinate local_offset(1, 2);  // Offset + shape exceeds global shape
 
     EXPECT_ANY_THROW(DistributedHostBuffer::create(global_shape, local_shape, local_offset));
 }
 
 TEST(DistributedHostBufferTest, WithDimensionMismatch) {
-    distributed::MeshShape global_shape(2, 3);
-    distributed::MeshShape local_shape(1, 1, 1);  // 3D shape vs 2D global shape
-    distributed::MeshCoordinate local_offset(1, 0);
+    MeshShape global_shape(2, 3);
+    MeshShape local_shape(1, 1, 1);  // 3D shape vs 2D global shape
+    MeshCoordinate local_offset(1, 0);
 
     EXPECT_ANY_THROW(DistributedHostBuffer::create(global_shape, local_shape, local_offset));
 }
 
 TEST(DistributedHostBufferTest, GetBuffer) {
-    distributed::MeshShape global_shape(3);
-    distributed::MeshShape local_shape(3);
-    distributed::MeshCoordinate local_offset(0);
+    MeshShape global_shape(3);
+    MeshShape local_shape(3);
+    MeshCoordinate local_offset(0);
 
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
 
-    buffer.emplace_shard(distributed::MeshCoordinate(0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
-    buffer.emplace_shard(distributed::MeshCoordinate(1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
-    buffer.emplace_shard(distributed::MeshCoordinate(2), []() { return HostBuffer(std::vector<int>{7, 8, 9}); });
+    buffer.emplace_shard(MeshCoordinate(0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
+    buffer.emplace_shard(MeshCoordinate(1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
+    buffer.emplace_shard(MeshCoordinate(2), []() { return HostBuffer(std::vector<int>{7, 8, 9}); });
 
-    auto optional_buffer = buffer.get_shard(distributed::MeshCoordinate(0));
+    auto optional_buffer = buffer.get_shard(MeshCoordinate(0));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {1, 2, 3}));
 
-    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(1));
+    optional_buffer = buffer.get_shard(MeshCoordinate(1));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {4, 5, 6}));
 
-    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(2));
+    optional_buffer = buffer.get_shard(MeshCoordinate(2));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {7, 8, 9}));
 
     // Out of global bounds.
-    EXPECT_ANY_THROW(buffer.get_shard(distributed::MeshCoordinate(3)));
+    EXPECT_ANY_THROW(buffer.get_shard(MeshCoordinate(3)));
 }
 
 TEST(DistributedHostBufferTest, WithLocalMeshShape) {
-    distributed::MeshShape global_shape(2, 3);
-    distributed::MeshShape local_shape(2, 1);
-    distributed::MeshCoordinate local_offset(0, 1);
+    MeshShape global_shape(2, 3);
+    MeshShape local_shape(2, 1);
+    MeshCoordinate local_offset(0, 1);
 
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
     EXPECT_EQ(buffer.shape().mesh_size(), 6);  // 2×3 = 6
 
-    buffer.emplace_shard(distributed::MeshCoordinate(0, 0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
-    buffer.emplace_shard(distributed::MeshCoordinate(0, 1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
-    buffer.emplace_shard(distributed::MeshCoordinate(0, 2), []() { return HostBuffer(std::vector<int>{7, 8, 9}); });
-    buffer.emplace_shard(distributed::MeshCoordinate(1, 0), []() { return HostBuffer(std::vector<int>{10, 11, 12}); });
-    buffer.emplace_shard(distributed::MeshCoordinate(1, 1), []() { return HostBuffer(std::vector<int>{13, 14, 15}); });
-    buffer.emplace_shard(distributed::MeshCoordinate(1, 2), []() { return HostBuffer(std::vector<int>{16, 17, 18}); });
+    buffer.emplace_shard(MeshCoordinate(0, 0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
+    buffer.emplace_shard(MeshCoordinate(0, 1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
+    buffer.emplace_shard(MeshCoordinate(0, 2), []() { return HostBuffer(std::vector<int>{7, 8, 9}); });
+    buffer.emplace_shard(MeshCoordinate(1, 0), []() { return HostBuffer(std::vector<int>{10, 11, 12}); });
+    buffer.emplace_shard(MeshCoordinate(1, 1), []() { return HostBuffer(std::vector<int>{13, 14, 15}); });
+    buffer.emplace_shard(MeshCoordinate(1, 2), []() { return HostBuffer(std::vector<int>{16, 17, 18}); });
 
     EXPECT_THAT(
         buffer.shard_coords(),
         UnorderedElementsAre(
-            distributed::MeshCoordinate(0, 0),
-            distributed::MeshCoordinate(0, 1),
-            distributed::MeshCoordinate(0, 2),
-            distributed::MeshCoordinate(1, 0),
-            distributed::MeshCoordinate(1, 1),
-            distributed::MeshCoordinate(1, 2)));
+            MeshCoordinate(0, 0),
+            MeshCoordinate(0, 1),
+            MeshCoordinate(0, 2),
+            MeshCoordinate(1, 0),
+            MeshCoordinate(1, 1),
+            MeshCoordinate(1, 2)));
 
-    auto optional_buffer = buffer.get_shard(distributed::MeshCoordinate(0, 0));
+    auto optional_buffer = buffer.get_shard(MeshCoordinate(0, 0));
     EXPECT_FALSE(optional_buffer.has_value());
 
-    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(0, 1));
+    optional_buffer = buffer.get_shard(MeshCoordinate(0, 1));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {4, 5, 6}));
 
-    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(0, 2));
+    optional_buffer = buffer.get_shard(MeshCoordinate(0, 2));
     EXPECT_FALSE(optional_buffer.has_value());
 
-    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(1, 0));
+    optional_buffer = buffer.get_shard(MeshCoordinate(1, 0));
     EXPECT_FALSE(optional_buffer.has_value());
 
-    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(1, 1));
+    optional_buffer = buffer.get_shard(MeshCoordinate(1, 1));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {13, 14, 15}));
 
-    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(1, 2));
+    optional_buffer = buffer.get_shard(MeshCoordinate(1, 2));
     EXPECT_FALSE(optional_buffer.has_value());
 
     // Out of global bounds.
-    EXPECT_ANY_THROW(buffer.get_shard(distributed::MeshCoordinate(2, 0)));
+    EXPECT_ANY_THROW(buffer.get_shard(MeshCoordinate(2, 0)));
 }
 
 TEST(DistributedHostBufferTest, Transform) {
-    distributed::MeshShape global_shape(2);
-    distributed::MeshShape local_shape(2);
-    distributed::MeshCoordinate local_offset(0);
+    MeshShape global_shape(2);
+    MeshShape local_shape(2);
+    MeshCoordinate local_offset(0);
 
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
     EXPECT_EQ(buffer.shape().mesh_size(), 2);
 
-    buffer.emplace_shard(distributed::MeshCoordinate(0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
-    buffer.emplace_shard(distributed::MeshCoordinate(1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
+    buffer.emplace_shard(MeshCoordinate(0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
+    buffer.emplace_shard(MeshCoordinate(1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
 
     auto transformed_buffer = buffer.transform([](const HostBuffer& buffer) {
         auto span = buffer.view_as<int>();
@@ -149,26 +149,26 @@ TEST(DistributedHostBufferTest, Transform) {
         return HostBuffer(std::move(new_data));
     });
 
-    auto optional_buffer = transformed_buffer.get_shard(distributed::MeshCoordinate(0));
+    auto optional_buffer = transformed_buffer.get_shard(MeshCoordinate(0));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {2, 4, 6}));
 
-    optional_buffer = transformed_buffer.get_shard(distributed::MeshCoordinate(1));
+    optional_buffer = transformed_buffer.get_shard(MeshCoordinate(1));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {8, 10, 12}));
 }
 
 TEST(DistributedHostBufferTest, TransformWithLocalShape) {
-    distributed::MeshShape global_shape(3, 1);
-    distributed::MeshShape local_shape(2, 1);
-    distributed::MeshCoordinate local_offset(1, 0);
+    MeshShape global_shape(3, 1);
+    MeshShape local_shape(2, 1);
+    MeshCoordinate local_offset(1, 0);
 
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
     EXPECT_EQ(buffer.shape().mesh_size(), 3);  // 3×1 = 3
 
-    buffer.emplace_shard(distributed::MeshCoordinate(0, 0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
-    buffer.emplace_shard(distributed::MeshCoordinate(1, 0), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
-    buffer.emplace_shard(distributed::MeshCoordinate(2, 0), []() { return HostBuffer(std::vector<int>{7, 8, 9}); });
+    buffer.emplace_shard(MeshCoordinate(0, 0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
+    buffer.emplace_shard(MeshCoordinate(1, 0), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
+    buffer.emplace_shard(MeshCoordinate(2, 0), []() { return HostBuffer(std::vector<int>{7, 8, 9}); });
 
     auto transformed_buffer = buffer.transform([](const HostBuffer& buffer) {
         auto span = buffer.view_as<int>();
@@ -179,25 +179,25 @@ TEST(DistributedHostBufferTest, TransformWithLocalShape) {
         return HostBuffer(std::move(new_data));
     });
 
-    auto optional_buffer = transformed_buffer.get_shard(distributed::MeshCoordinate(1, 0));
+    auto optional_buffer = transformed_buffer.get_shard(MeshCoordinate(1, 0));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {8, 10, 12}));
 
-    optional_buffer = transformed_buffer.get_shard(distributed::MeshCoordinate(2, 0));
+    optional_buffer = transformed_buffer.get_shard(MeshCoordinate(2, 0));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {14, 16, 18}));
 }
 
 TEST(DistributedHostBufferTest, Apply) {
-    distributed::MeshShape global_shape(2);
-    distributed::MeshShape local_shape(2);
-    distributed::MeshCoordinate local_offset(0);
+    MeshShape global_shape(2);
+    MeshShape local_shape(2);
+    MeshCoordinate local_offset(0);
 
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
     EXPECT_EQ(buffer.shape().mesh_size(), 2);
 
-    buffer.emplace_shard(distributed::MeshCoordinate(0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
-    buffer.emplace_shard(distributed::MeshCoordinate(1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
+    buffer.emplace_shard(MeshCoordinate(0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
+    buffer.emplace_shard(MeshCoordinate(1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
 
     std::vector<std::vector<int>> values;
     buffer.apply([&values](const HostBuffer& buffer) {
@@ -211,16 +211,16 @@ TEST(DistributedHostBufferTest, Apply) {
 }
 
 TEST(DistributedHostBufferTest, ApplyWithLocalShape) {
-    distributed::MeshShape global_shape(3, 1);
-    distributed::MeshShape local_shape(2, 1);
-    distributed::MeshCoordinate local_offset(1, 0);
+    MeshShape global_shape(3, 1);
+    MeshShape local_shape(2, 1);
+    MeshCoordinate local_offset(1, 0);
 
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
     EXPECT_EQ(buffer.shape().mesh_size(), 3);  // 3×1 = 3
 
-    buffer.emplace_shard(distributed::MeshCoordinate(0, 0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
-    buffer.emplace_shard(distributed::MeshCoordinate(1, 0), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
-    buffer.emplace_shard(distributed::MeshCoordinate(2, 0), []() { return HostBuffer(std::vector<int>{7, 8, 9}); });
+    buffer.emplace_shard(MeshCoordinate(0, 0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
+    buffer.emplace_shard(MeshCoordinate(1, 0), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
+    buffer.emplace_shard(MeshCoordinate(2, 0), []() { return HostBuffer(std::vector<int>{7, 8, 9}); });
 
     std::vector<std::vector<int>> values;
     buffer.apply([&values](const HostBuffer& buffer) {

--- a/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
+++ b/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
@@ -21,9 +21,9 @@ namespace tt::tt_metal {
 
 std::shared_ptr<Program> EltwiseBinaryProgramGenerator(
 
-    const std::shared_ptr<distributed::MeshBuffer>& src0_buf,
-    const std::shared_ptr<distributed::MeshBuffer>& src1_buf,
-    const std::shared_ptr<distributed::MeshBuffer>& output_buf,
+    const std::shared_ptr<MeshBuffer>& src0_buf,
+    const std::shared_ptr<MeshBuffer>& src1_buf,
+    const std::shared_ptr<MeshBuffer>& output_buf,
     uint32_t num_tiles,
     uint32_t single_tile_size,
     uint8_t eltwise_op_index,
@@ -108,7 +108,7 @@ std::shared_ptr<Program> EltwiseBinaryProgramGenerator(
 }
 }  // namespace tt::tt_metal
 
-namespace tt::tt_metal::distributed::test {
+namespace tt::tt_metal::test {
 
 using MeshEndToEndT3kTests = T3000MeshDeviceFixture;
 using ::testing::Each;
@@ -156,7 +156,7 @@ TEST_F(MeshEndToEndT3kTests, ProgramDispatchTest) {
 }
 
 TEST_F(MeshEndToEndT3kTests, BufferRoundtripTest) {
-    using tt::tt_metal::distributed::ShardedBufferConfig;
+    using tt::tt_metal::MeshShardedBufferConfig;
 
     auto& cq = mesh_device_->mesh_command_queue();
 
@@ -176,7 +176,7 @@ TEST_F(MeshEndToEndT3kTests, BufferRoundtripTest) {
         .buffer_type = BufferType::L1,
         .buffer_layout = TensorMemoryLayout::INTERLEAVED,
         .bottom_up = false};
-    auto distributed_buffer_config = ShardedBufferConfig{
+    auto distributed_buffer_config = MeshShardedBufferConfig{
         .global_size = distributed_buffer_size_bytes,
         .global_buffer_shape = distributed_buffer_shape,
         .shard_shape = shard_shape};
@@ -208,7 +208,7 @@ TEST_F(MeshEndToEndT3kTests, UntracedEltwiseAddTest) {
         .buffer_type = BufferType::DRAM,
         .buffer_layout = TensorMemoryLayout::INTERLEAVED,
         .bottom_up = false};
-    auto distributed_buffer_config = tt::tt_metal::distributed::ShardedBufferConfig{
+    auto distributed_buffer_config = tt::tt_metal::MeshShardedBufferConfig{
         .global_size = distributed_buffer_size_bytes,
         .global_buffer_shape = distributed_buffer_shape,
         .shard_shape = shard_shape,
@@ -274,7 +274,7 @@ TEST_F(MeshEndToEndT3kTraceTests, EltwiseAddTest) {
         .buffer_type = BufferType::DRAM,
         .buffer_layout = TensorMemoryLayout::INTERLEAVED,
         .bottom_up = false};
-    auto distributed_buffer_config = tt::tt_metal::distributed::ShardedBufferConfig{
+    auto distributed_buffer_config = tt::tt_metal::MeshShardedBufferConfig{
         .global_size = distributed_buffer_size_bytes,
         .global_buffer_shape = distributed_buffer_shape,
         .shard_shape = shard_shape,
@@ -341,7 +341,7 @@ TEST_F(MeshEndToEndT3kTraceTests, EltwiseMulTest) {
         .buffer_type = BufferType::DRAM,
         .buffer_layout = TensorMemoryLayout::INTERLEAVED,
         .bottom_up = false};
-    auto distributed_buffer_config = tt::tt_metal::distributed::ShardedBufferConfig{
+    auto distributed_buffer_config = tt::tt_metal::MeshShardedBufferConfig{
         .global_size = distributed_buffer_size_bytes,
         .global_buffer_shape = distributed_buffer_shape,
         .shard_shape = shard_shape,
@@ -419,7 +419,7 @@ TEST_F(MeshEndToEndT3kTraceTests, SimulEltwiseTest) {
     uint32_t num_tiles_in_mesh =
         num_tiles_per_device * mesh_device_->num_devices();  // The total number of tiles in the distributed memory space
 
-    tt::tt_metal::distributed::ShardedBufferConfig global_buffer_config{
+    tt::tt_metal::MeshShardedBufferConfig global_buffer_config{
         .global_size = single_tile_size * num_tiles_in_mesh,  // Total size of the sharded buffer
         .global_buffer_shape =
             {num_tiles_in_mesh * TILE_WIDTH, TILE_HEIGHT},  // Data represents horizontally concatenated tiles
@@ -541,4 +541,4 @@ TEST_F(MeshEndToEndT3kTraceTests, SimulEltwiseTest) {
     EXPECT_THAT(sub_dst_span, Each(Bfloat16Eq(workload_1_src0_val - workload_1_src1_val)));
 }
 
-}  // namespace ttnn::distributed::test
+}  // namespace tt::tt_metal::test

--- a/tests/tt_metal/distributed/test_mesh_allocator.cpp
+++ b/tests/tt_metal/distributed/test_mesh_allocator.cpp
@@ -12,7 +12,7 @@
 #include <tt-metalium/host_api.hpp>
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 
-namespace tt::tt_metal::distributed::test {
+namespace tt::tt_metal::test {
 
 using MeshAllocatorTest = GenericMeshDeviceFixture;
 
@@ -34,4 +34,4 @@ TEST_F(MeshAllocatorTest, BasicAllocationSanityCheck) {
     EXPECT_EQ(buffer->buffer_type(), buffer_type);
 }
 
-}  // namespace tt::tt_metal::distributed::test
+}  // namespace tt::tt_metal::test

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -30,7 +30,7 @@ namespace {
 
 using ::testing::IsEmpty;
 using ::testing::SizeIs;
-using ::tt::tt_metal::distributed::MeshContainer;
+using ::tt::tt_metal::MeshContainer;
 
 TEST(MeshDeviceInitTest, Init1x1Mesh) {
     auto& sys = SystemMesh::instance();
@@ -38,7 +38,7 @@ TEST(MeshDeviceInitTest, Init1x1Mesh) {
     MeshDeviceConfig config(MeshShape(1, 1));
 
     EXPECT_NO_THROW({
-        auto mesh = tt::tt_metal::distributed::MeshDevice::create(
+        auto mesh = tt::tt_metal::MeshDevice::create(
             config, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, tt::tt_metal::DispatchCoreType::WORKER);
         mesh->close();
     });

--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -67,7 +67,7 @@ class MeshConfigurationTest : public T3KReshapeTestFixture, public ::testing::Wi
 
 TEST_P(MeshConfigurationTest, MeshConfigurations) {
     const auto& shape = GetParam();
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
+    auto mesh = tt::tt_metal::MeshDevice::create(
         MeshDeviceConfig(shape),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
@@ -100,7 +100,7 @@ TEST_P(MeshDeviceReshapeRoundtripTest, ReshapeBetweenConfigurations) {
         GTEST_SKIP() << "Either old or new shape is in line configuration; we test this in From1x4To2x2Invalid";
     }
 
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
+    auto mesh = tt::tt_metal::MeshDevice::create(
         MeshDeviceConfig(old_shape),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
@@ -137,7 +137,7 @@ INSTANTIATE_TEST_SUITE_P(
 using MeshDeviceReshapeTest = T3KReshapeTestFixture;
 
 TEST_F(MeshDeviceReshapeTest, InvalidRequestedShape) {
-    auto& system_mesh = tt::tt_metal::distributed::SystemMesh::instance();
+    auto& system_mesh = tt::tt_metal::SystemMesh::instance();
 
     // Shape too big.
     EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshShape(9)));
@@ -155,7 +155,7 @@ TEST_F(MeshDeviceReshapeTest, InvalidRequestedShape) {
 }
 
 TEST_F(MeshDeviceReshapeTest, InvalidReshapeDimensions) {
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
+    auto mesh = tt::tt_metal::MeshDevice::create(
         MeshDeviceConfig(MeshShape(1, 8)),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
@@ -171,7 +171,7 @@ TEST_F(MeshDeviceReshapeTest, InvalidReshapeDimensions) {
 }
 
 TEST_F(MeshDeviceReshapeTest, From1x8To2x4ThenBackTo1x8) {
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
+    auto mesh = tt::tt_metal::MeshDevice::create(
         MeshDeviceConfig(MeshShape(1, 8)),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
@@ -203,7 +203,7 @@ TEST_F(MeshDeviceReshapeTest, From1x8To2x4ThenBackTo1x8) {
 }
 
 TEST_F(MeshDeviceReshapeTest, InvalidTotalDeviceCount) {
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
+    auto mesh = tt::tt_metal::MeshDevice::create(
         MeshDeviceConfig(MeshShape(1, 8)),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
@@ -219,7 +219,7 @@ TEST_F(MeshDeviceReshapeTest, InvalidTotalDeviceCount) {
 }
 
 TEST_F(MeshDeviceReshapeTest, From1x4To2x2Invalid) {
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
+    auto mesh = tt::tt_metal::MeshDevice::create(
         MeshDeviceConfig(MeshShape(1, 4)),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
@@ -231,14 +231,14 @@ TEST_F(MeshDeviceReshapeTest, From1x4To2x2Invalid) {
 }
 
 TEST_F(MeshDeviceReshapeTest, From1x4To2x2Valid) {
-    auto& system_mesh = tt::tt_metal::distributed::SystemMesh::instance();
+    auto& system_mesh = tt::tt_metal::SystemMesh::instance();
 
     // Fetch the device ids for a physically connected 2x2 mesh.
     auto physical_device_ids = system_mesh.get_mapped_physical_device_ids(MeshShape(2, 2));
 
     // Supply the physical device ids to the mesh constructor that we know we know is 2x2 physically connected.
     // We will create a 1x4 mesh and then reshape it to 2x2.
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
+    auto mesh = tt::tt_metal::MeshDevice::create(
         MeshDeviceConfig(MeshShape(1, 4), /*offset=*/std::nullopt, /*physical_device_ids=*/physical_device_ids),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
@@ -254,7 +254,7 @@ TEST_F(MeshDeviceReshapeTest, From1x4To2x2Valid) {
 }
 
 TEST_F(MeshDeviceReshapeTest, From2x2To1x4) {
-    auto mesh = tt::tt_metal::distributed::MeshDevice::create(
+    auto mesh = tt::tt_metal::MeshDevice::create(
         MeshDeviceConfig(MeshShape(2, 2)),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -29,7 +29,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/util.hpp>
 
-namespace tt::tt_metal::distributed::test {
+namespace tt::tt_metal::test {
 namespace {
 
 using MeshEventsTestT3000 = T3000MultiCQMeshDeviceFixture;
@@ -91,7 +91,7 @@ TEST_F(MeshEventsTestT3000, ShardedAsyncIO) {
 
     uint32_t global_buffer_size = global_buffer_shape.height() * global_buffer_shape.width() * sizeof(uint32_t);
 
-    ShardedBufferConfig sharded_config{
+    MeshShardedBufferConfig sharded_config{
         .global_size = global_buffer_size,
         .global_buffer_shape = global_buffer_shape,
         .shard_shape = shard_shape,
@@ -133,8 +133,8 @@ TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
 
     CoreCoord worker_grid_size = mesh_device_->compute_with_storage_grid_size();
 
-    auto programs = tt::tt_metal::distributed::test::utils::create_eltwise_bin_programs(
-        mesh_device_, src0_bufs, src1_bufs, output_bufs);
+    auto programs =
+        tt::tt_metal::test::utils::create_eltwise_bin_programs(mesh_device_, src0_bufs, src1_bufs, output_bufs);
     uint32_t num_rows_in_workload = mesh_device_->num_rows() / 2;
     auto mesh_workload = CreateMeshWorkload();
     MeshCoordinateRange devices_0(
@@ -335,4 +335,4 @@ TEST_F(MeshEventsTestSuite, MultiCQNonBlockingReads) {
 }
 
 }  // namespace
-}  // namespace tt::tt_metal::distributed::test
+}  // namespace tt::tt_metal::test

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -72,7 +72,7 @@ void verify_socket_configs(
 }
 
 void test_single_connection_single_device_socket(
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& md0,
+    const std::shared_ptr<tt::tt_metal::MeshDevice>& md0,
     std::size_t socket_fifo_size,
     std::size_t page_size,
     std::size_t data_size,
@@ -219,7 +219,7 @@ void test_single_connection_single_device_socket(
 }
 
 void test_single_device_socket_with_workers(
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& md0,
+    const std::shared_ptr<tt::tt_metal::MeshDevice>& md0,
     std::size_t socket_fifo_size,
     std::size_t page_size,
     std::size_t data_size,
@@ -542,8 +542,8 @@ void test_single_device_socket_with_workers(
 }
 
 void test_single_connection_multi_device_socket(
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& md0,
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& md1,
+    const std::shared_ptr<tt::tt_metal::MeshDevice>& md0,
+    const std::shared_ptr<tt::tt_metal::MeshDevice>& md1,
     std::size_t socket_fifo_size,
     std::size_t page_size,
     std::size_t data_size,
@@ -739,8 +739,8 @@ void test_single_connection_multi_device_socket(
 }
 
 void test_single_connection_multi_device_socket_with_workers(
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& md0,
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& md1,
+    const std::shared_ptr<tt::tt_metal::MeshDevice>& md0,
+    const std::shared_ptr<tt::tt_metal::MeshDevice>& md1,
     std::size_t socket_fifo_size,
     std::size_t page_size,
     std::size_t data_size) {
@@ -1307,10 +1307,10 @@ std::shared_ptr<Program> create_recv_program(
 }
 
 void test_multi_sender_single_recv(
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& sender_0,
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& sender_1,
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& reducer,
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& receiver,
+    const std::shared_ptr<tt::tt_metal::MeshDevice>& sender_0,
+    const std::shared_ptr<tt::tt_metal::MeshDevice>& sender_1,
+    const std::shared_ptr<tt::tt_metal::MeshDevice>& reducer,
+    const std::shared_ptr<tt::tt_metal::MeshDevice>& receiver,
     const std::vector<uint32_t>& link_indices,
     std::size_t socket_fifo_size,
     std::size_t page_size,

--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -39,7 +39,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/util.hpp>
 
-namespace tt::tt_metal::distributed::test {
+namespace tt::tt_metal::test {
 namespace {
 
 namespace tt::tt_metal {
@@ -268,4 +268,4 @@ TEST_F(MeshSubDeviceTestSuite, SubDeviceBasicProgramsReuse) {
 }
 }
 }  // namespace
-}  // namespace tt::tt_metal::distributed::test
+}  // namespace tt::tt_metal::test

--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -50,7 +50,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/util.hpp>
 
-namespace tt::tt_metal::distributed::test {
+namespace tt::tt_metal::test {
 namespace {
 
 // Helper functions that return MeshCoordinateRange spanning various parts of the T3000 device.
@@ -116,7 +116,7 @@ TEST_F(MeshTraceTestSuite, Sanity) {
         std::vector<std::shared_ptr<MeshWorkload>> mesh_workloads = {};
         for (int i = 0; i < num_workloads_per_trace * num_traces; i++) {
             auto workload = std::make_shared<MeshWorkload>();
-            auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+            auto programs = tt::tt_metal::test::utils::create_random_programs(
                 1, mesh_device_->compute_with_storage_grid_size(), seed);
             AddProgramToMeshWorkload(*workload, std::move(*programs[0]), all_devices);
             EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
@@ -167,22 +167,22 @@ TEST_F(MeshTraceTestT3000, EltwiseBinaryMeshTrace) {
     MeshCoordinateRange col_2({0, 3}, {1, 3});
 
     // Create first workload: running addition on top row and multiplication on bottom row
-    auto programs = tt::tt_metal::distributed::test::utils::create_eltwise_bin_programs(
-        mesh_device_, src0_bufs, src1_bufs, intermed_bufs_0);
+    auto programs =
+        tt::tt_metal::test::utils::create_eltwise_bin_programs(mesh_device_, src0_bufs, src1_bufs, intermed_bufs_0);
     auto mesh_workload = CreateMeshWorkload();
     AddProgramToMeshWorkload(mesh_workload, std::move(*programs[0]), row_0);
     AddProgramToMeshWorkload(mesh_workload, std::move(*programs[1]), row_1);
     // Create second workload: running addition on top row (src1 + intermed0) and multiplication on
     // bottom row (src1 * intermed0)
-    auto programs_1 = tt::tt_metal::distributed::test::utils::create_eltwise_bin_programs(
+    auto programs_1 = tt::tt_metal::test::utils::create_eltwise_bin_programs(
         mesh_device_, intermed_bufs_0, src1_bufs, intermed_bufs_1);
     auto mesh_workload_1 = CreateMeshWorkload();
     AddProgramToMeshWorkload(mesh_workload_1, std::move(*programs_1[1]), row_0);
     AddProgramToMeshWorkload(mesh_workload_1, std::move(*programs_1[0]), row_1);
     // Create third workload: running addition on 1st col (src1 + intermed1), multiplication on
     // second col (src1 * intermed1) and subtraction on the third col( src1 - intermed1)
-    auto programs_2 = tt::tt_metal::distributed::test::utils::create_eltwise_bin_programs(
-        mesh_device_, intermed_bufs_1, src1_bufs, output_bufs);
+    auto programs_2 =
+        tt::tt_metal::test::utils::create_eltwise_bin_programs(mesh_device_, intermed_bufs_1, src1_bufs, output_bufs);
     auto mesh_workload_2 = CreateMeshWorkload();
     AddProgramToMeshWorkload(mesh_workload_2, std::move(*programs_2[0]), col_0);
     AddProgramToMeshWorkload(mesh_workload_2, std::move(*programs_2[1]), col_1);
@@ -514,8 +514,8 @@ TEST_F(MeshTraceTestSuite, MeshTraceAsserts) {
     srand(seed);
     MeshCoordinateRange all_devices(mesh_device_->shape());
     auto workload = std::make_shared<MeshWorkload>();
-    auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
-        1, mesh_device_->compute_with_storage_grid_size(), seed);
+    auto programs =
+        tt::tt_metal::test::utils::create_random_programs(1, mesh_device_->compute_with_storage_grid_size(), seed);
     AddProgramToMeshWorkload(*workload, std::move(*programs[0]), all_devices);
     auto trace_id = BeginTraceCapture(mesh_device_.get(), 0);
     EXPECT_THROW(EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, true), std::runtime_error);
@@ -540,7 +540,7 @@ void run_heterogenous_trace_sweep(
         for (int i = 0; i < num_workloads; i++) {
             auto workload = std::make_shared<MeshWorkload>();
             for (auto& program_grid : workload_grid) {
-                auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+                auto programs = tt::tt_metal::test::utils::create_random_programs(
                     1, mesh_device->compute_with_storage_grid_size(), seed);
                 AddProgramToMeshWorkload(*workload, std::move(*programs[0]), program_grid);
             }
@@ -733,4 +733,4 @@ INSTANTIATE_TEST_SUITE_P(
                                                        {MeshCoordinateRange({0, 1}, {3, 3})}})));
 
 }  // namespace
-}  // namespace tt::tt_metal::distributed::test
+}  // namespace tt::tt_metal::test

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -52,7 +52,7 @@
 #include "umd/device/tt_core_coordinates.h"
 #include <tt-metalium/util.hpp>
 
-namespace tt::tt_metal::distributed::test {
+namespace tt::tt_metal::test {
 namespace {
 
 using ::testing::HasSubstr;
@@ -213,7 +213,7 @@ TEST_F(MeshWorkloadTestSuite, TestMeshWorkloadOnActiveEth) {
 TEST_F(MeshWorkloadTestSuite, OverlappingProgramRanges) {
     MeshWorkload workload;
 
-    auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+    auto programs = tt::tt_metal::test::utils::create_random_programs(
         /*num_programs=*/2, mesh_device_->compute_with_storage_grid_size(), /*seed=*/0);
     uint32_t num_rows_in_workload = mesh_device_->num_rows() / 2;
     auto mesh_workload = CreateMeshWorkload();
@@ -239,7 +239,7 @@ TEST_F(MeshWorkloadTestT3000, SimultaneousMeshWorkloads) {
 
     log_info("Create MeshWorkloads with multiple programs each");
 
-    auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+    auto programs = tt::tt_metal::test::utils::create_random_programs(
         num_programs, mesh_device_->compute_with_storage_grid_size(), seed);
     std::vector<std::shared_ptr<MeshWorkload>> mesh_workloads = {};
 
@@ -260,7 +260,7 @@ TEST_F(MeshWorkloadTestT3000, SimultaneousMeshWorkloads) {
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *random_workload, false);
         mesh_workloads.push_back(random_workload);
     }
-    programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+    programs = tt::tt_metal::test::utils::create_random_programs(
         num_programs, mesh_device_->compute_with_storage_grid_size(), seed);
     for (int i = 0; i < num_programs; i += 4) {
         std::shared_ptr<MeshWorkload> random_workload = std::make_shared<MeshWorkload>();
@@ -275,7 +275,7 @@ TEST_F(MeshWorkloadTestT3000, SimultaneousMeshWorkloads) {
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *random_workload, false);
         mesh_workloads.push_back(random_workload);
     }
-    programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+    programs = tt::tt_metal::test::utils::create_random_programs(
         num_heterogeneous_programs, mesh_device_->compute_with_storage_grid_size(), seed);
     for (int i = 0; i < num_heterogeneous_programs; i += 8) {
         std::shared_ptr<MeshWorkload> random_workload = std::make_shared<MeshWorkload>();
@@ -327,7 +327,7 @@ TEST_F(MeshWorkloadTestTG, SimultaneousMeshWorkloads) {
 
     log_info(tt::LogTest, "Compile and load {} MeshWorkloads", 2 * (num_programs_0 + num_programs_1));
 
-    auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+    auto programs = tt::tt_metal::test::utils::create_random_programs(
         num_programs_0, mesh_device_->compute_with_storage_grid_size(), seed);
 
     for (int i = 0; i < num_programs_0; i += 2) {
@@ -340,7 +340,7 @@ TEST_F(MeshWorkloadTestTG, SimultaneousMeshWorkloads) {
         mesh_workloads.push_back(random_workload);
     }
 
-    programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+    programs = tt::tt_metal::test::utils::create_random_programs(
         num_programs_0, mesh_device_->compute_with_storage_grid_size(), seed);
 
     for (int i = 0; i < num_programs_0; i += 2) {
@@ -353,7 +353,7 @@ TEST_F(MeshWorkloadTestTG, SimultaneousMeshWorkloads) {
         mesh_workloads.push_back(random_workload);
     }
 
-    programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+    programs = tt::tt_metal::test::utils::create_random_programs(
         num_programs_1, mesh_device_->compute_with_storage_grid_size(), seed);
 
     for (int i = 0; i < num_programs_1; i += 4) {
@@ -371,7 +371,7 @@ TEST_F(MeshWorkloadTestTG, SimultaneousMeshWorkloads) {
         mesh_workloads.push_back(random_workload);
     }
 
-    programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+    programs = tt::tt_metal::test::utils::create_random_programs(
         num_programs_1, mesh_device_->compute_with_storage_grid_size(), seed);
     for (int i = 0; i < num_programs_1; i += 8) {
         std::shared_ptr<MeshWorkload> random_workload = std::make_shared<MeshWorkload>();
@@ -414,7 +414,7 @@ TEST_F(MeshWorkloadTestSuite, RandomizedMeshWorkload) {
     log_info(tt::LogTest, "Using Test Seed: {}", seed);
     srand(seed);
     log_info("Create {} MeshWorkloads", num_programs);
-    auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+    auto programs = tt::tt_metal::test::utils::create_random_programs(
         num_programs, mesh_device_->compute_with_storage_grid_size(), seed);
     std::mt19937 rng(seed);
     std::uniform_int_distribution<int> gen_col(1, mesh_device_->num_cols());
@@ -454,8 +454,8 @@ TEST_F(MeshWorkloadTestSuite, EltwiseBinaryMeshWorkload) {
 
     CoreCoord worker_grid_size = mesh_device_->compute_with_storage_grid_size();
 
-    auto programs = tt::tt_metal::distributed::test::utils::create_eltwise_bin_programs(
-        mesh_device_, src0_bufs, src1_bufs, output_bufs);
+    auto programs =
+        tt::tt_metal::test::utils::create_eltwise_bin_programs(mesh_device_, src0_bufs, src1_bufs, output_bufs);
     uint32_t num_rows_in_workload = mesh_device_->num_rows() / 2;
     auto mesh_workload = CreateMeshWorkload();
     MeshCoordinateRange devices_0(
@@ -718,4 +718,4 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSemaphoreDifferentPrograms) {
 }
 
 }  // namespace
-}  // namespace tt::tt_metal::distributed::test
+}  // namespace tt::tt_metal::test

--- a/tests/tt_metal/distributed/test_thread_pool.cpp
+++ b/tests/tt_metal/distributed/test_thread_pool.cpp
@@ -6,7 +6,7 @@
 #include "tt_metal/common/thread_pool.hpp"
 #include "impl/context/metal_context.hpp"
 
-namespace tt::tt_metal::distributed::test {
+namespace tt::tt_metal::test {
 namespace {
 
 // Stress test for thread pool used by TT-Mesh
@@ -51,4 +51,4 @@ TEST(ThreadPoolTest, Exception) {
 
 }  // namespace
 
-}  // namespace tt::tt_metal::distributed::test
+}  // namespace tt::tt_metal::test

--- a/tests/tt_metal/distributed/utils.cpp
+++ b/tests/tt_metal/distributed/utils.cpp
@@ -32,7 +32,7 @@
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/utils.hpp>
 
-namespace tt::tt_metal::distributed::test::utils {
+namespace tt::tt_metal::test::utils {
 
 std::vector<std::shared_ptr<Program>> create_eltwise_bin_programs(
     std::shared_ptr<MeshDevice>& mesh_device,
@@ -406,4 +406,4 @@ std::vector<std::shared_ptr<Program>> create_random_programs(
     return programs;
 }
 
-}  // namespace tt::tt_metal::distributed::test::utils
+}  // namespace tt::tt_metal::test::utils

--- a/tests/tt_metal/distributed/utils.hpp
+++ b/tests/tt_metal/distributed/utils.hpp
@@ -16,14 +16,12 @@
 
 namespace tt {
 namespace tt_metal {
-namespace distributed {
 class MeshBuffer;
 class MeshDevice;
-}  // namespace distributed
 }  // namespace tt_metal
 }  // namespace tt
 
-namespace tt::tt_metal::distributed::test::utils {
+namespace tt::tt_metal::test::utils {
 
 std::vector<std::shared_ptr<Program>> create_eltwise_bin_programs(
     std::shared_ptr<MeshDevice>& mesh_device,
@@ -36,4 +34,4 @@ std::vector<std::shared_ptr<Program>> create_random_programs(
     CoreCoord worker_grid_size,
     uint32_t seed,
     const std::unordered_set<CoreCoord>& active_eth_cores = {});
-}  // namespace tt::tt_metal::distributed::test::utils
+}  // namespace tt::tt_metal::test::utils

--- a/tests/tt_metal/multihost/common/multihost_test_tools.hpp
+++ b/tests/tt_metal/multihost/common/multihost_test_tools.hpp
@@ -12,10 +12,10 @@
 #include <fmt/format.h>
 namespace multihost::common {
 
-using ContextPtr = std::shared_ptr<tt::tt_metal::distributed::multihost::DistributedContext>;
-using ReduceOp = tt::tt_metal::distributed::multihost::ReduceOp;
-using tt::tt_metal::distributed::multihost::dtype_of_v;
-using tt::tt_metal::distributed::multihost::is_supported_dtype_v;
+using ContextPtr = std::shared_ptr<tt::tt_metal::multihost::DistributedContext>;
+using ReduceOp = tt::tt_metal::multihost::ReduceOp;
+using tt::tt_metal::multihost::dtype_of_v;
+using tt::tt_metal::multihost::is_supported_dtype_v;
 //----------------------------------------------------------------------
 //  internal helpers
 //----------------------------------------------------------------------
@@ -66,10 +66,7 @@ void assert_true_all_ranks(const BoolLike& cond, const ContextPtr& ctx) {
     int local = static_cast<int>(cond ? 1 : 0);
     int global = 0;
     ctx->all_reduce(
-        as_bytes_single(local),
-        as_bytes_single(global),
-        ReduceOp::LAND,
-        tt::tt_metal::distributed::multihost::DType::INT32);
+        as_bytes_single(local), as_bytes_single(global), ReduceOp::LAND, tt::tt_metal::multihost::DType::INT32);
     ASSERT_EQ(global, 1) << "Rank " << *ctx->rank() << " violated collective TRUE condition.";
 }
 
@@ -95,13 +92,13 @@ inline void barrier(const ContextPtr& ctx) { ctx->barrier(); }
 //  multihost test main function
 // ----------------------------------------------------------------------
 inline int multihost_main(int argc, char** argv) {
-    tt::tt_metal::distributed::multihost::DistributedContext::create(argc, argv);
-    using Rank = tt::tt_metal::distributed::multihost::Rank;
-    using Tag = tt::tt_metal::distributed::multihost::Tag;
+    tt::tt_metal::multihost::DistributedContext::create(argc, argv);
+    using Rank = tt::tt_metal::multihost::Rank;
+    using Tag = tt::tt_metal::multihost::Tag;
 
     ::testing::InitGoogleTest(&argc, argv);
 
-    auto ctx = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
+    auto ctx = tt::tt_metal::multihost::DistributedContext::get_current_world();
 
     // Skip all tests if lacking fault tolerance.
     if (!ctx->supports_fault_tolerance()) {
@@ -118,7 +115,7 @@ inline int multihost_main(int argc, char** argv) {
     int local_rc = RUN_ALL_TESTS();
 
     // need to make sure that  we get context after the tests, old one could be revoked
-    auto context = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
+    auto context = tt::tt_metal::multihost::DistributedContext::get_current_world();
     fmt::print("Rank {}: local rc = {}\n", *context->rank(), local_rc);
     // Propagate the worst return code to all ranks
 

--- a/tests/tt_metal/multihost/fault_tolerance_tests/ulfm_tests.cpp
+++ b/tests/tt_metal/multihost/fault_tolerance_tests/ulfm_tests.cpp
@@ -6,11 +6,11 @@
 #include "common/multihost_test_tools.hpp"
 #include <thread>
 
-using tt::tt_metal::distributed::multihost::Color;
-using tt::tt_metal::distributed::multihost::DistributedContext;
-using tt::tt_metal::distributed::multihost::DistributedException;
-using tt::tt_metal::distributed::multihost::Key;
-using tt::tt_metal::distributed::multihost::Rank;
+using tt::tt_metal::multihost::Color;
+using tt::tt_metal::multihost::DistributedContext;
+using tt::tt_metal::multihost::DistributedException;
+using tt::tt_metal::multihost::Key;
+using tt::tt_metal::multihost::Rank;
 
 TEST(FaultTolerance, ShrinkAfterRankFailure) {
     //----------------------------------------------------------------------

--- a/tests/tt_metal/multihost/single_host_mp_tests/test_context.cpp
+++ b/tests/tt_metal/multihost/single_host_mp_tests/test_context.cpp
@@ -8,15 +8,15 @@
 #include <thread>
 
 namespace {
-using Rank = tt::tt_metal::distributed::multihost::Rank;
-using Tag = tt::tt_metal::distributed::multihost::Tag;
-using Size = tt::tt_metal::distributed::multihost::Size;
-using DistributedContext = tt::tt_metal::distributed::multihost::DistributedContext;
-using ReduceOp = tt::tt_metal::distributed::multihost::ReduceOp;
-using Color = tt::tt_metal::distributed::multihost::Color;
-using Key = tt::tt_metal::distributed::multihost::Key;
-using RequestPtr = std::shared_ptr<tt::tt_metal::distributed::multihost::Request>;
-using ContextPtr = std::shared_ptr<tt::tt_metal::distributed::multihost::DistributedContext>;
+using Rank = tt::tt_metal::multihost::Rank;
+using Tag = tt::tt_metal::multihost::Tag;
+using Size = tt::tt_metal::multihost::Size;
+using DistributedContext = tt::tt_metal::multihost::DistributedContext;
+using ReduceOp = tt::tt_metal::multihost::ReduceOp;
+using Color = tt::tt_metal::multihost::Color;
+using Key = tt::tt_metal::multihost::Key;
+using RequestPtr = std::shared_ptr<tt::tt_metal::multihost::Request>;
+using ContextPtr = std::shared_ptr<tt::tt_metal::multihost::DistributedContext>;
 
 tt::stl::Span<std::byte> int_to_byte_span(int* val_ptr) {
     return tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(val_ptr), sizeof(int));
@@ -26,7 +26,7 @@ tt::stl::Span<std::byte> int_to_byte_span(int* val_ptr) {
 TEST(DistributedContextTest, TestSendRecv) {
     // assuming context is already initialized in main with argc, argv
     // in this case we will just get a world context
-    auto context = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
+    auto context = tt::tt_metal::multihost::DistributedContext::get_current_world();
 
     auto size = context->size();
 
@@ -53,10 +53,10 @@ TEST(DistributedContextTest, TestSendRecv) {
 TEST(DistributedContextTest, AllReduceInt) {
     // assuming context is already initialized in main with argc, argv
     // in this case we will just get a world context
-    auto context = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
-    using Rank = tt::tt_metal::distributed::multihost::Rank;
-    using Tag = tt::tt_metal::distributed::multihost::Tag;
-    using Size = tt::tt_metal::distributed::multihost::Size;
+    auto context = tt::tt_metal::multihost::DistributedContext::get_current_world();
+    using Rank = tt::tt_metal::multihost::Rank;
+    using Tag = tt::tt_metal::multihost::Tag;
+    using Size = tt::tt_metal::multihost::Size;
 
     auto size = context->size();
 
@@ -68,7 +68,7 @@ TEST(DistributedContextTest, AllReduceInt) {
     std::vector<int> result(10);
     tt::stl::Span<int> view(data.data(), data.size());
     tt::stl::Span<int> result_view(result.data(), result.size());
-    context->all_reduce(view, result_view, tt::tt_metal::distributed::multihost::ReduceOp::SUM);
+    context->all_reduce(view, result_view, tt::tt_metal::multihost::ReduceOp::SUM);
     for (int i = 0; i < 10; ++i) {
         int expected = 0;
         for (int j = 0; j < *size; ++j) {

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -311,7 +311,7 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
     std::unordered_map<RoutingDirection, std::vector<chip_id_t>> physical_end_device_ids_by_dir;
     fabric_hops[direction] = num_hops;
 
-    tt::tt_metal::distributed::MeshShape mesh_shape;
+    tt::tt_metal::MeshShape mesh_shape;
     std::vector<chan_id_t> eth_chans;
     chan_id_t edm_port;
 
@@ -766,7 +766,7 @@ void RunTestMCastConnAPI(
     fabric_hops[fwd_dir] = fwd_hops;
     fabric_hops[bwd_dir] = bwd_hops;
 
-    tt::tt_metal::distributed::MeshShape mesh_shape;
+    tt::tt_metal::MeshShape mesh_shape;
     const auto topology = control_plane.get_fabric_context().get_fabric_topology();
     uint32_t is_2d_fabric = topology == Topology::Mesh;
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -40,11 +40,11 @@ TEST_F(ControlPlaneFixture, TestTGMeshAPIs) {
     auto user_meshes = control_plane.get_user_physical_mesh_ids();
     EXPECT_EQ(user_meshes.size(), 1);
     EXPECT_EQ(user_meshes[0], MeshId{4});
-    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{0}), tt::tt_metal::distributed::MeshShape(1, 1));
-    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{1}), tt::tt_metal::distributed::MeshShape(1, 1));
-    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{2}), tt::tt_metal::distributed::MeshShape(1, 1));
-    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{3}), tt::tt_metal::distributed::MeshShape(1, 1));
-    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{4}), tt::tt_metal::distributed::MeshShape(4, 8));
+    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{0}), tt::tt_metal::MeshShape(1, 1));
+    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{1}), tt::tt_metal::MeshShape(1, 1));
+    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{2}), tt::tt_metal::MeshShape(1, 1));
+    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{3}), tt::tt_metal::MeshShape(1, 1));
+    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{4}), tt::tt_metal::MeshShape(4, 8));
 }
 
 TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
@@ -161,7 +161,7 @@ TEST_F(ControlPlaneFixture, TestQuantaGalaxyMeshAPIs) {
     auto user_meshes = control_plane.get_user_physical_mesh_ids();
     EXPECT_EQ(user_meshes.size(), 1);
     EXPECT_EQ(user_meshes[0], MeshId{0});
-    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{0}), tt::tt_metal::distributed::MeshShape(8, 4));
+    EXPECT_EQ(control_plane.get_physical_mesh_shape(MeshId{0}), tt::tt_metal::MeshShape(8, 4));
 }
 
 

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -89,15 +89,15 @@ protected:
 
 class MeshDeviceFixtureBase : public ::testing::Test {
 public:
-    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> get_mesh_device() {
+    std::shared_ptr<tt::tt_metal::MeshDevice> get_mesh_device() {
         TT_FATAL(mesh_device_, "MeshDevice not initialized in {}", __FUNCTION__);
         return mesh_device_;
     }
 
 protected:
-    using MeshDevice = ::tt::tt_metal::distributed::MeshDevice;
-    using MeshDeviceConfig = ::tt::tt_metal::distributed::MeshDeviceConfig;
-    using MeshShape = ::tt::tt_metal::distributed::MeshShape;
+    using MeshDevice = ::tt::tt_metal::MeshDevice;
+    using MeshDeviceConfig = ::tt::tt_metal::MeshDeviceConfig;
+    using MeshShape = ::tt::tt_metal::MeshShape;
 
     enum class MeshDeviceType {
         // N150/P150 devices opened as 1x1 meshes.
@@ -182,7 +182,7 @@ protected:
         }
     }
 
-    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device_;
+    std::shared_ptr<tt::tt_metal::MeshDevice> mesh_device_;
 
 private:
     // Returns the mesh shape for a given mesh device type.

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -38,11 +38,11 @@
 #include "umd/device/types/xy_pair.h"
 
 using tt::tt_metal::IDevice;
-using tt::tt_metal::distributed::MeshCoordinate;
-using tt::tt_metal::distributed::MeshDevice;
-using tt::tt_metal::distributed::MeshDeviceConfig;
-using tt::tt_metal::distributed::MeshDeviceView;
-using tt::tt_metal::distributed::MeshShape;
+using tt::tt_metal::MeshCoordinate;
+using tt::tt_metal::MeshDevice;
+using tt::tt_metal::MeshDeviceConfig;
+using tt::tt_metal::MeshDeviceView;
+using tt::tt_metal::MeshShape;
 
 class T3000TestDevice {
 public:

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -59,13 +59,13 @@ struct SubdeviceInfo {
     std::unordered_map<chip_id_t, SubDeviceId> fabric_subdevice_id;
 };
 
-using tt::tt_metal::distributed::MeshContainer;
-using tt::tt_metal::distributed::MeshCoordinate;
-using tt::tt_metal::distributed::MeshDevice;
-using tt::tt_metal::distributed::MeshDeviceConfig;
-using tt::tt_metal::distributed::MeshDeviceView;
-using tt::tt_metal::distributed::MeshShape;
-using tt::tt_metal::distributed::SystemMesh;
+using tt::tt_metal::MeshContainer;
+using tt::tt_metal::MeshCoordinate;
+using tt::tt_metal::MeshDevice;
+using tt::tt_metal::MeshDeviceConfig;
+using tt::tt_metal::MeshDeviceView;
+using tt::tt_metal::MeshShape;
+using tt::tt_metal::SystemMesh;
 
 class BaseFabricFixture {
 protected:

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -30,13 +30,13 @@ ttnn::global_semaphore::MultiDeviceGlobalSemaphore create_global_semaphore(const
         10);
 }
 
-std::vector<IDevice*> get_line_devices(distributed::MeshDevice* mesh_device) {
+std::vector<IDevice*> get_line_devices(MeshDevice* mesh_device) {
     auto view = mesh_device->get_view();
     return {
-        view.get_device(distributed::MeshCoordinate(0, 0)),
-        view.get_device(distributed::MeshCoordinate(0, 1)),
-        view.get_device(distributed::MeshCoordinate(0, 2)),
-        view.get_device(distributed::MeshCoordinate(0, 3))};
+        view.get_device(MeshCoordinate(0, 0)),
+        view.get_device(MeshCoordinate(0, 1)),
+        view.get_device(MeshCoordinate(0, 2)),
+        view.get_device(MeshCoordinate(0, 3))};
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE

--- a/tests/ttnn/unit_tests/gtests/emitc/test_sanity.cpp
+++ b/tests/ttnn/unit_tests/gtests/emitc/test_sanity.cpp
@@ -16,7 +16,7 @@ ttnn::Tensor add(ttnn::Tensor v1, ttnn::Tensor v2) {
 }
 
 std::tuple<ttnn::Tensor, ttnn::Tensor> create_inputs_for_add() {
-    ttnn::distributed::MeshDevice* v1 = ttnn::DeviceGetter::getInstance();
+    ttnn::MeshDevice* v1 = ttnn::DeviceGetter::getInstance();
     ttnn::Tensor v2 = ttnn::ones(
         ttnn::Shape({32, 32}),
         ttnn::DataType::BFLOAT16,

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -39,16 +39,16 @@
 
 #include "gtest/gtest.h"
 
-namespace ttnn::distributed::test {
+namespace ttnn::test {
 
 using namespace tt;
 using namespace tt_metal;
 
-using tt::tt_metal::distributed::MeshCoordinate;
-using tt::tt_metal::distributed::MeshDevice;
-using tt::tt_metal::distributed::MeshDeviceConfig;
-using tt::tt_metal::distributed::MeshDeviceView;
-using tt::tt_metal::distributed::MeshShape;
+using tt::tt_metal::MeshCoordinate;
+using tt::tt_metal::MeshDevice;
+using tt::tt_metal::MeshDeviceConfig;
+using tt::tt_metal::MeshDeviceView;
+using tt::tt_metal::MeshShape;
 
 // Custom Fixture using 1D Fabric on a Multi-CQ MeshDevice
 class T3000MultiCQFabricMeshDeviceFixture : public T3000MultiCQMeshDeviceFixture {
@@ -391,4 +391,4 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
     log_info(tt::LogTest, "Finished");
 }
 
-}  // namespace ttnn::distributed::test
+}  // namespace ttnn::test

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.cpp
@@ -35,13 +35,11 @@ struct UnaryWithParam;
 }  // namespace ttnn
 namespace tt {
 namespace tt_metal {
-namespace distributed {
 class MeshDevice;
-}  // namespace distributed
 }  // namespace tt_metal
 }  // namespace tt
 
-namespace ttnn::distributed::test {
+namespace ttnn::test {
 
 static constexpr size_t TEST_WORKERS_SUBDEVICE_INDEX = 0;
 static constexpr size_t TEST_EDM_FABRIC_SUBDEVICE_INDEX = 1;
@@ -160,7 +158,7 @@ std::tuple<
     ttnn::global_semaphore::MultiDeviceGlobalSemaphore,
     ttnn::global_semaphore::MultiDeviceGlobalSemaphore,
     ttnn::global_semaphore::MultiDeviceGlobalSemaphore>
-create_global_semaphores(std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device, IDevice* device) {
+create_global_semaphores(std::shared_ptr<tt::tt_metal::MeshDevice>& mesh_device, IDevice* device) {
     auto from_remote_multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore_with_same_address(
         mesh_device->get_devices(),
         device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
@@ -190,4 +188,4 @@ create_global_semaphores(std::shared_ptr<tt::tt_metal::distributed::MeshDevice>&
         to_remote_multi_device_global_semaphore,
         multi_device_global_semaphore};
 }
-}  // namespace ttnn::distributed::test
+}  // namespace ttnn::test

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.hpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.hpp
@@ -15,7 +15,7 @@
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 
-namespace ttnn::distributed::test {
+namespace ttnn::test {
 
 using namespace tt;
 using namespace tt_metal;
@@ -52,6 +52,6 @@ std::tuple<
     ttnn::global_semaphore::MultiDeviceGlobalSemaphore,
     ttnn::global_semaphore::MultiDeviceGlobalSemaphore,
     ttnn::global_semaphore::MultiDeviceGlobalSemaphore>
-create_global_semaphores(std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device, IDevice* device);
+create_global_semaphores(std::shared_ptr<tt::tt_metal::MeshDevice>& mesh_device, IDevice* device);
 
-}  // namespace ttnn::distributed::test
+}  // namespace ttnn::test

--- a/tests/ttnn/unit_tests/gtests/tensor/common_tensor_test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/common_tensor_test_utils.cpp
@@ -26,9 +26,7 @@ class Shape;
 namespace test_utils {
 
 void test_tensor_on_device(
-    const ttnn::Shape& input_shape,
-    const tt::tt_metal::TensorLayout& layout,
-    tt::tt_metal::distributed::MeshDevice* device) {
+    const ttnn::Shape& input_shape, const tt::tt_metal::TensorLayout& layout, tt::tt_metal::MeshDevice* device) {
     using namespace tt::tt_metal;
 
     const ttnn::QueueId io_cq = ttnn::DefaultQueueId;
@@ -69,7 +67,7 @@ void test_tensor_on_device(
 }
 
 void test_tensor_on_device(const ttnn::Shape& input_shape, const tt::tt_metal::TensorLayout& layout) {
-    auto device = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(0);
+    auto device = tt::tt_metal::MeshDevice::create_unit_mesh(0);
     test_tensor_on_device(input_shape, layout, device.get());
 }
 

--- a/tests/ttnn/unit_tests/gtests/tensor/common_tensor_test_utils.hpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/common_tensor_test_utils.hpp
@@ -18,8 +18,6 @@ class TensorLayout;
 
 namespace test_utils {
 void test_tensor_on_device(
-    const ttnn::Shape& input_shape,
-    const tt::tt_metal::TensorLayout& layout,
-    tt::tt_metal::distributed::MeshDevice* device);
+    const ttnn::Shape& input_shape, const tt::tt_metal::TensorLayout& layout, tt::tt_metal::MeshDevice* device);
 void test_tensor_on_device(const ttnn::Shape& input_shape, const tt::tt_metal::TensorLayout& layout);
 }  // namespace test_utils

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -42,7 +42,7 @@ class IDevice;
 
 namespace {
 
-void run_create_tensor_test(tt::tt_metal::distributed::MeshDevice* device, const ttnn::Shape& input_shape) {
+void run_create_tensor_test(tt::tt_metal::MeshDevice* device, const ttnn::Shape& input_shape) {
     MemoryConfig mem_cfg = MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
 
     const ttnn::QueueId io_cq = ttnn::DefaultQueueId;
@@ -62,7 +62,7 @@ void run_create_tensor_test(tt::tt_metal::distributed::MeshDevice* device, const
     ASSERT_EQ(input_buf_size_datums * datum_size_bytes, tensor_spec.compute_packed_buffer_size_bytes());
     auto input_buffer = tt::tt_metal::tensor_impl::allocate_mesh_buffer_on_device(device, tensor_spec);
 
-    auto input_storage = tt::tt_metal::DeviceStorage{input_buffer, {tt::tt_metal::distributed::MeshCoordinate{0, 0}}};
+    auto input_storage = tt::tt_metal::DeviceStorage{input_buffer, {tt::tt_metal::MeshCoordinate{0, 0}}};
 
     Tensor input_tensor = Tensor(input_storage, tensor_spec, ReplicateTensor{});
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
@@ -17,7 +17,7 @@
 #include "ttnn/tensor/enum_types.hpp"
 #include "ttnn_test_fixtures.hpp"
 
-namespace ttnn::distributed::test {
+namespace ttnn::test {
 namespace {
 
 using ::testing::Each;
@@ -43,7 +43,7 @@ TEST_F(MultiDeviceTensorCreationTest, Empty) {
         mesh_device,
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
 
-    EXPECT_THAT(get_device_tensors(mesh_replicated_tensor), SizeIs(mesh_device->num_devices()));
+    EXPECT_THAT(distributed::get_device_tensors(mesh_replicated_tensor), SizeIs(mesh_device->num_devices()));
 }
 
 TEST_F(MultiDeviceTensorCreationTest, EmptyLike) {
@@ -67,7 +67,7 @@ TEST_F(MultiDeviceTensorCreationTest, EmptyLike) {
         *mesh_device,
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
 
-    EXPECT_THAT(get_device_tensors(mesh_replicated_tensor), SizeIs(mesh_device->num_devices()));
+    EXPECT_THAT(distributed::get_device_tensors(mesh_replicated_tensor), SizeIs(mesh_device->num_devices()));
 }
 
 TEST_F(MultiDeviceTensorCreationTest, Full) {
@@ -85,7 +85,7 @@ TEST_F(MultiDeviceTensorCreationTest, Full) {
     EXPECT_EQ(mesh_replicated_tensor.get_dtype(), DataType::FLOAT32);
     EXPECT_EQ(mesh_replicated_tensor.get_layout(), Layout::ROW_MAJOR);
 
-    auto device_tensors = get_device_tensors(mesh_replicated_tensor);
+    auto device_tensors = distributed::get_device_tensors(mesh_replicated_tensor);
     EXPECT_THAT(device_tensors, SizeIs(mesh_device->num_devices()));
     for (const auto& device_tensor : device_tensors) {
         auto values = device_tensor.to_vector<float>();
@@ -118,7 +118,7 @@ TEST_F(MultiDeviceTensorCreationTest, FullLike) {
     EXPECT_EQ(mesh_replicated_tensor.get_dtype(), tensor.get_dtype());
     EXPECT_EQ(mesh_replicated_tensor.get_layout(), tensor.get_layout());
 
-    auto device_tensors = get_device_tensors(mesh_replicated_tensor);
+    auto device_tensors = distributed::get_device_tensors(mesh_replicated_tensor);
     EXPECT_THAT(device_tensors, SizeIs(mesh_device->num_devices()));
     for (const auto& device_tensor : device_tensors) {
         auto values = device_tensor.to_vector<float>();
@@ -161,7 +161,7 @@ TEST_F(MultiDeviceTensorCreationTest, FullLikeWithOptTensor) {
     EXPECT_EQ(mesh_replicated_tensor.get_padded_shape(), tensor.get_padded_shape());
     EXPECT_EQ(mesh_replicated_tensor.get_dtype(), tensor.get_dtype());
     EXPECT_EQ(mesh_replicated_tensor.get_layout(), tensor.get_layout());
-    EXPECT_THAT(get_device_tensors(mesh_replicated_tensor), SizeIs(mesh_device->num_devices()));
+    EXPECT_THAT(distributed::get_device_tensors(mesh_replicated_tensor), SizeIs(mesh_device->num_devices()));
 }
 
 TEST_F(MultiDeviceTensorCreationTest, Arange) {
@@ -175,11 +175,11 @@ TEST_F(MultiDeviceTensorCreationTest, Arange) {
         std::ref(*mesh_device));
 
     EXPECT_EQ(tensor.get_logical_shape(), ttnn::Shape({1024}));
-    EXPECT_THAT(get_device_tensors(tensor), SizeIs(mesh_device->num_devices()));
+    EXPECT_THAT(distributed::get_device_tensors(tensor), SizeIs(mesh_device->num_devices()));
 
     std::vector<float> expected(1024);
     std::iota(expected.begin(), expected.end(), 0.0f);
-    for (const auto& device_tensor : get_device_tensors(tensor)) {
+    for (const auto& device_tensor : distributed::get_device_tensors(tensor)) {
         auto values = device_tensor.to_vector<float>();
         EXPECT_THAT(values, SizeIs(1024));
         EXPECT_THAT(values, Pointwise(FloatEq(), expected));
@@ -187,4 +187,4 @@ TEST_F(MultiDeviceTensorCreationTest, Arange) {
 }
 
 }  // namespace
-}  // namespace ttnn::distributed::test
+}  // namespace ttnn::test

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -17,7 +17,7 @@
 #include <ttnn/distributed/types.hpp>
 #include <ttnn/distributed/distributed_tensor.hpp>
 
-namespace ttnn::distributed::test {
+namespace ttnn::test {
 namespace {
 
 using ::testing::ElementsAre;
@@ -100,7 +100,7 @@ TEST_F(MeshTensorTest, ReplicateOwnedTensor) {
     EXPECT_TRUE(output_host_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
     EXPECT_EQ(output_host_tensor.get_tensor_spec().logical_shape(), shape);
 
-    for (const auto& tensor : get_device_tensors(output_host_tensor)) {
+    for (const auto& tensor : distributed::get_device_tensors(output_host_tensor)) {
         EXPECT_EQ(tensor.get_tensor_spec().logical_shape(), shape);
         EXPECT_THAT(tensor.to_vector<float>(), Pointwise(FloatEq(), host_data));
     }
@@ -124,8 +124,8 @@ TEST_F(MeshTensorTest, GetDeviceTensors) {
     EXPECT_THAT(device_storage->coords, SizeIs(mesh_device_->num_devices()));
 
     // Validate each tensor shard.
-    std::vector<Tensor> device_tensors = get_device_tensors(device_tensor);
-    std::vector<distributed::MeshCoordinate> device_shard_coords;
+    std::vector<Tensor> device_tensors = distributed::get_device_tensors(device_tensor);
+    std::vector<MeshCoordinate> device_shard_coords;
     EXPECT_THAT(device_tensors, SizeIs(mesh_device_->num_devices()));
     for (const auto& tensor_shard : device_tensors) {
         auto* shard_storage = std::get_if<tt::tt_metal::DeviceStorage>(&tensor_shard.get_storage());
@@ -137,8 +137,8 @@ TEST_F(MeshTensorTest, GetDeviceTensors) {
     }
 
     // Expect coordiantes to cover the entire mesh.
-    std::vector<::testing::Matcher<distributed::MeshCoordinate>> coord_matchers;
-    for (const auto& expected_coord : distributed::MeshCoordinateRange(mesh_device_->shape())) {
+    std::vector<::testing::Matcher<MeshCoordinate>> coord_matchers;
+    for (const auto& expected_coord : MeshCoordinateRange(mesh_device_->shape())) {
         coord_matchers.push_back(Eq(expected_coord));
     }
     EXPECT_THAT(device_shard_coords, ElementsAreArray(coord_matchers));
@@ -159,8 +159,8 @@ TEST_F(MeshTensorTestT3K, AggregateAsTensor) {
     Tensor device_tensor2 =
         tensor_impl::to_device_mesh_tensor_wrapper(input_host_tensor, mesh_device_.get(), MemoryConfig{});
 
-    auto device_tensors1 = get_device_tensors(device_tensor1);
-    auto device_tensors2 = get_device_tensors(device_tensor2);
+    auto device_tensors1 = distributed::get_device_tensors(device_tensor1);
+    auto device_tensors2 = distributed::get_device_tensors(device_tensor2);
 
     EXPECT_THAT(device_tensors1, SizeIs(mesh_device_->num_devices()));
     EXPECT_THAT(device_tensors2, SizeIs(mesh_device_->num_devices()));
@@ -169,7 +169,7 @@ TEST_F(MeshTensorTestT3K, AggregateAsTensor) {
     EXPECT_THAT(
         ([&]() {
             std::vector<Tensor> shards_to_aggregate = {device_tensors1[0], device_tensors2[1]};
-            aggregate_as_tensor(shards_to_aggregate, AllGatherTensor{});
+            distributed::aggregate_as_tensor(shards_to_aggregate, AllGatherTensor{});
         }),
         ThrowsMessage<std::runtime_error>(HasSubstr("tensor shards must be allocated on the same mesh buffer.")));
 
@@ -177,12 +177,12 @@ TEST_F(MeshTensorTestT3K, AggregateAsTensor) {
     EXPECT_THAT(
         ([&]() {
             std::vector<Tensor> shards_to_aggregate = {device_tensors1[0], device_tensors1[0]};
-            aggregate_as_tensor(shards_to_aggregate, AllGatherTensor{});
+            distributed::aggregate_as_tensor(shards_to_aggregate, AllGatherTensor{});
         }),
         ThrowsMessage<std::runtime_error>(HasSubstr("Found a tensor shard at duplicate coordiante")));
 
     // Aggregate every second shard into a new mesh tensor.
-    auto partial_tensor = aggregate_as_tensor(
+    auto partial_tensor = distributed::aggregate_as_tensor(
         std::vector<Tensor>{device_tensors1[6], device_tensors1[4], device_tensors1[2], device_tensors1[0]},
         AllGatherTensor{});
 
@@ -192,10 +192,10 @@ TEST_F(MeshTensorTestT3K, AggregateAsTensor) {
 
     // Validate the shards are sorted, and are as expected.
     ASSERT_THAT(partial_device_storage->coords, SizeIs(4));
-    EXPECT_EQ(partial_device_storage->coords[0], (distributed::MeshCoordinate{0, 0}));
-    EXPECT_EQ(partial_device_storage->coords[1], (distributed::MeshCoordinate{0, 2}));
-    EXPECT_EQ(partial_device_storage->coords[2], (distributed::MeshCoordinate{1, 0}));
-    EXPECT_EQ(partial_device_storage->coords[3], (distributed::MeshCoordinate{1, 2}));
+    EXPECT_EQ(partial_device_storage->coords[0], (MeshCoordinate{0, 0}));
+    EXPECT_EQ(partial_device_storage->coords[1], (MeshCoordinate{0, 2}));
+    EXPECT_EQ(partial_device_storage->coords[2], (MeshCoordinate{1, 0}));
+    EXPECT_EQ(partial_device_storage->coords[3], (MeshCoordinate{1, 2}));
 }
 
 struct MeshTensorWriteTestParams {
@@ -204,7 +204,7 @@ struct MeshTensorWriteTestParams {
 
     // Shape of the resulting shards.
     ttnn::Shape sharded_shape;
-    std::vector<distributed::MeshCoordinate> expected_coords;
+    std::vector<MeshCoordinate> expected_coords;
     std::function<std::unique_ptr<ttnn::distributed::TensorToMesh>(MeshDevice*)> get_mapper;
 };
 
@@ -218,7 +218,7 @@ TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {
     const ttnn::Shape shape = GetParam().shape;
     const ttnn::Shape sharded_shape = GetParam().sharded_shape;
 
-    std::vector<::testing::Matcher<distributed::MeshCoordinate>> coord_matchers;
+    std::vector<::testing::Matcher<MeshCoordinate>> coord_matchers;
     for (const auto& expected_coord : GetParam().expected_coords) {
         coord_matchers.push_back(Eq(expected_coord));
     }
@@ -235,7 +235,7 @@ TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {
     EXPECT_EQ(input_host_tensor_sharded.get_distributed_tensor_config(), mapper->config());
     EXPECT_EQ(input_host_tensor_sharded.get_tensor_spec().logical_shape(), sharded_shape);
 
-    std::vector<Tensor> input_host_shards = get_device_tensors(input_host_tensor_sharded);
+    std::vector<Tensor> input_host_shards = distributed::get_device_tensors(input_host_tensor_sharded);
 
     auto device_tensor = [&]() {
         if (GetParam().use_pre_allocated_tensor) {
@@ -259,7 +259,7 @@ TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {
     auto output_host_tensor = tensor_impl::to_host_mesh_tensor_wrapper(device_tensor);
     EXPECT_EQ(output_host_tensor.get_distributed_tensor_config(), mapper->config());
 
-    std::vector<Tensor> output_host_shards = get_device_tensors(output_host_tensor);
+    std::vector<Tensor> output_host_shards = distributed::get_device_tensors(output_host_tensor);
     ASSERT_EQ(output_host_shards.size(), input_host_shards.size());
     for (int i = 0; i < output_host_shards.size(); i++) {
         EXPECT_THAT(
@@ -274,53 +274,53 @@ auto get_mesh_tensor_write_test_params() {
             .shape = ttnn::Shape{1, 8, 32, 32},
             .sharded_shape = ttnn::Shape{1, 1, 32, 32},
             .expected_coords =
-                {distributed::MeshCoordinate{0, 0},
-                 distributed::MeshCoordinate{0, 1},
-                 distributed::MeshCoordinate{0, 2},
-                 distributed::MeshCoordinate{0, 3},
-                 distributed::MeshCoordinate{1, 0},
-                 distributed::MeshCoordinate{1, 1},
-                 distributed::MeshCoordinate{1, 2},
-                 distributed::MeshCoordinate{1, 3}},
-            .get_mapper = [](MeshDevice* device) { return shard_tensor_to_mesh_mapper(*device, 1); },
+                {MeshCoordinate{0, 0},
+                 MeshCoordinate{0, 1},
+                 MeshCoordinate{0, 2},
+                 MeshCoordinate{0, 3},
+                 MeshCoordinate{1, 0},
+                 MeshCoordinate{1, 1},
+                 MeshCoordinate{1, 2},
+                 MeshCoordinate{1, 3}},
+            .get_mapper = [](MeshDevice* device) { return distributed::shard_tensor_to_mesh_mapper(*device, 1); },
         },
         MeshTensorWriteTestParams{
             .shape = ttnn::Shape{1, 1, 32, 32},
             .sharded_shape = ttnn::Shape{1, 1, 32, 32},
             .expected_coords =
-                {distributed::MeshCoordinate{0, 0},
-                 distributed::MeshCoordinate{0, 1},
-                 distributed::MeshCoordinate{0, 2},
-                 distributed::MeshCoordinate{0, 3},
-                 distributed::MeshCoordinate{1, 0},
-                 distributed::MeshCoordinate{1, 1},
-                 distributed::MeshCoordinate{1, 2},
-                 distributed::MeshCoordinate{1, 3}},
-            .get_mapper = [](MeshDevice* device) { return replicate_tensor_to_mesh_mapper(*device); },
+                {MeshCoordinate{0, 0},
+                 MeshCoordinate{0, 1},
+                 MeshCoordinate{0, 2},
+                 MeshCoordinate{0, 3},
+                 MeshCoordinate{1, 0},
+                 MeshCoordinate{1, 1},
+                 MeshCoordinate{1, 2},
+                 MeshCoordinate{1, 3}},
+            .get_mapper = [](MeshDevice* device) { return distributed::replicate_tensor_to_mesh_mapper(*device); },
         },
         MeshTensorWriteTestParams{
             .shape = ttnn::Shape{7, 3, 32, 32},
             .sharded_shape = ttnn::Shape{7, 1, 32, 32},
             .expected_coords =
-                {distributed::MeshCoordinate{0, 0},
-                 distributed::MeshCoordinate{0, 1},
-                 distributed::MeshCoordinate{0, 2},
-                 distributed::MeshCoordinate{1, 0},
-                 distributed::MeshCoordinate{1, 1},
-                 distributed::MeshCoordinate{1, 2}},
+                {MeshCoordinate{0, 0},
+                 MeshCoordinate{0, 1},
+                 MeshCoordinate{0, 2},
+                 MeshCoordinate{1, 0},
+                 MeshCoordinate{1, 1},
+                 MeshCoordinate{1, 2}},
             .get_mapper =
                 [](MeshDevice* device) {
                     // Replicate to a submesh 2x3
                     // Replicate within each row, then split by second dimension.
-                    return create_mesh_mapper(
+                    return distributed::create_mesh_mapper(
                         *device,
-                        MeshMapperConfig{
+                        distributed::MeshMapperConfig{
                             .placements =
                                 {
-                                    MeshMapperConfig::Replicate(),
-                                    MeshMapperConfig::Shard(1),
+                                    distributed::MeshMapperConfig::Replicate(),
+                                    distributed::MeshMapperConfig::Shard(1),
                                 }},
-                        MeshShape(2, 3));
+                        distributed::MeshShape(2, 3));
                 },
         },
     };
@@ -339,4 +339,4 @@ INSTANTIATE_TEST_SUITE_P(
     MeshTensorWriteTest, MeshTensorWriteTest, ::testing::ValuesIn(get_mesh_tensor_write_test_params()));
 
 }  // namespace
-}  // namespace ttnn::distributed::test
+}  // namespace ttnn::test

--- a/tests/ttnn/unit_tests/gtests/test_conv2d.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_conv2d.cpp
@@ -129,7 +129,7 @@ TEST_P(Conv2DFixture, Conv2DCalculateCorrectly) {
     // Without this, the convolution operation will fail due to L1_SMALL Out of Memory error
     const size_t l1_small_size = 16384;
 
-    auto device = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(
+    auto device = tt::tt_metal::MeshDevice::create_unit_mesh(
         /*device_id=*/0, l1_small_size);
 
     try {

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
@@ -42,8 +42,8 @@ namespace ttnn::operations::binary::test {
 
 class TTNNFixtureWithTraceEnabledDevice : public ::testing::Test {
 protected:
-    tt::tt_metal::distributed::MeshDevice* device_ = nullptr;
-    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> device_holder_;
+    tt::tt_metal::MeshDevice* device_ = nullptr;
+    std::shared_ptr<tt::tt_metal::MeshDevice> device_holder_;
     tt::ARCH arch_ = tt::ARCH::Invalid;
     size_t num_devices_ = 0;
 

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -80,8 +80,7 @@ struct NewInfraWorkloadFactory {
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value) {
         return cached_mesh_workload_t(
-            tt::tt_metal::distributed::MeshWorkload(),
-            std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t>());
+            tt::tt_metal::MeshWorkload(), std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t>());
     }
 
     static void override_runtime_arguments(

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -102,8 +102,8 @@ TEST_F(MultiProducerCommandQueueTest, DISABLED_EventSync) {
     const ttnn::QueueId write_cq = ttnn::DefaultQueueId;
     const ttnn::QueueId read_cq = ttnn::QueueId(1);
 
-    std::optional<tt::tt_metal::distributed::MeshEvent> write_event;
-    std::optional<tt::tt_metal::distributed::MeshEvent> read_event;
+    std::optional<tt::tt_metal::MeshEvent> write_event;
+    std::optional<tt::tt_metal::MeshEvent> read_event;
     std::mutex event_mutex;
 
     Tensor device_tensor = create_device_tensor(tensor_spec, device);

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -53,8 +53,8 @@ public:
 
 class TTNNFixtureWithDevice : public TTNNFixtureBase {
 protected:
-    tt::tt_metal::distributed::MeshDevice* device_ = nullptr;
-    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> device_holder_;
+    tt::tt_metal::MeshDevice* device_ = nullptr;
+    std::shared_ptr<tt::tt_metal::MeshDevice> device_holder_;
 
     void SetUp() override {
         device_holder_ = ttnn::open_mesh_device(/*device_id=*/0, l1_small_size_, trace_region_size_);
@@ -71,8 +71,8 @@ protected:
 
 class MultiCommandQueueSingleDeviceFixture : public TTNNFixtureBase {
 protected:
-    tt::tt_metal::distributed::MeshDevice* device_ = nullptr;
-    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> device_holder_;
+    tt::tt_metal::MeshDevice* device_ = nullptr;
+    std::shared_ptr<tt::tt_metal::MeshDevice> device_holder_;
 
     void SetUp() override {
         check_slow_dispatch();
@@ -83,7 +83,7 @@ protected:
                 tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
             dispatch_core_type = DispatchCoreType::ETH;
         }
-        device_holder_ = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(
+        device_holder_ = tt::tt_metal::MeshDevice::create_unit_mesh(
             0, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 2, DispatchCoreConfig{dispatch_core_type});
         device_ = device_holder_.get();
     }
@@ -93,7 +93,7 @@ protected:
 
 class MultiCommandQueueT3KFixture : public TTNNFixtureBase {
 protected:
-    std::map<chip_id_t, std::shared_ptr<tt::tt_metal::distributed::MeshDevice>> devs;
+    std::map<chip_id_t, std::shared_ptr<tt::tt_metal::MeshDevice>> devs;
 
     void SetUp() override {
         check_slow_dispatch();
@@ -103,7 +103,7 @@ protected:
         }
 
         // Enable Ethernet Dispatch for Multi-CQ tests.
-        devs = tt::tt_metal::distributed::MeshDevice::create_unit_meshes(
+        devs = tt::tt_metal::MeshDevice::create_unit_meshes(
             {0, 1, 2, 3, 4, 5, 6, 7},
             DEFAULT_L1_SMALL_SIZE,
             DEFAULT_TRACE_REGION_SIZE,

--- a/tt-train/sources/examples/linear_regression_ddp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_ddp/main.cpp
@@ -32,7 +32,7 @@ int main() {
     const size_t num_targets = 32;
     const float noise = 0.0F;
     const bool bias = true;
-    ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
+    ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::MeshShape(1, 2));
 
     auto training_params = ttml::datasets::MakeRegressionParams{
         .n_samples = training_samples_count,

--- a/tt-train/sources/examples/mnist_mlp/main.cpp
+++ b/tt-train/sources/examples/mnist_mlp/main.cpp
@@ -68,7 +68,7 @@ TrainingConfig parse_config(const YAML::Node &yaml_config) {
 void initialize_device(bool enable_tp) {
     if (enable_tp) {
         // we support only N300 for now
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::MeshShape(1, 2));
     }
 }
 

--- a/tt-train/sources/examples/mnist_mlp/model.cpp
+++ b/tt-train/sources/examples/mnist_mlp/model.cpp
@@ -7,10 +7,10 @@
 #include "ops/unary_ops.hpp"
 
 MNISTTensorParallel::MNISTTensorParallel() {
-    m_linear1 = std::make_shared<ttml::modules::distributed::ColumnParallelLinear>(
-        784, 128, /* has_bias */ true, /* gather_output */ false);
-    m_linear2 = std::make_shared<ttml::modules::distributed::RowParallelLinear>(
-        128, 10, /* has_bias */ true, /* input_is_parallel */ true);
+    m_linear1 =
+        std::make_shared<ttml::modules::ColumnParallelLinear>(784, 128, /* has_bias */ true, /* gather_output */ false);
+    m_linear2 =
+        std::make_shared<ttml::modules::RowParallelLinear>(128, 10, /* has_bias */ true, /* input_is_parallel */ true);
     create_name("mlp");
     register_module(m_linear1, "linear1");
     register_module(m_linear2, "linear2");

--- a/tt-train/sources/examples/mnist_mlp/model.hpp
+++ b/tt-train/sources/examples/mnist_mlp/model.hpp
@@ -13,6 +13,6 @@ public:
     ttml::autograd::TensorPtr operator()(ttml::autograd::TensorPtr tensor);
 
 private:
-    std::shared_ptr<ttml::modules::distributed::ColumnParallelLinear> m_linear1;
-    std::shared_ptr<ttml::modules::distributed::RowParallelLinear> m_linear2;
+    std::shared_ptr<ttml::modules::ColumnParallelLinear> m_linear1;
+    std::shared_ptr<ttml::modules::RowParallelLinear> m_linear2;
 };

--- a/tt-train/sources/examples/nano_gpt/3tier/common.cpp
+++ b/tt-train/sources/examples/nano_gpt/3tier/common.cpp
@@ -114,7 +114,7 @@ uint32_t round_up_to_tile(uint32_t value, uint32_t tile_size) {
 void initialize_device(bool ddp, bool tp) {
     if (ddp || tp) {
         // currently supports only N300 device
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::MeshShape(1, 2));
     }
 }
 

--- a/tt-train/sources/examples/nano_gpt/3tier/optimizer_worker.cpp
+++ b/tt-train/sources/examples/nano_gpt/3tier/optimizer_worker.cpp
@@ -20,27 +20,27 @@ using SortedParameters = std::map<std::string, ttml::autograd::TensorPtr>;
 
 void send_weights_to_aggregator(
     const ttml::autograd::DistributedContext &ctx, const SortedParameters &sorted_model_parameters) {
-    auto aggregator_rank = ttml::core::distributed::Rank(*ctx.rank() - 1);
+    auto aggregator_rank = ttml::core::Rank(*ctx.rank() - 1);
     for (auto &[name, tensor_ptr] : sorted_model_parameters) {
         if (!tensor_ptr->get_requires_grad()) {
             continue;
         }
 
         auto tensor = tensor_ptr->get_value();
-        ttml::core::distributed::send_tensor(ctx, tensor, aggregator_rank);
+        ttml::core::send_tensor(ctx, tensor, aggregator_rank);
     }
 }
 
 void receive_gradients_from_aggregator(
     const ttml::autograd::DistributedContext &ctx, const SortedParameters &sorted_model_parameters) {
-    auto aggregator_rank = ttml::core::distributed::Rank(*ctx.rank() - 1);
+    auto aggregator_rank = ttml::core::Rank(*ctx.rank() - 1);
     for (auto &[name, tensor_ptr] : sorted_model_parameters) {
         if (!tensor_ptr->get_requires_grad()) {
             continue;
         }
 
         auto tensor = ttnn::empty_like(tensor_ptr->get_value());
-        ttml::core::distributed::recv_tensor(ctx, tensor, aggregator_rank);
+        ttml::core::recv_tensor(ctx, tensor, aggregator_rank);
         tensor_ptr->set_grad(tensor);
     }
 }
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
 
     auto create_model = [enable_tp](const auto &config) -> std::shared_ptr<ttml::autograd::ModuleBase> {
         if (enable_tp) {
-            return ttml::models::distributed::gpt2::create(config);
+            return ttml::models::gpt2::create(config);
         }
         return ttml::models::gpt2::create(config);
     };

--- a/tt-train/sources/examples/nano_gpt/3tier/remote_optimizer.cpp
+++ b/tt-train/sources/examples/nano_gpt/3tier/remote_optimizer.cpp
@@ -8,7 +8,7 @@
 
 RemoteOptimizer::RemoteOptimizer(ttml::serialization::NamedParameters parameters, int aggregator_rank) :
     ttml::optimizers::OptimizerBase(std::move(parameters)) {
-    m_aggregator_rank = ttml::core::distributed::Rank{aggregator_rank};
+    m_aggregator_rank = ttml::core::Rank{aggregator_rank};
     m_sorted_parameters = SortedParameters(m_parameters.begin(), m_parameters.end());
 
     auto workers_and_aggregator_ranks =
@@ -51,14 +51,14 @@ void RemoteOptimizer::send_gradients() {
     for (auto& [name, tensor_ptr] : m_sorted_parameters) {
         if (tensor_ptr->get_requires_grad() && tensor_ptr->is_grad_initialized()) {
             auto grad = tensor_ptr->get_grad();
-            ttml::core::distributed::send_tensor(*m_distributed_ctx, grad, m_aggregator_rank);
+            ttml::core::send_tensor(*m_distributed_ctx, grad, m_aggregator_rank);
         }
     }
 }
 void RemoteOptimizer::receive_weights() {
     for (auto& [name, tensor_ptr] : m_sorted_parameters) {
         auto tensor = tensor_ptr->get_value();
-        ttml::core::distributed::broadcast_tensor(*m_distributed_ctx, tensor, m_aggregator_rank);
+        ttml::core::broadcast_tensor(*m_distributed_ctx, tensor, m_aggregator_rank);
         tensor_ptr->set_value(tensor);
     }
 }

--- a/tt-train/sources/examples/nano_gpt/3tier/remote_optimizer.hpp
+++ b/tt-train/sources/examples/nano_gpt/3tier/remote_optimizer.hpp
@@ -39,6 +39,6 @@ public:
 private:
     size_t m_steps{0};
     SortedParameters m_sorted_parameters;
-    ttml::core::distributed::Rank m_aggregator_rank{0};
+    ttml::core::Rank m_aggregator_rank{0};
     std::shared_ptr<ttml::autograd::DistributedContext> m_distributed_ctx;
 };

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -721,13 +721,13 @@ int main(int argc, char **argv) {
         [enable_tp](auto &&arg) -> Model {
             if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, ttml::models::llama::LlamaConfig>) {
                 if (enable_tp) {
-                    return ttml::models::distributed::llama::create(arg);
+                    return ttml::models::llama::create(arg);
                 } else {
                     return ttml::models::llama::create(arg);
                 }
             } else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, ttml::models::gpt2::TransformerConfig>) {
                 if (enable_tp) {
-                    return ttml::models::distributed::gpt2::create(arg);
+                    return ttml::models::gpt2::create(arg);
                 } else {
                     return ttml::models::gpt2::create(arg);
                 }
@@ -875,7 +875,7 @@ int main(int argc, char **argv) {
                 // synchronize gradients for multi-device case, no-op if single device
                 auto parameters = get_model_parameters(model);
                 if (!enable_tp) {
-                    ttml::core::distributed::synchronize_parameters(parameters);
+                    ttml::core::synchronize_parameters(parameters);
                 }
 
                 if (config.use_clip_grad_norm) {

--- a/tt-train/sources/examples/nano_gpt/utils.cpp
+++ b/tt-train/sources/examples/nano_gpt/utils.cpp
@@ -97,6 +97,6 @@ std::unique_ptr<ttml::schedulers::LRSchedulerBase> create_warmup_with_linear_sch
 void initialize_device(bool ddp, bool tp) {
     if (ddp || tp) {
         // currently supports only N300 device
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::MeshShape(1, 2));
     }
 }

--- a/tt-train/sources/examples/sample_app/main.cpp
+++ b/tt-train/sources/examples/sample_app/main.cpp
@@ -7,7 +7,7 @@
 
 #include "ttml.hpp"
 
-std::shared_ptr<tt::tt_metal::distributed::MeshDevice> device;
+std::shared_ptr<tt::tt_metal::MeshDevice> device;
 
 void print_tensor(const tt::tt_metal::Tensor& tensor) {
     // IMPORTANT. This function prints the tensor data assuming the tensor is in ROW_MAJOR layout
@@ -53,7 +53,7 @@ int main() {
     std::srand(0);
     num_devices_ = tt::tt_metal::GetNumAvailableDevices();
     std::cout << "num_devices:" << num_devices_ << std::endl;
-    device = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(0);
+    device = tt::tt_metal::MeshDevice::create_unit_mesh(0);
     std::cout << "Device created" << std::endl;
     // AutoFormat::SetDefaultDevice(device);  // set the default device to the one we just opened
 

--- a/tt-train/sources/examples/simple_cnn/main.cpp
+++ b/tt-train/sources/examples/simple_cnn/main.cpp
@@ -12,7 +12,7 @@ int main() {
     std::srand(0);
     auto num_devices_ = tt::tt_metal::GetNumAvailableDevices();
     std::cout << "num_devices:" << num_devices_ << std::endl;
-    auto device = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(0);
+    auto device = tt::tt_metal::MeshDevice::create_unit_mesh(0);
     std::cout << "Device created" << std::endl;
     device.reset();
     return 0;

--- a/tt-train/sources/ttml/autograd/auto_context.cpp
+++ b/tt-train/sources/ttml/autograd/auto_context.cpp
@@ -57,7 +57,7 @@ void AutoContext::close_device() {
     m_device = nullptr;
 }
 
-ttnn::distributed::MeshDevice& AutoContext::get_device() {
+ttnn::MeshDevice& AutoContext::get_device() {
     if (!m_device) {
         open_device();
     }
@@ -68,14 +68,14 @@ ttnn::distributed::MeshDevice& AutoContext::get_device() {
 AutoContext::AutoContext() : m_generator(m_seed) {
 }
 
-void AutoContext::set_mesh_shape(tt::tt_metal::distributed::MeshShape shape) {
+void AutoContext::set_mesh_shape(tt::tt_metal::MeshShape shape) {
     if (m_device) {
         throw std::runtime_error("set_mesh_shape was called after the device was created.");
     }
     m_mesh_shape = shape;
 }
 
-tt::tt_metal::distributed::MeshShape AutoContext::get_mesh_shape() const {
+tt::tt_metal::MeshShape AutoContext::get_mesh_shape() const {
     return m_mesh_shape;
 }
 

--- a/tt-train/sources/ttml/autograd/auto_context.hpp
+++ b/tt-train/sources/ttml/autograd/auto_context.hpp
@@ -15,7 +15,7 @@ namespace ttml::autograd {
 
 enum class GradMode { ENABLED, DISABLED };
 
-using DistributedContext = tt::tt_metal::distributed::multihost::DistributedContext;
+using DistributedContext = tt::tt_metal::multihost::DistributedContext;
 
 class AutoContext {
 public:
@@ -44,10 +44,10 @@ public:
 
     ~AutoContext() = default;  // to make it work with unique_ptr.
 
-    ttnn::distributed::MeshDevice& get_device();
+    ttnn::MeshDevice& get_device();
 
-    void set_mesh_shape(tt::tt_metal::distributed::MeshShape shape);
-    [[nodiscard]] tt::tt_metal::distributed::MeshShape get_mesh_shape() const;
+    void set_mesh_shape(tt::tt_metal::MeshShape shape);
+    [[nodiscard]] tt::tt_metal::MeshShape get_mesh_shape() const;
 
     void open_device();
 
@@ -65,7 +65,7 @@ private:
     GradMode m_grads_mode = GradMode::ENABLED;
 
     Graph m_graph;
-    tt::tt_metal::distributed::MeshShape m_mesh_shape = tt::tt_metal::distributed::MeshShape(1, 1);
+    tt::tt_metal::MeshShape m_mesh_shape = tt::tt_metal::MeshShape(1, 1);
     std::unique_ptr<core::MeshDevice> m_device;
 
     std::shared_ptr<DistributedContext> m_distributed_context;

--- a/tt-train/sources/ttml/core/device.cpp
+++ b/tt-train/sources/ttml/core/device.cpp
@@ -8,7 +8,7 @@
 
 namespace ttml::core {
 
-Device::Device(int device_index) : m_device(tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_index)) {
+Device::Device(int device_index) : m_device(tt::tt_metal::MeshDevice::create_unit_mesh(device_index)) {
 }
 
 [[nodiscard]] tt::tt_metal::IDevice& Device::get_device() {

--- a/tt-train/sources/ttml/core/device.hpp
+++ b/tt-train/sources/ttml/core/device.hpp
@@ -24,6 +24,6 @@ public:
     [[nodiscard]] tt::tt_metal::IDevice& get_device();
 
 private:
-    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> m_device;
+    std::shared_ptr<tt::tt_metal::MeshDevice> m_device;
 };
 }  // namespace ttml::core

--- a/tt-train/sources/ttml/core/distributed/distributed.cpp
+++ b/tt-train/sources/ttml/core/distributed/distributed.cpp
@@ -24,7 +24,7 @@ ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor) {
     }
 
     // all_reduce Mean is not supported, use sum and divide by #devices
-    auto result = ttnn_fixed::distributed::all_reduce(tensor);
+    auto result = ttnn_fixed::all_reduce(tensor);
     result = ttnn::multiply(result, 1.0F / static_cast<float>(devices_count));
     return result;
 }

--- a/tt-train/sources/ttml/core/distributed/distributed.hpp
+++ b/tt-train/sources/ttml/core/distributed/distributed.hpp
@@ -11,8 +11,8 @@
 
 namespace ttml::core::distributed {
 
-using Rank = tt::tt_metal::distributed::multihost::Rank;
-using Tag = tt::tt_metal::distributed::multihost::Tag;
+using Rank = tt::tt_metal::multihost::Rank;
+using Tag = tt::tt_metal::multihost::Tag;
 
 ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor);
 void synchronize_parameters(const serialization::NamedParameters& parameters);

--- a/tt-train/sources/ttml/core/distributed_mapping.hpp
+++ b/tt-train/sources/ttml/core/distributed_mapping.hpp
@@ -20,7 +20,7 @@ std::vector<xt::xarray<T>> chunk(const xt::xarray<T>& tensor, int num_chunks, in
 template <class Derived, typename T>
 class XTensorToMesh {
 public:
-    XTensorToMesh(tt::tt_metal::distributed::MeshShape mesh_shape) : m_mesh_shape(std::move(mesh_shape)) {
+    XTensorToMesh(tt::tt_metal::MeshShape mesh_shape) : m_mesh_shape(std::move(mesh_shape)) {
     }
 
     std::vector<xt::xarray<T>> map(const xt::xarray<T>& tensor) const {
@@ -32,7 +32,7 @@ public:
     }
 
 protected:
-    tt::tt_metal::distributed::MeshShape m_mesh_shape;
+    tt::tt_metal::MeshShape m_mesh_shape;
 
     size_t get_num_devices() const {
         return m_mesh_shape.mesh_size();
@@ -42,7 +42,7 @@ protected:
 template <class Derived, typename T>
 class MeshToXTensor {
 public:
-    MeshToXTensor(tt::tt_metal::distributed::MeshShape mesh_shape) : m_mesh_shape(std::move(mesh_shape)) {
+    MeshToXTensor(tt::tt_metal::MeshShape mesh_shape) : m_mesh_shape(std::move(mesh_shape)) {
     }
 
     std::vector<xt::xarray<T>> compose(const std::vector<xt::xarray<T>>& tensors) const {
@@ -50,15 +50,14 @@ public:
     }
 
 protected:
-    tt::tt_metal::distributed::MeshShape m_mesh_shape;
+    tt::tt_metal::MeshShape m_mesh_shape;
 };
 
 template <typename T>
 class ShardXTensorToMesh : public XTensorToMesh<ShardXTensorToMesh<T>, T> {
 public:
     using Base = XTensorToMesh<ShardXTensorToMesh<T>, T>;
-    ShardXTensorToMesh(tt::tt_metal::distributed::MeshShape mesh_shape, int dim) :
-        Base(std::move(mesh_shape)), m_shard_dim(dim) {
+    ShardXTensorToMesh(tt::tt_metal::MeshShape mesh_shape, int dim) : Base(std::move(mesh_shape)), m_shard_dim(dim) {
     }
 
     std::vector<xt::xarray<T>> map_impl(const xt::xarray<T>& tensor) const {
@@ -80,8 +79,7 @@ class ShardTensor2dMesh : public XTensorToMesh<ShardTensor2dMesh<T>, T> {
 public:
     using Base = XTensorToMesh<ShardTensor2dMesh<T>, T>;
     ShardTensor2dMesh(
-        tt::tt_metal::distributed::MeshShape mesh_shape,
-        const std::pair<std::optional<int>, std::optional<int>>& dims) :
+        tt::tt_metal::MeshShape mesh_shape, const std::pair<std::optional<int>, std::optional<int>>& dims) :
         Base(std::move(mesh_shape)), m_dims(dims) {
         // We trust the provided mesh shape and do not validate against a MeshDevice.
     }
@@ -151,8 +149,7 @@ template <typename T>
 class ConcatMesh2dToTensor : public MeshToXTensor<ConcatMesh2dToTensor<T>, T> {
 public:
     using Base = MeshToXTensor<ConcatMesh2dToTensor<T>, T>;
-    ConcatMesh2dToTensor(
-        tt::tt_metal::distributed::MeshShape mesh_shape, const tt::tt_metal::distributed::MeshShape& dims) :
+    ConcatMesh2dToTensor(tt::tt_metal::MeshShape mesh_shape, const tt::tt_metal::MeshShape& dims) :
         Base(std::move(mesh_shape)), m_dims(dims) {
         if (m_dims[0] == m_dims[1]) {
             throw std::invalid_argument("Dimensions in 'dims' must be different");
@@ -182,14 +179,14 @@ public:
     }
 
 private:
-    tt::tt_metal::distributed::MeshShape m_dims;
+    tt::tt_metal::MeshShape m_dims;
 };
 
 template <typename T>
 class ReplicateXTensorToMesh : public XTensorToMesh<ReplicateXTensorToMesh<T>, T> {
 public:
     using Base = XTensorToMesh<ReplicateXTensorToMesh<T>, T>;
-    ReplicateXTensorToMesh(tt::tt_metal::distributed::MeshShape mesh_shape) : Base(std::move(mesh_shape)) {
+    ReplicateXTensorToMesh(tt::tt_metal::MeshShape mesh_shape) : Base(std::move(mesh_shape)) {
     }
 
     std::vector<xt::xarray<T>> map_impl(const xt::xarray<T>& tensor) const {
@@ -212,8 +209,7 @@ template <typename T>
 class ConcatMeshToXTensor : public MeshToXTensor<ConcatMeshToXTensor<T>, T> {
 public:
     using Base = MeshToXTensor<ConcatMeshToXTensor<T>, T>;
-    ConcatMeshToXTensor(tt::tt_metal::distributed::MeshShape mesh_shape, int dim) :
-        Base(std::move(mesh_shape)), m_concat_dim(dim) {
+    ConcatMeshToXTensor(tt::tt_metal::MeshShape mesh_shape, int dim) : Base(std::move(mesh_shape)), m_concat_dim(dim) {
     }
 
     std::vector<xt::xarray<T>> compose_impl(const std::vector<xt::xarray<T>>& tensors) const {
@@ -228,7 +224,7 @@ template <typename T>
 class VectorMeshToXTensor : public MeshToXTensor<VectorMeshToXTensor<T>, T> {
 public:
     using Base = MeshToXTensor<VectorMeshToXTensor<T>, T>;
-    VectorMeshToXTensor([[maybe_unused]] tt::tt_metal::distributed::MeshShape mesh_shape) : Base(mesh_shape) {
+    VectorMeshToXTensor([[maybe_unused]] tt::tt_metal::MeshShape mesh_shape) : Base(mesh_shape) {
     }
     std::vector<xt::xarray<T>> compose_impl(const std::vector<xt::xarray<T>>& tensors) const {
         return tensors;

--- a/tt-train/sources/ttml/core/mesh_device.cpp
+++ b/tt-train/sources/ttml/core/mesh_device.cpp
@@ -6,8 +6,8 @@
 
 namespace ttml::core {
 
-MeshDevice::MeshDevice(tt::tt_metal::distributed::MeshShape shape) :
-    m_mesh_device(ttnn::distributed::open_mesh_device(
+MeshDevice::MeshDevice(tt::tt_metal::MeshShape shape) :
+    m_mesh_device(ttnn::open_mesh_device(
         shape,
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
@@ -16,14 +16,14 @@ MeshDevice::MeshDevice(tt::tt_metal::distributed::MeshShape shape) :
     assert(m_mesh_device);
 }
 
-[[nodiscard]] ttnn::distributed::MeshDevice& MeshDevice::get_device() {
+[[nodiscard]] ttnn::MeshDevice& MeshDevice::get_device() {
     assert(m_mesh_device);
     return *m_mesh_device;
 }
 
 MeshDevice::~MeshDevice() {
     assert(m_mesh_device);
-    ttnn::distributed::close_mesh_device(m_mesh_device);
+    ttnn::close_mesh_device(m_mesh_device);
 }
 
 }  // namespace ttml::core

--- a/tt-train/sources/ttml/core/mesh_device.hpp
+++ b/tt-train/sources/ttml/core/mesh_device.hpp
@@ -11,7 +11,7 @@ namespace ttml::core {
 // should I implement pimpl or its fine
 class MeshDevice {
 public:
-    explicit MeshDevice(tt::tt_metal::distributed::MeshShape shape);
+    explicit MeshDevice(tt::tt_metal::MeshShape shape);
     MeshDevice(MeshDevice&& device) = default;
     MeshDevice(const MeshDevice&) = delete;
 
@@ -19,9 +19,9 @@ public:
     MeshDevice& operator=(MeshDevice&&) = default;
     ~MeshDevice();
 
-    [[nodiscard]] ttnn::distributed::MeshDevice& get_device();
+    [[nodiscard]] ttnn::MeshDevice& get_device();
 
 private:
-    std::shared_ptr<ttnn::distributed::MeshDevice> m_mesh_device;
+    std::shared_ptr<ttnn::MeshDevice> m_mesh_device;
 };
 }  // namespace ttml::core

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -122,20 +122,19 @@ tt::tt_metal::Tensor ones_like(const tt::tt_metal::Tensor& tensor) {
 }
 
 tt::tt_metal::Tensor empty(
-    const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, const ttnn::MemoryConfig& memory_config) {
+    const ttnn::Shape& shape, ttnn::MeshDevice* device, const ttnn::MemoryConfig& memory_config) {
     return ttnn::empty(shape, ttnn::DataType::BFLOAT16, ttnn::Layout::TILE, device, memory_config);
 }
 
-tt::tt_metal::Tensor full(
-    const ttnn::Shape& shape, float value, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype) {
+tt::tt_metal::Tensor full(const ttnn::Shape& shape, float value, ttnn::MeshDevice* device, ttnn::DataType dtype) {
     return ttnn::full(shape, value, dtype, ttnn::Layout::TILE, std::ref(*device));
 }
 
-tt::tt_metal::Tensor zeros(const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype) {
+tt::tt_metal::Tensor zeros(const ttnn::Shape& shape, ttnn::MeshDevice* device, ttnn::DataType dtype) {
     return core::full(shape, 0.F, device, dtype);
 }
 
-tt::tt_metal::Tensor ones(const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype) {
+tt::tt_metal::Tensor ones(const ttnn::Shape& shape, ttnn::MeshDevice* device, ttnn::DataType dtype) {
     return core::full(shape, 1.F, device, dtype);
 }
 
@@ -187,10 +186,7 @@ template tt::tt_metal::Tensor from_xtensors_to_host<int32_t, tt::tt_metal::DataT
 
 template <>
 tt::tt_metal::Tensor from_vector<float, ttnn::DataType::BFLOAT16>(
-    const std::vector<float>& buffer,
-    const ttnn::Shape& shape,
-    ttnn::distributed::MeshDevice* device,
-    ttnn::Layout layout) {
+    const std::vector<float>& buffer, const ttnn::Shape& shape, ttnn::MeshDevice* device, ttnn::Layout layout) {
     assert(device != nullptr);
     const ttnn::DataType data_type = ttnn::DataType::BFLOAT16;
     ttnn::MemoryConfig output_mem_config{};
@@ -223,10 +219,7 @@ tt::tt_metal::Tensor from_vector<float, ttnn::DataType::BFLOAT16>(
 // it is expected that tilize will be fixed in the after next tt-metal main update
 template <>
 tt::tt_metal::Tensor from_vector<float, ttnn::DataType::FLOAT32>(
-    const std::vector<float>& buffer,
-    const ttnn::Shape& shape,
-    ttnn::distributed::MeshDevice* device,
-    ttnn::Layout layout) {
+    const std::vector<float>& buffer, const ttnn::Shape& shape, ttnn::MeshDevice* device, ttnn::Layout layout) {
     auto tensor = from_vector<float, ttnn::DataType::BFLOAT16>(buffer, shape, device, layout);
     return ttnn::typecast(tensor, ttnn::DataType::FLOAT32);
 }
@@ -236,10 +229,7 @@ From vector uint32 doesn't support tilize_with_zero_padding on device
 */
 template <>
 tt::tt_metal::Tensor from_vector<uint32_t, ttnn::DataType::UINT32>(
-    const std::vector<uint32_t>& buffer,
-    const ttnn::Shape& shape,
-    ttnn::distributed::MeshDevice* device,
-    ttnn::Layout layout) {
+    const std::vector<uint32_t>& buffer, const ttnn::Shape& shape, ttnn::MeshDevice* device, ttnn::Layout layout) {
     ttnn::MemoryConfig output_mem_config{};
     auto volume = shape.volume();
     if (buffer.size() != volume) {
@@ -266,10 +256,7 @@ From vector int32 doesn't support tilize_with_zero_padding on device
 */
 template <>
 tt::tt_metal::Tensor from_vector<int32_t, ttnn::DataType::INT32>(
-    const std::vector<int32_t>& buffer,
-    const ttnn::Shape& shape,
-    ttnn::distributed::MeshDevice* device,
-    ttnn::Layout layout) {
+    const std::vector<int32_t>& buffer, const ttnn::Shape& shape, ttnn::MeshDevice* device, ttnn::Layout layout) {
     ttnn::MemoryConfig output_mem_config{};
     auto volume = shape.volume();
     if (buffer.size() != volume) {
@@ -310,7 +297,7 @@ void print_tensor_stats(const tt::tt_metal::Tensor& tensor, const std::string& n
 template <class T, ttnn::DataType TensorType>
 tt::tt_metal::Tensor from_xtensor(
     const xt::xarray<T>& tensor,
-    ttnn::distributed::MeshDevice* device,
+    ttnn::MeshDevice* device,
     const XTensorToMeshVariant<T>& composer,
     ttnn::Layout layout) {
     auto sharded_tensors = std::visit([&tensor](auto&& arg) { return arg.map(tensor); }, composer);
@@ -334,19 +321,19 @@ tt::tt_metal::Tensor from_xtensor(
 
 template tt::tt_metal::Tensor from_xtensor<float, ttnn::DataType::BFLOAT16>(
     const xt::xarray<float>& tensor,
-    ttnn::distributed::MeshDevice* device,
+    ttnn::MeshDevice* device,
     const XTensorToMeshVariant<float>& composer,
     ttnn::Layout layout);
 
 template tt::tt_metal::Tensor from_xtensor<int32_t, ttnn::DataType::INT32>(
     const xt::xarray<int32_t>& tensor,
-    ttnn::distributed::MeshDevice* device,
+    ttnn::MeshDevice* device,
     const XTensorToMeshVariant<int32_t>& composer,
     ttnn::Layout layout);
 
 template tt::tt_metal::Tensor from_xtensor<uint32_t, ttnn::DataType::UINT32>(
     const xt::xarray<uint32_t>& tensor,
-    ttnn::distributed::MeshDevice* device,
+    ttnn::MeshDevice* device,
     const XTensorToMeshVariant<uint32_t>& composer,
     ttnn::Layout layout);
 

--- a/tt-train/sources/ttml/core/tt_tensor_utils.hpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.hpp
@@ -18,23 +18,19 @@ void print_tensor_stats(const tt::tt_metal::Tensor& tensor, const std::string& n
 tt::tt_metal::Tensor zeros_like(const tt::tt_metal::Tensor& tensor);
 tt::tt_metal::Tensor ones_like(const tt::tt_metal::Tensor& tensor);
 
-tt::tt_metal::Tensor empty(
-    const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, const ttnn::MemoryConfig& memory_config);
+tt::tt_metal::Tensor empty(const ttnn::Shape& shape, ttnn::MeshDevice* device, const ttnn::MemoryConfig& memory_config);
 tt::tt_metal::Tensor full(
-    const ttnn::Shape& shape,
-    float value,
-    ttnn::distributed::MeshDevice* device,
-    ttnn::DataType dtype = ttnn::DataType::BFLOAT16);
+    const ttnn::Shape& shape, float value, ttnn::MeshDevice* device, ttnn::DataType dtype = ttnn::DataType::BFLOAT16);
 tt::tt_metal::Tensor zeros(
-    const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype = ttnn::DataType::BFLOAT16);
+    const ttnn::Shape& shape, ttnn::MeshDevice* device, ttnn::DataType dtype = ttnn::DataType::BFLOAT16);
 tt::tt_metal::Tensor ones(
-    const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype = ttnn::DataType::BFLOAT16);
+    const ttnn::Shape& shape, ttnn::MeshDevice* device, ttnn::DataType dtype = ttnn::DataType::BFLOAT16);
 
 template <class VectorType = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
 [[nodiscard]] tt::tt_metal::Tensor from_vector(
     const std::vector<VectorType>& buffer,
     const ttnn::Shape& shape,
-    ttnn::distributed::MeshDevice* device,
+    ttnn::MeshDevice* device,
     ttnn::Layout layout = ttnn::Layout::TILE);
 
 template <class VectorType = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
@@ -52,7 +48,7 @@ template <class T = float>
 
 template <class T = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
 [[nodiscard]] tt::tt_metal::Tensor from_xtensor(
-    const xt::xarray<T>& buffer, ttnn::distributed::MeshDevice* device, ttnn::Layout layout = ttnn::Layout::TILE) {
+    const xt::xarray<T>& buffer, ttnn::MeshDevice* device, ttnn::Layout layout = ttnn::Layout::TILE) {
     auto shape = ttnn::experimental::xtensor::get_shape_from_xarray(buffer);
     auto buffer_view = xtensor_to_span(buffer);
     return from_vector<T, TensorType>(std::vector<T>(buffer_view.begin(), buffer_view.end()), shape, device, layout);
@@ -71,7 +67,7 @@ template <class T = float>
 auto to_xtensor(const tt::tt_metal::Tensor& tensor, const MeshToXTensorVariant<T>& composer) {
     auto cpu_tensor = tensor.cpu();
     cpu_tensor = cpu_tensor.to_layout(ttnn::Layout::ROW_MAJOR);
-    auto cpu_tensors = ttnn::distributed::get_device_tensors(cpu_tensor);
+    auto cpu_tensors = ttnn::get_device_tensors(cpu_tensor);
     std::vector<xt::xarray<T>> res;
     res.reserve(cpu_tensors.size());
     for (const auto& shard : cpu_tensors) {
@@ -83,7 +79,7 @@ auto to_xtensor(const tt::tt_metal::Tensor& tensor, const MeshToXTensorVariant<T
 template <class T = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
 tt::tt_metal::Tensor from_xtensor(
     const xt::xarray<T>& tensor,
-    ttnn::distributed::MeshDevice* device,
+    ttnn::MeshDevice* device,
     const XTensorToMeshVariant<T>& composer,
     ttnn::Layout layout = ttnn::Layout::TILE);
 

--- a/tt-train/sources/ttml/models/distributed/gpt2.cpp
+++ b/tt-train/sources/ttml/models/distributed/gpt2.cpp
@@ -19,7 +19,7 @@
 #include "ops/binary_ops.hpp"
 #include "ops/unary_ops.hpp"
 
-namespace ttml::models::distributed::gpt2 {
+namespace ttml::models::gpt2 {
 
 namespace {
 
@@ -106,11 +106,11 @@ DistributedTransformer::DistributedTransformer(const TransformerConfig& config) 
     pos_emb = create_positional_embedding();
     blocks.reserve(num_blocks);
     for (uint32_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
-        blocks.push_back(std::make_shared<ttml::modules::distributed::DistributedGPTBlock>(
+        blocks.push_back(std::make_shared<ttml::modules::DistributedGPTBlock>(
             embedding_dim, num_heads, dropout_prob, use_composite_layernorm));
     }
     ln_fc = std::make_shared<ttml::modules::LayerNormLayer>(embedding_dim, use_composite_layernorm);
-    fc = std::make_shared<ttml::modules::distributed::ColumnParallelLinear>(
+    fc = std::make_shared<ttml::modules::ColumnParallelLinear>(
         embedding_dim, vocab_size, /* bias */ false, /* gather_output */ true);
 
     create_name("transformer");
@@ -158,4 +158,4 @@ std::shared_ptr<DistributedTransformer> create(const YAML::Node& config) {
     return std::make_shared<DistributedTransformer>(transformer_config);
 }
 
-}  // namespace ttml::models::distributed::gpt2
+}  // namespace ttml::models::gpt2

--- a/tt-train/sources/ttml/models/distributed/gpt2.hpp
+++ b/tt-train/sources/ttml/models/distributed/gpt2.hpp
@@ -14,7 +14,7 @@
 #include "modules/layer_norm_module.hpp"
 #include "modules/positional_embeddings.hpp"
 
-namespace ttml::models::distributed::gpt2 {
+namespace ttml::models::gpt2 {
 
 using models::gpt2::PositionalEmbeddingType;
 using models::gpt2::RunnerType;
@@ -40,4 +40,4 @@ public:
 [[nodiscard]] std::shared_ptr<DistributedTransformer> create(const TransformerConfig& config);
 [[nodiscard]] std::shared_ptr<DistributedTransformer> create(const YAML::Node& config);
 
-}  // namespace ttml::models::distributed::gpt2
+}  // namespace ttml::models::gpt2

--- a/tt-train/sources/ttml/models/distributed/llama.cpp
+++ b/tt-train/sources/ttml/models/distributed/llama.cpp
@@ -14,7 +14,7 @@
 #include "ops/rope_op.hpp"
 #include "ops/unary_ops.hpp"
 
-namespace ttml::models::distributed::llama {
+namespace ttml::models::llama {
 
 namespace {
 
@@ -99,11 +99,11 @@ DistributedLlama::DistributedLlama(const LlamaConfig& config) {
         /*rope_scaling_params=*/rope_scaling_params);
     blocks.reserve(num_blocks);
     for (uint32_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
-        blocks.push_back(std::make_shared<modules::distributed::DistributedLlamaBlock>(
+        blocks.push_back(std::make_shared<modules::DistributedLlamaBlock>(
             embedding_dim, num_heads, num_groups, m_rope_params, dropout_prob));
     }
     ln_fc = std::make_shared<ttml::modules::RMSNormLayer>(embedding_dim);
-    fc = std::make_shared<ttml::modules::distributed::ColumnParallelLinear>(
+    fc = std::make_shared<ttml::modules::ColumnParallelLinear>(
         embedding_dim, vocab_size, /* has_bias */ false, /* gather_output */ true);
 
     create_name("llama");
@@ -143,4 +143,4 @@ std::shared_ptr<DistributedLlama> create(const YAML::Node& config) {
     return std::make_shared<DistributedLlama>(llama_config);
 }
 
-}  // namespace ttml::models::distributed::llama
+}  // namespace ttml::models::llama

--- a/tt-train/sources/ttml/models/distributed/llama.hpp
+++ b/tt-train/sources/ttml/models/distributed/llama.hpp
@@ -12,7 +12,7 @@
 #include "ops/rope_op.hpp"
 #include "yaml-cpp/yaml.h"
 
-namespace ttml::models::distributed::llama {
+namespace ttml::models::llama {
 
 using RunnerType = common::transformer::RunnerType;
 using models::llama::LlamaConfig;
@@ -35,4 +35,4 @@ public:
 [[nodiscard]] std::shared_ptr<DistributedLlama> create(const LlamaConfig& config);
 [[nodiscard]] std::shared_ptr<DistributedLlama> create(const YAML::Node& config);
 
-}  // namespace ttml::models::distributed::llama
+}  // namespace ttml::models::llama

--- a/tt-train/sources/ttml/modules/distributed/gpt_block.hpp
+++ b/tt-train/sources/ttml/modules/distributed/gpt_block.hpp
@@ -22,8 +22,8 @@ public:
     autograd::TensorPtr operator()(const autograd::TensorPtr& input) override;
 
 private:
-    std::shared_ptr<distributed::ColumnParallelLinear> m_fc1;
-    std::shared_ptr<distributed::RowParallelLinear> m_fc2;
+    std::shared_ptr<ColumnParallelLinear> m_fc1;
+    std::shared_ptr<RowParallelLinear> m_fc2;
     std::shared_ptr<DropoutLayer> m_dropout;
 };
 

--- a/tt-train/sources/ttml/modules/distributed/linear.cpp
+++ b/tt-train/sources/ttml/modules/distributed/linear.cpp
@@ -32,11 +32,11 @@ RowParallelLinear::RowParallelLinear(
 autograd::TensorPtr RowParallelLinear::operator()(const autograd::TensorPtr& tensor) {
     auto x = tensor;
     if (!m_input_is_parallel) {
-        x = ops::distributed::scatter(x, tensor->get_rank() - 1U);
+        x = ops::scatter(x, tensor->get_rank() - 1U);
     }
     // do not pass bias
     x = ops::linear_op(x, m_weight, /* bias */ nullptr);
-    x = ops::distributed::all_reduce(x);
+    x = ops::all_reduce(x);
     if (m_bias != nullptr) {
         x = ops::add(x, m_bias);
     }
@@ -86,10 +86,10 @@ ColumnParallelLinear::ColumnParallelLinear(
 
 autograd::TensorPtr ColumnParallelLinear::operator()(const autograd::TensorPtr& tensor) {
     auto x = tensor;
-    x = ops::distributed::broadcast(x);
+    x = ops::broadcast(x);
     x = ops::linear_op(x, m_weight, m_bias);
     if (m_gather_output) {
-        x = ops::distributed::all_gather(x, tensor->get_rank() - 1U);
+        x = ops::all_gather(x, tensor->get_rank() - 1U);
     }
     return x;
 }

--- a/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
+++ b/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
@@ -14,7 +14,7 @@
 namespace ttml::ops::distributed {
 
 autograd::TensorPtr scatter(const autograd::TensorPtr& tensor, int dim) {
-    auto out = autograd::create_tensor(ttnn_fixed::distributed::scatter(tensor->get_value(), dim));
+    auto out = autograd::create_tensor(ttnn_fixed::scatter(tensor->get_value(), dim));
     autograd::GradFunction grad = [tensor, out, dim]() { tensor->add_grad(ttnn::all_gather(out->get_grad(), dim)); };
     auto links = autograd::get_links(tensor);
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
@@ -23,16 +23,14 @@ autograd::TensorPtr scatter(const autograd::TensorPtr& tensor, int dim) {
 
 autograd::TensorPtr all_gather(const autograd::TensorPtr& tensor, int dim) {
     auto out = autograd::create_tensor(ttnn::all_gather(tensor->get_value(), dim));
-    autograd::GradFunction grad = [tensor, out, dim]() {
-        tensor->add_grad(ttnn_fixed::distributed::scatter(out->get_grad(), dim));
-    };
+    autograd::GradFunction grad = [tensor, out, dim]() { tensor->add_grad(ttnn_fixed::scatter(out->get_grad(), dim)); };
     auto links = autograd::get_links(tensor);
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
     return out;
 }
 
 autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor) {
-    auto out = autograd::create_tensor(ttnn_fixed::distributed::all_reduce(tensor->get_value()));
+    auto out = autograd::create_tensor(ttnn_fixed::all_reduce(tensor->get_value()));
     autograd::GradFunction grad = [tensor, out]() { tensor->add_grad(out->get_grad()); };
     auto links = autograd::get_links(tensor);
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
@@ -41,9 +39,7 @@ autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor) {
 
 autograd::TensorPtr broadcast(const autograd::TensorPtr& tensor) {
     auto out = autograd::create_tensor(tensor->get_value());
-    autograd::GradFunction grad = [tensor, out]() {
-        tensor->add_grad(ttnn_fixed::distributed::all_reduce(out->get_grad()));
-    };
+    autograd::GradFunction grad = [tensor, out]() { tensor->add_grad(ttnn_fixed::all_reduce(out->get_grad())); };
     auto links = autograd::get_links(tensor);
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
     return out;

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
@@ -90,7 +90,7 @@ tt::tt_metal::Tensor scatter(const tt::tt_metal::Tensor& tensor, int dim) {
             ttnn::Shape(scattered_shape),
             tt::tt_metal::TensorLayout(tensor.dtype(), tensor.layout(), tensor.memory_config())),
         current_device);
-    auto scattered_tensors = ttnn::distributed::get_device_tensors(scattered_tensor);
+    auto scattered_tensors = ttnn::get_device_tensors(scattered_tensor);
     if (scattered_tensors.size() != num_devices) {
         throw std::logic_error(fmt::format(
             "Number of scattered tensors should be equal to the number of devices. Tensor is not properly replicated."
@@ -103,14 +103,14 @@ tt::tt_metal::Tensor scatter(const tt::tt_metal::Tensor& tensor, int dim) {
     ttnn::SmallVector<uint32_t> end{tensor_shape[0], tensor_shape[1], tensor_shape[2], tensor_shape[3]};
     const ttnn::SmallVector<uint32_t> stride{1U, 1U, 1U, 1U};
     size_t idx = 0;
-    for (const auto& tensor_shard : ttnn::distributed::get_device_tensors(tensor)) {
+    for (const auto& tensor_shard : ttnn::get_device_tensors(tensor)) {
         start[dim] = split_size_per_device * idx;
         end[dim] = split_size_per_device * (idx + 1);
 
         ttnn::slice(tensor_shard, start, end, stride, std::nullopt, scattered_tensors[idx]);
         ++idx;
     }
-    return ttnn::distributed::aggregate_as_tensor(scattered_tensors, tt::tt_metal::AllGatherTensor{});
+    return ttnn::aggregate_as_tensor(scattered_tensors, tt::tt_metal::AllGatherTensor{});
 }
 
 }  // namespace ttml::ttnn_fixed::distributed

--- a/tt-train/tests/core/distributed_test.cpp
+++ b/tt-train/tests/core/distributed_test.cpp
@@ -11,7 +11,7 @@
 
 namespace {
 
-using MetalMeshShape = ::tt::tt_metal::distributed::MeshShape;
+using MetalMeshShape = ::tt::tt_metal::MeshShape;
 using ::testing::SizeIs;
 
 template <typename T>

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -26,7 +26,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::MeshShape(1, 2));
         ttml::autograd::ctx().open_device();
     }
 

--- a/tt-train/tests/model/linear_regression_ddp_test.cpp
+++ b/tt-train/tests/model/linear_regression_ddp_test.cpp
@@ -34,7 +34,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::MeshShape(1, 2));
         ttml::autograd::ctx().open_device();
     }
 

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -39,7 +39,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::MeshShape(1, 2));
         ttml::autograd::ctx().open_device();
     }
 
@@ -54,7 +54,7 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNotInputParallel) {
     bool has_bias = true;
     bool input_is_parallel = false;
 
-    auto layer = ttml::modules::distributed::RowParallelLinear(in_features, out_features, has_bias, input_is_parallel);
+    auto layer = ttml::modules::RowParallelLinear(in_features, out_features, has_bias, input_is_parallel);
     auto parameters = layer.parameters();
     EXPECT_EQ(parameters.size(), 1UL + static_cast<size_t>(has_bias));
 
@@ -97,7 +97,7 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasNotInputParallel) {
     bool has_bias = false;
     bool input_is_parallel = false;
 
-    auto layer = ttml::modules::distributed::RowParallelLinear(in_features, out_features, has_bias, input_is_parallel);
+    auto layer = ttml::modules::RowParallelLinear(in_features, out_features, has_bias, input_is_parallel);
     auto parameters = layer.parameters();
     EXPECT_EQ(parameters.size(), 1UL + static_cast<size_t>(has_bias));
 
@@ -134,7 +134,7 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasInputParallel) {
     bool has_bias = true;
     bool input_is_parallel = true;
 
-    auto layer = ttml::modules::distributed::RowParallelLinear(in_features, out_features, has_bias, input_is_parallel);
+    auto layer = ttml::modules::RowParallelLinear(in_features, out_features, has_bias, input_is_parallel);
     auto parameters = layer.parameters();
     EXPECT_EQ(parameters.size(), 1UL + static_cast<size_t>(has_bias));
 
@@ -173,7 +173,7 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasInputParallel) {
     bool has_bias = false;
     bool input_is_parallel = true;
 
-    auto layer = ttml::modules::distributed::RowParallelLinear(in_features, out_features, has_bias, input_is_parallel);
+    auto layer = ttml::modules::RowParallelLinear(in_features, out_features, has_bias, input_is_parallel);
     auto parameters = layer.parameters();
     EXPECT_EQ(parameters.size(), 1UL + static_cast<size_t>(has_bias));
 
@@ -207,7 +207,7 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasAllGather) {
     bool has_bias = true;
     bool use_all_gather = true;
 
-    auto layer = ttml::modules::distributed::ColumnParallelLinear(in_features, out_features, has_bias, use_all_gather);
+    auto layer = ttml::modules::ColumnParallelLinear(in_features, out_features, has_bias, use_all_gather);
     auto parameters = layer.parameters();
     EXPECT_EQ(parameters.size(), 1UL + static_cast<size_t>(has_bias));
 
@@ -248,7 +248,7 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasAllGather) {
     bool has_bias = false;
     bool use_all_gather = true;
 
-    auto layer = ttml::modules::distributed::ColumnParallelLinear(in_features, out_features, has_bias, use_all_gather);
+    auto layer = ttml::modules::ColumnParallelLinear(in_features, out_features, has_bias, use_all_gather);
     auto parameters = layer.parameters();
     EXPECT_EQ(parameters.size(), 1UL + static_cast<size_t>(has_bias));
 
@@ -283,7 +283,7 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasNoAllGather) {
     bool has_bias = true;
     bool use_all_gather = false;
 
-    auto layer = ttml::modules::distributed::ColumnParallelLinear(in_features, out_features, has_bias, use_all_gather);
+    auto layer = ttml::modules::ColumnParallelLinear(in_features, out_features, has_bias, use_all_gather);
     auto parameters = layer.parameters();
     EXPECT_EQ(parameters.size(), 1UL + static_cast<size_t>(has_bias));
 
@@ -332,7 +332,7 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasNoAllGather) {
     bool has_bias = false;
     bool use_all_gather = false;
 
-    auto layer = ttml::modules::distributed::ColumnParallelLinear(in_features, out_features, has_bias, use_all_gather);
+    auto layer = ttml::modules::ColumnParallelLinear(in_features, out_features, has_bias, use_all_gather);
     auto parameters = layer.parameters();
     EXPECT_EQ(parameters.size(), 1UL + static_cast<size_t>(has_bias));
 
@@ -380,7 +380,7 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNanoGPT) {
 
     auto generator = ttml::autograd::ctx().get_generator();
 
-    auto layer = ttml::modules::distributed::RowParallelLinear(in_features, out_features, has_bias, input_is_parallel);
+    auto layer = ttml::modules::RowParallelLinear(in_features, out_features, has_bias, input_is_parallel);
     auto parameters = layer.parameters();
     EXPECT_EQ(parameters.size(), 1UL + static_cast<size_t>(has_bias));
 
@@ -447,7 +447,7 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasNanoGPT) {
 
     auto generator = ttml::autograd::ctx().get_generator();
 
-    auto layer = ttml::modules::distributed::ColumnParallelLinear(in_features, out_features, has_bias, use_all_gather);
+    auto layer = ttml::modules::ColumnParallelLinear(in_features, out_features, has_bias, use_all_gather);
     auto parameters = layer.parameters();
     EXPECT_EQ(parameters.size(), 1UL + static_cast<size_t>(has_bias));
 
@@ -514,7 +514,7 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasNanoGPT) {
 
     auto generator = ttml::autograd::ctx().get_generator();
 
-    auto layer = ttml::modules::distributed::ColumnParallelLinear(in_features, out_features, has_bias, use_all_gather);
+    auto layer = ttml::modules::ColumnParallelLinear(in_features, out_features, has_bias, use_all_gather);
     auto parameters = layer.parameters();
     EXPECT_EQ(parameters.size(), 1UL + static_cast<size_t>(has_bias));
 

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -29,7 +29,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::MeshShape(1, 2));
         ttml::autograd::ctx().open_device();
     }
 
@@ -50,7 +50,7 @@ TEST_F(N300CommOpsTest, TestAllReduceNotFullyTiled) {
     ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
     auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, shard_composer);
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
-    auto all_reduce_tensor = ttml::ops::distributed::all_reduce(tensor);
+    auto all_reduce_tensor = ttml::ops::all_reduce(tensor);
 
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
     auto all_reduce_xtensor = ttml::core::to_xtensor<float>(all_reduce_tensor->get_value(), identity_composer);
@@ -105,7 +105,7 @@ TEST_F(N300CommOpsTest, TestAllReduceNanoGPT) {
     ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
     auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, shard_composer);
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
-    auto all_reduce_tensor = ttml::ops::distributed::all_reduce(tensor);
+    auto all_reduce_tensor = ttml::ops::all_reduce(tensor);
 
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
     auto all_reduce_xtensor = ttml::core::to_xtensor<float>(all_reduce_tensor->get_value(), identity_composer);
@@ -154,7 +154,7 @@ TEST_F(N300CommOpsTest, TestAllReduceFullyTiled) {
     ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
     auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, shard_composer);
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
-    auto all_reduce_tensor = ttml::ops::distributed::all_reduce(tensor);
+    auto all_reduce_tensor = ttml::ops::all_reduce(tensor);
 
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
     auto all_reduce_xtensor = ttml::core::to_xtensor<float>(all_reduce_tensor->get_value(), identity_composer);
@@ -202,7 +202,7 @@ TEST_F(N300CommOpsTest, TestAllGatherNotFullyTiled) {
     ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
     auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, shard_composer);
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
-    auto gathered_tensor = ttml::ops::distributed::all_gather(tensor, 3);
+    auto gathered_tensor = ttml::ops::all_gather(tensor, 3);
 
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
     auto gathered_xtensor = ttml::core::to_xtensor<float>(gathered_tensor->get_value(), identity_composer);
@@ -247,7 +247,7 @@ TEST_F(N300CommOpsTest, TestAllGatherFullyTiled) {
     ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
     auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, shard_composer);
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
-    auto gathered_tensor = ttml::ops::distributed::all_gather(tensor, 3);
+    auto gathered_tensor = ttml::ops::all_gather(tensor, 3);
 
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
     auto gathered_xtensor = ttml::core::to_xtensor<float>(gathered_tensor->get_value(), identity_composer);
@@ -290,7 +290,7 @@ TEST_F(N300CommOpsTest, TestScatterNotFullyTiled) {
     ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
     auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, replicate_composer);
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
-    auto scattered_tensor = ttml::ops::distributed::scatter(tensor, 3);
+    auto scattered_tensor = ttml::ops::scatter(tensor, 3);
 
     // check forward
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
@@ -340,7 +340,7 @@ TEST_F(N300CommOpsTest, TestScatterFullyTiled) {
     EXPECT_TRUE(xt::allclose(xtensor, xtensor_after_replication[1], /* rtol */ 1e-3, /* atol */ 1e-2));
 
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
-    auto scattered_tensor = ttml::ops::distributed::scatter(tensor, 3);
+    auto scattered_tensor = ttml::ops::scatter(tensor, 3);
 
     // check forward
     auto xtensors_back = ttml::core::to_xtensor<float>(scattered_tensor->get_value(), identity_composer);

--- a/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
@@ -27,7 +27,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::MeshShape(1, 2));
         ttml::autograd::ctx().open_device();
     }
 
@@ -47,7 +47,7 @@ TEST_F(TrivialTnnFixedDistributedTest, TestCustomScatterDim0) {
     auto shape = ttml::core::create_shape({size, 1, 1, 1});
     auto tensor = ttml::core::from_vector(data, shape, device);
 
-    auto scattered_tensor = ttml::ttnn_fixed::distributed::scatter(tensor, /* dim */ 0);
+    auto scattered_tensor = ttml::ttnn_fixed::scatter(tensor, /* dim */ 0);
 
     auto mesh_shape = device->shape();
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
@@ -74,7 +74,7 @@ TEST_F(TrivialTnnFixedDistributedTest, TestCustomScatterDim1) {
     auto shape = ttml::core::create_shape({1, size, 1, 1});
     auto tensor = ttml::core::from_vector(data, shape, device);
 
-    auto scattered_tensor = ttml::ttnn_fixed::distributed::scatter(tensor, /* dim */ 1);
+    auto scattered_tensor = ttml::ttnn_fixed::scatter(tensor, /* dim */ 1);
 
     auto mesh_shape = device->shape();
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
@@ -101,7 +101,7 @@ TEST_F(TrivialTnnFixedDistributedTest, TestCustomScatterDim2) {
     auto shape = ttml::core::create_shape({1, 1, size, 1});
     auto tensor = ttml::core::from_vector(data, shape, device);
 
-    auto scattered_tensor = ttml::ttnn_fixed::distributed::scatter(tensor, /* dim */ 2);
+    auto scattered_tensor = ttml::ttnn_fixed::scatter(tensor, /* dim */ 2);
 
     auto mesh_shape = device->shape();
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
@@ -128,7 +128,7 @@ TEST_F(TrivialTnnFixedDistributedTest, TestCustomScatterDim3) {
     auto shape = ttml::core::create_shape({1, 1, 1, size});
     auto tensor = ttml::core::from_vector(data, shape, device);
 
-    auto scattered_tensor = ttml::ttnn_fixed::distributed::scatter(tensor, /* dim */ 3);
+    auto scattered_tensor = ttml::ttnn_fixed::scatter(tensor, /* dim */ 3);
 
     auto mesh_shape = device->shape();
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -49,9 +49,7 @@ class SystemMemoryManager;
 class TraceBuffer;
 struct TraceDescriptor;
 
-namespace distributed {
 class MeshDevice;
-}
 
 class IDevice {
 public:
@@ -223,7 +221,7 @@ public:
 
     // Allowing to get corresponding MeshDevice for a given device to properly schedule programs / create buffers for
     // it. This is currently used exclusively by profiler.
-    virtual std::shared_ptr<distributed::MeshDevice> get_mesh_device() = 0;
+    virtual std::shared_ptr<MeshDevice> get_mesh_device() = 0;
 
     static constexpr MemoryAllocator allocator_scheme_ = MemoryAllocator::L1_BANKING;
 };

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -24,17 +24,13 @@
 namespace tt {
 namespace tt_metal {
 class Program;
-namespace distributed {
 class MeshDevice;
-}  // namespace distributed
 }  // namespace tt_metal
 }  // namespace tt
 
 namespace tt::tt_metal {
 
 class IDevice;
-
-namespace distributed {
 
 MeshWorkload CreateMeshWorkload();
 
@@ -123,5 +119,4 @@ void Synchronize(
 
 void Finish(MeshCommandQueue& mesh_cq, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
-}  // namespace distributed
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/distributed_context.hpp
+++ b/tt_metal/api/tt-metalium/distributed_context.hpp
@@ -12,7 +12,7 @@
 #include <cstdint>
 #include <complex>
 
-namespace tt::tt_metal::distributed::multihost {
+namespace tt::tt_metal::multihost {
 
 enum class ReduceOp : std::uint8_t { SUM, MAX, MIN, PROD, LAND, LOR, BAND, BOR };
 
@@ -232,4 +232,4 @@ public:
 
     virtual ~DistributedContext() = default;
 };
-}  // namespace tt::tt_metal::distributed::multihost
+}  // namespace tt::tt_metal::multihost

--- a/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
@@ -30,19 +30,17 @@ public:
     // consistent with the global shape. `global_buffers` that are remote to this host will be deallocated and ignored
     // for all subsequent operations. Only local buffers will be retained by this `DistributedHostBuffer` instance.
     static DistributedHostBuffer create(
-        const distributed::MeshShape& global_shape,
-        const distributed::MeshShape& local_shape,
-        const distributed::MeshCoordinate& local_offset);
+        const MeshShape& global_shape, const MeshShape& local_shape, const MeshCoordinate& local_offset);
 
     // Returns the shard at the specified `coord`.
     // Returns `std::nullopt` if the index is out of local bounds.
     // Throws if the index is out of global bounds.
-    std::optional<HostBuffer> get_shard(const distributed::MeshCoordinate& coord) const;
+    std::optional<HostBuffer> get_shard(const MeshCoordinate& coord) const;
 
     // Emplaces the shard at the specified `coord`, calling `produce_buffer` to create the buffer only when needed.
     // No-op if the index is out of local bounds.
     // Throws if the index is out of global bounds.
-    void emplace_shard(const distributed::MeshCoordinate& coord, const std::function<HostBuffer()>& produce_buffer);
+    void emplace_shard(const MeshCoordinate& coord, const std::function<HostBuffer()>& produce_buffer);
 
     // `transform` and `apply` functions abstract away the details of the underlying data storage.
     // `linear_index` will be supplied by `DistributedHostBuffer` to indicate the position of the buffer.
@@ -56,26 +54,24 @@ public:
     void apply(const ApplyFn& fn) const;
 
     // Returns the global shape of the buffer.
-    distributed::MeshShape shape() const;
+    MeshShape shape() const;
 
     // Returns the coordinates of populated shards in the buffer.
-    const std::unordered_set<distributed::MeshCoordinate>& shard_coords() const;
+    const std::unordered_set<MeshCoordinate>& shard_coords() const;
 
 private:
-    std::optional<distributed::MeshCoordinate> global_to_local(const distributed::MeshCoordinate& coord) const;
+    std::optional<MeshCoordinate> global_to_local(const MeshCoordinate& coord) const;
 
     DistributedHostBuffer(
-        distributed::MeshShape global_shape,
-        distributed::MeshCoordinate local_offset,
-        distributed::MeshContainer<HostBuffer> local_buffers) :
+        MeshShape global_shape, MeshCoordinate local_offset, MeshContainer<HostBuffer> local_buffers) :
         global_shape_(std::move(global_shape)),
         local_offset_(std::move(local_offset)),
         local_buffers_(std::move(local_buffers)) {}
 
-    distributed::MeshShape global_shape_;
-    distributed::MeshCoordinate local_offset_;
-    distributed::MeshContainer<HostBuffer> local_buffers_;
-    std::unordered_set<distributed::MeshCoordinate> populated_shards_;
+    MeshShape global_shape_;
+    MeshCoordinate local_offset_;
+    MeshContainer<HostBuffer> local_buffers_;
+    std::unordered_set<MeshCoordinate> populated_shards_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/global_circular_buffer.hpp
@@ -51,8 +51,8 @@ private:
 
     // GlobalCircularBuffer is implemented as a wrapper around a sharded buffer
     // This can be updated in the future to be its own container with optimized dispatch functions
-    distributed::AnyBuffer cb_buffer_;
-    distributed::AnyBuffer cb_config_buffer_;
+    AnyBuffer cb_buffer_;
+    AnyBuffer cb_config_buffer_;
     IDevice* device_;
     std::vector<std::pair<CoreCoord, CoreRangeSet>> sender_receiver_core_mapping_;
     CoreRangeSet sender_cores_;

--- a/tt_metal/api/tt-metalium/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/global_semaphore.hpp
@@ -51,7 +51,7 @@ private:
 
     // GlobalSemaphore is implemented as a wrapper around a sharded buffer
     // This can be updated in the future to be its own container with optimized dispatch functions
-    distributed::AnyBuffer buffer_;
+    AnyBuffer buffer_;
     IDevice* device_;
     CoreRangeSet cores_;
 };

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -944,7 +944,7 @@ void LoadTrace(IDevice* device, uint8_t cq_id, uint32_t trace_id, const TraceDes
  * */
 // clang-format on
 void DumpMeshDeviceProfileResults(
-    distributed::MeshDevice& mesh_device,
+    MeshDevice& mesh_device,
     ProfilerDumpState state = ProfilerDumpState::NORMAL,
     const std::optional<ProfilerOptionalMetadata>& metadata = {});
 

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -37,15 +37,13 @@ namespace tt_metal {
 class IDevice;
 class SystemMemoryManager;
 class WorkerConfigBufferMgr;
-namespace distributed {
 class MeshDevice;
 class MeshWorkload;
-}  // namespace distributed
 struct ProgramCommandSequence;
 }  // namespace tt_metal
 }  // namespace tt
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 class MeshEvent;
 class MeshTraceDescriptor;
@@ -130,4 +128,4 @@ public:
     virtual void enqueue_trace(const MeshTraceId& trace_id, bool blocking) = 0;
 };
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_config.hpp
+++ b/tt_metal/api/tt-metalium/mesh_config.hpp
@@ -8,7 +8,7 @@
 
 #include <tt-metalium/mesh_coord.hpp>
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 using chip_id_t = int;
 
@@ -35,4 +35,4 @@ private:
     std::vector<chip_id_t> physical_device_ids_;
 };
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -14,7 +14,7 @@
 #include <tt-metalium/shape_base.hpp>
 #include <tt-metalium/utils.hpp>
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 class MeshShape : public ShapeBase {
 public:
@@ -450,41 +450,40 @@ typename MeshContainer<T>::ConstIterator MeshContainer<T>::end() const {
     return ConstIterator(this, coord_range_.end(), shape_.mesh_size());
 }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal
 
 namespace std {
 
 template <typename T>
-struct tuple_size<tt::tt_metal::distributed::detail::MeshCoordinateValueProxy<T>> : std::integral_constant<size_t, 2> {
+struct tuple_size<tt::tt_metal::detail::MeshCoordinateValueProxy<T>> : std::integral_constant<size_t, 2> {};
+
+template <typename T>
+struct tuple_element<0, tt::tt_metal::detail::MeshCoordinateValueProxy<T>> {
+    using type = const tt::tt_metal::MeshCoordinate;
 };
 
 template <typename T>
-struct tuple_element<0, tt::tt_metal::distributed::detail::MeshCoordinateValueProxy<T>> {
-    using type = const tt::tt_metal::distributed::MeshCoordinate;
-};
-
-template <typename T>
-struct tuple_element<1, tt::tt_metal::distributed::detail::MeshCoordinateValueProxy<T>> {
+struct tuple_element<1, tt::tt_metal::detail::MeshCoordinateValueProxy<T>> {
     using type = T;
 };
 
 template <>
-struct hash<tt::tt_metal::distributed::MeshCoordinate> {
-    size_t operator()(const tt::tt_metal::distributed::MeshCoordinate& coord) const noexcept {
+struct hash<tt::tt_metal::MeshCoordinate> {
+    size_t operator()(const tt::tt_metal::MeshCoordinate& coord) const noexcept {
         return tt::stl::hash::hash_objects_with_default_seed(coord.attribute_values());
     }
 };
 
 template <>
-struct hash<tt::tt_metal::distributed::MeshCoordinateRange> {
-    size_t operator()(const tt::tt_metal::distributed::MeshCoordinateRange& range) const noexcept {
+struct hash<tt::tt_metal::MeshCoordinateRange> {
+    size_t operator()(const tt::tt_metal::MeshCoordinateRange& range) const noexcept {
         return tt::stl::hash::hash_objects_with_default_seed(range.attribute_values());
     }
 };
 
 template <>
-struct hash<tt::tt_metal::distributed::MeshCoordinateRangeSet> {
-    size_t operator()(const tt::tt_metal::distributed::MeshCoordinateRangeSet& range_set) const noexcept {
+struct hash<tt::tt_metal::MeshCoordinateRangeSet> {
+    size_t operator()(const tt::tt_metal::MeshCoordinateRangeSet& range_set) const noexcept {
         return tt::stl::hash::hash_objects_with_default_seed(range_set.attribute_values());
     }
 };

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -55,8 +55,6 @@ class SubDeviceManagerTracker;
 class ThreadPool;
 class TraceDescriptor;
 
-namespace distributed {
-
 class MeshCommandQueue;
 class MeshDeviceView;
 class MeshTraceBuffer;
@@ -253,7 +251,7 @@ public:
     std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
         tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) override;
     bool is_mmio_capable() const override;
-    std::shared_ptr<distributed::MeshDevice> get_mesh_device() override;
+    std::shared_ptr<MeshDevice> get_mesh_device() override;
 
     // A MeshDevice is a collection of devices arranged in a 2D grid.
     // The type parameter allows the caller to specify how to linearize the devices in the mesh.
@@ -337,7 +335,5 @@ public:
 };
 
 std::ostream& operator<<(std::ostream& os, const MeshDevice& mesh_device);
-
-}  // namespace distributed
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_device_view.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device_view.hpp
@@ -16,7 +16,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/shape2d.hpp>
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 // Forward declaration of MeshDevice
 class MeshDevice;
@@ -112,4 +112,4 @@ private:
     std::optional<Shape2D> shape_2d_;
 };
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_event.hpp
+++ b/tt_metal/api/tt-metalium/mesh_event.hpp
@@ -12,13 +12,11 @@
 
 namespace tt {
 namespace tt_metal {
-namespace distributed {
 class MeshDevice;
-}  // namespace distributed
 }  // namespace tt_metal
 }  // namespace tt
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 class MeshEvent {
 public:
@@ -39,4 +37,4 @@ private:
     MeshCoordinateRange device_range_;
 };
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -25,10 +25,10 @@ enum class ARCH;
 
 namespace tt::tt_fabric {
 
-using tt::tt_metal::distributed::MeshContainer;
-using tt::tt_metal::distributed::MeshCoordinate;
-using tt::tt_metal::distributed::MeshCoordinateRange;
-using tt::tt_metal::distributed::MeshShape;
+using tt::tt_metal::MeshContainer;
+using tt::tt_metal::MeshCoordinate;
+using tt::tt_metal::MeshCoordinateRange;
+using tt::tt_metal::MeshShape;
 
 struct ChipSpec {
     tt::ARCH arch;

--- a/tt_metal/api/tt-metalium/mesh_socket.hpp
+++ b/tt_metal/api/tt-metalium/mesh_socket.hpp
@@ -6,7 +6,7 @@
 
 #include <tt-metalium/mesh_buffer.hpp>
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 // Multi-Dimensional coordinate struct used to access individual cores in a MeshDevice.
 struct MeshCoreCoord {
@@ -74,4 +74,4 @@ private:
     SocketConfig config_;
 };
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_trace_id.hpp
+++ b/tt_metal/api/tt-metalium/mesh_trace_id.hpp
@@ -7,9 +7,9 @@
 #include <tt_stl/strong_type.hpp>
 #include <cstdint>
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 // Identifier for a mesh trace.
 using MeshTraceId = tt::stl::StrongType<uint32_t, struct MeshTraceIdTag>;
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_workload.hpp
+++ b/tt_metal/api/tt-metalium/mesh_workload.hpp
@@ -8,7 +8,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 class MeshWorkloadImpl;
 
@@ -49,4 +49,4 @@ private:
     friend void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking);
     friend FDMeshCommandQueue;
 };
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/program.hpp
+++ b/tt_metal/api/tt-metalium/program.hpp
@@ -44,10 +44,8 @@ uint32_t program_base_addr_on_core(
     WorkloadType& workload, DeviceType generic_device, HalProgrammableCoreType core_type);
 }  // namespace program_dispatch
 
-namespace distributed {
 class MeshWorkload;
 class MeshWorkloadImpl;
-}  // namespace distributed
 
 class JitBuildOptions;
 class EnqueueProgramCommand;
@@ -176,8 +174,8 @@ private:
 
     friend HWCommandQueue;
     friend EnqueueProgramCommand;
-    friend distributed::MeshWorkload;
-    friend distributed::MeshWorkloadImpl;
+    friend MeshWorkload;
+    friend MeshWorkloadImpl;
     friend detail::Internal_;
 };
 

--- a/tt_metal/api/tt-metalium/program_cache.hpp
+++ b/tt_metal/api/tt-metalium/program_cache.hpp
@@ -59,10 +59,10 @@ public:
 
 template <typename shared_variables_t>
 struct CachedMeshWorkload {
-    tt::tt_metal::distributed::MeshWorkload workload;
+    tt::tt_metal::MeshWorkload workload;
     shared_variables_t shared_variables;
 
-    CachedMeshWorkload(tt::tt_metal::distributed::MeshWorkload&& workload, shared_variables_t&& shared_variables) :
+    CachedMeshWorkload(tt::tt_metal::MeshWorkload&& workload, shared_variables_t&& shared_variables) :
         workload{std::move(workload)}, shared_variables{std::move(shared_variables)} {}
 };
 
@@ -71,12 +71,12 @@ struct CachedMeshWorkload {
 // then stamped out to the entire mesh.
 template <typename shared_variables_t>
 struct AdaptedCachedMeshWorkload {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<distributed::MeshCoordinateRange, shared_variables_t> shared_variables;
+    tt::tt_metal::MeshWorkload workload;
+    std::unordered_map<MeshCoordinateRange, shared_variables_t> shared_variables;
 
     AdaptedCachedMeshWorkload(
-        tt::tt_metal::distributed::MeshWorkload&& workload,
-        std::unordered_map<distributed::MeshCoordinateRange, shared_variables_t>&& shared_variables) :
+        tt::tt_metal::MeshWorkload&& workload,
+        std::unordered_map<MeshCoordinateRange, shared_variables_t>&& shared_variables) :
         workload{std::move(workload)}, shared_variables{std::move(shared_variables)} {}
 };
 

--- a/tt_metal/api/tt-metalium/system_mesh.hpp
+++ b/tt_metal/api/tt-metalium/system_mesh.hpp
@@ -18,7 +18,7 @@ class Indestructible;
 }  // namespace stl
 }  // namespace tt
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 // SystemMesh creates a virtualization over the physical devices in the system.
 // It creates a logical mesh of devices and manages the mapping between logical and physical device coordinates.
@@ -56,4 +56,4 @@ public:
         const MeshShape& shape, const std::optional<MeshCoordinate>& offset = std::nullopt) const;
 };
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -21,7 +21,7 @@
 #include "shape_base.hpp"
 #include "small_vector.hpp"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 namespace {
 
 // Returns the last valid coordinate for the provided `shape`.
@@ -433,4 +433,4 @@ std::ostream& operator<<(std::ostream& os, const MeshCoordinateRangeSet& range_s
     return os;
 }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/coordinate_translation.cpp
+++ b/tt_metal/distributed/coordinate_translation.cpp
@@ -17,7 +17,7 @@
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/cluster_descriptor_types.h>
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 const MeshContainer<PhysicalMeshCoordinate>& get_system_mesh_coordinate_translation_map() {
     static tt::stl::Indestructible<MeshContainer<PhysicalMeshCoordinate>> kTranslationMap([]() {
@@ -54,4 +54,4 @@ const MeshContainer<PhysicalMeshCoordinate>& get_system_mesh_coordinate_translat
     return kTranslationMap.get();
 }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/coordinate_translation.hpp
+++ b/tt_metal/distributed/coordinate_translation.hpp
@@ -10,14 +10,12 @@
 
 namespace tt {
 namespace tt_metal {
-namespace distributed {
 template <typename T>
 class MeshContainer;
-}  // namespace distributed
 }  // namespace tt_metal
 }  // namespace tt
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 // PhysicalMeshCoordinate is a 2D-coordinate in the physical mesh as defined by the Fabric layer.
 // MeshCoordinate[0] is the mesh_id and MeshCoordinate[1] is the physical_device_id.
@@ -38,4 +36,4 @@ private:
 // Returns a map of all physical mesh coordinates in the system.
 const MeshContainer<PhysicalMeshCoordinate>& get_system_mesh_coordinate_translation_map();
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -12,7 +12,7 @@
 #include "tt-metalium/program.hpp"
 #include "dispatch/system_memory_manager.hpp"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 MeshWorkload CreateMeshWorkload() { return MeshWorkload(); }
 
@@ -88,4 +88,4 @@ void Finish(MeshCommandQueue& mesh_cq, tt::stl::Span<const SubDeviceId> sub_devi
     mesh_cq.finish(sub_device_ids);
 }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -51,7 +51,7 @@ struct ProgramCommandSequence;
 }  // namespace tt_metal
 }  // namespace tt
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 struct MeshReadEventDescriptor {
     ReadEventDescriptor single_device_descriptor;
@@ -891,4 +891,4 @@ void FDMeshCommandQueue::update_launch_messages_for_device_profiler(
 #endif
 }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -14,7 +14,7 @@
 #include "dispatch/worker_config_buffer.hpp"
 #include "mesh_trace.hpp"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 struct MeshReadEventDescriptor;
 struct MeshBufferReadDescriptor;
@@ -223,4 +223,4 @@ public:
     void read_l1_data_from_completion_queue(MeshCoreDataReadDescriptor& read_l1_data_descriptor);
 };
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -19,7 +19,7 @@
 #include "tt_cluster.hpp"
 #include "dispatch/dispatch_settings.hpp"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 void MeshCommandQueueBase::write_sharded_buffer(const MeshBuffer& buffer, const void* src) {
     auto global_buffer_shape = buffer.global_shard_spec().global_buffer_shape;
@@ -286,4 +286,4 @@ void MeshCommandQueueBase::enqueue_read(
     this->enqueue_read_shards(shard_data_transfers, buffer, blocking);
 }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -8,7 +8,7 @@
 
 #include "tt_metal/common/thread_pool.hpp"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 class MeshCommandQueueBase : public MeshCommandQueue {
 protected:
@@ -70,4 +70,4 @@ public:
         bool blocking) override;
 };
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -59,7 +59,7 @@ struct ProgramCache;
 }  // namespace tt_metal
 }  // namespace tt
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 namespace {
 
 int generate_unique_mesh_id() {
@@ -913,6 +913,6 @@ const std::unique_ptr<Allocator>& MeshDevice::allocator(SubDeviceId sub_device_i
     return sub_device_manager_tracker_->get_active_sub_device_manager()->allocator(sub_device_id);
 }
 
-std::shared_ptr<distributed::MeshDevice> MeshDevice::get_mesh_device() { return shared_from_this(); }
+std::shared_ptr<MeshDevice> MeshDevice::get_mesh_device() { return shared_from_this(); }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -17,7 +17,7 @@
 #include "shape2d.hpp"
 #include "shape_base.hpp"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 namespace {
 
 std::vector<IDevice*> get_devices_from_coordinates(
@@ -223,4 +223,4 @@ std::vector<IDevice*> MeshDeviceView::get_ring_devices() const {
 
 MeshDeviceView::DeviceView MeshDeviceView::get_devices() const { return this->devices_.values(); }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_event.cpp
+++ b/tt_metal/distributed/mesh_event.cpp
@@ -6,7 +6,7 @@
 
 #include "mesh_device.hpp"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 MeshEvent::MeshEvent(uint32_t id, MeshDevice* device, uint32_t mesh_cq_id, const MeshCoordinateRange& device_range) :
     id_(id), device_(device), mesh_cq_id_(mesh_cq_id), device_range_(device_range) {}
@@ -22,4 +22,4 @@ std::ostream& operator<<(std::ostream& os, const MeshEvent& event) {
     return os;
 }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_socket.cpp
+++ b/tt_metal/distributed/mesh_socket.cpp
@@ -5,7 +5,7 @@
 #include "tt_metal/distributed/mesh_socket_utils.hpp"
 #include "impl/context/metal_context.hpp"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 std::pair<MeshSocket, MeshSocket> MeshSocket::create_sockets(
     const std::shared_ptr<MeshDevice>& sender,
@@ -35,4 +35,4 @@ std::shared_ptr<MeshBuffer> MeshSocket::get_config_buffer() const { return confi
 
 const SocketConfig& MeshSocket::get_config() const { return config_; }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -9,7 +9,7 @@
 
 #include "tt_metal/hw/inc/socket.h"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 namespace {
 
@@ -209,7 +209,7 @@ void write_socket_configs(
                 md.downstream_bytes_sent_addr = peer_addr;
                 md.is_sender = is_sender;
             }
-            distributed::WriteShard(mesh_device->mesh_command_queue(0), config_buffer, config_data, device_coord, true);
+            WriteShard(mesh_device->mesh_command_queue(0), config_buffer, config_data, device_coord, true);
         }
     } else {
         std::vector<receiver_socket_md> config_data(
@@ -240,7 +240,7 @@ void write_socket_configs(
                 md.upstream_bytes_acked_addr = peer_addr;
                 md.is_sender = is_sender;
             }
-            distributed::WriteShard(mesh_device->mesh_command_queue(0), config_buffer, config_data, device_coord, true);
+            WriteShard(mesh_device->mesh_command_queue(0), config_buffer, config_data, device_coord, true);
         }
     }
 }
@@ -251,4 +251,4 @@ uint32_t get_physical_mesh_id(MeshDevice* mesh_device, const MeshCoordinate& coo
     return SystemMesh::instance().get_physical_mesh_id(global_coord);
 }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_socket_utils.hpp
+++ b/tt_metal/distributed/mesh_socket_utils.hpp
@@ -7,7 +7,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/fabric_types.hpp>
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 enum class SocketEndpoint : uint8_t { SENDER, RECEIVER };
 
@@ -32,4 +32,4 @@ void write_socket_configs(
 // Given a MeshDevice and a logical device coordinate, determine the device's physical mesh id
 uint32_t get_physical_mesh_id(MeshDevice* mesh_device, const MeshCoordinate& coord);
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -36,7 +36,7 @@
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/trace/dispatch.hpp"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 MeshTraceId MeshTrace::next_id() {
     static std::atomic<uint32_t> global_trace_id{0};
@@ -201,4 +201,4 @@ void MeshTrace::populate_mesh_buffer(MeshCommandQueue& mesh_cq, std::shared_ptr<
     }
 }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_trace.hpp
+++ b/tt_metal/distributed/mesh_trace.hpp
@@ -8,7 +8,7 @@
 #include <tt-metalium/mesh_trace_id.hpp>
 #include "trace/trace_buffer.hpp"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 // MeshTrace capture consists of 3 steps:
 // 1. Staging: Workload dispatch commands are recorded inside a host data structure
@@ -81,4 +81,4 @@ public:
     static void populate_mesh_buffer(MeshCommandQueue& mesh_cq, std::shared_ptr<MeshTraceBuffer>& trace_buffer);
 };
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -45,7 +45,7 @@ enum class HalProgrammableCoreType;
 }  // namespace tt_metal
 }  // namespace tt
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 namespace {
 
 // Returns an intersecting range from `programs` if it exists, otherwise returns std::nullopt.
@@ -467,4 +467,4 @@ uint32_t MeshWorkload::get_cb_size(
     return pimpl_->get_cb_size(mesh_device, logical_core, core_type);
 }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_workload_impl.hpp
+++ b/tt_metal/distributed/mesh_workload_impl.hpp
@@ -10,7 +10,7 @@
 #include <tt-metalium/mesh_buffer.hpp>
 #include "program/program_impl.hpp"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 using RuntimeArgsPerCore = std::vector<std::vector<RuntimeArgsData>>;
 
 class MeshCommandQueue;
@@ -76,4 +76,4 @@ public:
     uint32_t get_cb_base_addr(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
     uint32_t get_cb_size(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
 };
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_workload_utils.cpp
+++ b/tt_metal/distributed/mesh_workload_utils.cpp
@@ -17,7 +17,7 @@
 
 enum class CoreType;
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 // Use this function to send go signals to a device not running a program.
 // In the MeshWorkload context, a go signal must be sent to each device when
@@ -77,4 +77,4 @@ void write_go_signal(
     sysmem_manager.fetch_queue_reserve_back(cq_id);
     sysmem_manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);
 }
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_workload_utils.hpp
+++ b/tt_metal/distributed/mesh_workload_utils.hpp
@@ -17,7 +17,7 @@ class SystemMemoryManager;
 
 // Utility functions for dispatch MeshWorkloads
 // Used by MeshCommandQueue
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 void write_go_signal(
     uint8_t cq_id,
@@ -29,4 +29,4 @@ void write_go_signal(
     bool send_mcast,
     bool send_unicasts);
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/multihost/distributed_context.cpp
+++ b/tt_metal/distributed/multihost/distributed_context.cpp
@@ -10,7 +10,7 @@
 #include "single_host_context.hpp"
 #endif
 
-namespace tt::tt_metal::distributed::multihost {
+namespace tt::tt_metal::multihost {
 
 #if defined(OPEN_MPI)
 using ContextImpl = MPIContext;
@@ -24,4 +24,4 @@ void DistributedContext::create(int argc, char** argv) { ContextImpl::create(arg
 const ContextPtr& DistributedContext::get_current_world() { return ContextImpl::get_current_world(); }
 
 void DistributedContext::set_current_world(const ContextPtr& ctx) { ContextImpl::set_current_world(ctx); }
-}  // namespace tt::tt_metal::distributed::multihost
+}  // namespace tt::tt_metal::multihost

--- a/tt_metal/distributed/multihost/mpi_distributed_context.cpp
+++ b/tt_metal/distributed/multihost/mpi_distributed_context.cpp
@@ -20,7 +20,7 @@
 #define OMPI_HAS_ULFM 0
 #endif
 
-namespace tt::tt_metal::distributed::multihost {
+namespace tt::tt_metal::multihost {
 
 /* ----------------------------- helpers ---------------------------------- */
 
@@ -528,4 +528,4 @@ MPIContext::~MPIContext() {
         MPI_Comm_free(&comm_);
     }
 }
-}  // namespace tt::tt_metal::distributed::multihost
+}  // namespace tt::tt_metal::multihost

--- a/tt_metal/distributed/multihost/mpi_distributed_context.hpp
+++ b/tt_metal/distributed/multihost/mpi_distributed_context.hpp
@@ -8,7 +8,7 @@
 #include <memory>
 #include "api/tt-metalium/distributed_context.hpp"
 
-namespace tt::tt_metal::distributed::multihost {
+namespace tt::tt_metal::multihost {
 
 class MPIContext;
 class MPIRequest;
@@ -124,4 +124,4 @@ private:
     inline static ContextPtr current_world_;
 };
 
-}  // namespace tt::tt_metal::distributed::multihost
+}  // namespace tt::tt_metal::multihost

--- a/tt_metal/distributed/multihost/single_host_context.cpp
+++ b/tt_metal/distributed/multihost/single_host_context.cpp
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <cstring>
 
-namespace tt::tt_metal::distributed::multihost {
+namespace tt::tt_metal::multihost {
 // ---------------------------------------------------------------------
 //                           Context implementation
 // ---------------------------------------------------------------------
@@ -119,4 +119,4 @@ void SingleHostContext::revoke_and_shrink() {
     TT_THROW("method revoke_and_shrink is unsupported for single-host distributed contexts.");
 }
 
-}  // namespace tt::tt_metal::distributed::multihost
+}  // namespace tt::tt_metal::multihost

--- a/tt_metal/distributed/multihost/single_host_context.hpp
+++ b/tt_metal/distributed/multihost/single_host_context.hpp
@@ -7,7 +7,7 @@
 #include <memory>
 #include "api/tt-metalium/distributed_context.hpp"
 
-namespace tt::tt_metal::distributed::multihost {
+namespace tt::tt_metal::multihost {
 // ---------------------------------------------------------------------
 //                       Main distributed context
 // ---------------------------------------------------------------------
@@ -78,4 +78,4 @@ private:
     inline static ContextPtr current_world_;
 };
 
-}  // namespace tt::tt_metal::distributed::multihost
+}  // namespace tt::tt_metal::multihost

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -8,7 +8,7 @@
 #include <mesh_event.hpp>
 #include <tt-metalium/tt_metal.hpp>
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 SDMeshCommandQueue::SDMeshCommandQueue(MeshDevice* mesh_device, uint32_t id) :
     MeshCommandQueueBase(mesh_device, id, create_passthrough_thread_pool()) {}
@@ -87,4 +87,4 @@ void SDMeshCommandQueue::record_end() { TT_THROW("Not supported for slow dispatc
 
 void SDMeshCommandQueue::enqueue_trace(const MeshTraceId&, bool) { TT_THROW("Not supported for slow dispatch"); }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -6,7 +6,7 @@
 
 #include "mesh_command_queue_base.hpp"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 class SDMeshCommandQueue final : public MeshCommandQueueBase {
 protected:
@@ -49,4 +49,4 @@ public:
     void enqueue_trace(const MeshTraceId& trace_id, bool blocking) override;
 };
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -20,7 +20,7 @@
 #include <tt_stl/span.hpp>
 #include "tt_metal/distributed/coordinate_translation.hpp"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 
 class SystemMesh::Impl {
 private:
@@ -205,4 +205,4 @@ std::vector<chip_id_t> SystemMesh::get_mapped_physical_device_ids(
     return pimpl_->get_mapped_physical_device_ids(shape, offset);
 }
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -75,7 +75,7 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
         .shard_parameters = shard_parameters,
     };
-    cb_buffer_ = distributed::AnyBuffer::create(cb_buffer_shard_config);
+    cb_buffer_ = AnyBuffer::create(cb_buffer_shard_config);
 
     auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
     // is_sender, receiver_val, fifo_start_addr, fifo_size, fifo_ptr, noc_xy coords, and pages_sent
@@ -92,7 +92,7 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
         .shard_parameters = std::move(shard_parameters),
     };
-    cb_config_buffer_ = distributed::AnyBuffer::create(cb_config_buffer_shard_config);
+    cb_config_buffer_ = AnyBuffer::create(cb_config_buffer_shard_config);
 
     // Write the config buffer to the device
     // Only block for the slow dispatch case
@@ -134,8 +134,7 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         }
     }
     if (auto mesh_buffer = cb_config_buffer_.get_mesh_buffer()) {
-        distributed::EnqueueWriteMeshBuffer(
-            mesh_buffer->device()->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
+        EnqueueWriteMeshBuffer(mesh_buffer->device()->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
     } else {
         if (device_->using_slow_dispatch()) {
             detail::WriteToBuffer(*cb_config_buffer_.get_buffer(), cb_config_host_buffer);

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -51,7 +51,7 @@ void GlobalSemaphore::setup_buffer(uint32_t initial_value, BufferType buffer_typ
         .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
         .shard_parameters = std::move(shard_parameters),
     };
-    buffer_ = distributed::AnyBuffer::create(sem_shard_config);
+    buffer_ = AnyBuffer::create(sem_shard_config);
 
     this->reset_semaphore_value(initial_value);
 }
@@ -70,7 +70,7 @@ void GlobalSemaphore::reset_semaphore_value(uint32_t reset_value) const {
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device_->id());
     } else {
         if (auto mesh_buffer = buffer_.get_mesh_buffer()) {
-            distributed::EnqueueWriteMeshBuffer(mesh_buffer->device()->mesh_command_queue(), mesh_buffer, host_buffer);
+            EnqueueWriteMeshBuffer(mesh_buffer->device()->mesh_command_queue(), mesh_buffer, host_buffer);
         } else {
             EnqueueWriteBuffer(device_->command_queue(), *buffer_.get_buffer(), host_buffer, false);
         }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1655,7 +1655,7 @@ HalMemType Device::get_mem_type_of_core(CoreCoord virtual_core) const {
     }
 }
 
-std::shared_ptr<distributed::MeshDevice> Device::get_mesh_device() { return mesh_device.lock(); }
+std::shared_ptr<MeshDevice> Device::get_mesh_device() { return mesh_device.lock(); }
 
 }  // namespace tt_metal
 

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -188,8 +188,8 @@ public:
 
     bool is_mmio_capable() const override;
     // TODO #20966: Remove these APIs
-    std::shared_ptr<distributed::MeshDevice> get_mesh_device() override;
-    void set_mesh_device(std::shared_ptr<distributed::MeshDevice> mesh_device) { this->mesh_device = mesh_device; };
+    std::shared_ptr<MeshDevice> get_mesh_device() override;
+    void set_mesh_device(std::shared_ptr<MeshDevice> mesh_device) { this->mesh_device = mesh_device; };
 
 private:
     static constexpr uint32_t DEFAULT_NUM_SUB_DEVICES = 1;
@@ -233,7 +233,7 @@ private:
     std::vector<std::unique_ptr<Program>> command_queue_programs_;
     bool using_fast_dispatch_ = false;
     // TODO #20966: Remove this member
-    std::weak_ptr<distributed::MeshDevice> mesh_device;
+    std::weak_ptr<MeshDevice> mesh_device;
 
     // Fabric program includes ethernet router kernel
     std::unique_ptr<Program> fabric_program_;

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -71,9 +71,7 @@ namespace tt {
 namespace tt_metal {
 
 void DumpMeshDeviceProfileResults(
-    distributed::MeshDevice& mesh_device,
-    ProfilerDumpState state,
-    const std::optional<ProfilerOptionalMetadata>& metadata) {
+    MeshDevice& mesh_device, ProfilerDumpState state, const std::optional<ProfilerOptionalMetadata>& metadata) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
     for (IDevice* device : mesh_device.get_devices()) {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -2404,8 +2404,8 @@ void set_go_signal_noc_data_on_dispatch(
 }
 
 template uint32_t program_base_addr_on_core<ProgramImpl, IDevice*>(ProgramImpl&, IDevice*, HalProgrammableCoreType);
-template uint32_t program_base_addr_on_core<distributed::MeshWorkloadImpl, distributed::MeshDevice*>(
-    distributed::MeshWorkloadImpl&, distributed::MeshDevice*, HalProgrammableCoreType);
+template uint32_t program_base_addr_on_core<MeshWorkloadImpl, MeshDevice*>(
+    MeshWorkloadImpl&, MeshDevice*, HalProgrammableCoreType);
 }  // namespace program_dispatch
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -340,8 +340,8 @@ private:
     friend EnqueueProgramCommand;
     friend Program;
     friend Internal_;
-    friend distributed::MeshWorkload;
-    friend distributed::MeshWorkloadImpl;
+    friend MeshWorkload;
+    friend MeshWorkloadImpl;
 };
 
 }  // namespace detail

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -74,9 +74,9 @@ void SubDeviceManagerTracker::reset_sub_device_state(const std::unique_ptr<SubDe
     auto num_sub_devices = sub_device_manager->num_sub_devices();
     // Dynamic resolution of device types is unclean and poor design. This will be cleaned up
     // when MeshCommandQueue + CommandQueue are unified under the same API
-    if (dynamic_cast<distributed::MeshDevice*>(device_)) {
+    if (dynamic_cast<MeshDevice*>(device_)) {
         // Multi CQ support for MeshDevice is not currently available
-        distributed::MeshDevice* mesh_device = dynamic_cast<distributed::MeshDevice*>(device_);
+        MeshDevice* mesh_device = dynamic_cast<MeshDevice*>(device_);
         mesh_device->mesh_command_queue().reset_worker_state(
             true, num_sub_devices, sub_device_manager->noc_mcast_unicast_data());
     } else {

--- a/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
+++ b/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
@@ -18,7 +18,7 @@
 int main() {
     using namespace tt::tt_metal;
     using namespace tt::tt_metal::distributed;
-    using tt::tt_metal::distributed::ShardedBufferConfig;
+    using tt::tt_metal::ShardedBufferConfig;
 
     auto mesh_device = MeshDevice::create(MeshDeviceConfig(MeshShape(2, 4)));
     auto& cq = mesh_device->mesh_command_queue();

--- a/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
+++ b/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
@@ -101,7 +101,7 @@ int main() {
         .buffer_type = BufferType::DRAM,
         .buffer_layout = TensorMemoryLayout::INTERLEAVED,
         .bottom_up = false};
-    auto distributed_buffer_config = tt::tt_metal::distributed::ShardedBufferConfig{
+    auto distributed_buffer_config = tt::tt_metal::ShardedBufferConfig{
         .global_size = distributed_buffer_size_bytes,
         .global_buffer_shape = distributed_buffer_shape,
         .shard_shape = shard_shape,

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -148,7 +148,7 @@ int main() {
         num_tiles_per_device * mesh_device->num_devices();  // The total number of tiles in the distributed memory space
 
     // Specify data layout in distributed memory space - Data will be sharded in row major order across the Virtual Mesh
-    tt::tt_metal::distributed::ShardedBufferConfig global_buffer_config{
+    tt::tt_metal::ShardedBufferConfig global_buffer_config{
         .global_size = single_tile_size * num_tiles_in_mesh,  // Total size of the sharded buffer
         .global_buffer_shape =
             {num_tiles_in_mesh * TILE_WIDTH, TILE_HEIGHT},  // Data represents horizontally concatenated tiles

--- a/ttnn/api/ttnn/async_runtime.hpp
+++ b/ttnn/api/ttnn/async_runtime.hpp
@@ -26,17 +26,17 @@ void read_buffer(
     bool blocking = true);
 
 void queue_synchronize(tt::tt_metal::CommandQueue& cq);
-void queue_synchronize(tt::tt_metal::distributed::MeshCommandQueue& cq);
+void queue_synchronize(tt::tt_metal::MeshCommandQueue& cq);
 
 void event_synchronize(const std::shared_ptr<tt::tt_metal::Event>& event);
-void event_synchronize(const tt::tt_metal::distributed::MeshEvent& event);
+void event_synchronize(const tt::tt_metal::MeshEvent& event);
 
 void wait_for_event(tt::tt_metal::CommandQueue& cq, const std::shared_ptr<tt::tt_metal::Event>& event);
-void wait_for_event(tt::tt_metal::distributed::MeshCommandQueue& cq, const tt::tt_metal::distributed::MeshEvent& event);
+void wait_for_event(tt::tt_metal::MeshCommandQueue& cq, const tt::tt_metal::MeshEvent& event);
 
 void record_event(tt::tt_metal::CommandQueue& cq, const std::shared_ptr<tt::tt_metal::Event>& event);
 // Record an event for device to device synchronization. This event should be passed to `wait_for_event`.
-tt::tt_metal::distributed::MeshEvent record_event(tt::tt_metal::distributed::MeshCommandQueue& cq);
+tt::tt_metal::MeshEvent record_event(tt::tt_metal::MeshCommandQueue& cq);
 // Record an event for device to host synchronization. This event should be passed to `event_synchronize`.
-tt::tt_metal::distributed::MeshEvent record_event_to_host(tt::tt_metal::distributed::MeshCommandQueue& cq);
+tt::tt_metal::MeshEvent record_event_to_host(tt::tt_metal::MeshCommandQueue& cq);
 }  // namespace ttnn

--- a/ttnn/api/ttnn/device.hpp
+++ b/ttnn/api/ttnn/device.hpp
@@ -11,7 +11,7 @@ namespace ttnn {
 namespace device {
 
 using IDevice = ttnn::IDevice;
-using MeshDevice = tt::tt_metal::distributed::MeshDevice;
+using MeshDevice = tt::tt_metal::MeshDevice;
 
 std::shared_ptr<MeshDevice> open_mesh_device(
     int device_id,

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -365,15 +365,15 @@ void enqueue_mesh_workload(
     const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
     const typename mesh_device_operation_t::tensor_args_t& tensor_args,
     typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
-    distributed::MeshDevice* mesh_device,
-    tt::tt_metal::distributed::MeshWorkload& workload) {
+    MeshDevice* mesh_device,
+    tt::tt_metal::MeshWorkload& workload) {
     mesh_device_operation_utils::set_runtime_id(workload);
     if (mesh_device_operation_utils::track_workload(workload, mesh_device)) {
         return;
     }
     {
         ZoneScopedN("EnqueueMeshWorkload");
-        tt::tt_metal::distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(*cq_id), workload, false);
+        tt::tt_metal::EnqueueMeshWorkload(mesh_device->mesh_command_queue(*cq_id), workload, false);
     }
 
     TracyOpMeshWorkload(

--- a/ttnn/api/ttnn/distributed/types.hpp
+++ b/ttnn/api/ttnn/distributed/types.hpp
@@ -13,14 +13,14 @@
 
 namespace ttnn::distributed {
 
-using MeshShape = tt::tt_metal::distributed::MeshShape;
-using MeshCoordinate = tt::tt_metal::distributed::MeshCoordinate;
-using MeshCoordinateRange = tt::tt_metal::distributed::MeshCoordinateRange;
-using MeshCoordinateRangeSet = tt::tt_metal::distributed::MeshCoordinateRangeSet;
-using MeshDevice = tt::tt_metal::distributed::MeshDevice;
-using SystemMesh = tt::tt_metal::distributed::SystemMesh;
-using MeshDeviceView = tt::tt_metal::distributed::MeshDeviceView;
-using MeshDeviceConfig = tt::tt_metal::distributed::MeshDeviceConfig;
+using MeshShape = tt::tt_metal::MeshShape;
+using MeshCoordinate = tt::tt_metal::MeshCoordinate;
+using MeshCoordinateRange = tt::tt_metal::MeshCoordinateRange;
+using MeshCoordinateRangeSet = tt::tt_metal::MeshCoordinateRangeSet;
+using MeshDevice = tt::tt_metal::MeshDevice;
+using SystemMesh = tt::tt_metal::SystemMesh;
+using MeshDeviceView = tt::tt_metal::MeshDeviceView;
+using MeshDeviceConfig = tt::tt_metal::MeshDeviceConfig;
 
 }  // namespace ttnn::distributed
 

--- a/ttnn/api/ttnn/events.hpp
+++ b/ttnn/api/ttnn/events.hpp
@@ -15,7 +15,7 @@
 
 namespace ttnn {
 
-using MeshEvent = tt::tt_metal::distributed::MeshEvent;
+using MeshEvent = tt::tt_metal::MeshEvent;
 
 namespace events {
 

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -106,7 +106,7 @@ struct MeshDeviceOperationAdapter {
             tensor_return_value_t& tensor_return_value) {
             ProgramFactory program_factory;
 
-            tt::tt_metal::distributed::MeshWorkload mesh_workload;
+            tt::tt_metal::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
             for (const auto& range : tensor_coords.ranges()) {
                 auto cached_program = program_factory.create(attrs, tensor_args, tensor_return_value);
@@ -140,9 +140,7 @@ struct MeshDeviceOperationAdapter {
     };
 
     static tt::stl::hash::hash_t compute_mesh_workload_hash(
-        tt::tt_metal::distributed::MeshDevice* mesh_device,
-        const operation_attributes_t& attrs,
-        const tensor_args_t& tensor_args) {
+        tt::tt_metal::MeshDevice* mesh_device, const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
         // Hash the program hash and the tensor coordinates the workload is targeting.
         auto hash = compute_program_hash(attrs, tensor_args);
         for (const auto& coord : mesh_device_operation_utils::extract_tensor_coordinates(tensor_args)) {

--- a/ttnn/api/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_utils.hpp
@@ -129,14 +129,14 @@ std::vector<ttnn::MeshCoordinate> extract_tensor_coordinates(const TensorArgs& t
 }
 
 // Sets runtime ID for all programs in `workload`.
-inline void set_runtime_id(tt::tt_metal::distributed::MeshWorkload& workload) {
+inline void set_runtime_id(tt::tt_metal::MeshWorkload& workload) {
     for (auto& [_, program] : workload.get_programs()) {
         program.set_runtime_id(ttnn::CoreIDs::instance().fetch_and_increment_device_operation_id());
     }
 }
 
 // Tracks all programs in `workload` and returns true if any program was hooked.
-inline bool track_workload(tt::tt_metal::distributed::MeshWorkload& workload, ttnn::MeshDevice* mesh_device) {
+inline bool track_workload(tt::tt_metal::MeshWorkload& workload, ttnn::MeshDevice* mesh_device) {
     bool hook_program = false;
     for (auto& [_, program] : workload.get_programs()) {
         tt::tt_metal::GraphTracker::instance().track_program(&program, mesh_device);

--- a/ttnn/api/ttnn/operation.hpp
+++ b/ttnn/api/ttnn/operation.hpp
@@ -46,15 +46,11 @@ struct CacheableProgram {
 
 template <typename OutputTensors = Tensors>
 using OverrideRuntimeArgumentsWorkloadCallback = std::function<void(
-    const void* operation,
-    distributed::MeshWorkload&,
-    const Tensors&,
-    const OptionalConstTensors&,
-    const OutputTensors&)>;
+    const void* operation, MeshWorkload&, const Tensors&, const OptionalConstTensors&, const OutputTensors&)>;
 
 template <typename OutputTensors = Tensors>
 struct CacheableMeshWorkload {
-    distributed::MeshWorkload workload;
+    MeshWorkload workload;
 
     // Either one of these callbacks can be set, but not both.
     // TODO: #19569 - `per_program_callbacks` is used to assist old infra migration, which relied on per-program
@@ -544,7 +540,7 @@ public:
 
     void override_runtime_arguments(
         OverrideRuntimeArgumentsWorkloadCallback<OutputTensors>& override_runtime_arguments_callback,
-        distributed::MeshWorkload& workload,
+        MeshWorkload& workload,
         const Tensors& input_tensors,
         const OptionalConstTensors& optional_input_tensors,
         OutputTensors& output_tensors) const {
@@ -771,7 +767,7 @@ public:
         override_runtime_arguments_workload_impl_{
             [](const storage_t& storage,
                OverrideRuntimeArgumentsWorkloadCallback<OutputTensors>& callback,
-               distributed::MeshWorkload& workload,
+               MeshWorkload& workload,
                const Tensors& input_tensors,
                const OptionalConstTensors& optional_input_tensors,
                OutputTensors& output_tensors) -> void {
@@ -995,7 +991,7 @@ private:
     void (*override_runtime_arguments_workload_impl_)(
         const storage_t& value,
         OverrideRuntimeArgumentsWorkloadCallback<OutputTensors>&,
-        distributed::MeshWorkload&,
+        MeshWorkload&,
         const Tensors&,
         const std::vector<std::optional<const Tensor>>&,
         OutputTensors&);

--- a/ttnn/api/ttnn/reports.hpp
+++ b/ttnn/api/ttnn/reports.hpp
@@ -10,7 +10,7 @@
 
 #include <tt-metalium/buffer_types.hpp>
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
 class MeshDevice;
 }
 
@@ -36,7 +36,7 @@ struct DeviceInfo {
     size_t cb_limit;
 };
 
-DeviceInfo get_device_info(tt::tt_metal::distributed::MeshDevice* device);
+DeviceInfo get_device_info(tt::tt_metal::MeshDevice* device);
 
 struct BufferInfo {
     uint32_t device_id;
@@ -45,7 +45,7 @@ struct BufferInfo {
     tt::tt_metal::BufferType buffer_type;
 };
 
-std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed::MeshDevice*>& devices);
+std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::MeshDevice*>& devices);
 
 struct BufferPageInfo {
     uint32_t device_id;
@@ -59,5 +59,5 @@ struct BufferPageInfo {
     tt::tt_metal::BufferType buffer_type;
 };
 
-std::vector<BufferPageInfo> get_buffer_pages(const std::vector<tt::tt_metal::distributed::MeshDevice*>& devices);
+std::vector<BufferPageInfo> get_buffer_pages(const std::vector<tt::tt_metal::MeshDevice*>& devices);
 }  // namespace ttnn::reports

--- a/ttnn/api/ttnn/tensor/serialization.hpp
+++ b/ttnn/api/ttnn/tensor/serialization.hpp
@@ -14,7 +14,7 @@ namespace tt::tt_metal {
 void dump_tensor(
     const std::string& file_name, const Tensor& tensor, const std::unordered_map<std::string, std::string>& strategy);
 
-Tensor load_tensor(const std::string& file_name, distributed::MeshDevice* device = nullptr);
+Tensor load_tensor(const std::string& file_name, MeshDevice* device = nullptr);
 
 void dump_memory_config(FILE* output_file, const MemoryConfig& memory_config);
 void dump_memory_config(const std::string& file_name, const MemoryConfig& memory_config);
@@ -29,6 +29,6 @@ MemoryConfig load_memory_config(const std::string& file_name);
 // 2. Metadata includes data offsets and sizes for tensor / tensor shards (multi device context).
 // TODO: #22259 - the format is not yet finalized, and is not stable. Avoid using it in production.
 void dump_tensor_flatbuffer(const std::string& file_name, const Tensor& tensor);
-Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::MeshDevice* device = nullptr);
+Tensor load_tensor_flatbuffer(const std::string& file_name, MeshDevice* device = nullptr);
 
 }  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -25,17 +25,16 @@ struct HostStorage {
 };
 
 struct DeviceStorage {
-    std::vector<distributed::MeshCoordinate> coords;
+    std::vector<MeshCoordinate> coords;
     std::shared_ptr<Buffer> buffer;
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer;
+    std::shared_ptr<MeshBuffer> mesh_buffer;
 
     DeviceStorage() = default;
     DeviceStorage(std::shared_ptr<Buffer> buffer_);
-    DeviceStorage(
-        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords_);
+    DeviceStorage(std::shared_ptr<MeshBuffer> mesh_buffer_, std::vector<MeshCoordinate> coords_);
 
     Buffer* get_buffer() const;
-    std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer() const;
+    std::shared_ptr<MeshBuffer> get_mesh_buffer() const;
 
     static constexpr auto attribute_names = std::forward_as_tuple();
     auto attribute_values() const { return std::forward_as_tuple(); }

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -33,10 +33,8 @@ namespace tt {
 
 namespace tt_metal {
 
-namespace distributed {
 class MeshDevice;
 class MeshCommandQueue;
-}  // namespace distributed
 
 class Tensor {
 public:
@@ -49,7 +47,7 @@ public:
     // Shorthand for checking if this Tensor is allocated on MeshDevice. If set, is never nullptr.
     // If not set, the tensor can either be on host or allocated on a single device.
     // TODO: #21099 - This won't be needed after the migration to MeshDevice is complete.
-    std::optional<distributed::MeshDevice*> mesh_device_ = std::nullopt;
+    std::optional<MeshDevice*> mesh_device_ = std::nullopt;
 
     // ======================================================================================
     //                                  Hi Level APIs
@@ -90,7 +88,7 @@ public:
     static Tensor from_span(
         tt::stl::Span<const T> buffer,
         const TensorSpec& spec,
-        distributed::MeshDevice* device = nullptr,
+        MeshDevice* device = nullptr,
         ttnn::QueueId cq_id = ttnn::DefaultQueueId,
         T pad_value = 0);
 
@@ -119,7 +117,7 @@ public:
     static Tensor from_vector(
         const std::vector<T>& buffer,
         const TensorSpec& spec,
-        distributed::MeshDevice* device = nullptr,
+        MeshDevice* device = nullptr,
         ttnn::QueueId cq_id = ttnn::DefaultQueueId,
         T pad_value = 0) {
         return from_span(tt::stl::Span<const T>(buffer), spec, device, cq_id, pad_value);
@@ -131,7 +129,7 @@ public:
     static Tensor from_vector(
         std::vector<T>&& buffer,
         const TensorSpec& spec,
-        distributed::MeshDevice* device = nullptr,
+        MeshDevice* device = nullptr,
         ttnn::QueueId cq_id = ttnn::DefaultQueueId,
         T pad_value = 0);
 
@@ -149,13 +147,13 @@ public:
         ttnn::QueueId cq_id = ttnn::DefaultQueueId) const;
 
     Tensor to_device(
-        distributed::MeshDevice* mesh_device,
+        MeshDevice* mesh_device,
         const MemoryConfig& mem_config = MemoryConfig{},
         ttnn::QueueId cq_id = ttnn::DefaultQueueId) const;
 
     Tensor to_layout(Layout target_layout, IDevice* worker = nullptr) const;
 
-    Tensor to_layout(Layout target_layout, distributed::MeshDevice* mesh_device) const;
+    Tensor to_layout(Layout target_layout, MeshDevice* mesh_device) const;
 
     Tensor pad(const ttnn::Shape& output_padded_shape, const ttnn::Shape& input_tensor_start, float pad_value) const;
 
@@ -234,10 +232,10 @@ public:
 
     // Returns device `MeshBuffer`.
     // Throws if the tensor is not allocated on a device.
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer() const;
+    std::shared_ptr<MeshBuffer> mesh_buffer() const;
 
     // TODO: #21099 - Remove the overload `mesh_device()`, and instead use `device()`.
-    distributed::MeshDevice* mesh_device() const;
+    MeshDevice* mesh_device() const;
 
     // Returns the device the tensor is allocated on.
     // Throws if the tensor is not allocated on a device.
@@ -278,7 +276,7 @@ void memcpy(
     const std::optional<BufferRegion>& region = std::nullopt,
     bool blocking = true);
 void memcpy(
-    distributed::MeshCommandQueue& queue,
+    MeshCommandQueue& queue,
     void* dst,
     const Tensor& src,
     const std::optional<BufferRegion>& region = std::nullopt,
@@ -287,18 +285,12 @@ void memcpy(
 void memcpy(
     CommandQueue& queue, Tensor& dst, const void* src, const std::optional<BufferRegion>& region = std::nullopt);
 void memcpy(
-    distributed::MeshCommandQueue& queue,
-    Tensor& dst,
-    const void* src,
-    const std::optional<BufferRegion>& region = std::nullopt);
+    MeshCommandQueue& queue, Tensor& dst, const void* src, const std::optional<BufferRegion>& region = std::nullopt);
 
 void memcpy(
     CommandQueue& queue, Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt);
 void memcpy(
-    distributed::MeshCommandQueue& queue,
-    Tensor& dst,
-    const Tensor& src,
-    const std::optional<BufferRegion>& region = std::nullopt);
+    MeshCommandQueue& queue, Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt);
 
 void memcpy(
     void* dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt, bool blocking = true);
@@ -308,7 +300,7 @@ void memcpy(Tensor& dst, const void* src, const std::optional<BufferRegion>& reg
 void memcpy(Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt);
 
 // Allocates a tensor on a mesh device through mesh buffer.
-Tensor allocate_tensor_on_mesh(const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device);
+Tensor allocate_tensor_on_mesh(const TensorSpec& tensor_spec, MeshDevice* mesh_device);
 
 void write_tensor(const Tensor& host_tensor, Tensor device_tensor, ttnn::QueueId cq_id = ttnn::DefaultQueueId);
 

--- a/ttnn/api/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_attributes.hpp
@@ -22,7 +22,7 @@ public:
     const DistributedTensorConfig& get_distributed_tensor_config() const;
 
     // Determines mesh coordinates for the tensor based on the strategy and the mesh shape.
-    std::vector<distributed::MeshCoordinate> determine_distribution(const distributed::MeshShape& mesh_shape) const;
+    std::vector<MeshCoordinate> determine_distribution(const MeshShape& mesh_shape) const;
 
 private:
     Storage storage_;

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -170,8 +170,7 @@ std::vector<T> decode_tensor_data(std::vector<T>&& physical_data, const TensorSp
 
 std::shared_ptr<Buffer> allocate_buffer_on_device(IDevice* device, const TensorSpec& tensor_spec);
 
-std::shared_ptr<distributed::MeshBuffer> allocate_mesh_buffer_on_device(
-    distributed::MeshDevice* mesh_device, const TensorSpec& tensor_spec);
+std::shared_ptr<MeshBuffer> allocate_mesh_buffer_on_device(MeshDevice* mesh_device, const TensorSpec& tensor_spec);
 
 template <typename T>
 void read_data_from_device_buffer(CommandQueue& cq, Buffer& device_buffer, void* host_buffer_data, bool blocking) {
@@ -205,7 +204,7 @@ Tensor to_device(
 template <typename T>
 Tensor to_device_mesh_tensor(
     const Tensor& tensor,
-    distributed::MeshDevice* mesh_device,
+    MeshDevice* mesh_device,
     const MemoryConfig& memory_config,
     QueueId cq_id = ttnn::DefaultQueueId);
 

--- a/ttnn/api/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_ops.hpp
@@ -10,9 +10,7 @@ namespace tt::tt_metal {
 struct Tensor;
 struct MemoryConfig;
 class CommandQueue;
-namespace distributed {
 class MeshDevice;
-}  // namespace distributed
 
 class IDevice;
 
@@ -23,11 +21,11 @@ namespace tt::tt_metal::tensor_ops {
 Tensor tensor_to_device(
     const Tensor& input_tensor, IDevice* target_device, const MemoryConfig& mem_config, QueueId cq_id);
 Tensor tensor_to_device(
-    const Tensor& input_tensor, distributed::MeshDevice* mesh_device, const MemoryConfig& mem_config, QueueId cq_id);
+    const Tensor& input_tensor, MeshDevice* mesh_device, const MemoryConfig& mem_config, QueueId cq_id);
 
 Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, IDevice* worker);
 
-Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distributed::MeshDevice* mesh_device);
+Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, MeshDevice* mesh_device);
 
 Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, QueueId cq_id);
 

--- a/ttnn/core/async_runtime.cpp
+++ b/ttnn/core/async_runtime.cpp
@@ -52,21 +52,18 @@ void queue_synchronize(CommandQueue& cq) {
     // Wait for device CQ to finish
     Finish(cq);
 }
-void queue_synchronize(tt::tt_metal::distributed::MeshCommandQueue& cq) { cq.finish(); }
+void queue_synchronize(tt::tt_metal::MeshCommandQueue& cq) { cq.finish(); }
 
 void event_synchronize(const std::shared_ptr<Event>& event) { EventSynchronize(event); }
-void event_synchronize(const tt::tt_metal::distributed::MeshEvent& event) {
-    tt::tt_metal::distributed::EventSynchronize(event);
-}
+void event_synchronize(const tt::tt_metal::MeshEvent& event) { tt::tt_metal::EventSynchronize(event); }
 
 void wait_for_event(CommandQueue& cq, const std::shared_ptr<Event>& event) {
     auto cq_id = cq.id();
     auto cq_worker = cq.device();
     EnqueueWaitForEvent(cq_worker->command_queue(cq_id), event);
 }
-void wait_for_event(
-    tt::tt_metal::distributed::MeshCommandQueue& cq, const tt::tt_metal::distributed::MeshEvent& event) {
-    tt::tt_metal::distributed::EnqueueWaitForEvent(cq, event);
+void wait_for_event(tt::tt_metal::MeshCommandQueue& cq, const tt::tt_metal::MeshEvent& event) {
+    tt::tt_metal::EnqueueWaitForEvent(cq, event);
 }
 
 void record_event(CommandQueue& cq, const std::shared_ptr<Event>& event) {
@@ -74,11 +71,11 @@ void record_event(CommandQueue& cq, const std::shared_ptr<Event>& event) {
     auto cq_worker = cq.device();
     EnqueueRecordEvent(cq_worker->command_queue(cq_id), event);
 }
-tt::tt_metal::distributed::MeshEvent record_event(tt::tt_metal::distributed::MeshCommandQueue& cq) {
-    return tt::tt_metal::distributed::EnqueueRecordEvent(cq);
+tt::tt_metal::MeshEvent record_event(tt::tt_metal::MeshCommandQueue& cq) {
+    return tt::tt_metal::EnqueueRecordEvent(cq);
 }
-tt::tt_metal::distributed::MeshEvent record_event_to_host(tt::tt_metal::distributed::MeshCommandQueue& cq) {
-    return tt::tt_metal::distributed::EnqueueRecordEventToHost(cq);
+tt::tt_metal::MeshEvent record_event_to_host(tt::tt_metal::MeshCommandQueue& cq) {
+    return tt::tt_metal::EnqueueRecordEventToHost(cq);
 }
 
 }  // namespace ttnn

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -138,7 +138,7 @@ Tensor aggregate_as_tensor(
 }
 
 std::vector<int> get_t3k_physical_device_ids_ring() {
-    using namespace tt::tt_metal::distributed;
+    using namespace tt::tt_metal;
     auto& instance = SystemMesh::instance();
     auto num_devices = instance.get_shape().mesh_size();
     TT_FATAL(num_devices == 8, "T3000 ring topology only works with 8 devices");

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -24,7 +24,7 @@ namespace ttnn::distributed {
 namespace {
 
 using ::tt::tt_metal::DistributedHostBuffer;
-using ::tt::tt_metal::distributed::MeshContainer;
+using ::tt::tt_metal::MeshContainer;
 
 // Increments `indices` in-place given `limits`, to support row-major order iteration.
 bool increment_indices(const tt::stl::SmallVector<int>& limits, tt::stl::SmallVector<int>& indices) {

--- a/ttnn/core/events.cpp
+++ b/ttnn/core/events.cpp
@@ -15,10 +15,9 @@
 namespace ttnn::events {
 
 using ::tt::tt_metal::EnqueueRecordEvent;
+using ::tt::tt_metal::EnqueueRecordEventToHost;
 using ::tt::tt_metal::EnqueueWaitForEvent;
-using ::tt::tt_metal::distributed::EnqueueRecordEventToHost;
-using ::tt::tt_metal::distributed::EnqueueWaitForEvent;
-using ::tt::tt_metal::distributed::EventSynchronize;
+using ::tt::tt_metal::EventSynchronize;
 
 std::shared_ptr<tt::tt_metal::Event> record_event(
     tt::tt_metal::IDevice* device, QueueId cq_id, const std::vector<tt::tt_metal::SubDeviceId>& sub_device_ids) {

--- a/ttnn/core/reports.cpp
+++ b/ttnn/core/reports.cpp
@@ -17,7 +17,7 @@
 
 namespace ttnn::reports {
 
-DeviceInfo get_device_info(tt::tt_metal::distributed::MeshDevice* device) {
+DeviceInfo get_device_info(tt::tt_metal::MeshDevice* device) {
     DeviceInfo info{};
     const auto& dispatch_core_config = tt::tt_metal::get_dispatch_core_config();
     const auto descriptor =
@@ -46,7 +46,7 @@ DeviceInfo get_device_info(tt::tt_metal::distributed::MeshDevice* device) {
     return info;
 }
 
-std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed::MeshDevice*>& devices) {
+std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::MeshDevice*>& devices) {
     std::vector<BufferInfo> buffer_infos;
     for (auto device : devices) {
         for (const auto& buffer : device->allocator()->get_allocated_buffers()) {
@@ -98,7 +98,7 @@ std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed:
     return buffer_infos;
 }
 
-std::vector<BufferPageInfo> get_buffer_pages(const std::vector<tt::tt_metal::distributed::MeshDevice*>& devices) {
+std::vector<BufferPageInfo> get_buffer_pages(const std::vector<tt::tt_metal::MeshDevice*>& devices) {
     std::vector<BufferPageInfo> buffer_page_infos;
     for (auto device : devices) {
         for (const auto& buffer : device->allocator()->get_allocated_buffers()) {

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -27,25 +27,23 @@ namespace ttnn {
 namespace {
 
 flatbuffers::Offset<flatbuffer::MeshCoordinate> to_flatbuffer(
-    const tt::tt_metal::distributed::MeshCoordinate& coord, flatbuffers::FlatBufferBuilder& builder) {
+    const tt::tt_metal::MeshCoordinate& coord, flatbuffers::FlatBufferBuilder& builder) {
     auto values_vector = builder.CreateVector(std::vector<uint32_t>(coord.coords().begin(), coord.coords().end()));
     return flatbuffer::CreateMeshCoordinate(builder, values_vector);
 }
 
-tt::tt_metal::distributed::MeshCoordinate from_flatbuffer(const flatbuffer::MeshCoordinate* coord) {
-    return tt::tt_metal::distributed::MeshCoordinate(
-        std::vector<uint32_t>(coord->values()->begin(), coord->values()->end()));
+tt::tt_metal::MeshCoordinate from_flatbuffer(const flatbuffer::MeshCoordinate* coord) {
+    return tt::tt_metal::MeshCoordinate(std::vector<uint32_t>(coord->values()->begin(), coord->values()->end()));
 }
 
 flatbuffers::Offset<flatbuffer::MeshShape> to_flatbuffer(
-    const tt::tt_metal::distributed::MeshShape& shape, flatbuffers::FlatBufferBuilder& builder) {
+    const tt::tt_metal::MeshShape& shape, flatbuffers::FlatBufferBuilder& builder) {
     auto dimensions_vector = builder.CreateVector(std::vector<uint32_t>(shape.view().begin(), shape.view().end()));
     return flatbuffer::CreateMeshShape(builder, dimensions_vector);
 }
 
-tt::tt_metal::distributed::MeshShape from_flatbuffer(const flatbuffer::MeshShape* shape) {
-    return tt::tt_metal::distributed::MeshShape(
-        std::vector<uint32_t>(shape->dimensions()->begin(), shape->dimensions()->end()));
+tt::tt_metal::MeshShape from_flatbuffer(const flatbuffer::MeshShape* shape) {
+    return tt::tt_metal::MeshShape(std::vector<uint32_t>(shape->dimensions()->begin(), shape->dimensions()->end()));
 }
 
 tt::tt_metal::HostBuffer create_host_buffer_from_bytes(uint64_t size_bytes, const TensorSpec& spec) {
@@ -176,7 +174,7 @@ Tensor from_flatbuffer(const ttnn::flatbuffer::Tensor* fb_tensor, tt::stl::Span<
             tt::tt_metal::DistributedTensorConfig strategy;
             auto* mesh_shape = sharded->mesh_shape();
             if (mesh_shape != nullptr) {
-                const tt::tt_metal::distributed::MeshShape ttnn_mesh_shape = from_flatbuffer(mesh_shape);
+                const tt::tt_metal::MeshShape ttnn_mesh_shape = from_flatbuffer(mesh_shape);
                 strategy = tt::tt_metal::ShardTensor2D{
                     tt::tt_metal::ShardMesh{.y = ttnn_mesh_shape[0], .x = ttnn_mesh_shape[1]}};
             }

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -23,7 +23,7 @@
 
 namespace tt::tt_metal {
 
-using MeshDevice = distributed::MeshDevice;
+using MeshDevice = MeshDevice;
 
 namespace {
 

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -12,8 +12,7 @@ namespace tt::tt_metal {
 
 DeviceStorage::DeviceStorage(std::shared_ptr<Buffer> buffer_) { buffer = std::move(buffer_); }
 
-DeviceStorage::DeviceStorage(
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords_) :
+DeviceStorage::DeviceStorage(std::shared_ptr<MeshBuffer> mesh_buffer_, std::vector<MeshCoordinate> coords_) :
     coords(std::move(coords_)), mesh_buffer(std::move(mesh_buffer_)) {}
 
 Buffer* DeviceStorage::get_buffer() const {
@@ -24,7 +23,7 @@ Buffer* DeviceStorage::get_buffer() const {
     return this->buffer.get();
 }
 
-std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer() const {
+std::shared_ptr<MeshBuffer> DeviceStorage::get_mesh_buffer() const {
     TT_FATAL(mesh_buffer != nullptr, "Mesh buffer is not allocated");
     return mesh_buffer;
 }

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -32,14 +32,13 @@ const DistributedTensorConfig& TensorAttributes::get_distributed_tensor_config()
     return distributed_tensor_config_;
 }
 
-std::vector<distributed::MeshCoordinate> TensorAttributes::determine_distribution(
-    const distributed::MeshShape& mesh_shape) const {
+std::vector<MeshCoordinate> TensorAttributes::determine_distribution(const MeshShape& mesh_shape) const {
     const auto coord_range = [this, &mesh_shape]() {
         if (auto* shard2d_strategy = std::get_if<ShardTensor2D>(&distributed_tensor_config_)) {
-            distributed::MeshShape distribution_shape(shard2d_strategy->shard_mesh.y, shard2d_strategy->shard_mesh.x);
-            return distributed::MeshCoordinateRange(distribution_shape);
+            MeshShape distribution_shape(shard2d_strategy->shard_mesh.y, shard2d_strategy->shard_mesh.x);
+            return MeshCoordinateRange(distribution_shape);
         } else {
-            return distributed::MeshCoordinateRange(mesh_shape);
+            return MeshCoordinateRange(mesh_shape);
         }
     }();
 
@@ -57,7 +56,7 @@ std::vector<distributed::MeshCoordinate> TensorAttributes::determine_distributio
         num_shards,
         mesh_shape.mesh_size());
 
-    std::vector<distributed::MeshCoordinate> coords;
+    std::vector<MeshCoordinate> coords;
     coords.reserve(num_shards);
     auto coord_it = coord_range.begin();
     for (int i = 0; i < num_shards; ++coord_it, ++i) {

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -45,7 +45,7 @@ Tensor tensor_to_device(
 }
 
 Tensor tensor_to_device(
-    const Tensor& input_tensor, distributed::MeshDevice* mesh_device, const MemoryConfig& mem_config, QueueId cq_id) {
+    const Tensor& input_tensor, MeshDevice* mesh_device, const MemoryConfig& mem_config, QueueId cq_id) {
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::to_device", input_tensor, mesh_device, mem_config);
     if (input_tensor.storage_type() == StorageType::DEVICE) {
@@ -90,7 +90,7 @@ Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, IDevic
     return output;
 }
 
-Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distributed::MeshDevice* mesh_device) {
+Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, MeshDevice* mesh_device) {
     ZoneScoped;
     TT_FATAL(
         is_cpu_tensor(input_tensor) || is_multi_device_host_tensor(input_tensor),

--- a/ttnn/cpp/ttnn-pybind/__init__.cpp
+++ b/ttnn/cpp/ttnn-pybind/__init__.cpp
@@ -233,7 +233,7 @@ PYBIND11_MODULE(_ttnn, module) {
     ttnn::core::py_module_types(m_core);
     ttnn::device::py_device_module_types(m_device);
     ttnn::fabric::py_bind_fabric_api(m_fabric);
-    ttnn::distributed::py_module_types(m_multi_device);
+    ttnn::py_module_types(m_multi_device);
     ttnn::events::py_module_types(m_events);
     ttnn::global_circular_buffer::py_module_types(m_global_circular_buffer);
     ttnn::global_semaphore::py_module_types(m_global_semaphore);
@@ -258,7 +258,7 @@ PYBIND11_MODULE(_ttnn, module) {
     ttnn::activation::py_module(m_activation);
     ttnn::cluster::py_cluster_module(m_cluster);
     ttnn::device::py_device_module(m_device);
-    ttnn::distributed::py_module(m_multi_device);
+    ttnn::py_module(m_multi_device);
     ttnn::events::py_module(m_events);
     ttnn::global_circular_buffer::py_module(m_global_circular_buffer);
     ttnn::global_semaphore::py_module(m_global_semaphore);

--- a/ttnn/cpp/ttnn-pybind/core.cpp
+++ b/ttnn/cpp/ttnn-pybind/core.cpp
@@ -54,7 +54,7 @@ void py_module(py::module& module) {
     py::class_<tt::tt_metal::LightMetalReplay>(module, "LightMetalReplay")
         .def_static(
             "create",
-            [](LightMetalBinary binary, distributed::MeshDevice* device = nullptr) {
+            [](LightMetalBinary binary, MeshDevice* device = nullptr) {
                 return std::make_unique<tt::tt_metal::LightMetalReplay>(std::move(binary), device);
             },
             py::arg("binary"),

--- a/ttnn/cpp/ttnn-pybind/device.cpp
+++ b/ttnn/cpp/ttnn-pybind/device.cpp
@@ -494,7 +494,7 @@ void device_module(py::module& m_device) {
     m_device.def(
         "synchronize_device",
         [](MeshDevice* device, std::optional<QueueId> cq_id, const std::vector<SubDeviceId>& sub_device_ids) {
-            tt::tt_metal::distributed::Synchronize(
+            tt::tt_metal::Synchronize(
                 device, cq_id.has_value() ? std::make_optional(**cq_id) : std::nullopt, sub_device_ids);
         },
         synchronize_device_doc.data(),

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -382,7 +382,7 @@ Tensor convert_python_tensors_to_tt_tensors(
             pad_value,
             /*force_disable_borrow=*/true));
     }
-    auto output = distributed::aggregate_as_tensor(tt_shards, get_distributed_tensor_config(strategy));
+    auto output = ttnn::distributed::aggregate_as_tensor(tt_shards, get_distributed_tensor_config(strategy));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;

--- a/ttnn/cpp/ttnn-pybind/reports.cpp
+++ b/ttnn/cpp/ttnn-pybind/reports.cpp
@@ -10,7 +10,7 @@
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/mesh_device.hpp>
 
-using tt::tt_metal::distributed::MeshDevice;
+using tt::tt_metal::MeshDevice;
 
 namespace ttnn::reports {
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
@@ -128,7 +128,7 @@ struct AllGather {
     const ccl::Topology topology;
     std::optional<uint32_t> cluster_axis;
     std::vector<IDevice*> devices;
-    const distributed::MeshDevice* mesh_device = nullptr;
+    const MeshDevice* mesh_device = nullptr;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor> &input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -105,10 +105,7 @@ SenderRecieverConfig get_device_sender_receiver_config(
 }
 
 SenderRecieverConfig get_device_sender_receiver_config_in_ring(
-    const MeshCoordinate& mesh_coord,
-    const distributed::MeshDevice* mesh_device,
-    uint32_t cluster_axis,
-    int ring_size) {
+    const MeshCoordinate& mesh_coord, const MeshDevice* mesh_device, uint32_t cluster_axis, int ring_size) {
     SenderRecieverConfig config;
     const auto& mesh_view = mesh_device->get_view();
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -42,7 +42,7 @@ SenderRecieverConfig get_device_sender_receiver_config(
 
 // Returns `SenderRecieverConfig` for a given device in a ring topology with a given cluster axis.
 SenderRecieverConfig get_device_sender_receiver_config_in_ring(
-    const MeshCoordinate& mesh_coord, const distributed::MeshDevice* mesh_device, uint32_t cluster_axis, int ring_size);
+    const MeshCoordinate& mesh_coord, const MeshDevice* mesh_device, uint32_t cluster_axis, int ring_size);
 
 // Returns a vector of devices that the given tensor is stored on.
 std::vector<IDevice*> get_active_physical_devices(const Tensor& tensor);

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
@@ -640,7 +640,7 @@ void EdmLineFabricOpInterface::set_firmware_context_switch_interval(size_t inter
 }
 
 void initialize_edm_fabric(
-    distributed::MeshDevice* mesh_device,
+    MeshDevice* mesh_device,
     bool wrap_fabric_around_mesh,
     std::optional<size_t> context_switch_interval_override,
     Topology topology) {
@@ -722,7 +722,7 @@ void initialize_edm_fabric(
     }
 }
 
-void teardown_edm_fabric(distributed::MeshDevice* mesh_device, bool wrap_fabric_around_mesh, Topology topology) {
+void teardown_edm_fabric(MeshDevice* mesh_device, bool wrap_fabric_around_mesh, Topology topology) {
     auto teardown = [topology](const std::vector<IDevice*>& line_view) {
         std::vector<tt::tt_metal::Program> programs(line_view.size());
         std::vector<tt::tt_metal::Program*> program_ptrs;

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.hpp
@@ -129,12 +129,12 @@ private:
 };
 
 void initialize_edm_fabric(
-    distributed::MeshDevice* mesh_device,
+    MeshDevice* mesh_device,
     bool wrap_fabric_around_mesh = false,
     std::optional<size_t> context_switch_interval_override = std::nullopt,
     Topology topology = Topology::Linear);
 void teardown_edm_fabric(
-    distributed::MeshDevice* mesh_device, bool wrap_fabric_around_mesh = false, Topology topology = Topology::Linear);
+    MeshDevice* mesh_device, bool wrap_fabric_around_mesh = false, Topology topology = Topology::Linear);
 
 };  // namespace ccl
 };  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
@@ -24,7 +24,7 @@ struct ReduceScatter {
     const std::optional<size_t> user_defined_num_buffers_per_channel;
     const std::optional<uint32_t> cluster_axis;
     const std::vector<IDevice*> devices;
-    const distributed::MeshDevice* mesh_device = nullptr;
+    const MeshDevice* mesh_device = nullptr;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1468,7 +1468,7 @@ template ttnn::Tensor fold_tensor<IDevice>(
 
 template ttnn::Tensor fold_tensor<MeshDevice>(
     const ttnn::Tensor& tensor,
-    tt::tt_metal::distributed::MeshDevice* device,
+    tt::tt_metal::MeshDevice* device,
     std::array<uint32_t, 2> stride,
     std::array<uint32_t, 2> kernel_size,
     std::array<uint32_t, 4> padding_n4,

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
@@ -232,7 +232,7 @@ template ttnn::Tensor prepare_conv_transpose2d_weights(
     std::array<uint32_t, 2> dilation,
     const bool has_bias,
     uint32_t groups,
-    tt::tt_metal::distributed::MeshDevice* device,
+    tt::tt_metal::MeshDevice* device,
     const std::optional<const Conv2dConfig>& conv_config_,
     const std::optional<const DeviceComputeKernelConfig>& compute_config_,
     bool mirror_kernel);
@@ -269,7 +269,7 @@ template ttnn::Tensor prepare_conv_transpose2d_bias(
     std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
     std::array<uint32_t, 2> dilation,
     uint32_t groups,
-    tt::tt_metal::distributed::MeshDevice* device,
+    tt::tt_metal::MeshDevice* device,
     const std::optional<const Conv2dConfig>& conv_config_,
     const std::optional<const DeviceComputeKernelConfig>& compute_config_);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.hpp
@@ -34,7 +34,7 @@ struct AllReduceAsync {
     const GlobalSemaphore semaphore;
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
     uint32_t cluster_axis;
-    const distributed::MeshDevice* mesh_device;
+    const MeshDevice* mesh_device;
 
     AllReduceAsync(
         uint32_t num_links,
@@ -45,7 +45,7 @@ struct AllReduceAsync {
         GlobalSemaphore semaphore,
         std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
         uint32_t cluster_axis,
-        const distributed::MeshDevice* mesh_device) :
+        const MeshDevice* mesh_device) :
         num_links(num_links),
         ring_size(ring_size),
         dtype(dtype),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
@@ -254,7 +254,7 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_mesh_workload(
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
+    tt::tt_metal::MeshWorkload workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
     for (const auto& coord : tensor_coords.coords()) {
         auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
@@ -268,7 +268,7 @@ LlamaReduceScatterCreateHeadsDeviceOperation::LlamaReduceScatterCreateHeads::cre
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
-    tt::tt_metal::distributed::MeshWorkload workload;
+    tt::tt_metal::MeshWorkload workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
     for (const auto& coord : tensor_coords.coords()) {
         auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.hpp
@@ -14,7 +14,7 @@ namespace ttnn {
 struct ReduceScatterAsync {
     ReduceScatterAsync(
         std::vector<IDevice*> devices,
-        const distributed::MeshDevice* mesh_device,
+        const MeshDevice* mesh_device,
         const ttnn::operations::binary::BinaryOpType binary_op_type,
         const uint32_t scatter_dim,
         const uint32_t ring_size,
@@ -39,7 +39,7 @@ struct ReduceScatterAsync {
         cluster_axis(cluster_axis) {}
 
     std::vector<IDevice*> devices;
-    const distributed::MeshDevice* mesh_device;
+    const MeshDevice* mesh_device;
     const ttnn::operations::binary::BinaryOpType binary_op_type;
     const uint32_t scatter_dim;
     const uint32_t ring_size;

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -356,7 +356,7 @@ DropoutMeshWorkloadFactory::cached_mesh_workload_t DropoutMeshWorkloadFactory::c
     tensor_return_value_t& output) {
     TT_ASSERT(args.use_per_device_seed, "DropoutMeshWorkloadFactory should only be used if per-device seed is used.");
 
-    tt::tt_metal::distributed::MeshWorkload workload;
+    tt::tt_metal::MeshWorkload workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
     for (const auto& mesh_coord_range : tensor_coords.ranges()) {
         for (const auto& mesh_coord : mesh_coord_range) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -2350,7 +2350,7 @@ MeshCoordinateRange get_range_from_mesh_coords(const ttnn::MeshCoordinateRangeSe
 
 operation::CacheableMeshWorkload<std::vector<Tensor>> create_homogenous_mesh_workload(
     tt::tt_metal::operation::ProgramWithCallbacks& matmul_program, const ttnn::MeshCoordinateRangeSet& tensor_coords) {
-    tt::tt_metal::distributed::MeshWorkload matmul_workload = tt::tt_metal::distributed::CreateMeshWorkload();
+    tt::tt_metal::MeshWorkload matmul_workload = tt::tt_metal::CreateMeshWorkload();
     std::unordered_map<MeshCoordinateRange, MatmulCallback> callbacks = {};
 
     auto workload_device_range = get_range_from_mesh_coords(tensor_coords);
@@ -2473,7 +2473,7 @@ operation::CacheableMeshWorkload<std::vector<Tensor>> Matmul::create_mesh_worklo
                 // DRAM Sharded Matmul generates different programs across devices, since it depends on harvesting.
                 // Account for this by creating a heterogenous MeshWorkload.
                 auto workload_device_range = get_range_from_mesh_coords(tensor_coords);
-                tt::tt_metal::distributed::MeshWorkload dram_sharded_mm_workload;
+                tt::tt_metal::MeshWorkload dram_sharded_mm_workload;
                 std::unordered_map<MeshCoordinateRange, MatmulCallback> callbacks;
 
                 for (const auto& coord : workload_device_range) {

--- a/ttnn/cpp/ttnn/operations/sharding_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/sharding_utilities.cpp
@@ -752,9 +752,7 @@ ShardingConfig get_specs_for_sharding_partition(
 
 namespace sharded_accessor_utils {
 ShardedAccessorArgs get_sharded_accessor_args(
-    const distributed::MeshDevice& mesh_device,
-    const BufferDistributionSpec& buffer_distribution_spec,
-    const CoreType& bank_type) {
+    const MeshDevice& mesh_device, const BufferDistributionSpec& buffer_distribution_spec, const CoreType& bank_type) {
     const auto& tensor_shape = buffer_distribution_spec.get_tensor_shape_in_pages();
     const auto& shard_shape = buffer_distribution_spec.get_shard_shape_in_pages();
     const auto& bank_coords = buffer_distribution_spec.get_cores();

--- a/ttnn/cpp/ttnn/operations/sharding_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/sharding_utilities.hpp
@@ -97,9 +97,7 @@ struct ShardedAccessorArgs {
     std::vector<uint32_t> shapes_and_bank_coords;
 };
 ShardedAccessorArgs get_sharded_accessor_args(
-    const distributed::MeshDevice& mesh_device,
-    const BufferDistributionSpec& buffer_distribution_spec,
-    const CoreType& bank_type);
+    const MeshDevice& mesh_device, const BufferDistributionSpec& buffer_distribution_spec, const CoreType& bank_type);
 
 }  // namespace sharded_accessor_utils
 

--- a/ttnn/cpp/ttnn/operations/trace.hpp
+++ b/ttnn/cpp/ttnn/operations/trace.hpp
@@ -11,7 +11,7 @@
 
 namespace ttnn {
 
-using MeshTraceId = tt::tt_metal::distributed::MeshTraceId;
+using MeshTraceId = tt::tt_metal::MeshTraceId;
 
 namespace operations {
 namespace trace {


### PR DESCRIPTION
…metal namespace

- Move all distributed types from tt::tt_metal::distributed to tt::tt_metal namespace
- Move all distributed types from tt::tt_metal::distributed::multihost to tt::tt_metal::multihost namespace
- Update all references across the codebase including tests, examples, and training code
- This change makes distributed functionality a native part of tt_metal rather than a sub-namespace

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes