### PR TITLE
Revert "Remove tunneling reservation logic and add fabric connection args when fabric is enabled"

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -597,10 +597,6 @@ int main(int argc, char** argv) {
             host_completion_queue_wr_ptr,
             dev_completion_queue_wr_ptr,
             dev_completion_queue_rd_ptr,
-            MetalContext::instance().dispatch_mem_map(CoreType::WORKER).get_dispatch_stream_index(0),
-            0,  // unused for single device - used to "virtualize" the number of eth cores across devices
-            0,  // unused for single device - used to "virtualize" the number of eth cores across devices
-            0,  // unused for single device - used to "virtualize" the number of eth cores across devices
             0,
             0,
             0,
@@ -609,17 +605,9 @@ int main(int argc, char** argv) {
             0,
             0,
             0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
+            0,     // unused for single device - used to "virtualize" the number of eth cores across devices
+            0,     // unused for single device - used to "virtualize" the number of eth cores across devices
+            0,     // unused for single device - used to "virtualize" the number of eth cores across devices
             true,  // is_dram_variant
             true,  // is_host_variant
         };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2058,26 +2058,14 @@ void configure_for_single_chip(
         0,                                           // unused: for prefetch_hd <--> dispatch_hd
         0,                                           // unused: for prefetch_hd <--> dispatch_hd
         0,                                           // unused: for prefetch_hd <--> dispatch_hd
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
         scratch_db_size_g,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
     };
 
     constexpr NOC my_noc_index = NOC::NOC_0;
@@ -2363,29 +2351,17 @@ void configure_for_single_chip(
         host_completion_queue_wr_ptr,
         dev_completion_queue_wr_ptr,
         dev_completion_queue_rd_ptr,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
         MetalContext::instance().dispatch_mem_map(DISPATCH_CORE_TYPE).get_dispatch_stream_index(0),
         0,  // unused for single device - used to "virtualize" the number of eth cores across devices
         0,  // unused for single device - used to "virtualize" the number of eth cores across devices
         0,  // unused for single device - used to "virtualize" the number of eth cores across devices
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
     };
 
     CoreCoord phys_upstream_from_dispatch_core = split_prefetcher_g ? phys_prefetch_d_core : phys_prefetch_core_g;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -865,7 +865,7 @@ void Device::clear_dram_state() {
 
 void Device::compile_command_queue_programs() {
     ZoneScoped;
-    if (this->is_mmio_capable() && !tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
+    if (this->is_mmio_capable()) {
         auto command_queue_program_ptr = create_and_compile_cq_program(this);
         this->command_queue_programs_.push_back(std::move(command_queue_program_ptr));
         // Since devices could be set up in any order, on mmio device do a pass and populate cores for tunnelers.

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -14,7 +14,6 @@
 #include <set>
 #include <utility>
 
-#include "assert.hpp"
 #include "control_plane.hpp"
 #include "core_coord.hpp"
 #include "device_impl.hpp"

--- a/tt_metal/impl/dispatch/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/command_queue_common.hpp
@@ -21,9 +21,8 @@ enum class CommandQueueDeviceAddrType : uint8_t {
     COMPLETION_Q0_LAST_EVENT = 4,
     COMPLETION_Q1_LAST_EVENT = 5,
     DISPATCH_S_SYNC_SEM = 6,
-    FABRIC_HEADER_RB = 7,
-    FABRIC_SYNC_STATUS = 8,
-    UNRESERVED = 9,
+    FABRIC_INTERFACE = 7,
+    UNRESERVED = 8
 };
 
 // likely only used in impl

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -3,15 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <magic_enum/magic_enum.hpp>
-#include <tt-metalium/fabric_edm_packet_header.hpp>
+#include <tt-metalium/fabric_host_interface.h>
 #include <tt-metalium/tt_align.hpp>
+#include <optional>
 
 #include "dispatch_mem_map.hpp"
 #include "assert.hpp"
 #include "command_queue_common.hpp"
-#include "control_plane.hpp"
 #include "dispatch_settings.hpp"
-#include "fabric/fabric_context.hpp"
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include "utils.hpp"
@@ -127,7 +126,7 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
         DispatchSettings::DISPATCH_MESSAGE_ENTRIES <= DispatchSettings::DISPATCH_MESSAGES_MAX_OFFSET / l1_alignment + 1,
         "Number of dispatch message entries exceeds max representable offset");
 
-    constexpr uint8_t num_dev_cq_addrs = magic_enum::enum_count<CommandQueueDeviceAddrType>();
+    uint8_t num_dev_cq_addrs = magic_enum::enum_count<CommandQueueDeviceAddrType>();
     std::vector<uint32_t> device_cq_addr_sizes_(num_dev_cq_addrs, 0);
     for (auto dev_addr_idx = 0; dev_addr_idx < num_dev_cq_addrs; dev_addr_idx++) {
         CommandQueueDeviceAddrType dev_addr_type =
@@ -138,14 +137,12 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
             device_cq_addr_sizes_[dev_addr_idx] = settings.prefetch_q_pcie_rd_ptr_size_;
         } else if (dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM) {
             device_cq_addr_sizes_[dev_addr_idx] = settings.dispatch_s_sync_sem_;
-        } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_HEADER_RB) {
-            // At this point fabric context is not initialized yet
-            // Hardcode to 64B (more than enough space) for now
-            // const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-            // const auto& fabric_context = control_plane.get_fabric_context();
-            device_cq_addr_sizes_[dev_addr_idx] = tt::tt_metal::DispatchSettings::FABRIC_HEADER_RB_ENTRIES * 64;
-        } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_SYNC_STATUS) {
-            device_cq_addr_sizes_[dev_addr_idx] = sizeof(uint32_t);
+        } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_INTERFACE) {
+            if (tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
+                device_cq_addr_sizes_[dev_addr_idx] = tt_fabric::PACKET_HEADER_SIZE_BYTES;
+            } else {
+                device_cq_addr_sizes_[dev_addr_idx] = 0;
+            }
         } else {
             device_cq_addr_sizes_[dev_addr_idx] = settings.other_ptrs_size;
         }
@@ -158,9 +155,7 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
         CommandQueueDeviceAddrType dev_addr_type = magic_enum::enum_value<CommandQueueDeviceAddrType>(dev_addr_idx);
         if (dev_addr_type == CommandQueueDeviceAddrType::UNRESERVED) {
             device_cq_addrs_[dev_addr_idx] = align(device_cq_addrs_[dev_addr_idx], pcie_alignment);
-        } else if (
-            dev_addr_type == CommandQueueDeviceAddrType::FABRIC_HEADER_RB ||
-            dev_addr_type == CommandQueueDeviceAddrType::FABRIC_SYNC_STATUS) {
+        } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_INTERFACE) {
             device_cq_addrs_[dev_addr_idx] = align(device_cq_addrs_[dev_addr_idx], l1_alignment);
         }
     }

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -142,9 +142,6 @@ public:
     static constexpr uint32_t MAX_DEV_CHANNEL_SIZE = 1 << 28;                                      // 256 MB;
     static constexpr uint32_t DEVICES_PER_UMD_CHANNEL = MAX_HUGEPAGE_SIZE / MAX_DEV_CHANNEL_SIZE;  // 256 MB;
 
-    // Number of entries in the fabric header ring buffer
-    static constexpr uint32_t FABRIC_HEADER_RB_ENTRIES = 1;
-
     //
     // Configurable Settings
     //

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -1,7 +1,6 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-
 #include "dispatch.hpp"
 
 #include <host_api.hpp>
@@ -18,7 +17,6 @@
 #include "demux.hpp"
 #include "device.hpp"
 #include "dispatch/kernel_config/fd_kernel.hpp"
-#include "dispatch/kernel_config/relay_mux.hpp"
 #include "dispatch/kernels/packet_queue_ctrl.hpp"
 #include "dispatch/dispatch_settings.hpp"
 #include "dispatch_core_common.hpp"
@@ -41,13 +39,6 @@ void DispatchKernel::GenerateStaticConfigs() {
         tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
     uint8_t cq_id_ = this->cq_id_;
     auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
-
-    // May be zero if not using dispatch on fabric
-    static_config_.fabric_header_rb_base =
-        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_HEADER_RB);
-    static_config_.fabric_header_rb_entries = tt::tt_metal::DispatchSettings::FABRIC_HEADER_RB_ENTRIES;
-    static_config_.my_fabric_sync_status_addr =
-        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_SYNC_STATUS);
 
     if (static_config_.is_h_variant.value() && this->static_config_.is_d_variant.value()) {
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
@@ -124,14 +115,10 @@ void DispatchKernel::GenerateStaticConfigs() {
 
         static_config_.split_dispatch_page_preamble_size = 0;
         // TODO: why is this hard-coded to 1 CQ on Galaxy?
-        if (MetalContext::instance().rtoptions().get_fd_fabric()) {
-            static_config_.prefetch_h_max_credits = my_dispatch_constants.prefetch_d_buffer_pages();
+        if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
+            static_config_.prefetch_h_max_credits = my_dispatch_constants.mux_buffer_pages(1);
         } else {
-            if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
-                static_config_.prefetch_h_max_credits = my_dispatch_constants.mux_buffer_pages(1);
-            } else {
-                static_config_.prefetch_h_max_credits = my_dispatch_constants.mux_buffer_pages(device_->num_hw_cqs());
-            }
+            static_config_.prefetch_h_max_credits = my_dispatch_constants.mux_buffer_pages(device_->num_hw_cqs());
         }
 
         static_config_.packed_write_max_unicast_sub_cmds =
@@ -170,17 +157,18 @@ void DispatchKernel::GenerateStaticConfigs() {
         static_config_.completion_queue_base_addr = 0;
         static_config_.completion_queue_size = 0;
 
+        static_config_.my_downstream_cb_sem_id = tt::tt_metal::CreateSemaphore(
+            *program_,
+            logical_core_,
+            my_dispatch_constants.mux_buffer_pages(device_->num_hw_cqs()),
+            GetCoreType());  // Apparently unused
+
         if (MetalContext::instance().rtoptions().get_fd_fabric()) {
             static_config_.split_dispatch_page_preamble_size = 0;
-            static_config_.prefetch_h_max_credits = my_dispatch_constants.prefetch_d_buffer_pages();
-            static_config_.my_downstream_cb_sem_id = tt::tt_metal::CreateSemaphore(
-                *program_, logical_core_, my_dispatch_constants.prefetch_d_buffer_pages(), GetCoreType());
         } else {
             static_config_.split_dispatch_page_preamble_size = sizeof(tt::packet_queue::dispatch_packet_header_t);
-            static_config_.prefetch_h_max_credits = my_dispatch_constants.mux_buffer_pages(device_->num_hw_cqs());
-            static_config_.my_downstream_cb_sem_id = tt::tt_metal::CreateSemaphore(
-                *program_, logical_core_, my_dispatch_constants.mux_buffer_pages(device_->num_hw_cqs()), GetCoreType());
         }
+        static_config_.prefetch_h_max_credits = my_dispatch_constants.mux_buffer_pages(device_->num_hw_cqs());
 
         static_config_.packed_write_max_unicast_sub_cmds =
             device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
@@ -207,11 +195,6 @@ void DispatchKernel::GenerateStaticConfigs() {
             my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
     } else {
         TT_FATAL(false, "DispatchKernel must be one of (or both) H and D variants");
-    }
-
-    if ((static_config_.is_h_variant.value() ^ static_config_.is_d_variant.value()) &&
-        tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
-        create_edm_connection_sems(edm_connection_attributes_);
     }
 }
 
@@ -253,13 +236,9 @@ void DispatchKernel::GenerateDependentConfigs() {
         dependent_config_.downstream_cb_base = 0;                         // Unused
         dependent_config_.downstream_cb_size = 0;                         // Unused
         dependent_config_.downstream_cb_sem_id = UNUSED_SEM_ID;           // Unused
-        dependent_config_.num_hops = 0;
     } else if (static_config_.is_h_variant.value()) {
         // Upstream, expect DEMUX
         // Or direct connection to DISPATCH_D if using fabric
-
-        // May be overwritten below
-        dependent_config_.num_hops = 0;
         TT_ASSERT(upstream_kernels_.size() == 1);
         if (auto demux_kernel = dynamic_cast<DemuxKernel*>(upstream_kernels_[0])) {
             dependent_config_.upstream_logical_core = demux_kernel->GetLogicalCore();
@@ -273,44 +252,22 @@ void DispatchKernel::GenerateDependentConfigs() {
             dependent_config_.upstream_dispatch_cb_sem_id =
                 dispatch_d->GetStaticConfig().my_downstream_cb_sem_id.value();
             dependent_config_.upstream_sync_sem = 0;  // Unused
-            dependent_config_.num_hops = tt::tt_metal::get_num_hops(device_id_, dispatch_d->GetDeviceId());
         } else {
             TT_FATAL(false, "Unimplemented path");
         }
 
-        // Downstream
-        // PREFETCH_H || FABRIC_MUX
         // Downstream, no official downstream core but use the field to connect is to the PREFETCH_H that we need to
         // write to when resuming sending of commands post exec_buf stall.
-        bool found_prefetch_h = false;
-        bool found_relay_mux = false;
-        for (FDKernel* ds_kernel : downstream_kernels_) {
-            if (auto prefetch_h_kernel = dynamic_cast<PrefetchKernel*>(ds_kernel)) {
-                TT_ASSERT(prefetch_h_kernel && prefetch_h_kernel->GetStaticConfig().is_h_variant.value());
-                TT_ASSERT(!found_prefetch_h, "DISPATCH_H has multiple downstream PREFETCH_H kernels.");
-                found_prefetch_h = true;
-                dependent_config_.prefetch_h_noc_xy = tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(
-                    prefetch_h_kernel->GetVirtualCore().x, prefetch_h_kernel->GetVirtualCore().y);
-                dependent_config_.prefetch_h_local_downstream_sem_addr =
-                    prefetch_h_kernel->GetStaticConfig().my_downstream_cb_sem_id;
-            } else if (auto relay_mux = dynamic_cast<tt::tt_metal::RelayMux*>(ds_kernel)) {
-                TT_ASSERT(!found_relay_mux, "DISPATCH_H has multiple downstream RELAY_MUX kernels.");
-                found_relay_mux = true;
-
-                constexpr tt::tt_fabric::FabricMuxChannelType ch_type =
-                    tt::tt_fabric::FabricMuxChannelType::HEADER_ONLY_CHANNEL;
-                tt::tt_metal::assemble_fabric_mux_client_config_args(
-                    node_id_, ch_type, relay_mux, dependent_config_.fabric_mux_client_config);
-            } else {
-                TT_FATAL(false, "DISPATCH_H Downstream - Unimplemented path");
-            }
-        }
-
-        TT_ASSERT(found_prefetch_h, "DISPATCH_H expects a PREFETCH_H downstream");
-
+        TT_ASSERT(downstream_kernels_.size() == 1);
+        auto prefetch_h_kernel = dynamic_cast<PrefetchKernel*>(downstream_kernels_[0]);
+        TT_ASSERT(prefetch_h_kernel && prefetch_h_kernel->GetStaticConfig().is_h_variant.value());
         dependent_config_.downstream_logical_core = UNUSED_LOGICAL_CORE;
         dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
         dependent_config_.split_prefetch = true;
+        dependent_config_.prefetch_h_noc_xy = tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(
+            prefetch_h_kernel->GetVirtualCore().x, prefetch_h_kernel->GetVirtualCore().y);
+        dependent_config_.prefetch_h_local_downstream_sem_addr =
+            prefetch_h_kernel->GetStaticConfig().my_downstream_cb_sem_id;
         dependent_config_.downstream_cb_base = 0;    // Unused
         dependent_config_.downstream_cb_size = 0;    // Unused
         dependent_config_.downstream_cb_sem_id = 0;  // Unused
@@ -322,8 +279,6 @@ void DispatchKernel::GenerateDependentConfigs() {
         dependent_config_.upstream_logical_core = prefetch_kernel->GetLogicalCore();
         dependent_config_.upstream_dispatch_cb_sem_id = prefetch_kernel->GetStaticConfig().my_downstream_cb_sem_id;
         dependent_config_.upstream_sync_sem = prefetch_kernel->GetStaticConfig().downstream_sync_sem_id;
-        // May be overwritten below
-        dependent_config_.num_hops = 0;
 
         if (prefetch_kernel->GetStaticConfig().is_h_variant.value() &&
             prefetch_kernel->GetStaticConfig().is_d_variant.value()) {
@@ -348,14 +303,11 @@ void DispatchKernel::GenerateDependentConfigs() {
         bool found_dispatch_s = false;
         bool found_mux = false;
         bool found_dispatch_h = false;
-        bool found_relay_mux = false;  // fabric mux
         for (auto ds_kernel : downstream_kernels_) {
             if (auto dispatch_s_kernel = dynamic_cast<DispatchSKernel*>(ds_kernel)) {
-                TT_ASSERT(!found_dispatch_s, "DISPATCH_D has multiple downstream DISPATCH_S kernels.");
                 dependent_config_.downstream_s_logical_core = dispatch_s_kernel->GetLogicalCore();
                 found_dispatch_s = true;
             } else if (auto mux_kernel = dynamic_cast<MuxKernel*>(ds_kernel)) {
-                TT_ASSERT(!found_mux, "DISPATCH_D has multiple downstream MUX_D kernels.");
                 dependent_config_.downstream_logical_core = mux_kernel->GetLogicalCore();
                 // Some configs depend on which port this kernel connects to on the downstream kernel
                 int dispatch_d_idx =
@@ -370,22 +322,12 @@ void DispatchKernel::GenerateDependentConfigs() {
                 dependent_config_.downstream_cb_sem_id = dispatch_d_idx;
                 found_mux = true;
             } else if (auto dispatch_h_kernel = dynamic_cast<DispatchKernel*>(ds_kernel)) {
-                TT_ASSERT(!found_dispatch_h, "DISPATCH_D has multiple downstream DISPATCH_H kernels.");
                 dependent_config_.downstream_logical_core = dispatch_h_kernel->GetLogicalCore();
                 dependent_config_.downstream_cb_size = dispatch_h_kernel->GetDispatchBufferSize();
                 dependent_config_.downstream_cb_base = dispatch_h_kernel->GetStaticConfig().dispatch_cb_base.value();
                 dependent_config_.downstream_cb_sem_id =
                     dispatch_h_kernel->GetStaticConfig().my_dispatch_cb_sem_id.value();
-                dependent_config_.num_hops = tt::tt_metal::get_num_hops(dispatch_h_kernel->GetDeviceId(), device_id_);
                 found_dispatch_h = true;
-            } else if (auto relay_mux = dynamic_cast<tt::tt_metal::RelayMux*>(ds_kernel)) {
-                TT_ASSERT(!found_relay_mux, "DISPATCH_D has multiple downstream RELAY_MUX kernels.");
-                found_relay_mux = true;
-
-                constexpr tt::tt_fabric::FabricMuxChannelType ch_type =
-                    tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
-                tt::tt_metal::assemble_fabric_mux_client_config_args(
-                    node_id_, ch_type, relay_mux, dependent_config_.fabric_mux_client_config);
             } else {
                 TT_FATAL(false, "Unexpected downstream kernel for dispatch_d");
             }
@@ -458,39 +400,24 @@ void DispatchKernel::CreateKernel() {
         static_config_.dev_completion_q_wr_ptr.value(),
         static_config_.dev_completion_q_rd_ptr.value(),
 
+        dependent_config_.downstream_mesh_id.value_or(0),
+        dependent_config_.downstream_dev_id.value_or(0),
+        dependent_config_.upstream_mesh_id.value_or(0),
+        dependent_config_.upstream_dev_id.value_or(0),
+        dependent_config_.fabric_router_noc_xy.value_or(0),
+        dependent_config_.outbound_eth_chan.value_or(0),
+        static_config_.client_interface_addr.value_or(0),
+
         static_config_.first_stream_used.value(),
 
         virtualize_num_eth_cores,
         num_virtual_active_eth_cores,
         num_physical_active_eth_cores,
 
-        static_config_.fabric_header_rb_base.value(),
-        static_config_.fabric_header_rb_entries.value(),
-        static_config_.my_fabric_sync_status_addr.value(),
-
-        dependent_config_.fabric_mux_client_config.virtual_x.value_or(0),
-        dependent_config_.fabric_mux_client_config.virtual_y.value_or(0),
-        dependent_config_.fabric_mux_client_config.num_buffers_per_channel.value_or(0),
-        dependent_config_.fabric_mux_client_config.channel_buffer_size_bytes.value_or(0),
-        dependent_config_.fabric_mux_client_config.channel_base_address.value_or(0),
-        dependent_config_.fabric_mux_client_config.connection_info_address.value_or(0),
-        dependent_config_.fabric_mux_client_config.connection_handshake_address.value_or(0),
-        dependent_config_.fabric_mux_client_config.flow_control_address.value_or(0),
-        dependent_config_.fabric_mux_client_config.buffer_index_address.value_or(0),
-        dependent_config_.fabric_mux_client_config.status_address.value_or(0),
-        dependent_config_.fabric_mux_client_config.termination_signal_address.value_or(0),
-        dependent_config_.fabric_mux_client_config.worker_credits_stream_id.value_or(0),
-
-        edm_connection_attributes_.worker_flow_control_sem,
-        edm_connection_attributes_.worker_teardown_sem,
-        edm_connection_attributes_.worker_buffer_index_sem,
-
-        dependent_config_.num_hops.value(),
-
         static_config_.is_d_variant.value(),
         static_config_.is_h_variant.value(),
     };
-
+    TT_ASSERT(compile_args.size() == 42);
     auto my_virtual_core = get_virtual_core_coord(logical_core_, GetCoreType());
     auto upstream_virtual_core = get_virtual_core_coord(dependent_config_.upstream_logical_core.value(), GetCoreType());
     auto downstream_virtual_core =
@@ -543,4 +470,23 @@ void DispatchKernel::ConfigureCore() {
         detail::WriteToDeviceL1(device_, logical_core_, completion_q0_last_event_ptr, zero, GetCoreType());
         detail::WriteToDeviceL1(device_, logical_core_, completion_q1_last_event_ptr, zero, GetCoreType());
     }
+}
+
+void DispatchKernel::UpdateArgsForFabric(
+    const CoreCoord& fabric_router_virtual,
+    uint32_t outbound_eth_chan,
+    tt::tt_fabric::MeshId upstream_mesh_id,
+    chip_id_t upstream_dev_id,
+    tt::tt_fabric::MeshId downstream_mesh_id,
+    chip_id_t downstream_dev_id) {
+    dependent_config_.fabric_router_noc_xy =
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(fabric_router_virtual.x, fabric_router_virtual.y);
+    dependent_config_.upstream_mesh_id = *upstream_mesh_id;
+    dependent_config_.upstream_dev_id = upstream_dev_id;
+    dependent_config_.downstream_mesh_id = *downstream_mesh_id;
+    dependent_config_.downstream_dev_id = downstream_dev_id;
+    dependent_config_.outbound_eth_chan = outbound_eth_chan;
+    auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
+    static_config_.client_interface_addr =
+        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_INTERFACE);
 }

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +9,6 @@
 
 #include "assert.hpp"
 #include "core_coord.hpp"
-#include "dispatch/kernel_config/relay_mux.hpp"
 #include "fd_kernel.hpp"
 #include "mesh_graph.hpp"
 #include "impl/context/metal_context.hpp"
@@ -48,12 +47,11 @@ struct dispatch_static_config_t {
     std::optional<uint32_t> dev_completion_q_wr_ptr;
     std::optional<uint32_t> dev_completion_q_rd_ptr;
 
-    std::optional<uint32_t> fabric_header_rb_base;
-    std::optional<uint32_t> fabric_header_rb_entries;
-    std::optional<uint32_t> my_fabric_sync_status_addr;
-
     std::optional<bool> is_d_variant;
     std::optional<bool> is_h_variant;
+
+    // Populated if fabric is being used to talk to downstream
+    std::optional<uint32_t> client_interface_addr;
 };
 
 struct dispatch_dependent_config_t {
@@ -73,9 +71,13 @@ struct dispatch_dependent_config_t {
     std::optional<uint32_t> prefetch_h_noc_xy;                     // Dependent. Used if split_prefetch is true
     std::optional<uint32_t> prefetch_h_local_downstream_sem_addr;  // Dependent. Used if split_prefetch is true
 
-    std::optional<uint32_t> num_hops;
-
-    tt::tt_metal::relay_mux_client_config fabric_mux_client_config;
+    // Populated if fabric is being used to talk to downstream
+    std::optional<uint32_t> fabric_router_noc_xy;
+    std::optional<uint32_t> upstream_mesh_id;
+    std::optional<uint32_t> upstream_dev_id;
+    std::optional<uint32_t> downstream_mesh_id;
+    std::optional<uint32_t> downstream_dev_id;
+    std::optional<uint32_t> outbound_eth_chan;
 };
 
 class DispatchKernel : public FDKernel {
@@ -120,6 +122,14 @@ public:
 
     void ConfigureCore() override;
 
+    void UpdateArgsForFabric(
+        const CoreCoord& fabric_router,
+        uint32_t outbound_eth_chan,
+        tt::tt_fabric::MeshId src_mesh_id,
+        chip_id_t src_chip_id,
+        tt::tt_fabric::MeshId dst_mesh_id,
+        chip_id_t dst_chip_id) override;
+
     uint32_t GetDispatchBufferSize() const {
         return (1 << static_config_.dispatch_cb_log_page_size.value()) * static_config_.dispatch_cb_pages.value();
     }
@@ -128,7 +138,6 @@ public:
 private:
     dispatch_static_config_t static_config_;
     dispatch_dependent_config_t dependent_config_;
-    FDKernelEdmConnectionAttributes edm_connection_attributes_;
 };
 
 }  // namespace tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -167,6 +167,9 @@ KernelHandle FDKernel::configure_kernel_variant(
     if (rt_options.watcher_dispatch_disabled()) {
         defines["FORCE_WATCHER_OFF"] = "1";
     }
+    if (tt::tt_metal::MetalContext::instance().get_fabric_config() != FabricConfig::FABRIC_2D) {
+        defines["FVC_MODE_PULL"] = "1";
+    }
     if (!DPrintServerReadsDispatchCores(device_->id())) {
         defines["FORCE_DPRINT_OFF"] = "1";
     }
@@ -196,10 +199,4 @@ KernelHandle FDKernel::configure_kernel_variant(
                 .defines = defines,
                 .opt_level = opt_level});
     }
-}
-
-void FDKernel::create_edm_connection_sems(FDKernelEdmConnectionAttributes& attributes) {
-    attributes.worker_flow_control_sem = tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
-    attributes.worker_buffer_index_sem = tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
-    attributes.worker_teardown_sem = tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
 }

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -1,7 +1,6 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-
 #pragma once
 
 #include <tt-metalium/program.hpp>
@@ -103,6 +102,16 @@ public:
     // after above functions and before FD kernels are launched.
     virtual void ConfigureCore() {}
 
+    // Override for specific kernels that can be configured for fabric. Will be called by the FABRIC_ROUTER_VC, which is
+    // an intermediary FDKernel for indicating a fabric router path needs to be found.
+    virtual void UpdateArgsForFabric(
+        const CoreCoord& fabric_router_virtual,
+        uint32_t outbound_eth_chan,
+        tt::tt_fabric::MeshId upstream_mesh_id,
+        chip_id_t upstream_chip_id,
+        tt::tt_fabric::MeshId downstream_mesh_id,
+        chip_id_t downstream_chip_id) {}
+
     // Generator function to create a kernel of a given type. New kernels need to be added here.
     static FDKernel* Generate(
         int node_id,
@@ -146,13 +155,6 @@ public:
     void AddProgram(tt::tt_metal::Program* program) { program_ = program; }
 
 protected:
-    // Attributes for an EDM client to connect to the router
-    struct FDKernelEdmConnectionAttributes {
-        size_t worker_flow_control_sem;
-        size_t worker_teardown_sem;
-        size_t worker_buffer_index_sem;
-    };
-
     [[maybe_unused]] KernelHandle configure_kernel_variant(
         const string& path,
         const std::vector<uint32_t>& compile_args,
@@ -177,8 +179,7 @@ protected:
     static chip_id_t GetDownstreamDeviceId(chip_id_t device_id, int tunnel = -1);
     // Helper function to get the tunnel stop index of current device
     static uint32_t GetTunnelStop(chip_id_t device_id);
-    // Create and populate semaphores for the EDM connection
-    void create_edm_connection_sems(FDKernelEdmConnectionAttributes& attributes);
+
     tt::tt_metal::IDevice* device_ = nullptr;  // Set at configuration time by AddDeviceAndProgram()
     tt::tt_metal::Program* program_ = nullptr;
     tt_cxy_pair logical_core_;

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -1,7 +1,6 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-
 #include "prefetch.hpp"
 
 #include <host_api.hpp>
@@ -9,6 +8,7 @@
 #include <array>
 #include <map>
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -18,10 +18,10 @@
 #include "dispatch.hpp"
 #include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch/dispatch_settings.hpp"
-#include "dispatch/kernel_config/relay_mux.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch_s.hpp"
 #include "eth_router.hpp"
+#include "hal.hpp"
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
@@ -36,13 +36,6 @@ void PrefetchKernel::GenerateStaticConfigs() {
         tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
     uint8_t cq_id_ = this->cq_id_;
     auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
-
-    // May be zero if not using dispatch on fabric
-    static_config_.fabric_header_rb_base =
-        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_HEADER_RB);
-    static_config_.fabric_header_rb_entries = tt::tt_metal::DispatchSettings::FABRIC_HEADER_RB_ENTRIES;
-    static_config_.my_fabric_sync_status_addr =
-        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_SYNC_STATUS);
 
     if (static_config_.is_h_variant.value() && this->static_config_.is_d_variant.value()) {
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
@@ -133,15 +126,14 @@ void PrefetchKernel::GenerateStaticConfigs() {
         // Workaround for now. Need downstream to initialize my semaphore. Can't defer creating semaphore yet
         {
             uint32_t downstream_cb_pages;
-            if (tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
-                downstream_cb_pages = my_dispatch_constants.prefetch_d_buffer_pages();
-            } else if (tt::tt_metal::MetalContext::instance()
-                           .get_cluster()
-                           .is_galaxy_cluster()) {  // TODO: whys is this hard-coded for galaxy?
+            if (tt::tt_metal::MetalContext::instance()
+                    .get_cluster()
+                    .is_galaxy_cluster()) {  // TODO: whys is this hard-coded for galaxy?
                 downstream_cb_pages = my_dispatch_constants.mux_buffer_pages(1);
             } else {
                 downstream_cb_pages = my_dispatch_constants.mux_buffer_pages(device_->num_hw_cqs());
             }
+
             static_config_.my_downstream_cb_sem_id =
                 tt::tt_metal::CreateSemaphore(*program_, logical_core_, downstream_cb_pages, GetCoreType());
         }
@@ -208,11 +200,6 @@ void PrefetchKernel::GenerateStaticConfigs() {
     } else {
         TT_FATAL(false, "PrefetchKernel must be one of (or both) H and D variants");
     }
-
-    if ((static_config_.is_h_variant.value() ^ static_config_.is_d_variant.value()) &&
-        tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
-        create_edm_connection_sems(edm_connection_attributes_);
-    }
 }
 
 void PrefetchKernel::GenerateDependentConfigs() {
@@ -262,68 +249,53 @@ void PrefetchKernel::GenerateDependentConfigs() {
             dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
             dependent_config_.downstream_dispatch_s_cb_sem_id = UNUSED_SEM_ID;
         }
-        dependent_config_.num_hops = 0;
     } else if (static_config_.is_h_variant.value()) {
         // Upstream, just host so no dispatch core
         TT_ASSERT(upstream_kernels_.size() == 0);
         dependent_config_.upstream_logical_core = UNUSED_LOGICAL_CORE;
         dependent_config_.upstream_cb_sem_id = 0;  // Used in prefetch_d only
-        // May be overwritten below
-        dependent_config_.num_hops = 0;
 
-        // Process downstream
-        // ROUTER ||
-        // PREFETCH_D ||
-        // FABRIC_MUX
-        for (FDKernel* ds_kernel : downstream_kernels_) {
-            if (auto router_kernel = dynamic_cast<EthRouterKernel*>(ds_kernel)) {
-                dependent_config_.downstream_logical_core = router_kernel->GetLogicalCore();
-                dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
-                uint32_t router_idx =
-                    router_kernel->GetUpstreamPort(this);  // Need the port that this connects to downstream
-                auto downstream_buffer_size = router_kernel->GetStaticConfig().rx_queue_size_words.value() << 4;
-                dependent_config_.downstream_cb_base =
-                    (router_kernel->GetStaticConfig().rx_queue_start_addr_words.value() << 4) +
-                    downstream_buffer_size * router_idx;
-                dependent_config_.downstream_cb_sem_id =
-                    router_kernel->GetStaticConfig().input_packetize_local_sem[router_idx];
-                dependent_config_.downstream_dispatch_s_cb_sem_id = 0;  // No downstream DISPATCH_S in this case
+        // Downstream
+        // one ROUTER or direct connection to PREFETCH_D if using fabric
+        TT_ASSERT(downstream_kernels_.size() == 1);
+        if (auto router_kernel = dynamic_cast<EthRouterKernel*>(downstream_kernels_[0])) {
+            dependent_config_.downstream_logical_core = router_kernel->GetLogicalCore();
+            dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
+            uint32_t router_idx =
+                router_kernel->GetUpstreamPort(this);  // Need the port that this connects to downstream
+            auto downstream_buffer_size = router_kernel->GetStaticConfig().rx_queue_size_words.value() << 4;
+            dependent_config_.downstream_cb_base =
+                (router_kernel->GetStaticConfig().rx_queue_start_addr_words.value() << 4) +
+                downstream_buffer_size * router_idx;
+            dependent_config_.downstream_cb_sem_id =
+                router_kernel->GetStaticConfig().input_packetize_local_sem[router_idx];
+            dependent_config_.downstream_dispatch_s_cb_sem_id = 0;  // No downstream DISPATCH_S in this case
 
-                dependent_config_.downstream_cb_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
-                dependent_config_.downstream_cb_pages =
-                    downstream_buffer_size / (1 << DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
-            } else if (auto prefetch_d = dynamic_cast<PrefetchKernel*>(ds_kernel)) {
-                TT_ASSERT(
-                    prefetch_d->GetStaticConfig().is_d_variant.value() &&
-                    !prefetch_d->GetStaticConfig().is_h_variant.value());
+            dependent_config_.downstream_cb_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
+            dependent_config_.downstream_cb_pages =
+                downstream_buffer_size / (1 << DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
+        } else if (auto prefetch_d = dynamic_cast<PrefetchKernel*>(downstream_kernels_[0])) {
+            TT_ASSERT(
+                prefetch_d->GetStaticConfig().is_d_variant.value() &&
+                !prefetch_d->GetStaticConfig().is_h_variant.value());
 
-                dependent_config_.downstream_logical_core = prefetch_d->GetLogicalCore();
-                dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
-                dependent_config_.downstream_cb_base = prefetch_d->GetStaticConfig().cmddat_q_base.value();
-                dependent_config_.downstream_cb_sem_id = prefetch_d->GetStaticConfig().my_upstream_cb_sem_id.value();
-                dependent_config_.downstream_dispatch_s_cb_sem_id = 0;
+            dependent_config_.downstream_logical_core = prefetch_d->GetLogicalCore();
+            dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
+            dependent_config_.downstream_cb_base = prefetch_d->GetStaticConfig().cmddat_q_base.value();
+            dependent_config_.downstream_cb_sem_id = prefetch_d->GetStaticConfig().my_upstream_cb_sem_id.value();
+            dependent_config_.downstream_dispatch_s_cb_sem_id = 0;
 
-                static_assert(
-                    DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE ==
-                    DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE);
-                dependent_config_.downstream_cb_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
-                dependent_config_.downstream_cb_pages = prefetch_d->GetStaticConfig().cmddat_q_pages.value();
-                dependent_config_.num_hops = tt::tt_metal::get_num_hops(device_id_, prefetch_d->GetDeviceId());
-            } else if (auto fabric_mux = dynamic_cast<tt::tt_metal::RelayMux*>(ds_kernel)) {
-                constexpr tt::tt_fabric::FabricMuxChannelType ch_type =
-                    tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
-                tt::tt_metal::assemble_fabric_mux_client_config_args(
-                    node_id_, ch_type, fabric_mux, dependent_config_.fabric_mux_client_config);
-            } else {
-                TT_FATAL(false, "PREFETCH_H Downstream - Unimplemented path");
-            }
+            static_assert(
+                DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE == DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE);
+            dependent_config_.downstream_cb_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
+            dependent_config_.downstream_cb_pages = prefetch_d->GetStaticConfig().cmddat_q_pages.value();
+        } else {
+            TT_FATAL(false, "Path not implemented");
         }
     } else if (static_config_.is_d_variant.value()) {
         // Upstream
         // One ROUTER or direct connection to PREFETCH_H if using fabric
         TT_ASSERT(upstream_kernels_.size() == 1);
-        // May be overwritten below
-        dependent_config_.num_hops = 0;
         if (auto router_kernel = dynamic_cast<EthRouterKernel*>(upstream_kernels_[0])) {
             dependent_config_.upstream_logical_core = router_kernel->GetLogicalCore();
             int router_idx = router_kernel->GetDownstreamPort(this);
@@ -332,16 +304,19 @@ void PrefetchKernel::GenerateDependentConfigs() {
         } else if (auto prefetch_h = dynamic_cast<PrefetchKernel*>(upstream_kernels_[0])) {
             dependent_config_.upstream_logical_core = prefetch_h->GetLogicalCore();
             dependent_config_.upstream_cb_sem_id = prefetch_h->GetStaticConfig().my_downstream_cb_sem_id.value();
-            dependent_config_.num_hops = tt::tt_metal::get_num_hops(prefetch_h->GetDeviceId(), device_id_);
         } else {
             TT_FATAL(false, "Path not implemented");
         }
 
-        // Downstream
-        // DISPATCH_D || DISPATCH_S || FABRIC_MUX
+        // Downstream, expect a DISPATCH_D and s DISPATCH_S
+        // Prefetch_d will always be local with dispatch_d
+        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
+            TT_ASSERT(downstream_kernels_.size() == 2);
+        } else {
+            TT_ASSERT(downstream_kernels_.size() == 1);
+        }
         bool found_dispatch = false;
         bool found_dispatch_s = false;
-        bool found_relay_mux = false;
         for (FDKernel* k : downstream_kernels_) {
             if (auto dispatch_kernel = dynamic_cast<DispatchKernel*>(k)) {
                 TT_ASSERT(!found_dispatch, "PREFETCH kernel has multiple downstream DISPATCH kernels.");
@@ -361,19 +336,10 @@ void PrefetchKernel::GenerateDependentConfigs() {
                 dependent_config_.downstream_s_logical_core = dispatch_s_kernel->GetLogicalCore();
                 dependent_config_.downstream_dispatch_s_cb_sem_id =
                     dispatch_s_kernel->GetStaticConfig().my_dispatch_cb_sem_id;
-            } else if (auto relay_mux = dynamic_cast<tt::tt_metal::RelayMux*>(k)) {
-                TT_ASSERT(!found_relay_mux, "PREFETCH_D kernel has multiple downstream RELAY_MUX kernels.");
-                found_relay_mux = true;
-                constexpr tt::tt_fabric::FabricMuxChannelType ch_type =
-                    tt::tt_fabric::FabricMuxChannelType::HEADER_ONLY_CHANNEL;
-                tt::tt_metal::assemble_fabric_mux_client_config_args(
-                    node_id_, ch_type, relay_mux, dependent_config_.fabric_mux_client_config);
             } else {
                 TT_FATAL(false, "Unrecognized downstream kernel.");
             }
         }
-        // No check needed for found relay mux. A direct connection to PREFETCH_H on the same core
-        // is possible (used in test prefetcher) and does not need tunneling.
         if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
             // Should have found dispatch_s in the downstream kernels
             TT_ASSERT(found_dispatch && found_dispatch_s);
@@ -419,35 +385,18 @@ void PrefetchKernel::CreateKernel() {
         dependent_config_.downstream_dispatch_s_cb_sem_id.value(),
         static_config_.dispatch_s_buffer_size.value(),
         static_config_.dispatch_s_cb_log_page_size.value(),
+        dependent_config_.downstream_mesh_id.value_or(0),
+        dependent_config_.downstream_dev_id.value_or(0),
+        dependent_config_.upstream_mesh_id.value_or(0),
+        dependent_config_.upstream_dev_id.value_or(0),
+        dependent_config_.fabric_router_noc_xy.value_or(0),
+        dependent_config_.outbound_eth_chan.value_or(0),
+        static_config_.client_interface_addr.value_or(0),
         static_config_.ringbuffer_size.value(),
-
-        static_config_.fabric_header_rb_base.value(),
-        static_config_.fabric_header_rb_entries.value(),
-        static_config_.my_fabric_sync_status_addr.value(),
-
-        dependent_config_.fabric_mux_client_config.virtual_x.value_or(0),
-        dependent_config_.fabric_mux_client_config.virtual_y.value_or(0),
-        dependent_config_.fabric_mux_client_config.num_buffers_per_channel.value_or(0),
-        dependent_config_.fabric_mux_client_config.channel_buffer_size_bytes.value_or(0),
-        dependent_config_.fabric_mux_client_config.channel_base_address.value_or(0),
-        dependent_config_.fabric_mux_client_config.connection_info_address.value_or(0),
-        dependent_config_.fabric_mux_client_config.connection_handshake_address.value_or(0),
-        dependent_config_.fabric_mux_client_config.flow_control_address.value_or(0),
-        dependent_config_.fabric_mux_client_config.buffer_index_address.value_or(0),
-        dependent_config_.fabric_mux_client_config.status_address.value_or(0),
-        dependent_config_.fabric_mux_client_config.termination_signal_address.value_or(0),
-        dependent_config_.fabric_mux_client_config.worker_credits_stream_id.value_or(0),
-
-        edm_connection_attributes_.worker_flow_control_sem,
-        edm_connection_attributes_.worker_teardown_sem,
-        edm_connection_attributes_.worker_buffer_index_sem,
-
-        dependent_config_.num_hops.value(),
-
         static_config_.is_d_variant.value(),
         static_config_.is_h_variant.value(),
     };
-
+    TT_ASSERT(compile_args.size() == 36);
     auto my_virtual_core = get_virtual_core_coord(logical_core_, GetCoreType());
     auto upstream_virtual_core = get_virtual_core_coord(dependent_config_.upstream_logical_core.value(), GetCoreType());
     auto downstream_virtual_core =
@@ -522,4 +471,24 @@ void PrefetchKernel::ConfigureCore() {
             device_, logical_core_, prefetch_q_pcie_rd_ptr, prefetch_q_pcie_rd_ptr_addr_data, GetCoreType());
         detail::WriteToDeviceL1(device_, logical_core_, prefetch_q_base, prefetch_q, GetCoreType());
     }
+}
+
+void PrefetchKernel::UpdateArgsForFabric(
+    const CoreCoord& fabric_router_virtual,
+    uint32_t outbound_eth_chan,
+    tt::tt_fabric::MeshId upstream_mesh_id,
+    chip_id_t upstream_dev_id,
+    tt::tt_fabric::MeshId downstream_mesh_id,
+    chip_id_t downstream_dev_id) {
+    dependent_config_.fabric_router_noc_xy =
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(fabric_router_virtual.x, fabric_router_virtual.y);
+    dependent_config_.upstream_mesh_id = *upstream_mesh_id;
+    dependent_config_.upstream_dev_id = upstream_dev_id;
+    dependent_config_.downstream_mesh_id = *downstream_mesh_id;
+    dependent_config_.downstream_dev_id = downstream_dev_id;
+    dependent_config_.outbound_eth_chan = outbound_eth_chan;
+
+    auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
+    static_config_.client_interface_addr =
+        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_INTERFACE);
 }

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +13,6 @@
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.h>
-#include "dispatch/kernel_config/relay_mux.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -49,12 +48,11 @@ struct prefetch_static_config_t {
     std::optional<uint32_t> dispatch_s_buffer_size;
     std::optional<uint32_t> dispatch_s_cb_log_page_size;
 
-    std::optional<uint32_t> fabric_header_rb_base;
-    std::optional<uint32_t> fabric_header_rb_entries;
-    std::optional<uint32_t> my_fabric_sync_status_addr;
-
     std::optional<bool> is_d_variant;
     std::optional<bool> is_h_variant;
+
+    // Populated if fabric is being used to talk to downstream
+    std::optional<uint32_t> client_interface_addr;
 };
 
 struct prefetch_dependent_config_t {
@@ -71,9 +69,13 @@ struct prefetch_dependent_config_t {
 
     std::optional<uint32_t> downstream_dispatch_s_cb_sem_id;
 
-    std::optional<uint32_t> num_hops;
-
-    tt::tt_metal::relay_mux_client_config fabric_mux_client_config;
+    // Populated if fabric is being used to talk to downstream
+    std::optional<uint32_t> fabric_router_noc_xy;
+    std::optional<uint32_t> upstream_mesh_id;
+    std::optional<uint32_t> upstream_dev_id;
+    std::optional<uint32_t> downstream_mesh_id;
+    std::optional<uint32_t> downstream_dev_id;
+    std::optional<uint32_t> outbound_eth_chan;
 };
 
 class PrefetchKernel : public FDKernel {
@@ -104,21 +106,22 @@ public:
         }
         this->kernel_type_ = FDKernelType::DISPATCH;
     }
-
     void CreateKernel() override;
-
     void GenerateStaticConfigs() override;
-
     void GenerateDependentConfigs() override;
-
     void ConfigureCore() override;
-
+    void UpdateArgsForFabric(
+        const CoreCoord& fabric_router,
+        uint32_t outbound_eth_chan,
+        tt::tt_fabric::MeshId src_mesh_id,
+        chip_id_t src_chip_id,
+        tt::tt_fabric::MeshId dst_mesh_id,
+        chip_id_t dst_chip_id) override;
     const prefetch_static_config_t& GetStaticConfig() { return static_config_; }
 
 private:
     prefetch_static_config_t static_config_;
     prefetch_dependent_config_t dependent_config_;
-    FDKernelEdmConnectionAttributes edm_connection_attributes_;
 };
 
 }  // namespace tt_metal

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +10,6 @@
 //  - # blocks must evenly divide the dispatch buffer size
 //  - dispatch buffer base must be page size aligned
 
-#include "dataflow_api.h"
 #include "debug/assert.h"
 #include "debug/dprint.h"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
@@ -53,38 +52,23 @@ constexpr uint32_t host_completion_q_wr_ptr = get_compile_time_arg_val(26);
 constexpr uint32_t dev_completion_q_wr_ptr = get_compile_time_arg_val(27);
 constexpr uint32_t dev_completion_q_rd_ptr = get_compile_time_arg_val(28);
 
-constexpr uint32_t first_stream_used = get_compile_time_arg_val(29);
+// used for fd on fabric
+constexpr uint32_t downstream_mesh_id = get_compile_time_arg_val(29);
+constexpr uint32_t downstream_dev_id = get_compile_time_arg_val(30);
+constexpr uint32_t upstream_mesh_id = get_compile_time_arg_val(31);
+constexpr uint32_t upstream_dev_id = get_compile_time_arg_val(32);
+constexpr uint32_t fabric_router_noc_xy = get_compile_time_arg_val(33);
+constexpr uint32_t outbound_eth_chan = get_compile_time_arg_val(34);
+constexpr uint32_t client_interface_addr = get_compile_time_arg_val(35);
 
-constexpr uint32_t virtualize_unicast_cores = get_compile_time_arg_val(30);
-constexpr uint32_t num_virtual_unicast_cores = get_compile_time_arg_val(31);
-constexpr uint32_t num_physical_unicast_cores = get_compile_time_arg_val(32);
+constexpr uint32_t first_stream_used = get_compile_time_arg_val(36);
 
-// fabric mux connection
-constexpr uint32_t fabric_header_rb_base = get_compile_time_arg_val(33);
-constexpr uint32_t fabric_header_rb_entries = get_compile_time_arg_val(34);
-constexpr uint32_t my_fabric_sync_status_addr = get_compile_time_arg_val(35);
+constexpr uint32_t virtualize_unicast_cores = get_compile_time_arg_val(37);
+constexpr uint32_t num_virtual_unicast_cores = get_compile_time_arg_val(38);
+constexpr uint32_t num_physical_unicast_cores = get_compile_time_arg_val(39);
 
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(36);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(37);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(38);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(39);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(40);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(41);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(42);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(43);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(44);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(45);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(46);
-constexpr size_t worker_credits_stream_id = get_compile_time_arg_val(47);
-
-constexpr size_t fabric_worker_flow_control_sem = get_compile_time_arg_val(48);
-constexpr size_t fabric_worker_teardown_sem = get_compile_time_arg_val(49);
-constexpr size_t fabric_worker_buffer_index_sem = get_compile_time_arg_val(50);
-
-constexpr uint32_t num_hops = get_compile_time_arg_val(51);
-
-constexpr uint32_t is_d_variant = get_compile_time_arg_val(52);
-constexpr uint32_t is_h_variant = get_compile_time_arg_val(53);
+constexpr uint32_t is_d_variant = get_compile_time_arg_val(40);
+constexpr uint32_t is_h_variant = get_compile_time_arg_val(41);
 
 constexpr uint8_t upstream_noc_index = UPSTREAM_NOC_INDEX;
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,7 +17,6 @@
 //
 
 #include "dataflow_api.h"
-#include "dataflow_api_addrgen.h"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_common.hpp"
 #include "debug/dprint.h"
@@ -71,34 +70,19 @@ constexpr uint32_t downstream_dispatch_s_cb_sem_id = get_compile_time_arg_val(23
 constexpr uint32_t dispatch_s_buffer_size = get_compile_time_arg_val(24);
 constexpr uint32_t dispatch_s_cb_log_page_size = get_compile_time_arg_val(25);
 
-constexpr uint32_t ringbuffer_size = get_compile_time_arg_val(26);
+// used for fd on fabric
+constexpr uint32_t downstream_mesh_id = get_compile_time_arg_val(26);
+constexpr uint32_t downstream_dev_id = get_compile_time_arg_val(27);
+constexpr uint32_t upstream_mesh_id = get_compile_time_arg_val(28);
+constexpr uint32_t upstream_dev_id = get_compile_time_arg_val(29);
+constexpr uint32_t fabric_router_noc_xy = get_compile_time_arg_val(30);
+constexpr uint32_t outbound_eth_chan = get_compile_time_arg_val(31);
+constexpr uint32_t client_interface_addr = get_compile_time_arg_val(32);
 
-// fabric mux connection
-constexpr uint32_t fabric_header_rb_base = get_compile_time_arg_val(27);
-constexpr uint32_t fabric_header_rb_entries = get_compile_time_arg_val(28);
-constexpr uint32_t my_fabric_sync_status_addr = get_compile_time_arg_val(29);
+constexpr uint32_t ringbuffer_size = get_compile_time_arg_val(33);
 
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(30);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(31);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(32);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(33);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(34);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(35);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(36);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(37);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(38);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(39);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(40);
-constexpr size_t worker_credits_stream_id = get_compile_time_arg_val(41);
-
-constexpr size_t fabric_worker_flow_control_sem = get_compile_time_arg_val(42);
-constexpr size_t fabric_worker_teardown_sem = get_compile_time_arg_val(43);
-constexpr size_t fabric_worker_buffer_index_sem = get_compile_time_arg_val(44);
-
-constexpr uint32_t num_hops = get_compile_time_arg_val(45);
-
-constexpr uint32_t is_d_variant = get_compile_time_arg_val(46);
-constexpr uint32_t is_h_variant = get_compile_time_arg_val(47);
+constexpr uint32_t is_d_variant = get_compile_time_arg_val(34);
+constexpr uint32_t is_h_variant = get_compile_time_arg_val(35);
 
 constexpr uint32_t prefetch_q_end = prefetch_q_base + prefetch_q_size;
 constexpr uint32_t cmddat_q_end = cmddat_q_base + cmddat_q_size;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1010,7 +1010,7 @@ void Cluster::reserve_ethernet_cores_for_tunneling() {
         }
         std::map<std::tuple<chip_id_t, chip_id_t>, bool> reserved_chip_connections = {};
         for (const auto &chip_id : devices) {
-            if (!TT_METAL_SLOW_DISPATCH_MODE && arch_ == ARCH::WORMHOLE_B0 && !rtoptions_.get_fd_fabric()) {
+            if (TT_METAL_SLOW_DISPATCH_MODE == nullptr and arch_ == ARCH::WORMHOLE_B0) {
                 for (const auto &[connected_chip_id, active_eth_cores] :
                      this->get_ethernet_cores_grouped_by_connected_chips(chip_id)) {
                     for (const auto &eth_core : active_eth_cores) {


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#23080
Breaks t3k unit test
https://github.com/tenstorrent/tt-metal/actions/runs/15474208392