### PR TITLE
transpose_wh_init: fix incorrect llk_unpack_A_hw_configure CB index.

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -207,6 +207,7 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
+@skip_for_blackhole("Bad CosineSimilarity on BH. Issue #21881")
 @pytest.mark.parametrize("dim1", [1])
 @pytest.mark.parametrize(
     "dim2", [50257]

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -207,7 +207,6 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
-@skip_for_blackhole("Bad CosineSimilarity on BH. Issue #21881")
 @pytest.mark.parametrize("dim1", [1])
 @pytest.mark.parametrize(
     "dim2", [50257]
@@ -222,6 +221,10 @@ def test_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
     torch_dtype = torch.bfloat16
 
     input = torch.randn(shape, dtype=torch_dtype) * 0.9
+    # Make every 256th element 10000
+    # This produced a reproducible failure for WH/BH: https://github.com/tenstorrent/tt-metal/issues/21881
+    for i in range(256, input.numel(), 256):
+        input[0][i] = 10000
 
     pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=dim, largest=largest, sorted=True)
 

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -32,7 +32,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
     PACK((llk_pack_init(ocb)));
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
 
-    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(0, true)));
+    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(icb, true)));
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true)));
 }
 


### PR DESCRIPTION
### Ticket

#21881

### Problem description

`transpose_wh_init` used a hardcoded CB index of 0 for `llk_unpack_A_hw_configure_disaggregated`, which meant it wouldn't work correctly for `icb != 0`.

In the referenced ticket (topk), this meant that the flush denormals flag was not being disabled in the case of CBs with data type uint16.

### What's changed

Use `icb` instead of `0` when calling `llk_unpack_A_hw_configure_disaggregated`.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes