### PR TITLE
Add error handling for uninitialized inspector data

### DIFF
--- a/tt_metal/impl/debug/inspector.cpp
+++ b/tt_metal/impl/debug/inspector.cpp
@@ -14,7 +14,11 @@
 namespace tt::tt_metal {
 
 static inspector::Data* get_inspector_data() {
-    return tt::tt_metal::MetalContext::instance().get_inspector_data();
+    auto* data = tt::tt_metal::MetalContext::instance().get_inspector_data();
+    if (!data) {
+        throw std::runtime_error("Inspector data is not initialized.");
+    }
+    return data;
 }
 
 bool Inspector::is_enabled() {


### PR DESCRIPTION
Uninitialized Inspector was crashing tests. It looks like `MetalContext::initialize` is not being called in them.

https://github.com/tenstorrent/tt-metal/actions/runs/15513355840/job/43680506961
https://github.com/tenstorrent/tt-metal/actions/runs/15513355835/job/43677255489
https://github.com/tenstorrent/tt-metal/actions/runs/15513355835/job/43677255489

This unblocks pipelines and I'll revisit error handling (throwing exception and then catching it) in following PR.