### PR TITLE
Don't use transpose_shards in BS conv2d

### DIFF
--- a/models/demos/bert_tiny/tests/test_performance.py
+++ b/models/demos/bert_tiny/tests/test_performance.py
@@ -112,7 +112,7 @@ def test_perf_device_bare_metal(batch_size, expected_perf):
     margin = 0.03
 
     if is_wormhole_b0():
-        expected_perf = 5076.2
+        expected_perf = 5116
     else:
         expected_perf = 3460.0
 

--- a/models/demos/convnet_mnist/tt/convnet_mnist.py
+++ b/models/demos/convnet_mnist/tt/convnet_mnist.py
@@ -22,7 +22,6 @@ def convnet_mnist(
         weights_dtype=ttnn.bfloat16,
         activation="",
         shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-        transpose_shards=False,
         reshard_if_not_optimal=True,
         deallocate_activation=True,
         reallocate_halo_output=True,

--- a/models/demos/mobilenetv2/tt/common.py
+++ b/models/demos/mobilenetv2/tt/common.py
@@ -61,7 +61,6 @@ class TtMobileNetV2Conv2D:
             activation="",
             shard_layout=self.shard_layout,
             act_block_w_div=1,
-            transpose_shards=False,
             deallocate_activation=self.deallocate_activation,
             enable_act_double_buffer=self.enable_act_double_buffer,
             enable_split_reader=self.enable_split_reader,

--- a/models/demos/segformer/tt/common.py
+++ b/models/demos/segformer/tt/common.py
@@ -43,7 +43,6 @@ class Conv:
             weights_dtype=ttnn.bfloat16,
             activation=self.activation,
             shard_layout=self.shard_layout,
-            transpose_shards=False,
             reshard_if_not_optimal=self.reshard,
             deallocate_activation=self.deallocate,
             reallocate_halo_output=True,

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
@@ -163,7 +163,6 @@ class resnet50Bottleneck:
         input_width,
         reshard_if_not_optimal=False,
         height_sharding=None,
-        transpose_shards=True,
         packer_l1_accum_enabled=True if not is_grayskull() else False,
         enable_act_double_buffer=False,
         enable_split_reader=False,
@@ -192,7 +191,6 @@ class resnet50Bottleneck:
                     deallocate_activation=True,
                     reallocate_halo_output=True,
                     reshard_if_not_optimal=reshard_if_not_optimal,
-                    transpose_shards=transpose_shards,
                     enable_act_double_buffer=enable_act_double_buffer
                     if height_sharding
                     else True
@@ -252,7 +250,6 @@ class resnet50Bottleneck:
         reshard_if_not_optimal=False,
         height_sharding=None,
         eltwise_binary_out_in_place=True,
-        transpose_shards=True,
         packer_l1_acc=True if not is_grayskull() else False,
         enable_act_double_buffer=False,
         enable_split_reader=False,
@@ -291,7 +288,6 @@ class resnet50Bottleneck:
                 if height_sharding
                 else ttnn.TensorMemoryLayout.BLOCK_SHARDED,
                 reshard_if_not_optimal=reshard_if_not_optimal,
-                transpose_shards=transpose_shards,
             ),
         }
 
@@ -355,7 +351,6 @@ class resnet50Bottleneck:
                 ds_input_width,
                 reshard_if_not_optimal,
                 height_sharding,
-                transpose_shards=transpose_shards,
                 packer_l1_accum_enabled=packer_l1_acc,
                 enable_act_double_buffer=False,
                 enable_split_reader=enable_split_reader,
@@ -402,7 +397,6 @@ class resnet50Bottleneck:
                 if height_sharding
                 else ttnn.TensorMemoryLayout.BLOCK_SHARDED,
                 reshard_if_not_optimal=reshard_if_not_optimal,
-                transpose_shards=transpose_shards,
                 enable_act_double_buffer=enable_act_double_buffer,
                 enable_weights_double_buffer=True,
                 enable_split_reader=enable_split_reader,
@@ -503,7 +497,6 @@ class resnet50Bottleneck:
                 if height_sharding
                 else ttnn.TensorMemoryLayout.BLOCK_SHARDED,
                 reshard_if_not_optimal=reshard_if_not_optimal,
-                transpose_shards=transpose_shards,
             ),
         }
 
@@ -547,7 +540,6 @@ class resnet50Bottleneck:
                 ds_input_width,
                 reshard_if_not_optimal,
                 height_sharding,
-                transpose_shards=transpose_shards,
                 packer_l1_accum_enabled=packer_l1_acc,
                 enable_act_double_buffer=enable_act_double_buffer,
                 enable_split_reader=enable_split_reader,
@@ -678,16 +670,10 @@ class resnet50:
             compute_kernel_config=compute_kernel_config,
         )  # num_classes = 1000
 
-        self.transpose_shards = True
-
         act_block_h_override = 0
 
         if is_wormhole_b0():
-            self.transpose_shards = False
             act_block_h_override = 1568
-
-        if is_blackhole() and self.batch_size < 20:
-            self.transpose_shards = False
 
         if is_blackhole() and self.batch_size == 32:
             act_block_h_override = 49 * 32
@@ -698,7 +684,6 @@ class resnet50:
             activation="relu",
             deallocate_activation=dealloc_input,
             act_block_h_override=act_block_h_override,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=is_wormhole_b0() or is_blackhole(),
             enable_split_reader=True,
             enable_subblock_padding=False,
@@ -974,7 +959,6 @@ class resnet50:
             x_width,
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True,
             enable_split_reader=True,
             enable_subblock_padding=not is_grayskull(),
@@ -997,7 +981,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=False,
             enable_split_reader=True,
             enable_subblock_padding=not is_grayskull(),
@@ -1011,7 +994,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=False,
             enable_split_reader=True,
             enable_subblock_padding=not is_grayskull(),
@@ -1055,7 +1037,6 @@ class resnet50:
             x_width,
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True,
             enable_split_reader=True,
             enable_subblock_padding=False,
@@ -1079,7 +1060,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True,
             enable_split_reader=True,
             enable_subblock_padding=False,
@@ -1093,7 +1073,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True,
             enable_split_reader=True,
             enable_subblock_padding=False,
@@ -1107,7 +1086,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True,
             enable_split_reader=True,
             enable_subblock_padding=False,
@@ -1147,7 +1125,6 @@ class resnet50:
             x_width,
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True,
             enable_split_reader=False,
             enable_subblock_padding=False,
@@ -1170,7 +1147,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True,
             enable_split_reader=False,
             enable_subblock_padding=False,
@@ -1183,7 +1159,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True,
             enable_split_reader=False,
             enable_subblock_padding=False,
@@ -1197,7 +1172,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True,
             enable_split_reader=False,
             enable_subblock_padding=False,
@@ -1211,7 +1185,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True,
             enable_split_reader=False,
             enable_subblock_padding=False,
@@ -1226,7 +1199,6 @@ class resnet50:
             x_height,
             x_width,
             eltwise_binary_out_in_place=True,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True,
             enable_split_reader=False,
             enable_subblock_padding=False,
@@ -1275,7 +1247,6 @@ class resnet50:
             x_width,
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True,
             enable_split_reader=False,
             enable_subblock_padding=False,
@@ -1290,7 +1261,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True,
             enable_split_reader=False,
             enable_subblock_padding=False,
@@ -1304,7 +1274,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True,
             enable_split_reader=False,
             enable_subblock_padding=False,

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xxlarge_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xxlarge_new_conv_api.py
@@ -181,7 +181,6 @@ class resnet50Bottleneck:
                     deallocate_activation=True,
                     reallocate_halo_output=True,
                     reshard_if_not_optimal=reshard_if_not_optimal,
-                    transpose_shards=height_sharding,
                 ),
             }
 
@@ -260,7 +259,6 @@ class resnet50Bottleneck:
                 if height_sharding
                 else ttnn.TensorMemoryLayout.BLOCK_SHARDED,
                 reshard_if_not_optimal=reshard_if_not_optimal,
-                transpose_shards=height_sharding,
             ),
         }
 
@@ -394,7 +392,6 @@ class resnet50Bottleneck:
                 if height_sharding
                 else ttnn.TensorMemoryLayout.BLOCK_SHARDED,
                 reshard_if_not_optimal=reshard_if_not_optimal,
-                transpose_shards=height_sharding,
             ),
         }
 
@@ -450,7 +447,6 @@ class resnet50Bottleneck:
                 if height_sharding
                 else ttnn.TensorMemoryLayout.BLOCK_SHARDED,
                 reshard_if_not_optimal=reshard_if_not_optimal,
-                transpose_shards=height_sharding,
             ),
         }
         if not ttnn.is_tensor_storage_on_device(self.conv3_weight_tensor):

--- a/models/demos/ufld_v2/tests/test_ufld_v2_perf.py
+++ b/models/demos/ufld_v2/tests/test_ufld_v2_perf.py
@@ -117,7 +117,7 @@ def test_ufld_v2_perf(device, batch_size, input_channels, height, width, use_pre
 @pytest.mark.parametrize(
     "batch_size, expected_perf,test",
     [
-        [1, 304, "UFLD-v2"],
+        [1, 330, "UFLD-v2"],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/vgg/tests/test_perf_vgg.py
+++ b/models/demos/vgg/tests/test_perf_vgg.py
@@ -122,10 +122,10 @@ def test_perf_device_bare_metal_vgg(batch_size, model_name):
     margin = 0.03
 
     if model_name == "ttnn_vgg11":
-        expected_perf = 150 if is_grayskull() else 372
+        expected_perf = 150 if is_grayskull() else 447
         command = f"pytest tests/ttnn/integration_tests/vgg/test_ttnn_vgg11.py"
     else:
-        expected_perf = 138 if is_grayskull() else 286
+        expected_perf = 138 if is_grayskull() else 362
         command = f"pytest tests/ttnn/integration_tests/vgg/test_ttnn_vgg16.py"
 
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/demos/vgg/tt/ttnn_vgg.py
+++ b/models/demos/vgg/tt/ttnn_vgg.py
@@ -92,7 +92,6 @@ def ttnn_vgg16(
                 activation="relu",
                 deallocate_activation=False,
                 reallocate_halo_output=False,
-                transpose_shards=True,
                 shard_layout=(
                     ttnn.TensorMemoryLayout.HEIGHT_SHARDED if h_sharding else ttnn.TensorMemoryLayout.BLOCK_SHARDED
                 ),
@@ -244,7 +243,6 @@ def ttnn_vgg11(
                 activation="relu",
                 deallocate_activation=False,
                 reallocate_halo_output=False,
-                transpose_shards=True,
                 shard_layout=(
                     ttnn.TensorMemoryLayout.HEIGHT_SHARDED if h_sharding else ttnn.TensorMemoryLayout.BLOCK_SHARDED
                 ),

--- a/models/demos/vgg_unet/ttnn/model_preprocessing.py
+++ b/models/demos/vgg_unet/ttnn/model_preprocessing.py
@@ -99,7 +99,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.s1["0"]["deallocate_activation"] = True
     parameters.conv_args.s1["0"]["reshard_if_not_optimal"] = False
     parameters.conv_args.s1["0"]["shard_layout"] = None
-    parameters.conv_args.s1["0"]["transpose_shards"] = False
     parameters.conv_args.s1["0"]["activation"] = "relu"
 
     parameters.conv_args.s1["2"]["act_block_h"] = None
@@ -108,7 +107,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.s1["2"]["deallocate_activation"] = True
     parameters.conv_args.s1["2"]["reshard_if_not_optimal"] = False
     parameters.conv_args.s1["2"]["shard_layout"] = None
-    parameters.conv_args.s1["2"]["transpose_shards"] = False
     parameters.conv_args.s1["2"]["activation"] = "relu"
 
     parameters.conv_args.s2["5"]["act_block_h"] = None
@@ -117,7 +115,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.s2["5"]["deallocate_activation"] = True
     parameters.conv_args.s2["5"]["reshard_if_not_optimal"] = False
     parameters.conv_args.s2["5"]["shard_layout"] = None
-    parameters.conv_args.s2["5"]["transpose_shards"] = False
     parameters.conv_args.s2["5"]["activation"] = "relu"
 
     parameters.conv_args.s2["7"]["act_block_h"] = None
@@ -126,7 +123,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.s2["7"]["deallocate_activation"] = True
     parameters.conv_args.s2["7"]["reshard_if_not_optimal"] = False
     parameters.conv_args.s2["7"]["shard_layout"] = None
-    parameters.conv_args.s2["7"]["transpose_shards"] = False
     parameters.conv_args.s2["7"]["activation"] = "relu"
 
     parameters.conv_args.s3["10"]["act_block_h"] = None
@@ -135,7 +131,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.s3["10"]["deallocate_activation"] = True
     parameters.conv_args.s3["10"]["reshard_if_not_optimal"] = False
     parameters.conv_args.s3["10"]["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    parameters.conv_args.s3["10"]["transpose_shards"] = False
     parameters.conv_args.s3["10"]["activation"] = "relu"
 
     parameters.conv_args.s3["12"]["act_block_h"] = None
@@ -144,7 +139,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.s3["12"]["deallocate_activation"] = True
     parameters.conv_args.s3["12"]["reshard_if_not_optimal"] = False
     parameters.conv_args.s3["12"]["shard_layout"] = None
-    parameters.conv_args.s3["12"]["transpose_shards"] = False
     parameters.conv_args.s3["12"]["activation"] = "relu"
 
     parameters.conv_args.s3["14"]["act_block_h"] = None
@@ -153,7 +147,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.s3["14"]["deallocate_activation"] = True
     parameters.conv_args.s3["14"]["reshard_if_not_optimal"] = False
     parameters.conv_args.s3["14"]["shard_layout"] = None
-    parameters.conv_args.s3["14"]["transpose_shards"] = False
     parameters.conv_args.s3["14"]["activation"] = "relu"
 
     parameters.conv_args.s3["16"]["act_block_h"] = None
@@ -162,7 +155,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.s3["16"]["deallocate_activation"] = True
     parameters.conv_args.s3["16"]["reshard_if_not_optimal"] = False
     parameters.conv_args.s3["16"]["shard_layout"] = None
-    parameters.conv_args.s3["16"]["transpose_shards"] = False
     parameters.conv_args.s3["16"]["activation"] = "relu"
 
     parameters.conv_args.s4["19"]["act_block_h"] = None
@@ -171,7 +163,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.s4["19"]["deallocate_activation"] = True
     parameters.conv_args.s4["19"]["reshard_if_not_optimal"] = False
     parameters.conv_args.s4["19"]["shard_layout"] = None
-    parameters.conv_args.s4["19"]["transpose_shards"] = False
     parameters.conv_args.s4["19"]["activation"] = "relu"
 
     parameters.conv_args.s4["21"]["act_block_h"] = None
@@ -180,7 +171,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.s4["21"]["deallocate_activation"] = True
     parameters.conv_args.s4["21"]["reshard_if_not_optimal"] = False
     parameters.conv_args.s4["21"]["shard_layout"] = None
-    parameters.conv_args.s4["21"]["transpose_shards"] = False
     parameters.conv_args.s4["21"]["activation"] = "relu"
 
     parameters.conv_args.s4["23"]["act_block_h"] = None
@@ -189,7 +179,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.s4["23"]["deallocate_activation"] = True
     parameters.conv_args.s4["23"]["reshard_if_not_optimal"] = False
     parameters.conv_args.s4["23"]["shard_layout"] = None
-    parameters.conv_args.s4["23"]["transpose_shards"] = False
     parameters.conv_args.s4["23"]["activation"] = "relu"
 
     parameters.conv_args.s4["25"]["act_block_h"] = None
@@ -198,7 +187,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.s4["25"]["deallocate_activation"] = True
     parameters.conv_args.s4["25"]["reshard_if_not_optimal"] = False
     parameters.conv_args.s4["25"]["shard_layout"] = None
-    parameters.conv_args.s4["25"]["transpose_shards"] = False
     parameters.conv_args.s4["25"]["activation"] = "relu"
 
     parameters.conv_args.b1["28"]["act_block_h"] = None
@@ -207,7 +195,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.b1["28"]["deallocate_activation"] = True
     parameters.conv_args.b1["28"]["reshard_if_not_optimal"] = False
     parameters.conv_args.b1["28"]["shard_layout"] = None
-    parameters.conv_args.b1["28"]["transpose_shards"] = False
     parameters.conv_args.b1["28"]["activation"] = "relu"
 
     parameters.conv_args.b1["30"]["act_block_h"] = None
@@ -216,7 +203,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.b1["30"]["deallocate_activation"] = True
     parameters.conv_args.b1["30"]["reshard_if_not_optimal"] = False
     parameters.conv_args.b1["30"]["shard_layout"] = None
-    parameters.conv_args.b1["30"]["transpose_shards"] = False
     parameters.conv_args.b1["30"]["activation"] = "relu"
 
     parameters.conv_args.b1["32"]["act_block_h"] = None
@@ -225,7 +211,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.b1["32"]["deallocate_activation"] = True
     parameters.conv_args.b1["32"]["reshard_if_not_optimal"] = False
     parameters.conv_args.b1["32"]["shard_layout"] = None
-    parameters.conv_args.b1["32"]["transpose_shards"] = False
     parameters.conv_args.b1["32"]["activation"] = "relu"
 
     parameters.conv_args.b1["34"]["act_block_h"] = None
@@ -234,7 +219,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.b1["34"]["deallocate_activation"] = True
     parameters.conv_args.b1["34"]["reshard_if_not_optimal"] = False
     parameters.conv_args.b1["34"]["shard_layout"] = None
-    parameters.conv_args.b1["34"]["transpose_shards"] = False
     parameters.conv_args.b1["34"]["activation"] = "relu"
 
     parameters.conv_args.d1.up["act_block_h"] = None
@@ -243,7 +227,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.d1.up["deallocate_activation"] = False
     parameters.conv_args.d1.up["reshard_if_not_optimal"] = False
     parameters.conv_args.d1.up["shard_layout"] = None
-    parameters.conv_args.d1.up["transpose_shards"] = False
     parameters.conv_args.d1.up["dtype"] = ttnn.bfloat16
 
     parameters.conv_args.d1.conv_block.conv1["act_block_h"] = None
@@ -252,7 +235,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.d1.conv_block.conv1["deallocate_activation"] = True
     parameters.conv_args.d1.conv_block.conv1["reshard_if_not_optimal"] = False
     parameters.conv_args.d1.conv_block.conv1["shard_layout"] = None
-    parameters.conv_args.d1.conv_block.conv1["transpose_shards"] = False
     parameters.conv_args.d1.conv_block.conv1["activation"] = "relu"
     parameters.conv_args.d1.conv_block.conv1["padding"] = (1, 1)
     parameters.conv_args.d1.conv_block.conv1["do_sharded_to_interleaved"] = True
@@ -263,7 +245,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.d1.conv_block.conv2["deallocate_activation"] = True
     parameters.conv_args.d1.conv_block.conv2["reshard_if_not_optimal"] = False
     parameters.conv_args.d1.conv_block.conv2["shard_layout"] = None
-    parameters.conv_args.d1.conv_block.conv2["transpose_shards"] = False
     parameters.conv_args.d1.conv_block.conv2["activation"] = "relu"
     parameters.conv_args.d1.conv_block.conv2["padding"] = (1, 1)
     parameters.conv_args.d1.conv_block.conv2["do_sharded_to_interleaved"] = True
@@ -274,7 +255,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.d2.up["deallocate_activation"] = True
     parameters.conv_args.d2.up["reshard_if_not_optimal"] = False
     parameters.conv_args.d2.up["shard_layout"] = None
-    parameters.conv_args.d2.up["transpose_shards"] = False
     parameters.conv_args.d2.up["dtype"] = ttnn.bfloat16
 
     parameters.conv_args.d2.conv_block.conv1["act_block_h"] = None
@@ -283,7 +263,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.d2.conv_block.conv1["deallocate_activation"] = True
     parameters.conv_args.d2.conv_block.conv1["reshard_if_not_optimal"] = False
     parameters.conv_args.d2.conv_block.conv1["shard_layout"] = None
-    parameters.conv_args.d2.conv_block.conv1["transpose_shards"] = False
     parameters.conv_args.d2.conv_block.conv1["activation"] = "relu"
     parameters.conv_args.d2.conv_block.conv1["padding"] = (1, 1)
     parameters.conv_args.d2.conv_block.conv1["do_sharded_to_interleaved"] = True
@@ -294,7 +273,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.d2.conv_block.conv2["deallocate_activation"] = True
     parameters.conv_args.d2.conv_block.conv2["reshard_if_not_optimal"] = False
     parameters.conv_args.d2.conv_block.conv2["shard_layout"] = None
-    parameters.conv_args.d2.conv_block.conv2["transpose_shards"] = False
     parameters.conv_args.d2.conv_block.conv2["activation"] = "relu"
     parameters.conv_args.d2.conv_block.conv2["padding"] = (1, 1)
     parameters.conv_args.d2.conv_block.conv2["do_sharded_to_interleaved"] = False
@@ -305,7 +283,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.d3.up["deallocate_activation"] = True
     parameters.conv_args.d3.up["reshard_if_not_optimal"] = False
     parameters.conv_args.d3.up["shard_layout"] = None
-    parameters.conv_args.d3.up["transpose_shards"] = False
     parameters.conv_args.d3.up["dtype"] = ttnn.bfloat16
 
     parameters.conv_args.d3.conv_block.conv1["act_block_h"] = None
@@ -314,7 +291,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.d3.conv_block.conv1["deallocate_activation"] = True
     parameters.conv_args.d3.conv_block.conv1["reshard_if_not_optimal"] = False
     parameters.conv_args.d3.conv_block.conv1["shard_layout"] = None
-    parameters.conv_args.d3.conv_block.conv1["transpose_shards"] = False
     parameters.conv_args.d3.conv_block.conv1["activation"] = "relu"
     parameters.conv_args.d3.conv_block.conv1["padding"] = (1, 1)
     parameters.conv_args.d3.conv_block.conv1["do_sharded_to_interleaved"] = True
@@ -325,7 +301,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.d3.conv_block.conv2["deallocate_activation"] = True
     parameters.conv_args.d3.conv_block.conv2["reshard_if_not_optimal"] = False
     parameters.conv_args.d3.conv_block.conv2["shard_layout"] = None
-    parameters.conv_args.d3.conv_block.conv2["transpose_shards"] = False
     parameters.conv_args.d3.conv_block.conv2["activation"] = "relu"
     parameters.conv_args.d3.conv_block.conv2["padding"] = (1, 1)
     parameters.conv_args.d3.conv_block.conv2["do_sharded_to_interleaved"] = True
@@ -336,7 +311,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.d4.up["deallocate_activation"] = True
     parameters.conv_args.d4.up["reshard_if_not_optimal"] = False
     parameters.conv_args.d4.up["shard_layout"] = None
-    parameters.conv_args.d4.up["transpose_shards"] = False
     parameters.conv_args.d4.up["dtype"] = ttnn.bfloat16
 
     parameters.conv_args.d4.conv_block.conv1["act_block_h"] = None
@@ -345,7 +319,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.d4.conv_block.conv1["deallocate_activation"] = True
     parameters.conv_args.d4.conv_block.conv1["reshard_if_not_optimal"] = False
     parameters.conv_args.d4.conv_block.conv1["shard_layout"] = None
-    parameters.conv_args.d4.conv_block.conv1["transpose_shards"] = False
     parameters.conv_args.d4.conv_block.conv1["activation"] = "relu"
     parameters.conv_args.d4.conv_block.conv1["padding"] = (1, 1)
     parameters.conv_args.d4.conv_block.conv1["do_sharded_to_interleaved"] = True
@@ -356,7 +329,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.d4.conv_block.conv2["deallocate_activation"] = True
     parameters.conv_args.d4.conv_block.conv2["reshard_if_not_optimal"] = False
     parameters.conv_args.d4.conv_block.conv2["shard_layout"] = None
-    parameters.conv_args.d4.conv_block.conv2["transpose_shards"] = False
     parameters.conv_args.d4.conv_block.conv2["activation"] = "relu"
     parameters.conv_args.d4.conv_block.conv2["padding"] = (1, 1)
     parameters.conv_args.d4.conv_block.conv2["do_sharded_to_interleaved"] = True
@@ -367,7 +339,6 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.out["deallocate_activation"] = True
     parameters.conv_args.out["reshard_if_not_optimal"] = False
     parameters.conv_args.out["shard_layout"] = None
-    parameters.conv_args.out["transpose_shards"] = False
     parameters.conv_args.out["activation"] = ""
     parameters.conv_args.out["padding"] = (0, 0)
 

--- a/models/demos/vgg_unet/ttnn/ttnn_vgg_unet.py
+++ b/models/demos/vgg_unet/ttnn/ttnn_vgg_unet.py
@@ -62,7 +62,6 @@ class Conv:
             enable_act_double_buffer=conv_param.enable_act_double_buffer,
             enable_split_reader=conv_param.enable_split_reader,
             output_layout=ttnn.ROW_MAJOR_LAYOUT,
-            transpose_shards=conv_param.transpose_shards,
         )
         config_override = None
         if conv_param.act_block_h is not None:

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_downsample_2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_downsample_2d_new_conv.py
@@ -120,7 +120,6 @@ class downsample_2d:
             weights_dtype=ttnn.bfloat8_b,
             activation="",
             shard_layout=self.shard_layout,
-            transpose_shards=False,
             reshard_if_not_optimal=False,
         )
 

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
@@ -444,7 +444,6 @@ class resnetBlock2D:
                 weights_dtype=ttnn.bfloat8_b,
                 activation="",
                 shard_layout=self.conv1_shard_layout,
-                transpose_shards=False,
                 reshard_if_not_optimal=False,
             )
             compute_config = ttnn.init_device_compute_kernel_config(
@@ -543,7 +542,6 @@ class resnetBlock2D:
                     weights_dtype=ttnn.bfloat8_b,
                     activation="",
                     shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-                    transpose_shards=False,
                     reshard_if_not_optimal=False,
                 )
                 compute_config = ttnn.init_device_compute_kernel_config(
@@ -697,7 +695,6 @@ class resnetBlock2D:
             weights_dtype=ttnn.bfloat8_b,
             activation="",
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            transpose_shards=False,
             reshard_if_not_optimal=False,
         )
         compute_config = get_default_compute_config(self.device)
@@ -765,7 +762,6 @@ class resnetBlock2D:
                 weights_dtype=ttnn.bfloat8_b,
                 activation="",
                 shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-                transpose_shards=False,
                 reshard_if_not_optimal=False,
             )
             compute_config = ttnn.init_device_compute_kernel_config(

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
@@ -243,7 +243,6 @@ class transformer_2d_model:
             weights_dtype=ttnn.bfloat8_b,
             activation="",
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            transpose_shards=False,
             reshard_if_not_optimal=False,
             override_sharding_config=True,
             core_grid=core_grid,
@@ -327,7 +326,6 @@ class transformer_2d_model:
                     weights_dtype=ttnn.bfloat8_b,
                     activation="",
                     shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-                    transpose_shards=False,
                 )
                 compute_config = ttnn.init_device_compute_kernel_config(
                     self.device.arch(),

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model_new_conv.py
@@ -355,7 +355,6 @@ class UNet2DConditionModel:
             weights_dtype=ttnn.bfloat8_b,
             activation="",
             shard_layout=shard_layout,
-            transpose_shards=False,
             reshard_if_not_optimal=True,
         )
         compute_config = get_default_compute_config(self.device)
@@ -639,7 +638,6 @@ class UNet2DConditionModel:
             activation="",
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             act_block_h_override=64,
-            transpose_shards=False,
             reshard_if_not_optimal=True,
         )
         compute_config = get_default_compute_config(self.device)

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_upsample_2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_upsample_2d_new_conv.py
@@ -82,7 +82,6 @@ class upsample2d:
             weights_dtype=ttnn.bfloat8_b,
             activation="",
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            transpose_shards=False,
             reshard_if_not_optimal=False,  # Reshard has error : 1616 Bytes unique+common runtime args targeting kernel reshard_reader on (x=0,y=0) are too large. Cannot be written as they will run into memory region reserved for result. Max allowable size is 1024 Bytes
         )
         compute_config = get_default_compute_config(self.device)

--- a/models/demos/yolov4/tt/common.py
+++ b/models/demos/yolov4/tt/common.py
@@ -29,7 +29,6 @@ class Conv:
             enable_act_double_buffer=conv_param.enable_act_double_buffer,
             enable_split_reader=conv_param.enable_split_reader,
             output_layout=ttnn.TILE_LAYOUT,
-            transpose_shards=conv_param.transpose_shards,
         )
         config_override = None
         if conv_param.act_block_h is not None:

--- a/models/demos/yolov4/tt/model_preprocessing.py
+++ b/models/demos/yolov4/tt/model_preprocessing.py
@@ -104,7 +104,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c1["deallocate_activation"] = True
         conv_args.c1["reshard_if_not_optimal"] = False
         conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        conv_args.c1["transpose_shards"] = False
 
         conv_args.c2["act_block_h"] = None
         conv_args.c2["enable_split_reader"] = True
@@ -112,7 +111,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c2["deallocate_activation"] = True
         conv_args.c2["reshard_if_not_optimal"] = False
         conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        conv_args.c2["transpose_shards"] = False
 
         conv_args.c3["act_block_h"] = None
         conv_args.c3["enable_split_reader"] = True
@@ -120,7 +118,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c3["deallocate_activation"] = False
         conv_args.c3["reshard_if_not_optimal"] = False
         conv_args.c3["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        conv_args.c3["transpose_shards"] = False
 
         conv_args.c4["act_block_h"] = None
         conv_args.c4["enable_split_reader"] = True
@@ -128,7 +125,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c4["deallocate_activation"] = True
         conv_args.c4["reshard_if_not_optimal"] = False
         conv_args.c4["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        conv_args.c4["transpose_shards"] = False
 
         conv_args.c5["act_block_h"] = None
         conv_args.c5["enable_split_reader"] = True
@@ -136,7 +132,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c5["deallocate_activation"] = False
         conv_args.c5["reshard_if_not_optimal"] = False
         conv_args.c5["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        conv_args.c5["transpose_shards"] = False
 
         conv_args.c6["act_block_h"] = None
         conv_args.c6["enable_split_reader"] = True
@@ -144,7 +139,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c6["deallocate_activation"] = True
         conv_args.c6["reshard_if_not_optimal"] = False
         conv_args.c6["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        conv_args.c6["transpose_shards"] = False
 
         conv_args.c7["act_block_h"] = None
         conv_args.c7["enable_split_reader"] = True
@@ -152,7 +146,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c7["deallocate_activation"] = True
         conv_args.c7["reshard_if_not_optimal"] = False
         conv_args.c7["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        conv_args.c7["transpose_shards"] = False
 
         conv_args.c8["act_block_h"] = None
         conv_args.c8["enable_split_reader"] = True
@@ -160,7 +153,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c8["deallocate_activation"] = True
         conv_args.c8["reshard_if_not_optimal"] = False
         conv_args.c8["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        conv_args.c8["transpose_shards"] = False
     elif resolution == (640, 640):
         conv_args.c1["act_block_h"] = 256
         conv_args.c1["enable_split_reader"] = False
@@ -168,7 +160,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c1["deallocate_activation"] = True
         conv_args.c1["reshard_if_not_optimal"] = False
         conv_args.c1["shard_layout"] = None
-        conv_args.c1["transpose_shards"] = True
 
         conv_args.c2["act_block_h"] = None
         conv_args.c2["enable_split_reader"] = False
@@ -176,7 +167,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c2["deallocate_activation"] = True
         conv_args.c2["reshard_if_not_optimal"] = False
         conv_args.c2["shard_layout"] = None
-        conv_args.c2["transpose_shards"] = False
 
         conv_args.c3["act_block_h"] = None
         conv_args.c3["enable_split_reader"] = True
@@ -184,7 +174,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c3["deallocate_activation"] = False
         conv_args.c3["reshard_if_not_optimal"] = False
         conv_args.c3["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        conv_args.c3["transpose_shards"] = False
 
         conv_args.c4["act_block_h"] = None
         conv_args.c4["enable_split_reader"] = True
@@ -192,7 +181,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c4["deallocate_activation"] = True
         conv_args.c4["reshard_if_not_optimal"] = False
         conv_args.c4["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        conv_args.c4["transpose_shards"] = False
 
         conv_args.c5["act_block_h"] = None
         conv_args.c5["enable_split_reader"] = True
@@ -200,7 +188,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c5["deallocate_activation"] = False
         conv_args.c5["reshard_if_not_optimal"] = False
         conv_args.c5["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        conv_args.c5["transpose_shards"] = False
 
         conv_args.c6["act_block_h"] = 256
         conv_args.c6["enable_split_reader"] = False
@@ -208,7 +195,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c6["deallocate_activation"] = True
         conv_args.c6["reshard_if_not_optimal"] = False
         conv_args.c6["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        conv_args.c6["transpose_shards"] = False
 
         conv_args.c7["act_block_h"] = None
         conv_args.c7["enable_split_reader"] = True
@@ -216,7 +202,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c7["deallocate_activation"] = True
         conv_args.c7["reshard_if_not_optimal"] = False
         conv_args.c7["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        conv_args.c7["transpose_shards"] = False
 
         conv_args.c8["act_block_h"] = None
         conv_args.c8["enable_split_reader"] = True
@@ -224,7 +209,6 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c8["deallocate_activation"] = True
         conv_args.c8["reshard_if_not_optimal"] = False
         conv_args.c8["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        conv_args.c8["transpose_shards"] = False
     else:
         raise ValueError(f"Unsupported resolution: {resolution}")
 
@@ -251,7 +235,6 @@ def _create_ds2_model_parameters(conv_args):
     conv_args.c1["deallocate_activation"] = True
     conv_args.c1["reshard_if_not_optimal"] = False
     conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c1["transpose_shards"] = False
 
     conv_args.c2["act_block_h"] = None
     conv_args.c2["enable_split_reader"] = True
@@ -259,7 +242,6 @@ def _create_ds2_model_parameters(conv_args):
     conv_args.c2["deallocate_activation"] = False
     conv_args.c2["reshard_if_not_optimal"] = False
     conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c2["transpose_shards"] = False
 
     conv_args.c3["act_block_h"] = None
     conv_args.c3["enable_split_reader"] = True
@@ -267,7 +249,6 @@ def _create_ds2_model_parameters(conv_args):
     conv_args.c3["deallocate_activation"] = True
     conv_args.c3["reshard_if_not_optimal"] = False
     conv_args.c3["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c3["transpose_shards"] = False
 
     conv_args.c4["act_block_h"] = None
     conv_args.c4["enable_split_reader"] = True
@@ -275,7 +256,6 @@ def _create_ds2_model_parameters(conv_args):
     conv_args.c4["deallocate_activation"] = False
     conv_args.c4["reshard_if_not_optimal"] = False
     conv_args.c4["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c4["transpose_shards"] = False
 
     conv_args.c5["act_block_h"] = None
     conv_args.c5["enable_split_reader"] = True
@@ -283,7 +263,6 @@ def _create_ds2_model_parameters(conv_args):
     conv_args.c5["deallocate_activation"] = True
     conv_args.c5["reshard_if_not_optimal"] = False
     conv_args.c5["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c5["transpose_shards"] = False
 
     conv_args.res["0"]["act_block_h"] = None
     conv_args.res["0"]["enable_split_reader"] = True
@@ -291,7 +270,6 @@ def _create_ds2_model_parameters(conv_args):
     conv_args.res["0"]["deallocate_activation"] = False
     conv_args.res["0"]["reshard_if_not_optimal"] = False
     conv_args.res["0"]["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.res["0"]["transpose_shards"] = False
 
     conv_args.res["3"]["act_block_h"] = None
     conv_args.res["3"]["enable_split_reader"] = True
@@ -299,7 +277,6 @@ def _create_ds2_model_parameters(conv_args):
     conv_args.res["3"]["deallocate_activation"] = True
     conv_args.res["3"]["reshard_if_not_optimal"] = False
     conv_args.res["3"]["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.res["3"]["transpose_shards"] = False
 
 
 def create_ds2_model_parameters(model: yolov4.Yolov4, input_tensor: torch.Tensor, resolution, device):
@@ -324,7 +301,6 @@ def _create_ds3_model_parameters(conv_args):
     conv_args.c1["deallocate_activation"] = True
     conv_args.c1["reshard_if_not_optimal"] = False
     conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c1["transpose_shards"] = False
 
     conv_args.c2["act_block_h"] = None
     conv_args.c2["enable_split_reader"] = False
@@ -332,7 +308,6 @@ def _create_ds3_model_parameters(conv_args):
     conv_args.c2["deallocate_activation"] = False
     conv_args.c2["reshard_if_not_optimal"] = False
     conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c2["transpose_shards"] = False
 
     conv_args.c3["act_block_h"] = None
     conv_args.c3["enable_split_reader"] = False
@@ -340,7 +315,6 @@ def _create_ds3_model_parameters(conv_args):
     conv_args.c3["deallocate_activation"] = True
     conv_args.c3["reshard_if_not_optimal"] = False
     conv_args.c3["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c3["transpose_shards"] = False
 
     conv_args.c4["act_block_h"] = None
     conv_args.c4["enable_split_reader"] = False
@@ -348,7 +322,6 @@ def _create_ds3_model_parameters(conv_args):
     conv_args.c4["deallocate_activation"] = False
     conv_args.c4["reshard_if_not_optimal"] = False
     conv_args.c4["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c4["transpose_shards"] = False
 
     conv_args.c5["act_block_h"] = None
     conv_args.c5["enable_split_reader"] = False
@@ -356,7 +329,6 @@ def _create_ds3_model_parameters(conv_args):
     conv_args.c5["deallocate_activation"] = True
     conv_args.c5["reshard_if_not_optimal"] = False
     conv_args.c5["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c5["transpose_shards"] = False
 
     conv_args.res["0"]["act_block_h"] = None
     conv_args.res["0"]["enable_split_reader"] = False
@@ -364,7 +336,6 @@ def _create_ds3_model_parameters(conv_args):
     conv_args.res["0"]["deallocate_activation"] = False
     conv_args.res["0"]["reshard_if_not_optimal"] = False
     conv_args.res["0"]["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.res["0"]["transpose_shards"] = False
 
     conv_args.res["3"]["act_block_h"] = None
     conv_args.res["3"]["enable_split_reader"] = False
@@ -372,7 +343,6 @@ def _create_ds3_model_parameters(conv_args):
     conv_args.res["3"]["deallocate_activation"] = True
     conv_args.res["3"]["reshard_if_not_optimal"] = False
     conv_args.res["3"]["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.res["3"]["transpose_shards"] = False
 
 
 def create_ds3_model_parameters(model: yolov4.Yolov4, input_tensor: torch.Tensor, resolution, device):
@@ -397,7 +367,6 @@ def _create_ds4_model_parameters(conv_args):
     conv_args.c1["deallocate_activation"] = False
     conv_args.c1["reshard_if_not_optimal"] = True
     conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c1["transpose_shards"] = False
 
     conv_args.c2["act_block_h"] = None
     conv_args.c2["enable_split_reader"] = False
@@ -405,7 +374,6 @@ def _create_ds4_model_parameters(conv_args):
     conv_args.c2["deallocate_activation"] = False
     conv_args.c2["reshard_if_not_optimal"] = False
     conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c2["transpose_shards"] = False
 
     conv_args.c3["act_block_h"] = None
     conv_args.c3["enable_split_reader"] = False
@@ -413,7 +381,6 @@ def _create_ds4_model_parameters(conv_args):
     conv_args.c3["deallocate_activation"] = False
     conv_args.c3["reshard_if_not_optimal"] = False
     conv_args.c3["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c3["transpose_shards"] = False
 
     conv_args.c4["act_block_h"] = None
     conv_args.c4["enable_split_reader"] = False
@@ -421,7 +388,6 @@ def _create_ds4_model_parameters(conv_args):
     conv_args.c4["deallocate_activation"] = False
     conv_args.c4["reshard_if_not_optimal"] = False
     conv_args.c4["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c4["transpose_shards"] = False
 
     conv_args.c5["act_block_h"] = None
     conv_args.c5["enable_split_reader"] = False
@@ -429,7 +395,6 @@ def _create_ds4_model_parameters(conv_args):
     conv_args.c5["deallocate_activation"] = True
     conv_args.c5["reshard_if_not_optimal"] = False
     conv_args.c5["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c5["transpose_shards"] = False
 
     conv_args.res["0"]["act_block_h"] = None
     conv_args.res["0"]["enable_split_reader"] = False
@@ -437,7 +402,6 @@ def _create_ds4_model_parameters(conv_args):
     conv_args.res["0"]["deallocate_activation"] = False
     conv_args.res["0"]["reshard_if_not_optimal"] = False
     conv_args.res["0"]["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.res["0"]["transpose_shards"] = False
 
     conv_args.res["3"]["act_block_h"] = None
     conv_args.res["3"]["enable_split_reader"] = False
@@ -445,7 +409,6 @@ def _create_ds4_model_parameters(conv_args):
     conv_args.res["3"]["deallocate_activation"] = True
     conv_args.res["3"]["reshard_if_not_optimal"] = False
     conv_args.res["3"]["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.res["3"]["transpose_shards"] = False
 
 
 def create_ds4_model_parameters(model: yolov4.Yolov4, input_tensor: torch.Tensor, resolution, device):
@@ -470,7 +433,6 @@ def _create_ds5_model_parameters(conv_args):
     conv_args.c1["deallocate_activation"] = False
     conv_args.c1["reshard_if_not_optimal"] = True
     conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c1["transpose_shards"] = False
 
     conv_args.c2["act_block_h"] = None
     conv_args.c2["enable_split_reader"] = False
@@ -478,7 +440,6 @@ def _create_ds5_model_parameters(conv_args):
     conv_args.c2["deallocate_activation"] = False
     conv_args.c2["reshard_if_not_optimal"] = False
     conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    conv_args.c2["transpose_shards"] = False
 
     conv_args.c3["act_block_h"] = None
     conv_args.c3["enable_split_reader"] = False
@@ -486,7 +447,6 @@ def _create_ds5_model_parameters(conv_args):
     conv_args.c3["deallocate_activation"] = True
     conv_args.c3["reshard_if_not_optimal"] = False
     conv_args.c3["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c3["transpose_shards"] = False
 
     conv_args.c4["act_block_h"] = None
     conv_args.c4["enable_split_reader"] = False
@@ -494,7 +454,6 @@ def _create_ds5_model_parameters(conv_args):
     conv_args.c4["deallocate_activation"] = False
     conv_args.c4["reshard_if_not_optimal"] = False
     conv_args.c4["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    conv_args.c4["transpose_shards"] = False
 
     conv_args.c5["act_block_h"] = None
     conv_args.c5["enable_split_reader"] = False
@@ -502,7 +461,6 @@ def _create_ds5_model_parameters(conv_args):
     conv_args.c5["deallocate_activation"] = True
     conv_args.c5["reshard_if_not_optimal"] = False
     conv_args.c5["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c5["transpose_shards"] = False
 
     conv_args.res["0"]["act_block_h"] = None
     conv_args.res["0"]["enable_split_reader"] = False
@@ -510,7 +468,6 @@ def _create_ds5_model_parameters(conv_args):
     conv_args.res["0"]["deallocate_activation"] = False
     conv_args.res["0"]["reshard_if_not_optimal"] = False
     conv_args.res["0"]["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    conv_args.res["0"]["transpose_shards"] = False
 
     conv_args.res["3"]["act_block_h"] = None
     conv_args.res["3"]["enable_split_reader"] = False
@@ -518,7 +475,6 @@ def _create_ds5_model_parameters(conv_args):
     conv_args.res["3"]["deallocate_activation"] = True
     conv_args.res["3"]["reshard_if_not_optimal"] = False
     conv_args.res["3"]["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    conv_args.res["3"]["transpose_shards"] = False
 
 
 def create_ds5_model_parameters(model: yolov4.Yolov4, input_tensor: torch.Tensor, resolution, device):
@@ -543,7 +499,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c1["deallocate_activation"] = True
     conv_args.c1["reshard_if_not_optimal"] = True
     conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c1["transpose_shards"] = False
 
     conv_args.c2["act_block_h"] = None
     conv_args.c2["enable_split_reader"] = False
@@ -551,7 +506,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c2["deallocate_activation"] = True
     conv_args.c2["reshard_if_not_optimal"] = False
     conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    conv_args.c2["transpose_shards"] = False
 
     conv_args.c3["act_block_h"] = None
     conv_args.c3["enable_split_reader"] = False
@@ -559,7 +513,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c3["deallocate_activation"] = True
     conv_args.c3["reshard_if_not_optimal"] = False
     conv_args.c3["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c3["transpose_shards"] = False
 
     conv_args.c4["act_block_h"] = None
     conv_args.c4["enable_split_reader"] = False
@@ -567,7 +520,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c4["deallocate_activation"] = True
     conv_args.c4["reshard_if_not_optimal"] = False
     conv_args.c4["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c4["transpose_shards"] = False
 
     conv_args.c5["act_block_h"] = None
     conv_args.c5["enable_split_reader"] = False
@@ -575,7 +527,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c5["deallocate_activation"] = True
     conv_args.c5["reshard_if_not_optimal"] = False
     conv_args.c5["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    conv_args.c5["transpose_shards"] = False
 
     conv_args.c6["act_block_h"] = None
     conv_args.c6["enable_split_reader"] = False
@@ -583,7 +534,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c6["deallocate_activation"] = True
     conv_args.c6["reshard_if_not_optimal"] = False
     conv_args.c6["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c6["transpose_shards"] = False
 
     conv_args.c7["act_block_h"] = None
     conv_args.c7["enable_split_reader"] = False
@@ -591,7 +541,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c7["deallocate_activation"] = False
     conv_args.c7["reshard_if_not_optimal"] = False
     conv_args.c7["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    conv_args.c7["transpose_shards"] = False
 
     conv_args.c7_2["act_block_h"] = None
     conv_args.c7_2["enable_split_reader"] = True
@@ -599,7 +548,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c7_2["deallocate_activation"] = True
     conv_args.c7_2["reshard_if_not_optimal"] = False
     conv_args.c7_2["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c7_2["transpose_shards"] = False
 
     conv_args.c7_3["act_block_h"] = None
     conv_args.c7_3["enable_split_reader"] = True
@@ -607,7 +555,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c7_3["deallocate_activation"] = True
     conv_args.c7_3["reshard_if_not_optimal"] = False
     conv_args.c7_3["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c7_3["transpose_shards"] = False
 
     conv_args.c7_4["act_block_h"] = None
     conv_args.c7_4["enable_split_reader"] = True
@@ -615,7 +562,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c7_4["deallocate_activation"] = True
     conv_args.c7_4["reshard_if_not_optimal"] = False
     conv_args.c7_4["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c7_4["transpose_shards"] = False
 
     conv_args.c7_5["act_block_h"] = None
     conv_args.c7_5["enable_split_reader"] = True
@@ -623,7 +569,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c7_5["deallocate_activation"] = True
     conv_args.c7_5["reshard_if_not_optimal"] = False
     conv_args.c7_5["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c7_5["transpose_shards"] = False
 
     conv_args.c8["act_block_h"] = None
     conv_args.c8["enable_split_reader"] = False
@@ -631,7 +576,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c8["deallocate_activation"] = True
     conv_args.c8["reshard_if_not_optimal"] = False
     conv_args.c8["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c8["transpose_shards"] = False
 
     conv_args.c8_2["act_block_h"] = None
     conv_args.c8_2["enable_split_reader"] = False
@@ -639,7 +583,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c8_2["deallocate_activation"] = True
     conv_args.c8_2["reshard_if_not_optimal"] = False
     conv_args.c8_2["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c8_2["transpose_shards"] = False
 
     conv_args.c9["act_block_h"] = None
     conv_args.c9["enable_split_reader"] = True
@@ -647,7 +590,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c9["deallocate_activation"] = False
     conv_args.c9["reshard_if_not_optimal"] = False
     conv_args.c9["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c9["transpose_shards"] = False
 
     conv_args.c9_2["act_block_h"] = None
     conv_args.c9_2["enable_split_reader"] = False
@@ -655,7 +597,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c9_2["deallocate_activation"] = True
     conv_args.c9_2["reshard_if_not_optimal"] = False
     conv_args.c9_2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c9_2["transpose_shards"] = False
 
     conv_args.c9_3["act_block_h"] = None
     conv_args.c9_3["enable_split_reader"] = False
@@ -663,7 +604,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c9_3["deallocate_activation"] = True
     conv_args.c9_3["reshard_if_not_optimal"] = False
     conv_args.c9_3["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c9_3["transpose_shards"] = False
 
     conv_args.c9_4["act_block_h"] = None
     conv_args.c9_4["enable_split_reader"] = False
@@ -671,7 +611,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c9_4["deallocate_activation"] = True
     conv_args.c9_4["reshard_if_not_optimal"] = False
     conv_args.c9_4["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c9_4["transpose_shards"] = False
 
     conv_args.c9_5["act_block_h"] = None
     conv_args.c9_5["enable_split_reader"] = False
@@ -679,7 +618,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c9_5["deallocate_activation"] = True
     conv_args.c9_5["reshard_if_not_optimal"] = False
     conv_args.c9_5["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c9_5["transpose_shards"] = False
 
     conv_args.c10["act_block_h"] = None
     conv_args.c10["enable_split_reader"] = False
@@ -687,7 +625,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c10["deallocate_activation"] = True
     conv_args.c10["reshard_if_not_optimal"] = False
     conv_args.c10["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c10["transpose_shards"] = False
 
     conv_args.c10_2["act_block_h"] = None
     conv_args.c10_2["enable_split_reader"] = False
@@ -695,7 +632,6 @@ def _create_neck_model_parameters(conv_args):
     conv_args.c10_2["deallocate_activation"] = True
     conv_args.c10_2["reshard_if_not_optimal"] = False
     conv_args.c10_2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c10_2["transpose_shards"] = False
 
 
 def create_neck_model_parameters(model: yolov4.Yolov4, input_tensor: torch.Tensor, resolution, device):
@@ -722,7 +658,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c1["deallocate_activation"] = False
     conv_args.c1["reshard_if_not_optimal"] = True
     conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c1["transpose_shards"] = False
 
     conv_args.c2["act_block_h"] = None
     conv_args.c2["enable_split_reader"] = False
@@ -730,7 +665,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c2["deallocate_activation"] = True
     conv_args.c2["reshard_if_not_optimal"] = False
     conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    conv_args.c2["transpose_shards"] = False
     conv_args.c2["out_channels"] = 256
 
     conv_args.c3["act_block_h"] = None
@@ -739,7 +673,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c3["deallocate_activation"] = False
     conv_args.c3["reshard_if_not_optimal"] = True
     conv_args.c3["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c3["transpose_shards"] = False
 
     conv_args.c4["act_block_h"] = None
     conv_args.c4["enable_split_reader"] = False
@@ -747,7 +680,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c4["deallocate_activation"] = True
     conv_args.c4["reshard_if_not_optimal"] = False
     conv_args.c4["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c4["transpose_shards"] = False
 
     conv_args.c5["act_block_h"] = None
     conv_args.c5["enable_split_reader"] = False
@@ -755,7 +687,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c5["deallocate_activation"] = True
     conv_args.c5["reshard_if_not_optimal"] = False
     conv_args.c5["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c5["transpose_shards"] = False
 
     conv_args.c6["act_block_h"] = None
     conv_args.c6["enable_split_reader"] = False
@@ -763,7 +694,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c6["deallocate_activation"] = True
     conv_args.c6["reshard_if_not_optimal"] = False
     conv_args.c6["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c6["transpose_shards"] = False
 
     conv_args.c7["act_block_h"] = None
     conv_args.c7["enable_split_reader"] = False
@@ -771,7 +701,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c7["deallocate_activation"] = True
     conv_args.c7["reshard_if_not_optimal"] = False
     conv_args.c7["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c7["transpose_shards"] = False
 
     conv_args.c8["act_block_h"] = None
     conv_args.c8["enable_split_reader"] = False
@@ -779,7 +708,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c8["deallocate_activation"] = True
     conv_args.c8["reshard_if_not_optimal"] = False
     conv_args.c8["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c8["transpose_shards"] = False
 
     conv_args.c9["act_block_h"] = None
     conv_args.c9["enable_split_reader"] = False
@@ -787,7 +715,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c9["deallocate_activation"] = False
     conv_args.c9["reshard_if_not_optimal"] = False
     conv_args.c9["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c9["transpose_shards"] = False
 
     conv_args.c10["act_block_h"] = None
     conv_args.c10["enable_split_reader"] = False
@@ -795,7 +722,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c10["deallocate_activation"] = True
     conv_args.c10["reshard_if_not_optimal"] = False
     conv_args.c10["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c10["transpose_shards"] = False
     conv_args.c10["out_channels"] = 256
 
     conv_args.c11["act_block_h"] = None
@@ -809,7 +735,6 @@ def _create_head_model_parameters(conv_args, resolution):
         conv_args.c11["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
     else:
         raise ValueError(f"Unsupported resolution: {resolution}")
-    conv_args.c11["transpose_shards"] = False
 
     conv_args.c12["act_block_h"] = None
     conv_args.c12["enable_split_reader"] = False
@@ -817,7 +742,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c12["deallocate_activation"] = True
     conv_args.c12["reshard_if_not_optimal"] = False
     conv_args.c12["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c12["transpose_shards"] = False
 
     conv_args.c13["act_block_h"] = None
     conv_args.c13["enable_split_reader"] = False
@@ -825,7 +749,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c13["deallocate_activation"] = True
     conv_args.c13["reshard_if_not_optimal"] = False
     conv_args.c13["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    conv_args.c13["transpose_shards"] = False
 
     conv_args.c14["act_block_h"] = None
     conv_args.c14["enable_split_reader"] = False
@@ -833,7 +756,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c14["deallocate_activation"] = True
     conv_args.c14["reshard_if_not_optimal"] = False
     conv_args.c14["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c14["transpose_shards"] = False
 
     conv_args.c15["act_block_h"] = None
     conv_args.c15["enable_split_reader"] = False
@@ -841,7 +763,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c15["deallocate_activation"] = True
     conv_args.c15["reshard_if_not_optimal"] = False
     conv_args.c15["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    conv_args.c15["transpose_shards"] = False
 
     conv_args.c16["act_block_h"] = None
     conv_args.c16["enable_split_reader"] = False
@@ -849,7 +770,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c16["deallocate_activation"] = True
     conv_args.c16["reshard_if_not_optimal"] = False
     conv_args.c16["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c16["transpose_shards"] = False
 
     conv_args.c17["act_block_h"] = None
     conv_args.c17["enable_split_reader"] = False
@@ -857,7 +777,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c17["deallocate_activation"] = True
     conv_args.c17["reshard_if_not_optimal"] = False
     conv_args.c17["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    conv_args.c17["transpose_shards"] = False
 
     conv_args.c18["act_block_h"] = None
     conv_args.c18["enable_split_reader"] = False
@@ -865,7 +784,6 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c18["deallocate_activation"] = True
     conv_args.c18["reshard_if_not_optimal"] = False
     conv_args.c18["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    conv_args.c18["transpose_shards"] = False
     conv_args.c18["out_channels"] = 256
 
 

--- a/models/demos/yolov8x/tt/ttnn_yolov8x.py
+++ b/models/demos/yolov8x/tt/ttnn_yolov8x.py
@@ -97,7 +97,6 @@ class TtConv:
             activation="",
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             act_block_w_div=1,
-            transpose_shards=False,
             deallocate_activation=False,
             enable_act_double_buffer=self.enable_act_double_buffer,
             enable_split_reader=self.enable_split_reader,

--- a/models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py
+++ b/models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py
@@ -228,7 +228,7 @@ def test_vanilla_unet(device, reset_seeds):
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 68.5],
+        [1, 73],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -13,7 +13,7 @@ def test_sdxl_unet_perf_device():
 
     inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
     post_processed_results = run_device_perf(command, subdir="sdxl_unet", num_iterations=3, cols=cols, batch_size=1)
-    expected_perf_cols = {inference_time_key: 498886445}
+    expected_perf_cols = {inference_time_key: 478272848}
     expected_results = check_device_perf(
         post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
     )

--- a/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
@@ -27,7 +27,6 @@ class ModelOptimisations:
             act_block_h_override=256,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["ABH_128_NO_ADB_HS"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -43,7 +42,6 @@ class ModelOptimisations:
             act_block_h_override=128,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
 
         # BLOCK SHARDED
@@ -61,7 +59,6 @@ class ModelOptimisations:
             act_block_h_override=32,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["ABH_64_NO_ADB_BS"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -77,7 +74,6 @@ class ModelOptimisations:
             act_block_h_override=64,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["ABH_64_NO_ADB_WDB_BS"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -94,7 +90,6 @@ class ModelOptimisations:
             act_block_h_override=64,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["ABH_64_ADB_WDB_BS"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -111,7 +106,6 @@ class ModelOptimisations:
             act_block_h_override=64,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
 
         self.conv_configs["ABH_64_NO_ADB_BS_BF16"] = ttnn.Conv2dConfig(
@@ -128,7 +122,6 @@ class ModelOptimisations:
             act_block_h_override=64,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
 
         self.conv_configs["ABH_128_ADB_BS"] = ttnn.Conv2dConfig(
@@ -145,7 +138,6 @@ class ModelOptimisations:
             act_block_h_override=128,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["ABH_128_ADB_WDB_BS"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -162,7 +154,6 @@ class ModelOptimisations:
             act_block_h_override=128,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["ABH_128_NO_ADB_BS"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -178,7 +169,6 @@ class ModelOptimisations:
             act_block_h_override=128,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["ABH_128_NO_ADB_WDB_BS"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -195,7 +185,6 @@ class ModelOptimisations:
             act_block_h_override=128,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["ABH_128_ADB_WDB_NO_DEALLOC_BS"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -212,7 +201,6 @@ class ModelOptimisations:
             act_block_h_override=128,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["ABH_128_NO_ADB_WDB_NO_DEALLOC_BS"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -229,7 +217,6 @@ class ModelOptimisations:
             act_block_h_override=128,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["ABH_256_NO_ADB_BS"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -245,7 +232,6 @@ class ModelOptimisations:
             act_block_h_override=256,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
 
         # WIDTH SHARDED
@@ -264,7 +250,6 @@ class ModelOptimisations:
             act_block_h_override=256,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["ABH_512_NO_ADB_WS"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -281,7 +266,6 @@ class ModelOptimisations:
             act_block_h_override=512,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
 
         # DEFAULT CONF
@@ -298,7 +282,6 @@ class ModelOptimisations:
             act_block_h_override=0,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
 
         # DRAM CONF
@@ -315,7 +298,6 @@ class ModelOptimisations:
             act_block_h_override=64,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["ABH_128_NO_ADB_DRAM"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -330,7 +312,6 @@ class ModelOptimisations:
             act_block_h_override=128,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["ABH_512_NO_ADB_DRAM"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -345,7 +326,6 @@ class ModelOptimisations:
             act_block_h_override=512,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["DEFAULT_DRAM"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -360,7 +340,6 @@ class ModelOptimisations:
             act_block_h_override=0,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
         self.conv_configs["ABH_256_NO_ADB_HS"] = ttnn.Conv2dConfig(
             dtype=conv_act_dtype,
@@ -376,7 +355,6 @@ class ModelOptimisations:
             act_block_h_override=256,
             preprocess_weights_on_device=False,
             always_preprocess_weights=False,
-            transpose_shards=True,
         )
 
     def clear_weight_preprocess(self):

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -188,7 +188,7 @@ class TtResnetBlock2D(nn.Module):
             grid_coord = ttnn.CoreCoord(self.norm_core_grid_1.x - 1, self.norm_core_grid_1.y - 1)
             shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
             shard_shape = B * H * W // self.norm_core_grid_1.x, C // self.norm_core_grid_1.y
-            shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.COL_MAJOR)
+            shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
             sharded_mem_config = ttnn.MemoryConfig(
                 ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
             )
@@ -268,7 +268,7 @@ class TtResnetBlock2D(nn.Module):
         grid_coord = ttnn.CoreCoord(self.norm_core_grid_2.x - 1, self.norm_core_grid_2.y - 1)
         shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
         shard_shape = B * H * W // self.norm_core_grid_2.x, C // self.norm_core_grid_2.y
-        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.COL_MAJOR)
+        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
         sharded_mem_config = ttnn.MemoryConfig(
             ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
         )

--- a/models/experimental/yolov10/tests/perf/test_perf_yolov10.py
+++ b/models/experimental/yolov10/tests/perf/test_perf_yolov10.py
@@ -98,7 +98,7 @@ def test_perf(device, use_weights_from_ultralytics):
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 38.5],
+        [1, 41],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
+++ b/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
@@ -78,7 +78,6 @@ class TtConv:
             activation="",
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             act_block_w_div=1,
-            transpose_shards=False,
             deallocate_activation=False,
             enable_act_double_buffer=self.enable_act_double_buffer,
             enable_split_reader=self.enable_split_reader,

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -78,7 +78,7 @@ def run_conv(
     config_override,
     dilation_h=1,
     dilation_w=1,
-    transpose_shards=True,  # https://github.com/tenstorrent/tt-metal/issues/17897
+    transpose_shards=False,
     fp32_accum=False,
     packer_l1_acc=False,
     input_layout=ttnn.ROW_MAJOR_LAYOUT,
@@ -754,7 +754,6 @@ def test_conv_dram(
         fp32_accum=fp32_accum,
         packer_l1_acc=packer_l1_acc,
         preprocess_weights_on_device=False,
-        transpose_shards=True,
         run_twice=False,
         fast_compare=True,
         slice_config=ttnn.Conv2dSliceConfig(

--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -180,7 +180,6 @@ def test_conv_dram(
         fp32_accum=fp32_accum,
         packer_l1_acc=packer_l1_acc,
         preprocess_weights_on_device=False,
-        transpose_shards=True,
         run_twice=False,
         fast_compare=True,
         slice_config=ttnn.Conv2dSliceConfig(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -431,7 +431,7 @@ void py_bind_conv2d(py::module& module) {
         py::arg("override_sharding_config") = false,
         py::arg("shard_layout") = std::nullopt,
         py::arg("core_grid") = std::nullopt,
-        py::arg("transpose_shards") = true,
+        py::arg("transpose_shards") = false,
         py::arg("output_layout") = Layout::TILE,
         py::arg("preprocess_weights_on_device") = false,
         py::arg("always_preprocess_weights") = false,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -57,7 +57,7 @@ struct Conv2dConfig {
     std::optional<CoreRangeSet> core_grid = std::nullopt;
 
     // used only if override_sharding_config is true and shard_layout is set to BLOCK_SHARDED
-    bool transpose_shards = true;
+    bool transpose_shards = false;
 
     // Useful when output is BFLOAT16.
     // BFLOAT8 is always Tile layout.


### PR DESCRIPTION
Issue #17897

On WH and BH arch dram cores are placed as columns on the grid. To get good dram bandwidth we need
dram readers to be perpendicular to dram cores,
meaning they need to be placed as rows on the grid.

transpose_shards on Block Sharded Conv2d was causing dram readers to be placed as columns on the grid.

Change default for transpose_shards to False in
Conv2dConfig, and remove usage of transpose_shards from model code.

Resolved reamining issues in code when transpose_shards == False.

Primary motivation for this change is to improve
unet performance of SDXL on WH arch.
Up to 2x performance on block sharded conv2ds in
unet SDXL.

Other models that have improved device performance: vgg, ufld_v2, vanilla_unet, yolov10

Also bump timeout for device perf pipeline as we are super close on the limit.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/17897)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15495227971)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15522888628) Red but same as main
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15522881825)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/15506091533)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15506084941) 
- [x] [Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/15522892103)