### PR TITLE
Add SDXL unet device perf to device perf pipeline

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal", timeout: 75},
+          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal", timeout: 90},
         ]
     name: "${{ matrix.test-info.name }} device perf"
     runs-on: ${{ matrix.test-info.runs-on }}

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -87,6 +87,7 @@ jobs:
           WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/yolov10/tests -m models_device_performance_bare_metal
           WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/ufld_v2/tests -m models_device_performance_bare_metal
           WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/vit/demo/test_vit_device_perf.py -m models_device_performance_bare_metal
+          WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py -m models_device_performance_bare_metal
           python3 models/perf/merge_device_perf_results.py
 
       - name: Check device perf report exists

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
@@ -72,7 +72,6 @@ def prepare_ttnn_tensors(
         ((1, 4, 128, 128), (1,), (1, 77, 2048), (1, 1280), (1, 6)),
     ],
 )
-@pytest.mark.parametrize("single_run", [True, False])
 @pytest.mark.parametrize("conv_weights_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("transformer_weights_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 4 * 16384}], indirect=True)
@@ -87,7 +86,6 @@ def test_unet(
     reset_seeds,
     conv_weights_dtype,
     transformer_weights_dtype,
-    single_run,
 ):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
@@ -133,29 +131,6 @@ def test_unet(
         device, torch_input_tensor, torch_timestep_tensor, torch_temb_tensor, torch_encoder_tensor, torch_time_ids
     )
 
-    import tracy
-
-    if not single_run:
-        tracy.signpost("Compilation pass")
-        _, _ = tt_unet.forward(
-            ttnn_input_tensor,
-            [B, C, H, W],
-            timestep=ttnn_timestep_tensor,
-            encoder_hidden_states=ttnn_encoder_tensor,
-            added_cond_kwargs=ttnn_added_cond_kwargs,
-        )
-
-        (
-            ttnn_input_tensor,
-            [B, C, H, W],
-            ttnn_timestep_tensor,
-            ttnn_encoder_tensor,
-            ttnn_added_cond_kwargs,
-        ) = prepare_ttnn_tensors(
-            device, torch_input_tensor, torch_timestep_tensor, torch_temb_tensor, torch_encoder_tensor, torch_time_ids
-        )
-
-        tracy.signpost("Second pass")
     ttnn_output_tensor, output_shape = tt_unet.forward(
         ttnn_input_tensor,
         [B, C, H, W],

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -8,11 +8,11 @@ from models.perf.device_perf_utils import run_device_perf, check_device_perf, pr
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    command = f"pytest tests/nightly/single_card/stable_diffusion_xl_base/test_module_tt_unet.py::test_unet[device_params0-transformer_weights_dtype0-conv_weights_dtype0-True-input_shape0-timestep_shape0-encoder_shape0-temb_shape0-time_ids_shape0]"
+    command = f"pytest tests/nightly/single_card/stable_diffusion_xl_base/test_module_tt_unet.py::test_unet[device_params0-transformer_weights_dtype0-conv_weights_dtype0-input_shape0-timestep_shape0-encoder_shape0-temb_shape0-time_ids_shape0]"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
     inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
-    post_processed_results = run_device_perf(command, subdir="unet_shallow", num_iterations=3, cols=cols, batch_size=1)
+    post_processed_results = run_device_perf(command, subdir="sdxl_unet", num_iterations=3, cols=cols, batch_size=1)
     expected_perf_cols = {inference_time_key: 547286899}
     expected_results = check_device_perf(
         post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from models.perf.device_perf_utils import run_device_perf, check_device_perf, prep_device_perf_report
+
+
+@pytest.mark.models_device_performance_bare_metal
+def test_sdxl_unet_perf_device():
+    command = f"pytest tests/nightly/single_card/stable_diffusion_xl_base/test_module_tt_unet.py::test_unet[device_params0-transformer_weights_dtype0-conv_weights_dtype0-True-input_shape0-timestep_shape0-encoder_shape0-temb_shape0-time_ids_shape0]"
+    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
+
+    inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
+    post_processed_results = run_device_perf(command, subdir="unet_shallow", num_iterations=3, cols=cols, batch_size=1)
+    expected_perf_cols = {inference_time_key: 547286899}
+    expected_results = check_device_perf(
+        post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
+    )
+    prep_device_perf_report(
+        model_name=f"sdxl_unet_single_iter",
+        batch_size=1,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments="",
+    )

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_crossattndownblock2d.py
@@ -27,6 +27,7 @@ class TtCrossAttnDownBlock2D(nn.Module):
         num_layers = 2
         self.attentions = []
         self.resnets = []
+        self.device = device
 
         for i in range(num_layers):
             self.attentions.append(
@@ -74,6 +75,8 @@ class TtCrossAttnDownBlock2D(nn.Module):
             hidden_states = attn.forward(hidden_states, [B, C, H, W], encoder_hidden_states=encoder_hidden_states)
             residual = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
             output_states = output_states + (residual,)
+
+        ttnn.DumpDeviceProfiler(self.device)
 
         if self.downsamplers is not None:
             hidden_states, [C, H, W] = self.downsamplers.forward(hidden_states, [B, C, H, W])

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnupblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnupblock2d.py
@@ -27,6 +27,7 @@ class TtCrossAttnUpBlock2D(nn.Module):
         num_layers = 3
         self.attentions = []
         self.resnets = []
+        self.device = device
 
         for i in range(num_layers):
             self.attentions.append(
@@ -84,6 +85,8 @@ class TtCrossAttnUpBlock2D(nn.Module):
             hidden_states = attn.forward(
                 hidden_states, [B, C, H, W], encoder_hidden_states=encoder_hidden_states, attention_mask=attention_mask
             )
+
+        ttnn.DumpDeviceProfiler(self.device)
 
         if self.upsamplers is not None:
             hidden_states = ttnn.reshape(hidden_states, [B, H, W, C])

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
@@ -212,6 +212,8 @@ class TtUNet2DConditionModel(nn.Module):
         residuals = (sample,)
 
         temb = ttnn.typecast(temb, dtype=ttnn.bfloat16)
+
+        ttnn.DumpDeviceProfiler(self.device)
         for i, down_block in enumerate(self.down_blocks):
             if i == 0:
                 sample, [C, H, W], block_residuals = down_block.forward(sample, [B, C, H, W], temb=temb)
@@ -221,10 +223,12 @@ class TtUNet2DConditionModel(nn.Module):
                 )
 
             residuals += block_residuals
+        ttnn.DumpDeviceProfiler(self.device)
 
         sample, [C, H, W] = self.mid_block.forward(
             sample, [B, C, H, W], temb=temb, encoder_hidden_states=encoder_hidden_states
         )
+        ttnn.DumpDeviceProfiler(self.device)
 
         encoder_hidden_states = ttnn.to_memory_config(encoder_hidden_states, ttnn.DRAM_MEMORY_CONFIG)
         for i, up_block in enumerate(self.up_blocks):
@@ -246,6 +250,8 @@ class TtUNet2DConditionModel(nn.Module):
                     temb=temb,
                     encoder_hidden_states=encoder_hidden_states,
                 )
+
+        ttnn.DumpDeviceProfiler(self.device)
 
         sample = ttnn.to_layout(sample, ttnn.ROW_MAJOR_LAYOUT)
 


### PR DESCRIPTION
Add SDXL unet device perf to device perf pipeline
Increase timeout for device perf pipeline (already running on the edge)

### Checklist
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15520378372)