### PR TITLE
#17952: add trace support for ufld_v2 demo

### DIFF
--- a/models/demos/ufld_v2/README.md
+++ b/models/demos/ufld_v2/README.md
@@ -16,31 +16,40 @@ Resource link - [source](https://github.com/cfzd/Ultra-Fast-Lane-Detection-v2)
 - Batch Size :1
 - Supported Input Resolution - (320,800) (Height,Width)
 
-Export the following command before running pytests on N300:
+### How to Run:
+If running on Wormhole N300 (not required for N150 or Blackhole), the following environment variable needs to be set as the model requires at least 8x8 core grid size:
+```sh
+export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+```
 
-`WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml`
+### Build Command to Use:
+To obtain the perf reports through profiler, please build with following command:
+```
+./build_metal.sh -p
+```
 
 Use the following command to run the model :
 
-`pytest tests/ttnn/integration_tests/ufld_v2/test_ttnn_ufld_v2.py::test_ufld_v2_model`
+```
+pytest --disable-warnings tests/ttnn/integration_tests/ufld_v2/test_ttnn_ufld_v2.py::test_ufld_v2_model
+```
 
-Use the following command to run the e2e perf:
+### Performant Model with Trace+2CQ
+- end-2-end perf is 302 FPS
 
-`pytest models/demos/ufld_v2/tests/test_ufld_v2_perf.py::test_ufld_v2_perf`
+Use the following command to run the performant Model with Trace+2CQs:
 
-Use the following command to run the e2e perf with trace(107 FPS):
+```
+pytest --disable-warnings models/demos/ufld_v2/tests/test_ufld_v2_e2e_performant.py
+```
 
-`pytest models/demos/ufld_v2/tests/test_ufld_v2_e2e_performant.py`
+### Performant Demo with Trace+2CQ
 
-Use the following command to generate device perf (306 FPS):
+Use the following command to run the performant Demo with Trace+2CQs:
 
-`pytest models/demos/ufld_v2/tests/test_ufld_v2_perf.py::test_perf_device_bare_metal_ufld_v2`
-
-### Demo
-
-Use the following command to run the demo :
-
-`pytest models/demos/ufld_v2/demo/demo.py`
+```
+pytest --disable-warnings models/demos/ufld_v2/demo/demo.py
+```
 
 To run the demo on your data:
 

--- a/models/demos/ufld_v2/demo/demo.py
+++ b/models/demos/ufld_v2/demo/demo.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,13 +9,11 @@ import numpy as np
 import pytest
 import torch
 from loguru import logger
-from ttnn.model_preprocessing import infer_ttnn_module_args, preprocess_model_parameters
 
 from models.demos.ufld_v2.demo import model_config as cfg
 from models.demos.ufld_v2.demo.demo_utils import LaneEval, run_test_tusimple
 from models.demos.ufld_v2.reference.ufld_v2_model import TuSimple34
-from models.demos.ufld_v2.ttnn.ttnn_ufld_v2 import TtnnUFLDv2
-from tests.ttnn.integration_tests.ufld_v2.test_ttnn_ufld_v2 import custom_preprocessor_whole_model
+from models.demos.ufld_v2.tests.ufld_v2_e2e_performant import UFLDPerformantRunner
 
 
 @pytest.mark.parametrize(
@@ -35,9 +33,12 @@ from tests.ttnn.integration_tests.ufld_v2.test_ttnn_ufld_v2 import custom_prepro
         "pretrained_weight_true",
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
-def test_UFLD_v2_demo(batch_size, input_channels, height, width, device, use_pretrained_weight):
-    torch_input_tensor = torch.randn((batch_size, input_channels, height, width))
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 79104, "trace_region_size": 23887872, "num_command_queues": 2}], indirect=True
+)
+def test_ufld_v2_demo(
+    batch_size, input_channels, height, width, device, use_pretrained_weight, use_program_cache, reset_seeds
+):
     reference_model = TuSimple34(input_height=height, input_width=width)
     if use_pretrained_weight:
         logger.info(f"Demo Inference using Pre-trained Weights")
@@ -68,19 +69,8 @@ def test_UFLD_v2_demo(batch_size, input_channels, height, width, device, use_pre
         col_anchor=cfg.col_anchor,
         device=None,
     )
-
-    parameters = preprocess_model_parameters(
-        initialize_model=lambda: reference_model,
-        custom_preprocessor=custom_preprocessor_whole_model,
-        device=device,
-    )
-    parameters.conv_args = {}
-    parameters.conv_args = infer_ttnn_module_args(
-        model=reference_model, run_model=lambda model: reference_model(torch_input_tensor), device=device
-    )
-    ttnn_model = TtnnUFLDv2(conv_args=parameters.conv_args, conv_pth=parameters, device=device)
     run_test_tusimple(
-        ttnn_model,
+        UFLDPerformantRunner,
         cfg.data_root,
         cfg.data_root,
         "ttnn_model_results",

--- a/models/demos/ufld_v2/tests/test_ufld_v2_perf.py
+++ b/models/demos/ufld_v2/tests/test_ufld_v2_perf.py
@@ -25,7 +25,7 @@ from tests.ttnn.integration_tests.ufld_v2.test_ttnn_ufld_v2 import custom_prepro
 
 
 def get_expected_times(name):
-    base = {"ufld_v2": (36.6, 0.23)}
+    base = {"ufld_v2": (36.6, 0.28)}
     return base[name]
 
 

--- a/models/demos/ufld_v2/tests/test_ufld_v2_performant.py
+++ b/models/demos/ufld_v2/tests/test_ufld_v2_performant.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/ufld_v2/tests/ufld_v2_e2e_performant.py
+++ b/models/demos/ufld_v2/tests/ufld_v2_e2e_performant.py
@@ -1,86 +1,114 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
+import torch
+
 import ttnn
-from models.demos.ufld_v2.tests.ufld_v2_test_infra import create_test_infra
-
-try:
-    pass
-
-    use_signpost = True
-except ModuleNotFoundError:
-    use_signpost = False
+from models.demos.ufld_v2.tests.ufld_v2_test_infra import UFLDPerformanceRunnerInfra
+from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-class UFLDv2Trace2CQ:
-    def __init__(self):
-        ...
-
-    def initialize_ufldv2_trace_2cqs_inference(
+class UFLDPerformantRunner:
+    def __init__(
         self,
         device,
-        device_batch_size,
+        device_batch_size=1,
         act_dtype=ttnn.bfloat16,
-        weight_dtype=ttnn.bfloat16,
+        weight_dtype=ttnn.bfloat8_b,
+        model_location_generator=None,
+        resolution=(320, 800),
+        torch_input_tensor=None,
     ):
-        self.test_infra = create_test_infra(
+        self.device = device
+        self.resolution = resolution
+        self.torch_input_tensor = torch_input_tensor
+        self.runner_infra = UFLDPerformanceRunnerInfra(
             device,
             device_batch_size,
+            act_dtype,
+            weight_dtype,
+            model_location_generator,
+            resolution=resolution,
+            torch_input_tensor=self.torch_input_tensor,
         )
-        self.device = device
-        self.tt_inputs_host, sharded_mem_config_DRAM, self.input_mem_config = self.test_infra.setup_dram_sharded_input(
-            device
-        )
+        (
+            self.tt_inputs_host,
+            sharded_mem_config_DRAM,
+            self.input_mem_config,
+        ) = self.runner_infra.setup_dram_sharded_input(device)
         self.tt_image_res = self.tt_inputs_host.to(device, sharded_mem_config_DRAM)
-        self.op_event = ttnn.record_event(device, 0)
 
+    def _capture_ufldv2_trace_2cqs(self):
+        # Initialize the op event so we can write
+        self.op_event = ttnn.record_event(self.device, 0)
+
+        # First run configures convs JIT
         ttnn.wait_for_event(1, self.op_event)
         ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
-        self.write_event = ttnn.record_event(device, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
         ttnn.wait_for_event(0, self.write_event)
-        self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
-        spec = self.test_infra.input_tensor.spec
-        self.op_event = ttnn.record_event(device, 0)
-        self.test_infra.run()
-        self.test_infra.validate()
-        self.test_infra.output_tensor_1.deallocate(force=True)
+        self.runner_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        spec = self.runner_infra.input_tensor.spec
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.run()
+        self.runner_infra.validate()
+        self.runner_infra.dealloc_output()
 
+        # Optimized run
         ttnn.wait_for_event(1, self.op_event)
         ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
-        self.write_event = ttnn.record_event(device, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
         ttnn.wait_for_event(0, self.write_event)
-        self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
-        self.op_event = ttnn.record_event(device, 0)
-        self.test_infra.run()
-        self.test_infra.validate()
+        self.runner_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.run()
+        self.runner_infra.validate()
 
+        # Capture
         ttnn.wait_for_event(1, self.op_event)
         ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
-        self.write_event = ttnn.record_event(device, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
         ttnn.wait_for_event(0, self.write_event)
-        self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
-        self.op_event = ttnn.record_event(device, 0)
-        self.test_infra.output_tensor_1.deallocate(force=True)
-        trace_input_addr = self.test_infra.input_tensor.buffer_address()
-        self.tid = ttnn.begin_trace_capture(device, cq_id=0)
-        self.test_infra.run()
-        self.input_tensor = ttnn.allocate_tensor_on_device(spec, device)
-        ttnn.end_trace_capture(device, self.tid, cq_id=0)
+        self.runner_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.dealloc_output()
+        trace_input_addr = self.runner_infra.input_tensor.buffer_address()
+        self.tid = ttnn.begin_trace_capture(self.device, cq_id=0)
+        self.runner_infra.run()
+        self.input_tensor = ttnn.allocate_tensor_on_device(spec, self.device)
+        ttnn.end_trace_capture(self.device, self.tid, cq_id=0)
         assert trace_input_addr == self.input_tensor.buffer_address()
 
-    def execute_ufldv2_trace_2cqs_inference(self, tt_inputs_host=None):
+    def _execute_ufldv2_trace_2cqs_inference(self, tt_inputs_host=None):
+        tt_inputs_host = self.tt_inputs_host if tt_inputs_host is None else tt_inputs_host
         ttnn.wait_for_event(1, self.op_event)
-
         ttnn.copy_host_to_device_tensor(tt_inputs_host, self.tt_image_res, 1)
         self.write_event = ttnn.record_event(self.device, 1)
         ttnn.wait_for_event(0, self.write_event)
-        self.input_tensor = ttnn.reshard(self.tt_image_res, self.input_mem_config, self.input_tensor)
+        if self.input_tensor.is_sharded():
+            self.input_tensor = ttnn.reshard(self.tt_image_res, self.input_mem_config, self.input_tensor)
         self.op_event = ttnn.record_event(self.device, 0)
         ttnn.execute_trace(self.device, self.tid, cq_id=0, blocking=False)
-        outputs = ttnn.from_device(self.test_infra.output_tensor_1, blocking=True)
+        return self.runner_infra.output_tensor_1
 
-        return outputs
+    def _validate(self, input_tensor, result_output_tensor):
+        torch_output_tensor = self.runner_infra.torch_output_tensor_1
+        assert_with_pcc(torch_output_tensor, result_output_tensor, self.runner_infra.valid_pcc)
 
-    def release_ufldv2_trace_2cqs_inference(self):
+    def run(self, torch_input_tensor):
+        n, c, h, w = torch_input_tensor.shape
+        torch_input_tensor = torch_input_tensor.permute(0, 2, 3, 1)
+        torch_input_tensor = torch.nn.functional.pad(torch_input_tensor, (0, 13))
+        torch_input_tensor = torch_input_tensor.reshape(
+            1,
+            1,
+            (torch_input_tensor.shape[0] * torch_input_tensor.shape[1] * torch_input_tensor.shape[2]),
+            torch_input_tensor.shape[3],
+        )
+        tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+        output = self._execute_ufldv2_trace_2cqs_inference(tt_inputs_host)
+        return output
+
+    def release(self):
         ttnn.release_trace(self.device, self.tid)

--- a/models/demos/ufld_v2/tests/ufld_v2_performant.py
+++ b/models/demos/ufld_v2/tests/ufld_v2_performant.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/ufld_v2/tests/ufld_v2_test_infra.py
+++ b/models/demos/ufld_v2/tests/ufld_v2_test_infra.py
@@ -1,8 +1,11 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import torch
+import torch.nn.functional as F
 from loguru import logger
 from ttnn.model_preprocessing import infer_ttnn_module_args, preprocess_model_parameters
 
@@ -17,6 +20,15 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 def load_torch_model():
     torch_model = TuSimple34(input_height=320, input_width=800)
     torch_model.eval()
+    weights_path = "models/demos/ufld_v2/tusimple_res34.pth"
+    if not os.path.exists(weights_path):
+        os.system("bash models/demos/ufld_v2/weights_download.sh")
+    state_dict = torch.load(weights_path)
+    new_state_dict = {}
+    for key, value in state_dict["model"].items():
+        new_key = key.replace("model.", "res_model.")
+        new_state_dict[new_key] = value
+    torch_model.load_state_dict(new_state_dict)
     return torch_model
 
 
@@ -34,30 +46,35 @@ def load_ttnn_model(device, torch_model, torch_input_tensor):
     return ttnn_model
 
 
-class UFLDv2TestInfra:
+class UFLDPerformanceRunnerInfra:
     def __init__(
         self,
         device,
-        batch_size,
+        batch_size=1,
+        act_dtype=ttnn.bfloat8_b,
+        weight_dtype=ttnn.bfloat8_b,
         model_location_generator=None,
+        resolution=(320, 800),
+        torch_input_tensor=None,
     ):
-        super().__init__()
         torch.manual_seed(0)
+        self.resolution = resolution
         self.pcc_passed = False
         self.pcc_message = "Did you forget to call validate()?"
         self.device = device
         self.batch_size = batch_size
+        self.act_dtype = act_dtype
+        self.weight_dtype = weight_dtype
         self.model_location_generator = model_location_generator
-        input_shape = (batch_size, 3, 320, 800)
-        self.torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
-        torch_model = load_torch_model()
-        self.ttnn_ufld_v2_model = load_ttnn_model(self.device, torch_model, self.torch_input_tensor)
-        self.tt_input_tensor = self.torch_input_tensor.permute(0, 3, 1, 2)
-        self.tt_input_tensor = ttnn.from_torch(self.tt_input_tensor, ttnn.bfloat16)
-        self.torch_output_tensor_1, self.torch_output_tensor_2 = torch_model(self.torch_input_tensor)
-
-    def run(self):
-        self.output_tensor_1 = self.ttnn_ufld_v2_model(input=self.input_tensor, batch_size=self.batch_size)
+        self.torch_input_tensor = torch_input_tensor
+        self.torch_input_tensor = (
+            torch.randn((1, 3, 320, 800), dtype=torch.float32)
+            if self.torch_input_tensor is None
+            else self.torch_input_tensor
+        )
+        self.torch_model = load_torch_model()
+        self.ttnn_ufld_v2_model = load_ttnn_model(self.device, self.torch_model, self.torch_input_tensor)
+        self.torch_output_tensor_1, self.torch_output_tensor_2 = self.torch_model(self.torch_input_tensor)
 
     def setup_l1_sharded_input(self, device, torch_input_tensor=None):
         if is_wormhole_b0():
@@ -77,9 +94,14 @@ class UFLDv2TestInfra:
             ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
         )
         torch_input_tensor = torch_input_tensor.permute(0, 2, 3, 1)
-        torch_input_tensor = torch_input_tensor.reshape(1, 1, h * w * n, c)
+        torch_input_tensor = F.pad(torch_input_tensor, (0, 13))
+        torch_input_tensor = torch_input_tensor.reshape(
+            1,
+            1,
+            (torch_input_tensor.shape[0] * torch_input_tensor.shape[1] * torch_input_tensor.shape[2]),
+            torch_input_tensor.shape[3],
+        )
         tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
-        tt_inputs_host = ttnn.pad(tt_inputs_host, [1, 1, n * h * w, 16], [0, 0, 0, 0], 0)
         return tt_inputs_host, input_mem_config
 
     def setup_dram_sharded_input(self, device, torch_input_tensor=None, mesh_mapper=None, mesh_composer=None):
@@ -91,7 +113,7 @@ class UFLDv2TestInfra:
             ),
             [
                 divup(tt_inputs_host.volume() // tt_inputs_host.shape[-1], (dram_grid_size.x * dram_grid_size.y)),
-                16,
+                tt_inputs_host.shape[-1],
             ],
             ttnn.ShardOrientation.ROW_MAJOR,
         )
@@ -101,12 +123,18 @@ class UFLDv2TestInfra:
 
         return tt_inputs_host, sharded_mem_config_DRAM, input_mem_config
 
-    def validate(self, output_tensor=None):
-        output_tensor_1 = ttnn.to_torch(self.output_tensor_1).squeeze(dim=0).squeeze(dim=0)
-        valid_pcc = 0.96
-        self.pcc_passed, self.pcc_message = assert_with_pcc(self.torch_output_tensor_1, output_tensor_1, pcc=valid_pcc)
+    def run(self):
+        self.output_tensor_1 = self.ttnn_ufld_v2_model(input=self.input_tensor, batch_size=self.batch_size)
 
-        logger.info(f"UFLD_V2 batch_size={self.batch_size}, PCC={self.pcc_message}")
+    def validate(self, output_tensor_1=None, torch_output_tensor_1=None):
+        ttnn_output_tensor = self.output_tensor_1 if output_tensor_1 is None else output_tensor_1
+        torch_output_tensor = self.torch_output_tensor_1 if torch_output_tensor_1 is None else torch_output_tensor_1
+        output_tensor = ttnn.to_torch(ttnn_output_tensor).squeeze(0).squeeze(0)
+        self.valid_pcc = 0.99
+        self.pcc_passed, self.pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc=self.valid_pcc)
+        logger.info(
+            f"ufld_v2 - batch_size={self.batch_size}, act_dtype={self.act_dtype}, weight_dtype={self.weight_dtype}, PCC={self.pcc_message}"
+        )
 
     def dealloc_output(self):
         ttnn.deallocate(self.output_tensor_1)
@@ -114,9 +142,13 @@ class UFLDv2TestInfra:
 
 def create_test_infra(
     device,
-    batch_size,
+    batch_size=1,
+    act_dtype=ttnn.bfloat8_b,
+    weight_dtype=ttnn.bfloat8_b,
+    model_location_generator=None,
+    resolution=(320, 800),
+    torch_input_tensor=None,
 ):
-    return UFLDv2TestInfra(
-        device,
-        batch_size,
+    return UFLDPerformanceRunnerInfra(
+        device, batch_size, act_dtype, weight_dtype, model_location_generator, resolution, torch_input_tensor
     )


### PR DESCRIPTION
### Ticket
Link to Github Issue - [#17952]

### Problem description
- Modified existing infra, peformant files to support demo for real_weights & inputs.

### What's changed
- Added trace support for existing demo.

### Checklist
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15529757852) (unrelated ones fail)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) - 
- [x] [ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml)  - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15529759865)
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15529729902) (unrelated ones fail) 
- [x] [Demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15533273554) (unrelated ones fail)

### Performance Details
Model (e2e) perf with trace+2cqs - 302 FPS