### PR TITLE
Convert most expensive ws conv in unet to bs conv

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
@@ -52,7 +52,7 @@ class ModelOptimisations:
             weights_dtype=self.conv_ws_dtype,
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             deallocate_activation=True,
-            reallocate_halo_output=False,
+            reallocate_halo_output=True,
             enable_act_double_buffer=False,
             enable_split_reader=False,
             enable_subblock_padding=False,
@@ -421,7 +421,7 @@ class ModelOptimisations:
 
             # UP BLOCK 0
             elif ("up_blocks.0.resnets.0.conv1" == conv_path) or ("up_blocks.0.resnets.1.conv1" == conv_path):
-                return self.conv_configs["ABH_256_NO_ADB_WS"]  # Note: ABH should be 512 (OOM)
+                return self.conv_configs["ABH_32_NO_ADB_BS"]
             elif "up_blocks.0.upsamplers.0" == conv_path:
                 return self.conv_configs["ABH_64_NO_ADB_BS"]
             elif ("up_blocks.0.resnets" in conv_path) and ("conv2" in conv_path):
@@ -431,7 +431,7 @@ class ModelOptimisations:
 
             # UP BLOCK 1
             elif "up_blocks.1.resnets.0.conv1" == conv_path:
-                return self.conv_configs["ABH_256_NO_ADB_WS"]
+                return self.conv_configs["ABH_32_NO_ADB_BS"]
             elif "up_blocks.1.resnets.1.conv1" == conv_path:
                 return self.conv_configs["ABH_64_NO_ADB_BS"]
             elif "up_blocks.1.resnets.2.conv1" == conv_path:

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3107,7 +3107,7 @@ def test_conv2d_model_fruit(
         (1, 1280, 1280, 64, 64, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 64,   1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, False, False),
         (1, 1280, 640, 64, 64,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 64,   1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, False, False),
         (1, 1920, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), WS, 512,  1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
-        (1, 1920, 640, 64, 64,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), WS, 256,  1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
+        (1, 1920, 640, 64, 64,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 32,   1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, False, False),
         (1, 2560, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), WS, 256,  1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
         (1, 320, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128,  1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),
         (1, 320, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128,  1, True, ttnn.MathFidelity.HiFi2, True, False, False, 1, 1, True, True),


### PR DESCRIPTION
Combined with pending improvements for block sharded convs > 2x speed up on most expensive conv2d in sdxl unet.

- [x][(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15529762304)

![output0](https://github.com/user-attachments/assets/9d8ec3f0-9883-4733-b320-89134d282ab4)