### PR TITLE
SDXL: GroupNorm update

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -64,8 +64,9 @@ class TtResnetBlock2D(nn.Module):
             conv_bias_3 = state_dict[f"{module_path}.conv_shortcut.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
 
         if split_in > 1:
-            self.norm_1_blocks = 16
-            self.norm_core_grid_1 = ttnn.CoreGrid(y=2 if "up_blocks.2.resnets.0" in module_path else 4, x=1)
+            self.norm_1_blocks = 6 if "up_blocks.2.resnets.0" in module_path else 3
+            core_x = core_y = 2 if "up_blocks.2.resnets.0" in module_path else 4
+            self.norm_core_grid_1 = ttnn.CoreGrid(y=core_y, x=core_x)
             self.gamma_t_1, self.beta_t_1 = prepare_gn_beta_gamma(
                 device, norm_weights_1, norm_bias_1, self.norm_core_grid_1.y
             )

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -411,14 +411,16 @@ def generate_sdxl_test_inputs():
     inputs = []
 
     # 1024x1024 resoultion
-    inputs.append((2, 1280, 64, 64))
-    inputs.append((2, 1280, 32, 32))
-    inputs.append((2, 1920, 32, 32))
-    inputs.append((2, 2560, 32, 32))
-    inputs.append((2, 320, 64, 64))
-    inputs.append((2, 640, 32, 32))
-    inputs.append((2, 640, 64, 64))
-    inputs.append((2, 960, 64, 64))
+    inputs.append((1, 1280, 64, 64))
+    inputs.append((1, 1280, 32, 32))
+    inputs.append((1, 1920, 64, 64))
+    inputs.append((1, 1920, 32, 32))
+    inputs.append((1, 2560, 32, 32))
+    inputs.append((1, 320, 128, 128))
+    inputs.append((1, 320, 64, 64))
+    inputs.append((1, 640, 64, 64))
+    inputs.append((1, 640, 32, 32))
+    inputs.append((1, 960, 64, 64))
 
     return inputs
 
@@ -463,7 +465,7 @@ def test_sdxl_base_group_norm(device, input_shape, use_program_cache):
     grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
     shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
     shard_shape = N * H * W // grid_size.x, C // grid_size.y
-    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.COL_MAJOR)
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     sharded_mem_config = ttnn.MemoryConfig(
         ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
     )

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -41,10 +41,8 @@ from models.utility_functions import skip_for_wormhole_b0, skip_for_blackhole
             4,
         ),  # test all groups on core fit in less than one tile, so need to reduce col core count
         # # # SDXL 1024x1024 resoultion
-        (2, 1920, 64, 64, 32, 4, 4, 4),
-        (2, 320, 128, 128, 32, 12, 2, 2),
-        (2, 640, 128, 128, 32, 6, 4, 4),
-        (2, 960, 128, 128, 32, 12, 2, 2),
+        (1, 640, 128, 128, 32, 3, 4, 4),
+        (1, 960, 128, 128, 32, 6, 2, 2),
         # VAE
         # tensor is too large, but good example
         (1, 256, 1024, 1024, 32, 128, 8, 4),


### PR DESCRIPTION
### What's changed
Increased the core grids for DRAM GroupNorm. Updated GN unit tests to match the state of the model.

New device perf: 500,178us

Model output with the above changes:
![output0](https://github.com/user-attachments/assets/ff50a04c-13a9-4d70-875c-3a2ddeada869)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15530247222) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15530251338) CI passes