### PR TITLE
SDXL: UNet sharded upsample

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -13,7 +13,7 @@ def test_sdxl_unet_perf_device():
 
     inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
     post_processed_results = run_device_perf(command, subdir="sdxl_unet", num_iterations=3, cols=cols, batch_size=1)
-    expected_perf_cols = {inference_time_key: 547286899}
+    expected_perf_cols = {inference_time_key: 498886445}
     expected_results = check_device_perf(
         post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
     )

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnupblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnupblock2d.py
@@ -91,6 +91,5 @@ class TtCrossAttnUpBlock2D(nn.Module):
         if self.upsamplers is not None:
             hidden_states = ttnn.reshape(hidden_states, [B, H, W, C])
             hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
-            hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
             hidden_states, [C, H, W] = self.upsamplers.forward(hidden_states)
         return hidden_states, [C, H, W]

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_upsample2d.py
@@ -46,6 +46,13 @@ class TtUpsample2D(nn.Module):
         )
 
     def interpolate(self, hidden_states):
+        memory_config = ttnn.create_sharded_memory_config(
+            shape=hidden_states.shape,
+            core_grid=ttnn.CoreGrid(y=8, x=5),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        hidden_states = ttnn.to_memory_config(hidden_states, memory_config)
         hidden_states = ttnn.upsample(hidden_states, (self.scale_factor, self.scale_factor))
         B, H, W, C = list(hidden_states.shape)
         return hidden_states, [B, C, H, W]


### PR DESCRIPTION
### What's changed
Added sharding before upsample op. New device perf with the changes from [#23257](https://github.com/tenstorrent/tt-metal/pull/23257): 497,480us

Model output with the above changes:

![output0](https://github.com/user-attachments/assets/e0345583-d211-4bf5-bfee-093186ee02b6)

### Checklist
In progress
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15531411832) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15531416965) CI passes