### PR TITLE
Llama70b return perf unit tests in model perf workflow

### DIFF
--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -43,7 +43,7 @@ jobs:
           },  # Austin Ho
           {
             name: "Galaxy Llama 70B model perf tests",
-            model-type: "Llama 70B",
+            model-type: "Llama-70B",
             arch: wormhole_b0,
             runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_llama_model_perf_tg_device --dispatch-mode ""',

--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -45,22 +45,10 @@ jobs:
             name: "Galaxy Llama 70B model perf tests",
             model-type: "Llama 70B",
             arch: wormhole_b0,
-            # cmd: "TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device",
-            # timeout: 100,
-            # tracy: true,
             runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_llama_model_perf_tg_device --dispatch-mode ""',
             owner_id: U053W15B6JF # Djordje Ivanovic
           },
-          # {
-          #   name: "Galaxy Llama 70B model dispatch perf tests",
-          #   arch: wormhole_b0,
-          #   cmd: "TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch",
-          #   timeout: 100,
-          #   tracy: true,
-          #   runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
-          #   owner_id: U053W15B6JF # Djordje Ivanovic
-          # },
           {
             name: "Llama Galaxy Perf Unit Tests",
             arch: wormhole_b0,

--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -43,21 +43,32 @@ jobs:
           },  # Austin Ho
           {
             name: "Galaxy Llama 70B model perf tests",
+            model-type: "Llama 70B",
             arch: wormhole_b0,
-            cmd: "TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device",
-            timeout: 100,
-            tracy: true,
+            # cmd: "TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device",
+            # timeout: 100,
+            # tracy: true,
             runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+            cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_llama_model_perf_tg_device --dispatch-mode ""',
             owner_id: U053W15B6JF # Djordje Ivanovic
           },
+          # {
+          #   name: "Galaxy Llama 70B model dispatch perf tests",
+          #   arch: wormhole_b0,
+          #   cmd: "TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch",
+          #   timeout: 100,
+          #   tracy: true,
+          #   runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+          #   owner_id: U053W15B6JF # Djordje Ivanovic
+          # },
           {
-            name: "Galaxy Llama 70B model dispatch perf tests",
+            name: "Llama Galaxy Perf Unit Tests",
             arch: wormhole_b0,
-            cmd: "TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch",
+            cmd: 'pytest models/demos/llama3_subdevices/tests/tg_perf_unit_tests',
             timeout: 100,
             tracy: true,
             runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
-            owner_id: U053W15B6JF # Djordje Ivanovic
+            owner_id: U071CKL4AFK # Ammar Vora
           },
           {
             name: "Galaxy Llama 70B prefill perf tests [128]",
@@ -77,15 +88,7 @@ jobs:
             runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
             owner_id: U03PUAKE719 # Miguel Tairum
           },
-          # { See GH Issue #22164
-          #   name: "Llama Galaxy Perf Unit Tests",
-          #   arch: wormhole_b0,
-          #   cmd: 'pytest models/demos/llama3_subdevices/tests/tg_perf_unit_tests',
-          #   timeout: 100,
-          #   tracy: true,
-          #   runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
-          #   owner_id: U071CKL4AFK # Ammar Vora
-          # },
+
         ]
     name: ${{ matrix.test-group.name }}
     env:

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -36,10 +36,10 @@ run_tg_llama_70b_model_perf_tests() {
   echo "LOG_METAL: Running run_tg_llama_70b_model_perf_tests"
 
   # Run kernel and op to op latency test
-  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device ; fail+=$?
+  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device ; fail+=$?
 
   # Run non-overlapped dispatch perf test
-  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch ; fail+=$?
+  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch ; fail+=$?
 
   # # Merge all the generated reports
   # env python3 models/perf/merge_perf_results.py; fail+=$?

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -41,9 +41,6 @@ run_tg_llama_70b_model_perf_tests() {
   # Run non-overlapped dispatch perf test
   TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch ; fail+=$?
 
-  # # Merge all the generated reports
-  # env python3 models/perf/merge_perf_results.py; fail+=$?
-
   if [[ $fail -ne 0 ]]; then
     echo "LOG_METAL: run_tg_llama_70b_model_perf_tests failed"
     exit 1

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -28,6 +28,28 @@ run_tg_cnn_tests() {
   fi
 }
 
+run_tg_llama_70b_model_perf_tests() {
+
+  # Llama3.3-70B
+  llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
+
+  echo "LOG_METAL: Running run_tg_llama_70b_model_perf_tests"
+
+  # Run kernel and op to op latency test
+  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device ; fail+=$?
+
+  # Run non-overlapped dispatch perf test
+  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch ; fail+=$?
+
+  # # Merge all the generated reports
+  # env python3 models/perf/merge_perf_results.py; fail+=$?
+
+  if [[ $fail -ne 0 ]]; then
+    echo "LOG_METAL: run_tg_llama_70b_model_perf_tests failed"
+    exit 1
+  fi
+}
+
 main() {
   # Parse the arguments
   while [[ $# -gt 0 ]]; do
@@ -67,8 +89,10 @@ main() {
     run_tg_llm_tests
   elif [[ "$pipeline_type" == "cnn_model_perf_tg_device" ]]; then
     run_tg_cnn_tests
+  elif [[ "$pipeline_type" == "tg_llama_model_perf_tg_device" ]]; then
+    run_tg_llama_70b_model_perf_tests
   else
-    echo "$pipeline_type is invalid (supported: [cnn_model_perf_tg_device, cnn_model_perf_tg_device])" 2>&1
+    echo "$pipeline_type is invalid (supported: [cnn_model_perf_tg_device, cnn_model_perf_tg_device, tg_llama_model_perf_tg_device])" 2>&1
     exit 1
   fi
 }


### PR DESCRIPTION

### Problem description
Perf unit tests were skipped in model perf pipeline due to hang when running consecutive pytest with profiler.
### What's changed
Since bug is fixed perf unit tests are brought back and model perf tests are scheduled together now (dispatch tests and op tests).

### Checklist
- [ ] [Model perf test](https://github.com/tenstorrent/tt-metal/actions/runs/15487505019)
TODO: Fix target ranges for perf unit tests