### PR TITLE
Enable cache on device by default

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -595,15 +595,10 @@ def get_devices(request):
     return devices
 
 
+# Deprecated, cache is active by default
 @pytest.fixture(scope="function")
 def use_program_cache(request):
     devices = get_devices(request)
-    if not devices:
-        logger.warning("No device fixture found to apply program cache to: PROGRAM CACHE DISABLED")
-    for dev in devices:
-        # Clean up before reenabling program cache
-        dev.disable_and_clear_program_cache()
-        dev.enable_program_cache()
     yield
     for dev in devices:
         dev.disable_and_clear_program_cache()

--- a/conftest.py
+++ b/conftest.py
@@ -601,6 +601,8 @@ def use_program_cache(request):
     if not devices:
         logger.warning("No device fixture found to apply program cache to: PROGRAM CACHE DISABLED")
     for dev in devices:
+        # Clean up before reenabling program cache
+        dev.disable_and_clear_program_cache()
         dev.enable_program_cache()
     yield
     for dev in devices:

--- a/models/demos/bert/demo/demo.py
+++ b/models/demos/bert/demo/demo.py
@@ -74,7 +74,8 @@ def run_bert_question_and_answering_inference(
     else:
         raise ValueError(f"Unknown bert: {bert}")
 
-    device.disable_and_clear_program_cache()
+    if not use_program_cache:
+        device.disable_and_clear_program_cache()
 
     profiler.start(f"preprocessing_parameter")
     parameters = preprocess_model_parameters(
@@ -177,7 +178,6 @@ def run_bert_question_and_answering_inference(
         logger.info(f"End to end inference Iteration {iteration}: {measurements['end_to_end_inference']} s")
         logger.info(f"iteration_{iteration} total time: {measurements['iteration']} s")
         profiler.clear()
-        device.enable_program_cache()
     return measurements
 
 

--- a/models/demos/metal_BERT_large_11/tests/test_bert.py
+++ b/models/demos/metal_BERT_large_11/tests/test_bert.py
@@ -196,6 +196,9 @@ def test_bert(
     if is_e75(device):
         pytest.skip(f"Bert large 11 is not supported on E75")
 
+    # https://github.com/tenstorrent/tt-metal/issues/23275
+    device.disable_and_clear_program_cache()
+
     model_config = get_model_config(batch, device.compute_with_storage_grid_size(), model_config_str)
     tt_cache_path = get_tt_cache_path(model_version)
 

--- a/models/demos/metal_BERT_large_11/tests/test_perf_device_bert.py
+++ b/models/demos/metal_BERT_large_11/tests/test_perf_device_bert.py
@@ -50,7 +50,7 @@ def test_perf_device_bare_metal(batch_size, test, expected_perf):
     "batch_size, test, expected_perf",
     [
         [7, "BERT_LARGE-batch_8-BFLOAT8_B-SHARDED", 322],
-        [8, "BERT_LARGE-batch_8-BFLOAT8_B-SHARDED", 360],
+        [8, "BERT_LARGE-batch_8-BFLOAT8_B-SHARDED", 371],
     ],
 )
 def test_perf_device_bare_metal_wh(batch_size, test, expected_perf):

--- a/models/demos/segformer/tests/perf/test_perf_segformer.py
+++ b/models/demos/segformer/tests/perf/test_perf_segformer.py
@@ -20,8 +20,6 @@ from models.utility_functions import run_for_wormhole_b0
     ],
 )
 def test_perf_segformer(device, batch_size, act_dtype, weight_dtype, expected_compile_time, expected_inference_time):
-    device.enable_program_cache()
-
     segformer = SegformerBare(
         device,
         batch_size,

--- a/models/demos/segformer/tests/perf/test_perf_segformer_trace_2cq.py
+++ b/models/demos/segformer/tests/perf/test_perf_segformer_trace_2cq.py
@@ -25,8 +25,6 @@ from models.utility_functions import run_for_wormhole_b0
 def test_perf_segformer_trace_2cq(
     device, batch_size, act_dtype, weight_dtype, expected_compile_time, expected_inference_time
 ):
-    device.enable_program_cache()
-
     segformer_t2cq = SegformerTrace2CQ(
         device,
         batch_size,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_generation.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_generation.py
@@ -126,8 +126,6 @@ def test_LlamaModel_inference(
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
-    t3k_mesh_device.enable_program_cache()
-
     args = construct_arg(
         implementation=implementation,
         llama_version=llama_version,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_perf.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_perf.py
@@ -301,8 +301,6 @@ def test_Llama_perf_host(
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
-    t3k_mesh_device.enable_program_cache()
-
     run_test_LlamaModel_end_to_end(
         t3k_mesh_device,
         batch,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_stress_test.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_stress_test.py
@@ -133,7 +133,6 @@ def test_Llama_stress_test(
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
-    t3k_mesh_device.enable_program_cache()
     run_test_LlamaModel_stress_test(
         devices,
         batch,

--- a/models/demos/ttnn_falcon7b/demo/demo.py
+++ b/models/demos/ttnn_falcon7b/demo/demo.py
@@ -96,8 +96,6 @@ def run_falcon_demo_kv(
 ):
     torch.manual_seed(0)
 
-    device.enable_program_cache()
-
     tt_cache_path = get_tt_cache_path(model_version)
 
     configuration = FalconConfig(**model_config_entries)
@@ -397,8 +395,6 @@ def run_falcon_demo_kv(
     logger.info(f"Total number of tokens generated in decode: {num_tokens_generated_decode}")
 
     print_output_prompts(generated_ids, tokenizer)
-
-    device.disable_and_clear_program_cache()
 
     generated_text = tokenizer.batch_decode(generated_ids.tolist())
 

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
@@ -276,8 +276,6 @@ def test_t3k_falcon_causal_lm_with_trace(
     model_config_str,
     num_loops,
 ):
-    t3k_mesh_device.enable_program_cache()
-
     torch.manual_seed(0)
     batch = device_batch_size * t3k_mesh_device.get_num_devices()
     if llm_mode == "decode":

--- a/models/demos/vgg_unet/demo/demo.py
+++ b/models/demos/vgg_unet/demo/demo.py
@@ -51,6 +51,8 @@ filterwarnings("ignore")
 def test_demo(
     device, use_program_cache, model_location_generator, reset_seeds, demo_type, model_type, use_pretrained_weight
 ):
+    # https://github.com/tenstorrent/tt-metal/issues/23270
+    device.disable_and_clear_program_cache()
     disable_persistent_kernel_cache()
     # Download latest version of the dataset
     path = kagglehub.dataset_download("mateuszbuda/lgg-mri-segmentation")

--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -375,6 +375,8 @@ def run_demo_whisper_for_audio_classification_dataset(ttnn_model, device):
 def run_demo_whisper_for_conditional_generation_inference(input_path, ttnn_model, device, num_inputs):
     torch.manual_seed(0)
 
+    # todo: add ticket if this is the actual issue
+    device.disable_and_clear_program_cache()
     # instantiate model inference pipeline
     model_pipeline = create_functional_whisper_for_conditional_generation_inference_pipeline(ttnn_model, device)
 

--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -375,8 +375,6 @@ def run_demo_whisper_for_audio_classification_dataset(ttnn_model, device):
 def run_demo_whisper_for_conditional_generation_inference(input_path, ttnn_model, device, num_inputs):
     torch.manual_seed(0)
 
-    # todo: add ticket if this is the actual issue
-    device.disable_and_clear_program_cache()
     # instantiate model inference pipeline
     model_pipeline = create_functional_whisper_for_conditional_generation_inference_pipeline(ttnn_model, device)
 

--- a/models/demos/wormhole/mamba/demo/demo.py
+++ b/models/demos/wormhole/mamba/demo/demo.py
@@ -415,6 +415,9 @@ def run_mamba_demo(
     ),
 )
 def test_demo(user_input, device, use_program_cache, get_tt_cache_path, model_version, max_gen_len):
+    # https://github.com/tenstorrent/tt-metal/issues/23282
+    device.disable_and_clear_program_cache()
+
     return run_mamba_demo(
         prompts=user_input,
         device=device,

--- a/models/demos/wormhole/stable_diffusion/demo/demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/demo.py
@@ -64,7 +64,6 @@ def preprocess_images(image_paths):
 
 def run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inference_steps, image_size=(256, 256)):
     enable_persistent_kernel_cache()
-    device.enable_program_cache()
     profiler.clear()
 
     # Until di/dt issues are resolved
@@ -229,7 +228,6 @@ def run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inferen
 
 def run_interactive_demo_inference(device, num_inference_steps, image_size=(256, 256)):
     enable_persistent_kernel_cache()
-    device.enable_program_cache()
 
     # Until di/dt issues are resolved
     os.environ["SLOW_MATMULS"] = "1"
@@ -375,7 +373,6 @@ def run_demo_inference_diffusiondb(
     device, reset_seeds, input_path, num_prompts, num_inference_steps, image_size=(256, 256)
 ):
     enable_persistent_kernel_cache()
-    device.enable_program_cache()
 
     # Until di/dt issues are resolved
     os.environ["SLOW_MATMULS"] = "1"

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
@@ -37,7 +37,6 @@ model_pipeline = None
 
 def create_model_pipeline(device, num_inference_steps, image_size=(256, 256)):
     disable_persistent_kernel_cache()
-    device.enable_program_cache()
 
     # Until di/dt issues are resolved
     os.environ["SLOW_MATMULS"] = "1"
@@ -193,7 +192,6 @@ def warmup_model():
     dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
     device_params["dispatch_core_config"] = dispatch_core_config
     device = ttnn.CreateDevice(device_id=device_id, **device_params)
-    device.enable_program_cache()
     num_inference_steps = 50
     image_size = (512, 512)
     create_model_pipeline(device, num_inference_steps, image_size)

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attention.py
@@ -41,7 +41,6 @@ def test_cross_attention_512x512(
     use_program_cache,
 ):
     torch.manual_seed(0)
-    device.enable_program_cache()
 
     N, C, H, W = input_shape
 

--- a/models/demos/yolov4/tests/pcc/test_ttnn_yolov4.py
+++ b/models/demos/yolov4/tests/pcc/test_ttnn_yolov4.py
@@ -28,6 +28,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 def run_yolov4(device, reset_seeds, model_location_generator, use_pretrained_weight, resolution):
     torch.manual_seed(0)
 
+    # https://github.com/tenstorrent/tt-metal/issues/23192
+    device.disable_and_clear_program_cache()
     if use_pretrained_weight:
         torch_model = load_torch_model(model_location_generator)
     else:

--- a/models/demos/yolov4/tests/perf/test_perf.py
+++ b/models/demos/yolov4/tests/perf/test_perf.py
@@ -32,6 +32,10 @@ def test_yolov4(
     model_location_generator,
 ):
     disable_persistent_kernel_cache()
+
+    # https://github.com/tenstorrent/tt-metal/issues/23271
+    device.disable_and_clear_program_cache()
+
     profiler.clear()
 
     batch_size = input_shape[0]

--- a/models/demos/yolov8s_world/tests/test_perf_yolov8s_world.py
+++ b/models/demos/yolov8s_world/tests/test_perf_yolov8s_world.py
@@ -43,6 +43,9 @@ def get_expected_times(name):
     ],
 )
 def test_perf(device, use_pretrained_weight, use_program_cache):
+    # https://github.com/tenstorrent/tt-metal/issues/23288
+    device.disable_and_clear_program_cache()
+
     disable_persistent_kernel_cache()
     torch_input = torch.randn(1, 3, 640, 640)
 

--- a/models/demos/yolov9c/tests/perf/test_perf.py
+++ b/models/demos/yolov9c/tests/perf/test_perf.py
@@ -54,8 +54,9 @@ def dealloc_output(output_tensor):
 )
 def test_perf(device, model_task, use_weights_from_ultralytics):
     disable_persistent_kernel_cache()
-
     enable_segment = model_task == "segment"
+    # https://github.com/tenstorrent/tt-metal/issues/23288
+    device.disable_and_clear_program_cache()
 
     torch_input, ttnn_input = create_yolov9c_input_tensors(device, model=True)
     batch_size = torch_input.shape[0]

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -100,6 +100,9 @@ def test_unet_trace_perf(
         test_unet_trace_2cq,
     )
 
+    # https://github.com/tenstorrent/tt-metal/issues/23272
+    device.disable_and_clear_program_cache()
+
     logger.info(f"Invoking underlying model test for {iterations} iterations...")
     result = test_unet_trace_2cq(batch, groups, iterations, device, use_program_cache, reset_seeds)
 

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -150,8 +150,6 @@ def test_unet_trace_perf_multi_device(
     )
 
     model_name = "unet_shallow-trace_2cq_same_io-multi_device"
-    # todo: add ticket if this is the actual issue
-    mesh_device.disable_and_clear_program_cache()
 
     logger.info(f"Invoking underlying model test for {iterations} iterations...")
     result = test_unet_trace_2cq_multi_device(batch, groups, iterations, mesh_device, use_program_cache, reset_seeds)

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -100,9 +100,6 @@ def test_unet_trace_perf(
         test_unet_trace_2cq,
     )
 
-    # https://github.com/tenstorrent/tt-metal/issues/23272
-    device.disable_and_clear_program_cache()
-
     logger.info(f"Invoking underlying model test for {iterations} iterations...")
     result = test_unet_trace_2cq(batch, groups, iterations, device, use_program_cache, reset_seeds)
 
@@ -148,14 +145,13 @@ def test_unet_trace_perf_multi_device(
     use_program_cache,
     reset_seeds,
 ):
-    # https://github.com/tenstorrent/tt-metal/issues/23272
-    mesh_device.disable_and_clear_program_cache()
-
     from models.experimental.functional_unet.tests.test_unet_trace import (
         test_unet_trace_2cq_multi_device,
     )
 
     model_name = "unet_shallow-trace_2cq_same_io-multi_device"
+    # todo: add ticket if this is the actual issue
+    mesh_device.disable_and_clear_program_cache()
 
     logger.info(f"Invoking underlying model test for {iterations} iterations...")
     result = test_unet_trace_2cq_multi_device(batch, groups, iterations, mesh_device, use_program_cache, reset_seeds)

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -148,6 +148,9 @@ def test_unet_trace_perf_multi_device(
     use_program_cache,
     reset_seeds,
 ):
+    # https://github.com/tenstorrent/tt-metal/issues/23272
+    mesh_device.disable_and_clear_program_cache()
+
     from models.experimental.functional_unet.tests.test_unet_trace import (
         test_unet_trace_2cq_multi_device,
     )

--- a/models/experimental/functional_vanilla_unet/demo/demo.py
+++ b/models/experimental/functional_vanilla_unet/demo/demo.py
@@ -121,6 +121,9 @@ def create_custom_preprocessor(device):
 @pytest.mark.parametrize("use_torch_model", [False])
 @run_for_wormhole_b0()
 def test_unet_demo_single_image(device, reset_seeds, model_location_generator, use_torch_model):
+    # https://github.com/tenstorrent/tt-metal/issues/23269
+    device.disable_and_clear_program_cache()
+
     weights_path = "models/experimental/functional_vanilla_unet/unet.pt"
     if not os.path.exists(weights_path):
         os.system("bash models/experimental/functional_vanilla_unet/weights_download.sh")

--- a/models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py
+++ b/models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py
@@ -129,6 +129,8 @@ def get_expected_times(name):
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True, ids=["0"])
 def test_vanilla_unet(device, reset_seeds):
     torch.manual_seed(0)
+    # https://github.com/tenstorrent/tt-metal/issues/23281
+    device.disable_and_clear_program_cache()
 
     weights_path = "models/experimental/functional_vanilla_unet/unet.pt"
     if not os.path.exists(weights_path):

--- a/models/tt_transformers/demo/multimodal_demo_chat.py
+++ b/models/tt_transformers/demo/multimodal_demo_chat.py
@@ -59,7 +59,6 @@ def test_multimodal_demo_chat(
         )
     else:
         logger.info(f"Creating TT model on {mesh_device.get_num_devices()} devices")
-        mesh_device.enable_program_cache()
 
         model_args, model, _ = create_multimodal_model(
             mesh_device, max_batch_size=max_batch_size, max_seq_len=max_seq_len

--- a/models/tt_transformers/demo/multimodal_demo_text.py
+++ b/models/tt_transformers/demo/multimodal_demo_text.py
@@ -65,7 +65,6 @@ def test_multimodal_demo_text(
         )
     else:
         logger.info(f"Creating TT model on {mesh_device.get_num_devices()} devices")
-        mesh_device.enable_program_cache()
 
         model_args, model, _ = create_multimodal_model(
             mesh_device, max_batch_size=max_batch_size, max_seq_len=max_seq_len

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -156,8 +156,6 @@ def test_multimodal_demo_text(
     ckpt_dir = os.environ["LLAMA_DIR"]
     tokenizer_path = str(Path(ckpt_dir) / "tokenizer.model")
 
-    mesh_device.enable_program_cache()
-
     num_devices = mesh_device.get_num_devices() if isinstance(mesh_device, ttnn.MeshDevice) else 1
     max_batch_size *= data_parallel  # input batch_size is interpreted as size per DP group
 

--- a/tests/tt_eager/integration_tests/test_bert.cpp
+++ b/tests/tt_eager/integration_tests/test_bert.cpp
@@ -358,10 +358,9 @@ void test_bert() {
         log_info(tt::LogTest, "average duration: {} average_duration", total_duration);
         log_info(tt::LogTest, "samples per second: {}", num_samples_per_second);
     };
-    device->enable_program_cache();
+
     run_bert();
     run_loop();
-    device->disable_and_clear_program_cache();
 }
 
 int main(int argc, char** argv) {

--- a/tests/tt_eager/ops/test_bcast_op.cpp
+++ b/tests/tt_eager/ops/test_bcast_op.cpp
@@ -115,11 +115,9 @@ int main(int argc, char** argv) {
         };
         run_operations();
 
-        device->enable_program_cache();
         run_operations();
         run_operations();
         run_operations();
-        device->disable_and_clear_program_cache();
     } catch (const std::exception& e) {
         pass = false;
         // Capture the exception error message

--- a/tests/tt_eager/ops/test_eltwise_binary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_binary_op.cpp
@@ -118,6 +118,8 @@ int main() {
         }
     };
 
+    // Since we are going to validate cache entries, we need to clear the cache
+    device->disable_and_clear_program_cache();
     device->enable_program_cache();
 
     run_binary_ops();

--- a/tests/tt_eager/ops/test_eltwise_binary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_binary_op.cpp
@@ -118,10 +118,6 @@ int main() {
         }
     };
 
-    // Since we are going to validate cache entries, we need to clear the cache
-    device->disable_and_clear_program_cache();
-    device->enable_program_cache();
-
     run_binary_ops();
     run_binary_ops();
 

--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -279,9 +279,6 @@ void test_program_cache() {
         run_test<UnaryOpType::SQRT>(device, ttnn::Shape({1, 1, 384, 4096}), 0.0f, 1.0f, 1e-1f, 1e-5f);
     };
 
-    // Since we are going to validate cache entries, we need to clear the cache
-    device->disable_and_clear_program_cache();
-    device->enable_program_cache();
     run_tests();
 
     TT_FATAL(device->num_program_cache_entries() == 4, "There are {} entries", device->num_program_cache_entries());

--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -279,6 +279,8 @@ void test_program_cache() {
         run_test<UnaryOpType::SQRT>(device, ttnn::Shape({1, 1, 384, 4096}), 0.0f, 1.0f, 1e-1f, 1e-5f);
     };
 
+    // Since we are going to validate cache entries, we need to clear the cache
+    device->disable_and_clear_program_cache();
     device->enable_program_cache();
     run_tests();
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -41,6 +41,9 @@ using namespace tt::tt_metal;
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 void RunTest(WatcherFixture* fixture, IDevice* device) {
+    // https://github.com/tenstorrent/tt-metal/issues/23306
+    device->disable_and_clear_program_cache();
+
     // Set up program
     Program program = Program();
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_device/test_enqueue_read_write_core.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_device/test_enqueue_read_write_core.cpp
@@ -297,6 +297,9 @@ TEST_F(CommandQueueSingleCardFixture, IdleEthTestInvalidReadWriteAddressL1) {
             GTEST_SKIP() << "No idle ethernet cores found";
         }
 
+        // https://github.com/tenstorrent/tt-metal/issues/23296
+        device->disable_and_clear_program_cache();
+
         std::unordered_set<CoreCoord> idle_ethernet_cores = device->get_inactive_ethernet_cores();
         const CoreCoord eth_core = *idle_ethernet_cores.begin();
         const CoreCoord virtual_core = device->ethernet_core_from_logical_core(eth_core);

--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -483,6 +483,9 @@ TEST_F(BlackholeSingleCardFixture, IdleEthKernelOnIdleErisc1) {
 }
 
 TEST_F(BlackholeSingleCardFixture, IdleEthKernelOnBothIdleEriscs) {
+    // https://github.com/tenstorrent/tt-metal/issues/23307
+    device_->disable_and_clear_program_cache();
+
     using namespace CMAKE_UNIQUE_NAMESPACE;
     uint32_t read_write_size_bytes = WORD_SIZE * 2048;
     uint32_t reader_dst_address =

--- a/tests/ttnn/integration_tests/distilbert/test_ttnn_distilbert.py
+++ b/tests/ttnn/integration_tests/distilbert/test_ttnn_distilbert.py
@@ -21,6 +21,9 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [768])
 def test_distilbert_for_question_answering(device, model_name, batch_size, sequence_size, reset_seeds):
+    # https://github.com/tenstorrent/tt-metal/issues/23275
+    device.disable_and_clear_program_cache()
+
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     HF_model = HF_DistilBertForQuestionAnswering.from_pretrained(model_name)
 

--- a/tests/ttnn/integration_tests/yolov8s_world/test_ttnn_yolov8s_world.py
+++ b/tests/ttnn/integration_tests/yolov8s_world/test_ttnn_yolov8s_world.py
@@ -694,6 +694,9 @@ def test_WorldModel(device, use_pretrained_weight, reset_seeds):
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @run_for_wormhole_b0()
 def test_YoloModel(device, use_pretrained_weight, reset_seeds):
+    # https://github.com/tenstorrent/tt-metal/issues/23275
+    device.disable_and_clear_program_cache()
+
     x = torch.randn(1, 3, 640, 640)
 
     if use_pretrained_weight:

--- a/tests/ttnn/integration_tests/yolov9c/test_ttnn_yolov9c.py
+++ b/tests/ttnn/integration_tests/yolov9c/test_ttnn_yolov9c.py
@@ -38,9 +38,6 @@ def test_yolov9c(use_weights_from_ultralytics, model_task, device, use_program_c
     torch_input, ttnn_input = create_yolov9c_input_tensors(device, model=True)
     state_dict = None
 
-    # todo: add ticket if this is the actual issue
-    device.disable_and_clear_program_cache()
-
     weights = "yolov9c-seg.pt" if model_task == "segment" else "yolov9c.pt"
     enable_segment = model_task == "segment"
 

--- a/tests/ttnn/integration_tests/yolov9c/test_ttnn_yolov9c.py
+++ b/tests/ttnn/integration_tests/yolov9c/test_ttnn_yolov9c.py
@@ -38,6 +38,9 @@ def test_yolov9c(use_weights_from_ultralytics, model_task, device, use_program_c
     torch_input, ttnn_input = create_yolov9c_input_tensors(device, model=True)
     state_dict = None
 
+    # todo: add ticket if this is the actual issue
+    device.disable_and_clear_program_cache()
+
     weights = "yolov9c-seg.pt" if model_task == "segment" else "yolov9c.pt"
     enable_segment = model_task == "segment"
 

--- a/tests/ttnn/profiling/profile_host_overhead.py
+++ b/tests/ttnn/profiling/profile_host_overhead.py
@@ -326,9 +326,6 @@ def test_host_overhead(device, user_input):
     python -m tracy -v -r -p -o host_overhead_profile --no-device -m "pytest tests/ttnn/profiling/profile_host_overhead.py --input-method cli --cli-input host_overhead_profile"
     """
 
-    # Enable program cache
-    device.enable_program_cache()
-
     if "::" in user_input[0]:
         splitted = user_input[0].split("::")
         out_directory = splitted[0]

--- a/tests/ttnn/tracy/test_dispatch_profiler.py
+++ b/tests/ttnn/tracy/test_dispatch_profiler.py
@@ -12,7 +12,6 @@ import ttnn
 def test_with_ops(device):
     torch.manual_seed(0)
 
-    device.enable_program_cache()
     m = 1024
     k = 1024
     n = 1024

--- a/tests/ttnn/tracy/test_profiler_sync.py
+++ b/tests/ttnn/tracy/test_profiler_sync.py
@@ -12,7 +12,6 @@ import ttnn
 def test_with_ops(device):
     torch.manual_seed(0)
 
-    device.enable_program_cache()
     m = 1024
     k = 1024
     n = 1024

--- a/tests/ttnn/tracy/test_trace_runs.py
+++ b/tests/ttnn/tracy/test_trace_runs.py
@@ -11,8 +11,6 @@ import ttnn
 
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 1996800}], indirect=True)
 def test_with_ops(device):
-    device.enable_program_cache()
-
     torch.manual_seed(0)
     m = 1024
     k = 1024

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -54,7 +54,6 @@ protected:
 };
 
 TEST_F(T3000MultiCQMeshDeviceFixture, AllGather) {
-    mesh_device_->enable_program_cache();
     auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
 
     std::vector<ttnn::Tensor> tensors;
@@ -76,7 +75,6 @@ TEST_F(T3000MultiCQMeshDeviceFixture, AllGather) {
 }
 
 TEST_F(T3000MultiCQFabricMeshDeviceFixture, AllGatherAsync) {
-    mesh_device_->enable_program_cache();
     auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
 
     std::vector<ttnn::Tensor> tensors;
@@ -100,7 +98,6 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AllGatherAsync) {
 }
 
 TEST_F(T3000MultiCQMeshDeviceFixture, ReduceScatter) {
-    mesh_device_->enable_program_cache();
     auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
 
     std::vector<ttnn::Tensor> tensors;
@@ -122,7 +119,6 @@ TEST_F(T3000MultiCQMeshDeviceFixture, ReduceScatter) {
 }
 
 TEST_F(T3000MultiCQMeshDeviceFixture, AllReduce) {
-    mesh_device_->enable_program_cache();
     auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
 
     std::vector<ttnn::Tensor> tensors;

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -69,7 +69,6 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
     constexpr size_t test_expected_num_devices = 4;
 
     MeshDevice* mesh_device = this->mesh_device_.get();
-    mesh_device->enable_program_cache();
 
     auto view = mesh_device->get_view();
 
@@ -217,7 +216,6 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
     constexpr size_t test_expected_num_devices = 4;
 
     MeshDevice* mesh_device = this->mesh_device_.get();
-    mesh_device->enable_program_cache();
 
     auto view = mesh_device->get_view();
 

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -274,6 +274,8 @@ TEST_F(LaunchOperationT3000Test, LaunchOpFilterTensorShards) {
 }
 
 TEST_F(LaunchOperationT3000Test, CachingHeterogeneousDispatch) {
+    // Since we are going to validate cache entries, we need to clear the cache
+    mesh_device_->disable_and_clear_program_cache();
     mesh_device_->enable_program_cache();
     EXPECT_EQ(mesh_device_->get_program_cache().num_entries(), 0);
 

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -274,9 +274,6 @@ TEST_F(LaunchOperationT3000Test, LaunchOpFilterTensorShards) {
 }
 
 TEST_F(LaunchOperationT3000Test, CachingHeterogeneousDispatch) {
-    // Since we are going to validate cache entries, we need to clear the cache
-    mesh_device_->disable_and_clear_program_cache();
-    mesh_device_->enable_program_cache();
     EXPECT_EQ(mesh_device_->get_program_cache().num_entries(), 0);
 
     const TensorSpec tensor_spec = TensorSpec(

--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -81,9 +81,7 @@ TEST_F(MultiCommandQueueT3KFixture, DISABLED_Test2CQMultiDeviceProgramsOnCQ1) {
             for (auto& dev : this->devs) {
                 auto dev_idx = dev.first;
                 auto device = dev.second;
-                if (i == 0 and outer_loop == 0) {
-                    device->enable_program_cache();
-                }
+
                 for (int j = 0; j < buf_size_datums; j++) {
                     host_data[j] = bfloat16(static_cast<float>(i + dev_idx));
                 }
@@ -139,9 +137,7 @@ TEST_F(MultiCommandQueueT3KFixture, DISABLED_Test2CQMultiDeviceProgramsOnCQ0) {
             for (auto& dev : this->devs) {
                 auto dev_idx = dev.first;
                 auto device = dev.second;
-                if (i == 0 and outer_loop == 0) {
-                    device->enable_program_cache();
-                }
+
                 for (int j = 0; j < buf_size_datums; j++) {
                     host_data[j] = bfloat16(static_cast<float>(i + dev_idx));
                 }
@@ -193,9 +189,6 @@ TEST_F(MultiCommandQueueT3KFixture, DISABLED_Test2CQMultiDeviceWithCQ1Only) {
             for (auto& dev : this->devs) {
                 auto dev_idx = dev.first;
                 auto device = dev.second;
-                if (i == 0 and outer_loop == 0) {
-                    device->enable_program_cache();
-                }
                 for (int j = 0; j < buf_size_datums; j++) {
                     host_data[j] = bfloat16(static_cast<float>(i + dev_idx));
                 }

--- a/tests/ttnn/unit_tests/light_metal/test_single_device_light_metal_trace.py
+++ b/tests/ttnn/unit_tests/light_metal/test_single_device_light_metal_trace.py
@@ -41,8 +41,6 @@ def reset_device_and_replay_binary(reset_device, device, binary_data):
 def test_single_op_test_light_metal_capture(device, reset_device, shape, blocking, tmp_path):
     ttnn.light_metal_begin_capture()
 
-    device.enable_program_cache()
-
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
     input_1_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
     output_tensor = ttnn.add(input_0_dev, input_1_dev)
@@ -64,7 +62,6 @@ def test_single_op_test_light_metal_capture(device, reset_device, shape, blockin
 def test_chain_op_test_light_metal_capture(device, reset_device, shape, blocking, tmp_path):
     ttnn.light_metal_begin_capture()
 
-    device.enable_program_cache()
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
     input_1_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
@@ -74,9 +74,6 @@ def run_reduce_scatter_test(
     profiler=BenchmarkProfiler(),
     topology=ttnn.Topology.Linear,
 ):
-    # Since we are going to validate cache entries, we need to clear the cache
-    mesh_device.disable_and_clear_program_cache()
-    mesh_device.enable_program_cache()
     num_pages_per_packet = 4
     cyclic_buffer_size = 8
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
@@ -74,6 +74,8 @@ def run_reduce_scatter_test(
     profiler=BenchmarkProfiler(),
     topology=ttnn.Topology.Linear,
 ):
+    # Since we are going to validate cache entries, we need to clear the cache
+    mesh_device.disable_and_clear_program_cache()
     mesh_device.enable_program_cache()
     num_pages_per_packet = 4
     cyclic_buffer_size = 8

--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_create_heads_async_TG.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_create_heads_async_TG.py
@@ -80,9 +80,6 @@ def run_reduce_scatter_test(
     dtype=ttnn.bfloat8_b,
     profiler=BenchmarkProfiler(),
 ):
-    # Since we are going to validate cache entries, we need to clear the cache
-    mesh_device.disable_and_clear_program_cache()
-    mesh_device.enable_program_cache()
     num_pages_per_packet = 4
     cyclic_buffer_size = 8
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_create_heads_async_TG.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_create_heads_async_TG.py
@@ -80,6 +80,8 @@ def run_reduce_scatter_test(
     dtype=ttnn.bfloat8_b,
     profiler=BenchmarkProfiler(),
 ):
+    # Since we are going to validate cache entries, we need to clear the cache
+    mesh_device.disable_and_clear_program_cache()
     mesh_device.enable_program_cache()
     num_pages_per_packet = 4
     cyclic_buffer_size = 8

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_TG_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_TG_nightly.py
@@ -119,8 +119,6 @@ def run_line_reduce_scatter_on_TG_with_mesh_tensor_along_rows(
     use_reduce_scatter_async=False,
     use_persistent_output=False,
 ):
-    mesh_device.enable_program_cache()
-
     per_reduce_scatter_output_shape = list(per_chip_input_shape)
     per_reduce_scatter_output_shape[dim] *= num_devices_per_line
     full_mesh_input_shape = list(per_reduce_scatter_output_shape)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1966,6 +1966,8 @@ profile_a_b_shape_pairs = [
 )
 @pytest.mark.parametrize("a_and_b_shape", profile_a_b_shape_pairs)
 def test_binary_bcast_profile(device, dtype_pt, dtype_tt, a_and_b_shape, memory_config_input):
+    # Since we are going to validate cache entries, we need to clear the cache
+    device.disable_and_clear_program_cache()
     device.enable_program_cache()
     torch.manual_seed(0)
     a_shape, b_shape = a_and_b_shape

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1966,9 +1966,6 @@ profile_a_b_shape_pairs = [
 )
 @pytest.mark.parametrize("a_and_b_shape", profile_a_b_shape_pairs)
 def test_binary_bcast_profile(device, dtype_pt, dtype_tt, a_and_b_shape, memory_config_input):
-    # Since we are going to validate cache entries, we need to clear the cache
-    device.disable_and_clear_program_cache()
-    device.enable_program_cache()
     torch.manual_seed(0)
     a_shape, b_shape = a_and_b_shape
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
@@ -139,7 +139,6 @@ profile_input_bcast_shape_pairs = [
 )
 @pytest.mark.parametrize("shape_and_broadcast_spec", profile_input_bcast_shape_pairs)
 def test_broadcast_to_profile(device, dtype_pt, dtype_tt, shape_and_broadcast_spec, memory_config_input):
-    device.enable_program_cache()
     torch.manual_seed(0)
     shape, broadcast_shape = shape_and_broadcast_spec
     if dtype_pt == torch.bfloat16 and shape[-1] < 2 and broadcast_shape[-1] < 2:

--- a/tests/ttnn/unit_tests/operations/reduce/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sort.py
@@ -171,6 +171,8 @@ def test_sort_l1_memory_tensor(shape, dim, descending, device):
 )
 def test_sort_program_cache(shape, dim, descending, device):
     torch.manual_seed(0)
+    # Since we are going to validate cache entries, we need to clear the cache
+    device.disable_and_clear_program_cache()
     device.enable_program_cache()
 
     torch_dtype = torch.bfloat16

--- a/tests/ttnn/unit_tests/operations/reduce/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sort.py
@@ -171,9 +171,6 @@ def test_sort_l1_memory_tensor(shape, dim, descending, device):
 )
 def test_sort_program_cache(shape, dim, descending, device):
     torch.manual_seed(0)
-    # Since we are going to validate cache entries, we need to clear the cache
-    device.disable_and_clear_program_cache()
-    device.enable_program_cache()
 
     torch_dtype = torch.bfloat16
     input = torch.randn(shape, dtype=torch_dtype)

--- a/tests/ttnn/unit_tests/operations/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/test_concat.py
@@ -154,8 +154,8 @@ def test_concat(device, height, width, dim):
     ),
 )
 def test_sharded_concat(device, inputs, output_shard_shape, shard_grid, strategy, layout, cache_mode):
-    if cache_mode:
-        device.enable_program_cache()
+    if not cache_mode:
+        device.disable_and_clear_program_cache()
 
     dim = 2 if strategy == ttnn.ShardStrategy.WIDTH else 3
 

--- a/tests/ttnn/unit_tests/operations/test_interleaved_to_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_interleaved_to_sharded.py
@@ -23,8 +23,6 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("input_in_l1", [True, False])
 @pytest.mark.parametrize("keep_l1_aligned", [True, False])
 def test_interleaved_to_sharded_hash(device, first_dtype, second_dtype, input_in_l1, keep_l1_aligned):
-    device.enable_program_cache()
-
     # Sample tensor size and shard config
     input_tensor_shape = (1, 1, 512, 512)
     input_memory_config = ttnn.L1_MEMORY_CONFIG if input_in_l1 else ttnn.DRAM_MEMORY_CONFIG

--- a/tests/ttnn/unit_tests/operations/test_moreh_logsoftmax.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_logsoftmax.py
@@ -358,7 +358,10 @@ def test_logsoftmax_backward_large_algorithm_for_dim_hw(shape_dim, dtype, comput
 )
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
+    # Since we are going to validate cache entries, we need to clear the cache
+    device.disable_and_clear_program_cache()
     device.enable_program_cache()
+
     shape, dim = shape_dim
     torch.manual_seed(0)
     rtol = atol = 0.1
@@ -395,7 +398,10 @@ def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, dtype, com
 )
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_logsoftmax_backward_for_dim_nc(shape_dim, dtype, compute_kernel_options, device):
+    # Since we are going to validate cache entries, we need to clear the cache
+    device.disable_and_clear_program_cache()
     device.enable_program_cache()
+
     shape, dim = shape_dim
     torch.manual_seed(0)
 
@@ -426,6 +432,8 @@ def test_logsoftmax_backward_for_dim_nc(shape_dim, dtype, compute_kernel_options
     ],
 )
 def test_logsoftmax_optional_output_tensor(shape_dim, dtype, device):
+    # Since we are going to validate cache entries, we need to clear the cache
+    device.disable_and_clear_program_cache()
     device.enable_program_cache()
 
     shape, dim = shape_dim

--- a/tests/ttnn/unit_tests/operations/test_moreh_logsoftmax.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_logsoftmax.py
@@ -358,10 +358,6 @@ def test_logsoftmax_backward_large_algorithm_for_dim_hw(shape_dim, dtype, comput
 )
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
-    # Since we are going to validate cache entries, we need to clear the cache
-    device.disable_and_clear_program_cache()
-    device.enable_program_cache()
-
     shape, dim = shape_dim
     torch.manual_seed(0)
     rtol = atol = 0.1
@@ -398,10 +394,6 @@ def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, dtype, com
 )
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_logsoftmax_backward_for_dim_nc(shape_dim, dtype, compute_kernel_options, device):
-    # Since we are going to validate cache entries, we need to clear the cache
-    device.disable_and_clear_program_cache()
-    device.enable_program_cache()
-
     shape, dim = shape_dim
     torch.manual_seed(0)
 
@@ -432,10 +424,6 @@ def test_logsoftmax_backward_for_dim_nc(shape_dim, dtype, compute_kernel_options
     ],
 )
 def test_logsoftmax_optional_output_tensor(shape_dim, dtype, device):
-    # Since we are going to validate cache entries, we need to clear the cache
-    device.disable_and_clear_program_cache()
-    device.enable_program_cache()
-
     shape, dim = shape_dim
     torch.manual_seed(0)
     rtol = atol = 0.05

--- a/tests/ttnn/unit_tests/operations/test_reallocate.py
+++ b/tests/ttnn/unit_tests/operations/test_reallocate.py
@@ -20,6 +20,9 @@ def test_reallocate_interleaved(device, mem_config, num_allocs):
     depth = 2
     batch = 2
 
+    # https://github.com/tenstorrent/tt-metal/issues/23236
+    device.disable_and_clear_program_cache()
+
     if num_allocs == 2 and mem_config == ttnn.DRAM_MEMORY_CONFIG:
         pytest.xfail("#7732: dram tensor corruption after move")
 

--- a/tests/ttnn/unit_tests/operations/test_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_scatter.py
@@ -74,6 +74,9 @@ def select_torch_dtype(ttnn_dtype):
 )
 def test_scatter_normal(input_shape, dim, index_and_source_shape, input_dtype, index_dtype, layout, device):
     torch.manual_seed(22052025)
+    # https://github.com/tenstorrent/tt-metal/issues/23205
+    device.disable_and_clear_program_cache()
+    
     torch_dtype = select_torch_dtype(input_dtype)
     torch_index_dtype = select_torch_dtype(index_dtype)
     ##

--- a/tests/ttnn/unit_tests/operations/test_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_scatter.py
@@ -76,7 +76,6 @@ def test_scatter_normal(input_shape, dim, index_and_source_shape, input_dtype, i
     torch.manual_seed(22052025)
     # https://github.com/tenstorrent/tt-metal/issues/23205
     device.disable_and_clear_program_cache()
-    
     torch_dtype = select_torch_dtype(input_dtype)
     torch_index_dtype = select_torch_dtype(index_dtype)
     ##

--- a/tests/ttnn/unit_tests/operations/test_split.py
+++ b/tests/ttnn/unit_tests/operations/test_split.py
@@ -26,6 +26,9 @@ dims = [0, 1, 2, 3, 4]
 @pytest.mark.parametrize("chunksize", chunksize_list)
 @pytest.mark.parametrize("dim", dims)
 def test_split(device, layout, dtype, shape, chunksize, dim):
+    # https://github.com/tenstorrent/tt-metal/issues/23237
+    device.disable_and_clear_program_cache()
+
     if dim > len(shape) - 1:
         pytest.skip("dim greater than rank")
 

--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -248,8 +248,6 @@ def test_multi_device_single_op_unary(mesh_device):
 
 def test_multi_device_single_op_unary_with_cache(mesh_device):
     """Multidevice API test: Running tensor-parallel multi-device single-op unary with cache"""
-    mesh_device.enable_program_cache()
-
     torch_input_tensor = torch.rand((1, 1, 32, 32 * mesh_device.get_num_devices()), dtype=torch.bfloat16)
     torch_output_golden = torch.nn.functional.gelu(torch_input_tensor)
     torch_golden = torch.nn.functional.gelu(torch_output_golden)

--- a/tests/ttnn/unit_tests/test_multi_device_async.py
+++ b/tests/ttnn/unit_tests/test_multi_device_async.py
@@ -132,8 +132,8 @@ def test_multi_device_unary_binary_op_chain(pcie_mesh_device, program_cache, sha
     """Multidevice API test: Running tensor-parallel multi-device chain of eltwise ops"""
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 
-    if program_cache:
-        pcie_mesh_device.enable_program_cache()
+    if not program_cache:
+        pcie_mesh_device.disable_and_clear_program_cache()
 
     torch_silu = torch.nn.SiLU()
     for i in range(50):
@@ -169,8 +169,8 @@ def test_multi_device_data_parallel_op_chain(pcie_mesh_device, program_cache, in
     """Multidevice API: Running data-parallel chain of ops with matmul"""
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor, ReplicateTensorToMesh
 
-    if program_cache:
-        pcie_mesh_device.enable_program_cache()
+    if not program_cache:
+        pcie_mesh_device.disable_and_clear_program_cache()
 
     torch_silu = torch.nn.SiLU()
     torch_mish = torch.nn.Mish()

--- a/tests/ttnn/unit_tests/test_multi_device_events.py
+++ b/tests/ttnn/unit_tests/test_multi_device_events.py
@@ -19,9 +19,6 @@ def test_multi_device_events(t3k_mesh_device, shape):
     if t3k_mesh_device.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
 
-    # Enable Program Cache
-    t3k_mesh_device.enable_program_cache()
-
     # Preallocate activation tensors.
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_mesh_device)
     input_1_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_mesh_device)

--- a/tests/ttnn/unit_tests/test_multi_device_trace.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace.py
@@ -25,9 +25,6 @@ def test_multi_device_single_trace(t3k_mesh_device, shape, use_all_gather, enabl
     if t3k_mesh_device.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
 
-    # Trace requires program cache to be enabled
-    t3k_mesh_device.enable_program_cache()
-
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_mesh_device)
     input_1_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_mesh_device)
@@ -131,8 +128,6 @@ def test_multi_device_multi_trace(t3k_mesh_device, shape, use_all_gather, enable
     torch.manual_seed(0)
     if t3k_mesh_device.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
-    # Trace requires program cache to be enabled
-    t3k_mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_mesh_device)

--- a/tests/ttnn/unit_tests/test_multi_device_trace_TG.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace_TG.py
@@ -24,8 +24,6 @@ NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 15))
 def test_multi_device_single_trace(mesh_device, shape, enable_multi_cq):
     if mesh_device.get_num_devices() < 32:
         pytest.skip("Test is only valid on Galaxy")
-    # Trace requires program cache to be enabled
-    mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, mesh_device)
@@ -118,9 +116,6 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_multi_cq):
     torch.manual_seed(0)
     if mesh_device.get_num_devices() < 32:
         pytest.skip("Test is only valid on Galaxy")
-
-    # Trace requires program cache to be enabled
-    mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, mesh_device)

--- a/tests/ttnn/unit_tests/test_multi_device_trace_tgg.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace_tgg.py
@@ -24,8 +24,6 @@ NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 15))
 def test_multi_device_single_trace(mesh_device, shape, enable_multi_cq):
     if mesh_device.get_num_devices() < 64:
         pytest.skip("Test is only valid on TGG")
-    # Trace requires program cache to be enabled
-    mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, mesh_device)
@@ -118,9 +116,6 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_multi_cq):
     torch.manual_seed(0)
     if mesh_device.get_num_devices() < 64:
         pytest.skip("Test is only valid on TGG")
-
-    # Trace requires program cache to be enabled
-    mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, mesh_device)

--- a/tests/ttnn/unit_tests/test_reshape.py
+++ b/tests/ttnn/unit_tests/test_reshape.py
@@ -22,6 +22,8 @@ from models.utility_functions import skip_for_grayskull
 )
 @pytest.mark.parametrize("enable_cache", [True])
 def test_ttnn_reshape_with_cache(device, enable_cache, input_shape, output_shape):
+    # Since we are going to validate cache entries, we need to clear the cache
+    device.disable_and_clear_program_cache()
     if enable_cache:
         device.enable_program_cache()
 
@@ -49,6 +51,7 @@ def test_ttnn_reshape_with_cache(device, enable_cache, input_shape, output_shape
 )
 @pytest.mark.parametrize("enable_cache", [True])
 def test_tensor_reshape_with_cache(device, enable_cache, input_shape, output_shape):
+    device.disable_and_clear_program_cache()
     if enable_cache:
         device.enable_program_cache()
 

--- a/tests/ttnn/unit_tests/test_reshape.py
+++ b/tests/ttnn/unit_tests/test_reshape.py
@@ -22,10 +22,8 @@ from models.utility_functions import skip_for_grayskull
 )
 @pytest.mark.parametrize("enable_cache", [True])
 def test_ttnn_reshape_with_cache(device, enable_cache, input_shape, output_shape):
-    # Since we are going to validate cache entries, we need to clear the cache
-    device.disable_and_clear_program_cache()
-    if enable_cache:
-        device.enable_program_cache()
+    if not enable_cache:
+        device.disable_program_cache()
 
     a = torch.randn(input_shape, dtype=torch.bfloat16)
     b = torch.randn(input_shape, dtype=torch.bfloat16)
@@ -51,9 +49,9 @@ def test_ttnn_reshape_with_cache(device, enable_cache, input_shape, output_shape
 )
 @pytest.mark.parametrize("enable_cache", [True])
 def test_tensor_reshape_with_cache(device, enable_cache, input_shape, output_shape):
-    device.disable_and_clear_program_cache()
-    if enable_cache:
-        device.enable_program_cache()
+    # respecting the parameters of the test, although cache should be active by default
+    if not enable_cache:
+        device.disable_and_clear_program_cache()
 
     a = torch.randn(input_shape, dtype=torch.bfloat16)
     b = torch.randn(output_shape, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/test_single_device_trace.py
+++ b/tests/ttnn/unit_tests/test_single_device_trace.py
@@ -15,8 +15,6 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("blocking", [True, False])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 200000}], indirect=True)
 def test_single_device_single_trace(device, shape, blocking):
-    device.enable_program_cache()
-
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
     input_1_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
@@ -72,8 +70,6 @@ def test_single_device_single_trace(device, shape, blocking):
 @pytest.mark.parametrize("blocking", [True, False])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 266240}], indirect=True)
 def test_single_device_multi_trace(device, shape, blocking):
-    device.enable_program_cache()
-
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
     input_1_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device)

--- a/tt-train/sources/examples/nano_gpt/3tier/aggregator_worker.cpp
+++ b/tt-train/sources/examples/nano_gpt/3tier/aggregator_worker.cpp
@@ -89,7 +89,6 @@ int main(int argc, char **argv) {
 
     auto [steps_per_dataset, vocab_size] = three_tier_arch::get_steps_per_dataset_and_vocab_size(config);
     auto *device = &ttml::autograd::ctx().get_device();
-    device->enable_program_cache();
 
     auto num_devices = static_cast<uint32_t>(device->num_devices());
     auto should_be_divisible_by = (enable_tp ? num_devices : 1U) * 32U;

--- a/tt-train/sources/examples/nano_gpt/3tier/optimizer_worker.cpp
+++ b/tt-train/sources/examples/nano_gpt/3tier/optimizer_worker.cpp
@@ -83,7 +83,6 @@ int main(int argc, char **argv) {
         config.max_steps);
 
     auto *device = &ctx.get_device();
-    device->enable_program_cache();
 
     auto num_devices = static_cast<uint32_t>(device->num_devices());
     auto should_be_divisible_by = (enable_tp ? num_devices : 1U) * 32U;

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -662,7 +662,6 @@ int main(int argc, char **argv) {
     initialize_device(device_config.mesh_shape, device_config.device_ids);
 
     auto *device = &ttml::autograd::ctx().get_device();
-    device->enable_program_cache();
 
     struct CachedHostData {
         std::vector<uint32_t> data;

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -224,7 +224,6 @@ TEST_F(N300UtilsTest, DropoutDifferentSeed) {
     xt::random::seed(42);
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();
-    device->enable_program_cache();
     auto shapes = {std::vector<int>{64, 1, 256, 384}, std::vector<int>{1, 1, 32, 32}};
     for (auto& shape : shapes) {
         fmt::println("Testing shape: {}", shape);

--- a/tt-train/tests/model/nano_gpt_test.cpp
+++ b/tt-train/tests/model/nano_gpt_test.cpp
@@ -79,9 +79,6 @@ void train_test(bool use_moreh_adamw = false, bool memory_efficient = false) {
     }
 
     auto *device = &ttml::autograd::ctx().get_device();
-    // Since we are going to validate cache entries, we need to clear the cache
-    device->disable_and_clear_program_cache();
-    device->enable_program_cache();
 
     auto sequence_length = config.transformer_config.max_sequence_length;
 

--- a/tt-train/tests/model/nano_gpt_test.cpp
+++ b/tt-train/tests/model/nano_gpt_test.cpp
@@ -79,6 +79,8 @@ void train_test(bool use_moreh_adamw = false, bool memory_efficient = false) {
     }
 
     auto *device = &ttml::autograd::ctx().get_device();
+    // Since we are going to validate cache entries, we need to clear the cache
+    device->disable_and_clear_program_cache();
     device->enable_program_cache();
 
     auto sequence_length = config.transformer_config.max_sequence_length;

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -87,7 +87,6 @@ TEST_F(N300CommOpsTest, TestAllReduceNotFullyTiled) {
 
 TEST_F(N300CommOpsTest, TestAllReduceNanoGPT) {
     auto* device = &ttml::autograd::ctx().get_device();
-    device->enable_program_cache();
     auto mesh_shape = device->shape();
 
     size_t batch_multiplier = rand() % 8 + 1;

--- a/tt-train/tests/ops/rmsnorm_op_test.cpp
+++ b/tt-train/tests/ops/rmsnorm_op_test.cpp
@@ -58,7 +58,6 @@ TEST_F(RMSNormOpTest, RMSNorm_Compare_Kernel_Composite) {
         {1U, 1U, 1U, (1U << 20U) - 18U}};
 
     auto* device = &ttml::autograd::ctx().get_device();
-    device->enable_program_cache();
 
     constexpr uint32_t iterations = 2U;
     for (const auto& shape : shapes) {

--- a/tt-train/tests/ttnn_fixed/dropout_op_test.cpp
+++ b/tt-train/tests/ttnn_fixed/dropout_op_test.cpp
@@ -30,9 +30,7 @@ TEST_F(DropoutTest, TestSeed) {
     float prob = 0.5F;
     xt::random::seed(42);
     auto* device = &ttml::autograd::ctx().get_device();
-    // Since we are going to validate cache entries, we need to clear the cache
-    device->disable_and_clear_program_cache();
-    device->enable_program_cache();
+
     auto shapes = {std::vector<int>{64, 1, 256, 384}, std::vector<int>{1, 1, 32, 32}};
     for (auto& shape : shapes) {
         fmt::println("Testing shape: {}", shape);

--- a/tt-train/tests/ttnn_fixed/dropout_op_test.cpp
+++ b/tt-train/tests/ttnn_fixed/dropout_op_test.cpp
@@ -30,6 +30,8 @@ TEST_F(DropoutTest, TestSeed) {
     float prob = 0.5F;
     xt::random::seed(42);
     auto* device = &ttml::autograd::ctx().get_device();
+    // Since we are going to validate cache entries, we need to clear the cache
+    device->disable_and_clear_program_cache();
     device->enable_program_cache();
     auto shapes = {std::vector<int>{64, 1, 256, 384}, std::vector<int>{1, 1, 32, 32}};
     for (auto& shape : shapes) {
@@ -61,7 +63,6 @@ TEST_F(DropoutTest, TestProb) {
     float scale = 1.0F;
     float prob = 0.2F;
     auto* device = &ttml::autograd::ctx().get_device();
-    device->enable_program_cache();
     xt::xarray<float> xtensor_a = xt::ones<float>({64, 1, 256, 384});
     std::vector<float> ratios;
     ratios.reserve(100);
@@ -109,7 +110,6 @@ TEST_F(DropoutTest, TestKeepRatioApproximatelyNormal) {
     xt::xarray<float> xtensor_a = xt::ones<float>({1, 1, 64, 64});
 
     auto* device = &ttml::autograd::ctx().get_device();
-    device->enable_program_cache();
     auto input_tensor = ttml::core::from_xtensor(xtensor_a, device);
 
     xt::xarray<int> keep_count = xt::zeros<int>(xtensor_a.shape());

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -184,6 +184,7 @@ public:
     // Program cache interface. Syncrhonize with worker worker threads before querying or
     // modifying this structure, since worker threads use this for compiling ops
     virtual void enable_program_cache() = 0;
+    virtual void clear_program_cache() = 0;
     virtual void disable_and_clear_program_cache() = 0;
     void set_program_cache_misses_allowed(bool allowed);
     virtual program_cache::detail::ProgramCache& get_program_cache() = 0;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -225,6 +225,7 @@ public:
     void init_fabric() override;
     bool close() override;
     void enable_program_cache() override;
+    void clear_program_cache() override;
     void disable_and_clear_program_cache() override;
     program_cache::detail::ProgramCache& get_program_cache() override;
     std::size_t num_program_cache_entries() override;

--- a/tt_metal/api/tt-metalium/program_cache.hpp
+++ b/tt_metal/api/tt-metalium/program_cache.hpp
@@ -128,7 +128,7 @@ struct ProgramCache {
     std::size_t num_entries() const { return this->cache_.size(); }
 
 private:
-    bool is_enabled_ = false;
+    bool is_enabled_ = true;
     bool allow_cache_misses_ = true;
     std::unordered_map<uint64_t, CachedProgramFactory> cache_{};
 };

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -536,6 +536,11 @@ void MeshDevice::enable_program_cache() {
     program_cache_->enable();
 }
 
+void MeshDevice::clear_program_cache() {
+    log_info(tt::LogMetal, "Clearing program cache on MeshDevice {}", this->id());
+    program_cache_->clear();
+}
+
 void MeshDevice::disable_and_clear_program_cache() {
     log_info(tt::LogMetal, "Disabling and clearing program cache on MeshDevice {}", this->id());
     if (program_cache_->is_enabled()) {

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -335,8 +335,8 @@ std::shared_ptr<MeshDevice> MeshDevice::create_submesh(
     for (auto device : submesh->get_devices()) {
         dynamic_cast<Device*>(device)->set_mesh_device(submesh);
     }
-    if (program_cache_->is_enabled()) {
-        submesh->enable_program_cache();
+    if (!program_cache_->is_enabled()) {
+        submesh->disable_and_clear_program_cache();
     }
 
     submeshes_.push_back(submesh);

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -335,9 +335,6 @@ std::shared_ptr<MeshDevice> MeshDevice::create_submesh(
     for (auto device : submesh->get_devices()) {
         dynamic_cast<Device*>(device)->set_mesh_device(submesh);
     }
-    if (!program_cache_->is_enabled()) {
-        submesh->disable_and_clear_program_cache();
-    }
 
     submeshes_.push_back(submesh);
     log_trace(LogMetal, "Instantiating submesh {}: {} with offset: {}", submesh->id(), submesh_shape, offset);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1024,6 +1024,8 @@ bool Device::initialize(
     tt::stl::Span<const std::uint32_t> l1_bank_remap,
     bool minimal) {
     ZoneScoped;
+    // Every initialization call should enable program cache
+    this->program_cache_.enable();
     log_info(tt::LogMetal, "Initializing device {}. Program cache is {}enabled", this->id_, this->program_cache_.is_enabled() ? "": "NOT ");
     log_debug(tt::LogMetal, "Running with {} cqs ", num_hw_cqs);
     TT_FATAL(num_hw_cqs > 0 and num_hw_cqs <= dispatch_core_manager::MAX_NUM_HW_CQS, "num_hw_cqs can be between 1 and {}", dispatch_core_manager::MAX_NUM_HW_CQS);
@@ -1415,6 +1417,11 @@ void Device::enable_program_cache() {
     log_info(tt::LogMetal, "Enabling program cache on device {}", this->id_);
     program_cache_.enable();
 }
+void Device::clear_program_cache() {
+    log_info(tt::LogMetal, "Clearing program cache on device {}", this->id_);
+    program_cache_.clear();
+}
+
 void Device::disable_and_clear_program_cache() {
     log_info(tt::LogMetal, "Disabling and clearing program cache on device {}", this->id_);
     if (this->program_cache_.is_enabled()) {

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -155,6 +155,7 @@ public:
     // Program cache interface. Synchronize with worker worker threads before querying or
     // modifying this structure, since worker threads use this for compiling ops
     void enable_program_cache() override;
+    void clear_program_cache() override;
     void disable_and_clear_program_cache() override;
     program_cache::detail::ProgramCache& get_program_cache() override { return program_cache_; }
     std::size_t num_program_cache_entries() override;

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -245,6 +245,12 @@ void py_module(py::module& module) {
                Enable program cache across all devices in the mesh.
            )doc")
         .def(
+            "enable_program_cache",
+            &MeshDevice::clear_program_cache,
+            R"doc(
+               Clear program cache across all devices in the mesh.
+           )doc")
+        .def(
             "disable_and_clear_program_cache",
             &MeshDevice::disable_and_clear_program_cache,
             R"doc(

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -245,7 +245,7 @@ void py_module(py::module& module) {
                Enable program cache across all devices in the mesh.
            )doc")
         .def(
-            "enable_program_cache",
+            "clear_program_cache",
             &MeshDevice::clear_program_cache,
             R"doc(
                Clear program cache across all devices in the mesh.

--- a/ttnn/ttnn/examples/usage/program_cache.py
+++ b/ttnn/ttnn/examples/usage/program_cache.py
@@ -10,8 +10,6 @@ import time
 device_id = 0
 device = ttnn.open_device(device_id=device_id)
 
-device.enable_program_cache()
-
 torch_input_tensor = torch.rand(2, 4, dtype=torch.float32)
 input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23267)

### Problem description
We currently have the device cache disabled, since some operations are failing with cache. We should activate it and report all the tests that are failing so we can focus on fixing those operations.

### What's changed
Enabled cache by default and disabled it in specific tests that are failing with cached operations. Created a ticket to address them individually

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes