### PR TITLE
increased timeout on tt-train

### DIFF
--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -18,7 +18,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 20
+        default: 25
 
 jobs:
   models:


### PR DESCRIPTION
### Problem description
All post commit failing due to timeout in tt-train tests on main.

Example of a failing: [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml). On a different branch took up to 9 retries to pass.

### What's changed
Increased timeout to 25min for these tests(20min on main currently).

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes