### PR TITLE
#0: Fix perf microbenchmark to not assume active eth core == active link

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -3521,9 +3521,9 @@ int main(int argc, char** argv) {
         if (test_device_id_g == 0) {
             device_r = device;
         } else {
+            const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
             auto const& device_active_eth_cores = device->get_active_ethernet_cores();
-            auto remote_chips =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(device_id_l);
+            auto remote_chips = cluster.get_devices_controlled_by_mmio_device(device_id_l);
             // remove mmio chip from the set. get_devices_controlled_by_mmio_device() returns a set that
             // holds mmio chips as well as remote chips accessed through that mmmio chip.
             remote_chips.erase(device_id_l);
@@ -3538,6 +3538,9 @@ int main(int argc, char** argv) {
 
             device_id_r = test_device_id_g;
             for (auto eth_core : device_active_eth_cores) {
+                if (!cluster.is_ethernet_link_up(device->id(), eth_core)) {
+                    continue;
+                }
                 auto [connected_device_id, eth_receiver_core] = device->get_connected_ethernet_core(eth_core);
                 if (remote_chips.find(connected_device_id) != remote_chips.end()) {
                     device_id_r = connected_device_id;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -367,9 +367,13 @@ std::vector<tt::tt_metal::hop_eth_sockets> build_eth_sockets_list(const std::vec
         std::size_t link = 0;
         std::unordered_map<uint64_t, int> edge_link_idx;
         auto const& active_eth_cores = curr_device->get_active_ethernet_cores(true);
+        const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
         auto eth_sender_core_iter = active_eth_cores.begin();
         bool found = false;
         for (; !found && eth_sender_core_iter != active_eth_cores.end(); eth_sender_core_iter++) {
+            if (!cluster.is_ethernet_link_up(curr_device->id(), *eth_sender_core_iter)) {
+                continue;
+            }
             auto [device_id, receiver_core] = curr_device->get_connected_ethernet_core(*eth_sender_core_iter);
             if (device_id == next_device->id()) {
                 uint64_t pair_edge =

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -223,30 +223,25 @@ int main(int argc, char** argv) {
     std::cout << "done setting up test fixture" << std::endl;
 
     const auto& device_0 = test_fixture.devices_.at(0);
-    std::cout << "1" << std::endl;
-    auto const& active_eth_cores = device_0->get_active_ethernet_cores(true);
-    std::cout << "2" << std::endl;
+    const auto& active_eth_cores = device_0->get_active_ethernet_cores(true);
     auto eth_sender_core_iter = active_eth_cores.begin();
     auto eth_sender_core_iter_end = active_eth_cores.end();
     chip_id_t device_id = std::numeric_limits<chip_id_t>::max();
-    std::cout << "3" << std::endl;
     tt_xy_pair eth_receiver_core;
     bool initialized = false;
     tt_xy_pair eth_sender_core;
-    std::cout << "4" << std::endl;
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     do {
         TT_ASSERT(eth_sender_core_iter != eth_sender_core_iter_end);
-        std::cout << "4a" << std::endl;
-        std::tie(device_id, eth_receiver_core) = device_0->get_connected_ethernet_core(*eth_sender_core_iter);
-        std::cout << "4b" << std::endl;
-        eth_sender_core = *eth_sender_core_iter;
+        if (cluster.is_ethernet_link_up(device_0->id(), *eth_sender_core_iter)) {
+            std::tie(device_id, eth_receiver_core) = device_0->get_connected_ethernet_core(*eth_sender_core_iter);
+            eth_sender_core = *eth_sender_core_iter;
+        }
         eth_sender_core_iter++;
     } while (device_id != 1);
-    std::cout << "5" << std::endl;
     TT_ASSERT(device_id == 1);
-    std::cout << "6" << std::endl;
     const auto& device_1 = test_fixture.devices_.at(device_id);
-    std::cout << "7" << std::endl;
+
     // Add more configurations here until proper argc parsing added
     bool success = false;
     success = true;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_2ep.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_2ep.cpp
@@ -262,19 +262,9 @@ int main(int argc, char** argv) {
         int device_id_l = test_device_id;
 
         tt_metal::IDevice* device = tt_metal::CreateDevice(device_id_l);
-        auto const& device_active_eth_cores = device->get_active_ethernet_cores();
+        auto eth_core_l = get_active_ethernet_core(device);
 
-        if (device_active_eth_cores.size() == 0) {
-            log_info(
-                LogTest,
-                "Device {} does not have enough active cores. Need 1 active ethernet core for this test.",
-                device_id_l);
-            tt_metal::CloseDevice(device);
-            throw std::runtime_error("Test cannot run on specified device.");
-        }
-
-        auto eth_core_iter = device_active_eth_cores.begin();
-        auto [device_id_r, eth_receiver_core] = device->get_connected_ethernet_core(*eth_core_iter);
+        auto [device_id_r, eth_receiver_core] = device->get_connected_ethernet_core(eth_core_l);
 
         tt_metal::IDevice* device_r = tt_metal::CreateDevice(device_id_r);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_4ep.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_4ep.cpp
@@ -262,19 +262,9 @@ int main(int argc, char** argv) {
         int device_id_l = test_device_id;
 
         tt_metal::IDevice* device = tt_metal::CreateDevice(device_id_l);
-        auto const& device_active_eth_cores = device->get_active_ethernet_cores();
+        auto eth_core_l = get_active_ethernet_core(device);
 
-        if (device_active_eth_cores.size() == 0) {
-            log_info(
-                LogTest,
-                "Device {} does not have enough active cores. Need 1 active ethernet core for this test.",
-                device_id_l);
-            tt_metal::CloseDevice(device);
-            throw std::runtime_error("Test cannot run on specified device.");
-        }
-
-        auto eth_core_iter = device_active_eth_cores.begin();
-        auto [device_id_r, eth_receiver_core] = device->get_connected_ethernet_core(*eth_core_iter);
+        auto [device_id_r, eth_receiver_core] = device->get_connected_ethernet_core(eth_core_l);
 
         tt_metal::IDevice* device_r = tt_metal::CreateDevice(device_id_r);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_loopback_tunnel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_loopback_tunnel.cpp
@@ -191,18 +191,9 @@ int main(int argc, char **argv) {
         int device_id_l = test_device_id;
 
         tt_metal::IDevice* device = tt_metal::CreateDevice(device_id_l);
-        auto const& device_active_eth_cores = device->get_active_ethernet_cores();
+        auto eth_core_l = get_active_ethernet_core(device);
 
-        if (device_active_eth_cores.size() == 0) {
-            log_info(LogTest,
-                "Device {} does not have enough active cores. Need 1 active ethernet core for this test.",
-                device_id_l);
-            tt_metal::CloseDevice(device);
-            throw std::runtime_error("Test cannot run on specified device.");
-        }
-
-        auto eth_core_iter = device_active_eth_cores.begin();
-        auto [device_id_r, eth_receiver_core] = device->get_connected_ethernet_core(*eth_core_iter);
+        auto [device_id_r, eth_receiver_core] = device->get_connected_ethernet_core(eth_core_l);
 
         tt_metal::IDevice* device_r = tt_metal::CreateDevice(device_id_r);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_uni_tunnel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_uni_tunnel.cpp
@@ -193,18 +193,9 @@ int main(int argc, char **argv) {
         int device_id_l = test_device_id;
 
         tt_metal::IDevice* device = tt_metal::CreateDevice(device_id_l);
-        auto const& device_active_eth_cores = device->get_active_ethernet_cores();
+        auto eth_core_l = get_active_ethernet_core(device);
 
-        if (device_active_eth_cores.size() == 0) {
-            log_info(LogTest,
-                "Device {} does not have enough active cores. Need 1 active ethernet core for this test.",
-                device_id_l);
-            tt_metal::CloseDevice(device);
-            throw std::runtime_error("Test cannot run on specified device.");
-        }
-
-        auto eth_core_iter = device_active_eth_cores.begin();
-        auto [device_id_r, eth_receiver_core] = device->get_connected_ethernet_core(*eth_core_iter);
+        auto [device_id_r, eth_receiver_core] = device->get_connected_ethernet_core(eth_core_l);
 
         tt_metal::IDevice* device_r = tt_metal::CreateDevice(device_id_r);
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Test assumed an active eth core also has an active link. This is not the case on BH and also no longer the case for WH either due to changes from https://github.com/tenstorrent/tt-metal/pull/23094.

### What's changed
Iterate over the active eth core list to find one with an active link in the test.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes