### PR TITLE
#23287: Add `combine_device_tensors` API for device side tensors

### DIFF
--- a/models/demos/llama3_subdevices/tt/llama_attention.py
+++ b/models/demos/llama3_subdevices/tt/llama_attention.py
@@ -663,6 +663,6 @@ class TtLlamaAttention(LightweightModule):
         # Get every 4th tensor starting from user_id // 8
         single_column_tensors = tensors[user_id // self.batch_size_per_device_group :: 4]
         # Create multi-device tensor
-        multi_device_tensor = ttnn.aggregate_as_tensor(single_column_tensors)
+        multi_device_tensor = ttnn.combine_device_tensors(single_column_tensors)
 
         return multi_device_tensor

--- a/models/demos/t3000/falcon40b/README.md
+++ b/models/demos/t3000/falcon40b/README.md
@@ -1,4 +1,4 @@
-# Falcon40B Demo 
+# Falcon40B Demo
 
 Falcon40b prefill uses 8x8 core grid size, so the following environment variable needs to be set on a T3000 setup:
 
@@ -11,16 +11,16 @@ export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
 - To run the model for a single prompt, you can use the command line input:
 
 ```sh
-pytest --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/t3000/falcon40b/demo/demo.py`
+pytest --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/t3000/falcon40b/demo/demo.py
 ```
 
 ## Inputs
 
-- A sample of input prompts for 32 users is provided in `models/demos/t3000/falcon40b/demo/input_data.json`. 
-- If you wish to run the model using a different set of input prompts you can provide a different path `--input-path`. 
+- A sample of input prompts for 32 users is provided in `models/demos/t3000/falcon40b/demo/input_data.json`.
+- If you wish to run the model using a different set of input prompts you can provide a different path `--input-path`.
 
 ```sh
-pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon40b/demo/input_data.json' models/demos/t3000/falcon40b/demo/demo.py`
+pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon40b/demo/input_data.json' models/demos/t3000/falcon40b/demo/demo.py
 ```
 
 ## Details

--- a/models/demos/t3000/falcon40b/tt/falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_mlp.py
@@ -117,21 +117,13 @@ class TtFalconMLP:
 
         hidden_states = ttnn.sharded_to_interleaved(hidden_states, memory_config=self.model_config["DEFAULT_MEMCFG"])
 
-        hidden_states = ttnn.get_device_tensors(
-            hidden_states
-        )  # Workaround for reduce_scatter only taking a vector of tensors and not mesh_device
-
-        hidden_states = ttnn.get_device_tensors(
-            ttnn.reduce_scatter(
-                ttnn.aggregate_as_tensor(hidden_states),
-                dim=3,
-                math_op=ttnn.ReduceType.Sum,
-                num_links=1,  # only unidirectional supported for now
-                memory_config=self.model_config["DEFAULT_MEMCFG"],
-            )
+        hidden_states = ttnn.reduce_scatter(
+            hidden_states,
+            dim=3,
+            math_op=ttnn.ReduceType.Sum,
+            num_links=1,  # only unidirectional supported for now
+            memory_config=self.model_config["DEFAULT_MEMCFG"],
         )
-
-        hidden_states = ttnn.aggregate_as_tensor(hidden_states)  # Workaround reverse
 
         hidden_states = ttnn.interleaved_to_sharded(
             hidden_states, self.model_config["MLP_REDUCE_SCATTER_OUTPUT_MEMCFG"]
@@ -193,21 +185,10 @@ class TtFalconMLP:
         if should_deallocate_ln_tensors:
             x.deallocate(True)
 
-        hidden_states = ttnn.get_device_tensors(
-            self.output
-        )  # Workaround for reduce_scatter only taking a vector of tensors and not mesh_device
-
-        hidden_states = ttnn.get_device_tensors(
-            ttnn.reduce_scatter(
-                ttnn.aggregate_as_tensor(hidden_states),
-                dim=3,
-                math_op=ttnn.ReduceType.Sum,
-                num_links=1,  # only one link supported for now
-                memory_config=self.model_config["DEFAULT_MEMCFG"],
-            )
+        return ttnn.reduce_scatter(
+            self.output,
+            dim=3,
+            math_op=ttnn.ReduceType.Sum,
+            num_links=1,  # only one link supported for now
+            memory_config=self.model_config["DEFAULT_MEMCFG"],
         )
-
-        hidden_states = ttnn.aggregate_as_tensor(hidden_states)  # Workaround reverse
-
-        # return TT Tensor
-        return hidden_states

--- a/models/experimental/stable_diffusion_35_large/tt/conv2d.py
+++ b/models/experimental/stable_diffusion_35_large/tt/conv2d.py
@@ -162,10 +162,10 @@ class TtConv2d:
         ]
 
         if len(results) > 1:
-            x = ttnn.aggregate_as_tensor([result.output for result in results])
-            self._weight = ttnn.aggregate_as_tensor([result.prepared_weight for result in results])
+            x = ttnn.combine_device_tensors([result.output for result in results])
+            self._weight = ttnn.combine_device_tensors([result.prepared_weight for result in results])
             self._bias = (
-                ttnn.aggregate_as_tensor([result.prepared_bias for result in results])
+                ttnn.combine_device_tensors([result.prepared_bias for result in results])
                 if self._bias is not None
                 else None  # type: ignore
             )

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -883,6 +883,6 @@ class Attention(LightweightModule):
         # Get every 4th tensor starting from user_id // 8
         single_column_tensors = tensors[user_id // self.batch_size_per_device_group :: 4]
         # Create multi-device tensor
-        multi_device_tensor = ttnn.aggregate_as_tensor(single_column_tensors)
+        multi_device_tensor = ttnn.combine_device_tensors(single_column_tensors)
 
         return multi_device_tensor

--- a/tests/sweep_framework/sweeps/ccl/all_gather_n300.py
+++ b/tests/sweep_framework/sweeps/ccl/all_gather_n300.py
@@ -67,15 +67,11 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 
 def mesh_device_fixture():
     assert ttnn.get_num_devices() == 2, "Not N300!"
+    mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, num_devices_requested))
 
-    num_devices = ttnn.GetNumAvailableDevices()
-    device_ids = [i for i in range(num_devices)]
+    yield (mesh_device, "N300 Fixture")
 
-    devices = ttnn.CreateDevices(device_ids)
-
-    yield ([devices[i] for i in range(num_devices)], "N300 Fixture")
-
-    ttnn.close_device(devices[0])
+    ttnn.close_mesh_device(mesh_device)
 
 
 # This is the run instructions for the test, defined by the developer.
@@ -94,8 +90,6 @@ def run(
     *,
     device,
 ) -> list:
-    all_devices = device
-
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")
 
@@ -104,18 +98,15 @@ def run(
     input_tensors = torch.chunk(input_tensor, num_devices, dim)
     tt_input_tensors = []
     for i, t in enumerate(input_tensors):
-        tt_input_tensors.append(
-            ttnn.Tensor(t, input_dtype, {}, ttnn.Tile(tile)).to(layout).to(all_devices[i], mem_config)
-        )
+        tt_input_tensors.append(ttnn.Tensor(t, input_dtype, {}, ttnn.Tile(tile)).to(layout))
 
-    input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
+    input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(device, mem_config)
     for i in range(num_iters):
         start_time = start_measuring_time()
         tt_out_tensor = ttnn.all_gather(input_tensor_mesh, dim, num_links=num_links, memory_config=mem_config)
         e2e_perf = stop_measuring_time(start_time)
 
-        for d in all_devices:
-            ttnn.synchronize_device(d)
+        ttnn.synchronize_device(device)
         logger.info(f"Done iteration {i}")
 
     for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):

--- a/tests/sweep_framework/sweeps/ccl/all_gather_n300_focused.py
+++ b/tests/sweep_framework/sweeps/ccl/all_gather_n300_focused.py
@@ -155,15 +155,11 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 
 def mesh_device_fixture():
     assert ttnn.get_num_devices() == 2, "Not N300!"
+    mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, num_devices_requested))
 
-    num_devices = ttnn.GetNumAvailableDevices()
-    device_ids = [i for i in range(num_devices)]
+    yield (mesh_device, "N300 Fixture")
 
-    devices = ttnn.CreateDevices(device_ids)
-
-    yield ([devices[i] for i in range(num_devices)], "N300 Fixture")
-
-    ttnn.close_device(devices[0])
+    ttnn.close_mesh_device(mesh_device)
 
 
 # This is the run instructions for the test, defined by the developer.
@@ -182,13 +178,8 @@ def run(
     *,
     device,
 ) -> list:
-    all_devices = device
-
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")
-
-    # for device in devices:
-    #    device.disable_and_clear_program_cache()
 
     input_shape_list = list(input_shape)
     input_shape_list[dim] *= num_devices
@@ -200,17 +191,15 @@ def run(
     tt_input_tensors = []
     for i, t in enumerate(input_tensors):
         t = ttnn.from_torch(t, input_dtype, tile=ttnn.Tile(tile), layout=ttnn.Layout.TILE)
-        t = t.to(all_devices[i], mem_config)
         tt_input_tensors.append(t)
 
-    input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
+    input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(device, mem_config)
     for i in range(num_iters):
         start_time = start_measuring_time()
         tt_out_tensor = ttnn.all_gather(input_tensor_mesh, dim, num_links=num_links, memory_config=mem_config)
         e2e_perf = stop_measuring_time(start_time)
 
-        for d in all_devices:
-            ttnn.synchronize_device(d)
+        ttnn.synchronize_device(device)
         logger.info(f"Done iteration {i}")
 
     for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):

--- a/tests/ttnn/distributed/test_distributed_tensor.py
+++ b/tests/ttnn/distributed/test_distributed_tensor.py
@@ -10,7 +10,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_
 from models.utility_functions import nearest_32
 
 
-def generate_ttnn_tensor_of_shards(num_shards, dtype, aggregate):
+def generate_ttnn_tensor_of_shards(num_shards, dtype):
     torch.manual_seed(1234)
 
     unconcatenated_ttnn_tensor_shards = []
@@ -27,10 +27,7 @@ def generate_ttnn_tensor_of_shards(num_shards, dtype, aggregate):
                 ttnn.from_torch(torch.randn(1, 1, 32, 64 // num_shards), dtype=dtype, layout=ttnn.TILE_LAYOUT)
             )
 
-    if aggregate:
-        return ttnn.aggregate_as_tensor(unconcatenated_ttnn_tensor_shards)
-    else:
-        return unconcatenated_ttnn_tensor_shards
+    return ttnn.aggregate_as_tensor(unconcatenated_ttnn_tensor_shards)
 
 
 def generate_2d_sharded_ttnn_tensor(num_shards, dtype, M, K, mesh_shape, shard_dim):
@@ -222,7 +219,7 @@ def test_concat_to_tensor_mesh_torch_comparison(mesh_device, dtype):
 
     num_shards = mesh_device.get_num_devices()
 
-    unconcatenated_ttnn_tensor = generate_ttnn_tensor_of_shards(num_shards, dtype, aggregate=True)
+    unconcatenated_ttnn_tensor = generate_ttnn_tensor_of_shards(num_shards, dtype)
 
     torch_concat_tensor = ttnn.to_torch(unconcatenated_ttnn_tensor, mesh_composer=torch_composer)
 
@@ -346,7 +343,7 @@ def test_concat_to_tensor(mesh_device, dtype):
     # This will be the same as the generated unconcatenated_ttnn_tensor due to the shared seeding
     torch_concat_tensor = torch.cat(torch_shards, dim=3)
 
-    unconcatenated_ttnn_tensor = generate_ttnn_tensor_of_shards(num_shards, dtype, aggregate=True)
+    unconcatenated_ttnn_tensor = generate_ttnn_tensor_of_shards(num_shards, dtype)
 
     composer = ttnn.concat_mesh_to_tensor_composer(dim=3)
 
@@ -376,7 +373,7 @@ def test_concat_slice_to_tensor(mesh_device, dtype):
     # This will be the same as concatenating the generated unconcatenated_ttnn_shards due to the shared order and seeding
     torch_concat_tensor = torch.cat(torch_shards, dim=3)
 
-    unconcatenated_ttnn_shards = generate_ttnn_tensor_of_shards(num_shards, dtype, aggregate=False)
+    unconcatenated_ttnn_shards = generate_ttnn_tensor_of_shards(num_shards, dtype)
 
     composer = ttnn.concat_mesh_to_tensor_composer(dim=3)
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -144,7 +144,7 @@ TEST_F(MeshTensorTest, GetDeviceTensors) {
     EXPECT_THAT(device_shard_coords, ElementsAreArray(coord_matchers));
 }
 
-TEST_F(MeshTensorTestT3K, AggregateAsTensor) {
+TEST_F(MeshTensorTestT3K, CombineDeviceTensors) {
     const ttnn::Shape shape{1, 1, 32, 32};
     const TensorSpec tensor_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
@@ -169,7 +169,7 @@ TEST_F(MeshTensorTestT3K, AggregateAsTensor) {
     EXPECT_THAT(
         ([&]() {
             std::vector<Tensor> shards_to_aggregate = {device_tensors1[0], device_tensors2[1]};
-            aggregate_as_tensor(shards_to_aggregate, AllGatherTensor{});
+            combine_device_tensors(shards_to_aggregate);
         }),
         ThrowsMessage<std::runtime_error>(HasSubstr("tensor shards must be allocated on the same mesh buffer.")));
 
@@ -177,14 +177,13 @@ TEST_F(MeshTensorTestT3K, AggregateAsTensor) {
     EXPECT_THAT(
         ([&]() {
             std::vector<Tensor> shards_to_aggregate = {device_tensors1[0], device_tensors1[0]};
-            aggregate_as_tensor(shards_to_aggregate, AllGatherTensor{});
+            combine_device_tensors(shards_to_aggregate);
         }),
-        ThrowsMessage<std::runtime_error>(HasSubstr("Found a tensor shard at duplicate coordiante")));
+        ThrowsMessage<std::runtime_error>(HasSubstr("Found a tensor shard at duplicate coordinate")));
 
     // Aggregate every second shard into a new mesh tensor.
-    auto partial_tensor = aggregate_as_tensor(
-        std::vector<Tensor>{device_tensors1[6], device_tensors1[4], device_tensors1[2], device_tensors1[0]},
-        AllGatherTensor{});
+    auto partial_tensor = combine_device_tensors(
+        std::vector<Tensor>{device_tensors1[6], device_tensors1[4], device_tensors1[2], device_tensors1[0]});
 
     auto* partial_device_storage = std::get_if<tt::tt_metal::DeviceStorage>(&partial_tensor.storage());
     ASSERT_NE(partial_device_storage, nullptr);

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
@@ -109,7 +109,7 @@ tt::tt_metal::Tensor scatter(const tt::tt_metal::Tensor& tensor, int dim) {
         ttnn::slice(tensor_shard, start, end, stride, std::nullopt, scattered_tensors[idx]);
         ++idx;
     }
-    return ttnn::distributed::aggregate_as_tensor(scattered_tensors, tt::tt_metal::AllGatherTensor{});
+    return ttnn::distributed::combine_device_tensors(scattered_tensors);
 }
 
 }  // namespace ttml::ttnn_fixed::distributed

--- a/ttnn/api/ttnn/distributed/api.hpp
+++ b/ttnn/api/ttnn/distributed/api.hpp
@@ -31,6 +31,10 @@ std::vector<Tensor> get_device_tensors(const Tensor& tensor);
 Tensor aggregate_as_tensor(
     const std::vector<Tensor>& tensor_shards, const tt::tt_metal::DistributedTensorConfig& config);
 
+// Combines tensor shards allocated on individual devices into a single multi-device tensor.
+// All tensors shards must be allocated on the same mesh buffer.
+Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards);
+
 std::vector<int> get_t3k_physical_device_ids_ring();
 
 }  // namespace ttnn::distributed

--- a/ttnn/api/ttnn/distributed/api.hpp
+++ b/ttnn/api/ttnn/distributed/api.hpp
@@ -28,6 +28,8 @@ void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device);
 std::vector<Tensor> get_device_tensors(const Tensor& tensor);
 
 // Given a list of per-device shards, returns multi-device tensor.
+// IMPORTANT: to combine on-device shards, prefer `combine_device_tensors` instead.
+// For on-host shards, a new API will be added to accommodate multi-host tensor distribution.
 Tensor aggregate_as_tensor(
     const std::vector<Tensor>& tensor_shards, const tt::tt_metal::DistributedTensorConfig& config);
 

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -602,6 +602,20 @@ void py_module(py::module& module) {
             Returns:
                 Tensor: The aggregated tensor.
             )doc");
+    module.def(
+        "combine_device_tensors",
+        [](const std::vector<Tensor>& tensors) -> Tensor { return combine_device_tensors(tensors); },
+        py::arg("tensors"),
+        py::kw_only(),
+        R"doc(
+            Combines tensor shards allocated on individual devices into a single multi-device tensor. All tensors shards must be allocated on the same mesh buffer.
+
+            Args:
+                tensors (List[Tensor]): The tensor shards to combine.
+
+            Returns:
+                Tensor: The combined tensor.
+            )doc");
     module.def("get_t3k_physical_device_ids_ring", &get_t3k_physical_device_ids_ring);
 }
 

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -570,25 +570,6 @@ void py_module(py::module& module) {
                 Tensor: The aggregated tensor.
             )doc");
     module.def(
-        "aggregate_tensor",
-        [](const std::vector<Tensor>& tensors, const MeshToTensor& composer) -> Tensor {
-            Tensor aggregated_tensor = aggregate_as_tensor(tensors, AllGatherTensor{});
-
-            return aggregate_tensor(aggregated_tensor, composer);
-        },
-        py::arg("tensor"),
-        py::arg("composer"),
-        R"doc(
-            Aggregates a set of shard tensors into a single host tensor using the provided composer.
-
-            Args:
-                tensor (Tensor): The tensor to aggregate.
-                composer (MeshToTensor): The composer to use for aggregation.
-
-            Returns:
-                Tensor: The aggregated tensor.
-            )doc");
-    module.def(
         "aggregate_as_tensor",
         [](const std::vector<Tensor>& tensors) -> Tensor { return aggregate_as_tensor(tensors, AllGatherTensor{}); },
         py::arg("tensors"),

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/barrier_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/barrier_pybind.cpp
@@ -56,16 +56,12 @@ void py_bind_barrier(pybind11::module& module) {
             ttnn.Tensor: the output tensor which is a copy of the input tensor
         Example:
             >>> full_tensor = torch.randn([1, 1, 256, 256], dtype=torch.bfloat16)
-            >>> input_tensors = torch.chunk(full_tensor, num_devices, dim)
-            >>> physical_device_ids = ttnn.open_mesh_device(ttnn.MeshShape(1, 8))
-            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8), physical_device_ids=physical_device_ids[:8])
-            >>> tt_input_tensors = []
-            >>> for i, t in enumerate(input_tensors):
-                    tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], mem_config))
-            >>> input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
-
-            >>> output = ttnn.barrier(input_tensor_mesh, topology=ttnn.Topology.Ring)
-
+            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8))
+            >>> input_tensor = ttnn.from_torch(
+                    full_tensor,
+                    mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=3),
+                )
+            >>> output = ttnn.barrier(input_tensor, topology=ttnn.Topology.Ring)
 
         )doc");
 }

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.cpp
@@ -122,17 +122,12 @@ void py_bind_reduce_scatter(pybind11::module& module) {
         Example:
 
             >>> full_tensor = torch.randn([1, 1, 256, 256], dtype=torch.bfloat16)
-            >>> num_devices = 8
-            >>> dim = 3
-            >>> input_tensors = torch.chunk(full_tensor, num_devices, dim)
-            >>> physical_device_ids = ttnn.get_t3k_physical_device_ids_ring()
-            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8), physical_device_ids=physical_device_ids[:8])
-            >>> tt_input_tensors = []
-            >>> for i, t in enumerate(input_tensors):
-                    tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], mem_config))
-            >>> input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
-
-            >>> output = ttnn.reduce_scatter(input_tensor_mesh, dim=0, topology=ttnn.Topology.Linear)
+            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8))
+            >>> input_tensor = ttnn.from_torch(
+                    full_tensor,
+                    mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=3),
+                )
+            >>> output = ttnn.reduce_scatter(input_tensor, dim=0, topology=ttnn.Topology.Linear)
 
         )doc");
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp
@@ -72,16 +72,12 @@ void py_bind_all_reduce(pybind11::module& module) {
         Example:
 
             >>> full_tensor = torch.randn([1, 1, 256, 256], dtype=torch.bfloat16)
-            >>> num_devices = 8
-            >>> input_tensors = torch.chunk(full_tensor, num_devices, dim)
-            >>> physical_device_ids = ttnn.get_t3k_physical_device_ids_ring()
-            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8), physical_device_ids=physical_device_ids[:8])
-            >>> tt_input_tensors = []
-            >>> for i, t in enumerate(input_tensors):
-                    tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], mem_config))
-            >>> input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
-
-            >>> output = ttnn.experimental.all_reduce(input_tensor_mesh, topology=ttnn.Topology.Linear)
+            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8))
+            >>> input_tensor = ttnn.from_torch(
+                    full_tensor,
+                    mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=3),
+                )
+            >>> output = ttnn.experimental.all_reduce(input_tensor, topology=ttnn.Topology.Linear)
 
         )doc");
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_pybind.cpp
@@ -163,16 +163,12 @@ void py_bind_all_reduce_async(pybind11::module& module) {
         Example:
 
             >>> full_tensor = torch.randn([1, 1, 256, 256], dtype=torch.bfloat16)
-            >>> num_devices = 8
-            >>> input_tensors = torch.chunk(full_tensor, num_devices)
-            >>> physical_device_ids = ttnn.get_t3k_physical_device_ids_ring()
-            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8), physical_device_ids=physical_device_ids[:8])
-            >>> tt_input_tensors = []
-            >>> for i, t in enumerate(input_tensors):
-                    tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], mem_config))
-            >>> input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
-
-            >>> output = ttnn.all_reduce_async(input_tensor_mesh, topology=ttnn.Topology.Linear)
+            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8))
+            >>> input_tensor = ttnn.from_torch(
+                    full_tensor,
+                    mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=3),
+                )
+            >>> output = ttnn.experimental.all_reduce_async(input_tensor, topology=ttnn.Topology.Linear)
 
         )doc");
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter_pybind.cpp
@@ -131,17 +131,12 @@ void py_bind_reduce_scatter_async(pybind11::module& module) {
         Example:
 
             >>> full_tensor = torch.randn([1, 1, 256, 256], dtype=torch.bfloat16)
-            >>> num_devices = 8
-            >>> dim = 3
-            >>> input_tensors = torch.chunk(full_tensor, num_devices, dim)
-            >>> physical_device_ids = ttnn.get_t3k_physical_device_ids_ring()
-            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8), physical_device_ids=physical_device_ids[:8])
-            >>> tt_input_tensors = []
-            >>> for i, t in enumerate(input_tensors):
-                    tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], mem_config))
-            >>> input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
-
-            >>> output = ttnn.reduce_scatter(input_tensor_mesh, dim=0, topology=ttnn.Topology.Linear)
+            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8))
+            >>> input_tensor = ttnn.from_torch(
+                    full_tensor,
+                    mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=3),
+                )
+            >>> output = ttnn.reduce_scatter(input_tensor, dim=0, topology=ttnn.Topology.Linear)
 
         )doc");
 }

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -101,6 +101,7 @@ from ttnn._ttnn.multi_device import (
     MeshComposerConfig,
     get_device_tensors,
     aggregate_as_tensor,
+    combine_device_tensors,
     replicate_tensor_to_mesh_mapper,
     shard_tensor_to_mesh_mapper,
     create_mesh_mapper,


### PR DESCRIPTION
### Ticket
#23287

### Problem description
`aggregate_as_tensor` serves 2 different purposes, depending on whether the provided shards are on host or on device. 
* For host-side tensors, it creates `MultiDeviceHostStorage` and records `DistributedTensorConfig` in tensor. Upon moving the tensor to device, `DistributedTensorConfig` will be used to map tensor shards from a linear list to ND mesh.
* For device-side tensors, we simply "stitch together" the shards, validating they are all allocated on the same `MeshBuffer`.

This dual use case is subtle, and best to be decoupled.

In subsequent PR, we will extend `aggregate_as_tensor` API to have more parameters for multi host systems (global / local shapes, local offset, and distribution shape) - this will replace the existing mechanism based on `DistributedTensorConfig`.

### What's changed
Create a dedicated API for combining on-device tensors.

Replace the usage, where appropriate.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15542121934)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15542117591)
- [x] [TG tests](https://github.com/tenstorrent/tt-metal/actions/runs/15542129208)