### PR TITLE
#23283: update erisc kernels on BH to point to a different RISCV type

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
@@ -121,12 +121,15 @@ inline void verify_kernel_coordinates(
     uint32_t cb_addr,
     bool idle_eth = false) {
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
-    tt::tt_metal::HalProgrammableCoreType hal_core_type = processor_class == tt::RISCV::ERISC
-                                                              ? tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH
-                                                              : tt::tt_metal::HalProgrammableCoreType::TENSIX;
+    tt::tt_metal::HalProgrammableCoreType hal_core_type =
+        (processor_class == tt::RISCV::ERISC || processor_class == tt::RISCV::ERISC1)
+            ? tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH
+            : tt::tt_metal::HalProgrammableCoreType::TENSIX;
     hal_core_type = idle_eth ? tt::tt_metal::HalProgrammableCoreType::IDLE_ETH : hal_core_type;
 
-    CoreType core_type = processor_class == tt::RISCV::ERISC ? CoreType::ETH : CoreType::WORKER;
+    CoreType core_type = (processor_class == tt::RISCV::ERISC || processor_class == tt::RISCV::ERISC1)
+                             ? CoreType::ETH
+                             : CoreType::WORKER;
     core_type = idle_eth ? CoreType::IDLE_ETH : core_type;
 
     const auto& sub_device_origin = device->worker_cores(hal_core_type, sub_device_id).bounding_box().start_coord;

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -150,8 +150,9 @@ enum RISCV : uint8_t {
     TRISC1 = 3,
     TRISC2 = 4,
     ERISC = 5,
-    COMPUTE = 6,  // Encompasses TRISC0, TRISC1, and TRISC2
-    MAX = 7,
+    ERISC1 = 6,
+    COMPUTE = 7,  // Encompasses TRISC0, TRISC1, and TRISC2
+    MAX = 8,
 };
 
 inline std::ostream& operator<<(std::ostream& os, const RISCV& riscv) {
@@ -162,6 +163,7 @@ inline std::ostream& operator<<(std::ostream& os, const RISCV& riscv) {
         case RISCV::TRISC1: os << "TRISC1"; break;
         case RISCV::TRISC2: os << "TRISC2"; break;
         case RISCV::ERISC: os << "ERISC"; break;
+        case RISCV::ERISC1: os << "ERISC1"; break;
         case RISCV::COMPUTE: os << "COMPUTE"; break;
         default: throw std::invalid_argument("Unknown format");
     }

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -108,7 +108,9 @@ HalProgrammableCoreType Kernel::get_kernel_programmable_core_type() const {
         case RISCV::BRISC:
         case RISCV::NCRISC:
         case RISCV::COMPUTE: return HalProgrammableCoreType::TENSIX;
-        case RISCV::ERISC: return this->is_idle_eth() ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH;
+        case RISCV::ERISC:
+        case RISCV::ERISC1:
+            return this->is_idle_eth() ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH;
         default: TT_ASSERT(false, "Unsupported kernel processor!");
     }
     return HalProgrammableCoreType::TENSIX;
@@ -120,7 +122,8 @@ CoreType Kernel::get_kernel_core_type() const {
         case RISCV::BRISC:
         case RISCV::NCRISC:
         case RISCV::COMPUTE: return CoreType::WORKER;
-        case RISCV::ERISC: return CoreType::ETH;
+        case RISCV::ERISC:
+        case RISCV::ERISC1: return CoreType::ETH;
         default: TT_ASSERT(false, "Unsupported kernel processor!");
     }
     return CoreType::WORKER;
@@ -599,7 +602,14 @@ RISCV DataMovementKernel::processor() const {
     return RISCV::BRISC;
 }
 
-RISCV EthernetKernel::processor() const { return RISCV::ERISC; }
+RISCV EthernetKernel::processor() const {
+    switch (this->config_.processor) {
+        case DataMovementProcessor::RISCV_0: return RISCV::ERISC;
+        case DataMovementProcessor::RISCV_1: return RISCV::ERISC1;
+        default: TT_THROW("Unsupported data movement processor");
+    }
+    return RISCV::ERISC;
+}
 
 RISCV ComputeKernel::processor() const { return RISCV::COMPUTE; }
 

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -252,7 +252,7 @@ static inline json get_kernels_json(chip_id_t device_id, const Program& program)
                     if (kernelSizes["ncrisc_max_kernel_size"] < kernel->get_binary_packed_size(device, 0)) {
                         kernelSizes["ncrisc_max_kernel_size"] = kernel->get_binary_packed_size(device, 0);
                     }
-                } else if (kernel->processor() == RISCV::ERISC) {
+                } else if (kernel->processor() == RISCV::ERISC or kernel->processor() == RISCV::ERISC1) {
                     if (kernelSizes["erisc_max_kernel_size"] < kernel->get_binary_packed_size(device, 0)) {
                         kernelSizes["erisc_max_kernel_size"] = kernel->get_binary_packed_size(device, 0);
                     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23283

### Problem description
Kernels on erisc0 or erisc1 where pointing to same RISCV type which is used to detect whether the same risc is being attempted to programmed twice. 

### What's changed
Add another RISCV type for erisc1. this is a hacky workaround and the proper solution is to deprecate RISCV enum and pull this from the HAL but this unblocks BH CI (fyi @williamlyTT). 

There is an open issue to generalize dispatch classes: https://github.com/tenstorrent/tt-metal/issues/17275

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15541931417) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15541943508) CI with demo tests passes (if applicable)