### PR TITLE
Remove more Program methods.

### DIFF
--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -33,6 +33,7 @@
 #include "umd/device/tt_core_coordinates.h"
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/util.hpp>
+#include "impl/program/program_impl.hpp"
 
 using std::vector;
 using namespace tt::tt_metal;
@@ -57,7 +58,7 @@ void validate_cb_address(
                 tt::tt_metal::detail::ReadFromDeviceL1(
                     device,
                     core_coord,
-                    program.get_cb_base_addr(device, core_coord, CoreType::WORKER),
+                    program.impl().get_cb_base_addr(device, core_coord, CoreType::WORKER),
                     cb_config_buffer_size,
                     cb_config_vector);
 
@@ -373,7 +374,7 @@ TEST_F(DeviceFixture, TensixTestUpdateCircularBufferPageSize) {
                     tt::tt_metal::detail::ReadFromDeviceL1(
                         device,
                         core_coord,
-                        program.get_cb_base_addr(device, core_coord, CoreType::WORKER),
+                        program.impl().get_cb_base_addr(device, core_coord, CoreType::WORKER),
                         cb_config_buffer_size,
                         cb_config_vector);
 
@@ -405,7 +406,7 @@ TEST_F(DeviceFixture, TensixTestUpdateCircularBufferPageSize) {
                     tt::tt_metal::detail::ReadFromDeviceL1(
                         device,
                         core_coord,
-                        program.get_cb_base_addr(device, core_coord, CoreType::WORKER),
+                        program.impl().get_cb_base_addr(device, core_coord, CoreType::WORKER),
                         cb_config_buffer_size,
                         cb_config_vector);
 

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
@@ -24,6 +24,7 @@
 #include "hostdevcommon/kernel_structs.h"
 #include <tt-metalium/program.hpp>
 #include "umd/device/tt_core_coordinates.h"
+#include "impl/program/program_impl.hpp"
 
 namespace tt {
 enum class DataFormat : uint8_t;
@@ -51,12 +52,12 @@ bool test_cb_config_written_to_core(
             for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                 for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     CoreCoord core_coord(x, y);
-                    uint32_t cb_config_buffer_size = program.get_cb_size(device, core_coord, CoreType::WORKER);
+                    uint32_t cb_config_buffer_size = program.impl().get_cb_size(device, core_coord, CoreType::WORKER);
 
                     tt::tt_metal::detail::ReadFromDeviceL1(
                         device,
                         core_coord,
-                        program.get_sem_base_addr(device, core_coord, CoreType::WORKER),
+                        program.impl().get_sem_base_addr(device, core_coord, CoreType::WORKER),
                         cb_config_buffer_size,
                         cb_config_vector);
 
@@ -112,7 +113,7 @@ TEST_F(DeviceFixture, TensixTestCreateCircularBufferAtValidIndices) {
 
     for (unsigned int id = 0; id < num_devices_; id++) {
         detail::CompileProgram(devices_.at(id), program);
-        program.finalize_offsets(devices_.at(id));
+        program.impl().finalize_offsets(devices_.at(id));
         EXPECT_TRUE(test_cb_config_written_to_core(program, this->devices_.at(id), cr_set, golden_cb_config));
     }
 }

--- a/tests/tt_metal/tt_metal/api/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_circular_buffers.cpp
@@ -21,6 +21,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -95,7 +96,7 @@ TEST_F(DispatchFixture, TensixProgramGlobalCircularBuffers) {
         auto remote_cb =
             tt::tt_metal::experimental::CreateCircularBuffer(program, receiver_cores, global_cb_config, global_cb);
         tt::tt_metal::detail::CompileProgram(device, program);
-        program.finalize_offsets(device);
+        program.impl().finalize_offsets(device);
         tt::tt_metal::experimental::UpdateDynamicCircularBufferAddress(program, remote_cb, global_cb);
         EXPECT_THROW(UpdateDynamicCircularBufferAddress(program, remote_cb, dummy_global_cb), std::exception);
     }
@@ -115,7 +116,7 @@ TEST_F(DispatchFixture, TensixProgramGlobalCircularBuffers) {
         auto remote_cb =
             tt::tt_metal::experimental::CreateCircularBuffer(program, receiver_cores, global_cb_config, global_cb);
         tt::tt_metal::detail::CompileProgram(device, program);
-        EXPECT_THROW(program.finalize_offsets(device), std::exception);
+        EXPECT_THROW(program.impl().finalize_offsets(device), std::exception);
     }
 }
 

--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -26,6 +26,7 @@
 #include <tt-metalium/semaphore.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "umd/device/tt_core_coordinates.h"
+#include "impl/program/program_impl.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -93,7 +94,7 @@ void create_and_read_max_num_semaphores(
     }
 
     tt_metal::detail::CompileProgram(device, program);
-    program.finalize_offsets(device);
+    program.impl().finalize_offsets(device);
 
     ASSERT_TRUE(tt_metal::detail::ConfigureDeviceWithProgram(device, program));
 
@@ -104,7 +105,7 @@ void create_and_read_max_num_semaphores(
             for (uint32_t i = 0; i < tt::tt_metal::NUM_SEMAPHORES; i++) {
                 std::vector<uint32_t> single_val;
                 uint32_t semaphore_addr =
-                    program.get_sem_base_addr(device, logical_core, CoreType::WORKER) +
+                    program.impl().get_sem_base_addr(device, logical_core, CoreType::WORKER) +
                     (tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1) * i);
                 uint32_t semaphore_size = sizeof(uint32_t);
                 tt_metal::detail::ReadFromDeviceL1(device, logical_core, semaphore_addr, semaphore_size, single_val);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -53,6 +53,7 @@
 #include "umd/device/types/arch.h"
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/utils.hpp>
+#include "impl/program/program_impl.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -202,7 +203,7 @@ bool cb_config_successful(IDevice* device, Program& program, const DummyProgramM
             tt::tt_metal::detail::ReadFromDeviceL1(
                 device,
                 core_coord,
-                program.get_cb_base_addr(device, core_coord, CoreType::WORKER),
+                program.impl().get_cb_base_addr(device, core_coord, CoreType::WORKER),
                 cb_config_buffer_size,
                 cb_config_vector);
 
@@ -325,7 +326,7 @@ bool test_dummy_EnqueueProgram_with_sems(
             uint32_t expected_semaphore_vals_for_core_idx = 0;
             const uint32_t semaphore_buffer_size =
                 program_config.num_sems * MetalContext::instance().hal().get_alignment(HalMemType::L1);
-            uint32_t semaphore_base = program.get_sem_base_addr(device, core_coord, CoreType::WORKER);
+            uint32_t semaphore_base = program.impl().get_sem_base_addr(device, core_coord, CoreType::WORKER);
             tt::tt_metal::detail::ReadFromDeviceL1(
                 device, core_coord, semaphore_base, semaphore_buffer_size, semaphore_vals);
             for (uint32_t i = 0; i < semaphore_vals.size();
@@ -1085,7 +1086,7 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestMultiCBSharedAddressSpace
         tt::tt_metal::detail::ReadFromDeviceL1(
             device,
             core_coord,
-            program.get_cb_base_addr(device, core_coord, CoreType::WORKER),
+            program.impl().get_cb_base_addr(device, core_coord, CoreType::WORKER),
             cb_config_buffer_size,
             cb_config_vector);
         uint32_t cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -31,6 +31,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "umd/device/tt_core_coordinates.h"
 #include "umd/device/types/xy_pair.h"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -269,12 +270,12 @@ TEST_F(DispatchFixture, TensixActiveEthTestCBsAcrossDifferentCoreTypes) {
         tt::tt_metal::detail::ReadFromDeviceL1(
             device,
             core_coord,
-            program.get_cb_base_addr(device, core_coord, CoreType::WORKER),
+            program.impl().get_cb_base_addr(device, core_coord, CoreType::WORKER),
             cb_config_buffer_size,
             cb_config_vector);
 
         // ETH core doesn't have CB
-        EXPECT_TRUE(program.get_cb_size(device, core_coord, CoreType::ETH) == 0);
+        EXPECT_TRUE(program.impl().get_cb_size(device, core_coord, CoreType::ETH) == 0);
 
         uint32_t cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
         uint32_t intermediate_index = intermediate_cb * sizeof(uint32_t);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_program_reuse.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_program_reuse.cpp
@@ -60,6 +60,7 @@
 #include "umd/device/types/arch.h"
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/utils.hpp>
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 struct CBConfig {
@@ -307,7 +308,7 @@ TEST_F(CommandQueueMultiDeviceFixture, TestProgramReuseSanity) {
         std::vector<uint32_t> semaphore_vals;
         for (const CoreCoord& core_coord : sem_cr_range) {
             uint32_t expected_sem_idx = 0;
-            uint32_t sem_base_addr = program->get_sem_base_addr(devices_[0], core_coord, CoreType::WORKER);
+            uint32_t sem_base_addr = program->impl().get_sem_base_addr(devices_[0], core_coord, CoreType::WORKER);
             detail::ReadFromDeviceL1(device, core_coord, sem_base_addr, semaphore_buffer_size, semaphore_vals);
             for (uint32_t i = 0; i < semaphore_vals.size();
                  i += (MetalContext::instance().hal().get_alignment(HalMemType::L1) / sizeof(uint32_t))) {
@@ -320,7 +321,7 @@ TEST_F(CommandQueueMultiDeviceFixture, TestProgramReuseSanity) {
             detail::ReadFromDeviceL1(
                 device,
                 core_coord,
-                program->get_cb_base_addr(device, core_coord, CoreType::WORKER),
+                program->impl().get_cb_base_addr(device, core_coord, CoreType::WORKER),
                 cb_config_buffer_size,
                 cb_config_vector);
             uint32_t cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -42,6 +42,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "umd/device/tt_core_coordinates.h"
 #include "umd/device/types/xy_pair.h"
+#include "impl/program/program_impl.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does
@@ -91,8 +92,8 @@ void check_semaphores_are_initialized(
                 tt_metal::detail::ReadFromDeviceL1(
                     device,
                     logical_core,
-                    program.get_sem_base_addr(device, logical_core, CoreType::WORKER),
-                    program.get_sem_size(device, logical_core, CoreType::WORKER),
+                    program.impl().get_sem_base_addr(device, logical_core, CoreType::WORKER),
+                    program.impl().get_sem_size(device, logical_core, CoreType::WORKER),
                     res);
                 std::vector<uint32_t> filtered_res;
                 static uint32_t num_u32_to_skip =

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -947,7 +947,7 @@ void Device::configure_command_queue_programs() {
     configure_dispatch_cores(this);
 
     // Run the cq program
-    command_queue_program.finalize_offsets(this);
+    command_queue_program.impl().finalize_offsets(this);
     detail::ConfigureDeviceWithProgram(this, command_queue_program, true);
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(this->id());
 }
@@ -1005,7 +1005,7 @@ void Device::init_fabric() {
 
     configure_fabric_cores(this);
 
-    fabric_program_->finalize_offsets(this);
+    fabric_program_->impl().finalize_offsets(this);
 
     detail::WriteRuntimeArgsToDevice(this, *fabric_program_, this->using_fast_dispatch());
     detail::ConfigureDeviceWithProgram(this, *fabric_program_, this->using_fast_dispatch());

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -131,7 +131,7 @@ void EnqueueProgramCommand::process() {
     program_dispatch::reserve_space_in_kernel_config_buffer(
         this->config_buffer_mgr,
         program.impl().get_program_config_sizes(),
-        program.get_program_binary_status(device->id()),
+        program.impl().get_program_binary_status(device->id()),
         num_workers,
         this->expected_num_workers_completed,
         dispatch_metadata);
@@ -140,7 +140,7 @@ void EnqueueProgramCommand::process() {
 
     // Access the program dispatch-command cache
     uint64_t command_hash = *device->get_active_sub_device_manager_id();
-    auto& cached_program_command_sequence = program.get_cached_program_command_sequences().at(command_hash);
+    auto& cached_program_command_sequence = program.impl().get_cached_program_command_sequences().at(command_hash);
     // Update the generated dispatch commands based on the state of the CQ and the ring buffer
     program_dispatch::update_program_dispatch_commands(
         program.impl(),
@@ -152,7 +152,7 @@ void EnqueueProgramCommand::process() {
         this->dispatch_core_type,
         this->sub_device_id,
         dispatch_metadata,
-        program.get_program_binary_status(device->id()));
+        program.impl().get_program_binary_status(device->id()));
     // Issue dispatch commands for this program
     program_dispatch::write_program_command_sequence(
         cached_program_command_sequence,
@@ -162,7 +162,7 @@ void EnqueueProgramCommand::process() {
         dispatch_metadata.stall_first,
         dispatch_metadata.stall_before_program);
     // Kernel Binaries are committed to DRAM, the first time the program runs on device. Reflect this on host.
-    program.set_program_binary_status(device->id(), ProgramBinaryStatus::Committed);
+    program.impl().set_program_binary_status(device->id(), ProgramBinaryStatus::Committed);
 }
 
 EnqueueTerminateCommand::EnqueueTerminateCommand(
@@ -276,7 +276,7 @@ void EnqueueProgram(CommandQueue& cq, Program& program, bool blocking) {
     cq.enqueue_program(program, blocking);
     // Program relinquishes ownership of all global buffers its using, once its been enqueued. Avoid mem
     // leaks on device.
-    program.release_buffers();
+    program.impl().release_buffers();
 }
 
 void EnqueueRecordEvent(

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -778,8 +778,8 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
         }
 
         detail::CompileProgram(device, program);
-        if (!program.is_finalized()) {
-            program.finalize_offsets(device);
+        if (!program.impl().is_finalized()) {
+            program.impl().finalize_offsets(device);
         }
 
         detail::WriteRuntimeArgsToDevice(device, program, force_slow_dispatch);
@@ -910,7 +910,7 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
                     llrt::write_hex_vec_to_core(device_id, physical_core, circular_buffer_config_vec, addr);
                 }
             }
-            program.init_semaphores(*device, logical_core, index);
+            program.impl().init_semaphores(*device, logical_core, index);
         }
     }
 
@@ -991,7 +991,7 @@ void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool force_slow
 
 void CompileProgram(IDevice* device, Program& program, bool force_slow_dispatch) {
     ZoneScoped;
-    program.compile(device, force_slow_dispatch);
+    program.impl().compile(device, force_slow_dispatch);
 }
 
 }  // namespace detail
@@ -1194,7 +1194,7 @@ const CircularBufferConfig& GetCircularBufferConfig(Program& program, CBHandle c
 void UpdateCircularBufferTotalSize(Program& program, CBHandle cb_handle, uint32_t total_size) {
     std::shared_ptr<CircularBuffer> circular_buffer = detail::GetCircularBuffer(program, cb_handle);
     if (not circular_buffer->globally_allocated()) {
-        program.invalidate_circular_buffer_allocation();
+        program.impl().invalidate_circular_buffer_allocation();
     }
     circular_buffer->config().set_total_size(total_size);
 }


### PR DESCRIPTION
### Problem description
Some methods on Program are related to details of program binary on-device storage and the fast dispatch commands needed to start running programs, and they shouldn't be included in the API.

### What's changed
Remove those methods on Program. Code that was using them has been changed to call the equivalent methods on ProgramImpl directly. This includes some dispatch unit tests, which used those methods to determine device addresses to retrieve data from.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes