### PR TITLE
Disable DMA globally when DPrint or Watcher is enabled

### DIFF
--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -1334,6 +1334,7 @@ void DprintServerAttach(chip_id_t device_id) {
     // If no server is running, create one
     if (!DprintServerIsRunning()) {
         DebugPrintServerContext* ctx = new DebugPrintServerContext();
+        tt::tt_metal::MetalContext::instance().rtoptions().set_disable_dma_ops(true);
     }
 
     // Add this device to the server
@@ -1348,6 +1349,7 @@ void DprintServerDetach(chip_id_t device_id) {
         if (DebugPrintServerContext::inst->GetNumAttachedDevices() == 0) {
             delete DebugPrintServerContext::inst;
             DebugPrintServerContext::inst = nullptr;
+            tt::tt_metal::MetalContext::instance().rtoptions().set_disable_dma_ops(false);
         }
     }
 }

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -433,7 +433,7 @@ void watcher_init(chip_id_t device_id) {
 
 void watcher_attach(chip_id_t device_id) {
     const std::lock_guard<std::mutex> lock(watcher::watch_mutex);
-    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
 
     if (!watcher::enabled && rtoptions.get_watcher_enabled()) {
         watcher::create_log_file();
@@ -444,6 +444,8 @@ void watcher_attach(chip_id_t device_id) {
         watcher::set_watcher_exception_message("");
 
         watcher::enabled = true;
+
+        rtoptions.set_disable_dma_ops(true);
 
         int sleep_usecs = rtoptions.get_watcher_interval() * 1000;
         std::thread watcher_thread = std::thread(&watcher::watcher_loop, sleep_usecs);
@@ -496,6 +498,8 @@ void watcher_detach(chip_id_t device_id) {
         while (watcher::server_running) {
             ;
         }
+
+        tt::tt_metal::MetalContext::instance().rtoptions().set_disable_dma_ops(false);
     }
 }
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -399,6 +399,7 @@ public:
     inline void set_arc_debug_buffer_size(uint32_t size) { arc_debug_buffer_size = size; }
 
     inline bool get_disable_dma_ops() const { return disable_dma_ops; }
+    inline void set_disable_dma_ops(bool disable) { disable_dma_ops = disable; }
 
 private:
     // Helper functions to parse feature-specific environment vaiables.


### PR DESCRIPTION
### Ticket
#23213 

The debug tools tests are hanging in CI non-deterministically due to DMA reads/writes in DPrint and Watcher. As a workaround for now, this PR globally disables DMA reads/writes while DPrint or Watcher is active.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15539971001)