### PR TITLE
[tt-train] Add support for specifying device IDs and MeshShape in YAML config for transformer training demo

### DIFF
--- a/tt-train/sources/examples/nano_gpt/utils.cpp
+++ b/tt-train/sources/examples/nano_gpt/utils.cpp
@@ -94,9 +94,8 @@ std::unique_ptr<ttml::schedulers::LRSchedulerBase> create_warmup_with_linear_sch
     return std::make_unique<ttml::schedulers::SequentialScheduler>(optimizer, std::move(schedulers), std::move(steps));
 }
 
-void initialize_device(bool ddp, bool tp) {
+void initialize_device(bool ddp, bool tp, tt::tt_metal::distributed::MeshShape mesh_shape) {
     if (ddp || tp) {
-        // currently supports only N300 device
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
+        ttml::autograd::ctx().set_mesh_shape(mesh_shape);
     }
 }

--- a/tt-train/sources/examples/nano_gpt/utils.hpp
+++ b/tt-train/sources/examples/nano_gpt/utils.hpp
@@ -175,4 +175,5 @@ std::string generate_run_name(const std::string &run_name, const TrainingConfig 
     return ss.str();
 }
 
-void initialize_device(bool ddp, bool tp);
+void initialize_device(
+    bool ddp, bool tp, tt::tt_metal::distributed::MeshShape mesh_shape = tt::tt_metal::distributed::MeshShape(1, 2));

--- a/tt-train/sources/ttml/autograd/auto_context.cpp
+++ b/tt-train/sources/ttml/autograd/auto_context.cpp
@@ -46,18 +46,19 @@ void AutoContext::reset_graph() {
     m_graph.reset();
 }
 
-void AutoContext::open_device() {
+void AutoContext::open_device(const std::vector<int>* device_ids) {
     if (m_device) {
         throw std::runtime_error("open_device was called after the device was created.");
     }
-    m_device = std::make_unique<core::MeshDevice>(m_mesh_shape);
+
+    m_device = std::make_unique<core::MeshDevice>(m_mesh_shape, device_ids);
 }
 
 void AutoContext::close_device() {
     m_device = nullptr;
 }
 
-ttnn::distributed::MeshDevice& AutoContext::get_device() {
+ttnn::distributed::MeshDevice& AutoContext::get_device(const std::vector<int>* device_ids) {
     if (!m_device) {
         open_device();
     }

--- a/tt-train/sources/ttml/autograd/auto_context.hpp
+++ b/tt-train/sources/ttml/autograd/auto_context.hpp
@@ -44,12 +44,12 @@ public:
 
     ~AutoContext() = default;  // to make it work with unique_ptr.
 
-    ttnn::distributed::MeshDevice& get_device();
+    ttnn::distributed::MeshDevice& get_device(const std::vector<int>* device_ids = nullptr);
 
     void set_mesh_shape(tt::tt_metal::distributed::MeshShape shape);
     [[nodiscard]] tt::tt_metal::distributed::MeshShape get_mesh_shape() const;
 
-    void open_device();
+    void open_device(const std::vector<int>* device_ids = nullptr);
 
     void close_device();
 

--- a/tt-train/sources/ttml/core/mesh_device.cpp
+++ b/tt-train/sources/ttml/core/mesh_device.cpp
@@ -6,13 +6,15 @@
 
 namespace ttml::core {
 
-MeshDevice::MeshDevice(tt::tt_metal::distributed::MeshShape shape) :
+MeshDevice::MeshDevice(tt::tt_metal::distributed::MeshShape shape, const std::vector<int> *device_ids) :
     m_mesh_device(ttnn::distributed::open_mesh_device(
         shape,
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
-        /* num_command_queues*/ 1,
-        tt::tt_metal::DispatchCoreConfig{})) {
+        /* num_command_queues=*/1,
+        tt::tt_metal::DispatchCoreConfig{},
+        /*offset=*/std::nullopt,
+        /*physical_device_ids=*/device_ids ? *device_ids : std::vector<int>{})) {
     assert(m_mesh_device);
 }
 

--- a/tt-train/sources/ttml/core/mesh_device.hpp
+++ b/tt-train/sources/ttml/core/mesh_device.hpp
@@ -11,7 +11,7 @@ namespace ttml::core {
 // should I implement pimpl or its fine
 class MeshDevice {
 public:
-    explicit MeshDevice(tt::tt_metal::distributed::MeshShape shape);
+    explicit MeshDevice(tt::tt_metal::distributed::MeshShape shape, const std::vector<int>* device_ids = nullptr);
     MeshDevice(MeshDevice&& device) = default;
     MeshDevice(const MeshDevice&) = delete;
 


### PR DESCRIPTION
### Ticket
- Raised on Slack by @anatarajan-tt and cloud team.

### Problem description
We currently use a hardcoded MeshShape and automatically use the entire set of devices available in the transformer training demo, which caused problems for configs like the LLM box without access to the full set of chips and for using larger DDP/TP configurations.

### What's changed
- Adds support for passing the mesh_shape as a 2 element YAML sequence of ints under `training_config->mesh_shape`. When not passed, we currently default to the n300 default shape of [1,2].
- Adds support for passing any set of device ids as a YAML sequence of ints under `training_config->device_ids`. When not passed we use all available devices.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes