### PR TITLE
#23309: Remove assertion for device-to-device sync when TT-Fabric is disabled

### DIFF
--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -366,12 +366,6 @@ void syncDeviceDevice(chip_id_t device_id_sender, chip_id_t device_id_receiver) 
     }
 
     if (device_sender != nullptr and device_receiver != nullptr) {
-        FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
-        TT_FATAL(
-            fabric_config != FabricConfig::DISABLED,
-            "Cannot support device to device synchronization when TT-Fabric is disabled.");
-        log_info(tt::LogMetal, "Calling {} when TT-Fabric is enabled. This may take a while", __FUNCTION__);
-
         constexpr std::uint16_t sample_count = 240;
         constexpr std::uint16_t sample_size = 16;
         constexpr std::uint16_t channel_count = 1;


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/23309)

### Problem description
 An assertion was re-introduced during a bad rebase that prevents device-to-device synchronization when TT-Fabric is disabled. This assertion is no longer necessary and should be removed.

### What's changed
Removed the `TT_FATAL` assertion and associated `log_info` statement from `syncDeviceDevice` function in `tt_metal/impl/profiler/tt_metal_profiler.cpp`. These checks were preventing device-to-device synchronization when TT-Fabric was disabled, which is no longer required.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/15543755544
- [x] T3000 Profiler Tests: https://github.com/tenstorrent/tt-metal/actions/runs/15543732176