### PR TITLE
#0: Move `SmallVector` out of Metalium API

### DIFF
--- a/scripts/validate_metalium_api.py
+++ b/scripts/validate_metalium_api.py
@@ -20,7 +20,6 @@ ALLOWED_PREFIXES = {
     "tt-metalium",
     "tt_stl",
     "umd",
-    "boost",
     "fmt",
     "magic_enum",
     "nlohmann",

--- a/tests/ttnn/benchmark/cpp/padding/pad_rm.cpp
+++ b/tests/ttnn/benchmark/cpp/padding/pad_rm.cpp
@@ -13,7 +13,7 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <ttnn/tensor/host_buffer/functions.hpp>
 #include <tt-metalium/host_buffer.hpp>
-#include "small_vector.hpp"
+#include <tt_stl/small_vector.hpp>
 
 namespace {
 template <typename T>

--- a/tests/ttnn/unit_tests/gtests/emitc/emitc.hpp
+++ b/tests/ttnn/unit_tests/gtests/emitc/emitc.hpp
@@ -7,7 +7,7 @@
 
 #include "tt-metalium/bfloat16.hpp"
 #include "tt-metalium/shape.hpp"
-#include "tt-metalium/small_vector.hpp"
+#include <tt_stl/small_vector.hpp>
 #include "ttnn/decorators.hpp"
 #include "ttnn/device.hpp"
 #include "ttnn/distributed/types.hpp"

--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -19,7 +19,7 @@
 #include <tt-metalium/device.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/shape.hpp>
-#include <tt-metalium/small_vector.hpp>
+#include <tt_stl/small_vector.hpp>
 #include <tt_stl/strong_type.hpp>
 #include "ttnn/async_runtime.hpp"
 #include "ttnn/common/queue_id.hpp"

--- a/tests/ttnn/unit_tests/gtests/test_conv2d.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_conv2d.cpp
@@ -9,7 +9,7 @@
 #include <vector>
 #include <tt-metalium/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
-#include <tt-metalium/small_vector.hpp>
+#include <tt_stl/small_vector.hpp>
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/device.hpp"
 #include "ttnn/tensor/tensor.hpp"

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -86,7 +86,6 @@ target_sources(
             api/tt-metalium/shape.hpp
             api/tt-metalium/shape2d.hpp
             api/tt-metalium/shape_base.hpp
-            api/tt-metalium/small_vector.hpp
             api/tt-metalium/sub_device.hpp
             api/tt-metalium/sub_device_types.hpp
             api/tt-metalium/system_mesh.hpp
@@ -328,8 +327,6 @@ target_link_libraries(
         umd::device
         magic_enum::magic_enum
         fmt::fmt-header-only
-        span
-        small_vector
         TracyClient
         nlohmann_json::nlohmann_json
         TT::Metalium::HostDevCommon

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -30,7 +30,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
 #include <tt-metalium/mesh_trace_id.hpp>
-#include <tt-metalium/small_vector.hpp>
+#include <tt_stl/small_vector.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 #include <umd/device/types/arch.h>
 

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -10,7 +10,7 @@
 #include <tt-metalium/circular_buffer_constants.h>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/mesh_coord.hpp>
-#include <tt-metalium/small_vector.hpp>
+#include <tt_stl/small_vector.hpp>
 
 #include <umd/device/tt_core_coordinates.h>
 

--- a/tt_metal/api/tt-metalium/shape.hpp
+++ b/tt_metal/api/tt-metalium/shape.hpp
@@ -11,7 +11,7 @@
 #include <tuple>
 
 #include <tt-metalium/shape_base.hpp>
-#include <tt-metalium/small_vector.hpp>
+#include <tt_stl/small_vector.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/shape_base.hpp
+++ b/tt_metal/api/tt-metalium/shape_base.hpp
@@ -6,7 +6,7 @@
 
 #include <vector>
 
-#include <tt-metalium/small_vector.hpp>
+#include <tt_stl/small_vector.hpp>
 #include <tt_stl/span.hpp>
 
 namespace tt::tt_metal {

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include "shape_base.hpp"
-#include "small_vector.hpp"
+#include <tt_stl/small_vector.hpp>
 
 namespace tt::tt_metal::distributed {
 namespace {

--- a/tt_metal/common/shape.cpp
+++ b/tt_metal/common/shape.cpp
@@ -7,7 +7,7 @@
 #include <boost/container/vector.hpp>
 #include <boost/move/utility_core.hpp>
 #include <tt-metalium/assert.hpp>
-#include <tt-metalium/small_vector.hpp>
+#include <tt_stl/small_vector.hpp>
 #include <functional>
 #include <numeric>
 #include <ostream>
@@ -81,7 +81,7 @@ tt::stl::SmallVector<uint32_t> compute_strides(const tt::tt_metal::Shape& shape)
         return tt::stl::SmallVector<uint32_t>(shape.rank(), 0);
     }
 
-    ttnn::SmallVector<uint32_t> strides;
+    tt::stl::SmallVector<uint32_t> strides;
     for (std::int32_t index = 0; index < shape.rank(); index++) {
         num_elements /= shape[index];
         strides.push_back(num_elements);

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -8,7 +8,7 @@
 #include <mesh_coord.hpp>
 #include <mesh_device.hpp>
 #include <mesh_device_view.hpp>
-#include <small_vector.hpp>
+#include <tt_stl/small_vector.hpp>
 #include <sub_device.hpp>
 #include <system_mesh.hpp>
 #include <tt_metal.hpp>

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -16,7 +16,7 @@
 #include "mesh_config.hpp"
 #include "mesh_coord.hpp"
 #include "shape_base.hpp"
-#include "small_vector.hpp"
+#include <tt_stl/small_vector.hpp>
 #include <tt_stl/span.hpp>
 #include "tt_metal/distributed/coordinate_translation.hpp"
 

--- a/tt_stl/CMakeLists.txt
+++ b/tt_stl/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(
             tt_stl/overloaded.hpp
             tt_stl/reflection.hpp
             tt_stl/slotmap.hpp
+            tt_stl/small_vector.hpp
             tt_stl/span.hpp
             tt_stl/strong_type.hpp
             tt_stl/type_name.hpp
@@ -37,6 +38,7 @@ target_link_libraries(
         magic_enum::magic_enum
         nlohmann_json::nlohmann_json
         span
+        small_vector
         fmt::fmt-header-only
         tt-logger::tt-logger
 )

--- a/tt_stl/tt_stl/small_vector.hpp
+++ b/tt_stl/tt_stl/small_vector.hpp
@@ -33,9 +33,9 @@ std::ostream& operator<<(std::ostream& os, const SmallVector<T, PREALLOCATED_SIZ
 
 }  // namespace tt::stl
 
-// TODO: remove this.
 namespace ttnn {
-using tt::stl::SmallVector;
+template <typename T, size_t PREALLOCATED_SIZE = tt::stl::SMALL_VECTOR_SIZE>
+using SmallVector [[deprecated("Use tt::stl::SmallVector instead")]] = tt::stl::SmallVector<T, PREALLOCATED_SIZE>;
 }
 
 template <typename T, size_t PREALLOCATED_SIZE>

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "tt-metalium/small_vector.hpp"
+#include <tt_stl/small_vector.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/distributed/types.hpp"
 

--- a/ttnn/api/ttnn/tensor/layout/alignment.hpp
+++ b/ttnn/api/ttnn/tensor/layout/alignment.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <tt-metalium/small_vector.hpp>
+#include <tt_stl/small_vector.hpp>
 #include <tt-metalium/shape_base.hpp>
 
 namespace tt::tt_metal {

--- a/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <span>
-#include <tt-metalium/small_vector.hpp>
+#include <tt_stl/small_vector.hpp>
 
 #include "ttnn/tensor/tensor.hpp"
 #include <ttnn/tensor/xtensor/xtensor_all_includes.hpp>

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -5,7 +5,7 @@
 #include "tensor/host_buffer/functions.hpp"
 #include "tt-metalium/shape.hpp"
 #include "tt-metalium/mesh_coord.hpp"
-#include "tt-metalium/small_vector.hpp"
+#include <tt_stl/small_vector.hpp>
 #include "tt-metalium/tilize_utils.hpp"
 #include "tt_stl/overloaded.hpp"
 #include "ttnn/distributed/api.hpp"

--- a/ttnn/cpp/ttnn-pybind/small_vector_caster.hpp
+++ b/ttnn/cpp/ttnn-pybind/small_vector_caster.hpp
@@ -8,7 +8,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <tt-metalium/small_vector.hpp>
+#include <tt_stl/small_vector.hpp>
 
 namespace PYBIND11_NAMESPACE {
 namespace detail {

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -151,7 +151,7 @@ std::vector<ttnn::Tensor> unpad_output_tensor(
     const std::vector<ttnn::Tensor>& output_tensor,
     const uint32_t num_devices,
     const ttnn::SmallVector<uint32_t>& unpad_elements,
-    const int dim){
+    const int dim) {
     std::vector<ttnn::Tensor> combined_tensors;
 
     ttnn::SmallVector<uint32_t> begins = {0, 0, 0, 0};

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -13,7 +13,7 @@
 #include "tt-metalium/assert.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include "tt-metalium/math.hpp"
-#include "tt-metalium/small_vector.hpp"
+#include <tt_stl/small_vector.hpp>
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/untilize/untilize.hpp"
 #include "ttnn/tensor/tensor.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "squeeze.hpp"
-#include "tt-metalium/small_vector.hpp"
+#include <tt_stl/small_vector.hpp>
 #include "ttnn/operations/core/core.hpp"
 
 namespace ttnn::operations::data_movement {

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "ttnn/decorators.hpp"
-#include "tt-metalium/small_vector.hpp"
+#include <tt_stl/small_vector.hpp>
 
 namespace ttnn {
 namespace operations::data_movement {

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to.cpp
@@ -5,7 +5,7 @@
 #include <optional>
 
 #include "bcast_to.hpp"
-#include "tt-metalium/small_vector.hpp"
+#include <tt_stl/small_vector.hpp>
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/experimental/bcast_to/device/bcast_to_device_operation.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/cumsum/cumsum.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/cumsum/cumsum.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <iterator>
 #include "tt-metalium/shape.hpp"
-#include "tt-metalium/small_vector.hpp"
+#include <tt_stl/small_vector.hpp>
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/permute/permute.hpp"

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -109,7 +109,11 @@ Tensor ProdOperation::invoke(
         const bool permute_required = third_last_dim_idx != positive_dim;
 
         ttnn::SmallVector<int64_t> post_permute_dims(input_a.logical_shape().rank());
+        std::iota(post_permute_dims.begin(), post_permute_dims.end(), 0);
         std::swap(post_permute_dims[third_last_dim_idx], post_permute_dims[positive_dim]);
+
+        // Tensor with target reduction dim at third last position
+        ttnn::Tensor permuted =
             permute_required ? ttnn::permute(input_a, post_permute_dims, output_mem_config) : input_a;
 
         // Now squeeze to 4D and do the 4D prod.
@@ -173,9 +177,15 @@ Tensor ProdOperation::invoke(
             const auto& input_shape = input_tensor_4d.logical_shape();
             ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
             ttnn::SmallVector<uint32_t> end_index = {input_shape[0], input_shape[1], 1, input_shape[2]};
+            Tensor new_unpad_tensor = ttnn::slice(required, start_index, end_index, step, std::nullopt);
             // permute back
             after_permute_dims = {0, 1, 3, 2};
             Tensor res_host = ttnn::permute(new_unpad_tensor, after_permute_dims, output_mem_config);
+            result = ttnn::squeeze_from_4D(res_host, old_rank);
+        }
+        return keepdim ? result : ttnn::squeeze(result, *dim);
+    }
+}
 
 Tensor ProdOperation::invoke(
     const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -109,11 +109,7 @@ Tensor ProdOperation::invoke(
         const bool permute_required = third_last_dim_idx != positive_dim;
 
         ttnn::SmallVector<int64_t> post_permute_dims(input_a.logical_shape().rank());
-        std::iota(post_permute_dims.begin(), post_permute_dims.end(), 0);
         std::swap(post_permute_dims[third_last_dim_idx], post_permute_dims[positive_dim]);
-
-        // Tensor with target reduction dim at third last position
-        ttnn::Tensor permuted =
             permute_required ? ttnn::permute(input_a, post_permute_dims, output_mem_config) : input_a;
 
         // Now squeeze to 4D and do the 4D prod.
@@ -177,15 +173,9 @@ Tensor ProdOperation::invoke(
             const auto& input_shape = input_tensor_4d.logical_shape();
             ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
             ttnn::SmallVector<uint32_t> end_index = {input_shape[0], input_shape[1], 1, input_shape[2]};
-            Tensor new_unpad_tensor = ttnn::slice(required, start_index, end_index, step, std::nullopt);
             // permute back
             after_permute_dims = {0, 1, 3, 2};
             Tensor res_host = ttnn::permute(new_unpad_tensor, after_permute_dims, output_mem_config);
-            result = ttnn::squeeze_from_4D(res_host, old_rank);
-        }
-        return keepdim ? result : ttnn::squeeze(result, *dim);
-    }
-}
 
 Tensor ProdOperation::invoke(
     const Tensor& input,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`SmallVector` belongs to tt stl, not Metalium API.

### What's changed
Move `SmallVector` out of Metalium API to tt stl, migrate the includes.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15547616834)
- [x] New/Existing tests provide coverage for changes