### PR TITLE
[skip ci] Lower UNET perf target

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -116,7 +116,7 @@ def test_unet_trace_perf(
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2519.0),)
+    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2419.0),)
 )
 def test_unet_trace_perf_multi_device(
     batch: int,


### PR DESCRIPTION
### Ticket
#23304 

### Problem description
Please see issue.

### What's changed
Lowered perf target to something below the three most recent runs:
2461.43
2456.35
2443.96

### Checklist
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/15545816654 CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes