### PR TITLE
#22045: Extend `DistributeHostBuffer` transform and apply with TaskFlow-based parallelization

### DIFF
--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -40,26 +40,32 @@ set_target_properties(
             ${PROJECT_BINARY_DIR}/test/tt_metal/distributed
 )
 
-add_executable(thread_pool_benchmark)
-target_sources(thread_pool_benchmark PRIVATE benchmark_thread_pool.cpp)
+add_executable(distributed_benchmarks)
+target_sources(
+    distributed_benchmarks
+    PRIVATE
+        benchmark_thread_pool.cpp
+        benchmark_distributed_host_buffer.cpp
+)
 
 target_link_libraries(
-    thread_pool_benchmark
+    distributed_benchmarks
     PRIVATE
         tt_metal
         test_common_libs
         benchmark::benchmark
+        benchmark::benchmark_main
 )
 
 target_include_directories(
-    thread_pool_benchmark
+    distributed_benchmarks
     PRIVATE
         "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
         ${PROJECT_SOURCE_DIR}/tests
 )
 
 set_target_properties(
-    thread_pool_benchmark
+    distributed_benchmarks
     PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY
             ${PROJECT_BINARY_DIR}/test/tt_metal/distributed

--- a/tests/tt_metal/distributed/benchmark_distributed_host_buffer.cpp
+++ b/tests/tt_metal/distributed/benchmark_distributed_host_buffer.cpp
@@ -1,0 +1,40 @@
+#include <benchmark/benchmark.h>
+
+#include <tt-metalium/distributed_host_buffer.hpp>
+
+#include <vector>
+#include <numeric>
+#include <algorithm>
+
+namespace tt::tt_metal {
+namespace {
+
+constexpr size_t kNumShards = 64;
+constexpr size_t kShardSize = 1 << 20;
+
+void BM_DistributedHostBufferParallelTransform(benchmark::State& state) {
+    auto buffer = DistributedHostBuffer::create(distributed::MeshShape(kNumShards));
+    std::vector<int> data(kShardSize);
+    std::iota(data.begin(), data.end(), 0);
+
+    for (size_t i = 0; i < kNumShards; ++i) {
+        buffer.emplace_shard(distributed::MeshCoordinate(i), [&data]() { return HostBuffer(data); });
+    }
+
+    for (auto _ : state) {
+        buffer.transform(
+            [](const HostBuffer& buffer) {
+                auto span = buffer.view_as<int>();
+                std::vector<int> new_data;
+                new_data.reserve(span.size());
+                std::transform(span.begin(), span.end(), std::back_inserter(new_data), [](int val) { return val * 2; });
+                return HostBuffer(std::move(new_data));
+            },
+            DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
+    }
+}
+
+BENCHMARK(BM_DistributedHostBufferParallelTransform)->Unit(benchmark::kMillisecond);
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/distributed/benchmark_distributed_host_buffer.cpp
+++ b/tests/tt_metal/distributed/benchmark_distributed_host_buffer.cpp
@@ -9,32 +9,61 @@
 namespace tt::tt_metal {
 namespace {
 
-constexpr size_t kNumShards = 64;
-constexpr size_t kShardSize = 1 << 20;
-
-void BM_DistributedHostBufferParallelTransform(benchmark::State& state) {
-    auto buffer = DistributedHostBuffer::create(distributed::MeshShape(kNumShards));
-    std::vector<int> data(kShardSize);
+DistributedHostBuffer create_distributed_host_buffer(int num_shards) {
+    auto buffer = DistributedHostBuffer::create(distributed::MeshShape(num_shards));
+    std::vector<int> data(num_shards);
     std::iota(data.begin(), data.end(), 0);
-
-    for (size_t i = 0; i < kNumShards; ++i) {
+    for (size_t i = 0; i < num_shards; ++i) {
         buffer.emplace_shard(distributed::MeshCoordinate(i), [&data]() { return HostBuffer(data); });
     }
 
+    return buffer;
+}
+
+std::function<HostBuffer(const HostBuffer&)> get_transform_fn() {
+    return [](const HostBuffer& buffer) {
+        auto span = buffer.view_as<int>();
+        std::vector<int> new_data;
+        new_data.reserve(span.size());
+        std::transform(span.begin(), span.end(), std::back_inserter(new_data), [](int v) { return v * 2; });
+        return HostBuffer(std::move(new_data));
+    };
+}
+
+void BM_DistributedHostBufferSequentialTransform(benchmark::State& state) {
+    auto buffer = create_distributed_host_buffer(state.range(0));
+    auto transform_fn = get_transform_fn();
+
     for (auto _ : state) {
-        buffer.transform(
-            [](const HostBuffer& buffer) {
-                auto span = buffer.view_as<int>();
-                std::vector<int> new_data;
-                new_data.reserve(span.size());
-                std::transform(span.begin(), span.end(), std::back_inserter(new_data), [](int val) { return val * 2; });
-                return HostBuffer(std::move(new_data));
-            },
-            DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
+        buffer.transform(transform_fn, DistributedHostBuffer::ProcessShardExecutionPolicy::SEQUENTIAL);
     }
 }
 
-BENCHMARK(BM_DistributedHostBufferParallelTransform)->Unit(benchmark::kMillisecond);
+void BM_DistributedHostBufferParallelTransform(benchmark::State& state) {
+    auto buffer = create_distributed_host_buffer(state.range(0));
+    auto transform_fn = get_transform_fn();
+
+    for (auto _ : state) {
+        buffer.transform(transform_fn, DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
+    }
+}
+
+BENCHMARK(BM_DistributedHostBufferSequentialTransform)
+    ->Unit(benchmark::kMillisecond)
+    ->Arg(1)
+    ->Arg(2)
+    ->Arg(4)
+    ->Arg(8)
+    ->Arg(16)
+    ->Arg(32);
+BENCHMARK(BM_DistributedHostBufferParallelTransform)
+    ->Unit(benchmark::kMillisecond)
+    ->Arg(1)
+    ->Arg(2)
+    ->Arg(4)
+    ->Arg(8)
+    ->Arg(16)
+    ->Arg(32);
 
 }  // namespace
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/distributed/benchmark_distributed_host_buffer.cpp
+++ b/tests/tt_metal/distributed/benchmark_distributed_host_buffer.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include <benchmark/benchmark.h>
 
 #include <tt-metalium/distributed_host_buffer.hpp>

--- a/tests/tt_metal/distributed/benchmark_thread_pool.cpp
+++ b/tests/tt_metal/distributed/benchmark_thread_pool.cpp
@@ -67,5 +67,3 @@ BENCHMARK(BM_DistributedBoostThreadPool)
     ->UseRealTime();
 
 BENCHMARK(BM_DeviceBoundThreadPool)->RangeMultiplier(2)->Range(1, 1 << 18)->Complexity(benchmark::oN)->UseRealTime();
-
-BENCHMARK_MAIN();

--- a/tests/tt_metal/distributed/test_distributed_host_buffer.cpp
+++ b/tests/tt_metal/distributed/test_distributed_host_buffer.cpp
@@ -21,7 +21,7 @@ using ::testing::Pointwise;
 using ::testing::SizeIs;
 using ::testing::UnorderedElementsAre;
 
-TEST(DistributedHostBufferTest, WithInvalidLocalShape) {
+TEST(DistributedHostBufferTest, InvalidLocalShape) {
     distributed::MeshShape global_shape(2, 3);
     distributed::MeshShape local_shape(2, 4);  // 2x4 > 2x3
     distributed::MeshCoordinate local_offset(0, 0);
@@ -29,7 +29,7 @@ TEST(DistributedHostBufferTest, WithInvalidLocalShape) {
     EXPECT_ANY_THROW(DistributedHostBuffer::create(global_shape, local_shape, local_offset));
 }
 
-TEST(DistributedHostBufferTest, WithInvalidLocalOffset) {
+TEST(DistributedHostBufferTest, InvalidLocalOffset) {
     distributed::MeshShape global_shape(2, 3);
     distributed::MeshShape local_shape(1, 2);
     distributed::MeshCoordinate local_offset(2, 0);  // Offset 2 in first dimension exceeds global shape
@@ -37,7 +37,7 @@ TEST(DistributedHostBufferTest, WithInvalidLocalOffset) {
     EXPECT_ANY_THROW(DistributedHostBuffer::create(global_shape, local_shape, local_offset));
 }
 
-TEST(DistributedHostBufferTest, WithInvalidCombination) {
+TEST(DistributedHostBufferTest, InvalidCombination) {
     distributed::MeshShape global_shape(2, 3);
     distributed::MeshShape local_shape(1, 2);
     distributed::MeshCoordinate local_offset(1, 2);  // Offset + shape exceeds global shape
@@ -45,7 +45,7 @@ TEST(DistributedHostBufferTest, WithInvalidCombination) {
     EXPECT_ANY_THROW(DistributedHostBuffer::create(global_shape, local_shape, local_offset));
 }
 
-TEST(DistributedHostBufferTest, WithDimensionMismatch) {
+TEST(DistributedHostBufferTest, DimensionMismatch) {
     distributed::MeshShape global_shape(2, 3);
     distributed::MeshShape local_shape(1, 1, 1);  // 3D shape vs 2D global shape
     distributed::MeshCoordinate local_offset(1, 0);
@@ -53,12 +53,8 @@ TEST(DistributedHostBufferTest, WithDimensionMismatch) {
     EXPECT_ANY_THROW(DistributedHostBuffer::create(global_shape, local_shape, local_offset));
 }
 
-TEST(DistributedHostBufferTest, GetBuffer) {
-    distributed::MeshShape global_shape(3);
-    distributed::MeshShape local_shape(3);
-    distributed::MeshCoordinate local_offset(0);
-
-    auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
+TEST(DistributedHostBufferTest, EmplaceAndGetBuffer) {
+    auto buffer = DistributedHostBuffer::create(distributed::MeshShape(3));
 
     buffer.emplace_shard(distributed::MeshCoordinate(0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
     buffer.emplace_shard(distributed::MeshCoordinate(1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
@@ -80,7 +76,26 @@ TEST(DistributedHostBufferTest, GetBuffer) {
     EXPECT_ANY_THROW(buffer.get_shard(distributed::MeshCoordinate(3)));
 }
 
-TEST(DistributedHostBufferTest, WithLocalMeshShape) {
+TEST(DistributedHostBufferTest, EmplaceAndGetBufferWithUnpopulatedLocalShards) {
+    auto buffer = DistributedHostBuffer::create(distributed::MeshShape(3));
+
+    buffer.emplace_shard(distributed::MeshCoordinate(1), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
+
+    auto optional_buffer = buffer.get_shard(distributed::MeshCoordinate(0));
+    EXPECT_FALSE(optional_buffer.has_value());
+
+    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(1));
+    ASSERT_TRUE(optional_buffer.has_value());
+    EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {1, 2, 3}));
+
+    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(2));
+    EXPECT_FALSE(optional_buffer.has_value());
+
+    // Out of global bounds.
+    EXPECT_ANY_THROW(buffer.get_shard(distributed::MeshCoordinate(3)));
+}
+
+TEST(DistributedHostBufferTest, EmplaceAndGetBufferWithLocalMeshShape) {
     distributed::MeshShape global_shape(2, 3);
     distributed::MeshShape local_shape(2, 1);
     distributed::MeshCoordinate local_offset(0, 1);
@@ -130,11 +145,7 @@ TEST(DistributedHostBufferTest, WithLocalMeshShape) {
 }
 
 TEST(DistributedHostBufferTest, Transform) {
-    distributed::MeshShape global_shape(2);
-    distributed::MeshShape local_shape(2);
-    distributed::MeshCoordinate local_offset(0);
-
-    auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
+    auto buffer = DistributedHostBuffer::create(distributed::MeshShape(2));
     EXPECT_EQ(buffer.shape().mesh_size(), 2);
 
     buffer.emplace_shard(distributed::MeshCoordinate(0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
@@ -156,6 +167,31 @@ TEST(DistributedHostBufferTest, Transform) {
     optional_buffer = transformed_buffer.get_shard(distributed::MeshCoordinate(1));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {8, 10, 12}));
+}
+
+TEST(DistributedHostBufferTest, TransformWithUnpopulatedLocalShards) {
+    auto buffer = DistributedHostBuffer::create(distributed::MeshShape(3));
+
+    buffer.emplace_shard(distributed::MeshCoordinate(1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
+
+    auto transformed_buffer = buffer.transform([](const HostBuffer& buffer) {
+        auto span = buffer.view_as<int>();
+        std::vector<int> new_data(span.begin(), span.end());
+        for (auto& val : new_data) {
+            val *= 2;
+        }
+        return HostBuffer(std::move(new_data));
+    });
+
+    auto optional_buffer = transformed_buffer.get_shard(distributed::MeshCoordinate(0));
+    ASSERT_FALSE(optional_buffer.has_value());
+
+    optional_buffer = transformed_buffer.get_shard(distributed::MeshCoordinate(1));
+    ASSERT_TRUE(optional_buffer.has_value());
+    EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {8, 10, 12}));
+
+    optional_buffer = transformed_buffer.get_shard(distributed::MeshCoordinate(2));
+    ASSERT_FALSE(optional_buffer.has_value());
 }
 
 TEST(DistributedHostBufferTest, TransformWithLocalShape) {
@@ -189,11 +225,7 @@ TEST(DistributedHostBufferTest, TransformWithLocalShape) {
 }
 
 TEST(DistributedHostBufferTest, Apply) {
-    distributed::MeshShape global_shape(2);
-    distributed::MeshShape local_shape(2);
-    distributed::MeshCoordinate local_offset(0);
-
-    auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
+    auto buffer = DistributedHostBuffer::create(distributed::MeshShape(2));
     EXPECT_EQ(buffer.shape().mesh_size(), 2);
 
     buffer.emplace_shard(distributed::MeshCoordinate(0), []() { return HostBuffer(std::vector<int>{1, 2, 3}); });
@@ -208,6 +240,21 @@ TEST(DistributedHostBufferTest, Apply) {
     ASSERT_THAT(values, SizeIs(2));
     EXPECT_THAT(values[0], ElementsAre(1, 2, 3));
     EXPECT_THAT(values[1], ElementsAre(4, 5, 6));
+}
+
+TEST(DistributedHostBufferTest, ApplyWithUnpopulatedLocalShards) {
+    auto buffer = DistributedHostBuffer::create(distributed::MeshShape(3));
+
+    buffer.emplace_shard(distributed::MeshCoordinate(1), []() { return HostBuffer(std::vector<int>{4, 5, 6}); });
+
+    std::vector<std::vector<int>> values;
+    buffer.apply([&values](const HostBuffer& buffer) {
+        auto span = buffer.view_as<int>();
+        values.push_back(std::vector<int>(span.begin(), span.end()));
+    });
+
+    ASSERT_THAT(values, SizeIs(1));
+    EXPECT_THAT(values[0], ElementsAre(4, 5, 6));
 }
 
 TEST(DistributedHostBufferTest, ApplyWithLocalShape) {

--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+
 #include <taskflow/taskflow.hpp>
 #include <thread>
 #include <stdexcept>

--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -79,6 +79,7 @@ target_link_libraries(
         Metalium::Metal::Impl
         Metalium::Metal::LLRT
         TT::Metalium::HostDevCommon
+        Taskflow::Taskflow
 )
 
 if(USE_MPI)

--- a/tt_metal/distributed/distributed_host_buffer.cpp
+++ b/tt_metal/distributed/distributed_host_buffer.cpp
@@ -3,11 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt_stl/span.hpp>
+#include <tt_stl/indestructible.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/distributed_host_buffer.hpp>
 #include <tt-metalium/assert.hpp>
 
 #include <vector>
+#include <functional>
+#include <taskflow/taskflow.hpp>
+#include "common/executor.hpp"
 
 namespace tt::tt_metal {
 
@@ -36,14 +40,16 @@ DistributedHostBuffer DistributedHostBuffer::create(
             global_shape[dim]);
     }
     return DistributedHostBuffer(
-        std::move(global_shape),
-        std::move(local_offset),
-        distributed::MeshContainer<HostBuffer>(local_shape, HostBuffer()));
+        global_shape, local_offset, distributed::MeshContainer<Shard>(local_shape, Shard{.is_populated = false}));
+}
+
+DistributedHostBuffer DistributedHostBuffer::create(const distributed::MeshShape& shape) {
+    return DistributedHostBuffer::create(shape, shape, distributed::MeshCoordinate::zero_coordinate(shape.dims()));
 }
 
 std::optional<distributed::MeshCoordinate> DistributedHostBuffer::global_to_local(
     const distributed::MeshCoordinate& coord) const {
-    const auto& local_shape = local_buffers_.shape();
+    const auto& local_shape = local_shards_.shape();
     tt::stl::SmallVector<uint32_t> local_coord(coord.dims());
     for (size_t dim = 0; dim < coord.dims(); ++dim) {
         if (coord[dim] < local_offset_[dim] || coord[dim] >= local_offset_[dim] + local_shape[dim]) {
@@ -54,6 +60,17 @@ std::optional<distributed::MeshCoordinate> DistributedHostBuffer::global_to_loca
     return distributed::MeshCoordinate(local_coord);
 }
 
+std::vector<size_t> DistributedHostBuffer::get_populated_local_shard_indices() const {
+    std::vector<size_t> indices;
+    indices.reserve(local_shards_.values().size());
+    for (size_t i = 0; i < local_shards_.values().size(); ++i) {
+        if (local_shards_.values()[i].is_populated) {
+            indices.push_back(i);
+        }
+    }
+    return indices;
+}
+
 std::optional<HostBuffer> DistributedHostBuffer::get_shard(const distributed::MeshCoordinate& coord) const {
     TT_FATAL(
         distributed::MeshCoordinateRange(global_shape_).contains(coord),
@@ -61,8 +78,12 @@ std::optional<HostBuffer> DistributedHostBuffer::get_shard(const distributed::Me
         coord,
         global_shape_);
 
-    auto local_coord_opt = global_to_local(coord);
-    return local_coord_opt.has_value() ? std::optional<HostBuffer>(local_buffers_.at(*local_coord_opt)) : std::nullopt;
+    if (auto local_coord_opt = global_to_local(coord);
+        local_coord_opt.has_value() && local_shards_.at(*local_coord_opt).is_populated) {
+        return std::make_optional(local_shards_.at(*local_coord_opt).buffer);
+    } else {
+        return std::nullopt;
+    }
 }
 
 void DistributedHostBuffer::emplace_shard(
@@ -76,33 +97,49 @@ void DistributedHostBuffer::emplace_shard(
     populated_shards_.insert(coord);
     auto local_coord_opt = global_to_local(coord);
     if (local_coord_opt.has_value()) {
-        local_buffers_.at(*local_coord_opt) = produce_buffer();
+        local_shards_.at(*local_coord_opt) = Shard{.buffer = produce_buffer(), .is_populated = true};
     }
 }
 
-DistributedHostBuffer DistributedHostBuffer::transform(const TransformFn& fn) const {
-    std::vector<HostBuffer> transformed_buffers;
-    transformed_buffers.reserve(local_buffers_.shape().mesh_size());
-    for (const auto& local_buffer : local_buffers_.values()) {
-        transformed_buffers.push_back(fn(local_buffer));
+DistributedHostBuffer DistributedHostBuffer::transform(
+    const TransformFn& fn, ProcessShardExecutionPolicy policy) const {
+    const std::vector<size_t> indices_to_process = get_populated_local_shard_indices();
+    const auto& local_shards = local_shards_.values();
+    std::vector<Shard> transformed_shards(local_shards.size());
+
+    std::function<void(size_t)> process_shard = [&](size_t i) {
+        transformed_shards[i] = Shard{.buffer = fn(local_shards[i].buffer), .is_populated = true};
+    };
+    if (policy == ProcessShardExecutionPolicy::SEQUENTIAL || indices_to_process.size() < 2) {
+        std::for_each(indices_to_process.begin(), indices_to_process.end(), process_shard);
+    } else {
+        tf::Taskflow taskflow;
+        taskflow.for_each(indices_to_process.begin(), indices_to_process.end(), process_shard);
+        detail::GetExecutor().run(taskflow).wait();
     }
+
     DistributedHostBuffer transformed_buffer(
         global_shape_,
         local_offset_,
-        distributed::MeshContainer<HostBuffer>(local_buffers_.shape(), std::move(transformed_buffers)));
+        distributed::MeshContainer<Shard>(local_shards_.shape(), std::move(transformed_shards)));
     return transformed_buffer;
 }
 
-void DistributedHostBuffer::apply(const ApplyFn& fn) const {
-    for (const auto& local_buffer : local_buffers_.values()) {
-        fn(local_buffer);
+void DistributedHostBuffer::apply(const ApplyFn& fn, ProcessShardExecutionPolicy policy) const {
+    const std::vector<size_t> indices_to_process = get_populated_local_shard_indices();
+    const auto& local_shards = local_shards_.values();
+    std::function<void(size_t)> process_shard = [&](size_t i) { fn(local_shards[i].buffer); };
+    if (policy == ProcessShardExecutionPolicy::SEQUENTIAL || indices_to_process.size() < 2) {
+        std::for_each(indices_to_process.begin(), indices_to_process.end(), process_shard);
+    } else {
+        tf::Taskflow taskflow;
+        taskflow.for_each(indices_to_process.begin(), indices_to_process.end(), process_shard);
+        detail::GetExecutor().run(taskflow).wait();
     }
 }
 
-distributed::MeshShape DistributedHostBuffer::shape() const { return global_shape_; }
+const distributed::MeshShape& DistributedHostBuffer::shape() const { return global_shape_; }
 
-const std::unordered_set<distributed::MeshCoordinate>& DistributedHostBuffer::shard_coords() const {
-    return populated_shards_;
-}
+const std::set<distributed::MeshCoordinate>& DistributedHostBuffer::shard_coords() const { return populated_shards_; }
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
#22045

### Problem description
To avoid exposing Metal's thread pool, we can rely on Taskflow to parallelize processing of multi-device shards on host in a general way.

Doing so in `DistributedHostBuffer` allows to re-use Taskflow's executor already used for JIT compilation. 

### What's changed
Use Taskflow in `transform` and `apply` functions in `DistributedHostBuffer`.

Added benchmark to confirm parallelization works. Running on T3K machine, with 1MB shards, and varying number of shards:
```
-----------------------------------------------------------------------------------------
Benchmark                                               Time             CPU   Iterations
-----------------------------------------------------------------------------------------
BM_DistributedHostBufferSequentialTransform/1       0.760 ms        0.760 ms          915
BM_DistributedHostBufferSequentialTransform/2        1.78 ms         1.78 ms          386
BM_DistributedHostBufferSequentialTransform/4        7.40 ms         7.40 ms           77
BM_DistributedHostBufferSequentialTransform/8        5.80 ms         5.80 ms          107
BM_DistributedHostBufferSequentialTransform/16       23.8 ms         23.8 ms           52
BM_DistributedHostBufferSequentialTransform/32       66.2 ms         66.2 ms           10
BM_DistributedHostBufferParallelTransform/1         0.592 ms        0.592 ms         1185
BM_DistributedHostBufferParallelTransform/2          2.25 ms        0.053 ms        10000
BM_DistributedHostBufferParallelTransform/4          3.08 ms        0.066 ms         1000
BM_DistributedHostBufferParallelTransform/8          4.71 ms        0.083 ms         1000
BM_DistributedHostBufferParallelTransform/16         5.53 ms        0.087 ms         1000
BM_DistributedHostBufferParallelTransform/32         4.74 ms        0.057 ms         1000
```

Other modification in the PR are from the pending https://github.com/tenstorrent/tt-metal/pull/22954.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15550552090)
- [X] New/Existing tests provide coverage for changes