### PR TITLE
Fix Incorrect Name of log level ENV TT_METAL_LOGGER_LEVEL

### DIFF
--- a/tt_metal/logging/logging.cpp
+++ b/tt_metal/logging/logging.cpp
@@ -15,8 +15,8 @@
 
 namespace tt::tt_metal::logging {
 
-constexpr auto file_env_var = "TT_Metal_LOGGER_FILE";
-constexpr auto level_env_var = "TT_Metal_LOGGER_LEVEL";
+constexpr auto file_env_var = "TT_METAL_LOGGER_FILE";
+constexpr auto level_env_var = "TT_METAL_LOGGER_LEVEL";
 constexpr auto log_pattern = "[%Y-%m-%d %H:%M:%S.%e] [%l] [%s:%#] %v";
 
 /**


### PR DESCRIPTION
### Problem description
I made a typo when defining the environment variable that controls log level.

### What's changed
TT_Metal_LOGGER_LEVEL -> TT_METAL_LOGGER_LEVEL

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes