### PR TITLE
Add MESH topology support to health check script for 6U and T3K

### DIFF
--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -113,16 +113,17 @@ jobs:
       - name: Run health tests
         timeout-minutes: 20
         # NOTE: These tests do not automatically get added to upstream tests. Please refer to dockerfile/upstream_test_images/.
+        # TODO #23350: This should use TORUS_2D topology not MESH since there are tests that depend on ring here.
         run: |
           ./build/test/tt_metal/tt_fabric/test_system_health --system-topology MESH
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardFixture.*";
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardProgramFixture.*";
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites";
-          ./build/test/ttnn/unit_tests_ttnn_ccl --gtest_filter="EdmFabric.RingDeadlockStabilityTest"
           ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
           ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
           TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
           TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
+          ./build/test/ttnn/unit_tests_ttnn_ccl --gtest_filter="EdmFabric.RingDeadlockStabilityTest"
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
@@ -166,6 +167,7 @@ jobs:
         timeout-minutes: 20
         # NOTE: These tests do not automatically get added to upstream tests. Please refer to dockerfile/upstream_test_images/.
         run: |
+          ./build/test/tt_metal/tt_fabric/test_system_health --system-topology MESH
           pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick";
           pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "quick";
           pytest models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py;

--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -114,7 +114,7 @@ jobs:
         timeout-minutes: 20
         # NOTE: These tests do not automatically get added to upstream tests. Please refer to dockerfile/upstream_test_images/.
         run: |
-          ./build/test/tt_metal/tt_fabric/test_system_health
+          ./build/test/tt_metal/tt_fabric/test_system_health --system-topology MESH
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardFixture.*";
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardProgramFixture.*";
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites";

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -244,32 +244,26 @@ TEST(Cluster, TestMeshFullConnectivity) {
             }
         }
         if (target_system_topology.has_value()) {
+            auto validate_num_connections = [&](uint32_t num_connections, uint32_t num_expected_chip_connections) {
+                EXPECT_EQ(num_connections, num_expected_chip_connections)
+                    << chip_ss.str() << " is connected to " << num_connections << " other chips, expected "
+                    << num_expected_chip_connections << " chips for " << magic_enum::enum_name(*target_system_topology)
+                    << " topology";
+            };
             if (*target_system_topology == FabricType::TORUS_2D) {
                 static constexpr std::uint32_t num_expected_chip_connections = 4;
-                EXPECT_EQ(num_connections_to_chip.size(), num_expected_chip_connections)
-                    << chip_ss.str() << " is connected to " << num_connections_to_chip.size()
-                    << " other chips, expected " << num_expected_chip_connections << " chips for "
-                    << magic_enum::enum_name(*target_system_topology) << " topology";
+                validate_num_connections(num_connections_to_chip.size(), num_expected_chip_connections);
             } else if (*target_system_topology == FabricType::MESH) {
                 // TODO: This is UBB specific where we only consider internal connections when determining MESH topology
                 if (is_chip_on_corner_of_mesh(chip)) {
                     static constexpr std::uint32_t num_expected_chip_connections = 2;
-                    EXPECT_EQ(num_internal_connections_to_chip.size(), num_expected_chip_connections)
-                        << chip_ss.str() << " is connected to " << num_internal_connections_to_chip.size()
-                        << " other chips, expected " << num_expected_chip_connections << " chips for "
-                        << magic_enum::enum_name(*target_system_topology) << " topology";
+                    validate_num_connections(num_internal_connections_to_chip.size(), num_expected_chip_connections);
                 } else if (is_chip_on_edge_of_mesh(chip)) {
                     static constexpr std::uint32_t num_expected_chip_connections = 3;
-                    EXPECT_EQ(num_internal_connections_to_chip.size(), num_expected_chip_connections)
-                        << chip_ss.str() << " is connected to " << num_internal_connections_to_chip.size()
-                        << " other chips, expected " << num_expected_chip_connections << " chips for "
-                        << magic_enum::enum_name(*target_system_topology) << " topology";
+                    validate_num_connections(num_internal_connections_to_chip.size(), num_expected_chip_connections);
                 } else {
                     static constexpr std::uint32_t num_expected_chip_connections = 4;
-                    EXPECT_EQ(num_internal_connections_to_chip.size(), num_expected_chip_connections)
-                        << chip_ss.str() << " is connected to " << num_internal_connections_to_chip.size()
-                        << " other chips, expected " << num_expected_chip_connections << " chips for "
-                        << magic_enum::enum_name(*target_system_topology) << " topology";
+                    validate_num_connections(num_internal_connections_to_chip.size(), num_expected_chip_connections);
                 }
             }
         }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Mesh support topology needed for 6U and T3K health check. Useful if we need to downshift if QSFP has issues.

### What's changed
Add support for mesh topology for 6U and T3K health check.
Update 6u health check in CI to check for mesh (since 6u ci systems aren't working for TORUS_2D).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes
TG Quick: https://github.com/tenstorrent/tt-metal/actions/runs/15561664605