### PR TITLE
[skip ci] Add job to publish wheel

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -251,7 +251,7 @@ jobs:
     needs: [build-artifact, test-wheels]
     runs-on: ubuntu-latest
     environment:
-      name: test-pypi
+      name: testpypi
       url: https://test.pypi.org/p/ttnn
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -245,3 +245,23 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     secrets: inherit
+  publish-to-test-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to Test PyPI
+    needs: [build-artifact, test-wheels]
+    runs-on: ubuntu-latest
+    environment:
+      name: test-pypi
+      url: https://test.pypi.org/p/ttnn
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+        path: dist/
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
### Ticket
#22986 

### Problem description
We need to publish ttnn wheel to pypi.

### What's changed
Add job in package-and-release.yaml which would publish our built wheel to test pypi.
This is a first step to put the infrastructure in place.
After this, we just wait for a swap to pypi.

### Checklist
- [x] [Package And Release](https://github.com/tenstorrent/tt-metal/actions/runs/15568567059) CI passes
- [x] New/Existing tests provide coverage for changes