### PR TITLE
Add Yolov8s-world Trace+2cqs pipeline

### DIFF
--- a/models/experimental/yolov8s_world/README.md
+++ b/models/experimental/yolov8s_world/README.md
@@ -1,21 +1,13 @@
-# Yolov8s-World Demo
-Demo showcasing Yolov8s-World running on Wormhole - n150, n300 using ttnn.
+# Yolov8s-World
 
-## Platforms:
-    WH N150, N300
+### Platforms:
 
-#### Resolution: 640x640
-#### Batch size: 1
+Wormhole N150, N300
 
-## Introduction:
-The YOLO-World Model introduces an advanced, real-time Ultralytics YOLOv8-based approach for Open-Vocabulary Detection tasks. This innovation enables the detection of any object within an image based on descriptive texts. By significantly lowering computational demands while preserving competitive performance, YOLO-World emerges as a versatile tool for numerous vision-based applications.
+**Note:** On N300, make sure to use `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` with the pytest.
 
-## Details:
-The entry point to yolov8s_world model is TtYOLOWorld in `models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py`. The model picks up certain configs and weights from Ultralytics pretrained model. We've used weights available [here](https://docs.ultralytics.com/models/yolo-world/#available-models-supported-tasks-and-operating-modes) in YOLOv8s-world row.
-
-## How to Run:
-If running on Wormhole N300 (not required for N150 or Blackhole), the following environment variable needs to be set as the model requires at least 8x8 core grid size:
-```sh
+Or, make sure to set the following environment variable in the terminal:
+```
 export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
 ```
 
@@ -23,22 +15,29 @@ To obtain the perf reports through profiler, please build with following command
 ```
 ./build_metal.sh -p
 ```
-Use the following command to run the Yolov8s-World model :
+### Introduction:
+
+The YOLO-World Model introduces an advanced, real-time Ultralytics YOLOv8-based approach for Open-Vocabulary Detection tasks. This innovation enables the detection of any object within an image based on descriptive texts. By significantly lowering computational demands while preserving competitive performance, YOLO-World emerges as a versatile tool for numerous vision-based applications.
+
+Resource link - [source](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/model.py)
+
+### Details:
+- The entry point to yolov8s_world model is TtYOLOWorld in `models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py`.
+- The model picks up certain configs and weights from Ultralytics pretrained model. We've used weights available [here](https://docs.ultralytics.com/models/yolo-world/#available-models-supported-tasks-and-operating-modes) in YOLOv8s-world row.
+- Batch size :1
+- Supported Input Resolution - (640,640) (Height,Width)
+
+### How to Run:
+
+Use the following command to run the model :
 ```
 pytest --disable-warnings tests/ttnn/integration_tests/yolov8s_world/test_ttnn_yolov8s_world.py::test_YoloModel
 ```
-### Demo
-Use the following command to run the demo :
-```
-pytest --disable-warnings models/experimental/yolov8s_world/demo/demo.py
-```
+### Performant Model with Trace+2CQ
+- end-2-end perf is 55 FPS
 
-## Outputs
-The Demo outputs are saved inside this directory: `models/experimental/yolov8s_world/demo/runs`
-
-## Model performant
-- end-2-end perf with Trace+2CQ is 55 FPS <br>
+Use the following command to run the performant Model with Trace+2CQs:
 
 ```
-pytest models/experimental/yolov8s_world/tests/test_e2e_performant.py::test_e2e_performant
+pytest --disable-warnings models/experimental/yolov8s_world/tests/test_e2e_performant.py::test_e2e_performant
 ```

--- a/models/experimental/yolov8s_world/README.md
+++ b/models/experimental/yolov8s_world/README.md
@@ -4,6 +4,9 @@ Demo showcasing Yolov8s-World running on Wormhole - n150, n300 using ttnn.
 ## Platforms:
     WH N150, N300
 
+#### Resolution: 640x640
+#### Batch size: 1
+
 ## Introduction:
 The YOLO-World Model introduces an advanced, real-time Ultralytics YOLOv8-based approach for Open-Vocabulary Detection tasks. This innovation enables the detection of any object within an image based on descriptive texts. By significantly lowering computational demands while preserving competitive performance, YOLO-World emerges as a versatile tool for numerous vision-based applications.
 
@@ -16,6 +19,10 @@ If running on Wormhole N300 (not required for N150 or Blackhole), the following 
 export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
 ```
 
+To obtain the perf reports through profiler, please build with following command:
+```
+./build_metal.sh -p
+```
 Use the following command to run the Yolov8s-World model :
 ```
 pytest --disable-warnings tests/ttnn/integration_tests/yolov8s_world/test_ttnn_yolov8s_world.py::test_YoloModel
@@ -28,3 +35,10 @@ pytest --disable-warnings models/experimental/yolov8s_world/demo/demo.py
 
 ## Outputs
 The Demo outputs are saved inside this directory: `models/experimental/yolov8s_world/demo/runs`
+
+## Model performant
+- end-2-end perf with Trace+2CQ is 55 FPS <br>
+
+```
+pytest models/experimental/yolov8s_world/tests/test_e2e_performant.py::test_e2e_performant
+```

--- a/models/experimental/yolov8s_world/runner/performant_runner.py
+++ b/models/experimental/yolov8s_world/runner/performant_runner.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch.nn.functional as F
+import torch
+
+import ttnn
+from models.experimental.yolov8s_world.runner.performant_runner_infra import YOLOv8sWorldPerformanceRunnerInfra
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def create_yolov8s_world_input_tensors(
+    device, batch_size=1, input_channels=3, input_height=640, input_width=640, model=False
+):
+    torch_input_tensor = torch.randn(batch_size, input_channels, input_height, input_width)
+    ttnn_input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))
+    memory_config = None
+    if model:
+        ttnn_input_tensor = F.pad(ttnn_input_tensor, (0, 29))
+        memory_config = ttnn.create_sharded_memory_config(
+            [6400, 32],
+            core_grid=device.core_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    memory_config = memory_config if memory_config else ttnn.L1_MEMORY_CONFIG
+    ttnn_input_tensor = ttnn.from_torch(
+        ttnn_input_tensor, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=memory_config
+    )
+    return torch_input_tensor, ttnn_input_tensor
+
+
+class YOLOv8sWorldPerformantRunner:
+    def __init__(
+        self,
+        device,
+        device_batch_size=1,
+        act_dtype=ttnn.bfloat16,
+        weight_dtype=ttnn.bfloat16,
+        model_location_generator=None,
+        resolution=(640, 640),
+        torch_input_tensor=None,
+    ):
+        self.device = device
+        self.resolution = resolution
+        self.torch_input_tensor = torch_input_tensor
+        self.runner_infra = YOLOv8sWorldPerformanceRunnerInfra(
+            device,
+            device_batch_size,
+            act_dtype,
+            weight_dtype,
+            model_location_generator,
+            resolution=resolution,
+        )
+
+        (
+            self.tt_inputs_host,
+            sharded_mem_config_DRAM,
+            self.input_mem_config,
+        ) = self.runner_infra.setup_dram_sharded_input(device)
+        self.tt_image_res = self.tt_inputs_host.to(device, sharded_mem_config_DRAM)
+
+    def _capture_yolov8s_world_trace_2cqs(self):
+        # Initialize the op event so we can write
+        self.op_event = ttnn.record_event(self.device, 0)
+
+        # First run configures convs JIT
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.runner_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        spec = self.runner_infra.input_tensor.spec
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.run()
+        self.runner_infra.validate()
+        self.runner_infra.dealloc_output()
+
+        # Optimized run
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.runner_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.run()
+        self.runner_infra.validate()
+
+        # Capture
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.runner_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.dealloc_output()
+        trace_input_addr = self.runner_infra.input_tensor.buffer_address()
+        self.tid = ttnn.begin_trace_capture(self.device, cq_id=0)
+        self.runner_infra.run()
+        self.input_tensor = ttnn.allocate_tensor_on_device(spec, self.device)
+        ttnn.end_trace_capture(self.device, self.tid, cq_id=0)
+        assert trace_input_addr == self.input_tensor.buffer_address()
+
+    def _execute_yolov8s_world_trace_2cqs_inference(self, tt_inputs_host=None):
+        tt_inputs_host = self.tt_inputs_host if tt_inputs_host is None else tt_inputs_host
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        # TODO: Add in place support to ttnn to_memory_config
+        if self.input_tensor.is_sharded():
+            self.input_tensor = ttnn.reshard(self.tt_image_res, self.input_mem_config, self.input_tensor)
+        self.op_event = ttnn.record_event(self.device, 0)
+        ttnn.execute_trace(self.device, self.tid, cq_id=0, blocking=False)
+        ttnn.synchronize_device(self.device)
+        return self.runner_infra.output_tensor
+
+    def _validate(self, input_tensor, result_output_tensor):
+        torch_output_tensor = self.runner_infra.torch_output_tensor
+        assert_with_pcc(torch_output_tensor, result_output_tensor, 0.99)
+
+    def run(self, torch_input_tensor, check_pcc=False):
+        n, h, w, c = torch_input_tensor.shape
+        torch_input_tensor = F.pad(torch_input_tensor, (0, 29), mode="constant", value=0)
+        tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+        output = self._execute_yolov8s_world_trace_2cqs_inference(tt_inputs_host)
+        if check_pcc:
+            torch_input_tensor = torch_input_tensor.reshape(n, h, w, c)
+            torch_input_tensor = torch_input_tensor.permute(0, 3, 1, 2)
+            self._validate(torch_input_tensor, output)
+
+        return output
+
+    def release(self):
+        ttnn.release_trace(self.device, self.tid)

--- a/models/experimental/yolov8s_world/runner/performant_runner_infra.py
+++ b/models/experimental/yolov8s_world/runner/performant_runner_infra.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+import torch.nn.functional as F
+from loguru import logger
+
+import ttnn
+from models.experimental.yolov8s_world.demo.demo_utils import load_torch_model
+
+from models.experimental.yolov8s_world.tt.ttnn_yolov8s_world import TtYOLOWorld
+from models.utility_functions import divup, is_wormhole_b0
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from ttnn.model_preprocessing import preprocess_model_parameters
+from models.experimental.yolov8s_world.tt.ttnn_yolov8s_world_utils import create_custom_preprocessor, move_to_device
+
+
+class YOLOv8sWorldPerformanceRunnerInfra:
+    def __init__(
+        self,
+        device,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        model_location_generator=None,
+        resolution=(640, 640),
+        torch_input_tensor=None,
+    ):
+        torch.manual_seed(0)
+        self.resolution = resolution
+        self.pcc_passed = False
+        self.pcc_message = "Did you forget to call validate()?"
+        self.device = device
+        self.batch_size = batch_size
+        self.act_dtype = act_dtype
+        self.weight_dtype = weight_dtype
+        self.model_location_generator = model_location_generator
+        self.torch_input_tensor = torch_input_tensor
+
+        self.torch_model = load_torch_model()
+        self.torch_input_tensor = (
+            torch.randn((1, 3, 640, 640), dtype=torch.float32)
+            if self.torch_input_tensor is None
+            else self.torch_input_tensor
+        )
+
+        parameters = preprocess_model_parameters(
+            initialize_model=lambda: self.torch_model, custom_preprocessor=create_custom_preprocessor(device)
+        )
+
+        for i in [12, 15, 19, 22]:
+            parameters["model"][i]["attn"]["gl"]["weight"] = ttnn.to_device(
+                parameters["model"][i]["attn"]["gl"]["weight"], device=device
+            )
+            parameters["model"][i]["attn"]["gl"]["bias"] = ttnn.to_device(
+                parameters["model"][i]["attn"]["gl"]["bias"], device=device
+            )
+            parameters["model"][i]["attn"]["bias"] = ttnn.to_device(
+                parameters["model"][i]["attn"]["bias"], device=device
+            )
+
+            parameters["model"][16] = move_to_device(parameters["model"][16], device)
+
+            parameters["model"][23]["cv4"] = move_to_device(parameters["model"][23]["cv4"], device)
+
+        self.parameters = parameters
+
+        self.ttnn_yolov8s_world_model = TtYOLOWorld(self.device, self.parameters)
+
+        self.torch_output_tensor = self.torch_model(self.torch_input_tensor)
+
+    def _setup_l1_sharded_input(self, device, torch_input_tensor=None):
+        if is_wormhole_b0():
+            core_grid = ttnn.CoreGrid(y=8, x=8)
+        else:
+            exit("Unsupported device")
+
+        num_devices = device.get_num_devices()
+        torch_input_tensor = self.torch_input_tensor if torch_input_tensor is None else torch_input_tensor
+
+        n, c, h, w = torch_input_tensor.shape
+
+        torch_input_tensor = torch_input_tensor.permute(0, 2, 3, 1)
+        torch_input_tensor = F.pad(torch_input_tensor, (0, 29))
+        input_mem_config = ttnn.create_sharded_memory_config(
+            [6400, 32],
+            core_grid=device.core_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+        return tt_inputs_host, input_mem_config
+
+    def setup_dram_sharded_input(self, device, torch_input_tensor=None, mesh_mapper=None, mesh_composer=None):
+        tt_inputs_host, input_mem_config = self._setup_l1_sharded_input(device)
+        dram_grid_size = device.dram_grid_size()
+        dram_shard_spec = ttnn.ShardSpec(
+            ttnn.CoreRangeSet(
+                {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
+            ),
+            [
+                divup(tt_inputs_host.volume() // tt_inputs_host.shape[-1], dram_grid_size.x * dram_grid_size.y),
+                tt_inputs_host.shape[-1],
+            ],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        sharded_mem_config_DRAM = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, dram_shard_spec
+        )
+
+        return tt_inputs_host, sharded_mem_config_DRAM, input_mem_config
+
+    def run(self):
+        self.output_tensor = self.ttnn_yolov8s_world_model(self.input_tensor)
+
+    def validate(self, output_tensor=None, torch_output_tensor=None):
+        ttnn_output_tensor = self.output_tensor if output_tensor is None else output_tensor
+        torch_output_tensor = self.torch_output_tensor if torch_output_tensor is None else torch_output_tensor
+        output_tensor = ttnn.to_torch(ttnn_output_tensor[0])
+
+        self.pcc_passed, self.pcc_message = assert_with_pcc(self.torch_output_tensor[0], output_tensor, pcc=0.99)
+
+        logger.info(
+            f"yolov8s_world - batch_size={self.batch_size}, act_dtype={self.act_dtype}, weight_dtype={self.weight_dtype}, PCC={self.pcc_message}"
+        )
+
+    def dealloc_output(self):
+        ttnn.deallocate(self.output_tensor[0])
+        for t in self.output_tensor[1]:
+            if isinstance(t, list):
+                for sub_t in t:
+                    ttnn.deallocate(sub_t)
+            else:
+                ttnn.deallocate(t)

--- a/models/experimental/yolov8s_world/tests/test_e2e_performant.py
+++ b/models/experimental/yolov8s_world/tests/test_e2e_performant.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+
+import pytest
+import torch
+import torch.nn.functional as F
+from loguru import logger
+
+import ttnn
+from models.experimental.yolov8s_world.runner.performant_runner import YOLOv8sWorldPerformantRunner
+from models.utility_functions import run_for_wormhole_b0
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 79104, "trace_region_size": 23887872, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "batch_size, act_dtype, weight_dtype",
+    ((1, ttnn.bfloat16, ttnn.bfloat8_b),),
+)
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (640, 640),
+    ],
+)
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
+def test_e2e_performant(
+    device,
+    use_program_cache,
+    batch_size,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    resolution,
+):
+    performant_runner = YOLOv8sWorldPerformantRunner(
+        device,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        resolution=resolution,
+        model_location_generator=None,
+    )
+    performant_runner._capture_yolov8s_world_trace_2cqs()
+    input_shape = (1, *resolution, 3)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_input_tensor = F.pad(torch_input_tensor, (0, 29), mode="constant", value=0)
+    tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    inference_times = []
+    for _ in range(10):
+        t0 = time.time()
+        _ = performant_runner._execute_yolov8s_world_trace_2cqs_inference(tt_inputs_host)
+        t1 = time.time()
+        inference_times.append(t1 - t0)
+
+    performant_runner.release()
+
+    inference_time_avg = round(sum(inference_times) / len(inference_times), 6)
+    logger.info(
+        f"ttnn_yolov8s_world_batch_size: {batch_size}, resolution: {resolution}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size/inference_time_avg)}"
+    )

--- a/models/experimental/yolov8s_world/tests/test_perf_yolov8s_world.py
+++ b/models/experimental/yolov8s_world/tests/test_perf_yolov8s_world.py
@@ -136,7 +136,7 @@ def test_perf(device, use_pretrained_weight, use_program_cache):
     ],
 )
 @pytest.mark.models_device_performance_bare_metal
-def test_perf_device_bare_metal_yolov9c(batch_size, expected_perf):
+def test_perf_device_bare_metal_yolov8s_world(batch_size, expected_perf):
     subdir = "ttnn_yolov8s_world"
     num_iterations = 1
     margin = 0.03

--- a/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
+++ b/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
@@ -1087,7 +1087,7 @@ class TtWorldModel:
         txt_feats = self.txt_feats if txt_feats is None else txt_feats
         # if len(txt_feats) != len(x) or False: #not invoked
         #     txt_feats = txt_feats.expand(x.shape[0], -1, -1)
-        ori_txt_feats = ttnn.clone(txt_feats)
+        ori_txt_feats = txt_feats
         y, dt, embeddings = [], [], []  # outputs
         save = [4, 6, 9, 9, 12, 12, 15, 15, 15, 19, 22]
         f_info = [

--- a/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
+++ b/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
@@ -2,16 +2,16 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import ttnn
 import math
-import torch
-from torch import nn
+
+import ttnn
 from models.experimental.yolov8s_world.tt.ttnn_yolov8s_world_utils import (
     ttnn_decode_bboxes,
     concat,
     determine_num_cores_for_upsample,
     get_core_grid_from_num_cores,
     tt_adaptive_to_max_pool2d,
+    ttnn_custom_normalize,
 )
 
 
@@ -37,7 +37,7 @@ class TtConv:
         width_shard=False,
         act_blocks=False,
         enable_act_double_buffer=True,
-        enable_split_reader=False,
+        enable_split_reader=True,
         reshard_if_not_optimal=True,
         batch_size=1,
         conv_math_fidelity=None,
@@ -77,16 +77,17 @@ class TtConv:
             weights_dtype=ttnn.bfloat16,
             activation="",
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            act_block_w_div=1,
             deallocate_activation=False,
             enable_act_double_buffer=self.enable_act_double_buffer,
             enable_split_reader=self.enable_split_reader,
-            enable_subblock_padding=False,
+            enable_subblock_padding=True,
             output_layout=self.output_layout,
             reallocate_halo_output=False,
             reshard_if_not_optimal=self.reshard_if_not_optimal,
         )
 
+        if self.input_params[4] == 3:
+            conv_config.act_block_h_override = 64
         if self.deallocate_activation:
             conv_config.deallocate_activation = self.deallocate_activation
 
@@ -144,7 +145,7 @@ class TtConv:
             conv_config=self.conv_config,
             compute_config=self.compute_config,
             groups=self.groups,
-            memory_config=ttnn.L1_MEMORY_CONFIG if self.change_shard == True else None,
+            # memory_config=ttnn.L1_MEMORY_CONFIG if self.change_shard == True else None,
             return_weights_and_bias=True,
             return_output_dim=True,
         )
@@ -311,7 +312,7 @@ class TtSPPF:
             device,
             parameters["cv2"],
             input_params=input_params[1],
-            change_shard=True,
+            # change_shard=True,
             deallocate_activation=True,
             conv_math_fidelity=ttnn.MathFidelity.HiFi2,
         )
@@ -383,7 +384,7 @@ class TtMaxSigmoidAttnBlock:
                 self.parameters["ec"],
                 input_params=None,
                 block_shard=self.block_shard,
-                change_shard=True,
+                # change_shard=True,
                 deallocate_activation=self.deallocate_activation,
             )
             if c1 != ec
@@ -396,7 +397,7 @@ class TtMaxSigmoidAttnBlock:
             self.parameters["proj_conv"],
             input_params=input_params,
             block_shard=self.block_shard,
-            change_shard=True,
+            # change_shard=True,
             deallocate_activation=self.deallocate_activation,
             is_act_false=True,
         )
@@ -489,7 +490,7 @@ class TtC2fAttn:
             self.device,
             self.parameters["cv2"],
             input_params=input_params[1],
-            change_shard=True,
+            # change_shard=True,
             deallocate_activation=self.deallocate_activation,
             conv_math_fidelity=ttnn.MathFidelity.HiFi2,
         )
@@ -537,7 +538,7 @@ class TtC2fAttn:
                 y[i] = ttnn.sharded_to_interleaved(y[i], ttnn.L1_MEMORY_CONFIG)
         y.append(self.attn(y[-1], guide)[0])
         y[-1] = ttnn.to_layout(y[-1], layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
-        x = ttnn.concat(y, 3)  # Decrease in Fps if we use shard concat
+        x = concat(y, 3, True)  # Decrease in Fps if we use shard concat
         for i in range(len(y)):
             ttnn.deallocate(y[i])
 
@@ -559,7 +560,7 @@ class TtImagePoolingAttn:
         self.key = [ttnn.layer_norm, ttnn.linear]
         self.value = [ttnn.layer_norm, ttnn.linear]
         self.proj = ttnn.linear
-        self.scale = nn.Parameter(torch.tensor([0.0]), requires_grad=True) if scale else 1.0
+        self.scale = 0.0 if scale else 1.0  # nn.Parameter(torch.tensor([0.0]), requires_grad=True) if scale else 1.0
         self.projections = [
             TtConv(
                 self.device,
@@ -595,29 +596,21 @@ class TtImagePoolingAttn:
                         channels=x.shape[-1],
                         kernel_size=[
                             tt_adaptive_to_max_pool2d(
-                                torch.randn(
-                                    x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
-                                ),
+                                [x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]],
                                 (3, 3),
                             )[0],
                             tt_adaptive_to_max_pool2d(
-                                torch.randn(
-                                    x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
-                                ),
+                                [x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]],
                                 (3, 3),
                             )[0],
                         ],
                         stride=[
                             tt_adaptive_to_max_pool2d(
-                                torch.randn(
-                                    x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
-                                ),
+                                [x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]],
                                 (3, 3),
                             )[1],
                             tt_adaptive_to_max_pool2d(
-                                torch.randn(
-                                    x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
-                                ),
+                                [x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]],
                                 (3, 3),
                             )[1],
                         ],
@@ -632,7 +625,7 @@ class TtImagePoolingAttn:
             )
             for (x, pool) in zip(x, self.im_pools)
         ]
-        x = ttnn.concat(x, dim=1)
+        x = concat(x, dim=1, use_sharded_concat=False)
         q = ttnn.clone(text)
         for index, module in enumerate(self.query):
             if module == ttnn.linear:
@@ -756,18 +749,9 @@ class TtContrastiveHead:
     def __call__(self, x, w):
         """Forward function of contrastive learning."""
         # x = ttnn.permute(x, (0, 3, 1, 2))
-        import torch.nn.functional as F
 
-        x = ttnn.to_torch(x).to(torch.float32)
-        w = ttnn.to_torch(w).to(torch.float32)
-        x = F.normalize(x, dim=-1, p=2)
-        w = F.normalize(w, dim=-1, p=2)
-        x = ttnn.from_torch(
-            x, device=self.device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG, dtype=ttnn.bfloat16
-        )
-        w = ttnn.from_torch(
-            w, device=self.device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG, dtype=ttnn.bfloat16
-        )
+        x = ttnn_custom_normalize(x, dim=-1, device=x.device())
+        w = ttnn_custom_normalize(w, dim=-1, device=w.device())
 
         ## Replacement for  x = torch.einsum("bchw,bkc->bkhw", x, w)
         batch, height, width, channel = x.shape
@@ -881,7 +865,7 @@ class TtWorldDetect:
             for module in self.cv3[i]:
                 cv3, _, _ = module(cv3)
 
-            x[i] = ttnn.concat((cv_2, self.cv4[i](cv3, text)), -1)
+            x[i] = concat((cv_2, self.cv4[i](cv3, text)), -1, False)
 
         # Inference path
         shape = x[0].shape
@@ -892,7 +876,7 @@ class TtWorldDetect:
             i = ttnn.reshape(i, (shape[0], -1, self.no), memory_config=ttnn.L1_MEMORY_CONFIG)
             xi.append(i)
 
-        x_cat = ttnn.concat(xi, 1, memory_config=ttnn.L1_MEMORY_CONFIG)
+        x_cat = concat(xi, 1, False)
         x_cat = ttnn.permute(x_cat, (0, 2, 1), memory_config=ttnn.L1_MEMORY_CONFIG)
 
         box = ttnn.slice(x_cat, [0, 0, 0], [1, 64, x_cat.shape[2]], memory_config=ttnn.L1_MEMORY_CONFIG)
@@ -901,7 +885,7 @@ class TtWorldDetect:
         dbox = ttnn_decode_bboxes(self.device, dfl, anchors)
         dbox = dbox * strides
 
-        return [ttnn.concat((dbox, ttnn.sigmoid(cls)), dim=1), x]
+        return [concat((dbox, ttnn.sigmoid(cls)), dim=1, use_sharded_concat=False), x]
 
 
 class TtWorldModel:
@@ -1016,6 +1000,7 @@ class TtWorldModel:
                 device,
                 parameters["model"][7],
                 input_params=[3, 2, 1, 512, 256],
+                block_shard=True
                 # deallocate_activation=True,
             ),
             TtC2f(
@@ -1155,8 +1140,10 @@ class TtWorldModel:
                     x = m(x, dim=-1)
                 elif m == ttnn.upsample:
                     if index == 10:
+                        x = ttnn.sharded_to_interleaved(x, memory_config=ttnn.L1_MEMORY_CONFIG)
                         x = ttnn.reshape(x, (1, 20, 20, 512))
                     else:
+                        x = ttnn.sharded_to_interleaved(x, memory_config=ttnn.L1_MEMORY_CONFIG)
                         x = ttnn.reshape(x, (1, 40, 40, 256))
                     x = ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT)
 

--- a/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world_utils.py
+++ b/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world_utils.py
@@ -147,7 +147,7 @@ def to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT):
     return x
 
 
-def sharded_concat(input_tensors, num_cores=56, dim=3):  # expected input tensors to be in fp16, RM, same (h*w)
+def sharded_concat(input_tensors, num_cores=64, dim=3):  # expected input tensors to be in fp16, RM, same (h*w)
     shard_grid = get_core_grid_from_num_cores(num_cores=num_cores)
     in_shard_width = input_tensors[0].shape[-1]
     shard_height = (input_tensors[0].shape[2] + num_cores - 1) // num_cores
@@ -179,7 +179,7 @@ def concat(tensors, dim=-1, use_sharded_concat=True):
         processed_tensors = [
             ttnn.to_dtype(to_layout(tensor, ttnn.ROW_MAJOR_LAYOUT), ttnn.bfloat16) for tensor in tensors
         ]
-        return sharded_concat(processed_tensors)
+        return sharded_concat(processed_tensors, dim=dim)
     else:
         return ttnn.concat([*tensors], dim=dim, memory_config=ttnn.L1_MEMORY_CONFIG)
 
@@ -578,11 +578,11 @@ def create_custom_preprocessor(device):
     return custom_preprocessor
 
 
-def tt_adaptive_to_max_pool2d(input_tensor, output_size):
+def tt_adaptive_to_max_pool2d(input_shape, output_size):
     if isinstance(output_size, int):
         output_size = (output_size, output_size)
 
-    input_height, input_width = input_tensor.shape[1], input_tensor.shape[2]
+    input_height, input_width = input_shape[1], input_shape[2]
     output_height, output_width = output_size
 
     # Check if dimensions are valid
@@ -627,3 +627,35 @@ def tt_adaptive_to_max_pool2d(input_tensor, output_size):
         )
 
     return kernel_w, stride_h, 0, message
+
+
+def ttnn_custom_normalize(x, dim, device):
+    # Convert input to tiled layout
+    if x.layout != ttnn.TILE_LAYOUT:
+        x = ttnn.to_layout(x, ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    # Square the tensor using multiply
+    x_squared = ttnn.multiply(x, x)
+
+    # Sum along the specified dimension
+    if dim == 1:
+        sum_squared = ttnn.sum(x_squared, dim=1, keepdim=True)
+    else:
+        sum_squared = ttnn.sum(x_squared, dim=-1, keepdim=True)
+
+    # Add small epsilon and calculate square root
+    sum_squared = ttnn.add(sum_squared, 1e-12)
+    norm = ttnn.sqrt(sum_squared)
+
+    # Create a tensor of ones with the same shape as x
+    ones = ttnn.ones_like(
+        tensor=x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+
+    # Multiply norm by ones to match input shape
+    norm_expanded = ttnn.multiply(norm, ones)
+
+    # Divide input by expanded norm
+    normalized = ttnn.divide(x, norm_expanded)
+
+    return normalized

--- a/tests/ttnn/integration_tests/yolov8s_world/test_ttnn_yolov8s_world.py
+++ b/tests/ttnn/integration_tests/yolov8s_world/test_ttnn_yolov8s_world.py
@@ -715,7 +715,7 @@ def test_YoloModel(device, use_pretrained_weight, reset_seeds):
 
     ttnn_x = x.permute(0, 2, 3, 1)
     ttnn_x = ttnn.from_torch(
-        ttnn_x, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+        ttnn_x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
     )
 
     parameters = preprocess_model_parameters(


### PR DESCRIPTION
### Problem description
Used torch normalization in yolov8s_world pipeline, and there is no tarce2cq pipeline.

### What's changed
Updated torch normalization with ttnn workaround in yolov8s_world model and added trace2cq support for the model.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)