### PR TITLE
#23274: SDXL - fuse part of matmuls + bias

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_attention.py
@@ -6,6 +6,7 @@ from loguru import logger
 import torch
 import pytest
 import ttnn
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
 from models.experimental.stable_diffusion_xl_base.tt.tt_attention import TtAttention
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -47,10 +48,12 @@ def test_attention(
         torch_attention = unet.down_blocks[down_block_id].attentions[0].transformer_blocks[0].attn1
     else:
         torch_attention = unet.down_blocks[down_block_id].attentions[0].transformer_blocks[0].attn2
+    model_config = ModelOptimisations()
     tt_attention = TtAttention(
         device,
         state_dict,
         f"down_blocks.{down_block_id}.attentions.0.transformer_blocks.0.attn{attn_id}",
+        model_config,
         query_dim,
         num_attn_heads,
         out_dim,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
@@ -19,7 +19,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
     "input_shape, temb_shape, encoder_shape, query_dim, num_attn_heads, out_dim, down_block_id, pcc",
     [
         ((1, 320, 64, 64), (1, 1280), (1, 77, 2048), 640, 10, 640, 1, 0.997),
-        ((1, 640, 32, 32), (1, 1280), (1, 77, 2048), 1280, 20, 1280, 2, 0.993),
+        ((1, 640, 32, 32), (1, 1280), (1, 77, 2048), 1280, 20, 1280, 2, 0.994),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
@@ -101,5 +101,5 @@ def test_crossattnmid(
     del unet, tt_crosattn
     gc.collect()
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.987)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.988)
     logger.info(f"PCC is: {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
@@ -26,7 +26,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
             20,
             1280,
             0,
-            0.959,
+            0.965,
         ),
         (
             (1, 1280, 64, 64),

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_feedforward.py
@@ -7,6 +7,7 @@ from loguru import logger
 import torch
 import pytest
 import ttnn
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
 from models.experimental.stable_diffusion_xl_base.tt.tt_feedforward import TtFeedForward
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -34,10 +35,12 @@ def test_feedforward(
 
     torch_ff = unet.down_blocks[block_id].attentions[0].transformer_blocks[transformer_block_id].ff
 
+    model_config = ModelOptimisations()
     tt_ff = TtFeedForward(
         device,
         state_dict,
         f"down_blocks.{block_id}.attentions.0.transformer_blocks.{transformer_block_id}.ff",
+        model_config,
         weights_dtype=transformer_weights_dtype,
     )
 

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
@@ -18,9 +18,9 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
     "input_shape, temb_shape, down_block_id, resnet_id, conv_shortcut, split_in, block, pcc",
     [
         ((1, 320, 128, 128), (1, 1280), 0, 0, False, 1, "down_blocks", 0.999),
-        ((1, 320, 64, 64), (1, 1280), 1, 0, True, 1, "down_blocks", 0.998),
+        ((1, 320, 64, 64), (1, 1280), 1, 0, True, 1, "down_blocks", 0.999),
         ((1, 640, 64, 64), (1, 1280), 1, 1, False, 1, "down_blocks", 0.997),
-        ((1, 640, 32, 32), (1, 1280), 2, 0, True, 1, "down_blocks", 0.998),
+        ((1, 640, 32, 32), (1, 1280), 2, 0, True, 1, "down_blocks", 0.999),
         ((1, 1280, 32, 32), (1, 1280), 2, 1, False, 1, "down_blocks", 0.997),
         ((1, 960, 128, 128), (1, 1280), 2, 0, True, 2, "up_blocks", 0.998),
         ((1, 640, 128, 128), (1, 1280), 2, 1, True, 2, "up_blocks", 0.998),

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformerblock.py
@@ -6,6 +6,7 @@ from loguru import logger
 import torch
 import pytest
 import ttnn
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
 from models.experimental.stable_diffusion_xl_base.tt.tt_transformerblock import TtBasicTransformerBlock
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -46,10 +47,12 @@ def test_transformerblock(
     state_dict = unet.state_dict()
 
     torch_transformerblock = unet.down_blocks[down_block_id].attentions[0].transformer_blocks[block_id]
+    model_config = ModelOptimisations()
     tt_transformerblock = TtBasicTransformerBlock(
         device,
         state_dict,
         f"down_blocks.{down_block_id}.attentions.0.transformer_blocks.{block_id}",
+        model_config,
         query_dim,
         num_attn_heads,
         out_dim,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformermodel.py
@@ -6,6 +6,7 @@ from loguru import logger
 import torch
 import pytest
 import ttnn
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
 from models.experimental.stable_diffusion_xl_base.tt.tt_transformermodel import TtTransformer2DModel
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -43,10 +44,12 @@ def test_transformermodel(
     state_dict = unet.state_dict()
 
     torch_transformerblock = unet.down_blocks[down_block_id].attentions[0]
+    model_config = ModelOptimisations()
     tt_transformerblock = TtTransformer2DModel(
         device,
         state_dict,
         f"down_blocks.{down_block_id}.attentions.0",
+        model_config,
         query_dim,
         num_attn_heads,
         out_dim,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -13,7 +13,7 @@ def test_sdxl_unet_perf_device():
 
     inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
     post_processed_results = run_device_perf(command, subdir="sdxl_unet", num_iterations=3, cols=cols, batch_size=1)
-    expected_perf_cols = {inference_time_key: 478272848}
+    expected_perf_cols = {inference_time_key: 464623492}
     expected_results = check_device_perf(
         post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
     )

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_crossattndownblock2d.py
@@ -35,6 +35,7 @@ class TtCrossAttnDownBlock2D(nn.Module):
                     device,
                     state_dict,
                     f"{module_path}.attentions.{i}",
+                    model_config,
                     query_dim,
                     num_attn_heads,
                     out_dim,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnmidblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnmidblock2d.py
@@ -33,6 +33,7 @@ class TtUNetMidBlock2DCrossAttn(nn.Module):
                     device,
                     state_dict,
                     f"{module_path}.attentions.{i}",
+                    model_config,
                     query_dim,
                     num_attn_heads,
                     out_dim,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnupblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnupblock2d.py
@@ -35,6 +35,7 @@ class TtCrossAttnUpBlock2D(nn.Module):
                     device,
                     state_dict,
                     f"{module_path}.attentions.{i}",
+                    model_config,
                     query_dim,
                     num_attn_heads,
                     out_dim,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
@@ -15,6 +15,7 @@ class TtFeedForward(nn.Module):
         device,
         state_dict,
         module_path,
+        model_config,
         weights_dtype=ttnn.bfloat16,
     ):
         super().__init__()
@@ -26,13 +27,19 @@ class TtFeedForward(nn.Module):
         bias = state_dict[f"{module_path}.net.2.bias"]
 
         self.tt_weights, self.tt_bias = prepare_linear_params(device, weights, bias, weights_dtype)
+        self.ff2_model_config = model_config.get_matmul_config(f"{module_path}.net.2")
+        assert self.ff2_model_config is not None, "ff2_model_config should not be None"
+        self.default_compute_kernel_config = model_config.get_mm_compute_config(module_path)
 
     def forward(self, hidden_states):
         hidden_states = self.tt_geglu(hidden_states)
+
         hidden_states = ttnn.linear(
             hidden_states,
             self.tt_weights,
             bias=self.tt_bias,
+            program_config=self.ff2_model_config,
+            compute_kernel_config=self.default_compute_kernel_config,
         )
 
         return hidden_states

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -165,6 +165,11 @@ class TtResnetBlock2D(nn.Module):
             else None
         )
 
+        mm_path = f"{module_path}.linear"
+        self.linear_program_config = model_config.get_matmul_config(matmul_path=f"{module_path}.linear")
+        assert self.linear_program_config is not None, "linear_program_config should not be None"
+        self.default_compute_config = model_config.get_mm_compute_config(mm_path)
+
     def forward(self, input_tensor, temb, input_shape):
         B, C, H, W = input_shape
         hidden_states = input_tensor
@@ -253,11 +258,15 @@ class TtResnetBlock2D(nn.Module):
             C = self.conv1_params["output_channels"]
 
         temb = ttnn.silu(temb)
+
         temb = ttnn.linear(
             temb,
             self.tt_time_emb_weights,
             bias=self.tt_time_emb_bias,
+            program_config=self.linear_program_config,
+            compute_kernel_config=self.default_compute_config,
         )
+
         temb = ttnn.unsqueeze_to_4D(temb)
         temb = ttnn.repeat(temb, (1, 1, H * W, 1))
 

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
@@ -10,18 +10,40 @@ from models.experimental.stable_diffusion_xl_base.tt.tt_feedforward import TtFee
 
 class TtBasicTransformerBlock(nn.Module):
     def __init__(
-        self, device, state_dict, module_path, query_dim, num_attn_heads, out_dim, weights_dtype=ttnn.bfloat16
+        self,
+        device,
+        state_dict,
+        module_path,
+        model_config,
+        query_dim,
+        num_attn_heads,
+        out_dim,
+        weights_dtype=ttnn.bfloat16,
     ):
         super().__init__()
 
         self.attn1 = TtAttention(
-            device, state_dict, f"{module_path}.attn1", query_dim, num_attn_heads, out_dim, weights_dtype=weights_dtype
+            device,
+            state_dict,
+            f"{module_path}.attn1",
+            model_config,
+            query_dim,
+            num_attn_heads,
+            out_dim,
+            weights_dtype=weights_dtype,
         )
         self.attn2 = TtAttention(
-            device, state_dict, f"{module_path}.attn2", query_dim, num_attn_heads, out_dim, weights_dtype=weights_dtype
+            device,
+            state_dict,
+            f"{module_path}.attn2",
+            model_config,
+            query_dim,
+            num_attn_heads,
+            out_dim,
+            weights_dtype=weights_dtype,
         )
 
-        self.ff = TtFeedForward(device, state_dict, f"{module_path}.ff", weights_dtype=weights_dtype)
+        self.ff = TtFeedForward(device, state_dict, f"{module_path}.ff", model_config, weights_dtype=weights_dtype)
 
         norm1_weights = state_dict[f"{module_path}.norm1.weight"]
         norm1_bias = state_dict[f"{module_path}.norm1.bias"]

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
@@ -16,7 +16,15 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 
 class TtTransformer2DModel(nn.Module):
     def __init__(
-        self, device, state_dict, module_path, query_dim, num_attn_heads, out_dim, weights_dtype=ttnn.bfloat16
+        self,
+        device,
+        state_dict,
+        module_path,
+        model_config,
+        query_dim,
+        num_attn_heads,
+        out_dim,
+        weights_dtype=ttnn.bfloat16,
     ):
         super().__init__()
 
@@ -37,6 +45,7 @@ class TtTransformer2DModel(nn.Module):
                     device,
                     state_dict,
                     f"{module_path}.transformer_blocks.{i}",
+                    model_config,
                     query_dim,
                     num_attn_heads,
                     out_dim,


### PR DESCRIPTION
### Ticket
#23274

### Problem description

### What's changed
Add bias fusing in ff, resnets and attention linears
Updated device perf
PCC's of various blocks got better

### Checklist
- [x] [Frequent tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) SDXL passing, other random failures present
- [ ] [[Device performance regression]](https://github.com/tenstorrent/tt-metal/actions/runs/15560349150) not ran due to other failures, updated targets based on local changes