### PR TITLE
Trace Support for MobileNetV2 Demo

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -36,11 +36,10 @@ jobs:
           { name: "stable_diffusion", runner-label: "N150", performance: false, cmd: run_stable_diffusion_func, owner_id: U045U3DEKM4}, # Mohamed Bahnas
           { name: "segformer", runner-label: "N150", performance: false, cmd: run_segformer_func, owner_id: U045U3DEKM4}, # Mohamed Bahnas (vguduruTT)
           { name: "yolov9c", runner-label: "N150", performance: false, cmd: run_yolov9c_perf, owner_id: U056BK5U81E}, # Dalar Vartanians
-          { name: "mobilenetv2", runner-label: "N150", performance: false, cmd: run_mobilenetv2_func, owner_id: U056BK5U81E}, # Dalar Vartanians
+          { name: "mobilenetv2", runner-label: "N150", performance: true, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E}, # Dalar Vartanians
           { name: "yolov8s_world", runner-label: "N150", performance: false, cmd: run_yolov8s_world_perf, owner_id: U056BK5U81E}, # Dalar Vartanians
           { name: "ufld_v2", runner-label: "N150", performance: false, cmd: run_ufld_v2_func, owner_id: U056BK5U81E}, # Dalar Vartanians
           { name: "vanilla_unet", runner-label: "N150", performance: false, cmd: run_vanilla_unet_demo, owner_id: U045U3DEKM4}, # Mohamed Bahnas (keerthana-r-mcw)
-          { name: "mobilenetv2", runner-label: "N150", performance: false, cmd: run_mobilenetv2_func, owner_id: U056BK5U81E}, # Dalar Vartanians
           { name: "yolov8x", runner-label: "N150", performance: false, cmd: run_yolov8x_perf, owner_id: U056BK5U81E}, # Dalar Vartanians
           { name: "vgg_unet", runner-label: "N150", performance: false, cmd: run_vgg_unet_demo, owner_id: U045U3DEKM4}, # Mohamed Bahnas (keerthana-r-mcw)
           { name: "resnet", runner-label: "N150", performance: true, cmd: run_resnet_stability, owner_id: U0837MYG788}, # Marko Radosavljevic
@@ -58,7 +57,7 @@ jobs:
           { name: "roberta", runner-label: "N300", performance: false, cmd: run_roberta_func, owner_id: U06F3ER8X9A}, # Stuti Raizada
           { name: "yolov8x", runner-label: "N300", performance: false, cmd: run_yolov8x_perf, owner_id: U056BK5U81E}, # Dalar Vartanians
           { name: "yolov9c", runner-label: "N300", performance: false, cmd: run_yolov9c_perf, owner_id: U056BK5U81E}, # Dalar Vartanians
-          { name: "mobilenetv2", runner-label: "N300", performance: false, cmd: run_mobilenetv2_func, owner_id: U056BK5U81E}, # Dalar Vartanians
+          { name: "mobilenetv2", runner-label: "N300", performance: true, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E}, # Dalar Vartanians
           { name: "ufld_v2", runner-label: "N300", performance: false, cmd: run_ufld_v2_func, owner_id: U056BK5U81E}, # Dalar Vartanians
           # { name: "mistral7b", runner-label: "N150", performance: false, cmd: run_mistral7b_perf, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
           { name: "mistral7b", runner-label: "N300", performance: true, cmd: run_mistral7b_perf, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati

--- a/models/demos/mobilenetv2/README.md
+++ b/models/demos/mobilenetv2/README.md
@@ -1,32 +1,33 @@
 # Mobilenetv2 Model
 
 ## Platforms:
-    WH N300
+    WH N150/N300
+**Note:** On N300 ,Make sure to use `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` with the pytest.
+
+Or, make sure to set the following environment variable in the terminal:
+```
+export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+```
+
+To obtain the perf reports through profiler, please build with following command:
+```
+./build_metal.sh -p
+```
 
 ## Introduction
 The MobileNetV2 model is a convolutional neural network (CNN) architecture designed for efficient mobile and embedded vision applications. It was introduced in the paper ["MobileNetV2: Inverted Residuals and Linear Bottlenecks"](https://arxiv.org/abs/1801.04381). </br>
 The MobileNetV2 model has been pre-trained on the ImageNet dataset and can be used for various tasks such as image classification, object detection, and semantic segmentation. It has achieved state-of-the-art performance on several benchmarks 1 for mobile and embedded vision applications.
 
 ## Details
-The entry point to mobilenetv2 model is MobileNetV2 in `models/demos/mobilenetv2/tt/ttnn_monilenetv2.py`.
+- The entry point to mobilenetv2 model is MobileNetV2 in `models/demos/mobilenetv2/tt/ttnn_monilenetv2.py`.
+- Supported Input Resolution - (224,224) (Height,Width)
+- Batch Size :8
 
-## How to Run:
-If running on Wormhole N300 (not required for N150 or Blackhole), the following environment variable needs to be set as the model requires at least 8x8 core grid size:
-```sh
-export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+### How to Run:
+Use the following command to run the model :
 ```
-### Demo
-
-- Use the following command to run the mobilenetv2 demo:
-```bash
-pytest -k "pretrained_weight_true" models/demos/mobilenetv2/demo/demo.py::test_mobilenetv2_imagenet_demo
+pytest --disable-warnings tests/ttnn/integration_tests/mobilenetv2/test_mobilenetv2.py
 ```
-
-- Use the following command to run the demo with different inputs by changing the image path in the method "test_mobilenetv2_demo":
-```bash
-pytest models/demos/mobilenetv2/demo/demo.py::test_mobilenetv2_demo
-```
-
 ### Model performant running with Trace+2CQ
 
 #### For 224x224:
@@ -37,12 +38,11 @@ pytest models/demos/mobilenetv2/demo/demo.py::test_mobilenetv2_demo
 pytest models/demos/mobilenetv2/tests/test_e2e_performant.py
 ```
 
-### Device Performant
+### Performant Demo with Trace+2CQ
 
-- Use the following command to run the device perf:
-
+Use the following command to run the performant Demo with Trace+2CQs:
 ```bash
-pytest models/demos/mobilenetv2/tests/test_perf_mobilenetv2.py::test_perf_device_bare_metal_mobilenetv2
+pytest  models/demos/mobilenetv2/demo/demo.py::test_mobilenetv2_imagenet_demo
 ```
 
 #### Note:

--- a/models/demos/mobilenetv2/demo/demo.py
+++ b/models/demos/mobilenetv2/demo/demo.py
@@ -1,180 +1,125 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-
-import os
 
 import pytest
 import torch
 from loguru import logger
-from PIL import Image
-from torchvision import transforms
+from tqdm import tqdm
+from transformers import AutoImageProcessor
 
 import ttnn
-from models.demos.mobilenetv2.demo.demo_utils import get_batch, get_data_loader
-from models.demos.mobilenetv2.reference.mobilenetv2 import Mobilenetv2
-from models.demos.mobilenetv2.tt import ttnn_mobilenetv2
-from models.demos.mobilenetv2.tt.model_preprocessing import create_mobilenetv2_model_parameters
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.demos.mobilenetv2.tests.mobilenetv2_e2e_performant import MobileNetV2Trace2CQ
+from models.demos.ttnn_resnet.tests.demo_utils import get_batch, get_data_loader
+from models.utility_functions import profiler, run_for_wormhole_b0
+
+NUM_VALIDATION_IMAGES_IMAGENET = 49920
 
 
-def mobilenetv2_imagenet_demo(
-    device,
-    reset_seeds,
-    model_location_generator,
-    imagenet_label_dict,
-    iterations,
-    batch_size,
-    res,
-    use_pretrained_weight,
-):
-    weights_path = "models/demos/mobilenetv2/mobilenet_v2-b0353104.pth"
-    if not os.path.exists(weights_path):
-        os.system("bash models/demos/mobilenetv2/weights_download.sh")
-
-    torch_model = Mobilenetv2()
-    if use_pretrained_weight:
-        state_dict = torch.load(weights_path)
-        ds_state_dict = {k: v for k, v in state_dict.items()}
-        new_state_dict = {
-            name1: parameter2
-            for (name1, _), (_, parameter2) in zip(torch_model.state_dict().items(), ds_state_dict.items())
-            if isinstance(parameter2, torch.FloatTensor)
-        }
-        torch_model.load_state_dict(new_state_dict)
-    else:
-        state_dict = torch_model.state_dict()
-
-    torch_model.eval()
-
-    logger.info("ImageNet-1k validation Dataset")
-    input_loc = str(model_location_generator("ImageNet_data"))
-    data_loader = get_data_loader(input_loc, batch_size, iterations)
-
-    parameters = create_mobilenetv2_model_parameters(torch_model, device=device)
-    ttnn_model = ttnn_mobilenetv2.TtMobileNetV2(parameters, device, batchsize=batch_size)
-    correct = 0
-
-    for iter in range(iterations):
-        predictions = []
-        inputs, labels = get_batch(data_loader, res)
-        torch_input_tensor = inputs.reshape(batch_size, 3, res, res)
-        torch_input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))
-
-        ttnn_input_tensor = torch_input_tensor.reshape(
-            1,
-            1,
-            torch_input_tensor.shape[0] * torch_input_tensor.shape[1] * torch_input_tensor.shape[2],
-            torch_input_tensor.shape[3],
-        )
-
-        ttnn_input_tensor = ttnn.from_torch(ttnn_input_tensor, dtype=ttnn.bfloat16)
-        tt_output = ttnn_model(ttnn_input_tensor)
-        tt_output = ttnn.from_device(tt_output, blocking=True).to_torch().to(torch.float)
-        prediction = tt_output.argmax(dim=-1)
-
-        for i in range(batch_size):
-            predicted_label = imagenet_label_dict[prediction[i].item()]
-            true_label = imagenet_label_dict[labels[i]]
-            predictions.append(predicted_label)
-            logger.info(
-                f"Iter: {iter} Sample: {i} - Expected Label: {true_label} -- Predicted Label: {predicted_label}"
-            )
-            if true_label == predicted_label:
-                correct += 1
-
-        del tt_output, inputs, labels, predictions
-
-    accuracy = correct / (batch_size * iterations)
-    logger.info(f"Accuracy for {batch_size}x{iterations} inputs: {accuracy}")
-
-
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@run_for_wormhole_b0()
 @pytest.mark.parametrize(
-    "use_pretrained_weight", [False, True], ids=["pretrained_weight_false", "pretrained_weight_true"]
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 1605632, "num_command_queues": 2}], indirect=True
 )
-@pytest.mark.parametrize("batch_size, resolution, iterations", [[8, 224, 100]])
+@pytest.mark.parametrize(
+    "batch_size_per_device, iterations, act_dtype, weight_dtype",
+    ((8, 100, ttnn.bfloat8_b, ttnn.bfloat8_b),),
+)
 def test_mobilenetv2_imagenet_demo(
     device,
-    reset_seeds,
+    use_program_cache,
+    batch_size_per_device,
     iterations,
-    batch_size,
-    resolution,
-    use_pretrained_weight,
-    model_location_generator,
     imagenet_label_dict,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    entire_imagenet_dataset=False,
+    expected_accuracy=0.68,
 ):
-    mobilenetv2_imagenet_demo(
-        device,
-        reset_seeds,
-        model_location_generator,
-        imagenet_label_dict,
-        iterations,
-        batch_size,
-        resolution,
-        use_pretrained_weight,
+    batch_size = batch_size_per_device * device.get_num_devices()
+    iterations = iterations // device.get_num_devices()
+
+    if entire_imagenet_dataset:
+        iterations = NUM_VALIDATION_IMAGES_IMAGENET // batch_size
+
+    profiler.clear()
+    with torch.no_grad():
+        mobilenetv2_trace_2cq = MobileNetV2Trace2CQ()
+
+        profiler.start(f"compile")
+        mobilenetv2_trace_2cq.initialize_mobilenetv2_trace_2cqs_inference(
+            device,
+            batch_size_per_device,
+            act_dtype,
+            weight_dtype,
+        )
+        profiler.end(f"compile")
+        model_version = "microsoft/resnet-50"
+        image_processor = AutoImageProcessor.from_pretrained(model_version)
+        logger.info("ImageNet-1k validation Dataset")
+        input_loc = str(model_location_generator("ImageNet_data"))
+        data_loader = get_data_loader(input_loc, batch_size, iterations, entire_imagenet_dataset)
+
+        input_tensors_all = []
+        input_labels_all = []
+        for iter in tqdm(range(iterations), desc="Preparing images"):
+            inputs, labels = get_batch(data_loader, image_processor)
+            input_tensors_all.append(inputs)
+            input_labels_all.append(labels)
+        logger.info("Processed ImageNet-1k validation Dataset")
+
+        logger.info("Starting inference")
+        correct = 0
+        total_inference_time = 0
+        for iter in range(iterations):
+            predictions = []
+            torch_input_tensor = input_tensors_all[iter]
+            labels = input_labels_all[iter]
+            profiler.start(f"run")
+
+            core_grid = ttnn.CoreGrid(y=8, x=8)
+            n, c, h, w = torch_input_tensor.shape
+            # sharded mem config for fold input
+            num_cores = core_grid.x * core_grid.y
+            shard_h = (n * w * h + num_cores - 1) // num_cores
+            grid_size = core_grid
+            grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
+            shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
+            shard_spec = ttnn.ShardSpec(shard_grid, (shard_h, 16), ttnn.ShardOrientation.ROW_MAJOR)
+            input_mem_config = ttnn.MemoryConfig(
+                ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
+            )
+            torch_input_tensor = torch_input_tensor.permute(0, 2, 3, 1)
+            torch_input_tensor = torch_input_tensor.reshape(1, 1, h * w * n, c)
+            tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+            tt_inputs_host = ttnn.pad(tt_inputs_host, [1, 1, n * h * w, 16], [0, 0, 0, 0], 0)
+            output = mobilenetv2_trace_2cq.execute_mobilenetv2_trace_2cqs_inference(tt_inputs_host)
+            output = ttnn.to_torch(output)
+            prediction = output.argmax(dim=-1)
+
+            profiler.end(f"run")
+            total_inference_time += profiler.get(f"run")
+            for i in range(batch_size):
+                predictions.append(imagenet_label_dict[prediction[i].item()])
+                logger.info(
+                    f"Iter: {iter} Sample: {i} - Expected Label: {imagenet_label_dict[labels[i]]} -- Predicted Label: {predictions[-1]}"
+                )
+                if imagenet_label_dict[labels[i]] == predictions[-1]:
+                    correct += 1
+        mobilenetv2_trace_2cq.release_mobilenetv2_trace_2cqs_inference()
+        accuracy = correct / (batch_size * iterations)
+        logger.info(f"=============")
+        logger.info(f"Accuracy for {batch_size}x{iterations} inputs: {accuracy}")
+        if entire_imagenet_dataset:
+            assert (
+                accuracy < expected_accuracy
+            ), f"Accuracy {accuracy} does not match expected accuracy {expected_accuracy}"
+
+        first_iter_time = profiler.get(f"compile")
+        inference_time_avg = total_inference_time / (iterations)
+
+        compile_time = first_iter_time - 2 * inference_time_avg
+    logger.info(
+        f"ttnn_{model_version}_batch_size{batch_size} tests inference time (avg): {inference_time_avg}, FPS: {batch_size/inference_time_avg}"
     )
-
-
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
-def test_mobilenetv2_demo(device, reset_seeds, batch_size=8):
-    weights_path = "models/demos/functional_mobilenetv2/mobilenet_v2-b0353104.pth"
-    if not os.path.exists(weights_path):
-        os.system("bash models/demos/functional_mobilenetv2/weights_download.sh")
-
-    state_dict = torch.load(weights_path)
-    ds_state_dict = {k: v for k, v in state_dict.items()}
-    torch_model = Mobilenetv2()
-
-    new_state_dict = {
-        name1: parameter2
-        for (name1, _), (_, parameter2) in zip(torch_model.state_dict().items(), ds_state_dict.items())
-        if isinstance(parameter2, torch.FloatTensor)
-    }
-    torch_model.load_state_dict(new_state_dict)
-    torch_model.eval()
-
-    transform = transforms.Compose(
-        [
-            transforms.Resize(224),
-            transforms.CenterCrop(224),
-            transforms.ToTensor(),
-            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-        ]
-    )
-
-    img = Image.open("models/experimental/functional_mobilenetv2/demo/images/strawberry.jpg")
-    img_t = transform(img)
-    img_batch_t = img_t.unsqueeze(0).repeat(batch_size, 1, 1, 1)
-
-    torch_input_tensor = img_batch_t
-    torch_output_tensor = torch_model(torch_input_tensor)
-
-    parameters = create_mobilenetv2_model_parameters(torch_model, device=device)
-    ttnn_input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))
-    ttnn_input_tensor = ttnn_input_tensor.reshape(
-        1,
-        1,
-        ttnn_input_tensor.shape[0] * ttnn_input_tensor.shape[1] * ttnn_input_tensor.shape[2],
-        ttnn_input_tensor.shape[3],
-    )
-    ttnn_input_tensor = ttnn.from_torch(ttnn_input_tensor, dtype=ttnn.bfloat16)
-
-    ttnn_model = ttnn_mobilenetv2.MobileNetV2(parameters, device, batchsize=batch_size)
-    output_tensor = ttnn_model(ttnn_input_tensor)
-    output_tensor = ttnn.to_torch(output_tensor)
-    output_tensor = output_tensor.reshape(torch_output_tensor.shape)
-    output_tensor = output_tensor.to(torch_input_tensor.dtype)
-
-    with open("models/experimental/functional_mobilenetv2/demo/imagenet_classes.txt") as f:
-        classes = [line.strip() for line in f.readlines()]
-
-    _, index = torch.max(output_tensor, 1)
-    percentage = torch.nn.functional.softmax(output_tensor, dim=1)[0] * 100
-    logger.info("\033[1m" + f"Predicted class: {classes[index[0]]}")
-    logger.info("\033[1m" + f"Probability: {percentage[index[0]].item():.2f}%")
-
-    _, indices = torch.sort(output_tensor, descending=True)
-    [(classes[idx], percentage[idx].item()) for idx in indices[0][:5]]
-
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.91)
+    logger.info(f"ttnn_{model_version}_batch_size{batch_size} compile time: {compile_time}")

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -217,9 +217,9 @@ run_yolov9c_perf() {
 
 }
 
-run_mobilenetv2_func(){
+run_mobilenetv2_perf(){
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -k "pretrained_weight_true" models/demos/mobilenetv2/demo/demo.py::test_mobilenetv2_imagenet_demo --timeout 600
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/mobilenetv2/demo/demo.py::test_mobilenetv2_imagenet_demo --timeout 600
 
 }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13798)

### Problem:
The existing MobileNetV2 demo in tt-metal currently operates as a "functional" demo. The objective is to 
write demo using trace.

### What's changed:
Support has been added to enable the MobileNetV2 demo to run with trace. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15629383912) CI passes
- [ ] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes