### PR TITLE
#0: Set up TTSL namespace

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_to_and_from_json.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_to_and_from_json.cpp
@@ -23,9 +23,9 @@ class TEST_MEMORY_CONFIG : public ::testing::TestWithParam<TestMemoryConfigParam
 
 TEST_P(TEST_MEMORY_CONFIG, SerializeDeserialize) {
     const auto& memory_config = GetParam().memory_config;
-    auto json_object = tt::stl::json::to_json(memory_config);
+    auto json_object = ttsl::json::to_json(memory_config);
 
-    auto deserialized_memory_config = tt::stl::json::from_json<ttnn::MemoryConfig>(json_object);
+    auto deserialized_memory_config = ttsl::json::from_json<ttnn::MemoryConfig>(json_object);
 
     ASSERT_EQ(memory_config, deserialized_memory_config);
 }
@@ -89,10 +89,10 @@ TEST(TEST_JSON_CONVERSION, TEST_MATMUL_CONFIG) {
         ttnn::operations::matmul::MatmulMultiCoreReuseProgramConfig{CoreCoord{2, 3}, 32, 64, 48, 128, 96};
     auto matmul_program_config = ttnn::operations::matmul::MatmulProgramConfig{matmul_multi_core_reuse_program_config};
 
-    auto json_object = tt::stl::json::to_json(matmul_program_config);
+    auto json_object = ttsl::json::to_json(matmul_program_config);
 
     auto deserialized_matmul_program_config =
-        tt::stl::json::from_json<ttnn::operations::matmul::MatmulProgramConfig>(json_object);
+        ttsl::json::from_json<ttnn::operations::matmul::MatmulProgramConfig>(json_object);
 
     ASSERT_EQ(
         matmul_multi_core_reuse_program_config.compute_with_storage_grid_size,

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -342,9 +342,9 @@ using HostDataType = std::variant<
 
 }  // namespace tt::tt_metal
 
-namespace tt::stl::json {
+namespace ttsl::json {
 template <>
-struct from_json_t<tt_metal::ShardSpec> {
-    tt_metal::ShardSpec operator()(const nlohmann::json& json_object) const;
+struct from_json_t<tt::tt_metal::ShardSpec> {
+    tt::tt_metal::ShardSpec operator()(const nlohmann::json& json_object) const;
 };
-}  // namespace tt::stl::json
+}  // namespace ttsl::json

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -260,7 +260,7 @@ struct hash<CoreRangeSet> {
 
 }  // namespace std
 
-namespace tt::stl::json {
+namespace ttsl::json {
 
 template <>
 struct to_json_t<CoreCoord> {
@@ -302,4 +302,4 @@ struct from_json_t<CoreRangeSet> {
     CoreRangeSet operator()(const nlohmann::json& json) noexcept;
 };
 
-}  // namespace tt::stl::json
+}  // namespace ttsl::json

--- a/tt_metal/api/tt-metalium/shape.hpp
+++ b/tt_metal/api/tt-metalium/shape.hpp
@@ -56,11 +56,11 @@ tt::stl::SmallVector<uint32_t> compute_strides(const tt::tt_metal::Shape& shape)
 }  // namespace tt::tt_metal
 
 template <>
-struct tt::stl::json::to_json_t<tt::tt_metal::Shape> {
+struct ttsl::json::to_json_t<tt::tt_metal::Shape> {
     nlohmann::json operator()(const tt::tt_metal::Shape& shape) const;
 };
 
 template <>
-struct tt::stl::json::from_json_t<tt::tt_metal::Shape> {
+struct ttsl::json::from_json_t<tt::tt_metal::Shape> {
     tt::tt_metal::Shape operator()(const nlohmann::json& json_object) const;
 };

--- a/tt_metal/api/tt-metalium/system_mesh.hpp
+++ b/tt_metal/api/tt-metalium/system_mesh.hpp
@@ -11,13 +11,6 @@
 
 #include <tt-metalium/mesh_coord.hpp>
 
-namespace tt {
-namespace stl {
-template <typename T>
-class Indestructible;
-}  // namespace stl
-}  // namespace tt
-
 namespace tt::tt_metal::distributed {
 
 // SystemMesh creates a virtualization over the physical devices in the system.

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -669,7 +669,7 @@ std::size_t hash<CoreRangeSet>::operator()(const CoreRangeSet& core_range_set) c
 
 }  // namespace std
 
-namespace tt::stl::json {
+namespace ttsl::json {
 
 nlohmann::json to_json_t<CoreCoord>::operator()(const CoreCoord& core_coord) noexcept {
     return {{"x", to_json(core_coord.x)}, {"y", to_json(core_coord.y)}};
@@ -704,4 +704,4 @@ CoreRangeSet from_json_t<CoreRangeSet>::operator()(const nlohmann::json& json) n
     return CoreRangeSet(from_json<std::vector<CoreRange>>(json));
 }
 
-}  // namespace tt::stl::json
+}  // namespace ttsl::json

--- a/tt_metal/common/shape.cpp
+++ b/tt_metal/common/shape.cpp
@@ -91,11 +91,10 @@ tt::stl::SmallVector<uint32_t> compute_strides(const tt::tt_metal::Shape& shape)
 
 }  // namespace tt::tt_metal
 
-nlohmann::json tt::stl::json::to_json_t<tt::tt_metal::Shape>::operator()(const tt::tt_metal::Shape& shape) const {
-    return tt::stl::json::to_json(shape.view());
+nlohmann::json ttsl::json::to_json_t<tt::tt_metal::Shape>::operator()(const tt::tt_metal::Shape& shape) const {
+    return ttsl::json::to_json(shape.view());
 }
 
-tt::tt_metal::Shape tt::stl::json::from_json_t<tt::tt_metal::Shape>::operator()(
-    const nlohmann::json& json_object) const {
-    return tt::tt_metal::Shape(tt::stl::json::from_json<tt::tt_metal::ShapeBase::Container>(json_object));
+tt::tt_metal::Shape ttsl::json::from_json_t<tt::tt_metal::Shape>::operator()(const nlohmann::json& json_object) const {
+    return tt::tt_metal::Shape(ttsl::json::from_json<tt::tt_metal::ShapeBase::Container>(json_object));
 }

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -655,25 +655,25 @@ DeviceAddr ShardSpecBuffer::num_pages() const {
 
 }  // namespace tt::tt_metal
 
-namespace tt::stl::json {
-tt_metal::ShardSpec from_json_t<tt_metal::ShardSpec>::operator()(const nlohmann::json& json_object) const {
-    const auto& shard_mode = from_json<tt_metal::ShardMode>(json_object.at("mode"));
+namespace ttsl::json {
+tt::tt_metal::ShardSpec from_json_t<tt::tt_metal::ShardSpec>::operator()(const nlohmann::json& json_object) const {
+    const auto& shard_mode = from_json<tt::tt_metal::ShardMode>(json_object.at("mode"));
     const auto& physical_shard_shape =
         from_json<std::optional<std::array<uint32_t, 2>>>(json_object.at("physical_shard_shape"));
     if (physical_shard_shape.has_value()) {
         TT_FATAL(
             shard_mode == tt::tt_metal::ShardMode::LOGICAL,
             "Physical shard shape can only be provided in logical sharding mode!");
-        return tt_metal::ShardSpec{
+        return tt::tt_metal::ShardSpec{
             from_json<CoreRangeSet>(json_object.at("grid")),
             from_json<std::array<uint32_t, 2>>(json_object.at("shape")),
             physical_shard_shape.value(),
-            from_json<tt_metal::ShardOrientation>(json_object.at("orientation"))};
+            from_json<tt::tt_metal::ShardOrientation>(json_object.at("orientation"))};
     }
-    return tt_metal::ShardSpec{
+    return tt::tt_metal::ShardSpec{
         from_json<CoreRangeSet>(json_object.at("grid")),
         from_json<std::array<uint32_t, 2>>(json_object.at("shape")),
-        from_json<tt_metal::ShardOrientation>(json_object.at("orientation")),
+        from_json<tt::tt_metal::ShardOrientation>(json_object.at("orientation")),
         shard_mode};
 }
-}  // namespace tt::stl::json
+}  // namespace ttsl::json

--- a/tt_stl/tt_stl/aligned_allocator.hpp
+++ b/tt_stl/tt_stl/aligned_allocator.hpp
@@ -7,7 +7,7 @@
 #include <limits>
 #include <new>
 
-namespace tt::stl {
+namespace ttsl {
 
 template <typename T, std::size_t Alignment = alignof(T)>
 class aligned_allocator {
@@ -53,4 +53,10 @@ constexpr bool operator==(const aligned_allocator<T, Alignment>&, const aligned_
     return true;
 }
 
-}  // namespace tt::stl
+}  // namespace ttsl
+
+namespace tt {
+namespace [[deprecated("Use ttsl namespace instead")]] stl {
+using namespace ::ttsl;
+}  // namespace stl
+}  // namespace tt

--- a/tt_stl/tt_stl/any_range.hpp
+++ b/tt_stl/tt_stl/any_range.hpp
@@ -10,7 +10,7 @@
 #include <typeinfo>
 #include <utility>
 
-namespace tt::stl {
+namespace ttsl {
 
 // Most types are not typically aligned more than the size of a pointer. If in the future there is a special case to
 // accommodate, these can be parameterized then.
@@ -970,4 +970,10 @@ using AnySizedRandomAccessRangeFor = AnyRangeFor<TReference, sized_random_access
         using __VA_ARGS__::BasicAnyRange; \
     }
 
-}  // namespace tt::stl
+}  // namespace ttsl
+
+namespace tt {
+namespace [[deprecated("Use ttsl namespace instead")]] stl {
+using namespace ::ttsl;
+}  // namespace stl
+}  // namespace tt

--- a/tt_stl/tt_stl/concepts.hpp
+++ b/tt_stl/tt_stl/concepts.hpp
@@ -6,7 +6,7 @@
 
 #include <reflect>
 
-namespace tt::stl::concepts {
+namespace ttsl::concepts {
 
 template <typename... T>
 inline constexpr bool always_false_v = false;
@@ -15,4 +15,10 @@ template <typename T>
 concept Reflectable =
     (std::is_aggregate_v<std::decay_t<T>> and requires { reflect::for_each([](auto I) {}, std::declval<T>()); });
 
-}  // namespace tt::stl::concepts
+}  // namespace ttsl::concepts
+
+namespace tt {
+namespace [[deprecated("Use ttsl namespace instead")]] stl {
+using namespace ::ttsl;
+}  // namespace stl
+}  // namespace tt

--- a/tt_stl/tt_stl/indestructible.hpp
+++ b/tt_stl/tt_stl/indestructible.hpp
@@ -8,7 +8,7 @@
 #include <new>
 #include <utility>
 
-namespace tt::stl {
+namespace ttsl {
 
 // `Indestructible` is a wrapper around `T` that behaves like `T` but does not call the destructor of `T`.
 // This is useful for creating objects with static storage duration: `Indestructible` avoids heap allocation, provides
@@ -48,4 +48,10 @@ private:
     alignas(T) std::byte storage_[sizeof(T)];
 };
 
-}  // namespace tt::stl
+}  // namespace ttsl
+
+namespace tt {
+namespace [[deprecated("Use ttsl namespace instead")]] stl {
+using namespace ::ttsl;
+}  // namespace stl
+}  // namespace tt

--- a/tt_stl/tt_stl/overloaded.hpp
+++ b/tt_stl/tt_stl/overloaded.hpp
@@ -6,7 +6,7 @@
 
 #include <type_traits>
 
-namespace tt::stl {
+namespace ttsl {
 
 // `overloaded` allows to combine multiple lambdas into a single object with the overloaded `operator()`.
 // This is useful for creating visitor objects for using in `std::visit`, for example:
@@ -17,7 +17,7 @@ namespace tt::stl {
 // ...
 //
 // std::visit(
-//     tt::stl::overloaded{
+//     ttsl::overloaded{
 //         [](const A&) { /*Process A...*/ },
 //         [](const B&) { /*Process B...*/ },
 //         [](const C&) { /*Process C...*/ },
@@ -49,4 +49,10 @@ struct overloaded : detail::overloaded_base_t<Ts>... {
 template <typename... Ts>
 overloaded(Ts&&...) -> overloaded<Ts...>;
 
-}  // namespace tt::stl
+}  // namespace ttsl
+
+namespace tt {
+namespace [[deprecated("Use ttsl namespace instead")]] stl {
+using namespace ::ttsl;
+}  // namespace stl
+}  // namespace tt

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -28,8 +28,7 @@
 #include <tt_stl/type_name.hpp>
 #include <tt-logger/tt-logger.hpp>
 
-namespace tt {
-namespace stl {
+namespace ttsl {
 
 template <typename T>
 constexpr std::string_view get_type_name() {
@@ -155,14 +154,14 @@ struct Attribute final {
             if constexpr (std::is_copy_constructible_v<BaseType>) {
                 return new (&self) BaseType{*reinterpret_cast<const BaseType*>(other)};
             } else {
-                static_assert(tt::stl::concepts::always_false_v<BaseType>);
+                static_assert(ttsl::concepts::always_false_v<BaseType>);
             }
         }},
         move_storage{[](storage_t& self, void* other) -> void* {
             if constexpr (std::is_move_constructible_v<BaseType>) {
                 return new (&self) BaseType{*reinterpret_cast<BaseType*>(other)};
             } else {
-                static_assert(tt::stl::concepts::always_false_v<BaseType>);
+                static_assert(ttsl::concepts::always_false_v<BaseType>);
             }
         }},
 
@@ -297,9 +296,9 @@ constexpr bool supports_conversion_to_string_v =
 
 template <typename T>
 Attributes get_attributes(const T& object) {
-    if constexpr (tt::stl::reflection::detail::supports_compile_time_attributes_v<std::decay_t<T>>) {
-        constexpr auto num_attributes = tt::stl::reflection::detail::get_num_attributes<std::decay_t<T>>();
-        tt::stl::reflection::Attributes attributes;
+    if constexpr (ttsl::reflection::detail::supports_compile_time_attributes_v<std::decay_t<T>>) {
+        constexpr auto num_attributes = ttsl::reflection::detail::get_num_attributes<std::decay_t<T>>();
+        ttsl::reflection::Attributes attributes;
         const auto attribute_values = object.attribute_values();
         [&object, &attributes, &attribute_values]<size_t... Ns>(std::index_sequence<Ns...>) {
             (
@@ -311,8 +310,8 @@ Attributes get_attributes(const T& object) {
                 ...);
         }(std::make_index_sequence<num_attributes>{});
         return attributes;
-    } else if constexpr (tt::stl::concepts::Reflectable<std::decay_t<T>>) {
-        tt::stl::reflection::Attributes attributes;
+    } else if constexpr (ttsl::concepts::Reflectable<std::decay_t<T>>) {
+        ttsl::reflection::Attributes attributes;
         reflect::for_each(
             [&object, &attributes](auto I) {
                 const auto& attribute_name = reflect::member_name<I>(object);
@@ -363,7 +362,7 @@ typename std::enable_if_t<detail::supports_conversion_to_string_v<T>, std::ostre
 
         os << ")";
     } else {
-        static_assert(tt::stl::concepts::always_false_v<T>, "Type cannot be converted to string");
+        static_assert(ttsl::concepts::always_false_v<T>, "Type cannot be converted to string");
     }
     return os;
 }
@@ -485,7 +484,7 @@ std::ostream& operator<<(std::ostream& os, const std::unordered_map<K, V>& map) 
 }
 
 template <typename T>
-    requires(tt::stl::concepts::Reflectable<T> and not(std::integral<T> or std::is_array<T>::value))
+    requires(ttsl::concepts::Reflectable<T> and not(std::integral<T> or std::is_array<T>::value))
 std::ostream& operator<<(std::ostream& os, const T& object) {
     os << reflect::type_name(object);
     os << "(";
@@ -512,8 +511,7 @@ void visit_object_of_type(auto&& callback, T&& object) {
 }
 
 template <typename T>
-    requires(not tt::stl::concepts::Reflectable<std::decay_t<T>>) and
-            (not requires { std::decay_t<T>::attribute_names; })
+    requires(not ttsl::concepts::Reflectable<std::decay_t<T>>) and (not requires { std::decay_t<T>::attribute_names; })
 struct visit_object_of_type_t<T> {
     template <typename object_t>
         requires std::same_as<std::decay_t<T>, object_t>
@@ -611,7 +609,7 @@ struct visit_object_of_type_t<T> {
 };
 
 template <typename T>
-    requires tt::stl::concepts::Reflectable<std::decay_t<T>>
+    requires ttsl::concepts::Reflectable<std::decay_t<T>>
 struct visit_object_of_type_t<T> {
     template <typename object_t>
         requires std::same_as<std::decay_t<T>, object_t>
@@ -651,8 +649,7 @@ auto transform_object_of_type(auto&& callback, T&& object) {
 }
 
 template <typename T>
-    requires(not tt::stl::concepts::Reflectable<std::decay_t<T>>) and
-            (not requires { std::decay_t<T>::attribute_names; })
+    requires(not ttsl::concepts::Reflectable<std::decay_t<T>>) and (not requires { std::decay_t<T>::attribute_names; })
 struct transform_object_of_type_t<T> {
     template <typename object_t>
         requires std::same_as<std::decay_t<T>, object_t>
@@ -740,7 +737,7 @@ struct transform_object_of_type_t<T> {
     template <typename object_t>
         requires(not std::same_as<std::decay_t<T>, object_t>)
     T operator()(auto&& callback, T&& object) const {
-        static_assert(tt::stl::concepts::always_false_v<T>, "Unsupported transform of object of type");
+        static_assert(ttsl::concepts::always_false_v<T>, "Unsupported transform of object of type");
     }
 
     template <typename object_t>
@@ -752,12 +749,12 @@ struct transform_object_of_type_t<T> {
     template <typename object_t>
         requires(not std::same_as<std::decay_t<T>, object_t>)
     T operator()(auto&& callback, const T& object) const {
-        static_assert(tt::stl::concepts::always_false_v<T>, "Unsupported transform of object of type");
+        static_assert(ttsl::concepts::always_false_v<T>, "Unsupported transform of object of type");
     }
 };
 
 template <typename T>
-    requires tt::stl::concepts::Reflectable<std::decay_t<T>>
+    requires ttsl::concepts::Reflectable<std::decay_t<T>>
 struct transform_object_of_type_t<T> {
     template <typename object_t>
         requires std::same_as<std::decay_t<T>, object_t>
@@ -801,8 +798,7 @@ auto get_first_object_of_type(const T& value) {
 }
 
 template <typename T>
-    requires(not tt::stl::concepts::Reflectable<std::decay_t<T>>) and
-            (not requires { std::decay_t<T>::attribute_names; })
+    requires(not ttsl::concepts::Reflectable<std::decay_t<T>>) and (not requires { std::decay_t<T>::attribute_names; })
 struct get_first_object_of_type_t<T> {
     template <typename object_t>
         requires std::same_as<std::decay_t<T>, object_t>
@@ -875,7 +871,7 @@ struct get_first_object_of_type_t<T> {
 };
 
 template <typename T>
-    requires tt::stl::concepts::Reflectable<std::decay_t<T>>
+    requires ttsl::concepts::Reflectable<std::decay_t<T>>
 struct get_first_object_of_type_t<T> {
     template <typename object_t>
         requires(std::same_as<std::decay_t<T>, object_t>)
@@ -891,15 +887,14 @@ struct get_first_object_of_type_t<T> {
 };
 
 }  // namespace reflection
-}  // namespace stl
-}  // namespace tt
+}  // namespace ttsl
 
 template <typename T>
-struct fmt::formatter<T, char, std::enable_if_t<tt::stl::reflection::detail::supports_conversion_to_string_v<T>>> {
+struct fmt::formatter<T, char, std::enable_if_t<ttsl::reflection::detail::supports_conversion_to_string_v<T>>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
     auto format(const T& object, format_context& ctx) const -> format_context::iterator {
-        using tt::stl::reflection::operator<<;
+        using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << object;
         return fmt::format_to(ctx.out(), "{}", ss.str());
@@ -911,7 +906,7 @@ struct fmt::formatter<T, char, std::enable_if_t<std::is_enum<T>::value>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
     auto format(const T& value, format_context& ctx) const -> format_context::iterator {
-        using tt::stl::reflection::operator<<;
+        using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << value;
         return fmt::format_to(ctx.out(), "{}", ss.str());
@@ -923,7 +918,7 @@ struct fmt::formatter<std::filesystem::path> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
     auto format(const std::filesystem::path& path, format_context& ctx) const -> format_context::iterator {
-        using tt::stl::reflection::operator<<;
+        using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << path;
         return fmt::format_to(ctx.out(), "{}", ss.str());
@@ -935,7 +930,7 @@ struct fmt::formatter<std::optional<T>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
     auto format(const std::optional<T>& optional, format_context& ctx) const -> format_context::iterator {
-        using tt::stl::reflection::operator<<;
+        using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << optional;
         return fmt::format_to(ctx.out(), "{}", ss.str());
@@ -947,7 +942,7 @@ struct fmt::formatter<std::variant<Ts...>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
     auto format(const std::variant<Ts...>& variant, format_context& ctx) const -> format_context::iterator {
-        using tt::stl::reflection::operator<<;
+        using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << variant;
         return fmt::format_to(ctx.out(), "{}", ss.str());
@@ -959,7 +954,7 @@ struct fmt::formatter<std::reference_wrapper<T>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
     auto format(const std::reference_wrapper<T> reference, format_context& ctx) const -> format_context::iterator {
-        using tt::stl::reflection::operator<<;
+        using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << reference;
         return fmt::format_to(ctx.out(), "{}", ss.str());
@@ -971,7 +966,7 @@ struct fmt::formatter<std::tuple<Ts...>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
     auto format(const std::tuple<Ts...>& tuple, format_context& ctx) const -> format_context::iterator {
-        using tt::stl::reflection::operator<<;
+        using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << tuple;
         return fmt::format_to(ctx.out(), "{}", ss.str());
@@ -983,7 +978,7 @@ struct fmt::formatter<std::array<T, N>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
     auto format(const std::array<T, N>& array, format_context& ctx) const -> format_context::iterator {
-        using tt::stl::reflection::operator<<;
+        using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << array;
         return fmt::format_to(ctx.out(), "{}", ss.str());
@@ -995,7 +990,7 @@ struct fmt::formatter<std::vector<T>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
     auto format(const std::vector<T>& vector, format_context& ctx) const -> format_context::iterator {
-        using tt::stl::reflection::operator<<;
+        using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << vector;
         return fmt::format_to(ctx.out(), "{}", ss.str());
@@ -1007,7 +1002,7 @@ struct fmt::formatter<std::set<T>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
     auto format(const std::set<T>& set, format_context& ctx) const -> format_context::iterator {
-        using tt::stl::reflection::operator<<;
+        using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << set;
         return fmt::format_to(ctx.out(), "{}", ss.str());
@@ -1019,7 +1014,7 @@ struct fmt::formatter<std::map<K, V>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
     auto format(const std::map<K, V>& map, format_context& ctx) const -> format_context::iterator {
-        using tt::stl::reflection::operator<<;
+        using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << map;
         return fmt::format_to(ctx.out(), "{}", ss.str());
@@ -1031,7 +1026,7 @@ struct fmt::formatter<std::unordered_map<K, V>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
     auto format(const std::unordered_map<K, V>& map, format_context& ctx) const -> format_context::iterator {
-        using tt::stl::reflection::operator<<;
+        using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << map;
         return fmt::format_to(ctx.out(), "{}", ss.str());
@@ -1040,21 +1035,20 @@ struct fmt::formatter<std::unordered_map<K, V>> {
 
 template <typename T>
     requires(
-        tt::stl::concepts::Reflectable<T> and not(std::integral<T> or std::is_array<T>::value or
-                                                  tt::stl::reflection::detail::supports_conversion_to_string_v<T>))
+        ttsl::concepts::Reflectable<T> and not(std::integral<T> or std::is_array<T>::value or
+                                               ttsl::reflection::detail::supports_conversion_to_string_v<T>))
 struct fmt::formatter<T> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
     auto format(const T& object, format_context& ctx) const -> format_context::iterator {
-        using tt::stl::reflection::operator<<;
+        using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << object;
         return fmt::format_to(ctx.out(), "{}", ss.str());
     }
 };
 
-namespace tt {
-namespace stl {
+namespace ttsl {
 namespace hash {
 
 namespace detail {
@@ -1113,12 +1107,12 @@ inline hash_t hash_object(const T& object) noexcept {
             fmt::print("Hashing {} using std::hash: {}\n", get_type_name<T>(), object);
         }
         return std::hash<T>{}(object);
-    } else if constexpr (tt::stl::reflection::detail::supports_to_hash_v<T>) {
+    } else if constexpr (ttsl::reflection::detail::supports_to_hash_v<T>) {
         if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
             fmt::print("Hashing struct {} using to_hash method: {}\n", get_type_name<T>(), object);
         }
         return object.to_hash();
-    } else if constexpr (tt::stl::reflection::detail::supports_compile_time_attributes_v<T>) {
+    } else if constexpr (ttsl::reflection::detail::supports_compile_time_attributes_v<T>) {
         if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
             fmt::print("Hashing struct {} using compile-time attributes: {}\n", get_type_name<T>(), object);
         }
@@ -1208,7 +1202,7 @@ inline hash_t hash_object(const T& object) noexcept {
         } else {
             return 0;
         }
-    } else if constexpr (tt::stl::concepts::Reflectable<T>) {
+    } else if constexpr (ttsl::concepts::Reflectable<T>) {
         if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
             fmt::print("Hashing struct {} using reflect library: {}\n", get_type_name<T>(), object);
         }
@@ -1216,8 +1210,7 @@ inline hash_t hash_object(const T& object) noexcept {
         reflect::for_each([&hash, &object](auto I) { hash = hash_objects(hash, reflect::get<I>(object)); }, object);
         return hash;
     } else {
-        static_assert(
-            tt::stl::concepts::always_false_v<T>, "Type doesn't support hashing using tt::stl::hash::hash_object");
+        static_assert(ttsl::concepts::always_false_v<T>, "Type doesn't support hashing using ttsl::hash::hash_object");
     }
 }
 
@@ -1518,7 +1511,7 @@ struct to_json_t<reflection::Attribute> {
 };
 
 template <typename T>
-    requires tt::stl::reflection::detail::supports_compile_time_attributes_v<T>
+    requires ttsl::reflection::detail::supports_compile_time_attributes_v<T>
 struct to_json_t<T> {
     nlohmann::json operator()(const T& object) noexcept {
         nlohmann::json json_object = nlohmann::json::object();
@@ -1537,7 +1530,7 @@ struct to_json_t<T> {
 };
 
 template <typename T>
-    requires tt::stl::concepts::Reflectable<T>
+    requires ttsl::concepts::Reflectable<T>
 struct to_json_t<T> {
     nlohmann::json operator()(const T& object) noexcept {
         nlohmann::json json_object = nlohmann::json::object();
@@ -1553,7 +1546,7 @@ struct to_json_t<T> {
 };
 
 template <typename T>
-    requires tt::stl::concepts::Reflectable<T>
+    requires ttsl::concepts::Reflectable<T>
 struct from_json_t<T> {
     T operator()(const nlohmann::json& json_object) noexcept {
         T object;
@@ -1572,11 +1565,15 @@ struct from_json_t<T> {
 template <typename T>
 struct to_json_t {
     nlohmann::json operator()(const T& optional) noexcept {
-        return fmt::format("tt::stl::json::to_json_t: Unsupported type {}", get_type_name<T>());
+        return fmt::format("ttsl::json::to_json_t: Unsupported type {}", get_type_name<T>());
     }
 };
 
 }  // namespace json
+}  // namespace ttsl
 
+namespace tt {
+namespace [[deprecated("Use ttsl namespace instead")]] stl {
+using namespace ::ttsl;
 }  // namespace stl
 }  // namespace tt

--- a/tt_stl/tt_stl/slotmap.hpp
+++ b/tt_stl/tt_stl/slotmap.hpp
@@ -26,7 +26,7 @@
 #include <utility>
 #include <vector>
 
-namespace tt::stl {
+namespace ttsl {
 
 template <typename T, size_t INDEX_BITS>
 struct Key {
@@ -68,9 +68,9 @@ public:
     friend auto operator<=>(Key, Key) = default;
 };
 
-#define MAKE_SLOTMAP_KEY(NAME, T, N)     \
-    struct NAME : ::tt::stl::Key<T, N> { \
-        using Key::Key;                  \
+#define MAKE_SLOTMAP_KEY(NAME, T, N)  \
+    struct NAME : ::ttsl::Key<T, N> { \
+        using Key::Key;               \
     };
 
 template <typename KeyT, typename T>
@@ -380,4 +380,10 @@ private:
     }
 };
 
-}  // namespace tt::stl
+}  // namespace ttsl
+
+namespace tt {
+namespace [[deprecated("Use ttsl namespace instead")]] stl {
+using namespace ::ttsl;
+}  // namespace stl
+}  // namespace tt

--- a/tt_stl/tt_stl/small_vector.hpp
+++ b/tt_stl/tt_stl/small_vector.hpp
@@ -8,7 +8,7 @@
 
 #include <tt_stl/reflection.hpp>
 
-namespace tt::stl {
+namespace ttsl {
 
 static constexpr size_t SMALL_VECTOR_SIZE = 8;
 
@@ -24,36 +24,42 @@ std::ostream& operator<<(std::ostream& os, const SmallVector<T, PREALLOCATED_SIZ
         if (i > 0) {
             os << ", ";
         }
-        using tt::stl::reflection::operator<<;
+        using ttsl::reflection::operator<<;
         os << vec[i];
     }
     os << "])";
     return os;
 }
 
-}  // namespace tt::stl
+}  // namespace ttsl
 
 namespace ttnn {
-template <typename T, size_t PREALLOCATED_SIZE = tt::stl::SMALL_VECTOR_SIZE>
-using SmallVector [[deprecated("Use tt::stl::SmallVector instead")]] = tt::stl::SmallVector<T, PREALLOCATED_SIZE>;
+template <typename T, size_t PREALLOCATED_SIZE = ttsl::SMALL_VECTOR_SIZE>
+using SmallVector [[deprecated("Use ttsl::SmallVector instead")]] = tt::stl::SmallVector<T, PREALLOCATED_SIZE>;
 }
 
+namespace tt {
+namespace [[deprecated("Use ttsl namespace instead")]] stl {
+using namespace ::ttsl;
+}  // namespace stl
+}  // namespace tt
+
 template <typename T, size_t PREALLOCATED_SIZE>
-struct std::hash<tt::stl::SmallVector<T, PREALLOCATED_SIZE>> {
-    size_t operator()(const tt::stl::SmallVector<T, PREALLOCATED_SIZE>& vec) const noexcept {
+struct std::hash<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
+    size_t operator()(const ttsl::SmallVector<T, PREALLOCATED_SIZE>& vec) const noexcept {
         size_t hash = 0;
         for (const auto& element : vec) {
-            hash = tt::stl::hash::detail::hash_objects(hash, element);
+            hash = ttsl::hash::detail::hash_objects(hash, element);
         }
         return hash;
     }
 };
 
 template <typename T, size_t PREALLOCATED_SIZE>
-struct fmt::formatter<tt::stl::SmallVector<T, PREALLOCATED_SIZE>> {
+struct fmt::formatter<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
-    auto format(const tt::stl::SmallVector<T, PREALLOCATED_SIZE>& vector, format_context& ctx) const
+    auto format(const ttsl::SmallVector<T, PREALLOCATED_SIZE>& vector, format_context& ctx) const
         -> format_context::iterator {
         std::stringstream ss;
         ss << vector;
@@ -62,8 +68,8 @@ struct fmt::formatter<tt::stl::SmallVector<T, PREALLOCATED_SIZE>> {
 };
 
 template <typename T, size_t PREALLOCATED_SIZE>
-struct ttsl::json::to_json_t<tt::stl::SmallVector<T, PREALLOCATED_SIZE>> {
-    nlohmann::json operator()(const tt::stl::SmallVector<T, PREALLOCATED_SIZE>& vector) const {
+struct ttsl::json::to_json_t<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
+    nlohmann::json operator()(const ttsl::SmallVector<T, PREALLOCATED_SIZE>& vector) const {
         nlohmann::json json_array = nlohmann::json::array();
         for (const auto& element : vector) {
             json_array.push_back(to_json(element));
@@ -73,9 +79,9 @@ struct ttsl::json::to_json_t<tt::stl::SmallVector<T, PREALLOCATED_SIZE>> {
 };
 
 template <typename T, size_t PREALLOCATED_SIZE>
-struct ttsl::json::from_json_t<tt::stl::SmallVector<T, PREALLOCATED_SIZE>> {
-    tt::stl::SmallVector<T, PREALLOCATED_SIZE> operator()(const nlohmann::json& json_object) const {
-        tt::stl::SmallVector<T, PREALLOCATED_SIZE> vector;
+struct ttsl::json::from_json_t<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
+    ttsl::SmallVector<T, PREALLOCATED_SIZE> operator()(const nlohmann::json& json_object) const {
+        ttsl::SmallVector<T, PREALLOCATED_SIZE> vector;
         for (const auto& element : json_object) {
             vector.push_back(from_json<T>(element));
         }

--- a/tt_stl/tt_stl/small_vector.hpp
+++ b/tt_stl/tt_stl/small_vector.hpp
@@ -62,7 +62,7 @@ struct fmt::formatter<tt::stl::SmallVector<T, PREALLOCATED_SIZE>> {
 };
 
 template <typename T, size_t PREALLOCATED_SIZE>
-struct tt::stl::json::to_json_t<tt::stl::SmallVector<T, PREALLOCATED_SIZE>> {
+struct ttsl::json::to_json_t<tt::stl::SmallVector<T, PREALLOCATED_SIZE>> {
     nlohmann::json operator()(const tt::stl::SmallVector<T, PREALLOCATED_SIZE>& vector) const {
         nlohmann::json json_array = nlohmann::json::array();
         for (const auto& element : vector) {
@@ -73,7 +73,7 @@ struct tt::stl::json::to_json_t<tt::stl::SmallVector<T, PREALLOCATED_SIZE>> {
 };
 
 template <typename T, size_t PREALLOCATED_SIZE>
-struct tt::stl::json::from_json_t<tt::stl::SmallVector<T, PREALLOCATED_SIZE>> {
+struct ttsl::json::from_json_t<tt::stl::SmallVector<T, PREALLOCATED_SIZE>> {
     tt::stl::SmallVector<T, PREALLOCATED_SIZE> operator()(const nlohmann::json& json_object) const {
         tt::stl::SmallVector<T, PREALLOCATED_SIZE> vector;
         for (const auto& element : json_object) {

--- a/tt_stl/tt_stl/span.hpp
+++ b/tt_stl/tt_stl/span.hpp
@@ -6,7 +6,7 @@
 
 #include <boost/core/span.hpp>
 
-namespace tt::stl {
+namespace ttsl {
 
 using boost::dynamic_extent;
 
@@ -114,4 +114,10 @@ auto as_writable_bytes(Span<T> span) noexcept {
     return Span<std::byte>(reinterpret_cast<std::byte*>(span.data()), span.size_bytes());
 }
 
-}  // namespace tt::stl
+}  // namespace ttsl
+
+namespace tt {
+namespace [[deprecated("Use ttsl namespace instead")]] stl {
+using namespace ::ttsl;
+}  // namespace stl
+}  // namespace tt

--- a/tt_stl/tt_stl/strong_type.hpp
+++ b/tt_stl/tt_stl/strong_type.hpp
@@ -8,7 +8,7 @@
 #include <tuple>
 #include <utility>
 
-namespace tt::stl {
+namespace ttsl {
 
 // `StrongType` provides a strongly-typed wrapper around a value to prevent accidental type conversions.
 //
@@ -102,14 +102,20 @@ private:
     T value_;
 };
 
-}  // namespace tt::stl
+}  // namespace ttsl
 
 template <typename T, typename Tag>
-std::ostream& operator<<(std::ostream& os, const tt::stl::StrongType<T, Tag>& h) {
+std::ostream& operator<<(std::ostream& os, const ttsl::StrongType<T, Tag>& h) {
     return os << *h;
 }
 
 template <typename T, typename Tag>
-struct std::hash<tt::stl::StrongType<T, Tag>> {
-    std::size_t operator()(const tt::stl::StrongType<T, Tag>& h) const noexcept { return std::hash<T>{}(*h); }
+struct std::hash<ttsl::StrongType<T, Tag>> {
+    std::size_t operator()(const ttsl::StrongType<T, Tag>& h) const noexcept { return std::hash<T>{}(*h); }
 };
+
+namespace tt {
+namespace [[deprecated("Use ttsl namespace instead")]] stl {
+using namespace ::ttsl;
+}  // namespace stl
+}  // namespace tt

--- a/tt_stl/tt_stl/type_name.hpp
+++ b/tt_stl/tt_stl/type_name.hpp
@@ -7,7 +7,7 @@
 #include <source_location>
 #include <string_view>
 
-namespace tt::stl {
+namespace ttsl {
 
 namespace detail {
 
@@ -90,4 +90,10 @@ inline constexpr std::string_view short_type_name = detail::short_name<T>();
 template <typename T>
 inline constexpr std::string_view long_type_name = detail::long_name<T>();
 
-}  // namespace tt::stl
+}  // namespace ttsl
+
+namespace tt {
+namespace [[deprecated("Use ttsl namespace instead")]] stl {
+using namespace ::ttsl;
+}  // namespace stl
+}  // namespace tt

--- a/tt_stl/tt_stl/unique_any.hpp
+++ b/tt_stl/tt_stl/unique_any.hpp
@@ -9,7 +9,7 @@
 
 #include <tt_stl/concepts.hpp>
 
-namespace tt::stl {
+namespace ttsl {
 
 template <auto MAX_STORAGE_SIZE, auto ALIGNMENT>
 struct unique_any final {
@@ -23,7 +23,7 @@ struct unique_any final {
             if constexpr (std::is_move_constructible_v<BaseType>) {
                 return new (&self) BaseType{std::move(*reinterpret_cast<BaseType*>(other))};
             } else {
-                static_assert(tt::stl::concepts::always_false_v<BaseType>);
+                static_assert(ttsl::concepts::always_false_v<BaseType>);
             }
         }} {
         static_assert(sizeof(BaseType) <= MAX_STORAGE_SIZE);
@@ -79,4 +79,10 @@ private:
     void* (*move_storage)(storage_t& storage, void*) = nullptr;
 };
 
-}  // namespace tt::stl
+}  // namespace ttsl
+
+namespace tt {
+namespace [[deprecated("Use ttsl namespace instead")]] stl {
+using namespace ::ttsl;
+}  // namespace stl
+}  // namespace tt

--- a/ttnn/api/ttnn/tensor/types.hpp
+++ b/ttnn/api/ttnn/tensor/types.hpp
@@ -167,11 +167,11 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Layout& layout);
 }  // namespace tt
 
 template <>
-struct tt::stl::json::to_json_t<tt::tt_metal::MemoryConfig> {
+struct ttsl::json::to_json_t<tt::tt_metal::MemoryConfig> {
     nlohmann::json operator()(const tt::tt_metal::MemoryConfig& config) const;
 };
 
 template <>
-struct tt::stl::json::from_json_t<tt::tt_metal::MemoryConfig> {
+struct ttsl::json::from_json_t<tt::tt_metal::MemoryConfig> {
     tt::tt_metal::MemoryConfig operator()(const nlohmann::json& json_object) const;
 };

--- a/ttnn/core/tensor/types.cpp
+++ b/ttnn/core/tensor/types.cpp
@@ -122,7 +122,7 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Layout& layout) {
 
 }  // namespace tt::tt_metal
 
-nlohmann::json tt::stl::json::to_json_t<tt::tt_metal::MemoryConfig>::operator()(
+nlohmann::json ttsl::json::to_json_t<tt::tt_metal::MemoryConfig>::operator()(
     const tt::tt_metal::MemoryConfig& config) const {
     nlohmann::json json_object;
     json_object["memory_layout"] = config.memory_layout();
@@ -130,28 +130,28 @@ nlohmann::json tt::stl::json::to_json_t<tt::tt_metal::MemoryConfig>::operator()(
     json_object["created_with_nd_shard_spec"] = config.created_with_nd_shard_spec();
     if (config.created_with_nd_shard_spec()) {
         if (config.nd_shard_spec().has_value()) {
-            json_object["nd_shard_spec"] = tt::stl::json::to_json(config.nd_shard_spec().value());
+            json_object["nd_shard_spec"] = ttsl::json::to_json(config.nd_shard_spec().value());
         }
     } else {
         if (config.shard_spec().has_value()) {
-            json_object["shard_spec"] = tt::stl::json::to_json(config.shard_spec().value());
+            json_object["shard_spec"] = ttsl::json::to_json(config.shard_spec().value());
         }
     }
     return json_object;
 }
 
-tt::tt_metal::MemoryConfig tt::stl::json::from_json_t<tt::tt_metal::MemoryConfig>::operator()(
+tt::tt_metal::MemoryConfig ttsl::json::from_json_t<tt::tt_metal::MemoryConfig>::operator()(
     const nlohmann::json& json_object) const {
     auto memory_layout = json_object["memory_layout"].get<tt::tt_metal::TensorMemoryLayout>();
     auto buffer_type = json_object["buffer_type"].get<tt::tt_metal::BufferType>();
     auto created_with_nd_shard_spec = json_object["created_with_nd_shard_spec"].get<bool>();
     if (created_with_nd_shard_spec) {
-        auto nd_shard_spec = tt::stl::json::from_json<tt::tt_metal::NdShardSpec>(json_object["nd_shard_spec"]);
+        auto nd_shard_spec = ttsl::json::from_json<tt::tt_metal::NdShardSpec>(json_object["nd_shard_spec"]);
         return tt::tt_metal::MemoryConfig(buffer_type, std::move(nd_shard_spec));
     } else {
         std::optional<tt::tt_metal::ShardSpec> shard_spec;
         if (json_object.contains("shard_spec")) {
-            shard_spec = tt::stl::json::from_json<tt::tt_metal::ShardSpec>(json_object["shard_spec"]);
+            shard_spec = ttsl::json::from_json<tt::tt_metal::ShardSpec>(json_object["shard_spec"]);
         }
         return tt::tt_metal::MemoryConfig(memory_layout, buffer_type, std::move(shard_spec));
     }

--- a/ttnn/cpp/ttnn-pybind/json_class.hpp
+++ b/ttnn/cpp/ttnn-pybind/json_class.hpp
@@ -16,11 +16,11 @@
 template <typename T>
 auto tt_serializable_class(const pybind11::module& m, auto name, auto desc) {
     return pybind11::class_<T>(m, name, desc)
-        .def("to_json", [](const T& self) -> std::string { return tt::stl::json::to_json(self).dump(); })
+        .def("to_json", [](const T& self) -> std::string { return ttsl::json::to_json(self).dump(); })
         .def(
             "from_json",
             [](const std::string& json_string) -> T {
-                return tt::stl::json::from_json<T>(nlohmann::json::parse(json_string));
+                return ttsl::json::from_json<T>(nlohmann::json::parse(json_string));
             })
         .def("__repr__", [](const T& self) { return fmt::format("{}", self); });
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -126,7 +126,7 @@ using FusedActivations = std::vector<ttnn::operations::unary::UnaryWithParam>;
 
 }  // namespace ttnn::operations::unary
 
-namespace tt::stl::json {
+namespace ttsl::json {
 
 template <>
 struct from_json_t<ttnn::operations::unary::UnaryWithParam> {
@@ -136,4 +136,4 @@ struct from_json_t<ttnn::operations::unary::UnaryWithParam> {
             from_json<std::vector<float>>(json_object["params"])};
     }
 };
-};  // namespace tt::stl::json
+};  // namespace ttsl::json


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`tt::stl` is problematic in that it defines a nested `namespace stl`, which conflates with "C++ STL". 

In addition, it is too long, and encourages people to create `using` aliases.

### What's changed
Move definitions from `tt::stl` to `ttsl`. Set up using aliases to accommodate the migration.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15563420034)
- [x] New/Existing tests provide coverage for changes