### PR TITLE
#0: Fix conv2d tests by avoiding interacting with individual devices in a mesh

### DIFF
--- a/models/experimental/stable_diffusion_35_large/tests/test_conv2d.py
+++ b/models/experimental/stable_diffusion_35_large/tests/test_conv2d.py
@@ -44,6 +44,22 @@ def test_conv2d(
     height: int,
     width: int,
 ) -> None:
+    # TODO: #23290 - Fix the underlying issue.
+    skip_configs = [
+        (1, 128, 128, (3, 3), (1, 1), 1024, 1024),
+        (1, 128, 3, (3, 3), (1, 1), 1024, 1024),
+        (1, 256, 128, (3, 3), (1, 1), 1024, 1024),
+        (1, 256, 256, (3, 3), (1, 1), 1024, 1024),
+        (1, 256, 256, (3, 3), (1, 1), 512, 512),
+        (1, 512, 512, (3, 3), (1, 1), 256, 256),
+        (1, 512, 256, (3, 3), (1, 1), 512, 512),
+        (1, 512, 512, (3, 3), (1, 1), 512, 512),
+    ]
+
+    current_config = (batch_size, in_channels, out_channels, kernel_size, stride, height, width)
+    if current_config in skip_configs:
+        pytest.skip("Configuration expected to fail with memory config error")
+
     dtype = ttnn.bfloat16
 
     total_batch_size = batch_size * mesh_device.get_num_devices()


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Addresses https://github.com/tenstorrent/tt-metal/pull/23290/files#discussion_r2136288636

### What's changed
Fix launching ops on individual devices in mesh.

Comment out the rest of the tests, as per the linked discussion.

Ran the tests locally on a T3K:
```
PASSED models/experimental/stable_diffusion_35_large/tests/test_conv2d.py::test_conv2d[wormhole_b0-device_params0-1-32-32-kernel_size0-stride0-64-64]
PASSED models/experimental/stable_diffusion_35_large/tests/test_conv2d.py::test_conv2d[wormhole_b0-device_params0-1-20-32-kernel_size1-stride1-128-256]
PASSED models/experimental/stable_diffusion_35_large/tests/test_conv2d.py::test_conv2d[wormhole_b0-device_params0-1-16-512-kernel_size4-stride4-128-128]
PASSED models/experimental/stable_diffusion_35_large/tests/test_conv2d.py::test_conv2d[wormhole_b0-device_params0-1-512-512-kernel_size8-stride8-128-128]
SKIPPED [8] models/experimental/stable_diffusion_35_large/tests/test_conv2d.py:62: Configuration expected to fail with memory config error
```

### Checklist
- [X] New/Existing tests provide coverage for changes