### PR TITLE
Generalize data-parallel batching

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -55,40 +55,54 @@ class Generator:
         self.formatter = formatter
         self.data_parallel = len(self.model)
 
-        max_batch_size = self.model_args[0].max_batch_size
-        assert all(
-            self.model_args[i].max_batch_size == max_batch_size for i in range(self.data_parallel)
-        ), "All models must have the same max batch size"
-
     # Note: This function is called by vLLM
     def prefill_forward_text(self, tokens: torch.Tensor, page_table=None, kv_cache=None, prompt_lens=None):
         batch_size, batch_seq_len = tokens.shape
-        max_batch_size_per_model, batch_size_per_model = self._get_batch_size_per_model(batch_size)
+        batch_size_per_model = (batch_size + self.data_parallel - 1) // self.data_parallel
+        padded_batch_size = batch_size_per_model * self.data_parallel
+        if batch_size < padded_batch_size:
+            logger.info(f"Padding batch size from {batch_size} to {padded_batch_size}")
 
         # Each model expected to run the same model, safe to use 1st vocab size
-        output_logits = torch.zeros(batch_size, 1, self.model_args[0].vocab_size)
-        prompt_lens = prompt_lens if prompt_lens is not None else torch.tensor([batch_seq_len] * batch_size)
+        output_logits = torch.zeros(padded_batch_size, 1, self.model_args[0].vocab_size)
+        prompt_lens = (
+            prompt_lens + [batch_seq_len] * (padded_batch_size - batch_size)
+            if prompt_lens is not None
+            else [batch_seq_len] * padded_batch_size
+        )
 
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
-            page_table = torch.split(page_table, batch_size_per_model)
+            page_table = torch.cat(
+                [
+                    page_table,
+                    torch.zeros(padded_batch_size - batch_size, page_table.shape[1], dtype=torch.int32),
+                ],
+                dim=0,
+            )
+
+            page_table = torch.chunk(page_table, self.data_parallel, 0)
 
         out_list = []
-        for group_user_id in range(max_batch_size_per_model):
+        for group_user_id in range(batch_size_per_model):
             for model_id in range(self.data_parallel):
-                if group_user_id >= batch_size_per_model[model_id]:
-                    # Skip users that are not in this model's batch size
-                    continue
+                user_id = group_user_id + model_id * batch_size_per_model
 
-                user_id = group_user_id + model_id * max_batch_size_per_model
                 logger.info(f"Prefilling User {user_id + 1}")
                 seq_len = int(prompt_lens[user_id])
                 last_token_idx = seq_len - 1
 
                 prefill_seq_len = get_padded_prefill_len(seq_len)
-                prefill_ids = torch.cat(
-                    [tokens[user_id : user_id + 1, :seq_len], torch.zeros(1, prefill_seq_len - seq_len).long()], dim=-1
-                )
+                if batch_size <= user_id:
+                    logger.info(
+                        f"User {user_id + 1} is out of bounds for tokens tensor, padding with zeros to seq_len {prefill_seq_len}"
+                    )
+                    prefill_ids = torch.zeros(1, prefill_seq_len).long()
+                else:
+                    prefill_ids = torch.cat(
+                        [tokens[user_id : user_id + 1, :seq_len], torch.zeros(1, prefill_seq_len - seq_len).long()],
+                        dim=-1,
+                    )
                 if page_table is not None:
                     page_table_user = self._get_prefill_user_page_table(
                         page_table[model_id], kv_cache[model_id], seq_len
@@ -105,22 +119,18 @@ class Generator:
                 out_list.append(logits)
 
         # We gather data back to how at the end of prefill
-        for group_user_id in range(max_batch_size_per_model):
-            for model_id in range(self.data_parallel):
-                if group_user_id >= batch_size_per_model[model_id]:
-                    # Skip users that are not in this model's batch size
-                    continue
+        for idx, out in enumerate(out_list):
+            model_id = idx % self.data_parallel
+            group_user_id = idx // self.data_parallel
+            user_id = group_user_id + model_id * batch_size_per_model
 
-                user_id = group_user_id + model_id * max_batch_size_per_model
-                out = out_list[group_user_id]
+            seq_len = int(prompt_lens[user_id])
+            last_token_idx = seq_len - 1
 
-                seq_len = int(prompt_lens[user_id])
-                last_token_idx = seq_len - 1
-
-                # Since we give unpadded_seq_len, only the tile containing the last token is returned
-                output_logits[user_id] = self.model[model_id].process_output_prefill(
-                    out, last_token_idx=(last_token_idx % 32)
-                )
+            # Since we give unpadded_seq_len, only the tile containing the last token is returned
+            output_logits[user_id] = self.model[model_id].process_output_prefill(
+                out, last_token_idx=(last_token_idx % 32)
+            )
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
         return output_logits
@@ -493,35 +503,69 @@ class Generator:
         Batched version of _prefill_forward_single_user for vision model.
         """
         batch_size, batch_seq_len = tokens.shape
-        max_batch_size_per_model, batch_size_per_model = self._get_batch_size_per_model(batch_size)
+        batch_size_per_model = (batch_size + self.data_parallel - 1) // self.data_parallel
+        padded_batch_size = batch_size_per_model * self.data_parallel
+        if batch_size < padded_batch_size:
+            logger.info(f"Padding batch size from {batch_size} to {padded_batch_size}")
 
-        output_logits = torch.zeros(batch_size, 1, self.model_args[0].vocab_size)
-
+        output_logits = torch.zeros(padded_batch_size, 1, self.model_args[0].vocab_size)
         out_list = [[] for _ in range(self.data_parallel)]
-        output_xattn_masks = [None for _ in range(batch_size)]
-        output_full_text_row_masked_out_masks = [None for _ in range(batch_size)]
+        output_xattn_masks = [None for _ in range(padded_batch_size)]
+        output_full_text_row_masked_out_masks = [None for _ in range(padded_batch_size)]
+
+        tokens = torch.cat(
+            [
+                tokens,
+                torch.zeros(padded_batch_size - batch_size, batch_seq_len).long(),
+            ],
+            dim=0,
+        )
+
+        total_lens = total_lens.tolist() if isinstance(total_lens, torch.Tensor) else total_lens
+        total_lens += [batch_seq_len] * (padded_batch_size - batch_size)
+        prompt_lens = prompt_lens.tolist() if isinstance(prompt_lens, torch.Tensor) else prompt_lens
+        prompt_lens += [batch_seq_len] * (padded_batch_size - batch_size)
 
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
-            page_table = torch.split(page_table, batch_size_per_model)
-
+            page_table = torch.cat(
+                [
+                    page_table,
+                    torch.zeros(padded_batch_size - batch_size, page_table.shape[1], dtype=torch.int32),
+                ],
+                dim=0,
+            )
+            page_table = torch.chunk(page_table, self.data_parallel, 0)  # cross_page_table
         if cross_page_table is not None:
             assert isinstance(cross_page_table, torch.Tensor), "cross_page_table mush be torch.Tensor"
-            cross_page_table = torch.split(cross_page_table, batch_size_per_model)
+            cross_page_table = torch.cat(
+                [
+                    cross_page_table,
+                    torch.zeros(padded_batch_size - batch_size, cross_page_table.shape[1], dtype=torch.int32),
+                ],
+                dim=0,
+            )
+            cross_page_table = torch.chunk(cross_page_table, self.data_parallel, 0)
 
-        for group_user_id in range(max_batch_size_per_model):
+        for group_user_id in range(batch_size_per_model):
             for model_id in range(self.data_parallel):
-                if group_user_id >= batch_size_per_model[model_id]:
-                    # Skip users that are not in this model's batch size
-                    continue
+                user_id = group_user_id + model_id * batch_size_per_model
 
-                user_id = group_user_id + model_id * max_batch_size_per_model
                 logger.info(f"Prefilling User {user_id + 1}")
                 seq_len = int(prompt_lens[user_id])
                 user_page_table = page_table[model_id] if page_table is not None else None
                 user_kv_cache = kv_cache[model_id] if kv_cache is not None else None
                 user_cross_page_table = cross_page_table[model_id] if kv_cache is not None else None
                 xattn_cache = xattn_caches[model_id] if xattn_caches is not None else None
+
+                if batch_size <= user_id:
+                    logger.info(
+                        f"User {user_id + 1} is out of bounds for tokens tensor, padding with zeros to seq_len {seq_len}"
+                    )
+                    prefill_ids = torch.zeros(1, seq_len).long()
+                else:
+                    prefill_ids = tokens[user_id : user_id + 1, :seq_len]  # Keep batch dimension
+
                 (
                     xattn_cache,
                     cross_attention_masks,
@@ -530,7 +574,7 @@ class Generator:
                 ) = self._prefill_forward_single_user(
                     vision_images=vision_images[user_id],
                     vision_mask=vision_masks[user_id],
-                    tokens=tokens[user_id : user_id + 1, :seq_len],  # Keep batch dimension
+                    tokens=prefill_ids,
                     xattn_caches=xattn_cache,
                     user_id=group_user_id,
                     total_len=total_lens[user_id],
@@ -547,13 +591,9 @@ class Generator:
                 output_full_text_row_masked_out_masks[user_id] = full_text_row_masked_out_mask
 
         # We gather prefill output at the end of prefill to reduce unnecessary device sync
-        for group_user_id in range(max_batch_size_per_model):
+        for group_user_id in range(batch_size_per_model):
             for model_id in range(self.data_parallel):
-                if group_user_id >= batch_size_per_model[model_id]:
-                    # Skip users that are not in this model's batch size
-                    continue
-
-                user_id = group_user_id + model_id * max_batch_size_per_model
+                user_id = group_user_id + model_id * batch_size_per_model
                 last_token_idx = prompt_lens[user_id] - 1
                 output_logits[user_id] = self.model[model_id].process_output_prefill(
                     out_list[model_id][group_user_id], 1, last_token_idx=(last_token_idx % 32)
@@ -577,23 +617,22 @@ class Generator:
         enable_trace=True,
         read_from_device=True,
     ):
-        batch_size = tokens.shape[0]
-        max_batch_size_per_model, batch_size_per_model = self._get_batch_size_per_model(batch_size)
-
-        tokens = torch.split(tokens, batch_size_per_model)
-        start_pos = torch.split(start_pos, batch_size_per_model)
-
+        B = tokens.shape[0]
+        data_parallel = min(B, self.data_parallel)
+        batch_per_device = B // data_parallel
+        tokens = torch.chunk(tokens, self.data_parallel, 0)
+        start_pos = torch.chunk(start_pos, self.data_parallel, 0)
         cross_attention_masks = [
-            cross_attention_masks[i * max_batch_size_per_model : (i + 1) * max_batch_size_per_model]
-            for i in range(self.data_parallel)
+            cross_attention_masks[i * batch_per_device : (i + 1) * batch_per_device] for i in range(data_parallel)
         ]
         full_text_row_masked_out_mask = [
-            full_text_row_masked_out_mask[i * max_batch_size_per_model : (i + 1) * max_batch_size_per_model]
-            for i in range(self.data_parallel)
+            full_text_row_masked_out_mask[i * batch_per_device : (i + 1) * batch_per_device]
+            for i in range(data_parallel)
         ]
-
-        page_table = torch.split(page_table, batch_size_per_model) if page_table is not None else None
-        cross_page_table = torch.split(cross_page_table, batch_size_per_model) if cross_page_table is not None else None
+        page_table = torch.chunk(page_table, self.data_parallel, 0) if page_table is not None else None
+        cross_page_table = (
+            torch.chunk(cross_page_table, self.data_parallel, 0) if cross_page_table is not None else None
+        )
 
         decode_kwargs = {
             "position_id": start_pos,
@@ -611,7 +650,7 @@ class Generator:
             tt_logits = self._decode_forward_no_trace(**decode_kwargs)
 
         if read_from_device:
-            to_host = self.read_decode_output(tt_logits, batch_size)
+            to_host = self.read_decode_output(tt_logits, B)
             return to_host
         else:
             return tt_logits
@@ -621,21 +660,13 @@ class Generator:
         """
         Input is ttnn device tensor of logits if is_tokens=False, otherwise tokens. Output is the corresponding torch tensor.
         """
-        _, batch_size_per_model = self._get_batch_size_per_model(unpadded_batch)
-
         logits = []
+        batch_size_per_model = (unpadded_batch + self.data_parallel - 1) // self.data_parallel
         for i in range(self.data_parallel):
-            if batch_size_per_model[i] == 0:
-                continue
-            logits_i = self.model[i].process_output_decode(
-                tt_out[i], B=batch_size_per_model[i], S=1, is_tokens=is_tokens
-            )
+            logits_i = self.model[i].process_output_decode(tt_out[i], B=batch_size_per_model, S=1, is_tokens=is_tokens)
             logits.append(logits_i)
-
         logits = torch.cat(logits, 0)
-        assert logits.shape[0] == unpadded_batch
-
-        return logits
+        return logits[:unpadded_batch]
 
     def _decode_forward_no_trace(
         self,
@@ -1189,17 +1220,6 @@ class Generator:
         block_size = get_block_size(kv_cache)
         num_blocks = num_blocks_in_seq(prefill_len, block_size)
         return page_table[:, :num_blocks]
-
-    def _get_batch_size_per_model(self, batch_size):
-        """
-        Returns the maximum batch size per model and a list of batch sizes for each model.
-        """
-        max_batch_size_per_model = (batch_size + self.data_parallel - 1) // self.data_parallel
-
-        return max_batch_size_per_model, [
-            max(min(max_batch_size_per_model, batch_size - i * max_batch_size_per_model), 0)
-            for i in range(self.data_parallel)
-        ]
 
     ## Destructor
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1190,6 +1190,8 @@ class Generator:
         """
         max_batch_size_per_model = (batch_size + self.data_parallel - 1) // self.data_parallel
 
+        # The logic ensures that the total batch size is divided as evenly as possible
+        # among the models, with any remainder distributed to the earlier models in the list.
         return max_batch_size_per_model, [
             max(min(max_batch_size_per_model, batch_size - i * max_batch_size_per_model), 0)
             for i in range(self.data_parallel)

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -55,11 +55,6 @@ class Generator:
         self.formatter = formatter
         self.data_parallel = len(self.model)
 
-        max_batch_size = self.model_args[0].max_batch_size
-        assert all(
-            self.model_args[i].max_batch_size == max_batch_size for i in range(self.data_parallel)
-        ), "All models must have the same max batch size"
-
     # Note: This function is called by vLLM
     def prefill_forward_text(self, tokens: torch.Tensor, page_table=None, kv_cache=None, prompt_lens=None):
         batch_size, batch_seq_len = tokens.shape

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -55,54 +55,40 @@ class Generator:
         self.formatter = formatter
         self.data_parallel = len(self.model)
 
+        max_batch_size = self.model_args[0].max_batch_size
+        assert all(
+            self.model_args[i].max_batch_size == max_batch_size for i in range(self.data_parallel)
+        ), "All models must have the same max batch size"
+
     # Note: This function is called by vLLM
     def prefill_forward_text(self, tokens: torch.Tensor, page_table=None, kv_cache=None, prompt_lens=None):
         batch_size, batch_seq_len = tokens.shape
-        batch_size_per_model = (batch_size + self.data_parallel - 1) // self.data_parallel
-        padded_batch_size = batch_size_per_model * self.data_parallel
-        if batch_size < padded_batch_size:
-            logger.info(f"Padding batch size from {batch_size} to {padded_batch_size}")
+        max_batch_size_per_model, batch_size_per_model = self._get_batch_size_per_model(batch_size)
 
         # Each model expected to run the same model, safe to use 1st vocab size
-        output_logits = torch.zeros(padded_batch_size, 1, self.model_args[0].vocab_size)
-        prompt_lens = (
-            prompt_lens + [batch_seq_len] * (padded_batch_size - batch_size)
-            if prompt_lens is not None
-            else [batch_seq_len] * padded_batch_size
-        )
+        output_logits = torch.zeros(batch_size, 1, self.model_args[0].vocab_size)
+        prompt_lens = prompt_lens if prompt_lens is not None else torch.tensor([batch_seq_len] * batch_size)
 
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
-            page_table = torch.cat(
-                [
-                    page_table,
-                    torch.zeros(padded_batch_size - batch_size, page_table.shape[1], dtype=torch.int32),
-                ],
-                dim=0,
-            )
-
-            page_table = torch.chunk(page_table, self.data_parallel, 0)
+            page_table = torch.split(page_table, batch_size_per_model)
 
         out_list = []
-        for group_user_id in range(batch_size_per_model):
+        for group_user_id in range(max_batch_size_per_model):
             for model_id in range(self.data_parallel):
-                user_id = group_user_id + model_id * batch_size_per_model
+                if group_user_id >= batch_size_per_model[model_id]:
+                    # Skip users that are not in this model's batch size
+                    continue
 
+                user_id = group_user_id + model_id * max_batch_size_per_model
                 logger.info(f"Prefilling User {user_id + 1}")
                 seq_len = int(prompt_lens[user_id])
                 last_token_idx = seq_len - 1
 
                 prefill_seq_len = get_padded_prefill_len(seq_len)
-                if batch_size <= user_id:
-                    logger.info(
-                        f"User {user_id + 1} is out of bounds for tokens tensor, padding with zeros to seq_len {prefill_seq_len}"
-                    )
-                    prefill_ids = torch.zeros(1, prefill_seq_len).long()
-                else:
-                    prefill_ids = torch.cat(
-                        [tokens[user_id : user_id + 1, :seq_len], torch.zeros(1, prefill_seq_len - seq_len).long()],
-                        dim=-1,
-                    )
+                prefill_ids = torch.cat(
+                    [tokens[user_id : user_id + 1, :seq_len], torch.zeros(1, prefill_seq_len - seq_len).long()], dim=-1
+                )
                 if page_table is not None:
                     page_table_user = self._get_prefill_user_page_table(
                         page_table[model_id], kv_cache[model_id], seq_len
@@ -119,18 +105,22 @@ class Generator:
                 out_list.append(logits)
 
         # We gather data back to how at the end of prefill
-        for idx, out in enumerate(out_list):
-            model_id = idx % self.data_parallel
-            group_user_id = idx // self.data_parallel
-            user_id = group_user_id + model_id * batch_size_per_model
+        for group_user_id in range(max_batch_size_per_model):
+            for model_id in range(self.data_parallel):
+                if group_user_id >= batch_size_per_model[model_id]:
+                    # Skip users that are not in this model's batch size
+                    continue
 
-            seq_len = int(prompt_lens[user_id])
-            last_token_idx = seq_len - 1
+                user_id = group_user_id + model_id * max_batch_size_per_model
+                out = out_list[group_user_id]
 
-            # Since we give unpadded_seq_len, only the tile containing the last token is returned
-            output_logits[user_id] = self.model[model_id].process_output_prefill(
-                out, last_token_idx=(last_token_idx % 32)
-            )
+                seq_len = int(prompt_lens[user_id])
+                last_token_idx = seq_len - 1
+
+                # Since we give unpadded_seq_len, only the tile containing the last token is returned
+                output_logits[user_id] = self.model[model_id].process_output_prefill(
+                    out, last_token_idx=(last_token_idx % 32)
+                )
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
         return output_logits
@@ -503,69 +493,35 @@ class Generator:
         Batched version of _prefill_forward_single_user for vision model.
         """
         batch_size, batch_seq_len = tokens.shape
-        batch_size_per_model = (batch_size + self.data_parallel - 1) // self.data_parallel
-        padded_batch_size = batch_size_per_model * self.data_parallel
-        if batch_size < padded_batch_size:
-            logger.info(f"Padding batch size from {batch_size} to {padded_batch_size}")
+        max_batch_size_per_model, batch_size_per_model = self._get_batch_size_per_model(batch_size)
 
-        output_logits = torch.zeros(padded_batch_size, 1, self.model_args[0].vocab_size)
+        output_logits = torch.zeros(batch_size, 1, self.model_args[0].vocab_size)
+
         out_list = [[] for _ in range(self.data_parallel)]
-        output_xattn_masks = [None for _ in range(padded_batch_size)]
-        output_full_text_row_masked_out_masks = [None for _ in range(padded_batch_size)]
-
-        tokens = torch.cat(
-            [
-                tokens,
-                torch.zeros(padded_batch_size - batch_size, batch_seq_len).long(),
-            ],
-            dim=0,
-        )
-
-        total_lens = total_lens.tolist() if isinstance(total_lens, torch.Tensor) else total_lens
-        total_lens += [batch_seq_len] * (padded_batch_size - batch_size)
-        prompt_lens = prompt_lens.tolist() if isinstance(prompt_lens, torch.Tensor) else prompt_lens
-        prompt_lens += [batch_seq_len] * (padded_batch_size - batch_size)
+        output_xattn_masks = [None for _ in range(batch_size)]
+        output_full_text_row_masked_out_masks = [None for _ in range(batch_size)]
 
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
-            page_table = torch.cat(
-                [
-                    page_table,
-                    torch.zeros(padded_batch_size - batch_size, page_table.shape[1], dtype=torch.int32),
-                ],
-                dim=0,
-            )
-            page_table = torch.chunk(page_table, self.data_parallel, 0)  # cross_page_table
+            page_table = torch.split(page_table, batch_size_per_model)
+
         if cross_page_table is not None:
             assert isinstance(cross_page_table, torch.Tensor), "cross_page_table mush be torch.Tensor"
-            cross_page_table = torch.cat(
-                [
-                    cross_page_table,
-                    torch.zeros(padded_batch_size - batch_size, cross_page_table.shape[1], dtype=torch.int32),
-                ],
-                dim=0,
-            )
-            cross_page_table = torch.chunk(cross_page_table, self.data_parallel, 0)
+            cross_page_table = torch.split(cross_page_table, batch_size_per_model)
 
-        for group_user_id in range(batch_size_per_model):
+        for group_user_id in range(max_batch_size_per_model):
             for model_id in range(self.data_parallel):
-                user_id = group_user_id + model_id * batch_size_per_model
+                if group_user_id >= batch_size_per_model[model_id]:
+                    # Skip users that are not in this model's batch size
+                    continue
 
+                user_id = group_user_id + model_id * max_batch_size_per_model
                 logger.info(f"Prefilling User {user_id + 1}")
                 seq_len = int(prompt_lens[user_id])
                 user_page_table = page_table[model_id] if page_table is not None else None
                 user_kv_cache = kv_cache[model_id] if kv_cache is not None else None
                 user_cross_page_table = cross_page_table[model_id] if kv_cache is not None else None
                 xattn_cache = xattn_caches[model_id] if xattn_caches is not None else None
-
-                if batch_size <= user_id:
-                    logger.info(
-                        f"User {user_id + 1} is out of bounds for tokens tensor, padding with zeros to seq_len {seq_len}"
-                    )
-                    prefill_ids = torch.zeros(1, seq_len).long()
-                else:
-                    prefill_ids = tokens[user_id : user_id + 1, :seq_len]  # Keep batch dimension
-
                 (
                     xattn_cache,
                     cross_attention_masks,
@@ -574,7 +530,7 @@ class Generator:
                 ) = self._prefill_forward_single_user(
                     vision_images=vision_images[user_id],
                     vision_mask=vision_masks[user_id],
-                    tokens=prefill_ids,
+                    tokens=tokens[user_id : user_id + 1, :seq_len],  # Keep batch dimension
                     xattn_caches=xattn_cache,
                     user_id=group_user_id,
                     total_len=total_lens[user_id],
@@ -591,9 +547,13 @@ class Generator:
                 output_full_text_row_masked_out_masks[user_id] = full_text_row_masked_out_mask
 
         # We gather prefill output at the end of prefill to reduce unnecessary device sync
-        for group_user_id in range(batch_size_per_model):
+        for group_user_id in range(max_batch_size_per_model):
             for model_id in range(self.data_parallel):
-                user_id = group_user_id + model_id * batch_size_per_model
+                if group_user_id >= batch_size_per_model[model_id]:
+                    # Skip users that are not in this model's batch size
+                    continue
+
+                user_id = group_user_id + model_id * max_batch_size_per_model
                 last_token_idx = prompt_lens[user_id] - 1
                 output_logits[user_id] = self.model[model_id].process_output_prefill(
                     out_list[model_id][group_user_id], 1, last_token_idx=(last_token_idx % 32)
@@ -617,22 +577,23 @@ class Generator:
         enable_trace=True,
         read_from_device=True,
     ):
-        B = tokens.shape[0]
-        data_parallel = min(B, self.data_parallel)
-        batch_per_device = B // data_parallel
-        tokens = torch.chunk(tokens, self.data_parallel, 0)
-        start_pos = torch.chunk(start_pos, self.data_parallel, 0)
+        batch_size = tokens.shape[0]
+        max_batch_size_per_model, batch_size_per_model = self._get_batch_size_per_model(batch_size)
+
+        tokens = torch.split(tokens, batch_size_per_model)
+        start_pos = torch.split(start_pos, batch_size_per_model)
+
         cross_attention_masks = [
-            cross_attention_masks[i * batch_per_device : (i + 1) * batch_per_device] for i in range(data_parallel)
+            cross_attention_masks[i * max_batch_size_per_model : (i + 1) * max_batch_size_per_model]
+            for i in range(self.data_parallel)
         ]
         full_text_row_masked_out_mask = [
-            full_text_row_masked_out_mask[i * batch_per_device : (i + 1) * batch_per_device]
-            for i in range(data_parallel)
+            full_text_row_masked_out_mask[i * max_batch_size_per_model : (i + 1) * max_batch_size_per_model]
+            for i in range(self.data_parallel)
         ]
-        page_table = torch.chunk(page_table, self.data_parallel, 0) if page_table is not None else None
-        cross_page_table = (
-            torch.chunk(cross_page_table, self.data_parallel, 0) if cross_page_table is not None else None
-        )
+
+        page_table = torch.split(page_table, batch_size_per_model) if page_table is not None else None
+        cross_page_table = torch.split(cross_page_table, batch_size_per_model) if cross_page_table is not None else None
 
         decode_kwargs = {
             "position_id": start_pos,
@@ -650,7 +611,7 @@ class Generator:
             tt_logits = self._decode_forward_no_trace(**decode_kwargs)
 
         if read_from_device:
-            to_host = self.read_decode_output(tt_logits, B)
+            to_host = self.read_decode_output(tt_logits, batch_size)
             return to_host
         else:
             return tt_logits
@@ -660,13 +621,21 @@ class Generator:
         """
         Input is ttnn device tensor of logits if is_tokens=False, otherwise tokens. Output is the corresponding torch tensor.
         """
+        _, batch_size_per_model = self._get_batch_size_per_model(unpadded_batch)
+
         logits = []
-        batch_size_per_model = (unpadded_batch + self.data_parallel - 1) // self.data_parallel
         for i in range(self.data_parallel):
-            logits_i = self.model[i].process_output_decode(tt_out[i], B=batch_size_per_model, S=1, is_tokens=is_tokens)
+            if batch_size_per_model[i] == 0:
+                continue
+            logits_i = self.model[i].process_output_decode(
+                tt_out[i], B=batch_size_per_model[i], S=1, is_tokens=is_tokens
+            )
             logits.append(logits_i)
+
         logits = torch.cat(logits, 0)
-        return logits[:unpadded_batch]
+        assert logits.shape[0] == unpadded_batch
+
+        return logits
 
     def _decode_forward_no_trace(
         self,
@@ -1220,6 +1189,17 @@ class Generator:
         block_size = get_block_size(kv_cache)
         num_blocks = num_blocks_in_seq(prefill_len, block_size)
         return page_table[:, :num_blocks]
+
+    def _get_batch_size_per_model(self, batch_size):
+        """
+        Returns the maximum batch size per model and a list of batch sizes for each model.
+        """
+        max_batch_size_per_model = (batch_size + self.data_parallel - 1) // self.data_parallel
+
+        return max_batch_size_per_model, [
+            max(min(max_batch_size_per_model, batch_size - i * max_batch_size_per_model), 0)
+            for i in range(self.data_parallel)
+        ]
 
     ## Destructor
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23042
This PR continues the work of https://github.com/tenstorrent/tt-metal/pull/23129

### Problem description
vLLM can send varying batch sizes in the same run so we have to add support for this. Currently, it's assumed that `batch_size` is a multiple of `data_parallel` which is not always the case.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15718294249)
- [x] [TG demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/15718289965)
- [x] [T3K demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/15685852329)
- [x] [vLLM nightly](https://github.com/tenstorrent/tt-metal/actions/runs/15718228990)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes