### PR TITLE
[tt-train] Add support for specifying device IDs and MeshShape in YAML config for transformer training demo

### DIFF
--- a/tt-train/configs/training_shakespear_gpt2xl.yaml
+++ b/tt-train/configs/training_shakespear_gpt2xl.yaml
@@ -12,6 +12,8 @@ training_config:
   use_kahan_summation: false
   gradient_accumulation_steps: 32
   tokenizer_type: bpe
+  enable_tp: true
+  mesh_shape: [1,2]
 
   transformer_config:
     runner_type: memory_efficient

--- a/tt-train/configs/training_shakespear_gpt2xl.yaml
+++ b/tt-train/configs/training_shakespear_gpt2xl.yaml
@@ -12,8 +12,6 @@ training_config:
   use_kahan_summation: false
   gradient_accumulation_steps: 32
   tokenizer_type: bpe
-  enable_tp: true
-  mesh_shape: [1,2]
 
   transformer_config:
     runner_type: memory_efficient
@@ -25,3 +23,7 @@ training_config:
     max_sequence_length: 1024
     experimental:
       use_composite_layernorm: false
+
+device_config:
+  enable_tp: true
+  mesh_shape: [1,2]

--- a/tt-train/configs/training_shakespeare_llama3_tensor_parallel.yaml
+++ b/tt-train/configs/training_shakespeare_llama3_tensor_parallel.yaml
@@ -12,6 +12,8 @@ training_config:
   use_kahan_summation: false
   use_clip_grad_norm: false
   clip_grad_norm_max_norm: 1.0
+  enable_tp: true
+  mesh_shape: [1,2]
   transformer_config:
     num_heads: 6
     num_groups: 2 # should be divisible by number of devices

--- a/tt-train/configs/training_shakespeare_llama3_tensor_parallel.yaml
+++ b/tt-train/configs/training_shakespeare_llama3_tensor_parallel.yaml
@@ -12,8 +12,6 @@ training_config:
   use_kahan_summation: false
   use_clip_grad_norm: false
   clip_grad_norm_max_norm: 1.0
-  enable_tp: true
-  mesh_shape: [1,2]
   transformer_config:
     num_heads: 6
     num_groups: 2 # should be divisible by number of devices
@@ -28,3 +26,6 @@ eval_config:
   temperature: 0.7
   top_k: 50
   top_p: 1.0
+device_config:
+  enable_tp: true
+  mesh_shape: [1,2]

--- a/tt-train/configs/training_shakespeare_nanogpt_ddp_n300.yaml
+++ b/tt-train/configs/training_shakespeare_nanogpt_ddp_n300.yaml
@@ -1,0 +1,32 @@
+training_config:
+    project_name: "tt_train_nano_gpt"
+    model_type: "gpt2"
+    seed: 5489
+    model_save_interval: 500
+    batch_size: 64
+    num_epochs: 1
+    max_steps: 5000
+    learning_rate: 0.0003
+    weight_decay: 0.01
+    enable_ddp: true
+    mesh_shape: [1,2]
+    use_moreh_adamw: true
+    use_kahan_summation: false
+    use_clip_grad_norm: false
+    clip_grad_norm_max_norm: 1.0
+    transformer_config:
+      num_heads: 6
+      embedding_dim: 384
+      dropout_prob: 0.2
+      num_blocks: 6
+      vocab_size: 96
+      max_sequence_length: 256
+      positional_embedding_type: trainable
+      runner_type: default
+      experimental:
+        use_composite_layernorm: false
+eval_config:
+    repetition_penalty: 1.0
+    temperature: 0.7
+    top_k: 50
+    top_p: 1.0

--- a/tt-train/configs/training_shakespeare_nanogpt_ddp_n300.yaml
+++ b/tt-train/configs/training_shakespeare_nanogpt_ddp_n300.yaml
@@ -8,8 +8,6 @@ training_config:
     max_steps: 5000
     learning_rate: 0.0003
     weight_decay: 0.01
-    enable_ddp: true
-    mesh_shape: [1,2]
     use_moreh_adamw: true
     use_kahan_summation: false
     use_clip_grad_norm: false
@@ -30,3 +28,7 @@ eval_config:
     temperature: 0.7
     top_k: 50
     top_p: 1.0
+device_config:
+    enable_ddp: true
+    mesh_shape: [1,2]
+    device_ids: [0,1]

--- a/tt-train/configs/training_shakespeare_tiny_llama3_tensor_parallel.yaml
+++ b/tt-train/configs/training_shakespeare_tiny_llama3_tensor_parallel.yaml
@@ -12,6 +12,8 @@ training_config:
   use_kahan_summation: false
   use_clip_grad_norm: false
   clip_grad_norm_max_norm: 1.0
+  enable_tp: true
+  mesh_shape: [1,2]
   transformer_config:
     num_heads: 32
     num_groups: 4

--- a/tt-train/configs/training_shakespeare_tiny_llama3_tensor_parallel.yaml
+++ b/tt-train/configs/training_shakespeare_tiny_llama3_tensor_parallel.yaml
@@ -12,8 +12,6 @@ training_config:
   use_kahan_summation: false
   use_clip_grad_norm: false
   clip_grad_norm_max_norm: 1.0
-  enable_tp: true
-  mesh_shape: [1,2]
   transformer_config:
     num_heads: 32
     num_groups: 4
@@ -30,3 +28,6 @@ eval_config:
   temperature: 0.7
   top_k: 50
   top_p: 1.0
+device_config:
+  enable_tp: true
+  mesh_shape: [1,2]

--- a/tt-train/sources/examples/linear_regression_ddp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_ddp/main.cpp
@@ -32,7 +32,7 @@ int main() {
     const size_t num_targets = 32;
     const float noise = 0.0F;
     const bool bias = true;
-    ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
+    ttml::autograd::ctx().open_device(tt::tt_metal::distributed::MeshShape(1, 2));
 
     auto training_params = ttml::datasets::MakeRegressionParams{
         .n_samples = training_samples_count,

--- a/tt-train/sources/examples/mnist_mlp/main.cpp
+++ b/tt-train/sources/examples/mnist_mlp/main.cpp
@@ -68,7 +68,10 @@ TrainingConfig parse_config(const YAML::Node &yaml_config) {
 void initialize_device(bool enable_tp) {
     if (enable_tp) {
         // we support only N300 for now
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
+        ttml::autograd::ctx().open_device(tt::tt_metal::distributed::MeshShape(1, 2));
+    } else {
+        // use single device defaults
+        ttml::autograd::ctx().open_device();
     }
 }
 

--- a/tt-train/sources/examples/nano_gpt/3tier/common.cpp
+++ b/tt-train/sources/examples/nano_gpt/3tier/common.cpp
@@ -113,8 +113,11 @@ uint32_t round_up_to_tile(uint32_t value, uint32_t tile_size) {
 
 void initialize_device(bool ddp, bool tp) {
     if (ddp || tp) {
-        // currently supports only N300 device
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
+        // FIXME: currently hardcoded for n300
+        ttml::autograd::ctx().open_device(tt::tt_metal::distributed::MeshShape(1, 2));
+    } else {
+        // use single device defaults
+        ttml::autograd::ctx().open_device();
     }
 }
 

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -505,12 +505,12 @@ int main(int argc, char **argv) {
         enable_wandb = false;
     }
 
-    // needs more validation for TP
-    if (config.enable_ddp) {
-        fmt::println("Distributed data parallel is enabled");
-    }
-    if (config.enable_tp) {
-        fmt::println("Tensor parallel is enabled");
+    if (config.enable_ddp || config.enable_tp) {
+        fmt::println("Multidevice config:");
+        fmt::println("  Tensor parallel enabled: {}", config.enable_tp);
+        fmt::println("  Distributed data-parallel enabled: {}", config.enable_ddp);
+        fmt::println("  Mesh shape: {}", config.mesh_shape);
+        fmt::println("  Device IDs: {}", config.device_ids);
     }
 
     if (config.enable_mpi) {
@@ -644,9 +644,6 @@ int main(int argc, char **argv) {
     fmt::print("Dataset size: {}\n", dataset.get_size());
     fmt::print("Vocab size: {}\n", tokenizer->get_vocab_size());
     fmt::print("Tokenizer type: {}\n", config.tokenizer_type);
-
-    fmt::println("Mesh shape: {}", config.mesh_shape);
-    fmt::println("Device IDs: {}", config.device_ids);
 
     initialize_device(config.mesh_shape, config.device_ids);
 

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -451,7 +451,7 @@ DeviceConfig parse_device_config(const YAML::Node &yaml_config) {
     if (!device_node) {
         return config;
     }
-    
+
     config.enable_ddp = device_node["enable_ddp"].as<bool>(false);
     config.enable_tp = device_node["enable_tp"].as<bool>(false);
 

--- a/tt-train/sources/examples/nano_gpt/utils.cpp
+++ b/tt-train/sources/examples/nano_gpt/utils.cpp
@@ -94,8 +94,12 @@ std::unique_ptr<ttml::schedulers::LRSchedulerBase> create_warmup_with_linear_sch
     return std::make_unique<ttml::schedulers::SequentialScheduler>(optimizer, std::move(schedulers), std::move(steps));
 }
 
-void initialize_device(bool ddp, bool tp, tt::tt_metal::distributed::MeshShape mesh_shape) {
+void initialize_device(
+    bool ddp, bool tp, const tt::tt_metal::distributed::MeshShape &mesh_shape, const std::vector<int> &device_ids) {
     if (ddp || tp) {
-        ttml::autograd::ctx().set_mesh_shape(mesh_shape);
+        ttml::autograd::ctx().open_device(mesh_shape, device_ids);
+    } else {
+        // use single-device defaults.
+        ttml::autograd::ctx().open_device();
     }
 }

--- a/tt-train/sources/examples/nano_gpt/utils.cpp
+++ b/tt-train/sources/examples/nano_gpt/utils.cpp
@@ -94,9 +94,8 @@ std::unique_ptr<ttml::schedulers::LRSchedulerBase> create_warmup_with_linear_sch
     return std::make_unique<ttml::schedulers::SequentialScheduler>(optimizer, std::move(schedulers), std::move(steps));
 }
 
-void initialize_device(bool ddp, bool tp) {
+void initialize_device(bool ddp, bool tp, tt::tt_metal::distributed::MeshShape mesh_shape) {
     if (ddp || tp) {
-        // currently supports only N300 device
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
+        ttml::autograd::ctx().set_mesh_shape(mesh_shape);
     }
 }

--- a/tt-train/sources/examples/nano_gpt/utils.cpp
+++ b/tt-train/sources/examples/nano_gpt/utils.cpp
@@ -94,12 +94,6 @@ std::unique_ptr<ttml::schedulers::LRSchedulerBase> create_warmup_with_linear_sch
     return std::make_unique<ttml::schedulers::SequentialScheduler>(optimizer, std::move(schedulers), std::move(steps));
 }
 
-void initialize_device(
-    bool ddp, bool tp, const tt::tt_metal::distributed::MeshShape &mesh_shape, const std::vector<int> &device_ids) {
-    if (ddp || tp) {
-        ttml::autograd::ctx().open_device(mesh_shape, device_ids);
-    } else {
-        // use single-device defaults.
-        ttml::autograd::ctx().open_device();
-    }
+void initialize_device(const tt::tt_metal::distributed::MeshShape &mesh_shape, const std::vector<int> &device_ids) {
+    ttml::autograd::ctx().open_device(mesh_shape, device_ids);
 }

--- a/tt-train/sources/examples/nano_gpt/utils.hpp
+++ b/tt-train/sources/examples/nano_gpt/utils.hpp
@@ -176,5 +176,5 @@ std::string generate_run_name(const std::string &run_name, const TrainingConfig 
 }
 
 void initialize_device(
-    const tt::tt_metal::distributed::MeshShape &mesh_shape = tt::tt_metal::distributed::MeshShape(1, 2),
-    const std::vector<int> &device_ids = std::vector<int>{});
+    const tt::tt_metal::distributed::MeshShape &mesh_shape,
+    const std::vector<int> &device_ids);

--- a/tt-train/sources/examples/nano_gpt/utils.hpp
+++ b/tt-train/sources/examples/nano_gpt/utils.hpp
@@ -175,4 +175,5 @@ std::string generate_run_name(const std::string &run_name, const TrainingConfig 
     return ss.str();
 }
 
-void initialize_device(bool ddp, bool tp);
+void initialize_device(
+    bool ddp, bool tp, tt::tt_metal::distributed::MeshShape mesh_shape = tt::tt_metal::distributed::MeshShape(1, 2));

--- a/tt-train/sources/examples/nano_gpt/utils.hpp
+++ b/tt-train/sources/examples/nano_gpt/utils.hpp
@@ -176,7 +176,5 @@ std::string generate_run_name(const std::string &run_name, const TrainingConfig 
 }
 
 void initialize_device(
-    bool ddp,
-    bool tp,
     const tt::tt_metal::distributed::MeshShape &mesh_shape = tt::tt_metal::distributed::MeshShape(1, 2),
     const std::vector<int> &device_ids = std::vector<int>{});

--- a/tt-train/sources/examples/nano_gpt/utils.hpp
+++ b/tt-train/sources/examples/nano_gpt/utils.hpp
@@ -176,4 +176,7 @@ std::string generate_run_name(const std::string &run_name, const TrainingConfig 
 }
 
 void initialize_device(
-    bool ddp, bool tp, tt::tt_metal::distributed::MeshShape mesh_shape = tt::tt_metal::distributed::MeshShape(1, 2));
+    bool ddp,
+    bool tp,
+    const tt::tt_metal::distributed::MeshShape &mesh_shape = tt::tt_metal::distributed::MeshShape(1, 2),
+    const std::vector<int> &device_ids = std::vector<int>{});

--- a/tt-train/sources/ttml/autograd/auto_context.cpp
+++ b/tt-train/sources/ttml/autograd/auto_context.cpp
@@ -46,11 +46,12 @@ void AutoContext::reset_graph() {
     m_graph.reset();
 }
 
-void AutoContext::open_device(const std::vector<int>* device_ids) {
+void AutoContext::open_device(
+    const tt::tt_metal::distributed::MeshShape& mesh_shape, const std::vector<int>& device_ids) {
     if (m_device) {
         throw std::runtime_error("open_device was called after the device was created.");
     }
-
+    m_mesh_shape = mesh_shape;
     m_device = std::make_unique<core::MeshDevice>(m_mesh_shape, device_ids);
 }
 
@@ -58,7 +59,7 @@ void AutoContext::close_device() {
     m_device = nullptr;
 }
 
-ttnn::distributed::MeshDevice& AutoContext::get_device(const std::vector<int>* device_ids) {
+ttnn::distributed::MeshDevice& AutoContext::get_device() {
     if (!m_device) {
         open_device();
     }
@@ -67,13 +68,6 @@ ttnn::distributed::MeshDevice& AutoContext::get_device(const std::vector<int>* d
 }
 
 AutoContext::AutoContext() : m_generator(m_seed) {
-}
-
-void AutoContext::set_mesh_shape(tt::tt_metal::distributed::MeshShape shape) {
-    if (m_device) {
-        throw std::runtime_error("set_mesh_shape was called after the device was created.");
-    }
-    m_mesh_shape = shape;
 }
 
 tt::tt_metal::distributed::MeshShape AutoContext::get_mesh_shape() const {

--- a/tt-train/sources/ttml/autograd/auto_context.cpp
+++ b/tt-train/sources/ttml/autograd/auto_context.cpp
@@ -46,18 +46,19 @@ void AutoContext::reset_graph() {
     m_graph.reset();
 }
 
-void AutoContext::open_device() {
+void AutoContext::open_device(const std::vector<int>* device_ids) {
     if (m_device) {
         throw std::runtime_error("open_device was called after the device was created.");
     }
-    m_device = std::make_unique<core::MeshDevice>(m_mesh_shape);
+
+    m_device = std::make_unique<core::MeshDevice>(m_mesh_shape, device_ids);
 }
 
 void AutoContext::close_device() {
     m_device = nullptr;
 }
 
-ttnn::distributed::MeshDevice& AutoContext::get_device() {
+ttnn::distributed::MeshDevice& AutoContext::get_device(const std::vector<int>* device_ids) {
     if (!m_device) {
         open_device();
     }

--- a/tt-train/sources/ttml/autograd/auto_context.hpp
+++ b/tt-train/sources/ttml/autograd/auto_context.hpp
@@ -44,12 +44,13 @@ public:
 
     ~AutoContext() = default;  // to make it work with unique_ptr.
 
-    ttnn::distributed::MeshDevice& get_device(const std::vector<int>* device_ids = nullptr);
+    ttnn::distributed::MeshDevice& get_device();
 
-    void set_mesh_shape(tt::tt_metal::distributed::MeshShape shape);
     [[nodiscard]] tt::tt_metal::distributed::MeshShape get_mesh_shape() const;
 
-    void open_device(const std::vector<int>* device_ids = nullptr);
+    void open_device(
+        const tt::tt_metal::distributed::MeshShape& mesh_shape = tt::tt_metal::distributed::MeshShape(1, 1),
+        const std::vector<int>& device_ids = std::vector<int>{});
 
     void close_device();
 

--- a/tt-train/sources/ttml/autograd/auto_context.hpp
+++ b/tt-train/sources/ttml/autograd/auto_context.hpp
@@ -44,12 +44,12 @@ public:
 
     ~AutoContext() = default;  // to make it work with unique_ptr.
 
-    ttnn::distributed::MeshDevice& get_device();
+    ttnn::distributed::MeshDevice& get_device(const std::vector<int>* device_ids = nullptr);
 
     void set_mesh_shape(tt::tt_metal::distributed::MeshShape shape);
     [[nodiscard]] tt::tt_metal::distributed::MeshShape get_mesh_shape() const;
 
-    void open_device();
+    void open_device(const std::vector<int>* device_ids = nullptr);
 
     void close_device();
 

--- a/tt-train/sources/ttml/core/mesh_device.cpp
+++ b/tt-train/sources/ttml/core/mesh_device.cpp
@@ -6,7 +6,7 @@
 
 namespace ttml::core {
 
-MeshDevice::MeshDevice(tt::tt_metal::distributed::MeshShape shape, const std::vector<int> *device_ids) :
+MeshDevice::MeshDevice(const tt::tt_metal::distributed::MeshShape& shape, const std::vector<int>& device_ids) :
     m_mesh_device(ttnn::distributed::open_mesh_device(
         shape,
         DEFAULT_L1_SMALL_SIZE,
@@ -14,7 +14,7 @@ MeshDevice::MeshDevice(tt::tt_metal::distributed::MeshShape shape, const std::ve
         /* num_command_queues=*/1,
         tt::tt_metal::DispatchCoreConfig{},
         /*offset=*/std::nullopt,
-        /*physical_device_ids=*/device_ids ? *device_ids : std::vector<int>{})) {
+        /*physical_device_ids=*/device_ids)) {
     assert(m_mesh_device);
 }
 

--- a/tt-train/sources/ttml/core/mesh_device.cpp
+++ b/tt-train/sources/ttml/core/mesh_device.cpp
@@ -6,13 +6,15 @@
 
 namespace ttml::core {
 
-MeshDevice::MeshDevice(tt::tt_metal::distributed::MeshShape shape) :
+MeshDevice::MeshDevice(tt::tt_metal::distributed::MeshShape shape, const std::vector<int> *device_ids) :
     m_mesh_device(ttnn::distributed::open_mesh_device(
         shape,
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
-        /* num_command_queues*/ 1,
-        tt::tt_metal::DispatchCoreConfig{})) {
+        /* num_command_queues=*/1,
+        tt::tt_metal::DispatchCoreConfig{},
+        /*offset=*/std::nullopt,
+        /*physical_device_ids=*/device_ids ? *device_ids : std::vector<int>{})) {
     assert(m_mesh_device);
 }
 

--- a/tt-train/sources/ttml/core/mesh_device.hpp
+++ b/tt-train/sources/ttml/core/mesh_device.hpp
@@ -11,7 +11,7 @@ namespace ttml::core {
 // should I implement pimpl or its fine
 class MeshDevice {
 public:
-    explicit MeshDevice(tt::tt_metal::distributed::MeshShape shape);
+    explicit MeshDevice(tt::tt_metal::distributed::MeshShape shape, const std::vector<int>* device_ids = nullptr);
     MeshDevice(MeshDevice&& device) = default;
     MeshDevice(const MeshDevice&) = delete;
 

--- a/tt-train/sources/ttml/core/mesh_device.hpp
+++ b/tt-train/sources/ttml/core/mesh_device.hpp
@@ -11,7 +11,7 @@ namespace ttml::core {
 // should I implement pimpl or its fine
 class MeshDevice {
 public:
-    explicit MeshDevice(tt::tt_metal::distributed::MeshShape shape, const std::vector<int>* device_ids = nullptr);
+    explicit MeshDevice(const tt::tt_metal::distributed::MeshShape& shape, const std::vector<int>& device_ids);
     MeshDevice(MeshDevice&& device) = default;
     MeshDevice(const MeshDevice&) = delete;
 

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -26,8 +26,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
-        ttml::autograd::ctx().open_device();
+        ttml::autograd::ctx().open_device(tt::tt_metal::distributed::MeshShape(1, 2));
     }
 
     void TearDown() override {

--- a/tt-train/tests/model/linear_regression_ddp_test.cpp
+++ b/tt-train/tests/model/linear_regression_ddp_test.cpp
@@ -34,8 +34,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
-        ttml::autograd::ctx().open_device();
+        ttml::autograd::ctx().open_device(tt::tt_metal::distributed::MeshShape(1, 2));
     }
 
     void TearDown() override {

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -39,8 +39,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
-        ttml::autograd::ctx().open_device();
+        ttml::autograd::ctx().open_device(tt::tt_metal::distributed::MeshShape(1, 2));
     }
 
     void TearDown() override {

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -29,8 +29,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
-        ttml::autograd::ctx().open_device();
+        ttml::autograd::ctx().open_device(tt::tt_metal::distributed::MeshShape(1, 2));
     }
 
     void TearDown() override {

--- a/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
@@ -27,8 +27,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
-        ttml::autograd::ctx().open_device();
+        ttml::autograd::ctx().open_device(tt::tt_metal::distributed::MeshShape(1, 2));
     }
 
     void TearDown() override {


### PR DESCRIPTION
### Ticket
- Raised on Slack by @anatarajan-tt and cloud team.

### Problem description
We currently use a hardcoded MeshShape and automatically use the entire set of devices available in the transformer training demo, which caused problems for configs like the LLM box without access to the full set of chips and for using larger DDP/TP configurations.

### What's changed
- Adds support for passing the mesh_shape as a 2 element YAML sequence of ints under `training_config->mesh_shape`. When not passed, we currently default to the n300 default shape of [1,2].
- Adds support for passing any set of device ids as a YAML sequence of ints under `training_config->device_ids`. When not passed we use all available devices.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes