### PR TITLE
#0: Remove unused methods on `HostBuffer`

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_host_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_host_buffer.cpp
@@ -22,15 +22,12 @@ using ::testing::Pointwise;
 
 TEST(HostBufferTest, Empty) {
     HostBuffer buffer;
-
-    EXPECT_FALSE(buffer.is_borrowed());
     EXPECT_TRUE(buffer.view_bytes().empty());
 }
 
 TEST(HostBufferTest, BasicOwned) {
     HostBuffer buffer(std::vector<int>{1, 2, 3});
 
-    EXPECT_FALSE(buffer.is_borrowed());
     EXPECT_THAT(buffer.view_as<int>(), Pointwise(Eq(), {1, 2, 3}));
 
     auto writable_view = buffer.view_as<int>();
@@ -49,7 +46,6 @@ TEST(HostBufferTest, BasicBorrowed) {
 
     EXPECT_EQ(num_increments, 1);
     EXPECT_EQ(num_decrements, 0);
-    EXPECT_TRUE(buffer.is_borrowed());
     EXPECT_THAT(buffer.view_as<int>(), Pointwise(Eq(), {1, 2, 3}));
 
     auto writable_view = buffer.view_as<int>();
@@ -62,39 +58,18 @@ TEST(HostBufferTest, IncorrectCast) {
     EXPECT_ANY_THROW({ buffer.view_as<float>(); });
 }
 
-TEST(HostBufferTest, MakePinFromOwned) {
+TEST(HostBufferTest, ShallowCopy) {
     HostBuffer buffer(std::vector<int>{1, 2, 3});
-    HostBuffer borrowed(buffer.view_as<int>(), buffer.pin());
+    HostBuffer copy = buffer;
 
-    EXPECT_FALSE(buffer.is_borrowed());
-    EXPECT_TRUE(borrowed.is_borrowed());
     EXPECT_THAT(buffer.view_as<int>(), Pointwise(Eq(), {1, 2, 3}));
-    EXPECT_THAT(borrowed.view_as<int>(), Pointwise(Eq(), {1, 2, 3}));
+    EXPECT_THAT(copy.view_as<int>(), Pointwise(Eq(), {1, 2, 3}));
 
     auto writable_view = buffer.view_as<int>();
     writable_view[1] = 5;
     EXPECT_THAT(buffer.view_as<int>(), Pointwise(Eq(), {1, 5, 3}));
-    EXPECT_THAT(borrowed.view_as<int>(), Pointwise(Eq(), {1, 5, 3}));
+    EXPECT_THAT(copy.view_as<int>(), Pointwise(Eq(), {1, 5, 3}));
 }
 
-TEST(HostBufferTest, MakePinFromBorrowed) {
-    int num_increments = 0;
-    int num_decrements = 0;
-    std::vector<int> vec = {1, 2, 3};
-    HostBuffer buffer(
-        tt::stl::Span<int>(vec.data(), vec.size()),
-        MemoryPin([&]() { num_increments++; }, [&]() { num_decrements++; }));
-
-    EXPECT_EQ(num_increments, 1);
-    EXPECT_EQ(num_decrements, 0);
-    {
-        HostBuffer borrowed(buffer.view_bytes(), buffer.pin());
-        EXPECT_EQ(num_increments, 2);
-        EXPECT_EQ(num_decrements, 0);
-    }
-
-    EXPECT_EQ(num_increments, 2);
-    EXPECT_EQ(num_decrements, 1);
-}
 }  // namespace
 }  // namespace tt::tt_metal

--- a/tt_metal/common/host_buffer.cpp
+++ b/tt_metal/common/host_buffer.cpp
@@ -14,7 +14,7 @@
 
 namespace tt::tt_metal {
 
-HostBuffer::HostBuffer() : pin_(), view_(tt::stl::Span<std::byte>()), type_info_(nullptr), is_borrowed_(false) {}
+HostBuffer::HostBuffer() : pin_(), view_(tt::stl::Span<std::byte>()), type_info_(nullptr) {}
 
 HostBuffer::HostBuffer(const HostBuffer& other) = default;
 
@@ -36,26 +36,11 @@ void HostBuffer::swap(HostBuffer& other) noexcept {
     swap(pin_, other.pin_);
     swap(view_, other.view_);
     swap(type_info_, other.type_info_);
-    swap(is_borrowed_, other.is_borrowed_);
 }
 
 tt::stl::Span<std::byte> HostBuffer::view_bytes() & noexcept { return view_; }
 
 tt::stl::Span<const std::byte> HostBuffer::view_bytes() const& noexcept { return view_; }
-
-bool HostBuffer::is_borrowed() const { return is_borrowed_; }
-
-HostBuffer HostBuffer::deep_copy() const {
-    auto copied_data = std::make_shared<std::vector<std::byte>>(view_bytes().begin(), view_bytes().end());
-    HostBuffer copy;
-    copy.view_ = tt::stl::Span<std::byte>(copied_data->data(), copied_data->size());
-    copy.pin_ = MemoryPin(copied_data);
-    copy.type_info_ = type_info_;
-    copy.is_borrowed_ = false;
-    return copy;
-}
-
-MemoryPin HostBuffer::pin() const { return pin_; }
 
 bool operator==(const HostBuffer& a, const HostBuffer& b) noexcept {
     auto a_view = a.view_bytes();


### PR DESCRIPTION
### Ticket
N/A

### Problem description
These were originally added to make "borrowing" from one host buffer to another more explicit. This is no longer needed; in practice, copy ctor / assignment works as a shallow copy already.

### What's changed
Remove unused methods.

Also add myself to the corresponding tests owners.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15564591414)
- [X] New/Existing tests provide coverage for changes