### PR TITLE
#0: Introduce TCMalloc as an optional memory allocator in Metal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ message(STATUS "Build with LTO: ${TT_LTO_ENABLED}")
 message(STATUS "Build with Shared TTNN Sublibraries: ${ENABLE_TTNN_SHARED_SUBLIBS}")
 message(STATUS "Build with LightMetal Trace Enabled: ${TT_ENABLE_LIGHT_METAL_TRACE}")
 message(STATUS "Build with Multihost Distributed Compute: ${ENABLE_DISTRIBUTED}")
+message(STATUS "Build with TCMalloc: ${ENABLE_TCMALLOC}")
 
 ############################################################################################################################
 
@@ -143,7 +144,33 @@ endif()
 #   These interface libs are linked with PUBLIC scope at lowest common target (tt_metal/common) and at tt_metal_libs level
 #   in order to propogate to the rest of tt_metal, tt_eager, etc.
 ############################################################################################################################
+
+add_library(tcmalloc INTERFACE)
+if(ENABLE_TCMALLOC)
+    find_library(TCMALLOC_LIB NAMES tcmalloc_minimal)
+    if(TCMALLOC_LIB)
+        message(STATUS "Found TCMalloc: ${TCMALLOC_LIB}")
+        target_compile_options(
+            tcmalloc
+            INTERFACE
+                -fno-builtin-malloc
+                -fno-builtin-calloc
+                -fno-builtin-realloc
+                -fno-builtin-free
+        )
+        target_link_libraries(tcmalloc INTERFACE ${TCMALLOC_LIB})
+    else()
+        message(
+            FATAL_ERROR
+            "TCMalloc requested but not found. Install libtcmalloc-minimal4 or disable with -DENABLE_TCMALLOC=OFF"
+        )
+    endif()
+else()
+    message(STATUS "TCMalloc: Disabled")
+endif()
+
 add_library(metal_common_libs INTERFACE)
+
 target_link_libraries(
     metal_common_libs
     INTERFACE
@@ -152,6 +179,7 @@ target_link_libraries(
         atomic
         hwloc
         numa
+        tcmalloc
 )
 
 add_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,20 +145,21 @@ endif()
 #   in order to propogate to the rest of tt_metal, tt_eager, etc.
 ############################################################################################################################
 
-add_library(tcmalloc INTERFACE)
+# optional_tcmalloc library is an interface for tcmalloc, non-empty only if ENABLE_TCMALLOC is ON.
+add_library(optional_tcmalloc INTERFACE)
 if(ENABLE_TCMALLOC)
     find_library(TCMALLOC_LIB NAMES tcmalloc_minimal)
     if(TCMALLOC_LIB)
         message(STATUS "Found TCMalloc: ${TCMALLOC_LIB}")
         target_compile_options(
-            tcmalloc
+            optional_tcmalloc
             INTERFACE
                 -fno-builtin-malloc
                 -fno-builtin-calloc
                 -fno-builtin-realloc
                 -fno-builtin-free
         )
-        target_link_libraries(tcmalloc INTERFACE ${TCMALLOC_LIB})
+        target_link_libraries(optional_tcmalloc INTERFACE ${TCMALLOC_LIB})
     else()
         message(
             FATAL_ERROR
@@ -179,7 +180,7 @@ target_link_libraries(
         atomic
         hwloc
         numa
-        tcmalloc
+        optional_tcmalloc
 )
 
 add_compile_options(

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -87,7 +87,7 @@ fi
 configure_only="OFF"
 enable_coverage="OFF"
 enable_distributed="ON"
-enable_tcmalloc="ON"
+enable_tcmalloc="OFF"
 with_python_bindings="ON"
 
 declare -a cmake_args

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -41,7 +41,7 @@ show_help() {
     echo "  --configure-only                 Only configure the project, do not build."
     echo "  --enable-coverage                Instrument the binaries for code coverage."
     echo "  --enable-distributed             Enable distributed compute support (OpenMPI)."
-    echo "  --enable-tcmalloc                Enable TCMalloc memory allocator."
+    echo "  --enable-tcmalloc                Build with TCMalloc enabled as the default memory allocator. Provides better performance for host-intensive applications."
     echo "  --without-python-bindings        Disable Python bindings (ttnncpp will be available as standalone library, otherwise ttnn will include the cpp backend and the python bindings), Enabled by default"
 }
 

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -41,6 +41,7 @@ show_help() {
     echo "  --configure-only                 Only configure the project, do not build."
     echo "  --enable-coverage                Instrument the binaries for code coverage."
     echo "  --enable-distributed             Enable distributed compute support (OpenMPI)."
+    echo "  --enable-tcmalloc                Enable TCMalloc memory allocator."
     echo "  --without-python-bindings        Disable Python bindings (ttnncpp will be available as standalone library, otherwise ttnn will include the cpp backend and the python bindings), Enabled by default"
 }
 
@@ -86,6 +87,7 @@ fi
 configure_only="OFF"
 enable_coverage="OFF"
 enable_distributed="ON"
+enable_tcmalloc="ON"
 with_python_bindings="ON"
 
 declare -a cmake_args
@@ -123,6 +125,7 @@ toolchain-path:
 configure-only
 enable-coverage
 enable-distributed
+enable-tcmalloc
 without-python-bindings
 "
 
@@ -153,6 +156,8 @@ while true; do
             enable_coverage="ON";;
         --enable-distributed)
             enable_distributed="ON";;
+        --enable-tcmalloc)
+            enable_tcmalloc="ON";;
 	--build-dir)
             build_dir="$2";shift;;
         -b|--build-type)
@@ -259,6 +264,7 @@ echo "INFO: Enable Unity builds: $unity_builds"
 echo "INFO: TTNN Shared sub libs : $ttnn_shared_sub_libs"
 echo "INFO: Enable Light Metal Trace: $light_metal_trace"
 echo "INFO: Enable Distributed: $enable_distributed"
+echo "INFO: Enable TCMalloc: $enable_tcmalloc"
 echo "INFO: With python bindings: $with_python_bindings"
 
 # Prepare cmake arguments
@@ -377,6 +383,12 @@ if [ "$enable_distributed" = "ON" ]; then
     cmake_args+=("-DENABLE_DISTRIBUTED=ON")
 else
     cmake_args+=("-DENABLE_DISTRIBUTED=OFF")
+fi
+
+if [ "$enable_tcmalloc" = "ON" ]; then
+    cmake_args+=("-DENABLE_TCMALLOC=ON")
+else
+    cmake_args+=("-DENABLE_TCMALLOC=OFF")
 fi
 
 # toolchain and cxx_compiler settings would conflict with eachother

--- a/cmake/project_options.cmake
+++ b/cmake/project_options.cmake
@@ -23,6 +23,7 @@ option(ENABLE_DISTRIBUTED "Enable multihost distributed compute support (OpenMPI
 option(TT_UMD_BUILD_SIMULATION "Force UMD to include its simulation harnessing" ON)
 option(TT_INSTALL "Define installation rules" ON)
 option(TT_USE_SYSTEM_SFPI "Use system path for SFPI. SFPI is used to compile firmware." OFF)
+option(ENABLE_TCMALLOC "Enable TCMalloc memory allocator" OFF)
 
 ###########################################################################################
 

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -13,6 +13,9 @@ COPY /install_dependencies.sh /opt/tt_metal_infra/scripts/docker/install_depende
 COPY /tt_metal/sfpi-version.sh /opt/tt_metal_infra/scripts/docker/sfpi-version.sh
 RUN /bin/bash /opt/tt_metal_infra/scripts/docker/install_dependencies.sh --docker --mode runtime
 
+# Ensure tcmalloc is used as the default memory allocator
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4:${LD_PRELOAD}
+
 #############################################################
 
 FROM base AS ci-build

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -13,6 +13,7 @@ usage()
     echo "[--validate, -v]            Validate that required packages are installed"
     echo "[--docker, -d]              Specialize execution for docker"
     echo "[--no-distributed]          Don't install distributed compute dependencies (OpenMPI)"
+    echo "[--no-tcmalloc]             Don't install tcmalloc"
     echo "[--mode, -m <mode>]         Select installation mode: runtime, build, baremetal"
     exit 1
 }
@@ -38,6 +39,7 @@ fi
 validate=0
 docker=0
 distributed=1
+tcmalloc=1
 mode="baremetal"
 
 while [ $# -gt 0 ]; do
@@ -55,6 +57,10 @@ while [ $# -gt 0 ]; do
             ;;
         --no-distributed)
             distributed=0
+            shift
+            ;;
+        --no-tcmalloc)
+            tcmalloc=0
             shift
             ;;
 	--mode|-m)
@@ -96,6 +102,9 @@ ub_runtime_packages()
     if [ "$distributed" -eq 1 ]; then
         UB_RUNTIME_LIST+=(openmpi-bin)
     fi
+    if [ "$tcmalloc" -eq 1 ]; then
+        UB_RUNTIME_LIST+=(libtcmalloc-minimal4)
+    fi
 }
 
 ub_buildtime_packages()
@@ -121,6 +130,9 @@ ub_buildtime_packages()
 
     if [ "$distributed" -eq 1 ]; then
         UB_BUILDTIME_LIST+=(libopenmpi-dev)
+    fi
+    if [ "$tcmalloc" -eq 1 ]; then
+        UB_BUILDTIME_LIST+=(libtcmalloc-minimal4)
     fi
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(
         small_vector
         Boost::algorithm
         TT::Metalium
+        tcmalloc
 )
 
 if(TT_METAL_BUILD_TESTS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(
         small_vector
         Boost::algorithm
         TT::Metalium
-        tcmalloc
+        optional_tcmalloc
 )
 
 if(TT_METAL_BUILD_TESTS)

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -353,6 +353,7 @@ target_link_libraries(
         Reflect::Reflect
         TT::STL
         tt-logger::tt-logger
+        tcmalloc
     PRIVATE
         Metalium::Metal::Impl
         metal_common_libs
@@ -450,6 +451,7 @@ if(TT_INSTALL)
             span
             small_vector
             tt-logger
+            tcmalloc
         EXPORT Metalium
         FILE_SET
         api

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -353,7 +353,7 @@ target_link_libraries(
         Reflect::Reflect
         TT::STL
         tt-logger::tt-logger
-        tcmalloc
+        optional_tcmalloc
     PRIVATE
         Metalium::Metal::Impl
         metal_common_libs
@@ -451,7 +451,7 @@ if(TT_INSTALL)
             span
             small_vector
             tt-logger
-            tcmalloc
+            optional_tcmalloc
         EXPORT Metalium
         FILE_SET
         api

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(
         umd::Firmware
         umd::device
         simde::simde
+        tcmalloc
     PRIVATE
         Metalium::Metal::Hardware
         Tracy::TracyClient

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(
         umd::Firmware
         umd::device
         simde::simde
-        tcmalloc
+        optional_tcmalloc
     PRIVATE
         Metalium::Metal::Hardware
         Tracy::TracyClient

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -91,7 +91,7 @@ target_include_directories(ttnn_core SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/
 target_link_libraries(
     ttnn_core
     PUBLIC
-        tcmalloc
+        optional_tcmalloc
     PRIVATE
         TT::Metalium
         xtensor
@@ -430,7 +430,7 @@ target_include_directories(
 target_link_libraries(
     ttnncpp
     PUBLIC
-        tcmalloc
+        optional_tcmalloc
     PRIVATE
         TT::Metalium
         TTNN::Core
@@ -528,7 +528,7 @@ if(WITH_PYTHON_BINDINGS)
         ttnn
         PUBLIC
             TTNN::CPP
-            tcmalloc
+            optional_tcmalloc
         PRIVATE
             pybind11::module
             Boost::algorithm

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -90,6 +90,8 @@ target_include_directories(
 target_include_directories(ttnn_core SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers)
 target_link_libraries(
     ttnn_core
+    PUBLIC
+        tcmalloc
     PRIVATE
         TT::Metalium
         xtensor
@@ -427,6 +429,8 @@ target_include_directories(
 
 target_link_libraries(
     ttnncpp
+    PUBLIC
+        tcmalloc
     PRIVATE
         TT::Metalium
         TTNN::Core
@@ -524,6 +528,7 @@ if(WITH_PYTHON_BINDINGS)
         ttnn
         PUBLIC
             TTNN::CPP
+            tcmalloc
         PRIVATE
             pybind11::module
             Boost::algorithm


### PR DESCRIPTION
### Ticket
#23353

### Problem description
As part investigating performance regression on whisper (p100) and falcon 7B (T3K), attempting to use tcmalloc bumps perf roughly by 10% on falcon 7B models.

### What's changed
Introduce TCMalloc as an optional dependency.

There are 2 ways to use TCMalloc - either by building C++ project with TCMalloc linked, or by setting `LD_PRELOAD` env variable. The former method is more robust for monolithic C++ codebases. The latter can be used when using TTNN dynamically - most notably, from Python.

Changes:
1. Add TCMalloc to `instal_dependencies.sh` with the default ON. This allows us to use `LD_PRELOAD` method on CI.
2. However, in Cmake set the default `ENABLE_TCMALLOC` to OFF. This is more user friendly (won't break any consumers), and doesn't force users to deal with dynamic linking. 
3. Modify dockerfiles to set `LD_PRELOAD`, so that TCMalloc is used on CI.

### Perf report
**Falcon 7B**
Out of 3 variants we are measuring perf for, tcmalloc-enabled consistently outperforms on throughput by 10-20%. Data for T3K:
* [wormhole_b0-user_input0-8-perf_mode_128_stochastic_verify]: 11700 prefill (11070 target), 3900 decode (3710 target).
* [wormhole_b0-user_input0-8-perf_mode_1024_stochastic_verify]: 14700 prefill (12200 target), 3600 decode (3434 target).
* [wormhole_b0-user_input0-8-perf_mode_2048_stochastic_verify]: 12500 prefill (10700 target), 3400 decode (3203 target). 

**LLama 3 vision**
* [wormhole_b0-device_params0-1-batch1-trace-normal-mesh_device0]: 13.47 prefill (10.8 target)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes