### PR TITLE
[DM] Directly Write to/Read from L1 for Test Preparation and Checking (Test: One From All)

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/documentation/ideal_performance.md
+++ b/tests/tt_metal/tt_metal/data_movement/documentation/ideal_performance.md
@@ -10,3 +10,4 @@ Units are **Bytes/cycle**.
 | One To One                        | 29            | 60        |
 | One From One                      | 28            | 60        |
 | One To All (Multicast + Linked)   | 19            | 34        |
+| One From All                      | 30            | 60        |

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between a gatherer Tensix core and a grid of sender Tensix cores.
 
 ## Test Flow
-Sharded L1 buffers are created on both the gatherer core and on all the sender cores -making sure that the sender core buffers have a total size equal to the size of the gatherer core buffer. Data is written into the L1 buffer of the sender cores. The gatherer kernel issues read NOC transactions to request a transfer of this data to its L1 buffer. A read barrier is placed after these transactions in order to ensure data validity.
+Data is written directly into the L1 memory of the sender cores. The gatherer kernel issues read NOC transactions to request a transfer of this data from each sender core to its L1 memory. A read barrier is placed after these transactions in order to ensure data validity.
 
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/kernels/gatherer.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/kernels/gatherer.cpp
@@ -8,24 +8,22 @@
 
 // L1 to L1 request
 void kernel_main() {
-    uint32_t dst_addr = get_compile_time_arg_val(0);
+    uint32_t l1_local_addr = get_compile_time_arg_val(0);
     constexpr uint32_t num_of_transactions = get_compile_time_arg_val(1);
-    constexpr uint32_t transaction_num_pages = get_compile_time_arg_val(2);
-    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(3);
-    constexpr uint32_t test_id = get_compile_time_arg_val(4);
-    constexpr uint32_t total_subordinate_cores = get_compile_time_arg_val(5);
+    constexpr uint32_t transaction_size_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t test_id = get_compile_time_arg_val(3);
+    constexpr uint32_t total_subordinate_cores = get_compile_time_arg_val(4);
 
     std::array<uint32_t, total_subordinate_cores> subordinate_l1_byte_addresses;
     std::array<std::array<uint32_t, 2>, total_subordinate_cores> responder_coords;
     uint32_t rt_args_idx = 0;
     for (uint32_t i = 0; i < total_subordinate_cores; i++) {
-        subordinate_l1_byte_addresses[i] = get_arg_val<uint32_t>(rt_args_idx++);
+        subordinate_l1_byte_addresses[i] = l1_local_addr;
         responder_coords[i][0] = get_arg_val<uint32_t>(rt_args_idx++);
         responder_coords[i][1] = get_arg_val<uint32_t>(rt_args_idx++);
     }
 
-    constexpr uint32_t transaction_size_bytes = transaction_num_pages * page_size_bytes;
-    constexpr uint32_t subordinate_size_bytes = num_of_transactions * transaction_num_pages * page_size_bytes;
+    constexpr uint32_t subordinate_size_bytes = num_of_transactions * transaction_size_bytes;
 
     DeviceTimestampedData("Number of transactions", num_of_transactions);
     DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes * total_subordinate_cores);
@@ -42,10 +40,10 @@ void kernel_main() {
                  * Then, we OR it with the local address in each iteration to get the full NOC address. */
                 uint64_t src_noc_addr = src_base_noc_addr | subordinate_l1_byte_addresses[sub_core];
 
-                noc_async_read(src_noc_addr, dst_addr, transaction_size_bytes);
+                noc_async_read(src_noc_addr, l1_local_addr, transaction_size_bytes);
 
                 subordinate_l1_byte_addresses[sub_core] += transaction_size_bytes;
-                dst_addr += transaction_size_bytes;
+                l1_local_addr += transaction_size_bytes;
             }
         }
         noc_async_read_barrier();

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -196,6 +196,9 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromAllDirectedIdeal) {
     // Parameters
     // Ideal: Less transactions, more data per transaction
     uint32_t num_of_transactions = 1;
+    if (max_transmittable_pages % (num_of_transactions * total_subordinate_cores) != 0) {
+        log_error(tt::LogTest, "Max transmittable pages not evenly divisible by transactions and subordinate cores");
+    }
     uint32_t transaction_size_pages = max_transmittable_pages / num_of_transactions / total_subordinate_cores;
 
     // Test config

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -52,19 +52,15 @@ bool run_dm(IDevice* device, const OneFromAllConfig& test_config) {
         tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.master_core_coord);
 
     auto sub_core_list = corerange_to_cores(test_config.subordinate_core_set);
-    // since the version on main has the get_l1_address_and_size return vals hard-coded,
-    // could we just remove this check? or is the function WIP
-    /*
     for (auto& core : sub_core_list) {
         L1AddressInfo subordinate_l1_info = tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, core);
         // Checks that both master and subordinate cores have the same L1 base address and size
         if (master_l1_info.base_address != subordinate_l1_info.base_address ||
             master_l1_info.size != subordinate_l1_info.size) {
-            log_error("Mismatch in L1 address or size between master and subordinate cores");
+            log_error(tt::LogTest, "Mismatch in L1 address or size between master and subordinate cores");
             return false;
         }
     }
-        */
     // Check if the L1 size is sufficient for the test configuration
     if (master_l1_info.size < total_size_bytes) {
         log_error(tt::LogTest, "Insufficient L1 size for the test configuration");

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -42,37 +42,44 @@ bool run_dm(IDevice* device, const OneFromAllConfig& test_config) {
     CoreRangeSet master_core_set({CoreRange(test_config.master_core_coord)});
     size_t total_subordinate_cores = test_config.subordinate_core_set.num_cores();
 
-    const size_t total_size_bytes = test_config.num_of_transactions * test_config.transaction_size_pages *
-                                    test_config.page_size_bytes * total_subordinate_cores;
-    const size_t total_size_pages =
-        test_config.num_of_transactions * test_config.transaction_size_pages * total_subordinate_cores;
+    const size_t transaction_size_bytes = test_config.transaction_size_pages * test_config.page_size_bytes;
+    const size_t total_size_bytes = test_config.num_of_transactions * transaction_size_bytes * total_subordinate_cores;
 
-    auto master_shard_parameters = ShardSpecBuffer(
-        master_core_set,
-        {1, total_size_bytes / 2},
-        ShardOrientation::ROW_MAJOR,
-        {1, test_config.page_size_bytes / 2},
-        {1, total_size_pages});
-    auto master_l1_buffer = CreateBuffer(ShardedBufferConfig{
-        .device = device,
-        .size = total_size_bytes,
-        .page_size = test_config.page_size_bytes,
-        .buffer_type = BufferType::L1,
-        .buffer_layout = TensorMemoryLayout::WIDTH_SHARDED,
-        .shard_parameters = std::move(master_shard_parameters),
-    });
-    uint32_t master_l1_byte_address = master_l1_buffer->address();
+    // Obtain L1 Address for Storing Data
+    // NOTE: We don't know if the whole block of memory is actually available.
+    //       This is something that could probably be checked
+    L1AddressInfo master_l1_info =
+        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.master_core_coord);
 
-    const size_t subordinate_size_bytes =
-        test_config.num_of_transactions * test_config.transaction_size_pages * test_config.page_size_bytes;
-    const size_t subordinate_size_pages = test_config.num_of_transactions * test_config.transaction_size_pages;
+    auto sub_core_list = corerange_to_cores(test_config.subordinate_core_set);
+    // since the version on main has the get_l1_address_and_size return vals hard-coded,
+    // could we just remove this check? or is the function WIP
+    /*
+    for (auto& core : sub_core_list) {
+        L1AddressInfo subordinate_l1_info = tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, core);
+        // Checks that both master and subordinate cores have the same L1 base address and size
+        if (master_l1_info.base_address != subordinate_l1_info.base_address ||
+            master_l1_info.size != subordinate_l1_info.size) {
+            log_error("Mismatch in L1 address or size between master and subordinate cores");
+            return false;
+        }
+    }
+        */
+    // Check if the L1 size is sufficient for the test configuration
+    if (master_l1_info.size < total_size_bytes) {
+        log_error(tt::LogTest, "Insufficient L1 size for the test configuration");
+        return false;
+    }
+    // Assigns a "safe" L1 local address for the master and subordinate cores
+    uint32_t l1_base_address = master_l1_info.base_address;
+
+    const size_t subordinate_size_bytes = test_config.num_of_transactions * transaction_size_bytes;
 
     // Compile-time arguments for kernels
     vector<uint32_t> gatherer_compile_args = {
-        (uint32_t)master_l1_byte_address,
+        (uint32_t)l1_base_address,
         (uint32_t)test_config.num_of_transactions,
-        (uint32_t)test_config.transaction_size_pages,
-        (uint32_t)test_config.page_size_bytes,
+        (uint32_t)transaction_size_bytes,
         (uint32_t)test_config.test_id,
         (uint32_t)total_subordinate_cores,
     };
@@ -90,27 +97,7 @@ bool run_dm(IDevice* device, const OneFromAllConfig& test_config) {
     // Runtime Arguments
     vector<uint32_t> master_runtime_args;
 
-    // Create buffers for each subordinate core and add to runtime args
-    vector<shared_ptr<Buffer>> subordinate_l1_buffers;
-    for (auto& core : corerange_to_cores(test_config.subordinate_core_set)) {
-        auto subordinate_shard_parameters = ShardSpecBuffer(
-            CoreRangeSet({CoreRange(core)}),
-            {1, subordinate_size_bytes / 2},
-            ShardOrientation::ROW_MAJOR,
-            {1, test_config.page_size_bytes / 2},
-            {1, subordinate_size_pages});
-        ShardedBufferConfig subordinate_buffer_config{
-            .device = device,
-            .size = subordinate_size_bytes,
-            .page_size = test_config.page_size_bytes,
-            .buffer_type = BufferType::L1,
-            .buffer_layout = TensorMemoryLayout::WIDTH_SHARDED,
-            .shard_parameters = std::move(subordinate_shard_parameters),
-        };
-        auto subordinate_l1_buffer = CreateBuffer(subordinate_buffer_config);
-        subordinate_l1_buffers.push_back(subordinate_l1_buffer);
-        master_runtime_args.push_back((uint32_t)subordinate_l1_buffer->address());
-
+    for (auto& core : sub_core_list) {
         CoreCoord physical_core = device->worker_core_from_logical_core(core);
         master_runtime_args.push_back(physical_core.x);
         master_runtime_args.push_back(physical_core.y);
@@ -127,18 +114,20 @@ bool run_dm(IDevice* device, const OneFromAllConfig& test_config) {
 
     // Golden output
     vector<uint32_t> packed_golden = packed_input;
-    vector<uint32_t> packed_output;
 
     // Launch program and record outputs
     for (size_t i = 0; i < total_subordinate_cores; i++) {
         auto begin = packed_input.data() + i * subordinate_size_bytes / sizeof(uint32_t);
         auto end = packed_input.data() + (i + 1) * subordinate_size_bytes / sizeof(uint32_t);
-        detail::WriteToBuffer(subordinate_l1_buffers[i], vector<uint32_t>(begin, end));
+        vector<uint32_t> partial_input(begin, end);
+        detail::WriteToDeviceL1(device, sub_core_list[i], l1_base_address, partial_input);
     }
     MetalContext::instance().get_cluster().l1_barrier(device->id());
 
     detail::LaunchProgram(device, program);
-    detail::ReadFromBuffer(master_l1_buffer, packed_output);
+
+    vector<uint32_t> packed_output;
+    detail::ReadFromDeviceL1(device, test_config.master_core_coord, l1_base_address, total_size_bytes, packed_output);
 
     // Results comparison
     bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
@@ -158,23 +147,23 @@ bool run_dm(IDevice* device, const OneFromAllConfig& test_config) {
 
 /* ========== Test case for one from all data movement; Test id = 15 ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
+    // Physical Constraints
+    auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+
     // Parameters
     uint32_t max_transactions = 256;
     uint32_t max_transaction_size_pages = 64;
-    uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
 
     // Cores
     CoreCoord master_core_coord = {0, 0};
     CoreRangeSet subordinate_core_set = {CoreRange(CoreCoord(1, 1), CoreCoord(4, 4))};
     size_t total_subordinate_cores = subordinate_core_set.num_cores();
 
-    uint32_t l1_size = 1024 * 1024;  // 1MB
-
     for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
         for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
              transaction_size_pages *= 2) {
-            if (num_of_transactions * transaction_size_pages * page_size_bytes * total_subordinate_cores >=
-                1024 * 1024) {
+            if (num_of_transactions * transaction_size_pages * total_subordinate_cores > max_transmittable_pages) {
                 continue;
             }
 
@@ -199,21 +188,19 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
 
 /* ========== Test case for one from all data movement; Test id = 30 ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneFromAllDirectedIdeal) {
-    // Parameters
-    uint32_t num_of_transactions, page_size_bytes;
-    uint32_t transaction_size_pages = 128;
-    if (arch_ == tt::ARCH::BLACKHOLE) {
-        page_size_bytes = 64;  // (=flit size): 64 bytes for BH
-        num_of_transactions = 5;
-    } else {
-        page_size_bytes = 32;  // (=flit size): 32 bytes for WH
-        num_of_transactions = 10;
-    }
+    // Physical Constraints
+    auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
 
     // Cores
     CoreCoord master_core_coord = {0, 0};
     CoreRangeSet subordinate_core_set = {CoreRange(CoreCoord(1, 1), CoreCoord(4, 4))};
     size_t total_subordinate_cores = subordinate_core_set.num_cores();
+
+    // Parameters
+    // Ideal: Less transactions, more data per transaction
+    uint32_t num_of_transactions = 1;
+    uint32_t transaction_size_pages = max_transmittable_pages / num_of_transactions / total_subordinate_cores;
 
     // Test config
     unit_tests::dm::core_to_core::OneFromAllConfig test_config = {

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -193,8 +193,8 @@ test_bounds = {
         16: {
             "riscv_0": {"latency": {"lower": 50, "upper": 30000}, "bandwidth": 0.4},
         },
-        30: {
-            "riscv_1": {"latency": {"lower": 20000, "upper": 23500}, "bandwidth": 28},
+        30: {  # One from One Directed Ideal
+            "riscv_1": {"latency": {"lower": 33000, "upper": 35000}, "bandwidth": 30},
         },
         50: {  # One to One Directed Ideal
             "riscv_0": {"latency": {"lower": 28000, "upper": 36000}, "bandwidth": 29},  # 33832
@@ -283,7 +283,9 @@ test_bounds = {
         16: {
             "riscv_0": {"latency": {"lower": 50, "upper": 30000}, "bandwidth": 0.4},
         },
-        30: {"riscv_1": {"latency": {"lower": 10000, "upper": 11500}, "bandwidth": 57}},
+        30: {  # One from One Directed Ideal
+            "riscv_1": {"latency": {"lower": 16500, "upper": 17500}, "bandwidth": 60},
+        },
         50: {  # One to One Directed Ideal
             "riscv_0": {"latency": {"lower": 12000, "upper": 19000}, "bandwidth": 59},  # 17000
         },

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -193,7 +193,7 @@ test_bounds = {
         16: {
             "riscv_0": {"latency": {"lower": 50, "upper": 30000}, "bandwidth": 0.4},
         },
-        30: {  # One from One Directed Ideal
+        30: {  # One from All Directed Ideal
             "riscv_1": {"latency": {"lower": 33000, "upper": 35000}, "bandwidth": 30},
         },
         50: {  # One to One Directed Ideal
@@ -283,7 +283,7 @@ test_bounds = {
         16: {
             "riscv_0": {"latency": {"lower": 50, "upper": 30000}, "bandwidth": 0.4},
         },
-        30: {  # One from One Directed Ideal
+        30: {  # One from All Directed Ideal
             "riscv_1": {"latency": {"lower": 16500, "upper": 17500}, "bandwidth": 60},
         },
         50: {  # One to One Directed Ideal


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22803)

### Problem description
The use of sharded buffers for allocating space on the master and subordinate cores limited the ability of the tests to make use of the entire available L1 spaces on each core. In the case of the One from All tests, this restricted the movement of data amounting to more than half of the available L1 space since a master buffer and a subordinate buffer were each being allocated for all cores, including the master and subordinate cores involved in the transactions.

### What's changed
This has been fixed for the One from All tests. Instead of using sharded buffers, the test now uses the `WriteToDeviceL1()` and `ReadFromDeviceL1()` APIs to set up the subordinate's L1 data and check the master's L1 data respectively.

In addition, at the kernel level, the directed ideal test case now performs a single transaction containing the maximum specified data size, as this is more ideal than performing multiple smaller transactions.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes