### PR TITLE
[Fabric] Add option to launch fabric on limited number of routing planes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -364,7 +364,7 @@ def reset_fabric(fabric_config):
     import ttnn
 
     if fabric_config:
-        ttnn.initialize_fabric_config(ttnn.FabricConfig.DISABLED)
+        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
 
 
 # Set fabric config to passed in value
@@ -375,7 +375,7 @@ def set_fabric(fabric_config):
 
     # If fabric_config is not None, set it to fabric_config
     if fabric_config:
-        ttnn.initialize_fabric_config(fabric_config)
+        ttnn.set_fabric_config(fabric_config)
 
 
 @pytest.fixture(scope="function")

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -94,11 +94,11 @@ public:
 };
 
 class Fabric1DFixture : public BaseFabricFixture {
-    void SetUp() override { this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_1D, 1); }
+    void SetUp() override { this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_1D); }
 };
 
 class Fabric2DFixture : public BaseFabricFixture {
-    void SetUp() override { this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_2D, 1); }
+    void SetUp() override { this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_2D); }
 };
 
 class Fabric2DDynamicFixture : public BaseFabricFixture {

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -26,8 +26,10 @@ class ControlPlaneFixture : public ::testing::Test {
                    "Control plane test suite can only be run with slow dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
                GTEST_SKIP();
            }
+           // reserve max available planes
+           uint8_t num_routing_planes = std::numeric_limits<uint8_t>::max();
            tt::tt_metal::MetalContext::instance().get_cluster().configure_ethernet_cores_for_fabric_routers(
-               tt::tt_metal::FabricConfig::FABRIC_2D);
+               tt::tt_metal::FabricConfig::FABRIC_2D, num_routing_planes);
        }
 
        void TearDown() override {
@@ -44,7 +46,7 @@ public:
     bool slow_dispatch_;
 
     const std::vector<tt::tt_metal::IDevice*>& get_devices() const { return devices_; }
-    void SetUpDevices(tt_metal::FabricConfig fabric_config) {
+    void SetUpDevices(tt_metal::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt) {
         slow_dispatch_ = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch_) {
             log_info(tt::LogTest, "Running fabric api tests with slow dispatch");
@@ -58,7 +60,7 @@ public:
         for (unsigned int id = 0; id < num_devices; id++) {
             ids.push_back(id);
         }
-        tt::tt_metal::detail::InitializeFabricConfig(fabric_config);
+        tt::tt_metal::detail::SetFabricConfig(fabric_config, num_routing_planes);
         devices_map_ = tt::tt_metal::detail::CreateDevices(ids);
         for (auto& [id, device] : devices_map_) {
             devices_.push_back(device);
@@ -87,16 +89,16 @@ public:
 
     void TearDown() override {
         tt::tt_metal::detail::CloseDevices(devices_map_);
-        tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
     }
 };
 
 class Fabric1DFixture : public BaseFabricFixture {
-    void SetUp() override { this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_1D); }
+    void SetUp() override { this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_1D, 1); }
 };
 
 class Fabric2DFixture : public BaseFabricFixture {
-    void SetUp() override { this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_2D); }
+    void SetUp() override { this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_2D, 1); }
 };
 
 class Fabric2DDynamicFixture : public BaseFabricFixture {

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -159,7 +159,7 @@ protected:
             (config_.num_cqs >= 2 and is_n300_or_t3k_cluster) ? DispatchCoreType::ETH : DispatchCoreType::WORKER;
 
         if (config_.fabric_config != FabricConfig::DISABLED) {
-            tt::tt_metal::detail::InitializeFabricConfig(config_.fabric_config);
+            tt::tt_metal::detail::SetFabricConfig(config_.fabric_config);
         }
         mesh_device_ = MeshDevice::create(
             MeshDeviceConfig(get_mesh_shape(*mesh_device_type)),
@@ -178,7 +178,7 @@ protected:
         mesh_device_->close();
         mesh_device_.reset();
         if (config_.fabric_config != FabricConfig::DISABLED) {
-            tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+            tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
         }
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -169,7 +169,7 @@ struct test_board_t {
             throw std::runtime_error("Odd number of chips detected, not supported currently");
         }
 
-        tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::CUSTOM);
+        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::CUSTOM);
 
         device_handle_map = tt::tt_metal::detail::CreateDevices(available_chip_ids);
         control_plane = &tt::tt_metal::MetalContext::instance().get_control_plane();

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -107,10 +107,10 @@ public:
     BaseFabricFixture() : device_open(false) {}
 
     BaseFabricFixture(tt::tt_metal::FabricConfig fabric_config) : device_open(false) {
-        tt::tt_metal::detail::InitializeFabricConfig(fabric_config);
+        tt::tt_metal::detail::SetFabricConfig(fabric_config);
     }
 
-    virtual ~BaseFabricFixture() { tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::DISABLED); }
+    virtual ~BaseFabricFixture() { tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED); }
 
     virtual void SetupDevices() = 0;
     virtual void TearDown() = 0;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -45,11 +45,11 @@ std::vector<IDevice*> get_line_devices(distributed::MeshDevice* mesh_device) {
 class T3000MultiCQFabricMeshDeviceFixture : public T3000MultiCQMeshDeviceFixture {
 protected:
     T3000MultiCQFabricMeshDeviceFixture() {
-        tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::FABRIC_1D);
+        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::FABRIC_1D);
     }
     void TearDown() override {
         T3000MultiCQMeshDeviceFixture::TearDown();
-        tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
     }
 };
 

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -54,11 +54,11 @@ using tt::tt_metal::distributed::MeshShape;
 class T3000MultiCQFabricMeshDeviceFixture : public T3000MultiCQMeshDeviceFixture {
 protected:
     T3000MultiCQFabricMeshDeviceFixture() {
-        tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::FABRIC_1D);
+        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::FABRIC_1D);
     }
     void TearDown() override {
         T3000MultiCQMeshDeviceFixture::TearDown();
-        tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
     }
 };
 

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -41,7 +41,7 @@ namespace detail {
 bool DispatchStateCheck(bool isFastDispatch);
 
 // Call before CreateDevices to enable fabric, which uses all free ethernet cores
-void InitializeFabricConfig(FabricConfig fabric_config);
+void SetFabricConfig(FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt);
 
 std::map<chip_id_t, IDevice*> CreateDevices(
     // TODO: delete this in favour of DevicePool

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -40,7 +40,21 @@ namespace detail {
 
 bool DispatchStateCheck(bool isFastDispatch);
 
-// Call before CreateDevices to enable fabric, which uses all free ethernet cores
+/**
+ * Call before CreateDevices to enable fabric, which uses the specified number of routing planes.
+ * Currently, setting num_routing_planes dictates how many routing planes the fabric should be active on
+ * for that init sequence. The number of routing planes fabric will be initialized on will be the max
+ * of all the values specified by different clients. If a client wants to initialize fabric on all the
+ * available routing planes, num_routing_planes can be left unspecifed.
+ * NOTE: This does not 'reserve' routing planes for any clients, but is rather a global setting.
+ *
+ * Return value: void
+ *
+ * | Argument           | Description                         | Data type         | Valid range | Required |
+ * |--------------------|-------------------------------------|-------------------|-------------|----------|
+ * | fabric_config      | Fabric config to set                | FabricConfig      |             | Yes      |
+ * | num_routing_planes | Number of routing planes for fabric | optional<uint8_t> |             | Yes      |
+ */
 void SetFabricConfig(FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt);
 
 std::map<chip_id_t, IDevice*> CreateDevices(

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -53,7 +53,7 @@ bool DispatchStateCheck(bool isFastDispatch);
  * | Argument           | Description                         | Data type         | Valid range | Required |
  * |--------------------|-------------------------------------|-------------------|-------------|----------|
  * | fabric_config      | Fabric config to set                | FabricConfig      |             | Yes      |
- * | num_routing_planes | Number of routing planes for fabric | optional<uint8_t> |             | Yes      |
+ * | num_routing_planes | Number of routing planes for fabric | optional<uint8_t> |             | No       |
  */
 void SetFabricConfig(FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt);
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -267,7 +267,7 @@ void MetalContext::set_default_control_plane_mesh_graph() {
     this->set_fabric_config(fabric_config_);
 }
 
-void MetalContext::deinitialize_fabric_config() {
+void MetalContext::teardown_fabric_config() {
     this->cluster_->configure_ethernet_cores_for_fabric_routers(tt_metal::FabricConfig::DISABLED);
     this->get_control_plane().clear_fabric_context();
 }
@@ -291,7 +291,7 @@ void MetalContext::set_fabric_config(
                 "Got num_routing_planes while disabling fabric, ignoring it and disabling all active routing planes");
         }
 
-        this->deinitialize_fabric_config();
+        this->teardown_fabric_config();
         return;
     }
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -256,7 +256,7 @@ void MetalContext::set_custom_control_plane_mesh_graph(
 
     global_control_plane_ = std::make_unique<tt::tt_fabric::GlobalControlPlane>(
         mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
-    this->initialize_fabric_config(fabric_config_);
+    this->set_fabric_config(fabric_config_);
 }
 
 void MetalContext::set_default_control_plane_mesh_graph() {
@@ -264,23 +264,70 @@ void MetalContext::set_default_control_plane_mesh_graph() {
         !DevicePool::is_initialized() || DevicePool::instance().get_all_active_devices().size() == 0,
         "Modifying control plane requires no devices to be active");
     global_control_plane_.reset();
-    this->initialize_fabric_config(fabric_config_);
+    this->set_fabric_config(fabric_config_);
 }
 
-void MetalContext::initialize_fabric_config(tt_metal::FabricConfig fabric_config) {
-    fabric_config_ = fabric_config;
-    cluster_->configure_ethernet_cores_for_fabric_routers(fabric_config);
+void MetalContext::deinitialize_fabric_config() {
+    this->cluster_->configure_ethernet_cores_for_fabric_routers(tt_metal::FabricConfig::DISABLED);
+    this->get_control_plane().clear_fabric_context();
+}
 
-    // Initialize fabric context in control plane if fabric is enabled
-    if (fabric_config != tt_metal::FabricConfig::DISABLED) {
-        if (tt::tt_fabric::is_tt_fabric_config(fabric_config)) {
-            this->get_control_plane().initialize_fabric_context(fabric_config);
-        }
+void MetalContext::set_fabric_config(
+    const tt_metal::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes) {
+    if (this->fabric_config_ == tt_metal::FabricConfig::DISABLED || fabric_config == tt_metal::FabricConfig::DISABLED) {
+        this->fabric_config_ = fabric_config;
     } else {
-        this->get_control_plane().clear_fabric_context();
+        TT_FATAL(
+            this->fabric_config_ == fabric_config,
+            "Tried to override previous value of fabric config: {}, with: {}",
+            this->fabric_config_,
+            fabric_config);
     }
 
-    this->get_control_plane().configure_routing_tables_for_fabric_ethernet_channels();
+    if (this->fabric_config_ == tt_metal::FabricConfig::DISABLED) {
+        if (num_routing_planes.has_value()) {
+            log_warning(
+                tt::LogMetal,
+                "Got num_routing_planes while disabling fabric, ignoring it and disabling all active routing planes");
+        }
+
+        this->deinitialize_fabric_config();
+        return;
+    }
+
+    if (num_routing_planes.has_value() && num_routing_planes.value() < this->num_fabric_active_routing_planes_) {
+        log_warning(
+            tt::LogMetal,
+            "Got num_routing_planes: {}, which is less than current value: {}, ignoring the override",
+            num_routing_planes.value(),
+            this->num_fabric_active_routing_planes_);
+        return;
+    }
+
+    // if num_routing_planes is not specified, use max avaialble number of routing planes
+    // ideally the highest value should be the maximum number of eth cores in a direction across all chips
+    const auto new_val = std::max(
+        this->num_fabric_active_routing_planes_, num_routing_planes.value_or(std::numeric_limits<uint8_t>::max()));
+    if (new_val != this->num_fabric_active_routing_planes_ && this->num_fabric_active_routing_planes_ > 0) {
+        log_info(
+            tt::LogMetal,
+            "Overriding the number of routing planes to activate from {} to {}",
+            this->num_fabric_active_routing_planes_,
+            new_val);
+    }
+    this->num_fabric_active_routing_planes_ = new_val;
+}
+
+void MetalContext::initialize_fabric_config() {
+    if (this->fabric_config_ == tt_metal::FabricConfig::DISABLED) {
+        return;
+    }
+
+    this->cluster_->configure_ethernet_cores_for_fabric_routers(
+        this->fabric_config_, this->num_fabric_active_routing_planes_);
+    auto& control_plane = this->get_control_plane();
+    control_plane.initialize_fabric_context(this->fabric_config_);
+    control_plane.configure_routing_tables_for_fabric_ethernet_channels();
 }
 
 tt_metal::FabricConfig MetalContext::get_fabric_config() const {

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -326,7 +326,9 @@ void MetalContext::initialize_fabric_config() {
     this->cluster_->configure_ethernet_cores_for_fabric_routers(
         this->fabric_config_, this->num_fabric_active_routing_planes_);
     auto& control_plane = this->get_control_plane();
-    control_plane.initialize_fabric_context(this->fabric_config_);
+    if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
+        control_plane.initialize_fabric_context(this->fabric_config_);
+    }
     control_plane.configure_routing_tables_for_fabric_ethernet_channels();
 }
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -304,7 +304,7 @@ void MetalContext::set_fabric_config(
         return;
     }
 
-    // if num_routing_planes is not specified, use max avaialble number of routing planes
+    // if num_routing_planes is not specified, use max available number of routing planes
     // ideally the highest value should be the maximum number of eth cores in a direction across all chips
     const auto new_val = std::max(
         this->num_fabric_active_routing_planes_, num_routing_planes.value_or(std::numeric_limits<uint8_t>::max()));

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -67,7 +67,9 @@ public:
         const std::string& mesh_graph_desc_file,
         const std::map<tt_fabric::FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping);
     void set_default_control_plane_mesh_graph();
-    void initialize_fabric_config(tt_metal::FabricConfig fabric_config);
+    void set_fabric_config(
+        tt_metal::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt);
+    void initialize_fabric_config();
     tt_metal::FabricConfig get_fabric_config() const;
 
 private:
@@ -80,6 +82,7 @@ private:
     void clear_dram_state(chip_id_t device_id);
     void clear_launch_messages_on_eth_cores(chip_id_t device_id);
     void initialize_control_plane();
+    void deinitialize_fabric_config();
 
     bool initialized_ = false;
     bool teardown_registered_ = false;
@@ -101,6 +104,7 @@ private:
     std::array<std::unique_ptr<DispatchMemMap>, magic_enum::enum_count<CoreType>()> dispatch_mem_map_;
     std::unique_ptr<tt::tt_fabric::GlobalControlPlane> global_control_plane_;
     tt_metal::FabricConfig fabric_config_ = tt_metal::FabricConfig::DISABLED;
+    uint8_t num_fabric_active_routing_planes_ = 0;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -82,7 +82,7 @@ private:
     void clear_dram_state(chip_id_t device_id);
     void clear_launch_messages_on_eth_cores(chip_id_t device_id);
     void initialize_control_plane();
-    void deinitialize_fabric_config();
+    void teardown_fabric_config();
 
     bool initialized_ = false;
     bool teardown_registered_ = false;

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -315,6 +315,7 @@ void DevicePool::initialize_active_devices() const {
     const auto& active_devices = this->get_all_active_devices();
 
     // Activate fabric (must be before FD)
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
     FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (tt_fabric::is_tt_fabric_config(fabric_config)) {
         log_info(tt::LogMetal, "Initializing Fabric");

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -272,6 +272,11 @@ void DevicePool::initialize(
             "consider using CreateDevices API.");
     }
 
+    // Need to reserve eth cores for fabric before we initialize individual devices to maintain consistent state
+    // while initializing default sub device state.
+    // This call will be a no-op if fabric is disabled.
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+
     _inst->skip_remote_devices = skip;
     _inst->use_max_eth_core_count_on_all_devices_ = use_max_eth_core_count_on_all_devices;
     _inst->add_devices_to_pool(device_ids);
@@ -315,7 +320,6 @@ void DevicePool::initialize_active_devices() const {
     const auto& active_devices = this->get_all_active_devices();
 
     // Activate fabric (must be before FD)
-    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
     FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (tt_fabric::is_tt_fabric_config(fabric_config)) {
         log_info(tt::LogMetal, "Initializing Fabric");

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1191,7 +1191,7 @@ void Cluster::reserve_ethernet_cores_for_fabric_routers(uint8_t num_routing_plan
                     continue;
                 }
 
-                if (this->device_eth_routing_info_.at(chip_id).at(eth_core) == EthRouterMode::IDLE &&
+                if (this->device_eth_routing_info_[chip_id][eth_core] == EthRouterMode::IDLE &&
                     this->device_eth_routing_info_.at(connnected_chip_id).at(connected_core) == EthRouterMode::IDLE) {
                     this->device_eth_routing_info_[chip_id][eth_core] = EthRouterMode::FABRIC_ROUTER;
                     this->device_eth_routing_info_[connnected_chip_id][connected_core] = EthRouterMode::FABRIC_ROUTER;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1210,6 +1210,7 @@ void Cluster::reserve_ethernet_cores_for_fabric_routers(uint8_t num_routing_plan
     }
 
     // re-init sockets to reflect fabric routing
+    this->ethernet_sockets_.clear();
     this->initialize_ethernet_sockets();
 }
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1139,24 +1139,78 @@ std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
     return active_ethernet_cores;
 }
 
-void Cluster::configure_ethernet_cores_for_fabric_routers(tt_metal::FabricConfig fabric_config) {
+void Cluster::configure_ethernet_cores_for_fabric_routers(
+    tt_metal::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes) {
     if (fabric_config != tt_metal::FabricConfig::DISABLED) {
-        this->reserve_ethernet_cores_for_fabric_routers();
+        TT_FATAL(num_routing_planes.has_value(), "num_routing_planes should be set for reserving cores for fabric");
+        TT_FATAL(num_routing_planes.value() > 0, "Expected non-zero num_routing_planes for reserving cores for fabric");
+        this->reserve_ethernet_cores_for_fabric_routers(num_routing_planes.value());
     } else {
+        if (num_routing_planes.has_value()) {
+            log_warning(
+                tt::LogMetal,
+                "Got num_routing_planes while releasing fabric cores, ignoring it and releasing all reserved cores");
+        }
         this->release_ethernet_cores_for_fabric_routers();
     }
 }
 
-void Cluster::reserve_ethernet_cores_for_fabric_routers() {
-    for (const auto& [chip_id, eth_cores] : this->device_eth_routing_info_) {
-        for (const auto& [eth_core, mode] : eth_cores) {
-            if (mode == EthRouterMode::IDLE) {
-                this->device_eth_routing_info_[chip_id][eth_core] = EthRouterMode::FABRIC_ROUTER;
+void Cluster::reserve_ethernet_cores_for_fabric_routers(uint8_t num_routing_planes) {
+    if (num_routing_planes == std::numeric_limits<uint8_t>::max()) {
+        // default behavior, reserve whatever cores are available
+        for (const auto& [chip_id, eth_cores] : this->device_eth_routing_info_) {
+            for (const auto& [eth_core, mode] : eth_cores) {
+                if (mode == EthRouterMode::IDLE) {
+                    this->device_eth_routing_info_[chip_id][eth_core] = EthRouterMode::FABRIC_ROUTER;
+                }
             }
         }
+
+        // Update sockets to reflect fabric routing
+        this->ethernet_sockets_.clear();
+        return;
     }
-    // Update sockets to reflect fabric routing
-    this->ethernet_sockets_.clear();
+
+    // to reserve specified number of cores, ensure that the same are avaialble on connected chip id as well
+    for (const auto& chip_id : this->driver_->get_target_device_ids()) {
+        const auto& connected_chips_and_cores = this->get_ethernet_cores_grouped_by_connected_chips(chip_id);
+        for (const auto& [connnected_chip_id, cores] : connected_chips_and_cores) {
+            const uint8_t num_cores_to_reserve = std::min(num_routing_planes, static_cast<uint8_t>(cores.size()));
+            uint8_t num_reserved_cores = 0;
+            for (auto i = 0; i < cores.size(); i++) {
+                if (num_reserved_cores == num_cores_to_reserve) {
+                    break;
+                }
+
+                const auto eth_core = cores[i];
+                const auto connected_core =
+                    std::get<1>(this->get_connected_ethernet_core(std::make_tuple(chip_id, eth_core)));
+                if (this->device_eth_routing_info_.at(chip_id).at(eth_core) == EthRouterMode::FABRIC_ROUTER) {
+                    // already reserved for fabric, potenially by the connected chip id
+                    num_reserved_cores++;
+                    continue;
+                }
+
+                if (this->device_eth_routing_info_.at(chip_id).at(eth_core) == EthRouterMode::IDLE &&
+                    this->device_eth_routing_info_.at(connnected_chip_id).at(connected_core) == EthRouterMode::IDLE) {
+                    this->device_eth_routing_info_[chip_id][eth_core] = EthRouterMode::FABRIC_ROUTER;
+                    this->device_eth_routing_info_[connnected_chip_id][connected_core] = EthRouterMode::FABRIC_ROUTER;
+                    num_reserved_cores++;
+                }
+            }
+
+            TT_FATAL(
+                num_reserved_cores == num_cores_to_reserve,
+                "Unable to reserve {} routing planes b/w chip {} and {} for fabric, reserved only {}",
+                num_cores_to_reserve,
+                chip_id,
+                connnected_chip_id,
+                num_reserved_cores);
+        }
+    }
+
+    // re-init sockets to reflect fabric routing
+    this->initialize_ethernet_sockets();
 }
 
 void Cluster::release_ethernet_cores_for_fabric_routers() {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -303,7 +303,8 @@ public:
     }
 
     // Configures ethernet cores for fabric routers depending on whether fabric is enabled
-    void configure_ethernet_cores_for_fabric_routers(tt_metal::FabricConfig fabric_config);
+    void configure_ethernet_cores_for_fabric_routers(
+        tt_metal::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt);
 
     // Returns whether we are running on Galaxy.
     bool is_galaxy_cluster() const;
@@ -395,8 +396,8 @@ private:
     // If any device has to board type of GALAXY, we are on a TG cluster.
     ClusterType cluster_type_ = ClusterType::INVALID;
 
-    // Reserves all free ethernet cores for fabric routers
-    void reserve_ethernet_cores_for_fabric_routers();
+    // Reserves specified number of ethernet cores for fabric routers
+    void reserve_ethernet_cores_for_fabric_routers(uint8_t num_routing_planes);
 
     // Releases all reserved ethernet cores for fabric routers
     void release_ethernet_cores_for_fabric_routers();

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -375,8 +375,8 @@ bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t 
     return true;
 }
 
-void InitializeFabricConfig(FabricConfig fabric_config) {
-    tt::tt_metal::MetalContext::instance().initialize_fabric_config(fabric_config);
+void SetFabricConfig(FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes) {
+    tt::tt_metal::MetalContext::instance().set_fabric_config(fabric_config, num_routing_planes);
 }
 
 std::map<chip_id_t, IDevice*> CreateDevices(

--- a/ttnn/cpp/ttnn-pybind/fabric.cpp
+++ b/ttnn/cpp/ttnn-pybind/fabric.cpp
@@ -20,7 +20,11 @@ void py_bind_fabric_api(py::module& module) {
         .value("FABRIC_2D", tt::tt_metal::FabricConfig::FABRIC_2D)
         .value("CUSTOM", tt::tt_metal::FabricConfig::CUSTOM);  // DISABLED = 0, FABRIC_1D = 1, FABRIC_2D = 2, CUSTOM = 4
 
-    module.def("initialize_fabric_config", &tt::tt_metal::detail::InitializeFabricConfig, py::arg("config"));
+    module.def(
+        "set_fabric_config",
+        &tt::tt_metal::detail::SetFabricConfig,
+        py::arg("config"),
+        py::arg("num_planes") = std::nullopt);
 }
 
 }  // namespace ttnn::fabric

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -131,7 +131,7 @@ from ttnn._ttnn.global_circular_buffer import (
     create_global_circular_buffer,
 )
 
-from ttnn._ttnn.fabric import FabricConfig, initialize_fabric_config
+from ttnn._ttnn.fabric import FabricConfig, set_fabric_config
 
 from ttnn._ttnn.global_semaphore import (
     create_global_semaphore,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23464)

### Problem description
Currently if fabric is enabled, we reserve all the available idle eth cores to run fabric routers. This was okay since we usually had OPs as the only workloads needing fabric and hence running fabric on all possible eth cores was fine. But with additional clients such as FD, we do not always need to run fabric on all the cores. This additionally has a side-effect when a test/workload needs FD but also needs eth cores, in which case there wont be any eth cores available for the test/workload to use.

### What's changed
1. Renamed the existing `InitializeFabricConfig` API to `SetFabricConfig` and added an optional parameter to specify the number of routing planes to use.
2. `SetFabricConfig` now essentially 'collects' the configurations needed for fabric before initializing the fabric fw. For instance in the case when FD requests only 1 routing plane and there is another workload requesting all of the available planes, we will launch on all the planes.
3. Updated the functionality of `initialize_fabric_config`. This now gets called at the very last moment (lazy init) instead of getting called over and over again.
4. Added an explicit `deinitialize_fabric_config` method to handle the case when fabric config is set as `FabricConfig::DISABLED`. This now gets called from `SetFabricConfig` whenever the fabric config is disabled.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15595991713)
- [x]  [T3K Unit] (https://github.com/tenstorrent/tt-metal/actions/runs/15595971484)
- [x]  [TG Unit] (https://github.com/tenstorrent/tt-metal/actions/runs/15591388221)
- [x]  [T3K Frequent] (https://github.com/tenstorrent/tt-metal/actions/runs/15586390451)
- [x]  [T3K Nightly] (https://github.com/tenstorrent/tt-metal/actions/runs/15586378209)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes