### PR TITLE
Remove skip for BH in model inference test, passes in CI

### DIFF
--- a/models/tt_transformers/tests/test_model.py
+++ b/models/tt_transformers/tests/test_model.py
@@ -16,7 +16,6 @@ from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
 
 @torch.no_grad()
 @skip_for_grayskull("Requires wormhole_b0 to run")
-# @skip_for_blackhole("Failing on DRAM harvested P100a, see #21419")
 @pytest.mark.timeout(1800)
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(

--- a/models/tt_transformers/tests/test_model.py
+++ b/models/tt_transformers/tests/test_model.py
@@ -11,12 +11,12 @@ import ttnn
 from models.tt_transformers.tt.common import PagedAttentionConfig, sample_host
 from models.tt_transformers.tt.model import Transformer
 from models.tt_transformers.tt.model_config import CheckpointType, DecodersPrecision, ModelArgs
-from models.utility_functions import comp_allclose, comp_pcc, skip_for_blackhole, skip_for_grayskull
+from models.utility_functions import comp_allclose, comp_pcc, skip_for_grayskull
 
 
 @torch.no_grad()
 @skip_for_grayskull("Requires wormhole_b0 to run")
-@skip_for_blackhole("Failing on DRAM harvested P100a, see #21419")
+# @skip_for_blackhole("Failing on DRAM harvested P100a, see #21419")
 @pytest.mark.timeout(1800)
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/21419)

### Problem description
DRAM Harvesting error for model inference test on P100 (no longer breaking in CI and Local)

### What's changed
Issue seems to have been fixed, passes here (with skip commented out) and passes locally with Mistral:
https://github.com/tenstorrent/tt-metal/actions/runs/15545831636/job/43768157266

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15545831636/job/43768157266)