### PR TITLE
#21997: [skip ci] Create initial BH QB pipeline

### DIFF
--- a/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
@@ -1,0 +1,90 @@
+name: "[internal] Blackhole LLMBox Demo tests impl"
+
+on:
+  workflow_call:
+    inputs:
+      build-artifact-name:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+      docker-image:
+        required: true
+        type: string
+      runner-label:
+        required: false
+        type: string
+        default: "BH-LLMBox"
+
+jobs:
+  single-card-demo-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          {
+            name: "llama3-8b quietbox data-parallel=4 performance",
+            arch: blackhole,
+            cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 4,
+            owner_id: U05RWH3QUPM # Salar Hosseini
+          }
+        ]
+    name: ${{ matrix.test-group.name }}
+    runs-on: ["in-service", "${{ inputs.runner-label }}", "pipeline-perf"]
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: ⬇️ Download Build
+        uses: actions/download-artifact@v4
+        timeout-minutes: 10
+        with:
+          name: ${{ inputs.build-artifact-name }}
+      - name: Extract files
+        run: tar -xvf ttm_any.tar
+      - name: ⬇️ Download Wheel
+        uses: actions/download-artifact@v4
+        timeout-minutes: 10
+        with:
+          name: ${{ inputs.wheel-artifact-name }}
+      - name: Enable Performance mode
+        if: ${{ contains(matrix.test-group.name, 'performance') }}
+        run: |
+          sudo cpupower frequency-set -g performance
+      - name: Run demo regression tests
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 70
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-group.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e HF_TOKEN=${{ secrets.HUGGINGFACE_TOKEN }}
+            -v /localdev/blackhole_demos:/localdev/blackhole_demos:ro
+          install_wheel: true
+          run_args: |
+            if [[ "${{ matrix.test-group.name }}" == *"llama"* ]]; then
+              pip install -r ${{ github.workspace }}/models/tt_transformers/requirements.txt
+            fi
+            ${{ matrix.test-group.cmd }}
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          path: generated/test_reports/
+          prefix: "test_reports_"
+      - name: Disable Performance mode
+        if: ${{ contains(matrix.test-group.name, 'performance') }}
+        run: |
+          sudo cpupower frequency-set -g ondemand
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: ${{ matrix.test-group.owner_id }}

--- a/.github/workflows/blackhole-llmbox-fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/blackhole-llmbox-fabric-build-and-unit-tests.yaml
@@ -34,7 +34,7 @@ jobs:
           {name: fabric 1D unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D.*" },
           {name: fabric 2D fixture unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*" },
           {name: fabric system health tests, cmd: ./build/test/tt_metal/tt_fabric/test_system_health },
-          {name: t3000 fast fabric tests, cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests" },
+          # {name: t3000 fast fabric tests, cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests" },
         ]
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on: >-
@@ -51,7 +51,6 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         PYTHONPATH: /work
         TT_METAL_HOME: /work
-        TT_METAL_SLOW_DISPATCH_MODE: 1
         GTEST_OUTPUT: xml:/work/generated/test_reports/
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691

--- a/.github/workflows/blackhole-llmbox-fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/blackhole-llmbox-fabric-build-and-unit-tests.yaml
@@ -1,0 +1,87 @@
+name: "[internal] Blackhole LLMBox Fabric unit tests impl"
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      runner-label:
+        required: true
+        type: string
+      timeout:
+        required: false
+        type: number
+        default: 10
+      build-artifact-name:
+        required: true
+        type: string
+      docker-image:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+
+jobs:
+  fabric-tests:
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+      fail-fast: false
+      matrix:
+        test-group: [
+          {name: fabric 1D unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D.*" },
+          {name: fabric 2D fixture unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*" },
+          {name: fabric system health tests, cmd: ./build/test/tt_metal/tt_fabric/test_system_health },
+          {name: t3000 fast fabric tests, cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests" },
+        ]
+    name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
+    runs-on: >-
+      ${{
+        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        || github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
+      }}
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved' }}
+      env:
+        ARCH_NAME: ${{ inputs.arch }}
+        LOGURU_LEVEL: INFO
+        LD_LIBRARY_PATH: /work/build/lib
+        PYTHONPATH: /work
+        TT_METAL_HOME: /work
+        TT_METAL_SLOW_DISPATCH_MODE: 1
+        GTEST_OUTPUT: xml:/work/generated/test_reports/
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    steps:
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: ${{ matrix.test-group.name }} tests
+        timeout-minutes: ${{ inputs.timeout }}
+        run: |
+          ${{ matrix.test-group.cmd }}
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: U06CXU895AP # Michael Chiou
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - name: Generate gtest annotations on failure
+        uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
+        if: ${{ failure() }}

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -27,61 +27,61 @@ jobs:
     with:
       build-wheel: true
       version: 22.04
-  bh-nightly:
-    needs: build-artifact
-    uses: ./.github/workflows/blackhole-nightly-tests-impl.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
-    secrets: inherit
-    with:
-      runner-label: ${{ matrix.card_type }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  ttnn-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/ttnn-post-commit.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.card_type }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  ttnn-l2-tests:
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/tt-metal-l2-nightly-impl.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.card_type }}
-      timeout: 120
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  didt-tests:
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/didt-tests.yaml
-    strategy:
-      fail-fast: false
-    with:
-      arch: blackhole
-      runner-label: P150
-      timeout: 10
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # bh-nightly:
+  #   needs: build-artifact
+  #   uses: ./.github/workflows/blackhole-nightly-tests-impl.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
+  #   secrets: inherit
+  #   with:
+  #     runner-label: ${{ matrix.card_type }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # ttnn-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   uses: ./.github/workflows/ttnn-post-commit.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ matrix.card_type }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # ttnn-l2-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   uses: ./.github/workflows/tt-metal-l2-nightly-impl.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ matrix.card_type }}
+  #     timeout: 120
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # didt-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   uses: ./.github/workflows/didt-tests.yaml
+  #   strategy:
+  #     fail-fast: false
+  #   with:
+  #     arch: blackhole
+  #     runner-label: P150
+  #     timeout: 10
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   blackhole-llmbox-demo-tests:
     needs: build-artifact
     secrets: inherit

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -82,3 +82,22 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  blackhole-llmbox-demo-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
+    with:
+      runner-label: BH-LLMBox
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  blackhole-llmbox-fabric-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/blackhole-llmbox-fabric-build-and-unit-tests.yaml
+    with:
+      arch: blackhole
+      runner-label: BH-LLMBox
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -27,61 +27,61 @@ jobs:
     with:
       build-wheel: true
       version: 22.04
-  # bh-nightly:
-  #   needs: build-artifact
-  #   uses: ./.github/workflows/blackhole-nightly-tests-impl.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
-  #   secrets: inherit
-  #   with:
-  #     runner-label: ${{ matrix.card_type }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # ttnn-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   uses: ./.github/workflows/ttnn-post-commit.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ matrix.card_type }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # ttnn-l2-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   uses: ./.github/workflows/tt-metal-l2-nightly-impl.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ matrix.card_type }}
-  #     timeout: 120
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # didt-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   uses: ./.github/workflows/didt-tests.yaml
-  #   strategy:
-  #     fail-fast: false
-  #   with:
-  #     arch: blackhole
-  #     runner-label: P150
-  #     timeout: 10
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  bh-nightly:
+    needs: build-artifact
+    uses: ./.github/workflows/blackhole-nightly-tests-impl.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
+    secrets: inherit
+    with:
+      runner-label: ${{ matrix.card_type }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  ttnn-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/ttnn-post-commit.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
+    with:
+      arch: blackhole
+      runner-label: ${{ matrix.card_type }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  ttnn-l2-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/tt-metal-l2-nightly-impl.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
+    with:
+      arch: blackhole
+      runner-label: ${{ matrix.card_type }}
+      timeout: 120
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  didt-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/didt-tests.yaml
+    strategy:
+      fail-fast: false
+    with:
+      arch: blackhole
+      runner-label: P150
+      timeout: 10
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   blackhole-llmbox-demo-tests:
     needs: build-artifact
     secrets: inherit

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -213,7 +213,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   metalium-smoke-tests:
-    needs: build-artifact
+    needs: [build-artifact, generate-matrix]
     strategy:
       fail-fast: false
       matrix:
@@ -225,7 +225,7 @@ jobs:
       runner: ${{ matrix.platform }}
       product: tt-metalium
   ttnn-smoke-tests:
-    needs: build-artifact
+    needs: [build-artifact, generate-matrix]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -16,6 +16,10 @@ on:
           description: 'Enable watcher in BH Post commit'
           default: false
           type: boolean
+      enable-llmbox-tests:
+          description: 'Run tests on LLMBox instead of single card (must set runner-label to BH-LLMBox)'
+          default: false
+          type: boolean
   workflow_dispatch:
     inputs:
       runner-label:
@@ -42,13 +46,17 @@ on:
         description: 'Enable watcher in BH Post commit'
         default: false
         type: boolean
+      enable-llmbox-tests:
+        description: 'Run tests on LLMBox instead of single card (must set runner-label to BH-LLMBox)'
+        default: false
+        type: boolean
   schedule:
     - cron: "0 */4 * * *"
   # Pause this since not enough runners to support every commit to main
   # push:
   #  branches: ["main"]
 
-run-name: ${{ inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled) ' || 'Blackhole post-commit tests' }}
+run-name: ${{ inputs.enable-llmbox-tests == true && 'Blackhole LLMBox tests' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled) ' || 'Blackhole post-commit tests') }}
 
 permissions:
   actions: read
@@ -60,6 +68,23 @@ permissions:
   checks: write
 
 jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          if [ "${{ inputs.enable-llmbox-tests }}" = "true" ]; then
+            if [ "${{ inputs.runner-label }}" != "BH-LLMBox" ]; then
+              echo "::warning::LLMBox tests are enabled but runner-label is not set to BH-LLMBox. Current value: ${{ inputs.runner-label }}"
+            fi
+            matrix='["BH-LLMBox"]'
+          else
+            matrix='["P100", "P150"]'
+          fi
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -86,7 +111,6 @@ jobs:
     secrets: inherit
     with:
       arch: "blackhole"
-      timeout: 20
       runner-label: ${{ inputs.runner-label || 'BH' }}
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
@@ -108,7 +132,6 @@ jobs:
     with:
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
-      timeout: 15
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -138,19 +161,16 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
   models-unit-tests:
-    needs: build-artifact
+    needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/models-post-commit.yaml
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { runner-label: P100 },
-          { runner-label: P150 },
-        ]
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     with:
       arch: blackhole
-      runner-label: ${{ matrix.test-group.runner-label }}
+      runner-label: ${{ matrix.test-group }}
       timeout: 20
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -160,7 +180,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
     with:
-      runner-label: BH
+      runner-label: ${{ inputs.runner-label || 'BH' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -178,19 +198,16 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
   ttnn-stress-tests:
-    needs: build-artifact
+    needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/ttnn-stress-tests-impl.yaml
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { runner-label: P100 },
-          { runner-label: P150 },
-        ]
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     with:
       arch: blackhole
-      runner-label: ${{ matrix.test-group.runner-label }}
+      runner-label: ${{ matrix.test-group }}
       timeout: 45
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
@@ -200,10 +217,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [
-          "P100",
-          "P150",
-        ]
+        platform: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     uses: ./.github/workflows/smoke.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
@@ -215,16 +229,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [
-          "P100",
-          "P150",
-        ]
+        platform: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     uses: ./.github/workflows/smoke.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
       runner: ${{ matrix.platform }}
       product: tt-nn
+
+  # LLMBox-only demo tests
+  blackhole-llmbox-demo-tests:
+    needs: build-artifact
+    if: ${{ inputs.enable-llmbox-tests }}
+    secrets: inherit
+    uses: ./.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
+    with:
+      runner-label: ${{ inputs.runner-label || 'BH' }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+
+  # LLMBox-only fabric tests
+  blackhole-llmbox-fabric-unit-tests:
+    needs: build-artifact
+    if: ${{ inputs.enable-llmbox-tests }}
+    secrets: inherit
+    uses: ./.github/workflows/blackhole-llmbox-fabric-build-and-unit-tests.yaml
+    with:
+      arch: blackhole
+      runner-label: ${{ inputs.runner-label || 'BH' }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+
 #   build-and-test-wheels:
 #     uses: Check all-post-commit yaml for directions
 #     secrets: inherit


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21997

### Problem description
Need to run tests on the BH P150x4 QB 

### What's changed
Update blackhole post commit workflow with initial set of tests for QB:
- BH single card tests
- Llama DP=4 Demo
- [Fabric unit tests](https://github.com/tenstorrent/tt-metal/issues/23295)

Adds to the nightly BH suite:
- Llama DP=4 Demo
- Fabric unit tests


### Checklist
- [x] BH post commit targeting QB: https://github.com/tenstorrent/tt-metal/actions/runs/15639167108
- [x] BH post commit: https://github.com/tenstorrent/tt-metal/actions/runs/15640932046
- [x] BH nightly (llmbox tests only): https://github.com/tenstorrent/tt-metal/actions/runs/15638560284