### PR TITLE
[skip ci] Add metalium-maintainers as global approver

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,260 +1,263 @@
-# Order is important; the last matching pattern takes the most
-# precedence.
+# Order is important; the last matching pattern takes the most precedence.
 
-# Top-level files
-/* @tenstorrent/metalium-developers-infra
-METALIUM_GUIDE.md @davorchap
+# Maintainers have god mode approval
+# Not using the subsequent line, because maintainers would become bottleneck for any non-owned files
+# * @tenstorrent/metalium-maintainers @tenstorrent/metalium-maintainers
+
+# Top-level files @tenstorrent/metalium-maintainers
+/* @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+METALIUM_GUIDE.md @davorchap @tenstorrent/metalium-maintainers
 
 # CI/CD
-.github/ @tenstorrent/metalium-developers-infra
-.github/workflows/ttnn-run-sweeps.yaml @xanderchin @jdesousa-TT @sjameelTT
+.github/ @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+.github/workflows/ttnn-run-sweeps.yaml @xanderchin @jdesousa-TT @sjameelTT @tenstorrent/metalium-maintainers
 
-/infra/ @tenstorrent/metalium-developers-infra
-scripts/build_scripts/ @tenstorrent/metalium-developers-infra
-cmake/ @tenstorrent/metalium-developers-infra
+/infra/ @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+scripts/build_scripts/ @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+cmake/ @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
 
 # Testing scripts and infra
-conftest.py @tenstorrent/metalium-developers-infra
-/conftest.py @cfjchu @SeanNijjar @tenstorrent/metalium-developers-infra
+conftest.py @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+/conftest.py @cfjchu @SeanNijjar @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
 
 # test scripts
-tests/CMakeLists.txt @tenstorrent/metalium-developers-infra
-tests/scripts/ @tenstorrent/metalium-developers-infra
-tests/scripts/run_profiler_regressions.sh @mo-tenstorrent @tenstorrent/metalium-developers-infra
+tests/CMakeLists.txt @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+tests/scripts/ @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+tests/scripts/run_profiler_regressions.sh @mo-tenstorrent @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
 
 # TT-STL
-tt_stl/ @patrickroberts @ayerofieiev-tt @dmakoviichuk-tt @sminakov-tt @omilyutin-tt
-tt_stl/**/CMakeLists.txt @patrickroberts @ayerofieiev-tt @dmakoviichuk-tt @sminakov-tt @omilyutin-tt @tenstorrent/metalium-developers-infra
+tt_stl/ @patrickroberts @ayerofieiev-tt @dmakoviichuk-tt @sminakov-tt @omilyutin-tt @tenstorrent/metalium-maintainers
+tt_stl/**/CMakeLists.txt @patrickroberts @ayerofieiev-tt @dmakoviichuk-tt @sminakov-tt @omilyutin-tt @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
 
 # metal runtime
-tt_metal/**/CMakeLists.txt @tenstorrent/metalium-developers-infra
-tt_metal/ @tenstorrent/metalium-developers-infra # nothing should be caught by this, if so, someone added a path somewhere
-tt_metal/api/ @tenstorrent/metalium-api-owners
-tt_metal/common/ @abhullar-tt @tt-aho @tt-asaigal @omilyutin-tt
-tt_metal/core_descriptors/ @abhullar-tt @aliuTT @ubcheema
-tt_metal/detail/ @abhullar-tt @tt-aho @tt-asaigal @omilyutin-tt # this should go away
-tt_metal/distributed/ @cfjchu @aliuTT @tt-asaigal @omilyutin-tt
-tt_metal/distributed/**/CMakeLists.txt @cfjchu @aliuTT @tt-asaigal @omilyutin-tt @tenstorrent/metalium-developers-infra
-tt_metal/fabric/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT
-tt_metal/fabric/**/CMakeLists.txt @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT @tenstorrent/metalium-developers-infra
-tt_metal/graph/ @dmakoviichuk-tt @sminakov-tt
-tt_metal/hostdevcommon/ @abhullar-tt @jbaumanTT @tt-dma # this should go away
-tt_metal/hw @abhullar-tt @jbaumanTT @pgkeller @nathan-TT
-tt_metal/hw/ckernels/ @rtawfik01 @rdjogoTT @ttmtrajkovic @nvelickovicTT
-tt_metal/hw/firmware/src/*erisc* @aliuTT @ubcheema
-tt_metal/hw/inc/ethernet/ @aliuTT @ubcheema
-tt_metal/hw/inc/wormhole/eth_l1_address_map.h @aliuTT @ubcheema
-tt_metal/hw/firmware/ @abhullar-tt @jbaumanTT @pgkeller @nathan-TT
-tt_metal/hw/toolchain/ @jbaumanTT @pgkeller @nathan-TT
-tt_metal/hw/**/CMakeLists.txt @tenstorrent/metalium-developers-infra @jbaumanTT @pgkeller @nathan-TT
-tt_metal/impl/allocator/ @abhullar-tt @tt-aho
-tt_metal/impl/buffers/ @abhullar-tt @jbaumanTT @omilyutin-tt @sminakov-tt @TT-BrianLiu
-tt_metal/impl/context/ @tt-dma @jbaumanTT @aliuTT
-tt_metal/impl/data_format/ @rtawfik01 @rdjogoTT @ttmtrajkovic @nvelickovicTT
-tt_metal/impl/debug/ @tt-dma @pgkeller
-tt_metal/impl/device/ @abhullar-tt @aliuTT @tt-asaigal @tt-aho @tt-dma
-tt_metal/impl/dispatch/ @pgkeller @jbaumanTT @nhuang-tt @mpiseTT @tt-asaigal @tt-aho
-tt_metal/impl/dispatch/kernels/packet_* @ubcheema @aliuTT
-tt_metal/impl/event @jbaumanTT @nhuang-tt @mpiseTT @tt-asaigal @tt-aho
-tt_metal/impl/flatbuffer/ @kmabeeTT @nsmithtt @omilyutin-tt
-tt_metal/impl/kernels/ @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho
-tt_metal/impl/lightmetal/ @kmabeeTT @gsarabandoTT
-tt_metal/impl/profiler/ @mo-tenstorrent @sagarwalTT
-tt_metal/impl/program/ @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho
-tt_metal/impl/sub_device/ @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho
-tt_metal/impl/trace/ @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho
-tt_metal/include/compute_kernel_api.h @davorchap @rtawfik01 @rdjogoTT @ttmtrajkovic @nvelickovicTT
-tt_metal/include/compute_kernel_api/ @rtawfik01 @rdjogoTT @ttmtrajkovic @nvelickovicTT
-tt_metal/jit_build/ @pgkeller @abhullar-tt @nathan-TT @jbaumanTT
-tt_metal/kernels/ @abhullar-tt # these should go away or get moved to tests
-tt_metal/llrt/ @abhullar-tt @jbaumanTT @pgkeller @tt-asaigal @tt-aho
-tt_metal/programming_examples/ @tt-asaigal @afuller-TT @mo-tenstorrent @tenstorrent/metalium-api-owners
-tt_metal/soc_descriptors @abhullar-tt @aliuTT @ubcheema
-tt_metal/test @tenstorrent/metalium-developers-infra
-tt_metal/tools/* @kmabeeTT @nhuang-tt @mo-tenstorrent @tt-dma @ihamer-tt
-tt_metal/tools/lightmetal_runner @kmabeeTT
-tt_metal/tools/mem_bench @nhuang-tt # should be moved to tests micro benchmark?
-tt_metal/tools/profiler/ @mo-tenstorrent @sagarwalTT
-tt_metal/tools/tt_gdb/ @tt-dma # I think this is dead code, can we delete it?
-tt_metal/tools/watcher_dump/ @tt-dma @pgkeller
+tt_metal/**/CMakeLists.txt @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+tt_metal/ @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers # Nothing should be caught
+tt_metal/api/ @tenstorrent/metalium-api-owners @tenstorrent/metalium-maintainers
+tt_metal/common/ @abhullar-tt @tt-aho @tt-asaigal @omilyutin-tt @tenstorrent/metalium-maintainers
+tt_metal/core_descriptors/ @abhullar-tt @aliuTT @ubcheema @tenstorrent/metalium-maintainers
+tt_metal/detail/ @abhullar-tt @tt-aho @tt-asaigal @omilyutin-tt @tenstorrent/metalium-maintainers # this should go away
+tt_metal/distributed/ @cfjchu @aliuTT @tt-asaigal @omilyutin-tt @tenstorrent/metalium-maintainers
+tt_metal/distributed/**/CMakeLists.txt @cfjchu @aliuTT @tt-asaigal @omilyutin-tt @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+tt_metal/fabric/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT @tenstorrent/metalium-maintainers
+tt_metal/fabric/**/CMakeLists.txt @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+tt_metal/graph/ @dmakoviichuk-tt @sminakov-tt @tenstorrent/metalium-maintainers
+tt_metal/hostdevcommon/ @abhullar-tt @jbaumanTT @tt-dma @tenstorrent/metalium-maintainers # this should go away
+tt_metal/hw @abhullar-tt @jbaumanTT @pgkeller @nathan-TT @tenstorrent/metalium-maintainers
+tt_metal/hw/ckernels/ @rtawfik01 @rdjogoTT @ttmtrajkovic @nvelickovicTT @tenstorrent/metalium-maintainers
+tt_metal/hw/firmware/src/*erisc* @aliuTT @ubcheema @tenstorrent/metalium-maintainers
+tt_metal/hw/inc/ethernet/ @aliuTT @ubcheema @tenstorrent/metalium-maintainers
+tt_metal/hw/inc/wormhole/eth_l1_address_map.h @aliuTT @ubcheema @tenstorrent/metalium-maintainers
+tt_metal/hw/firmware/ @abhullar-tt @jbaumanTT @pgkeller @nathan-TT @tenstorrent/metalium-maintainers
+tt_metal/hw/toolchain/ @jbaumanTT @pgkeller @nathan-TT @tenstorrent/metalium-maintainers
+tt_metal/hw/**/CMakeLists.txt @tenstorrent/metalium-developers-infra @jbaumanTT @pgkeller @nathan-TT @tenstorrent/metalium-maintainers
+tt_metal/impl/allocator/ @abhullar-tt @tt-aho @tenstorrent/metalium-maintainers
+tt_metal/impl/buffers/ @abhullar-tt @jbaumanTT @omilyutin-tt @sminakov-tt @TT-BrianLiu @tenstorrent/metalium-maintainers
+tt_metal/impl/context/ @tt-dma @jbaumanTT @aliuTT @tenstorrent/metalium-maintainers
+tt_metal/impl/data_format/ @rtawfik01 @rdjogoTT @ttmtrajkovic @nvelickovicTT @tenstorrent/metalium-maintainers
+tt_metal/impl/debug/ @tt-dma @pgkeller @tenstorrent/metalium-maintainers
+tt_metal/impl/device/ @abhullar-tt @aliuTT @tt-asaigal @tt-aho @tt-dma @tenstorrent/metalium-maintainers
+tt_metal/impl/dispatch/ @pgkeller @jbaumanTT @nhuang-tt @mpiseTT @tt-asaigal @tt-aho @tenstorrent/metalium-maintainers
+tt_metal/impl/dispatch/kernels/packet_* @ubcheema @aliuTT @tenstorrent/metalium-maintainers
+tt_metal/impl/event @jbaumanTT @nhuang-tt @mpiseTT @tt-asaigal @tt-aho @tenstorrent/metalium-maintainers
+tt_metal/impl/flatbuffer/ @kmabeeTT @nsmithtt @omilyutin-tt @tenstorrent/metalium-maintainers
+tt_metal/impl/kernels/ @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho @tenstorrent/metalium-maintainers
+tt_metal/impl/lightmetal/ @kmabeeTT @gsarabandoTT @tenstorrent/metalium-maintainers
+tt_metal/impl/profiler/ @mo-tenstorrent @sagarwalTT @tenstorrent/metalium-maintainers
+tt_metal/impl/program/ @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho @tenstorrent/metalium-maintainers
+tt_metal/impl/sub_device/ @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho @tenstorrent/metalium-maintainers
+tt_metal/impl/trace/ @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho @tenstorrent/metalium-maintainers
+tt_metal/include/compute_kernel_api.h @davorchap @rtawfik01 @rdjogoTT @ttmtrajkovic @nvelickovicTT @tenstorrent/metalium-maintainers
+tt_metal/include/compute_kernel_api/ @rtawfik01 @rdjogoTT @ttmtrajkovic @nvelickovicTT @tenstorrent/metalium-maintainers
+tt_metal/jit_build/ @pgkeller @abhullar-tt @nathan-TT @jbaumanTT @tenstorrent/metalium-maintainers
+tt_metal/kernels/ @abhullar-tt @tenstorrent/metalium-maintainers # this should go away
+tt_metal/llrt/ @abhullar-tt @jbaumanTT @pgkeller @tt-asaigal @tt-aho @tenstorrent/metalium-maintainers
+tt_metal/programming_examples/ @tt-asaigal @afuller-TT @mo-tenstorrent @tenstorrent/metalium-api-owners @tenstorrent/metalium-maintainers
+tt_metal/soc_descriptors @abhullar-tt @aliuTT @ubcheema @tenstorrent/metalium-maintainers
+tt_metal/test @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+tt_metal/tools/* @kmabeeTT @nhuang-tt @mo-tenstorrent @tt-dma @ihamer-tt @tenstorrent/metalium-maintainers
+tt_metal/tools/lightmetal_runner @kmabeeTT @tenstorrent/metalium-maintainers
+tt_metal/tools/mem_bench @nhuang-tt  @tenstorrent/metalium-maintainers # should be moved to tests micro benchmark?
+tt_metal/tools/profiler/ @mo-tenstorrent @sagarwalTT @tenstorrent/metalium-maintainers
+tt_metal/tools/tt_gdb/ @tt-dma @tenstorrent/metalium-maintainers # I think this is dead code, can we delete it?
+tt_metal/tools/watcher_dump/ @tt-dma @pgkeller @tenstorrent/metalium-maintainers
 
 # metal misc
-tt_metal/sfpi-version.sh @nathan-TT @tenstorrent/metalium-developers-infra
-tt_metal/tt_metal.cpp @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho @pgkeller @aliuTT @ayerofieiev-tt
-tt_metal/**/profiler/**/CMakeLists.txt @mo-tenstorrent @tenstorrent/metalium-developers-infra
-tt_metal/**/requirements*.txt @tenstorrent/metalium-developers-infra
+tt_metal/sfpi-version.sh @nathan-TT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+tt_metal/tt_metal.cpp @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho @pgkeller @aliuTT @ayerofieiev-tt @tenstorrent/metalium-maintainers
+tt_metal/**/profiler/**/CMakeLists.txt @mo-tenstorrent @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+tt_metal/**/requirements*.txt @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
 
-tt_metal/third_party/tt_llk @rtawfik01 @ttmtrajkovic @rdjogoTT @nvelickovicTT #does this actually do anything?
+tt_metal/third_party/tt_llk @rtawfik01 @ttmtrajkovic @rdjogoTT @nvelickovicTT @tenstorrent/metalium-maintainers #does this actually do anything?
 
 # metal tests
-tests/tt_metal/distributed/ @cfjchu @tt-asaigal @omilyutin-tt
-tests/tt_metal/distributed/**/CMakeLists.txt @cfjchu @tt-asaigal @omilyutin-tt @tenstorrent/metalium-developers-infra
-tests/tt_metal/microbenchmarks/ethernet/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT
-tests/tt_metal/tt_metal/ @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @nhuang-tt @tt-aho
-tests/tt_metal/tt_metal/perf_microbenchmark/routing/ @ubcheema @aagarwalTT
-tests/tt_metal/tt_metal/sfpi/ @nathan-TT @pgkeller
-tests/tt_metal/tt_metal/test_kernels/sfpi/ @nathan-TT @pgkeller
-tests/tt_metal/tt_metal/data_movement @rtawfik01 @vvukomanovicTT @atatuzunerTT
-tests/tt_metal/tt_fabric/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT
-tests/tt_metal/tools/profiler/ @mo-tenstorrent @sagarwalTT
+tests/tt_metal/distributed/ @cfjchu @tt-asaigal @omilyutin-tt @tenstorrent/metalium-maintainers
+tests/tt_metal/distributed/**/CMakeLists.txt @cfjchu @tt-asaigal @omilyutin-tt @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+tests/tt_metal/microbenchmarks/ethernet/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT @tenstorrent/metalium-maintainers
+tests/tt_metal/tt_metal/ @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @nhuang-tt @tt-aho @tenstorrent/metalium-maintainers
+tests/tt_metal/tt_metal/perf_microbenchmark/routing/ @ubcheema @aagarwalTT @tenstorrent/metalium-maintainers
+tests/tt_metal/tt_metal/sfpi/ @nathan-TT @pgkeller @tenstorrent/metalium-maintainers
+tests/tt_metal/tt_metal/test_kernels/sfpi/ @nathan-TT @pgkeller @tenstorrent/metalium-maintainers
+tests/tt_metal/tt_metal/data_movement @rtawfik01 @vvukomanovicTT @atatuzunerTT @tenstorrent/metalium-maintainers
+tests/tt_metal/tt_fabric/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT @tenstorrent/metalium-maintainers
+tests/tt_metal/tools/profiler/ @mo-tenstorrent @sagarwalTT @tenstorrent/metalium-maintainers
 
 # misc tests
-tests/didt/ @rdjogoTT @ttmtrajkovic
+tests/didt/ @rdjogoTT @ttmtrajkovic @tenstorrent/metalium-maintainers
 
 # TTNN
-ttnn/ @tenstorrent/metalium-developers-ttnn-core
-ttnn/ttnn/library_tweaks.py @ayerofieiev-tt @tenstorrent/metalium-developers-infra
-ttnn/ttnn/operations/moreh.py @razorback3 @dongjin-na @cfjchu @ayerofieiev-tt @dmakoviichuk-tt
-ttnn/ttnn/operations/conv2d.py @tenstorrent/metalium-developers-convolutions
-ttnn/ttnn/operations/pool.py @tenstorrent/metalium-developers-convolutions
+ttnn/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/metalium-maintainers
+ttnn/ttnn/library_tweaks.py @ayerofieiev-tt @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/ttnn/operations/moreh.py @razorback3 @dongjin-na @cfjchu @ayerofieiev-tt @dmakoviichuk-tt @tenstorrent/metalium-maintainers
+ttnn/ttnn/operations/conv2d.py @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+ttnn/ttnn/operations/pool.py @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
 ttnn/**/kernels/ # Removes the owners above from owning kernels unless specified afterwards
-ttnn/core/tensor/ @tenstorrent/metalium-developers-ttnn-core
-ttnn/**/CMakeLists.txt @tenstorrent/metalium-developers-ttnn-core @tenstorrent/metalium-developers-infra
+ttnn/core/tensor/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/metalium-maintainers
+ttnn/**/CMakeLists.txt @tenstorrent/metalium-developers-ttnn-core @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
 
-ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh*/ @razorback3 @dongjin-na @cfjchu @ayerofieiev-tt @dmakoviichuk-tt
-ttnn/cpp/ttnn/deprecated/tt_lib/csrc/ @ayerofieiev-tt @razorback3 @dongjin-na
+ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh*/ @razorback3 @dongjin-na @cfjchu @ayerofieiev-tt @dmakoviichuk-tt @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/deprecated/tt_lib/csrc/ @ayerofieiev-tt @razorback3 @dongjin-na @tenstorrent/metalium-maintainers
 
-ttnn/cpp/ttnn/operations/moreh*/ @razorback3 @dongjin-na @cfjchu @ayerofieiev-tt @dmakoviichuk-tt
-ttnn/cpp/ttnn/operations/moreh*/**/CMakeLists.txt @razorback3 @dongjin-na @cfjchu @ayerofieiev-tt @dmakoviichuk-tt @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/ccl/ @SeanNijjar @cfjchu @jvegaTT @tt-aho @sjameelTT @ntarafdar @nardoTT @llongTT @amorrisonTT
-ttnn/cpp/ttnn/operations/ccl/**/CMakeLists.txt @SeanNijjar @cfjchu @jvegaTT @tt-aho @sjameelTT @ntarafdar @nardoTT @llongTT @amorrisonTT @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/pool/ @tenstorrent/metalium-developers-convolutions
-ttnn/cpp/ttnn/operations/pool/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/conv/ @tenstorrent/metalium-developers-convolutions
-ttnn/cpp/ttnn/operations/conv/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/sliding_window/ @tenstorrent/metalium-developers-convolutions
-ttnn/cpp/ttnn/operations/sliding_window/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/data_movement/ @ntarafdar @sjameelTT @yugi957 @jvegaTT @llongTT @nardoTT @amorrisonTT
-ttnn/cpp/ttnn/operations/data_movement/**/CMakeLists.txt @ntarafdar @sjameelTT @yugi957 @jvegaTT @llongTT @nardoTT @amorrisonTT @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/data_movement/fold/ @tenstorrent/metalium-developers-convolutions
-ttnn/cpp/ttnn/operations/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT @vsureshTT @edwinleeTT @nsorabaTT
-ttnn/cpp/ttnn/operations/matmul/**/CMakeLists.txt @TT-BrianLiu @bbradelTT @yugaoTT @vsureshTT @edwinleeTT @nsorabaTT @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/experimental/ccl/ @SeanNijjar @jvegaTT @tt-aho @sjameelTT @ntarafdar @nardoTT @llongTT @amorrisonTT
-ttnn/cpp/ttnn/operations/experimental/ccl/**/CMakeLists.txt @SeanNijjar @jvegaTT @tt-aho @sjameelTT @ntarafdar @nardoTT @llongTT @amorrisonTT @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/experimental/conv3d/ @tenstorrent/metalium-developers-convolutions
-ttnn/cpp/ttnn/operations/experimental/conv3d/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/experimental/cnn/ @tenstorrent/metalium-developers-convolutions @esmalTT
-ttnn/cpp/ttnn/operations/experimental/cnn/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @esmalTT @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/experimental/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT @vsureshTT @edwinleeTT @nsorabaTT
-ttnn/cpp/ttnn/operations/experimental/matmul/**/CMakeLists.txt @TT-BrianLiu @bbradelTT @yugaoTT @vsureshTT @edwinleeTT @nsorabaTT @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/experimental/slice_write/ @tenstorrent/metalium-developers-convolutions @sjameelTT @ntarafdar @amorrisonTT
-ttnn/cpp/ttnn/operations/experimental/padded_slice/ @tenstorrent/metalium-developers-convolutions @sjameelTT @ntarafdar @amorrisonTT
-ttnn/cpp/ttnn/operations/experimental/reduction/ @bbradelTT @sjameelTT @vsureshTT @edwinleeTT @nsorabaTT @aczajkowskiTT
-ttnn/cpp/ttnn/operations/experimental/reduction/**/CMakeLists.txt @bbradelTT @sjameelTT @vsureshTT @edwinleeTT @nsorabaTT @aczajkowskiTT @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/eltwise/ @patrickroberts @sjameelTT @ntarafdar @dchenTT
-ttnn/cpp/ttnn/operations/eltwise/**/CMakeLists.txt @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/eltwise/quantization/ @wenbinlyuTT @patrickroberts @sjameelTT
-ttnn/cpp/ttnn/operations/eltwise/quantization/**/CMakeLists.txt @wenbinlyuTT @patrickroberts @sjameelTT @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/reduction/ @bbradelTT @sjameelTT @vsureshTT @edwinleeTT @nsorabaTT @aczajkowskiTT
-ttnn/cpp/ttnn/operations/reduction/**/CMakeLists.txt @bbradelTT @sjameelTT @vsureshTT @edwinleeTT @nsorabaTT @aczajkowskiTT @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/normalization/ @yugaoTT @tt-aho @bbradelTT @vsureshTT @edwinleeTT @nsorabaTT
-ttnn/cpp/ttnn/operations/normalization/**/CMakeLists.txt @yugaoTT @tt-aho @bbradelTT @vsureshTT @edwinleeTT @nsorabaTT @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/embedding/ @ntarafdar @tt-aho @TT-BrianLiu @yugi957 @sjameelTT @jaykru-tt @llongTT @nardoTT
-ttnn/cpp/ttnn/operations/embedding/**/CMakeLists.txt @ntarafdar @tt-aho @TT-BrianLiu @yugi957 @sjameelTT @jaykru-tt @llongTT @nardoTT @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/embedding_backward/ @ntarafdar @tt-aho @TT-BrianLiu @yugi957 @sjameelTT @jaykru-tt @llongTT @nardoTT
-ttnn/cpp/ttnn/operations/embedding_backward/**/CMakeLists.txt @ntarafdar @tt-aho @TT-BrianLiu @yugi957 @sjameelTT @jaykru-tt @llongTT @nardoTT @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/transformer/sdpa/ @tenstorrent/metallium-maintainers-llama-models
-ttnn/cpp/ttnn/operations/transformer/sdpa_decode/ @tenstorrent/metallium-maintainers-llama-models
-ttnn/cpp/ttnn/operations/experimental/paged_cache/ @tenstorrent/metallium-maintainers-llama-models
-ttnn/cpp/ttnn/operations/experimental/paged_cache/**/CMakeLists.txt @tenstorrent/metallium-maintainers-llama-models @tenstorrent/metalium-developers-infra
-ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/ @tenstorrent/metallium-maintainers-llama-models
-ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/ @tenstorrent/metallium-maintainers-llama-models
-ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/ @tenstorrent/metallium-maintainers-llama-models
-ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/ @tenstorrent/metallium-maintainers-llama-models
-ttnn/tracy/ @mo-tenstorrent @sagarwalTT
-ttnn/api/tools/profiler/ @mo-tenstorrent
-tests/ttnn/ @tenstorrent/metalium-developers-ttnn-core @razorback3 @dongjin-na @bbradelTT
-tests/ttnn/unit_tests/gtests/ccl/ @SeanNijjar @jvegaTT @cfjchu @tt-aho @sjameelTT @ntarafdar @nardoTT @llongTT @amorrisonTT
-tests/ttnn/unit_tests/operations/ccl/ @SeanNijjar @jvegaTT @tt-aho @sjameelTT @ntarafdar @nardoTT @llongTT @amorrisonTT
-tests/ttnn/unit_tests/operations/eltwise/ @patrickroberts @sjameelTT @ntarafdar @dchenTT
-tests/ttnn/unit_tests/operations/conv/ @tenstorrent/metalium-developers-convolutions
-tests/ttnn/unit_tests/operations/pool/ @tenstorrent/metalium-developers-convolutions
-tests/ttnn/unit_tests/operations/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT @nsorabaTT @vsureshTT @edwinleeTT
-/tests/ttnn/**/unit_tests/operations/fused/ @yugaoTT @bbradelTT @nsorabaTT @vsureshTT @edwinleeTT
-/tests/ttnn/**/unit_tests/operations/reduce/ @bbradelTT @sjameelTT @nsorabaTT @vsureshTT @edwinleeTT @aczajkowskiTT
-tests/ttnn/nightly/unit_tests/operations/conv/ @tenstorrent/metalium-developers-convolutions
-tests/ttnn/nightly/unit_tests/operations/pool/ @tenstorrent/metalium-developers-convolutions
-tests/ttnn/nightly/unit_tests/operations/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT @nsorabaTT @vsureshTT @edwinleeTT
-tests/ttnn/integration_tests/resnet/ @tenstorrent/metalium-developers-convolutions
-tests/sweep_framework/ @xanderchin @jdesousa-TT @sjameelTT
-tests/sweep_framework/sweeps
-tests/sweep_framework/sweeps/eltwise/ @patrickroberts @sjameelTT @ntarafdar @dchenTT
-tests/sweep_framework/sweeps/conv2d/  @tenstorrent/metalium-developers-convolutions
-tests/sweep_framework/sweeps/data_movement/  @sjameelTT @ntarafdar @yugi957 @llongTT @jvegaTT @nardoTT @amorrisonTT
-tests/sweep_framework/sweeps/fused/  @bbradelTT @nsorabaTT @vsureshTT @edwinleeTT
-tests/sweep_framework/sweeps/matmul/  @bbradelTT @nsorabaTT @vsureshTT @edwinleeTT
-tests/sweep_framework/sweeps/reduction/  @bbradelTT @nsorabaTT @vsureshTT @edwinleeTT @aczajkowskiTT
+ttnn/cpp/ttnn/operations/moreh*/ @razorback3 @dongjin-na @cfjchu @ayerofieiev-tt @dmakoviichuk-tt @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/moreh*/**/CMakeLists.txt @razorback3 @dongjin-na @cfjchu @ayerofieiev-tt @dmakoviichuk-tt @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/ccl/ @SeanNijjar @cfjchu @jvegaTT @tt-aho @sjameelTT @ntarafdar @nardoTT @llongTT @amorrisonTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/ccl/**/CMakeLists.txt @SeanNijjar @cfjchu @jvegaTT @tt-aho @sjameelTT @ntarafdar @nardoTT @llongTT @amorrisonTT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/pool/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/pool/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/conv/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/conv/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/sliding_window/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/sliding_window/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/data_movement/ @ntarafdar @sjameelTT @yugi957 @jvegaTT @llongTT @nardoTT @amorrisonTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/data_movement/**/CMakeLists.txt @ntarafdar @sjameelTT @yugi957 @jvegaTT @llongTT @nardoTT @amorrisonTT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/data_movement/fold/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT @vsureshTT @edwinleeTT @nsorabaTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/matmul/**/CMakeLists.txt @TT-BrianLiu @bbradelTT @yugaoTT @vsureshTT @edwinleeTT @nsorabaTT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/ccl/ @SeanNijjar @jvegaTT @tt-aho @sjameelTT @ntarafdar @nardoTT @llongTT @amorrisonTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/ccl/**/CMakeLists.txt @SeanNijjar @jvegaTT @tt-aho @sjameelTT @ntarafdar @nardoTT @llongTT @amorrisonTT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/conv3d/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/conv3d/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/cnn/ @tenstorrent/metalium-developers-convolutions @esmalTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/cnn/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @esmalTT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT @vsureshTT @edwinleeTT @nsorabaTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/matmul/**/CMakeLists.txt @TT-BrianLiu @bbradelTT @yugaoTT @vsureshTT @edwinleeTT @nsorabaTT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/slice_write/ @tenstorrent/metalium-developers-convolutions @sjameelTT @ntarafdar @amorrisonTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/padded_slice/ @tenstorrent/metalium-developers-convolutions @sjameelTT @ntarafdar @amorrisonTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/reduction/ @bbradelTT @sjameelTT @vsureshTT @edwinleeTT @nsorabaTT @aczajkowskiTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/reduction/**/CMakeLists.txt @bbradelTT @sjameelTT @vsureshTT @edwinleeTT @nsorabaTT @aczajkowskiTT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/eltwise/ @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/eltwise/**/CMakeLists.txt @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/eltwise/quantization/ @wenbinlyuTT @patrickroberts @sjameelTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/eltwise/quantization/**/CMakeLists.txt @wenbinlyuTT @patrickroberts @sjameelTT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/reduction/ @bbradelTT @sjameelTT @vsureshTT @edwinleeTT @nsorabaTT @aczajkowskiTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/reduction/**/CMakeLists.txt @bbradelTT @sjameelTT @vsureshTT @edwinleeTT @nsorabaTT @aczajkowskiTT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/normalization/ @yugaoTT @tt-aho @bbradelTT @vsureshTT @edwinleeTT @nsorabaTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/normalization/**/CMakeLists.txt @yugaoTT @tt-aho @bbradelTT @vsureshTT @edwinleeTT @nsorabaTT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/embedding/ @ntarafdar @tt-aho @TT-BrianLiu @yugi957 @sjameelTT @jaykru-tt @llongTT @nardoTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/embedding/**/CMakeLists.txt @ntarafdar @tt-aho @TT-BrianLiu @yugi957 @sjameelTT @jaykru-tt @llongTT @nardoTT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/embedding_backward/ @ntarafdar @tt-aho @TT-BrianLiu @yugi957 @sjameelTT @jaykru-tt @llongTT @nardoTT @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/embedding_backward/**/CMakeLists.txt @ntarafdar @tt-aho @TT-BrianLiu @yugi957 @sjameelTT @jaykru-tt @llongTT @nardoTT @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/transformer/sdpa/ @tenstorrent/metallium-maintainers-llama-models @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/transformer/sdpa_decode/ @tenstorrent/metallium-maintainers-llama-models @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/paged_cache/ @tenstorrent/metallium-maintainers-llama-models @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/paged_cache/**/CMakeLists.txt @tenstorrent/metallium-maintainers-llama-models @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/ @tenstorrent/metallium-maintainers-llama-models @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/ @tenstorrent/metallium-maintainers-llama-models @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/ @tenstorrent/metallium-maintainers-llama-models @tenstorrent/metalium-maintainers
+ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/ @tenstorrent/metallium-maintainers-llama-models @tenstorrent/metalium-maintainers
+ttnn/tracy/ @mo-tenstorrent @sagarwalTT @tenstorrent/metalium-maintainers
+ttnn/api/tools/profiler/ @mo-tenstorrent @tenstorrent/metalium-maintainers
+tests/ttnn/ @tenstorrent/metalium-developers-ttnn-core @razorback3 @dongjin-na @bbradelTT @tenstorrent/metalium-maintainers
+tests/ttnn/unit_tests/gtests/ccl/ @SeanNijjar @jvegaTT @cfjchu @tt-aho @sjameelTT @ntarafdar @nardoTT @llongTT @amorrisonTT @tenstorrent/metalium-maintainers
+tests/ttnn/unit_tests/operations/ccl/ @SeanNijjar @jvegaTT @tt-aho @sjameelTT @ntarafdar @nardoTT @llongTT @amorrisonTT @tenstorrent/metalium-maintainers
+tests/ttnn/unit_tests/operations/eltwise/ @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/metalium-maintainers
+tests/ttnn/unit_tests/operations/conv/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+tests/ttnn/unit_tests/operations/pool/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+tests/ttnn/unit_tests/operations/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT @nsorabaTT @vsureshTT @edwinleeTT @tenstorrent/metalium-maintainers
+/tests/ttnn/**/unit_tests/operations/fused/ @yugaoTT @bbradelTT @nsorabaTT @vsureshTT @edwinleeTT @tenstorrent/metalium-maintainers
+/tests/ttnn/**/unit_tests/operations/reduce/ @bbradelTT @sjameelTT @nsorabaTT @vsureshTT @edwinleeTT @aczajkowskiTT @tenstorrent/metalium-maintainers
+tests/ttnn/nightly/unit_tests/operations/conv/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+tests/ttnn/nightly/unit_tests/operations/pool/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+tests/ttnn/nightly/unit_tests/operations/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT @nsorabaTT @vsureshTT @edwinleeTT @tenstorrent/metalium-maintainers
+tests/ttnn/integration_tests/resnet/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+tests/sweep_framework/ @xanderchin @jdesousa-TT @sjameelTT @tenstorrent/metalium-maintainers
+tests/sweep_framework/sweeps @tenstorrent/metalium-maintainers
+tests/sweep_framework/sweeps/eltwise/ @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/metalium-maintainers
+tests/sweep_framework/sweeps/conv2d/  @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+tests/sweep_framework/sweeps/data_movement/  @sjameelTT @ntarafdar @yugi957 @llongTT @jvegaTT @nardoTT @amorrisonTT @tenstorrent/metalium-maintainers
+tests/sweep_framework/sweeps/fused/  @bbradelTT @nsorabaTT @vsureshTT @edwinleeTT @tenstorrent/metalium-maintainers
+tests/sweep_framework/sweeps/matmul/  @bbradelTT @nsorabaTT @vsureshTT @edwinleeTT @tenstorrent/metalium-maintainers
+tests/sweep_framework/sweeps/reduction/  @bbradelTT @nsorabaTT @vsureshTT @edwinleeTT @aczajkowskiTT @tenstorrent/metalium-maintainers
 
 # TTNN Distributed
-ttnn/ttnn/distributed/ @tenstorrent/metalium-developers-ttnn-core
-tests/ttnn/distributed/ @tenstorrent/metalium-developers-ttnn-core
+ttnn/ttnn/distributed/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/metalium-maintainers
+tests/ttnn/distributed/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/metalium-maintainers
 
 # models
-/models/ @uaydonat
-/models/*/**
-/**/functional_*/ @uaydonat @esmalTT
-models/common @yieldthought @mtairum @uaydonat
-models/datasets/llm_dataset_utils.py @skhorasganiTT @uaydonat
-models/demos @uaydonat
-models/**/bert*/ @TT-BrianLiu @uaydonat
-models/demos/metal_BERT_large_11 @tt-aho @TT-BrianLiu
-models/*/convnet_mnist/ @sjameelTT @uaydonat
-models/**/distilbert/ @tt-aho @uaydonat
-models/*/mnist/ @esmalTT @uaydonat
-models/*/roberta/ @sraizada-tt @uaydonat
-models/*/squeezebert/ @cfjchu @uaydonat
-models/demos/ttnn_falcon7b @cfjchu @uaydonat
-models/*/vgg/ @bbradelTT @uaydonat @mbahnasTT
-models/demos/wormhole @uaydonat
-models/demos/t3000 @uaydonat
-models/tt_transformers @cglagovichTT @yieldthought @mtairum @uaydonat
-models/demos/llama3_subdevices @johanna-rock-tt @kpaigwar @avoraTT @sraizada-tt @djordje-tt @mtairum @yalrawwashTT @alingTT
-models/tt_transformers/tt/generator*.py @cglagovichTT @yieldthought @mtairum @skhorasganiTT @uaydonat
-models/demos/qwen @sraizada-tt @mtairum @uaydonat @yieldthought
-models/demos/falcon7b_common @skhorasganiTT @djordje-tt @uaydonat
-models/demos/wormhole/mamba @esmalTT @uaydonat @kpaigwar
-models/demos/wormhole/falcon7b @skhorasganiTT @djordje-tt @uaydonat
-models/demos/wormhole/stable_diffusion @esmalTT @uaydonat @tenstorrent/metalium-developers-convolutions
-models/demos/blackhole/stable_diffusion @esmalTT @uaydonat @tenstorrent/metalium-developers-convolutions
-models/demos/t3000/falcon40b @uaydonat @djordje-tt @johanna-rock-tt
-models/demos/t3000/falcon7b @skhorasganiTT @djordje-tt @uaydonat
-models/demos/t3000/llama2_70b @cglagovichTT @uaydonat @johanna-rock-tt @djordje-tt @kpaigwar
-models/demos/t3000/llama3_70b @cglagovichTT @uaydonat @johanna-rock-tt @djordje-tt @kpaigwar
-models/demos/t3000/mixtral8x7b @yieldthought @mtairum @uaydonat
-models/demos/tg/falcon7b @skhorasganiTT @djordje-tt @uaydonat
-models/demos/whisper @skhorasganiTT @uaydonat
-models/demos/grayskull @uaydonat
-models/demos/yolov4 @dvartaniansTT @mbahnasTT @rdraskicTT @mbezuljTT @tenstorrent/metalium-developers-convolutions
-models/demos/**/*resnet* @tenstorrent/metalium-developers-convolutions
-models/experimental/ @sminakov-tt @dgomezTT @jmalone-tt @ayerofieiev-tt @uaydonat
-models/experimental/functional_unet @esmalTT @uaydonat @tenstorrent/metalium-developers-convolutions
-models/demos/ufld_v2 @tenstorrent/cse-developer-ttnn
-models/demos/vgg_unet @tenstorrent/cse-developer-ttnn
-models/experimental/openpdn_mnist @tenstorrent/cse-developer-ttnn
-models/experimental/functional_vanilla_unet @tenstorrent/cse-developer-ttnn
-models/experimental/sentence_bert @tenstorrent/cse-developer-ttnn
-models/experimental/grok @yieldthought @uaydonat
-models/demos/wormhole/vit @mbahnasTT @dvartaniansTT @uaydonat
-models/demos/vit  @mbahnasTT @dvartaniansTT @uaydonat
-models/experimental/*yolo*/ @mbahnasTT @uaydonat
-models/demos/segformer @mbahnasTT @uaydonat @tenstorrent/metalium-developers-convolutions
-models/perf/ @yieldthought @uaydonat
-models/perf/benchmarking_utils.py @skhorasganiTT @williamlyTT @uaydonat
-models/demos/utils/llm_demo_utils.py @skhorasganiTT @mtairum @uaydonat
-models/experimental/stable_diffusion_xl_base @mbezuljTT @pavlepopovic @ipotkonjak-tt @tenstorrent/metalium-developers-convolutions
-models/demos/mobilenetv2 @tenstorrent/cse-developer-ttnn
-models/experimental/yolov8s_world @tenstorrent/cse-developer-ttnn
-models/experimental/yolov10 @tenstorrent/cse-developer-ttnn
-models/demos/yolov9c @tenstorrent/cse-developer-ttnn
-models/demos/yolov8x @tenstorrent/cse-developer-ttnn
-models/experimental/stable_diffusion_35_large/ @jonathansuTT @cglagovichTT @tenstorrent/cse-developer-ttnn
+/models/ @uaydonat @tenstorrent/metalium-maintainers
+/models/*/** @tenstorrent/metalium-maintainers
+/**/functional_*/ @uaydonat @esmalTT @tenstorrent/metalium-maintainers
+models/common @yieldthought @mtairum @uaydonat @tenstorrent/metalium-maintainers
+models/datasets/llm_dataset_utils.py @skhorasganiTT @uaydonat @tenstorrent/metalium-maintainers
+models/demos @uaydonat @tenstorrent/metalium-maintainers
+models/**/bert*/ @TT-BrianLiu @uaydonat @tenstorrent/metalium-maintainers
+models/demos/metal_BERT_large_11 @tt-aho @TT-BrianLiu @tenstorrent/metalium-maintainers
+models/*/convnet_mnist/ @sjameelTT @uaydonat @tenstorrent/metalium-maintainers
+models/**/distilbert/ @tt-aho @uaydonat @tenstorrent/metalium-maintainers
+models/*/mnist/ @esmalTT @uaydonat @tenstorrent/metalium-maintainers
+models/*/roberta/ @sraizada-tt @uaydonat @tenstorrent/metalium-maintainers
+models/*/squeezebert/ @cfjchu @uaydonat @tenstorrent/metalium-maintainers
+models/demos/ttnn_falcon7b @cfjchu @uaydonat @tenstorrent/metalium-maintainers
+models/*/vgg/ @bbradelTT @uaydonat @mbahnasTT @tenstorrent/metalium-maintainers
+models/demos/wormhole @uaydonat @tenstorrent/metalium-maintainers
+models/demos/t3000 @uaydonat @tenstorrent/metalium-maintainers
+models/tt_transformers @cglagovichTT @yieldthought @mtairum @uaydonat @tenstorrent/metalium-maintainers
+models/demos/llama3_subdevices @johanna-rock-tt @kpaigwar @avoraTT @sraizada-tt @djordje-tt @mtairum @yalrawwashTT @alingTT @tenstorrent/metalium-maintainers
+models/tt_transformers/tt/generator*.py @cglagovichTT @yieldthought @mtairum @skhorasganiTT @uaydonat @tenstorrent/metalium-maintainers
+models/demos/qwen @sraizada-tt @mtairum @uaydonat @yieldthought @tenstorrent/metalium-maintainers
+models/demos/falcon7b_common @skhorasganiTT @djordje-tt @uaydonat @tenstorrent/metalium-maintainers
+models/demos/wormhole/mamba @esmalTT @uaydonat @kpaigwar @tenstorrent/metalium-maintainers
+models/demos/wormhole/falcon7b @skhorasganiTT @djordje-tt @uaydonat @tenstorrent/metalium-maintainers
+models/demos/wormhole/stable_diffusion @esmalTT @uaydonat @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+models/demos/blackhole/stable_diffusion @esmalTT @uaydonat @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+models/demos/t3000/falcon40b @uaydonat @djordje-tt @johanna-rock-tt @tenstorrent/metalium-maintainers
+models/demos/t3000/falcon7b @skhorasganiTT @djordje-tt @uaydonat @tenstorrent/metalium-maintainers
+models/demos/t3000/llama2_70b @cglagovichTT @uaydonat @johanna-rock-tt @djordje-tt @kpaigwar @tenstorrent/metalium-maintainers
+models/demos/t3000/llama3_70b @cglagovichTT @uaydonat @johanna-rock-tt @djordje-tt @kpaigwar @tenstorrent/metalium-maintainers
+models/demos/t3000/mixtral8x7b @yieldthought @mtairum @uaydonat @tenstorrent/metalium-maintainers
+models/demos/tg/falcon7b @skhorasganiTT @djordje-tt @uaydonat @tenstorrent/metalium-maintainers
+models/demos/whisper @skhorasganiTT @uaydonat @tenstorrent/metalium-maintainers
+models/demos/grayskull @uaydonat @tenstorrent/metalium-maintainers
+models/demos/yolov4 @dvartaniansTT @mbahnasTT @rdraskicTT @mbezuljTT @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+models/demos/**/*resnet* @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+models/experimental/ @sminakov-tt @dgomezTT @jmalone-tt @ayerofieiev-tt @uaydonat @tenstorrent/metalium-maintainers
+models/experimental/functional_unet @esmalTT @uaydonat @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+models/demos/ufld_v2 @tenstorrent/cse-developer-ttnn @tenstorrent/metalium-maintainers
+models/demos/vgg_unet @tenstorrent/cse-developer-ttnn @tenstorrent/metalium-maintainers
+models/experimental/openpdn_mnist @tenstorrent/cse-developer-ttnn @tenstorrent/metalium-maintainers
+models/experimental/functional_vanilla_unet @tenstorrent/cse-developer-ttnn @tenstorrent/metalium-maintainers
+models/experimental/sentence_bert @tenstorrent/cse-developer-ttnn @tenstorrent/metalium-maintainers
+models/experimental/grok @yieldthought @uaydonat @tenstorrent/metalium-maintainers
+models/demos/wormhole/vit @mbahnasTT @dvartaniansTT @uaydonat @tenstorrent/metalium-maintainers
+models/demos/vit  @mbahnasTT @dvartaniansTT @uaydonat @tenstorrent/metalium-maintainers
+models/experimental/*yolo*/ @mbahnasTT @uaydonat @tenstorrent/metalium-maintainers
+models/demos/segformer @mbahnasTT @uaydonat @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+models/perf/ @yieldthought @uaydonat @tenstorrent/metalium-maintainers
+models/perf/benchmarking_utils.py @skhorasganiTT @williamlyTT @uaydonat @tenstorrent/metalium-maintainers
+models/demos/utils/llm_demo_utils.py @skhorasganiTT @mtairum @uaydonat @tenstorrent/metalium-maintainers
+models/experimental/stable_diffusion_xl_base @mbezuljTT @pavlepopovic @ipotkonjak-tt @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-maintainers
+models/demos/mobilenetv2 @tenstorrent/cse-developer-ttnn @tenstorrent/metalium-maintainers
+models/experimental/yolov8s_world @tenstorrent/cse-developer-ttnn @tenstorrent/metalium-maintainers
+models/experimental/yolov10 @tenstorrent/cse-developer-ttnn @tenstorrent/metalium-maintainers
+models/demos/yolov9c @tenstorrent/cse-developer-ttnn @tenstorrent/metalium-maintainers
+models/demos/yolov8x @tenstorrent/cse-developer-ttnn @tenstorrent/metalium-maintainers
+models/experimental/stable_diffusion_35_large/ @jonathansuTT @cglagovichTT @tenstorrent/cse-developer-ttnn @tenstorrent/metalium-maintainers
 
 # docs
-docs/Makefile @tenstorrent/metalium-developers-infra
-docs/source/ttnn/ @tenstorrent/metalium-developers-ttnn-core @razorback3 @dongjin-na
+docs/Makefile @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
+docs/source/ttnn/ @tenstorrent/metalium-developers-ttnn-core @razorback3 @dongjin-na @tenstorrent/metalium-maintainers
 
 # misc
-dockerfile/upstream_test_images/ @tenstorrent/metalium-developers-infra
+dockerfile/upstream_test_images/ @tenstorrent/metalium-developers-infra @tenstorrent/metalium-maintainers
 
 # tt-train
-tt-train/** @dmakoviichuk-tt @rfurko-tt @ayerofieiev-tt
+tt-train/** @dmakoviichuk-tt @rfurko-tt @ayerofieiev-tt @tenstorrent/metalium-maintainers


### PR DESCRIPTION
### Problem description
At times it is necessary to bypass CODEOWNERS for getting hot fixes into Merge Gate.

### What's changed
Add @tenstorrent/metalium-maintainers as global approver for any PR.
This list is only three people right now, one of which I trust.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes