### PR TITLE
#23113: (Part 1) Add DRAM Sharding Support to the ShardedAddrGen

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_sharded_address_generators_new.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_sharded_address_generators_new.cpp
@@ -123,12 +123,12 @@ void run_full_block_test(ADDRgen addrgen, ADDRgenInfo constants, uint32_t bank_b
 }
 
 TEST(CclnewWidthShardedTensorSliceIndexer_Wormhole, width_sharded_test) {
-    constexpr std::size_t shard_type = static_cast<uint32_t>(tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED);
+    constexpr std::size_t shard_type = static_cast<std::size_t>(tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED);
     constexpr std::size_t number_of_cores = 8;
     constexpr std::size_t page_size_jump = 1024;
     constexpr std::size_t pages_per_tensor_row = 32;
     constexpr std::size_t contiguity =
-        static_cast<uint32_t>(shard_addr_gen_consts::ContiguityType::L1_NO_SHARD_PADDING);
+        static_cast<std::size_t>(shard_addr_gen_consts::ContiguityType::L1_NO_SHARD_PADDING);
     constexpr std::size_t pages_per_shard_width = 6;
     constexpr std::size_t rows_per_shard_height = 1;
     constexpr std::size_t tensor_address = 0x100000;
@@ -147,12 +147,13 @@ TEST(CclnewWidthShardedTensorSliceIndexer_Wormhole, width_sharded_test) {
 }
 
 TEST(CclnewHeightShardedTensorSliceIndexer_Wormhole, height_sharded_test) {
-    static constexpr std::size_t shard_type = static_cast<uint32_t>(tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED);
+    static constexpr std::size_t shard_type =
+        static_cast<std::size_t>(tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED);
     static constexpr std::size_t number_of_cores = 4;
     static constexpr std::size_t page_size_jump = 1024;
     static constexpr std::size_t pages_per_tensor_row = 32;
     static constexpr std::size_t contiguity =
-        static_cast<uint32_t>(shard_addr_gen_consts::ContiguityType::L1_NO_SHARD_PADDING);
+        static_cast<std::size_t>(shard_addr_gen_consts::ContiguityType::L1_NO_SHARD_PADDING);
     static constexpr std::size_t pages_per_shard_width = 1;
     static constexpr std::size_t rows_per_shard_height = 8;
     static constexpr std::size_t tensor_address = 0x100000;
@@ -171,12 +172,12 @@ TEST(CclnewHeightShardedTensorSliceIndexer_Wormhole, height_sharded_test) {
 }
 
 TEST(CclnewBlockShardedTensorSliceIndexer_Wormhole, block_sharded_test) {
-    static constexpr std::size_t shard_type = static_cast<uint32_t>(tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED);
+    static constexpr std::size_t shard_type = static_cast<std::size_t>(tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED);
     static constexpr std::size_t number_of_cores = 16;
     static constexpr std::size_t page_size_jump = 1024;
     static constexpr std::size_t pages_per_tensor_row = 32;
     static constexpr std::size_t contiguity =
-        static_cast<uint32_t>(shard_addr_gen_consts::ContiguityType::L1_NO_SHARD_PADDING);
+        static_cast<std::size_t>(shard_addr_gen_consts::ContiguityType::L1_NO_SHARD_PADDING);
     static constexpr std::size_t pages_per_shard_width = 8;
     static constexpr std::size_t rows_per_shard_height = 8;
     static constexpr std::size_t tensor_address = 0x1000000;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_sharded_address_generators_new.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_sharded_address_generators_new.cpp
@@ -25,6 +25,12 @@
 #define DYNAMIC_NOC_X(noc, x) NOC_0_X(noc, noc_size_x, (x))
 #define DYNAMIC_NOC_Y(noc, y) NOC_0_Y(noc, noc_size_y, (y))
 
+#define NOC_ADDR_COORD_SHIFT 36
+#define NUM_DRAM_BANKS 6
+#define NUM_NOCS 2
+int32_t bank_to_dram_offset[NUM_DRAM_BANKS];
+uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS];
+
 #endif
 #include "ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_sharded_address_generators_new.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_sharded_address_generators_new.cpp
@@ -121,7 +121,8 @@ TEST(CclnewWidthShardedTensorSliceIndexer_Wormhole, width_sharded_test) {
     constexpr std::size_t number_of_cores = 8;
     constexpr std::size_t page_size_jump = 1024;
     constexpr std::size_t pages_per_tensor_row = 32;
-    constexpr std::size_t contiguity = static_cast<uint32_t>(shard_addr_gen_consts::ContiguityType::NO_SHARD_PADDING);
+    constexpr std::size_t contiguity =
+        static_cast<uint32_t>(shard_addr_gen_consts::ContiguityType::L1_NO_SHARD_PADDING);
     constexpr std::size_t pages_per_shard_width = 6;
     constexpr std::size_t rows_per_shard_height = 1;
     constexpr std::size_t tensor_address = 0x100000;
@@ -145,7 +146,7 @@ TEST(CclnewHeightShardedTensorSliceIndexer_Wormhole, height_sharded_test) {
     static constexpr std::size_t page_size_jump = 1024;
     static constexpr std::size_t pages_per_tensor_row = 32;
     static constexpr std::size_t contiguity =
-        static_cast<uint32_t>(shard_addr_gen_consts::ContiguityType::NO_SHARD_PADDING);
+        static_cast<uint32_t>(shard_addr_gen_consts::ContiguityType::L1_NO_SHARD_PADDING);
     static constexpr std::size_t pages_per_shard_width = 1;
     static constexpr std::size_t rows_per_shard_height = 8;
     static constexpr std::size_t tensor_address = 0x100000;
@@ -169,7 +170,7 @@ TEST(CclnewBlockShardedTensorSliceIndexer_Wormhole, block_sharded_test) {
     static constexpr std::size_t page_size_jump = 1024;
     static constexpr std::size_t pages_per_tensor_row = 32;
     static constexpr std::size_t contiguity =
-        static_cast<uint32_t>(shard_addr_gen_consts::ContiguityType::NO_SHARD_PADDING);
+        static_cast<uint32_t>(shard_addr_gen_consts::ContiguityType::L1_NO_SHARD_PADDING);
     static constexpr std::size_t pages_per_shard_width = 8;
     static constexpr std::size_t rows_per_shard_height = 8;
     static constexpr std::size_t tensor_address = 0x1000000;

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/sharding_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/sharding_common.hpp
@@ -12,12 +12,17 @@ namespace shard_addr_gen_consts {
 
 enum class ContiguityType {
     // Indicates logical sharding placed padding between pages so no contiguous pages exist
-    PADDING_BETWEEN_PAGES = 0,
+    L1_PADDING_BETWEEN_PAGES = 0,
     // Indicates some padding exists in the rightmost shard since the pages did not divide evenly into shards
-    PADDING_IN_RIGHTMOST_SHARD,
+    L1_PADDING_IN_RIGHTMOST_SHARD,
     // Indicates no sharding based padding exists so all pages within the same shard are contiguous
     // This is useful for height sharded tensors as multiple rows of the tensor can be contiguous.
-    NO_SHARD_PADDING,
+    L1_NO_SHARD_PADDING,
+
+    // DRAM variants
+    DRAM_PADDING_BETWEEN_PAGES,
+    DRAM_PADDING_IN_RIGHTMOST_SHARD,
+    DRAM_NO_SHARD_PADDING,
 };
 
 }  // namespace shard_addr_gen_consts

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -194,20 +194,22 @@ struct ShardedAddrGen {
     FORCE_INLINE
     std::uint64_t get_sharded_addr(
         const uint32_t l1_addr, const uint32_t sharding_coordinates, const uint32_t noc = noc_index) const {
+        constexpr uint32_t SHIFT_BITS = 8;
+        constexpr uint32_t MASK = 0xFF;
         constexpr shard_addr_gen_consts::ContiguityType contiguity = CONSTANT_ARGS.contiguity;
         constexpr bool is_dram = contiguity == shard_addr_gen_consts::ContiguityType::DRAM_PADDING_BETWEEN_PAGES ||
                                  contiguity == shard_addr_gen_consts::ContiguityType::DRAM_PADDING_IN_RIGHTMOST_SHARD ||
                                  contiguity == shard_addr_gen_consts::ContiguityType::DRAM_NO_SHARD_PADDING;
         if constexpr (is_dram) {
-            uint32_t bank_id = (sharding_coordinates >> 8) & 0xFF;
+            uint32_t bank_id = (sharding_coordinates >> SHIFT_BITS) & MASK;
             uint32_t src_addr = l1_addr + bank_to_dram_offset[bank_id];
             uint32_t src_noc_xy = dram_bank_to_noc_xy[noc][bank_id];
             return ((uint64_t)(src_noc_xy) << NOC_ADDR_COORD_SHIFT) | src_addr;
         } else {
             // Extracts the X and Y value and using the l1 address gets the noc address
             return NOC_XY_ADDR(
-                DYNAMIC_NOC_X(noc, ((sharding_coordinates >> 8) & 0xFF)),
-                DYNAMIC_NOC_Y(noc, (sharding_coordinates & 0xFF)),
+                DYNAMIC_NOC_X(noc, ((sharding_coordinates >> SHIFT_BITS) & MASK)),
+                DYNAMIC_NOC_Y(noc, (sharding_coordinates & MASK)),
                 l1_addr);
         }
     }

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -57,7 +57,9 @@ struct ShardCoordInfo get_width_sharded_coordinates(uint32_t page_num) {
     uint32_t w_offset = page_col - w_core_id * columns_per_shard;
     coord_info.core_num = w_core_id;
     coord_info.page_num = page_row * columns_per_shard + w_offset;
-    if constexpr (contiguity != shard_addr_gen_consts::ContiguityType::PADDING_BETWEEN_PAGES) {
+    if constexpr (
+        contiguity != shard_addr_gen_consts::ContiguityType::L1_PADDING_BETWEEN_PAGES &&
+        contiguity != shard_addr_gen_consts::ContiguityType::DRAM_PADDING_BETWEEN_PAGES) {
         uint32_t space_left_in_shard = columns_per_shard - w_offset;
         uint32_t space_left_in_tensor = total_pages_last_dim - page_col;
         coord_info.num_contiguous_pages =
@@ -75,9 +77,13 @@ struct ShardCoordInfo get_height_sharded_coordinates(uint32_t page_num) {
     constexpr uint32_t num_pages_per_core = total_pages_last_dim * rows_per_shard;
     coord_info.core_num = page_num / num_pages_per_core;
     coord_info.page_num = page_num - coord_info.core_num * num_pages_per_core;
-    if constexpr (contiguity == shard_addr_gen_consts::ContiguityType::PADDING_BETWEEN_PAGES) {
+    if constexpr (
+        contiguity == shard_addr_gen_consts::ContiguityType::L1_PADDING_BETWEEN_PAGES ||
+        contiguity == shard_addr_gen_consts::ContiguityType::DRAM_PADDING_BETWEEN_PAGES) {
         coord_info.num_contiguous_pages = 1;
-    } else if constexpr (contiguity == shard_addr_gen_consts::ContiguityType::PADDING_IN_RIGHTMOST_SHARD) {
+    } else if constexpr (
+        contiguity == shard_addr_gen_consts::ContiguityType::L1_PADDING_IN_RIGHTMOST_SHARD ||
+        contiguity == shard_addr_gen_consts::ContiguityType::DRAM_PADDING_IN_RIGHTMOST_SHARD) {
         coord_info.num_contiguous_pages = total_pages_last_dim - page_num % total_pages_last_dim;
     } else {
         coord_info.num_contiguous_pages = num_pages_per_core - coord_info.page_num;
@@ -107,7 +113,9 @@ experimental::shard_addr_gen_utils::ShardCoordInfo get_block_sharded_coordinates
     // Find the coord_info
     coord_info.core_num = w_core_id + h_core_id * cores_per_block_row;
     coord_info.page_num = w_offset + h_offset * columns_per_shard;
-    if constexpr (contiguity != shard_addr_gen_consts::ContiguityType::PADDING_BETWEEN_PAGES) {
+    if constexpr (
+        contiguity != shard_addr_gen_consts::ContiguityType::L1_PADDING_BETWEEN_PAGES &&
+        contiguity != shard_addr_gen_consts::ContiguityType::DRAM_PADDING_BETWEEN_PAGES) {
         uint32_t space_left_in_shard = columns_per_shard - w_offset;
         uint32_t space_left_in_tensor = total_pages_last_dim - page_col;
         coord_info.num_contiguous_pages =
@@ -186,11 +194,25 @@ struct ShardedAddrGen {
     FORCE_INLINE
     std::uint64_t get_sharded_addr(
         const uint32_t l1_addr, const uint32_t sharding_coordinates, const uint32_t noc = noc_index) const {
-        // Extracts the X and Y value and using the l1 address gets the noc address
-        return NOC_XY_ADDR(
-            DYNAMIC_NOC_X(noc, ((sharding_coordinates >> 8) & 0xFF)),
-            DYNAMIC_NOC_Y(noc, (sharding_coordinates & 0xFF)),
-            l1_addr);
+        constexpr shard_addr_gen_consts::ContiguityType contiguity = CONSTANT_ARGS.contiguity;
+        constexpr bool is_dram = contiguity == shard_addr_gen_consts::ContiguityType::DRAM_PADDING_BETWEEN_PAGES ||
+                                 contiguity == shard_addr_gen_consts::ContiguityType::DRAM_PADDING_IN_RIGHTMOST_SHARD ||
+                                 contiguity == shard_addr_gen_consts::ContiguityType::DRAM_NO_SHARD_PADDING;
+        if constexpr (is_dram) {
+            const uint32_t x = (sharding_coordinates >> 8) & 0xFF;
+            const uint32_t y = sharding_coordinates & 0xFF;
+
+            const uint32_t bank_id = x;
+            const uint32_t src_addr = l1_addr + bank_to_dram_offset[bank_id];
+            const uint32_t src_noc_xy = dram_bank_to_noc_xy[noc][bank_id];  // copy of get_noc_xy<DRAM>
+            return get_noc_addr_helper(src_noc_xy, src_addr);
+        } else {
+            // Extracts the X and Y value and using the l1 address gets the noc address
+            return NOC_XY_ADDR(
+                DYNAMIC_NOC_X(noc, ((sharding_coordinates >> 8) & 0xFF)),
+                DYNAMIC_NOC_Y(noc, (sharding_coordinates & 0xFF)),
+                l1_addr);
+        }
     }
 
     std::uint32_t get_sharded_l1_addr(const uint32_t core_page, const uint32_t offset = 0) const {

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -12,7 +12,6 @@
 
 #endif
 
-#include "dataflow_api.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/types/sharding_common.hpp"
 
 using mapping_table_t = uint32_t;

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -12,6 +12,7 @@
 
 #endif
 
+#include "dataflow_api.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/types/sharding_common.hpp"
 
 using mapping_table_t = uint32_t;

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -199,12 +199,9 @@ struct ShardedAddrGen {
                                  contiguity == shard_addr_gen_consts::ContiguityType::DRAM_PADDING_IN_RIGHTMOST_SHARD ||
                                  contiguity == shard_addr_gen_consts::ContiguityType::DRAM_NO_SHARD_PADDING;
         if constexpr (is_dram) {
-            const uint32_t x = (sharding_coordinates >> 8) & 0xFF;
-            const uint32_t y = sharding_coordinates & 0xFF;
-
-            const uint32_t bank_id = x;
-            const uint32_t src_addr = l1_addr + bank_to_dram_offset[bank_id];
-            const uint32_t src_noc_xy = dram_bank_to_noc_xy[noc][bank_id];  // copy of get_noc_xy<DRAM>
+            uint32_t bank_id = (sharding_coordinates >> 8) & 0xFF;
+            uint32_t src_addr = l1_addr + bank_to_dram_offset[bank_id];
+            uint32_t src_noc_xy = dram_bank_to_noc_xy[noc][bank_id];
             return get_noc_addr_helper(src_noc_xy, src_addr);
         } else {
             // Extracts the X and Y value and using the l1 address gets the noc address

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -202,7 +202,7 @@ struct ShardedAddrGen {
             uint32_t bank_id = (sharding_coordinates >> 8) & 0xFF;
             uint32_t src_addr = l1_addr + bank_to_dram_offset[bank_id];
             uint32_t src_noc_xy = dram_bank_to_noc_xy[noc][bank_id];
-            return get_noc_addr_helper(src_noc_xy, src_addr);
+            return ((uint64_t)(src_noc_xy) << NOC_ADDR_COORD_SHIFT) | src_addr;
         } else {
             // Extracts the X and Y value and using the l1 address gets the noc address
             return NOC_XY_ADDR(

--- a/ttnn/cpp/ttnn/operations/ccl/sharding_addrgen_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/sharding_addrgen_helper.cpp
@@ -53,12 +53,9 @@ std::vector<CoreCoord> get_shard_cores(const tt::tt_metal::Tensor& t) {
                  x_index++) {
                 for (uint32_t y_index = core_ranges.at(cr).start_coord.y; y_index <= core_ranges.at(cr).end_coord.y;
                      y_index++) {
-                    if (is_dram) {
-                        coordinates.push_back(CoreCoord(x_index, y_index));
-                    } else {
-                        CoreCoord noc_core = device->worker_core_from_logical_core(CoreCoord(x_index, y_index));
-                        coordinates.push_back(noc_core);
-                    }
+                    CoreCoord noc_core = is_dram ? CoreCoord(x_index, y_index)
+                                                 : device->worker_core_from_logical_core(CoreCoord(x_index, y_index));
+                    coordinates.push_back(noc_core);
                 }
             }
         } else {
@@ -66,12 +63,9 @@ std::vector<CoreCoord> get_shard_cores(const tt::tt_metal::Tensor& t) {
                  y_index++) {
                 for (uint32_t x_index = core_ranges.at(cr).start_coord.x; x_index <= core_ranges.at(cr).end_coord.x;
                      x_index++) {
-                    if (is_dram) {
-                        coordinates.push_back(CoreCoord(x_index, y_index));
-                    } else {
-                        CoreCoord noc_core = device->worker_core_from_logical_core(CoreCoord(x_index, y_index));
-                        coordinates.push_back(noc_core);
-                    }
+                    CoreCoord noc_core = is_dram ? CoreCoord(x_index, y_index)
+                                                 : device->worker_core_from_logical_core(CoreCoord(x_index, y_index));
+                    coordinates.push_back(noc_core);
                 }
             }
         }


### PR DESCRIPTION
### Ticket
[#23113 ](https://github.com/tenstorrent/tt-metal/issues/23113#event-18005000203)

### Problem description
- The `ShardedAddrGen` did not support DRAM sharding

### What's changed
- Update the `ShardedAddrGen` to support DRAM sharding

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15568775505) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15573599683) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/15571530857/job/43848722634) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes