### PR TITLE
Add support for enabling ccache kernel in setup job for CI

### DIFF
--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Enable watcher'
     default: false
     type: boolean
+  enable-ccache-kernel-support:
+    description: 'Enable ccache kernel support'
+    required: false
+    default: 'true'
 runs:
   using: "composite"
   steps:
@@ -73,4 +77,12 @@ runs:
         echo "TT_METAL_WATCHER=1" >> $GITHUB_ENV
         echo "TT_METAL_WATCHER_APPEND=1" >> $GITHUB_ENV
         echo "TT_METAL_WATCHER_NOINLINE=1" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Set up env vars for ccache kernel support
+      if: ${{ inputs.enable-ccache-kernel-support == 'true' }}
+      working-directory: ${{ inputs.path }}
+      run: |
+        echo "Enabling TT Metal ccache kernel support"
+        echo "TT_METAL_CCACHE_KERNEL_SUPPORT=1" >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
There is an option to enable ccache for building kernels.
After enabling Inspector by default and generating debug info for all kernels, we have seen some test timeouts due to recompilation of dispatch kernels. This change will try to reduce time by compiling dispatch kernels only once per GitHub job.