### PR TITLE
#22308: Update where_impl to use binary_ng

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
@@ -8,6 +8,7 @@ import torch
 
 import ttnn
 
+from math import isnan
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
@@ -62,110 +63,109 @@ def test_mac_tensor_with_2_scalaras(device, h, w, scalar1, scalar2):
     assert_with_pcc(torch_output_tensor, output_tensor)
 
 
-@pytest.mark.parametrize("h", [64])
-@pytest.mark.parametrize("w", [128])
-def test_where_all_tensors(device, h, w):
-    torch.manual_seed(0)
+def assert_where_with_pcc(torch_input_tensor, torch_input1, torch_input2, device, pcc=0.9999):
+    def from_torch_if_tensor(x):
+        if not isinstance(x, torch.Tensor):
+            return x
 
-    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
-    torch_input_tensor1 = torch.rand((h, w), dtype=torch.bfloat16)
-    torch_input_tensor2 = torch.rand((h, w), dtype=torch.bfloat16)
+        return ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, device=device)
+
+    input_tensor, input1, input2 = (
+        from_torch_if_tensor(arg) for arg in (torch_input_tensor, torch_input1, torch_input2)
+    )
     golden_fn = ttnn.get_golden_function(ttnn.where)
-    torch_output_tensor = golden_fn(torch_input_tensor.to(torch.bool), torch_input_tensor1, torch_input_tensor2)
-
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor = ttnn.to_device(input_tensor, device)
-    input_tensor1 = ttnn.from_torch(torch_input_tensor1, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor1 = ttnn.to_device(input_tensor1, device)
-    input_tensor2 = ttnn.from_torch(torch_input_tensor2, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor2 = ttnn.to_device(input_tensor2, device)
-    output_tensor = ttnn.where(input_tensor, input_tensor1, input_tensor2)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
-    output_tensor = ttnn.from_device(output_tensor)
-    output_tensor = ttnn.to_torch(output_tensor)
-
-    assert_with_pcc(torch_output_tensor, output_tensor)
-
-
-@pytest.mark.parametrize("h", [64])
-@pytest.mark.parametrize("w", [128])
-@pytest.mark.parametrize("scalar", [15.5])
-def test_where_tts(device, h, w, scalar):
-    torch.manual_seed(0)
-
-    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
-    torch_input_tensor1 = torch.rand((h, w), dtype=torch.bfloat16)
-
-    golden_fn = ttnn.get_golden_function(ttnn.where)
-    torch_output_tensor = golden_fn(torch_input_tensor.to(torch.bool), torch_input_tensor1, scalar)
-
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor = ttnn.to_device(input_tensor, device)
-    input_tensor1 = ttnn.from_torch(torch_input_tensor1, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor1 = ttnn.to_device(input_tensor1, device)
-
-    output_tensor = ttnn.where(input_tensor, input_tensor1, scalar)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
-    output_tensor = ttnn.from_device(output_tensor)
-    output_tensor = ttnn.to_torch(output_tensor)
-
-    assert_with_pcc(torch_output_tensor, output_tensor)
-
-
-def run_ternary_test_where_TST(device, h, w, scalar, ttnn_function, torch_function, pcc=0.9999):
-    torch.manual_seed(0)
-
-    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
-    torch_input_tensor1 = torch.rand((h, w), dtype=torch.bfloat16)
-
-    golden_fn = ttnn.get_golden_function(ttnn.where)
-    torch_output_tensor = golden_fn(torch_input_tensor.to(torch.bool), scalar, torch_input_tensor1)
-
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor = ttnn.to_device(input_tensor, device)
-    input_tensor1 = ttnn.from_torch(torch_input_tensor1, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor1 = ttnn.to_device(input_tensor1, device)
-
-    output_tensor = ttnn_function(input_tensor, scalar, input_tensor1)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
-    output_tensor = ttnn.from_device(output_tensor)
+    torch_output_tensor = golden_fn(torch_input_tensor > 0, torch_input1, torch_input2)
+    output_tensor = ttnn.where(input_tensor, input1, input2)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)
 
 
-@pytest.mark.parametrize("h", [64])
-@pytest.mark.parametrize("w", [128])
-@pytest.mark.parametrize("scalar", [15.5])
-def test_where_tst(device, h, w, scalar):
-    run_ternary_test_where_TST(device, h, w, scalar, ttnn.where, torch.where)
-
-
-def run_ternary_test_where_TSS(device, h, w, scalar1, scalar2, ttnn_function, pcc=0.9999):
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize(
+    "hc, ht, hf, wc, wt, wf",
+    [
+        [64, 64, 64, 128, 128, 128],
+        [64, 64, 64, 128, 128, 1],
+        [64, 64, 64, 128, 1, 128],
+        [64, 64, 64, 1, 128, 128],
+        [64, 64, 1, 128, 128, 128],
+        [64, 1, 64, 128, 128, 128],
+        [1, 64, 64, 128, 128, 128],
+        [64, 64, 1, 128, 128, 1],
+        [64, 1, 64, 128, 1, 128],
+        [64, 1, 64, 128, 128, 1],
+        [64, 64, 1, 128, 1, 128],
+        [1, 1, 64, 128, 128, 1],
+        [64, 1, 64, 1, 1, 128],
+    ],
+)
+def test_where_bcast(device, dtype, hc, ht, hf, wc, wt, wf):
     torch.manual_seed(0)
 
-    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
+    torch_input_tensor = torch.rand((hc, wc), dtype=dtype).uniform_(-100, 100)
+    torch_input_tensor1 = torch.rand((ht, wt), dtype=dtype).uniform_(-100, 100)
+    torch_input_tensor2 = torch.rand((hf, wf), dtype=dtype).uniform_(-100, 100)
 
-    golden_fn = ttnn.get_golden_function(ttnn.where)
-    torch_output_tensor = golden_fn(torch_input_tensor.to(torch.bool), scalar1, scalar2)
-
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor = ttnn.to_device(input_tensor, device)
-
-    output_tensor = ttnn_function(input_tensor, scalar1, scalar2)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
-    output_tensor = ttnn.from_device(output_tensor)
-    output_tensor = ttnn.to_torch(output_tensor)
-
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_where_with_pcc(torch_input_tensor, torch_input_tensor1, torch_input_tensor2, device)
 
 
-@pytest.mark.parametrize("h", [64])
-@pytest.mark.parametrize("w", [128])
-@pytest.mark.parametrize("scalar1", [15.5])
-@pytest.mark.parametrize("scalar2", [31.2])
-def test_where_tss(device, h, w, scalar1, scalar2):
-    run_ternary_test_where_TSS(device, h, w, scalar1, scalar2, ttnn.where)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("h, w", [[64, 128]])
+@pytest.mark.parametrize("scalar", [15.5, float("nan")])
+def test_where_tts(device, dtype, h, w, scalar):
+    if dtype == torch.float32 and isnan(scalar):
+        pytest.xfail("#22308 ttnn.where erroneously propagates NaNs")
+
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((h, w), dtype=dtype).uniform_(-100, 100)
+    torch_input_tensor1 = torch.rand((h, w), dtype=dtype).uniform_(-100, 100)
+
+    assert_where_with_pcc(torch_input_tensor, torch_input_tensor1, scalar, device)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("h, w", [[64, 128]])
+@pytest.mark.parametrize("scalar", [15.5, float("nan")])
+def test_where_tst(device, dtype, h, w, scalar):
+    if dtype == torch.float32 and isnan(scalar):
+        pytest.xfail("#22308 ttnn.where erroneously propagates NaNs")
+
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((h, w), dtype=dtype).uniform_(-100, 100)
+    torch_input_tensor1 = torch.rand((h, w), dtype=dtype).uniform_(-100, 100)
+
+    assert_where_with_pcc(torch_input_tensor, scalar, torch_input_tensor1, device)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("h, w", [[64, 128]])
+@pytest.mark.parametrize("scalar1, scalar2", [[15.5, 31.2], [15.5, float("nan")], [float("nan"), 31.2]])
+def test_where_tss(device, dtype, h, w, scalar1, scalar2):
+    if dtype == torch.float32 and (isnan(scalar1) or isnan(scalar2)):
+        pytest.xfail("#22308 ttnn.where erroneously propagates NaNs")
+
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((h, w), dtype=dtype).uniform_(-100, 100)
+
+    assert_where_with_pcc(torch_input_tensor, scalar1, scalar2, device)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_where_nans(device, dtype):
+    if dtype == torch.float32:
+        pytest.xfail("#22308 ttnn.where erroneously propagates NaNs")
+
+    torch.manual_seed(0)
+
+    C = torch.ones(1, 4, 1, dtype=dtype)
+    T = torch.randn(1, 4, 768, dtype=dtype)
+    F = torch.full((1, 4, 768), float("nan"), dtype=dtype)
+
+    assert_where_with_pcc(C, T, F, device)
 
 
 def run_ternary_test_value(device, h, w, value, ttnn_function, pcc=0.9999):

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -164,7 +164,7 @@ std::map<std::string, std::string> get_defines(
 
     if (input_tensor_a_activation.has_value()) {
         defines.merge(ttnn::operations::unary::utils::get_defines(
-            input_tensor_a_activation.value().op_type, std::nullopt, "PRE_IN0_0", idst));
+            input_tensor_a_activation.value().op_type, std::nullopt, "PRE_IN0_0", idst, input_dtype));
     }
 
     return defines;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -103,7 +103,7 @@ Tensor _isclose(
     Tensor mul_result = ttnn::multiply(ttnn::abs(value2, output_mem_config), rtol, std::nullopt, output_mem_config);
     is_close_rhs = ttnn::add(mul_result, atol, std::nullopt, output_mem_config);
     mul_result.deallocate();
-    Tensor result = ttnn::where(ttnn::le(is_close_lhs, is_close_rhs, std::nullopt, output_mem_config), 1.0, 0.0);
+    Tensor result = ttnn::where(ttnn::le(is_close_lhs, is_close_rhs, std::nullopt, output_mem_config), 1.f, 0.f);
     return result;
 }
 
@@ -219,8 +219,7 @@ Tensor _atan2(const Tensor& input_b, const Tensor& input_a, const std::optional<
                 ttnn::where(
                     altz_bltz,
                     ttnn::subtract(result, M_PI, std::nullopt, output_mem_config),
-                    ttnn::where(
-                        az_bltz, -M_PI_2, ttnn::where(az_bgtz, M_PI_2, 0.0, output_mem_config), output_mem_config),
+                    ttnn::where(az_bltz, -pi_2, ttnn::where(az_bgtz, pi_2, 0.f, output_mem_config), output_mem_config),
                     output_mem_config),
                 output_mem_config),
             output_mem_config);

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.cpp
@@ -140,59 +140,8 @@ void bind_ternary_where(py::module& module, const ternary_operation_t& operation
         ttnn::pybind_overload_t{
             [](const ternary_operation_t& self,
                const Tensor& predicate,
-               const Tensor& true_value,
-               const Tensor& false_value,
-               const std::optional<MemoryConfig>& memory_config,
-               std::optional<Tensor> output_tensor,
-               QueueId queue_id) {
-                return self(queue_id, predicate, true_value, false_value, memory_config, output_tensor);
-            },
-            py::arg("predicate"),
-            py::arg("true_value"),
-            py::arg("false_value"),
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
-        ttnn::pybind_overload_t{
-            [](const ternary_operation_t& self,
-               const Tensor& predicate,
-               const float true_value,
-               const Tensor& false_value,
-               const std::optional<MemoryConfig>& memory_config,
-               std::optional<Tensor> output_tensor,
-               QueueId queue_id) {
-                return self(queue_id, predicate, true_value, false_value, memory_config, output_tensor);
-            },
-            py::arg("predicate"),
-            py::arg("true_value"),
-            py::arg("false_value"),
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
-        ttnn::pybind_overload_t{
-            [](const ternary_operation_t& self,
-               const Tensor& predicate,
-               const Tensor& true_value,
-               const float false_value,
-               const std::optional<MemoryConfig>& memory_config,
-               std::optional<Tensor> output_tensor,
-               QueueId queue_id) {
-                return self(queue_id, predicate, true_value, false_value, memory_config, output_tensor);
-            },
-            py::arg("predicate"),
-            py::arg("true_value"),
-            py::arg("false_value"),
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = DefaultQueueId},
-        ttnn::pybind_overload_t{
-            [](const ternary_operation_t& self,
-               const Tensor& predicate,
-               const float true_value,
-               const float false_value,
+               const std::variant<float, Tensor>& true_value,
+               const std::variant<float, Tensor>& false_value,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<Tensor> output_tensor,
                QueueId queue_id) {

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where.cpp
@@ -4,12 +4,10 @@
 
 #include "where.hpp"
 
-#include <functional>
 #include <utility>
 #include <variant>
 
 #include "ttnn/common/queue_id.hpp"
-#include "ttnn/decorators.hpp"
 
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
@@ -23,98 +21,57 @@ namespace ternary_utils {
 // where - ternary operator y = (predicate) ? value_true : value_false; elementwise
 // y = (predicate >= 0)*value_true + (predicate < 0)*value_false
 
-using FloatOrTensor = std::variant<Tensor, float>;
-
 Tensor where_impl(
     QueueId queue_id,
     const Tensor& predicate,
-    const FloatOrTensor& value_true,
-    const FloatOrTensor& value_false,
-    const std::optional<MemoryConfig>& output_mem_config,
-    std::optional<Tensor> output_tensor) {
-    auto get_multiplied = [&](const Tensor& condition, const FloatOrTensor& value) -> Tensor {
-        if (std::holds_alternative<Tensor>(value)) {
-            return ttnn::multiply(queue_id, condition, std::get<Tensor>(value), std::nullopt, output_mem_config);
-        } else {
-            return ttnn::multiply(queue_id, condition, std::get<float>(value), std::nullopt, output_mem_config);
-        }
+    const auto& value_true,
+    const auto& value_false,
+    const MemoryConfig& memory_config,
+    std::optional<Tensor> output) {
+    using FusedActivations = tt::stl::Span<const unary::UnaryWithParam>;
+    constexpr auto dtype = std::nullopt;
+    const auto get_multiplied = [&](const Tensor& condition, const auto& value) -> Tensor {
+        return ttnn::multiply(
+            queue_id,
+            condition,
+            value,
+            dtype,
+            memory_config,
+            /* output */ std::nullopt,
+            /* post_activations */ FusedActivations{},
+            /* lhs_activations */ FusedActivations{},
+            /* rhs_activations */ FusedActivations{},
+            /* use_legacy */ false);
     };
 
-    Tensor t2 = get_multiplied(ttnn::gtz(queue_id, predicate, output_mem_config), value_true);
-    Tensor t1 = get_multiplied(ttnn::lez(queue_id, predicate, output_mem_config), value_false);
-
-    if (output_tensor.has_value()) {
-        ttnn::add(queue_id, t2, t1, std::nullopt, output_mem_config, output_tensor);
-    } else {
-        output_tensor = ttnn::add(queue_id, t2, t1, std::nullopt, output_mem_config);
-    }
-
-    return output_tensor.value();
+    return ttnn::add(
+        queue_id,
+        get_multiplied(ttnn::gtz(queue_id, predicate, memory_config), value_true),
+        get_multiplied(ttnn::lez(queue_id, predicate, memory_config), value_false),
+        dtype,
+        memory_config,
+        output,
+        /* post_activations */ FusedActivations{},
+        /* lhs_activations */ FusedActivations{},
+        /* rhs_activations */ FusedActivations{},
+        /* use_legacy */ false);
 }
 
 }  // namespace ternary_utils
 Tensor WhereOperation::invoke(
     QueueId queue_id,
     const Tensor& predicate,
-    const Tensor& value_true,
-    const Tensor& value_false,
-    const std::optional<MemoryConfig>& output_mem_config,
-    std::optional<Tensor> output_tensor) {
-    return ternary_utils::where_impl(
-        queue_id,
-        predicate,
+    const std::variant<float, Tensor>& value_true,
+    const std::variant<float, Tensor>& value_false,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<Tensor> output) {
+    return std::visit(
+        [&](const auto&... values) {
+            return ternary_utils::where_impl(
+                queue_id, predicate, values..., memory_config.value_or(predicate.memory_config()), std::move(output));
+        },
         value_true,
-        value_false,
-        output_mem_config.value_or(predicate.memory_config()),
-        std::move(output_tensor));
-}
-
-Tensor WhereOperation::invoke(
-    QueueId queue_id,
-    const Tensor& predicate,
-    const float value_true,
-    const Tensor& value_false,
-    const std::optional<MemoryConfig>& output_mem_config,
-    std::optional<Tensor> output_tensor) {
-    return ternary_utils::where_impl(
-        queue_id,
-        predicate,
-        value_true,
-        value_false,
-        output_mem_config.value_or(predicate.memory_config()),
-        std::move(output_tensor));
-}
-
-Tensor WhereOperation::invoke(
-    QueueId queue_id,
-    const Tensor& predicate,
-    const Tensor& value_true,
-    const float value_false,
-    const std::optional<MemoryConfig>& output_mem_config,
-    std::optional<Tensor> output_tensor) {
-    return ternary_utils::where_impl(
-        queue_id,
-        predicate,
-        value_true,
-        value_false,
-        output_mem_config.value_or(predicate.memory_config()),
-        std::move(output_tensor));
-}
-
-Tensor WhereOperation::invoke(
-    QueueId queue_id,
-    const Tensor& predicate,
-    const float value_true,
-    const float value_false,
-    const std::optional<MemoryConfig>& output_mem_config,
-    std::optional<Tensor> output_tensor) {
-    return ternary_utils::where_impl(
-        queue_id,
-        predicate,
-        value_true,
-        value_false,
-        output_mem_config.value_or(predicate.memory_config()),
-        std::move(output_tensor));
+        value_false);
 }
 
 }  // namespace ternary

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <optional>
+#include <variant>
 
 #include "ttnn/decorators.hpp"
 #include "ttnn/common/queue_id.hpp"
@@ -19,70 +20,10 @@ struct WhereOperation {
     static Tensor invoke(
         QueueId queue_id,
         const Tensor& predicate,
-        const Tensor& value_true,
-        const Tensor& value_false,
+        const std::variant<float, Tensor>& value_true,
+        const std::variant<float, Tensor>& value_false,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<Tensor> output_tensor = std::nullopt);
-
-    static Tensor invoke(
-        QueueId queue_id,
-        const Tensor& predicate,
-        const float value_true,
-        const Tensor& value_false,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> output_tensor = std::nullopt);
-
-    static Tensor invoke(
-        QueueId queue_id,
-        const Tensor& predicate,
-        const Tensor& value_true,
-        const float value_false,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> output_tensor = std::nullopt);
-
-    static Tensor invoke(
-        QueueId queue_id,
-        const Tensor& predicate,
-        const float value_true,
-        const float value_false,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> output_tensor = std::nullopt);
-
-    static Tensor invoke(
-        const Tensor& predicate,
-        const Tensor& value_true,
-        const Tensor& value_false,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> output_tensor = std::nullopt) {
-        return invoke(DefaultQueueId, predicate, value_true, value_false, memory_config, output_tensor);
-    }
-
-    static Tensor invoke(
-        const Tensor& predicate,
-        const float value_true,
-        const Tensor& value_false,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> output_tensor = std::nullopt) {
-        return invoke(DefaultQueueId, predicate, value_true, value_false, memory_config, output_tensor);
-    }
-
-    static Tensor invoke(
-        const Tensor& predicate,
-        const Tensor& value_true,
-        const float value_false,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> output_tensor = std::nullopt) {
-        return invoke(DefaultQueueId, predicate, value_true, value_false, memory_config, output_tensor);
-    }
-
-    static Tensor invoke(
-        const Tensor& predicate,
-        const float value_true,
-        const float value_false,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> output_tensor = std::nullopt) {
-        return invoke(DefaultQueueId, predicate, value_true, value_false, memory_config, output_tensor);
-    }
 };
 
 }  // namespace ternary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -116,8 +116,8 @@ std::vector<Tensor> ExecuteUnaryBackwardHardtanh::invoke(
     std::vector<Tensor> grad_tensor;
     Tensor grad_result = ttnn::where(
         ttnn::le(input, min, std::nullopt, output_mem_config),
-        0.0,
-        ttnn::where(ttnn::ge(input, max, std::nullopt, output_mem_config), 0.0, grad),
+        0.f,
+        ttnn::where(ttnn::ge(input, max, std::nullopt, output_mem_config), 0.f, grad),
         output_mem_config);
     grad_tensor.emplace_back(grad_result);
     return grad_tensor;
@@ -135,7 +135,7 @@ std::vector<Tensor> ExecuteUnaryBackwardThreshold::invoke(
     Tensor result = ttnn::where(
         ttnn::gtz(ttnn::add(input, -threshold, std::nullopt, output_mem_config), output_mem_config),
         grad,
-        0.0,
+        0.f,
         output_mem_config);
     grad_tensor.emplace_back(result);
     return grad_tensor;
@@ -428,8 +428,8 @@ std::vector<Tensor> ExecuteUnaryBackwardTrunc::invoke(
 std::vector<Tensor> ExecuteUnaryBackwardLogSigmoid::invoke(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    Tensor max_deriv = ttnn::where(ttnn::ltz(input, output_mem_config), 1, 0, output_mem_config);
-    Tensor in_sign = ttnn::where(ttnn::ltz(input, output_mem_config), 1, -1, output_mem_config);
+    Tensor max_deriv = ttnn::where(ttnn::ltz(input, output_mem_config), 1.f, 0.f, output_mem_config);
+    Tensor in_sign = ttnn::where(ttnn::ltz(input, output_mem_config), 1.f, -1.f, output_mem_config);
     Tensor in_abs = ttnn::abs(input, output_mem_config);
     Tensor z = ttnn::exp(ttnn::neg(in_abs, output_mem_config), false, output_mem_config);
 
@@ -593,7 +593,7 @@ std::vector<Tensor> ExecuteUnaryBackwardHardsigmoid::invoke(
             ttnn::ge(input, 3, std::nullopt, output_mem_config),
             std::nullopt,
             output_mem_config),
-        0.0,
+        0.f,
         ttnn::multiply(grad, 1.0 / 6),
         output_mem_config);
     grad_tensor.emplace_back(grad_a);
@@ -777,7 +777,7 @@ std::vector<Tensor> ExecuteUnaryBackwardSoftshrink::invoke(
             std::nullopt,
             output_mem_config),
         grad,
-        0.0,
+        0.f,
         output_mem_config);
     grad_tensor.emplace_back(result);
     return grad_tensor;
@@ -973,7 +973,7 @@ std::vector<Tensor> ExecuteUnaryBackwardHardswish::invoke(
     std::vector<Tensor> grad_tensor;
     Tensor grad_result = where(
         ttnn::lt(input, -3.0f, std::nullopt, output_mem_config),
-        0.0,
+        0.f,
         where(
             ttnn::le(input, 3.0f, std::nullopt, output_mem_config),
             ttnn::multiply(
@@ -1020,7 +1020,7 @@ std::vector<Tensor> ExecuteUnaryBackwardAtanh::invoke(
     grad_a = where(ttnn::eqz(grad, output_mem_config), t_nan, grad_a, output_mem_config);
     grad_a = where(
         ttnn::logical_and(ttnn::eqz(grad, output_mem_config), ttnn::eqz(input, output_mem_config)),
-        0,
+        0.f,
         grad_a,
         output_mem_config);
     grad_a = where(
@@ -1296,7 +1296,7 @@ std::vector<Tensor> ExecuteUnaryBackwardLogiteps::invoke(
         output_mem_config);
     grad_result = where(
         ttnn::eq(ltl_gth, 1.0f, std::nullopt, output_mem_config),
-        where(ttnn::ltz(t_eps, output_mem_config), std::nanf(" "), 0.0, output_mem_config),
+        where(ttnn::ltz(t_eps, output_mem_config), std::nanf(" "), 0.f, output_mem_config),
         where(
             ttnn::logical_or(
                 ttnn::eq(input, 0.0, std::nullopt, output_mem_config),
@@ -1353,7 +1353,7 @@ std::vector<Tensor> ExecuteUnaryBackwardDivNoNan::invoke(
     Tensor val = ttnn::full_like(input, scalar, input.dtype(), input.layout(), std::nullopt, output_mem_config);
     Tensor result = where(
         ttnn::eq(val, 0, std::nullopt, output_mem_config),
-        0.0,
+        0.f,
         ttnn::multiply(grad, 1 / scalar, std::nullopt, output_mem_config),
         output_mem_config);
     grad_tensor.emplace_back(result);
@@ -1449,7 +1449,7 @@ std::vector<ComplexTensor> ExecuteUnaryBackwardAbs::invoke(
     Tensor result = ttnn::abs(input, output_mem_config);
     Tensor grad_inp_r = where(
         ttnn::eqz(result, output_mem_config),
-        0.0,
+        0.f,
         ttnn::multiply(
             grad,
             ttnn::multiply(input.real(), ttnn::reciprocal(result, output_mem_config), std::nullopt, output_mem_config),
@@ -1458,7 +1458,7 @@ std::vector<ComplexTensor> ExecuteUnaryBackwardAbs::invoke(
         output_mem_config);
     Tensor grad_inp_i = where(
         ttnn::eqz(result, output_mem_config),
-        0.0,
+        0.f,
         ttnn::multiply(
             grad,
             ttnn::multiply(input.imag(), ttnn::reciprocal(result, output_mem_config), std::nullopt, output_mem_config),

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
@@ -66,7 +66,8 @@ Tensor ArgmaxOperation::invoke(
             Tensor cmp_results = ttnn::eq(input_a, max_tensor, std::nullopt, output_memory_config);
             Tensor max_indices = ttnn::multiply(cmp_results, tindex, std::nullopt, output_memory_config);
             cmp_results.deallocate();
-            Tensor result = ttnn::where(ttnn::eqz(max_indices), size, max_indices, output_memory_config);
+            Tensor result =
+                ttnn::where(ttnn::eqz(max_indices), static_cast<float>(size), max_indices, output_memory_config);
             max_indices.deallocate();
             result = ttnn::min(result, (int)dim, true, output_memory_config);
             Tensor res_index = ttnn::zeros_like(result);
@@ -145,7 +146,7 @@ Tensor ArgmaxOperation::invoke(
     Tensor cmp_results = ttnn::eq(input_a, max_tensor, std::nullopt, output_memory_config);
     Tensor max_indices = ttnn::multiply(cmp_results, tindex, std::nullopt, output_memory_config);
     cmp_results.deallocate();
-    Tensor result = ttnn::where(ttnn::eqz(max_indices), size, max_indices, output_memory_config);
+    Tensor result = ttnn::where(ttnn::eqz(max_indices), static_cast<float>(size), max_indices, output_memory_config);
     max_indices.deallocate();
     result = ttnn::min(result, std::nullopt, true, output_memory_config);
     return result;


### PR DESCRIPTION
### Ticket
#22308

### Problem description
The problem reported is that `ttnn.where` would output NaN even when not selected by the condition. This is caused by using `(C > 0) * T + (C <= 0) * F` as the implementation, where operations are performed on the SFPU with IEEE semantics for NaN which propagate it even when multiplied by 0. In contrast, the FPU treats NaN as any other value, so multiplying with 0 yields 0, not NaN. The legacy implementation would use FPU multiply for FP32 when subtile broadcasting was required, but SFPU multiply otherwise. binary_ng consistently uses SFPU for FP32 multiply, and so always propagates NaN.

### What's changed
The ideal fix for this is to implement `ttnn.where` using SFPU to handle the conditional logic without multiply and add, which sidesteps issues with IEEE semantics for NaN. Until this implementation is available, we can document this behavior in `xfail` unit tests, and use binary_ng so it's at least consistent.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15622471556) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15622476544) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/15590869512) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15590871505) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes