### PR TITLE
#23113: (Part 2) Add DRAM Sharding to i2s

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_interleaved_to_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_interleaved_to_sharded.py
@@ -73,12 +73,12 @@ def test_interleaved_to_sharded_hash(device, first_dtype, second_dtype, input_in
         [
             [2, 2, 128, 64],
             (128, 64),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ],
         [
             [1, 1, 416, 64],
             (128, 64),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ],
     ],
 )
@@ -89,13 +89,13 @@ def test_interleaved_to_dram_height_sharded(
     # Output memory config
     output_shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
     output_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec  # TODO: (GR) Buffer Type
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, output_shard_spec
     )
 
     # Test
     torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
     ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=layout)
-    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)  # TODO: (GR): Remove this line
+    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)
     ttnn_output_tensor = ttnn.interleaved_to_sharded(ttnn_input_tensor, output_mem_config)
 
     assert_with_pcc(torch_input_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
@@ -109,12 +109,12 @@ def test_interleaved_to_dram_height_sharded(
         [
             [2, 1, 32, 512],
             (64, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ],
         [
             [1, 1, 64, 416],
             (64, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ],
     ],
 )
@@ -125,64 +125,13 @@ def test_interleaved_to_dram_width_sharded(
     # Output memory config
     output_shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
     output_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, output_shard_spec  # TODO: (GR) Buffer Type
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, output_shard_spec
     )
 
     # Test
     torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
     ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=layout)
-    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)  # TODO: (GR): Remove this line
-    ttnn_output_tensor = ttnn.interleaved_to_sharded(ttnn_input_tensor, output_mem_config)
-
-    assert_with_pcc(torch_input_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
-
-
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
-@pytest.mark.parametrize(
-    "tensor_shape, shard_shape, shard_grid",
-    [
-        [
-            [2, 2, 64, 256],
-            (128, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
-        ],
-        [
-            [1, 1, 192, 192],
-            (64, 64),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 2))}),
-        ],
-        [
-            [2, 1, 80, 128],
-            (128, 64),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
-        ],
-        [
-            [2, 1, 64, 160],
-            (64, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
-        ],
-        [
-            [2, 1, 80, 160],
-            (128, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
-        ],
-    ],
-)
-@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
-def test_interleaved_to_dram_block_sharded(
-    device, dtype, layout, tensor_shape, shard_shape, shard_grid, shard_orientation
-):
-    # Output memory config
-    output_shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
-    output_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, output_shard_spec  # TODO: (GR) Buffer Type
-    )
-
-    # Test
-    torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
-    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=layout)
-    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)  # TODO: (GR): Remove this line
+    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)
     ttnn_output_tensor = ttnn.interleaved_to_sharded(ttnn_input_tensor, output_mem_config)
 
     assert_with_pcc(torch_input_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
@@ -203,19 +152,13 @@ def test_interleaved_to_dram_block_sharded(
             [1, 1, 416, 64],
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             (128, 64),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ],
         [
             [1, 1, 64, 416],
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             (64, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
-        ],
-        [
-            [2, 1, 80, 160],
-            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            (128, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ],
     ],
 )
@@ -225,12 +168,12 @@ def test_interleaved_to_dram_sharded_convert_dtype(
 ):
     # Output memory config
     output_shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
-    output_mem_config = ttnn.MemoryConfig(shard_type, ttnn.BufferType.L1, output_shard_spec)  # TODO: (GR) Buffer Type
+    output_mem_config = ttnn.MemoryConfig(shard_type, ttnn.BufferType.DRAM, output_shard_spec)
 
     # Test
     torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
     ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=in_dtype, layout=layout)
-    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)  # TODO: (GR): Remove this line
+    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)
     ttnn_output_tensor = ttnn.interleaved_to_sharded(ttnn_input_tensor, output_mem_config, out_dtype)
 
     assert_with_pcc(torch_input_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)

--- a/tests/ttnn/unit_tests/operations/test_interleaved_to_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_interleaved_to_sharded.py
@@ -65,7 +65,7 @@ def test_interleaved_to_sharded_hash(device, first_dtype, second_dtype, input_in
         pcc_passed_b, pcc_message_b = assert_with_pcc(input_tensor_torch, ttnn.to_torch(output_tensor), pcc=0.9999)
 
 
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize(
     "tensor_shape, shard_shape, shard_grid",
@@ -86,6 +86,9 @@ def test_interleaved_to_sharded_hash(device, first_dtype, second_dtype, input_in
 def test_interleaved_to_dram_height_sharded(
     device, dtype, layout, tensor_shape, shard_shape, shard_grid, shard_orientation
 ):
+    if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("bfloat8_b not supported for i2s row-major")
+
     # Output memory config
     output_shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
     output_mem_config = ttnn.MemoryConfig(
@@ -101,7 +104,7 @@ def test_interleaved_to_dram_height_sharded(
     assert_with_pcc(torch_input_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
 
 
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize(
     "tensor_shape, shard_shape, shard_grid",
@@ -122,6 +125,9 @@ def test_interleaved_to_dram_height_sharded(
 def test_interleaved_to_dram_width_sharded(
     device, dtype, layout, tensor_shape, shard_shape, shard_grid, shard_orientation
 ):
+    if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("bfloat8_b not supported for i2s row-major")
+
     # Output memory config
     output_shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
     output_mem_config = ttnn.MemoryConfig(
@@ -140,8 +146,8 @@ def test_interleaved_to_dram_width_sharded(
 @pytest.mark.parametrize(
     "in_dtype, out_dtype",
     [
-        [ttnn.bfloat16, ttnn.float32],
-        [ttnn.float32, ttnn.bfloat16],
+        [ttnn.bfloat8_b, ttnn.float32],
+        [ttnn.float32, ttnn.bfloat8_b],
     ],
 )
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
@@ -175,5 +181,46 @@ def test_interleaved_to_dram_sharded_convert_dtype(
     ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=in_dtype, layout=layout)
     ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)
     ttnn_output_tensor = ttnn.interleaved_to_sharded(ttnn_input_tensor, output_mem_config, out_dtype)
+
+    assert_with_pcc(torch_input_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.float32])
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("input_mem_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
+@pytest.mark.parametrize(
+    "tensor_shape, shard_type, shard_shape, shard_grid",
+    [
+        [
+            [1, 1, 416, 64],
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            (128, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+        ],
+        [
+            [1, 1, 64, 416],
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            (64, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+        ],
+    ],
+)
+@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+def test_interleaved_to_dram_sharded_via_to_memory_layout(
+    device, dtype, layout, input_mem_config, tensor_shape, shard_type, shard_shape, shard_grid, shard_orientation
+):
+    if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("bfloat8_b not supported for i2s row-major")
+
+    # Output memory config
+    output_shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
+    output_mem_config = ttnn.MemoryConfig(shard_type, ttnn.BufferType.DRAM, output_shard_spec)
+
+    # Test
+    torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=dtype, layout=layout, device=device, memory_config=input_mem_config
+    )
+    ttnn_output_tensor = ttnn.to_memory_config(ttnn_input_tensor, output_mem_config)
 
     assert_with_pcc(torch_input_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)

--- a/tests/ttnn/unit_tests/operations/test_interleaved_to_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_interleaved_to_sharded.py
@@ -89,7 +89,7 @@ def test_interleaved_to_dram_height_sharded(
     # Output memory config
     output_shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
     output_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec  # TODO (GR): Buffer Type
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec  # TODO: (GR) Buffer Type
     )
 
     # Test
@@ -125,7 +125,7 @@ def test_interleaved_to_dram_width_sharded(
     # Output memory config
     output_shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
     output_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, output_shard_spec  # TODO (GR): Buffer Type
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, output_shard_spec  # TODO: (GR) Buffer Type
     )
 
     # Test
@@ -176,7 +176,7 @@ def test_interleaved_to_dram_block_sharded(
     # Output memory config
     output_shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
     output_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, output_shard_spec  # TODO (GR): Buffer Type
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, output_shard_spec  # TODO: (GR) Buffer Type
     )
 
     # Test
@@ -225,7 +225,7 @@ def test_interleaved_to_dram_sharded_convert_dtype(
 ):
     # Output memory config
     output_shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
-    output_mem_config = ttnn.MemoryConfig(shard_type, ttnn.BufferType.L1, output_shard_spec)  # TODO (GR): Buffer Type
+    output_mem_config = ttnn.MemoryConfig(shard_type, ttnn.BufferType.L1, output_shard_spec)  # TODO: (GR) Buffer Type
 
     # Test
     torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/test_interleaved_to_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_interleaved_to_sharded.py
@@ -186,3 +186,51 @@ def test_interleaved_to_dram_block_sharded(
     ttnn_output_tensor = ttnn.interleaved_to_sharded(ttnn_input_tensor, output_mem_config)
 
     assert_with_pcc(torch_input_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+
+
+@pytest.mark.parametrize(
+    "in_dtype, out_dtype",
+    [
+        [ttnn.bfloat16, ttnn.float32],
+        [ttnn.float32, ttnn.bfloat16],
+    ],
+)
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize(
+    "tensor_shape, shard_type, shard_shape, shard_grid",
+    [
+        [
+            [1, 1, 416, 64],
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            (128, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+        ],
+        [
+            [1, 1, 64, 416],
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            (64, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+        ],
+        [
+            [2, 1, 80, 160],
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            (128, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
+        ],
+    ],
+)
+@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+def test_interleaved_to_dram_sharded_convert_dtype(
+    device, in_dtype, out_dtype, layout, tensor_shape, shard_type, shard_shape, shard_grid, shard_orientation
+):
+    # Output memory config
+    output_shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
+    output_mem_config = ttnn.MemoryConfig(shard_type, ttnn.BufferType.L1, output_shard_spec)  # TODO (GR): Buffer Type
+
+    # Test
+    torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=in_dtype, layout=layout)
+    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)  # TODO: (GR): Remove this line
+    ttnn_output_tensor = ttnn.interleaved_to_sharded(ttnn_input_tensor, output_mem_config, out_dtype)
+
+    assert_with_pcc(torch_input_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -12,7 +12,6 @@
 
 #endif
 
-#include "dataflow_api.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/types/sharding_common.hpp"
 
 using mapping_table_t = uint32_t;

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -12,6 +12,7 @@
 
 #endif
 
+#include "dataflow_api.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/types/sharding_common.hpp"
 
 using mapping_table_t = uint32_t;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
@@ -22,7 +22,6 @@ void kernel_main() {
 
     // single-tile ublocks
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
-    const DataFormat data_format = get_dataformat(cb_id_out);
 
     using tensor_shard_info = ShardedInfo<
         get_compile_time_arg_val(1),   // Memory layout

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
 #include "dataflow_api.h"
 #include "ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
@@ -48,9 +49,9 @@ void kernel_main() {
             noc_async_write_tile(tile_id, s, l1_read_addr);
             tile_id++;
             l1_read_addr += tile_bytes;
-            noc_async_write_barrier();
         }
         row_start_tile_id += output_width_tiles;
     }
+    noc_async_write_barrier();
     cb_pop_front(cb_id_out, block_width_padded_num_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    // run-time args
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t block_height_tiles = get_arg_val<uint32_t>(1);
+    const uint32_t block_width_tiles = get_arg_val<uint32_t>(2);
+    const uint32_t block_num_tiles = get_arg_val<uint32_t>(3);  // block_height_tiles * block_width_tiles
+    const uint32_t output_width_tiles = get_arg_val<uint32_t>(4);
+    const uint32_t start_id_offset = get_arg_val<uint32_t>(5);
+    const uint32_t start_id_base = get_arg_val<uint32_t>(6);
+
+    // TODO: (GR) Don't think we need these since reader takes care of not passing in the uneven parts
+    // const uint32_t unpadded_block_height_tiles = get_arg_val<uint32_t>(3);
+    // const uint32_t unpadded_block_width_tiles = get_arg_val<uint32_t>(4);
+
+    // compile-time args
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+
+    // single-tile ublocks
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+    const DataFormat data_format = get_dataformat(cb_id_out);
+
+    // TODO: (GR) Update compile time arg indices
+    using tensor_shard_info = ShardedInfo<
+        get_compile_time_arg_val(1),   // Memory layout
+        get_compile_time_arg_val(2),   // The number of sharding cores
+        get_compile_time_arg_val(3),   // The page size we offset each write to
+        get_compile_time_arg_val(4),   // The number of pages in each sharding row not including padding pages
+        get_compile_time_arg_val(5),   // This defines times when contiguous pages can't be calculated
+        get_compile_time_arg_val(6),   // pages_per_shard_x
+        get_compile_time_arg_val(7)>;  // pages_per_shard_y
+
+    // TODO: (GR) Update runtime arg index
+    const auto [mapping_table, rt_increment] =
+        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(7));
+    experimental::ShardedAddrGen<tensor_shard_info> s = {.bank_base_address = dst_addr, .shard_array = mapping_table};
+
+    uint32_t row_start_tile_id = start_id_base + start_id_offset;
+    cb_wait_front(cb_id_out, block_num_tiles);
+    uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+    for (uint32_t h = 0; h < block_height_tiles; h++) {
+        uint32_t tile_id = row_start_tile_id;
+        for (uint32_t w = 0; w < block_width_tiles; w++) {
+            noc_async_write_tile(tile_id, s, l1_read_addr);
+            tile_id++;
+            l1_read_addr += tile_bytes;
+            noc_async_write_barrier();
+        }
+        row_start_tile_id += output_width_tiles;
+    }
+    cb_pop_front(cb_id_out, block_num_tiles);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
@@ -9,7 +9,7 @@ void kernel_main() {
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const uint32_t block_height_tiles = get_arg_val<uint32_t>(1);
     const uint32_t block_width_tiles = get_arg_val<uint32_t>(2);
-    const uint32_t block_num_tiles = get_arg_val<uint32_t>(3);  // block_height_tiles * block_width_tiles
+    const uint32_t block_width_padded_num_tiles = get_arg_val<uint32_t>(3);
     const uint32_t output_width_tiles = get_arg_val<uint32_t>(4);
     const uint32_t start_id_offset = get_arg_val<uint32_t>(5);
     const uint32_t start_id_base = get_arg_val<uint32_t>(6);
@@ -41,7 +41,7 @@ void kernel_main() {
     experimental::ShardedAddrGen<tensor_shard_info> s = {.bank_base_address = dst_addr, .shard_array = mapping_table};
 
     uint32_t row_start_tile_id = start_id_base + start_id_offset;
-    cb_wait_front(cb_id_out, block_num_tiles);
+    cb_wait_front(cb_id_out, block_width_padded_num_tiles);
     uint32_t l1_read_addr = get_read_ptr(cb_id_out);
     for (uint32_t h = 0; h < block_height_tiles; h++) {
         uint32_t tile_id = row_start_tile_id;
@@ -53,5 +53,5 @@ void kernel_main() {
         }
         row_start_tile_id += output_width_tiles;
     }
-    cb_pop_front(cb_id_out, block_num_tiles);
+    cb_pop_front(cb_id_out, block_width_padded_num_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
 void kernel_main() {
     // run-time args
@@ -25,7 +26,6 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
     const DataFormat data_format = get_dataformat(cb_id_out);
 
-    // TODO: (GR) Update compile time arg indices
     using tensor_shard_info = ShardedInfo<
         get_compile_time_arg_val(1),   // Memory layout
         get_compile_time_arg_val(2),   // The number of sharding cores
@@ -35,7 +35,6 @@ void kernel_main() {
         get_compile_time_arg_val(6),   // pages_per_shard_x
         get_compile_time_arg_val(7)>;  // pages_per_shard_y
 
-    // TODO: (GR) Update runtime arg index
     const auto [mapping_table, rt_increment] =
         experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(7));
     experimental::ShardedAddrGen<tensor_shard_info> s = {.bank_base_address = dst_addr, .shard_array = mapping_table};

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp
@@ -4,8 +4,10 @@
 
 #include <stdint.h>
 #include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
 void kernel_main() {
+    // run-time args
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const uint32_t stick_size = get_arg_val<uint32_t>(1);
     const uint32_t block_height = get_arg_val<uint32_t>(2);
@@ -14,14 +16,28 @@ void kernel_main() {
     const uint32_t input_width_offset_bytes = get_arg_val<uint32_t>(5);
     const uint32_t start_id = get_arg_val<uint32_t>(6);
 
+    // compile-time args
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
 
     constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
     constexpr bool dst_stick_size_is_pow2 = get_compile_time_arg_val(2) == 1;
     constexpr uint32_t dst_log_base_2_of_page_size = get_compile_time_arg_val(3);
 
-    const auto s0 = get_interleaved_addr_gen<dst0_is_dram, dst_stick_size_is_pow2>(
-        dst_addr + input_width_offset_bytes, stick_size, dst_log_base_2_of_page_size);
+    // TODO: (GR) Update indexing
+    using tensor_shard_info = ShardedInfo<
+        get_compile_time_arg_val(1),   // Memory layout
+        get_compile_time_arg_val(2),   // The number of sharding cores
+        get_compile_time_arg_val(3),   // The page size we offset each write to
+        get_compile_time_arg_val(4),   // The number of pages in each sharding row not including padding pages
+        get_compile_time_arg_val(5),   // This defines times when contiguous pages can't be calculated
+        get_compile_time_arg_val(6),   // pages_per_shard_x
+        get_compile_time_arg_val(7)>;  // pages_per_shard_y
+
+    // TODO: (GR) Update indexing
+    const auto [mapping_table, rt_increment] =
+        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(7));
+    experimental::ShardedAddrGen<tensor_shard_info> s = {
+        .bank_base_address = dst_addr + input_width_offset_bytes, .shard_array = mapping_table};
 
     uint32_t stick_id = start_id;
     cb_wait_front(cb_id_out0, block_height);
@@ -31,7 +47,7 @@ void kernel_main() {
         noc_async_write(l1_read_addr, dst_noc_addr, block_width_bytes);
         stick_id++;
         l1_read_addr += padded_block_width_bytes;
-        noc_async_write_barrier();
     }
+    noc_async_write_barrier();
     cb_pop_front(cb_id_out0, block_height);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp
@@ -9,21 +9,14 @@
 void kernel_main() {
     // run-time args
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    const uint32_t stick_size = get_arg_val<uint32_t>(1);
-    const uint32_t block_height = get_arg_val<uint32_t>(2);
-    const uint32_t block_width_bytes = get_arg_val<uint32_t>(3);
-    const uint32_t padded_block_width_bytes = get_arg_val<uint32_t>(4);
-    const uint32_t input_width_offset_bytes = get_arg_val<uint32_t>(5);
-    const uint32_t start_id = get_arg_val<uint32_t>(6);
+    const uint32_t block_height = get_arg_val<uint32_t>(1);
+    const uint32_t block_width_bytes = get_arg_val<uint32_t>(2);
+    const uint32_t start_id = get_arg_val<uint32_t>(3);
+    const uint32_t output_width_in_pages = get_arg_val<uint32_t>(4);
 
     // compile-time args
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
 
-    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr bool dst_stick_size_is_pow2 = get_compile_time_arg_val(2) == 1;
-    constexpr uint32_t dst_log_base_2_of_page_size = get_compile_time_arg_val(3);
-
-    // TODO: (GR) Update indexing
     using tensor_shard_info = ShardedInfo<
         get_compile_time_arg_val(1),   // Memory layout
         get_compile_time_arg_val(2),   // The number of sharding cores
@@ -33,9 +26,8 @@ void kernel_main() {
         get_compile_time_arg_val(6),   // pages_per_shard_x
         get_compile_time_arg_val(7)>;  // pages_per_shard_y
 
-    // TODO: (GR) Update indexing
     const auto [mapping_table, rt_increment] =
-        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(7));
+        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(5));
     experimental::ShardedAddrGen<tensor_shard_info> s = {
         .bank_base_address = dst_addr + input_width_offset_bytes, .shard_array = mapping_table};
 
@@ -43,10 +35,10 @@ void kernel_main() {
     cb_wait_front(cb_id_out0, block_height);
     uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
     for (uint32_t h = 0; h < block_height; ++h) {
-        uint64_t dst_noc_addr = get_noc_addr(stick_id, s0);
+        uint64_t dst_noc_addr = get_noc_addr(stick_id, s);
         noc_async_write(l1_read_addr, dst_noc_addr, block_width_bytes);
-        stick_id++;
-        l1_read_addr += padded_block_width_bytes;
+        stick_id += output_width_in_pages;
+        l1_read_addr += block_width_bytes;
     }
     noc_async_write_barrier();
     cb_pop_front(cb_id_out0, block_height);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp
@@ -11,8 +11,9 @@ void kernel_main() {
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const uint32_t block_height = get_arg_val<uint32_t>(1);
     const uint32_t block_width_bytes = get_arg_val<uint32_t>(2);
-    const uint32_t start_id = get_arg_val<uint32_t>(3);
-    const uint32_t output_width_in_pages = get_arg_val<uint32_t>(4);
+    const uint32_t padded_block_width_bytes = get_arg_val<uint32_t>(3);
+    const uint32_t start_id = get_arg_val<uint32_t>(4);
+    const uint32_t output_width_in_pages = get_arg_val<uint32_t>(5);
 
     // compile-time args
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
@@ -27,9 +28,8 @@ void kernel_main() {
         get_compile_time_arg_val(7)>;  // pages_per_shard_y
 
     const auto [mapping_table, rt_increment] =
-        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(5));
-    experimental::ShardedAddrGen<tensor_shard_info> s = {
-        .bank_base_address = dst_addr + input_width_offset_bytes, .shard_array = mapping_table};
+        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(6));
+    experimental::ShardedAddrGen<tensor_shard_info> s = {.bank_base_address = dst_addr, .shard_array = mapping_table};
 
     uint32_t stick_id = start_id;
     cb_wait_front(cb_id_out0, block_height);
@@ -38,7 +38,7 @@ void kernel_main() {
         uint64_t dst_noc_addr = get_noc_addr(stick_id, s);
         noc_async_write(l1_read_addr, dst_noc_addr, block_width_bytes);
         stick_id += output_width_in_pages;
-        l1_read_addr += block_width_bytes;
+        l1_read_addr += padded_block_width_bytes;
     }
     noc_async_write_barrier();
     cb_pop_front(cb_id_out0, block_height);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t stick_size = get_arg_val<uint32_t>(1);
+    const uint32_t block_height = get_arg_val<uint32_t>(2);
+    const uint32_t block_width_bytes = get_arg_val<uint32_t>(3);
+    const uint32_t padded_block_width_bytes = get_arg_val<uint32_t>(4);
+    const uint32_t input_width_offset_bytes = get_arg_val<uint32_t>(5);
+    const uint32_t start_id = get_arg_val<uint32_t>(6);
+
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
+
+    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr bool dst_stick_size_is_pow2 = get_compile_time_arg_val(2) == 1;
+    constexpr uint32_t dst_log_base_2_of_page_size = get_compile_time_arg_val(3);
+
+    const auto s0 = get_interleaved_addr_gen<dst0_is_dram, dst_stick_size_is_pow2>(
+        dst_addr + input_width_offset_bytes, stick_size, dst_log_base_2_of_page_size);
+
+    uint32_t stick_id = start_id;
+    cb_wait_front(cb_id_out0, block_height);
+    uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+    for (uint32_t h = 0; h < block_height; ++h) {
+        uint64_t dst_noc_addr = get_noc_addr(stick_id, s0);
+        noc_async_write(l1_read_addr, dst_noc_addr, block_width_bytes);
+        stick_id++;
+        l1_read_addr += padded_block_width_bytes;
+        noc_async_write_barrier();
+    }
+    cb_pop_front(cb_id_out0, block_height);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -18,6 +18,9 @@ void InterleavedToShardedDeviceOperation::validate(const std::vector<Tensor>& in
 
     TT_FATAL(input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
     TT_FATAL(this->output_mem_config.is_sharded(), "Error");
+    if (this->output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+        TT_FATAL(this->output_mem_config.buffer_type() == BufferType::L1, "We don't support DRAM block sharding");
+    }
     if (input_tensor.get_layout() == Layout::ROW_MAJOR) {
         TT_FATAL((*this->output_mem_config.shard_spec()).shape[1] * input_tensor.element_size() % hal::get_l1_alignment() == 0, "Shard page size must currently have L1 aligned page size");
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -18,8 +18,7 @@ void InterleavedToShardedDeviceOperation::validate(const std::vector<Tensor>& in
 
     TT_FATAL(input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
     TT_FATAL(this->output_mem_config.is_sharded(), "Error");
-    TT_FATAL(this->output_mem_config.buffer_type() == BufferType::L1, "Error");
-    if (input_tensor.layout() == Layout::ROW_MAJOR) {
+    if (input_tensor.get_layout() == Layout::ROW_MAJOR) {
         TT_FATAL((*this->output_mem_config.shard_spec()).shape[1] * input_tensor.element_size() % hal::get_l1_alignment() == 0, "Shard page size must currently have L1 aligned page size");
     }
     if (input_tensor.dtype() != this->output_dtype) {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -235,13 +235,14 @@ operation::ProgramWithCallbacks interleaved_to_sharded_multi_core(
             tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_run_time_args);
 
             // Writer run-time args
+            uint32_t pad_offset = (num_units_per_shard_width - shard_width) * output_unit_size;
             std::vector<uint32_t> writer_run_time_args;
             if (dst_is_dram) {
                 writer_run_time_args = {
                     dst_buffer->address(),
                     shard_height,
                     shard_width,
-                    padded_offset,
+                    pad_offset,
                     curr_num_units_per_shard,
                     num_units_offset,
                     curr_idx_h + curr_idx_w,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -43,7 +43,7 @@ operation::ProgramWithCallbacks interleaved_to_sharded_multi_core(
     auto src_buffer = input.buffer();
     auto dst_buffer = output.buffer();
     bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dst_is_dram = true; // dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM; TODO: (GR) Put back to normal
+    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     bool is_blackhole = (input.device()->arch() == tt::ARCH::BLACKHOLE);
 
     if (input.layout() == Layout::TILE) {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
+#include "cpp/ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 #include "cpp/ttnn/operations/data_movement/sharded/sharded_common.hpp"
 #include "cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp"
 #include <tt-metalium/tt_align.hpp>
@@ -349,6 +350,8 @@ operation::ProgramWithCallbacks interleaved_to_sharded_multi_core(
             const std::vector<Tensor>& output_tensors) {
             auto src_buffer = input_tensors.at(0).buffer();
             auto dst_buffer = output_tensors.at(0).buffer();
+
+            bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
 
             bool partial_op = num_slices > 1;
             uint32_t starting_idx_h = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "interleaved_to_sharded_program_factory.hpp"
+
 #include <math.h>
 
 #include "ttnn/operations/math.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -238,7 +238,7 @@ operation::ProgramWithCallbacks interleaved_to_sharded_multi_core(
                     dst_buffer->address(),
                     shard_height,
                     shard_width,
-                    shard_height * shard_width,
+                    curr_num_units_per_shard,
                     num_units_per_row,
                     curr_idx_h + curr_idx_w,
                     starting_idx_h};

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -106,7 +106,9 @@ operation::ProgramWithCallbacks interleaved_to_sharded_multi_core(
     tt::tt_metal::CircularBufferConfig output_cb_out_config =
         tt::tt_metal::CircularBufferConfig(num_input_units * output_page_size, {{out_cb_index, output_cb_data_format}})
             .set_page_size(out_cb_index, output_page_size)
-            .set_globally_allocated_address(*output.buffer());
+    if (!dst_is_dram) {
+        output_cb_out_config = output_cb_out_config.set_globally_allocated_address(*output.buffer());
+    }
     auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_out_config);
     uint32_t dram_alignment = hal::get_dram_alignment();
     if (src_is_dram && input_unit_size % dram_alignment != 0 or is_blackhole or keep_l1_aligned) {


### PR DESCRIPTION
### Ticket
[#23113 ](https://github.com/tenstorrent/tt-metal/issues/23113#event-18005000203)

### Problem description
- Output DRAM sharding was not supported for the `interleaved_to_sharded` op

### What's changed
- Add support for output DRAM height and width sharding (note that we don't support DRAM block sharding)
- DRAM sharding support added to the `ShardedAddrGen` in [this PR](https://github.com/tenstorrent/tt-metal/pull/23376)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes