### PR TITLE
Slightly increase Falcon7b WH demo CI perf targets

### DIFF
--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -11,9 +11,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 1412, "decode_t/s": 516, "decode_t/s/u": 16.11}, False, None),
-        (True, 1024, {"prefill_t/s": 2117, "decode_t/s": 440, "decode_t/s/u": 13.7}, False, None),
-        (True, 2048, {"prefill_t/s": 1967, "decode_t/s": 420, "decode_t/s/u": 13.12}, False, None),
+        (True, 128, {"prefill_t/s": 1597, "decode_t/s": 549, "decode_t/s/u": 17.16}, False, None),
+        (True, 1024, {"prefill_t/s": 2117, "decode_t/s": 448, "decode_t/s/u": 14.0}, False, None),
+        (True, 2048, {"prefill_t/s": 1967, "decode_t/s": 445, "decode_t/s/u": 13.91}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -12,7 +12,7 @@ from models.utility_functions import is_wormhole_b0
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
         (True, 128, {"prefill_t/s": 1597, "decode_t/s": 549, "decode_t/s/u": 17.16}, False, None),
-        (True, 1024, {"prefill_t/s": 2117, "decode_t/s": 448, "decode_t/s/u": 14.0}, False, None),
+        (True, 1024, {"prefill_t/s": 2117, "decode_t/s": 487, "decode_t/s/u": 15.24}, False, None),
         (True, 2048, {"prefill_t/s": 1967, "decode_t/s": 445, "decode_t/s/u": 13.91}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Falcon7b WH demo CI targets needed to be slightly increased after docker changes in https://github.com/tenstorrent/tt-metal/commit/d8dfec98e4fc550ae88409791c02ee2f124d9a43 (only affects CI).

### What's changed
- Slightly increased Falcon7b WH demo perf targets

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes