### PR TITLE
vLLM scheduled test now uses dev branch

### DIFF
--- a/.github/workflows/vllm-nightly-tests.yaml
+++ b/.github/workflows/vllm-nightly-tests.yaml
@@ -27,4 +27,4 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      vllm-commit: ${{ inputs.vllm-commit }}
+      vllm-commit: ${{ inputs.vllm-commit || 'dev' }}


### PR DESCRIPTION
### Ticket
n/a

### Problem description
Nightly vLLM test was using `main` branch instead of `dev`, hence failing to install vLLM for `device=tt`
https://github.com/tenstorrent/tt-metal/actions/runs/15572840735/job/43852715559#step:5:97

### What's changed
Define `dev` as default if the vLLM sha input does not exist.

### Checklist
vLLM manual test passes
https://github.com/tenstorrent/tt-metal/actions/runs/15561078419