### PR TITLE
#18990: VGG UNet demo with trace 2cq

### DIFF
--- a/models/demos/vgg_unet/README.md
+++ b/models/demos/vgg_unet/README.md
@@ -14,7 +14,7 @@ To use the model with the trained weights, follow these steps:
 
 - Download the weights from this [link](https://drive.google.com/file/d/1XZi_W5Pj4jLSI31WUAlYf0SWQMu0wL6X/view).
 
-- Place the downloaded file in the models/experimental/vgg_unet directory.
+- Place the downloaded file in the models/demos/vgg_unet directory.
 
 - Set the use_pretrained_weight option to True.
 
@@ -35,12 +35,12 @@ pytest tests/ttnn/integration_tests/vgg_unet/test_vgg_unet.py::test_vgg_unet[0-p
 Use the following command to run the e2e perf:
 
 ```sh
-pytest models/experimental/vgg_unet/tests/test_perf_vgg_unet.py::test_vgg_unet
+pytest models/demos/vgg_unet/tests/test_perf_vgg_unet.py::test_vgg_unet
 ```
 
 Use the following command to run the e2e perf with trace 2cq:
 ```sh
-pytest models/experimental/vgg_unet/tests/test_e2e_performant.py
+pytest models/demos/vgg_unet/tests/test_e2e_performant.py
 ```
 
 
@@ -54,13 +54,13 @@ The demo runs with random weights by default. To use real weights, download them
 Use the following command to run torch model demo
 
 ```sh
-pytest models/experimental/vgg_unet/demo/demo.py::test_demo[device_params0-pretrained_weight_false-torch_model-single]
+pytest models/demos/vgg_unet/demo/demo.py::test_demo[device_params0-pretrained_weight_false-torch_model-single]
 ```
 
 Use the following command to run ttnn model demo
 
 ```sh
-pytest models/experimental/vgg_unet/demo/demo.py::test_demo[device_params0-pretrained_weight_false-ttnn_model-single]
+pytest models/demos/vgg_unet/demo/demo.py::test_demo[device_params0-pretrained_weight_false-ttnn_model-single]
 ```
 
 ### Multiple images
@@ -68,13 +68,13 @@ pytest models/experimental/vgg_unet/demo/demo.py::test_demo[device_params0-pretr
 Use the following command to run torch model demo
 
 ```sh
-pytest models/experimental/vgg_unet/demo/demo.py::test_demo[device_params0-pretrained_weight_false-torch_model-multi]
+pytest models/demos/vgg_unet/demo/demo.py::test_demo[device_params0-pretrained_weight_false-torch_model-multi]
 ```
 
 Use the following command to run ttnn model demo
 
 ```sh
-pytest models/experimental/vgg_unet/demo/demo.py::test_demo[device_params0-pretrained_weight_false-ttnn_model-multi]
+pytest models/demos/vgg_unet/demo/demo.py::test_demo[device_params0-pretrained_weight_false-ttnn_model-multi]
 ```
 ## Supported Hardware
 

--- a/models/demos/vgg_unet/demo/demo.py
+++ b/models/demos/vgg_unet/demo/demo.py
@@ -11,8 +11,8 @@ import torch
 
 from models.demos.vgg_unet.demo.demo_utils import postprocess, prediction, preprocess, process_single_image
 from models.demos.vgg_unet.reference.vgg_unet import UNetVGG19
-from models.demos.vgg_unet.ttnn.model_preprocessing import create_vgg_unet_model_parameters
-from models.demos.vgg_unet.ttnn.ttnn_vgg_unet import Tt_vgg_unet
+from models.demos.vgg_unet.tests.vgg_unet_e2e_performant import VggUnetTrace2CQ
+from models.utility_functions import disable_persistent_kernel_cache
 
 for dirname, _, filenames in os.walk("/kaggle/input"):
     for filename in filenames:
@@ -38,15 +38,20 @@ filterwarnings("ignore")
     "use_pretrained_weight",
     [
         False,
-        # True,
+        # True,  # Requires downloading pretrained weights from Google Drive
     ],
     ids=[
         "pretrained_weight_false",
         # "pretrained_weight_true",
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
-def test_demo(device, reset_seeds, demo_type, model_type, use_pretrained_weight):
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 32768, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
+)
+def test_demo(
+    device, use_program_cache, model_location_generator, reset_seeds, demo_type, model_type, use_pretrained_weight
+):
+    disable_persistent_kernel_cache()
     # Download latest version of the dataset
     path = kagglehub.dataset_download("mateuszbuda/lgg-mri-segmentation")
     for dirname, _, filenames in os.walk("/kaggle/input"):
@@ -54,14 +59,16 @@ def test_demo(device, reset_seeds, demo_type, model_type, use_pretrained_weight)
             print(os.path.join(dirname, filename))
     model_seg = UNetVGG19()
     if use_pretrained_weight:
-        model_seg.load_state_dict(torch.load("models/experimental/vgg_unet/vgg_unet_torch.pth"))
+        model_seg.load_state_dict(torch.load("models/demos/vgg_unet/vgg_unet_torch.pth"))
     model_seg.eval()  # Set to evaluation mode
 
     if model_type == "ttnn_model":
-        # Weights pre-processing
-        torch_input = torch.randn((1, 3, 256, 256), dtype=torch.float)
-        parameters = create_vgg_unet_model_parameters(model_seg, torch_input, device)
-        ttnn_model = Tt_vgg_unet(device, parameters, parameters.conv_args)
+        vgg_unet_trace_2cq = VggUnetTrace2CQ()
+
+        vgg_unet_trace_2cq.initialize_vgg_unet_trace_2cqs_inference(
+            device,
+            model_location_generator,
+        )
 
     if demo_type == "multi":
         X_test = preprocess(path)
@@ -69,7 +76,7 @@ def test_demo(device, reset_seeds, demo_type, model_type, use_pretrained_weight)
         if model_type == "torch_model":
             df_pred = prediction(X_test, model_seg, model_type)
         else:
-            df_pred = prediction(X_test, ttnn_model, model_type)
+            df_pred = prediction(X_test, vgg_unet_trace_2cq, model_type)
         postprocess(df_pred, X_test, model_type)
     else:
         base_path = path
@@ -84,14 +91,14 @@ def test_demo(device, reset_seeds, demo_type, model_type, use_pretrained_weight)
                 img_path,
                 mask_path,
                 model_seg,
-                output_dir="models/experimental/vgg_unet/demo/output_single_image",
+                output_dir="models/demos/vgg_unet/demo/output_single_image",
                 model_type=model_type,
             )
         else:
             process_single_image(
                 img_path,
                 mask_path,
-                ttnn_model,
-                output_dir="models/experimental/vgg_unet/demo/output_single_image_ttnn",
+                vgg_unet_trace_2cq,
+                output_dir="models/demos/vgg_unet/demo/output_single_image_ttnn",
                 model_type=model_type,
             )

--- a/models/demos/vgg_unet/tests/test_perf_vgg_unet.py
+++ b/models/demos/vgg_unet/tests/test_perf_vgg_unet.py
@@ -49,7 +49,7 @@ def test_vgg_unet(device, reset_seeds, model_location_generator, use_pretrained_
 
     # Pre-trained weights processing
     if use_pretrained_weight:
-        weights_pth = "models/experimental/vgg_unet/vgg_unet_torch.pth"
+        weights_pth = "models/demos/vgg_unet/vgg_unet_torch.pth"
         torch_dict = torch.load(weights_pth)
         new_state_dict = dict(zip(torch_model.state_dict().keys(), torch_dict.values()))
         torch_model.load_state_dict(new_state_dict)
@@ -97,7 +97,7 @@ def test_vgg_unet(device, reset_seeds, model_location_generator, use_pretrained_
     expected_compile_time, expected_inference_time = get_expected_times("vgg_unet")
 
     prep_perf_report(
-        model_name="models/experimental/vgg_unet",
+        model_name="models/demos/vgg_unet",
         batch_size=batch_size,
         inference_and_compile_time=inference_and_compile_time,
         inference_time=inference_time,

--- a/models/demos/vgg_unet/ttnn/ttnn_vgg_unet.py
+++ b/models/demos/vgg_unet/ttnn/ttnn_vgg_unet.py
@@ -73,18 +73,7 @@ class Conv:
         else:
             self.bias = None
 
-        weight = ttnn.from_device(conv_pth.weight)
-        self.weight = weight
-
-        if conv_param.shard_layout is None:
-            self.input_memory_config = ttnn.L1_MEMORY_CONFIG
-        elif (
-            conv_param.shard_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-            and conv_param.shard_layout != ttnn.TensorMemoryLayout.WIDTH_SHARDED
-        ):
-            self.input_memory_config = ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG
-        else:
-            self.input_memory_config = ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
+        self.weight = ttnn.from_device(conv_pth.weight)
 
         self.conv_kwargs = {
             "in_channels": conv_param.in_channels,
@@ -100,25 +89,6 @@ class Conv:
             "device": device,
             "conv_config": self.conv_config,
         }
-
-        if not ttnn.is_tensor_storage_on_device(self.weight):
-            self.weight = ttnn.prepare_conv_weights(
-                weight_tensor=self.weight,
-                weights_format="OIHW",
-                input_memory_config=self.input_memory_config,
-                input_layout=input_tensor_layout,
-                has_bias=True,
-                **self.conv_kwargs,
-            )
-
-            self.bias = ttnn.prepare_conv_bias(
-                bias_tensor=self.bias,
-                input_memory_config=self.input_memory_config,
-                input_layout=ttnn.TILE_LAYOUT,
-                **self.conv_kwargs,
-            )
-            self.weight = ttnn.to_device(self.weight, device)
-            self.bias = ttnn.to_device(self.bias, device)
 
     def __str__(self) -> str:
         return f"Conv: {self.weights.shape} {self.bias.shape} {self.kernel_size}"

--- a/tests/ttnn/integration_tests/vgg_unet/test_vgg_unet.py
+++ b/tests/ttnn/integration_tests/vgg_unet/test_vgg_unet.py
@@ -41,7 +41,7 @@ def test_vgg_unet(device, reset_seeds, model_location_generator, use_pretrained_
 
     # Pre-trained weights processing
     if use_pretrained_weight:
-        weights_pth = "models/experimental/vgg_unet/vgg_unet_torch.pth"
+        weights_pth = "models/demos/vgg_unet/vgg_unet_torch.pth"
         torch_dict = torch.load(weights_pth)
         new_state_dict = dict(zip(torch_model.state_dict().keys(), torch_dict.values()))
         torch_model.load_state_dict(new_state_dict)


### PR DESCRIPTION
### Ticket
Link to Github Issue
https://github.com/tenstorrent/tt-metal/issues/18990

### Problem description
- Enable demo pipeline with trace 2cq

### Performance:
Perf sheet: [ops_perf_results_VGG_Unet_perf_2025_04_25_08_05_05.csv](https://github.com/user-attachments/files/19904996/ops_perf_results_VGG_Unet_perf_2025_04_25_08_05_05.csv)
E2E FPS: 75
Device FPS: 92.3

### Checklist
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15578787427)
- [ ] [single-card-demo-tests]
- [ ] [(Single-card) Model perf tests]
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/15603228012)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15578811900)