### PR TITLE
#22202: Uint32 index tensor support added for ttnn.gather

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -436,6 +436,7 @@ Data Movement
    ttnn.untilize
    ttnn.untilize_with_unpadding
    ttnn.indexed_fill
+   ttnn.experimental.gather
 
 Normalization
 =============

--- a/tests/ttnn/unit_tests/operations/reduce/test_gather.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_gather.py
@@ -155,8 +155,8 @@ def test_gather_long_tensor(input_shape, index_shape, dim, device):
     torch.manual_seed(0)
 
     torch_dtype = torch.bfloat16
-    max_uint16 = np.iinfo(np.uint32).max
-    max_idx_val = min(input_shape[dim], max_uint16)
+    max_uint32 = np.iinfo(np.uint32).max
+    max_idx_val = min(input_shape[dim], max_uint32)
     input = torch.randn(input_shape, dtype=torch_dtype)
     index = torch.randint(0, max_idx_val, index_shape, dtype=torch.int64)  # torch.int64 is required for torch.gather
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_gather.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_gather.py
@@ -20,15 +20,15 @@ TILE_HEIGHT = 32
         ([64, 128, 256], [64, 128, 128], -1),
         ([1, 2048, 1, 64], [1, 2048, 1, 32], -1),
         ([1, 1, 1, 1], [1, 1, 1, 1], -1),
-        ([4, 4], [4, 4], 1),  # xfail case
-        ([128, 64], [128, 32], 1),  # xfail case
-        ([16, 16, 16], [16, 16, 16], 0),  # xfail case
-        ([1, 1, 1, 1], [1, 1, 1, 1], 1),  # xfail case
-        ([64, 128, 256], [64, 128, 128], 1),  # xfail case
-        ([256, 2, 32], [160, 2, 32], 1),  # xfail case
-        ([2, 256, 2, 32], [2, 128, 2, 32], 1),  # xfail case
-        ([2, 32, 96], [2, 32, 32], 1),  # xfail case
-        ([128, 128], [128, 64], 1),  # xfail case
+        ([4, 4], [4, 4], 1),
+        ([128, 64], [128, 32], 1),
+        ([16, 16, 16], [16, 16, 16], 0),
+        ([1, 1, 1, 1], [1, 1, 1, 1], 1),
+        ([64, 128, 256], [64, 128, 128], 1),
+        ([256, 2, 32], [160, 2, 32], 1),
+        ([2, 256, 2, 32], [2, 128, 2, 32], 1),
+        ([2, 32, 96], [2, 32, 32], 1),
+        ([128, 128], [128, 64], 1),
     ],
 )
 def test_gather_general(input_shape, index_shape, dim, device):
@@ -39,11 +39,6 @@ def test_gather_general(input_shape, index_shape, dim, device):
     index = torch.randint(
         0, input_shape[dim], index_shape, dtype=torch.int64
     )  # torch.int64 is required for torch.gather
-
-    if dim != -1:
-        pytest.xfail(
-            reason="uint32 types support does not exist in ttnn.transpose yet which is used in ttnn.gather. See issue: https://github.com/tenstorrent/tt-metal/issues/18057"
-        )
 
     torch_gather = torch.gather(input, dim, index)
 
@@ -160,11 +155,7 @@ def test_gather_long_tensor(input_shape, index_shape, dim, device):
     torch.manual_seed(0)
 
     torch_dtype = torch.bfloat16
-    max_uint16 = np.iinfo(
-        np.uint16
-    ).max  # uint32 types support does not exist in ttnn.transpose yet which is used in ttnn.gather.
-    # See issue: https://github.com/tenstorrent/tt-metal/issues/18057
-    # We need to limit max index to uint16 max value
+    max_uint16 = np.iinfo(np.uint32).max
     max_idx_val = min(input_shape[dim], max_uint16)
     input = torch.randn(input_shape, dtype=torch_dtype)
     index = torch.randint(0, max_idx_val, index_shape, dtype=torch.int64)  # torch.int64 is required for torch.gather
@@ -172,7 +163,7 @@ def test_gather_long_tensor(input_shape, index_shape, dim, device):
     torch_gather = torch.gather(input, dim, index)
 
     ttnn_input = ttnn.from_torch(input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
-    ttnn_index = ttnn.from_torch(index, ttnn.uint16, layout=ttnn.Layout.TILE, device=device)
+    ttnn_index = ttnn.from_torch(index, ttnn.uint32, layout=ttnn.Layout.TILE, device=device)
 
     ttnn_gather = ttnn.experimental.gather(ttnn_input, dim, index=ttnn_index)
 

--- a/ttnn/cpp/ttnn/operations/experimental/gather/device/gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/gather/device/gather_device_operation.cpp
@@ -54,6 +54,11 @@ void GatherDeviceOperation::validate_on_program_cache_miss(
             output_tensor_shape,
             input_index_tensor_shape);
     }
+    TT_FATAL(
+        tensor_args.input_index_tensor.dtype() == DataType::UINT32 ||
+            tensor_args.input_index_tensor.dtype() == DataType::UINT16,
+        "Index tensor must be of type UINT32 or UINT16. Got: {}",
+        tensor_args.input_index_tensor.dtype());
 
     for (int i = 0; i < input_tensor_rank; ++i) {
         if (i != attributes.dim) {

--- a/ttnn/cpp/ttnn/operations/experimental/gather/gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/gather/gather_pybind.cpp
@@ -20,17 +20,16 @@ void bind_gather_operation(py::module& module) {
         For all dimensions except the specified one (`dim`), the size of the index tensor must not exceed the size of the input tensor.
         The output tensor will have the same shape as the index tensor. Note that the input and index tensors do not broadcast against each other.
 
-        .. code-block:: python
-
-        Parameters:
-            * `input` (Tensor): The source tensor from which values are gathered.
-            * `dim` (int): The dimension along which values are gathered.
-            * `index` (Tensor): A tensor containing the indices of elements to gather, with the same number of dimensions as the input tensor.
+        Args:
+            input (ttnn.Tensor): The source tensor from which values are gathered.
+            dim (int): The dimension along which values are gathered.
+            index (ttnn.Tensor): A tensor containing the indices of elements to gather, with the same number of dimensions as the input tensor.
+                                The index tensor must be of type uint16 or uint32.
 
         Keyword Arguments:
-            * `sparse_grad` (bool, optional): If `True`, the gradient computation will be sparse. Defaults to `False`.
-            * `memory_config` (MemoryConfig, optional): Specifies the memory configuration for the output tensor. Defaults to `None`.
-            * `out` (Tensor, optional): A preallocated tensor to store the gathered values. Defaults to `None`.
+            sparse_grad (bool, optional): If `True`, the gradient computation will be sparse. Defaults to `False`.
+            memory_config (ttnn.MemoryConfig, optional): Specifies the memory configuration for the output tensor. Defaults to `None`.
+            out (ttnn.Tensor, optional): A preallocated tensor to store the gathered values. Defaults to `None`.
 
         Additional Information:
             * Currently, the `sparse_grad` argument is not supported.


### PR DESCRIPTION
### Ticket
[Unify index tensor datatype for ttnn.gather](https://github.com/tenstorrent/tt-metal/issues/22202)

### Problem description
Due to the addition of the ability to perform transposition on 32-bit data, operations have been updated to include the ability to use 32 data for index tensor.

### What's changed
* Added uint32 index tensor support,
* Fixed and updated documentation.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes