### PR TITLE
#22198: Uint32 support for ttnn.sort index tensor added

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sort.py
@@ -199,3 +199,87 @@ def test_sort_program_cache(shape, dim, descending, device):
     assert cache_entries == 1, "Expected only one program cache entry for sort operation, but found {}".format(
         cache_entries
     )
+
+
+@pytest.mark.parametrize(
+    "shape, dim, descending, torch_value_dtype, ttnn_value_dtype, ttnn_index_dtype",
+    [
+        ([32, 64], -1, False, torch.bfloat16, ttnn.bfloat16, ttnn.uint16),
+        ([32, 64], -1, False, torch.bfloat16, ttnn.bfloat16, ttnn.uint32),
+        ([32, 64], -1, False, torch.uint8, ttnn.uint16, ttnn.uint16),
+        ([32, 64], -1, False, torch.uint8, ttnn.uint16, ttnn.uint32),
+    ],
+)
+def test_sort_datatypes(shape, dim, descending, torch_value_dtype, ttnn_value_dtype, ttnn_index_dtype, device):
+    torch.manual_seed(0)
+
+    if torch_value_dtype == torch.uint8 or torch_value_dtype == torch.int16:
+        input = torch.randint(100, shape, dtype=torch_value_dtype)
+    else:
+        input = torch.randn(shape, dtype=torch_value_dtype)
+    ttnn_input = ttnn.from_torch(input, ttnn_value_dtype, layout=ttnn.Layout.TILE, device=device)
+
+    torch_sort_values, torch_sort_indices = torch.sort(input, dim=dim, descending=descending)
+
+    ttnn_sort_values = ttnn.zeros_like(ttnn_input, dtype=ttnn_value_dtype)
+    ttnn_sort_indices = ttnn.zeros_like(ttnn_input, dtype=ttnn_index_dtype)
+    ttnn.experimental.sort(ttnn_input, dim=dim, descending=descending, out=(ttnn_sort_values, ttnn_sort_indices))
+
+    assert torch_sort_values.shape == ttnn_sort_values.shape
+    assert torch_sort_indices.shape == ttnn_sort_indices.shape
+
+    assert list(ttnn_sort_values.shape) == shape
+    assert list(ttnn_sort_indices.shape) == shape
+
+    if len(shape) == 0 or len(shape) == 1:
+        assert torch_sort_values == ttnn.to_torch(ttnn_sort_values)
+    else:
+        assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
+
+
+def create_descending_tensor(shape, dim, dtype=torch.bfloat16):
+    size_along_dim = shape[dim]
+
+    # Step 1: Create descending range [size-1, size-2, ..., 0]
+    descending_values = torch.arange(size_along_dim - 1, -1, -1, dtype=dtype)
+
+    # Step 2: Reshape to fit into the target dimension with unsqueeze
+    view_shape = [1] * len(shape)
+    view_shape[dim] = size_along_dim
+    descending_values = descending_values.view(*view_shape)
+
+    # Step 3: Broadcast to full shape
+    descending_tensor = descending_values.expand(*shape)
+
+    return descending_tensor
+
+
+@pytest.mark.parametrize(
+    "shape, dim, descending",
+    [
+        ([32, 64], -1, False),
+        ([1, 2048, 1, 64], -1, False),
+        ([1, 55, 43], -1, True),
+        ([11, 29, 14, 1], -1, True),
+    ],
+)
+def test_sort_indices(shape, dim, descending, device):
+    torch.manual_seed(0)
+
+    torch_dtype = torch.bfloat16
+    input = create_descending_tensor(shape, dim, dtype=torch_dtype)
+
+    ttnn_input = ttnn.from_torch(input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+    torch_sort_values, torch_sort_indices = torch.sort(input, dim=dim, descending=descending)
+    ttnn_sort_values, ttnn_sort_indices = ttnn.experimental.sort(ttnn_input, dim=dim, descending=descending)
+
+    assert torch_sort_values.shape == ttnn_sort_values.shape
+    assert torch_sort_indices.shape == ttnn_sort_indices.shape
+
+    assert list(ttnn_sort_values.shape) == shape
+    assert list(ttnn_sort_indices.shape) == shape
+
+    torch_converted_indices = ttnn.to_torch(ttnn_sort_indices).to(torch.int64)
+
+    assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
+    assert torch.allclose(torch_sort_indices.to(torch.int64), torch_converted_indices)

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
@@ -2,48 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
-#include <cstdint>
 #include "dataflow_api.h"
 
 #include "debug/dprint.h"
 
-FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
-    // Constants
-    constexpr uint32_t one_tile = 1;
+#include "sort_dataflow_common.hpp"
 
-    // Reserve space
-    cb_reserve_back(cb_id, one_tile);
-
-    // Writer config
-    const uint32_t writer_addr = get_write_ptr(cb_id);
-    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(writer_addr);
-    const uint16_t wt_offset = wt << 5;  // wt * 2^(5)
-
-    // Writer loop
-    uint32_t count = 0;
-    /*
-    The 32x32 tile is subdivided into four 16x16 quadrants(faces): top-left, top-right, bottom-left, and bottom-right.
-    These quadrants are stored contiguously in memory. Therefore, indices must be written in memory according
-    to their respective quadrant, rather than sequentially from left to right across the entire tile.
-    */
-    constexpr uint32_t tile_faces = 2;
-    constexpr uint32_t face_size = 16;
-    for (uint32_t i = 0; i < tile_faces; ++i) {
-        for (uint32_t j = 0; j < tile_faces; ++j) {
-            for (uint32_t k = 0; k < face_size; ++k) {
-                for (uint32_t l = 0; l < face_size; l++) {
-                    const uint16_t value = l + face_size * j + wt_offset;
-                    ptr[count] = value;
-                    count++;
-                }  // l loop
-            }  // k loop
-        }  // j loop
-    }  // i loop
-
-    // Push the tile
-    cb_push_back(cb_id, one_tile);
-}
+#include <cstdint>
 
 void kernel_main() {
     // Runtime args
@@ -69,6 +34,7 @@ void kernel_main() {
     constexpr bool input_tensor_is_dram = get_compile_time_arg_val(7) == 1;
     constexpr bool output_tensor_is_dram = get_compile_time_arg_val(8) == 1;
     constexpr bool output_index_tensor_is_dram = get_compile_time_arg_val(9) == 1;
+    constexpr bool is_32_bit_data = get_compile_time_arg_val(10) == 1;
 
     constexpr uint32_t one_tile = 1;
 
@@ -112,7 +78,11 @@ void kernel_main() {
         // Prepare and move data
         for (uint32_t w = 0; w < Wt; w++) {
             // Generate indexes
-            generate_index_tile(index_tensor_cb_index, w);
+            if (is_32_bit_data) {
+                generate_index_tile<uint32_t>(index_tensor_cb_index, w);
+            } else {
+                generate_index_tile<uint16_t>(index_tensor_cb_index, w);
+            }
 
             // Save index tile to output index tensor
             cb_wait_front(index_tensor_cb_index, one_tile);

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/sort_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/sort_dataflow_common.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+#include "debug/dprint.h"
+
+template <typename T = uint16_t>
+FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
+    // Constants
+    constexpr uint32_t one_tile = 1;
+
+    // Reserve space
+    cb_reserve_back(cb_id, one_tile);
+
+    // Writer config
+    const uint32_t writer_addr = get_write_ptr(cb_id);
+    volatile tt_l1_ptr T* ptr = reinterpret_cast<volatile tt_l1_ptr T*>(writer_addr);
+    const uint16_t wt_offset = wt << 5;  // wt * 2^(5)
+
+    // Writer loop
+    uint32_t count = 0;
+    /*
+    The 32x32 tile is subdivided into four 16x16 quadrants(faces): top-left, top-right, bottom-left, and bottom-right.
+    These quadrants are stored contiguously in memory. Therefore, indices must be written in memory according
+    to their respective quadrant, rather than sequentially from left to right across the entire tile.
+    */
+    constexpr uint32_t tile_faces = 2;
+    constexpr uint32_t face_size = 16;
+    for (uint32_t i = 0; i < tile_faces; ++i) {
+        for (uint32_t j = 0; j < tile_faces; ++j) {
+            for (uint32_t k = 0; k < face_size; ++k) {
+                for (uint32_t l = 0; l < face_size; l++) {
+                    const T value = l + face_size * j + wt_offset;
+                    ptr[count] = value;
+                    count++;
+                }  // l loop
+            }  // k loop
+        }  // j loop
+    }  // i loop
+
+    // Push the tile
+    cb_push_back(cb_id, one_tile);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/sort_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/sort_dataflow_common.hpp
@@ -4,8 +4,6 @@
 
 #include "dataflow_api.h"
 
-#include "debug/dprint.h"
-
 template <typename T = uint16_t>
 FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
     // Constants
@@ -17,7 +15,7 @@ FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
     // Writer config
     const uint32_t writer_addr = get_write_ptr(cb_id);
     volatile tt_l1_ptr T* ptr = reinterpret_cast<volatile tt_l1_ptr T*>(writer_addr);
-    const uint16_t wt_offset = wt << 5;  // wt * 2^(5)
+    const uint16_t w = wt << 5;  // wt * 2^(5)
 
     // Writer loop
     uint32_t count = 0;
@@ -32,7 +30,7 @@ FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
         for (uint32_t j = 0; j < tile_faces; ++j) {
             for (uint32_t k = 0; k < face_size; ++k) {
                 for (uint32_t l = 0; l < face_size; l++) {
-                    const T value = l + face_size * j + wt_offset;
+                    const T value = l + face_size * j + w;
                     ptr[count] = value;
                     count++;
                 }  // l loop

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
@@ -108,6 +108,17 @@ void SortDeviceOperation::validate_on_program_cache_miss(
                 "input tensor shape: {}",
                 output_indices_shape,
                 input_tensor_shape);
+            TT_FATAL(
+                tensor_args.output_tensors.at(0)->dtype() == tensor_args.input_tensor.dtype(),
+                "Output values tensor dtype must be the same as input tensor dtype. Got output values tensor dtype: {} "
+                "and input tensor dtype: {}",
+                tensor_args.output_tensors.at(0)->dtype(),
+                tensor_args.input_tensor.dtype());
+            TT_FATAL(
+                tensor_args.output_tensors.at(1)->dtype() == DataType::UINT16 ||
+                    tensor_args.output_tensors.at(1)->dtype() == DataType::UINT32,
+                "Output indices tensor dtype must be UINT16 or UINT32. Got output indices tensor dtype: {}",
+                tensor_args.output_tensors.at(1)->dtype());
         }
     }
 }
@@ -126,7 +137,7 @@ SortDeviceOperation::spec_return_value_t SortDeviceOperation::compute_output_spe
         TensorLayout(tensor_args.input_tensor.dtype(), PageConfig(Layout::TILE), attributes.output_mem_config));
 
     DataType index_dtype = DataType::UINT16;
-    if (output_shape[-1] > std::numeric_limits<uint16_t>::max()) {
+    if (output_shape[-1] >= std::numeric_limits<uint16_t>::max()) {
         index_dtype = DataType::UINT32;
     }
     auto index_spec =

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
@@ -124,8 +124,13 @@ SortDeviceOperation::spec_return_value_t SortDeviceOperation::compute_output_spe
     auto values_spec = TensorSpec(
         output_shape,
         TensorLayout(tensor_args.input_tensor.dtype(), PageConfig(Layout::TILE), attributes.output_mem_config));
-    auto index_spec = TensorSpec(
-        output_shape, TensorLayout(DataType::UINT16, PageConfig(Layout::TILE), attributes.output_mem_config));
+
+    DataType index_dtype = DataType::UINT16;
+    if (output_shape[-1] > std::numeric_limits<uint16_t>::max()) {
+        index_dtype = DataType::UINT32;
+    }
+    auto index_spec =
+        TensorSpec(output_shape, TensorLayout(index_dtype, PageConfig(Layout::TILE), attributes.output_mem_config));
 
     return {values_spec, index_spec};
 }
@@ -139,8 +144,8 @@ SortDeviceOperation::tensor_return_value_t SortDeviceOperation::create_output_te
     }
     auto output_specs = compute_output_specs(attributes, tensor_args);
     return {
-        create_device_tensor(output_specs[0], tensor_args.input_tensor.device()),
-        create_device_tensor(output_specs[1], tensor_args.input_tensor.device()),
+        create_device_tensor(output_specs[0], tensor_args.input_tensor.device()),  // Value tensor
+        create_device_tensor(output_specs[1], tensor_args.input_tensor.device()),  // Index tensor
     };
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
@@ -57,6 +57,9 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
     const uint32_t all_core_utilization_loop_count = Ht / total_number_of_cores;
     const uint32_t all_core_utilization_loop_residuum = Ht % total_number_of_cores;
 
+    // uint32 index tensor support
+    const bool is_32_bit_data = index_tensor_cb_data_format == tt::DataFormat::UInt32;
+
     // Calculate core range
     /**
      * Calculates the core range based on the input tensor shape (Ht) and the total number of cores available
@@ -186,7 +189,8 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
         Ht,
         total_number_of_cores,
         compute_with_storage_grid_size.x,
-        compute_with_storage_grid_size.y};
+        compute_with_storage_grid_size.y,
+        static_cast<uint32_t>(is_32_bit_data)};
     const std::string writer_kernel_path =
         "ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/"
         "writer_single_row_single_core.cpp";
@@ -215,7 +219,7 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
         program,
         compute_kernel_path,
         core_range,
-        tt::tt_metal::ComputeConfig{.compile_args = compute_compile_time_args});
+        tt::tt_metal::ComputeConfig{.fp32_dest_acc_en = is_32_bit_data, .compile_args = compute_compile_time_args});
     SetRuntimeArgs(
         program,
         compute_kernel_id,
@@ -748,6 +752,9 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
     const uint32_t all_core_utilization_loop_count = total_work_units / number_of_available_cores;
     const uint32_t all_core_utilization_loop_residuum = total_work_units % number_of_available_cores;
 
+    // uint32 index tensor support
+    const bool is_32_bit_data = index_tensor_cb_data_format == tt::DataFormat::UInt32;
+
     /**
      * Calculates the core range based on the input tensor shape (Wt) and the total number of cores available
      * in the device's compute grid (minus one reserved for coordinator). The core range determines which
@@ -872,7 +879,8 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
         index_tensor_cb_index,
         static_cast<uint32_t>(input_tensor_is_dram),
         static_cast<uint32_t>(value_tensor_is_dram),
-        static_cast<uint32_t>(index_tensor_is_dram)};
+        static_cast<uint32_t>(index_tensor_is_dram),
+        static_cast<uint32_t>(is_32_bit_data)};
     const std::string coordinator_kernel_path =
         "ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/"
         "coordinator_single_row_multi_core.cpp";
@@ -971,7 +979,7 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
         program,
         compute_kernel_path,
         core_range,
-        tt::tt_metal::ComputeConfig{.compile_args = compute_compile_time_args});
+        tt::tt_metal::ComputeConfig{.fp32_dest_acc_en = is_32_bit_data, .compile_args = compute_compile_time_args});
 
     return {
         std::move(program),

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
@@ -360,6 +360,9 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
         all_core_utilization_count,
         total_number_of_cores_virtual);
 
+    // uint32 index tensor support
+    const bool is_32_bit_data = index_tensor_cb_data_format == tt::DataFormat::UInt32;
+
     /**
      * Calculates the core range based on the number of work units (all_core_utilization_count) and the total number of
      * available cores in the device's compute grid. The core range determines which cores will be utilized for
@@ -596,7 +599,7 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
         number_of_tiles_per_core,
         total_number_of_cores_virtual,
         semaphore_exchange_readers,
-    };
+        static_cast<uint32_t>(is_32_bit_data)};
     const std::string writer_kernel_path =
         "ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/"
         "writer_cross_core_data_exchange.cpp";
@@ -630,7 +633,7 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
         program,
         compute_kernel_path,
         core_range,
-        tt::tt_metal::ComputeConfig{.compile_args = compute_compile_time_args});
+        tt::tt_metal::ComputeConfig{.fp32_dest_acc_en = is_32_bit_data, .compile_args = compute_compile_time_args});
 
     return {std::move(program), {reader_kernel_id, compute_kernel_id, writer_kernel_id, core_range}};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 
+#include <cmath>
 #include <cstdint>
 
 namespace ttnn::operations::experimental::reduction::sort::program {
@@ -755,6 +756,9 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
     // uint32 index tensor support
     const bool is_32_bit_data = index_tensor_cb_data_format == tt::DataFormat::UInt32;
 
+    // Log 2 of Wt for compute kernel
+    const uint32_t log2Wt = std::log2(Wt);
+
     /**
      * Calculates the core range based on the input tensor shape (Wt) and the total number of cores available
      * in the device's compute grid (minus one reserved for coordinator). The core range determines which
@@ -971,7 +975,8 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
         compute_with_storage_grid_size.x,
         compute_with_storage_grid_size.y,
         static_cast<uint32_t>(attributes.descending),
-        static_cast<uint32_t>(attributes.stable)};
+        static_cast<uint32_t>(attributes.stable),
+        log2Wt};
     const std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/"
         "sort_single_row_multi_core.cpp";

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/docs/Sort.md
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/docs/Sort.md
@@ -65,7 +65,7 @@ std::vector<Tensor> sorted_tensors = ttnn::sort(queue_id, input_tensor, dim, des
 ### Usage Limitations
 
 - Supported index tensor types: `uint32`, `uint16`,
-- Supported value tensor types: `float32`, `bfloat32`, `bfloat16`,
+- Supported value tensor types: `uint16`, `bfloat16`,
 - `stable=True` is not supported in this implementation.
 
 ## Strategy Comparison Overview

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
@@ -31,7 +31,7 @@ void bind_reduction_sort_operation(py::module& module) {
                 descending (bool, optional): If `True`, sorts in descending order. Defaults to `False`.
                 stable (bool, optional): If `True`, ensures the original order of equal elements is preserved. Defaults to `False`.
                 memory_config (ttnn.MemoryConfig, optional): Specifies the memory configuration for the output tensor. Defaults to `None`.
-                out (tuple of ttnn.Tensor, optional): Preallocated output tensors for the sorted values and indices. Defaults to `None`.
+                out (tuple of ttnn.Tensor, optional): Preallocated output tensors for the sorted values and indices. Defaults to `None`. The index tensor must be of type uint16 or uint32.
 
             Additional info:
                 * For now the `stable` argument is not supported.

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
@@ -23,15 +23,15 @@ void bind_reduction_sort_operation(py::module& module) {
 
                 return torch.sort(input_tensor, dim=-1)
 
-            Parameters:
-                * `input_tensor` (Tensor): The input tensor to be sorted.
+            Args:
+                input_tensor (ttnn.Tensor): The input tensor to be sorted.
 
             Keyword Arguments:
-                * `dim` (int, optional): The dimension along which to sort. Defaults to -1 (last dimension).
-                * `descending` (bool, optional): If `True`, sorts in descending order. Defaults to `False`.
-                * `stable` (bool, optional): If `True`, ensures the original order of equal elements is preserved. Defaults to `False`.
-                * `memory_config` (MemoryConfig, optional): Specifies the memory configuration for the output tensor. Defaults to `None`.
-                * `out` (tuple of Tensors, optional): Preallocated output tensors for the sorted values and indices. Defaults to `None`.
+                dim (int, optional): The dimension along which to sort. Defaults to `-1` (last dimension).
+                descending (bool, optional): If `True`, sorts in descending order. Defaults to `False`.
+                stable (bool, optional): If `True`, ensures the original order of equal elements is preserved. Defaults to `False`.
+                memory_config (ttnn.MemoryConfig, optional): Specifies the memory configuration for the output tensor. Defaults to `None`.
+                out (tuple of ttnn.Tensor, optional): Preallocated output tensors for the sorted values and indices. Defaults to `None`.
 
             Additional info:
                 * For now the `stable` argument is not supported.
@@ -41,19 +41,24 @@ void bind_reduction_sort_operation(py::module& module) {
             .. code-block:: python
 
                 import ttnn
+                import torch
 
                 # Create a tensor
-                input_tensor = ttnn.Tensor([3, 1, 2])
+                input_tensor = torch.Tensor([3, 1, 2])
+
+                # Convert tensor to ttnn format
+                input_tensor_ttnn = ttnn.from_torch(input_tensor, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
 
                 # Sort the tensor in ascending order
-                sorted_tensor, indices = ttnn.experimental.sort(input_tensor)
+                sorted_tensor, indices = ttnn.experimental.sort(input_tensor_ttnn)
 
                 # Sort the tensor in descending order
-                sorted_tensor_desc, indices_desc = ttnn.experimental.sort(input_tensor, descending=True)
+                sorted_tensor_desc, indices_desc = ttnn.experimental.sort(input_tensor_tnn, descending=True)
 
                 # Sort along a specific dimension
-                input_tensor_2d = ttnn.Tensor([[3, 1, 2], [6, 5, 4]])
-                sorted_tensor_dim, indices_dim = ttnn.experimental.sort(input_tensor_2d, dim=1)
+                input_tensor_2d = torch.Tensor([[3, 1, 2], [6, 5, 4]])
+                input_tensor_2d_ttnn = ttnn.from_torch(input_tensor_2d, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+                sorted_tensor_dim, indices_dim = ttnn.experimental.sort(input_tensor_2d_ttnn, dim=1)
         )doc";
 
     using OperationType = decltype(ttnn::experimental::sort);


### PR DESCRIPTION
### Ticket

[Unify index tensor datatype for ttnn.sort](https://github.com/tenstorrent/tt-metal/issues/22198)

This PR also resolves https://github.com/tenstorrent/tt-metal/issues/22138

### Problem description

Due to the added ability to use 32-bit variables in the `transpose` and `topk_local_sort` LLKs, the  operation has been updated to accept this type of data.

### What's changed
* Added ability to use uint32 for index tensor when sort dimension is larger than max value of uint16,
* Updated documentation.
* Small performance updates to Single Row Single Core and Single row Multi Core implementations.

### Performance updates

Wormhole measurements:

Tiles | Cores used | Tiles processed by core | Tile Width | DEVICE KERNEL DURATION PER CORE MIN [ms] | DEVICE KERNEL DURATION PER CORE MAX [ms] | DEVICE KERNEL DURATION PER CORE AVG [ms] | Bandwidth MElem/s
-- | -- | -- | -- | -- | -- | -- | --
Current Single Row Multi Core
64 | 32 | 2 | 32 | 5.246 | 5.246 | 5.246 | 0.390
128 | 64 | 2 | 32 | 3.029 | 3.036 | 3.031 | 1.352
256 | 64 | 4 | 32 | 5.855 | 5.855 | 5.856 | 1.399
512 | 64 | 8 | 32 | 11.845 | 11.852 | 11.847 | 1.383
1024 | 64 | 16 | 32 | 23.698 | 23.704 | 23.699 | 1.383
2048 | 64 | 32 | 32 | 48.680 | 48.687 | 48.682 | 1.346
4096 | 64 | 64 | 32 | 98.468 | 98.475 | 98.472 | 1.331
8192 | 64 | 128 | 32 | 204.805 | 204.812 | 204.806 | 1.280
New Single Row Multi core
64 | 32 | 2 | 32 | 1.425 | 1.427 | 1.426 | 1.437
128 | 64 | 2 | 32 | 2.832 | 2.838 | 2.833 | 1.446
256 | 64 | 4 | 32 | 5.513 | 5.519 | 5.514 | 1.486
512 | 64 | 8 | 32 | 11.225 | 11.232 | 11.226 | 1.460
1024 | 64 | 16 | 32 | 22.438 | 22.444 | 22.439 | 1.460
2048 | 64 | 32 | 32 | 24.207 | 24.215 | 24.210 | 2.707
4096 | 64 | 64 | 32 | 52.158 | 52.166 | 52.162 | 2.513
8192 | 64 | 128 | 32 | 111.831 | 111.838 | 111.834 | 2.344

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes