### PR TITLE
fix: correct transpose dest blackhole API after wormhole has been changed

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_transpose_dest_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_transpose_dest_api.h
@@ -7,6 +7,12 @@
 #include "llk_math_common_api.h"
 #include "llk_math_transpose_dest.h"
 
-inline void llk_math_transpose_dest(uint dst_index) { _llk_math_transpose_dest_(dst_index); }
+template <bool transpose_of_faces = true, bool is_32bit = false>
+inline void llk_math_transpose_dest(uint dst_index) {
+    _llk_math_transpose_dest_<transpose_of_faces, is_32bit>(dst_index);
+}
 
-inline void llk_math_transpose_dest_init() { _llk_math_transpose_dest_init_(); }
+template <bool transpose_of_faces = true, bool is_32bit = false>
+inline void llk_math_transpose_dest_init() {
+    _llk_math_transpose_dest_init_<transpose_of_faces, is_32bit>();
+}


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Change in WH API caused failure in BH post-commit

### What's changed
Updated BH API to match WH.

### Checklist
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15581536568) CI with demo tests passes (if applicable)