### PR TITLE
TG Llama70b CI Restructuring - upgrade choose your pipeline

### DIFF
--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       trigger_type:
-        description: "⚠️ Checkbox options below are used only when 'manual' is selected; otherwise, predefined settings apply. ⚠️"
+        description: "⚠️ CHECKBOX options below are used only when 'manual' is selected; otherwise, predefined settings apply. ⚠️"
         required: true
         type: choice
         options:

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -3,16 +3,8 @@ name: "(TG) Choose your pipeline"
 on:
   workflow_dispatch:
     inputs:
-      model-selection:
-        description: "Model selection ignored for now. "
-        required: true
-        type: choice
-        options:
-          - all
-          - llama3_70b
-        default: "all"
       trigger_type:
-        description: "⚠️ If not 'manual', all checkbox selections will be ignored. ⚠️"
+        description: "⚠️ Checkbox options below are used only when 'manual' is selected; otherwise, predefined settings apply. ⚠️"
         required: true
         type: choice
         options:

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -101,34 +101,34 @@ jobs:
             "model-pr")
               echo "run-quick=true" >> $GITHUB_OUTPUT
               echo "run-unit=false" >> $GITHUB_OUTPUT
-              echo "run-frequent=false" >> $GITHUB_OUTPUT
-              echo "run-demo=false" >> $GITHUB_OUTPUT
-              echo "run-model-perf=false" >> $GITHUB_OUTPUT
-              echo "run-stress=false" >> $GITHUB_OUTPUT
+              echo "run-frequent=true" >> $GITHUB_OUTPUT
+              echo "run-demo=true" >> $GITHUB_OUTPUT
+              echo "run-model-perf=true" >> $GITHUB_OUTPUT
+              echo "run-stress=true" >> $GITHUB_OUTPUT
               ;;
             "op-pr")
-              echo "run-quick=true" >> $GITHUB_OUTPUT
-              echo "run-unit=false" >> $GITHUB_OUTPUT
+              echo "run-quick=false" >> $GITHUB_OUTPUT
+              echo "run-unit=true" >> $GITHUB_OUTPUT
               echo "run-frequent=false" >> $GITHUB_OUTPUT
               echo "run-demo=false" >> $GITHUB_OUTPUT
               echo "run-model-perf=false" >> $GITHUB_OUTPUT
               echo "run-stress=false" >> $GITHUB_OUTPUT
               ;;
             "nightly")
-              echo "run-quick=true" >> $GITHUB_OUTPUT
-              echo "run-unit=false" >> $GITHUB_OUTPUT
-              echo "run-frequent=false" >> $GITHUB_OUTPUT
-              echo "run-demo=false" >> $GITHUB_OUTPUT
-              echo "run-model-perf=false" >> $GITHUB_OUTPUT
-              echo "run-stress=false" >> $GITHUB_OUTPUT
+              echo "run-quick=false" >> $GITHUB_OUTPUT
+              echo "run-unit=true" >> $GITHUB_OUTPUT
+              echo "run-frequent=true" >> $GITHUB_OUTPUT
+              echo "run-demo=true" >> $GITHUB_OUTPUT
+              echo "run-model-perf=true" >> $GITHUB_OUTPUT
+              echo "run-stress=true" >> $GITHUB_OUTPUT
               ;;
             "hw-self-test")
-              echo "run-quick=true" >> $GITHUB_OUTPUT
+              echo "run-quick=false" >> $GITHUB_OUTPUT
               echo "run-unit=false" >> $GITHUB_OUTPUT
-              echo "run-frequent=false" >> $GITHUB_OUTPUT
+              echo "run-frequent=true" >> $GITHUB_OUTPUT
               echo "run-demo=false" >> $GITHUB_OUTPUT
-              echo "run-model-perf=false" >> $GITHUB_OUTPUT
-              echo "run-stress=false" >> $GITHUB_OUTPUT
+              echo "run-model-perf=true" >> $GITHUB_OUTPUT
+              echo "run-stress=true" >> $GITHUB_OUTPUT
               ;;
             *)
               echo "run-quick=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -158,7 +158,7 @@ jobs:
       build-wheel: true
       version: 22.04
   tg-quick:
-    if: ${{ inputs.tg-quick || needs.determine-tests.outputs.run-quick == 'true' }}
+    if: ${{ needs.determine-tests.outputs.run-quick == 'true' }}
     needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-quick.yaml
@@ -171,7 +171,7 @@ jobs:
       topology-6u: ${{ needs.determine-tests.outputs.is-config-tg == 'false'}}
 
   tg-unit-tests:
-    if: ${{ inputs.tg-unit || needs.determine-tests.outputs.run-unit == 'true' }}
+    if: ${{ needs.determine-tests.outputs.run-unit == 'true' }}
     needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-unit-tests-impl.yaml
@@ -182,7 +182,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       topology: ${{ needs.determine-tests.outputs.is-config-tg == 'true' && 'config-tg' || 'topology-6u' }}
   tg-frequent-tests:
-    if: ${{ inputs.tg-frequent || needs.determine-tests.outputs.run-frequent == 'true' }}
+    if: ${{ needs.determine-tests.outputs.run-frequent == 'true' }}
     needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-frequent-tests-impl.yaml
@@ -193,7 +193,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       topology: ${{ needs.determine-tests.outputs.is-config-tg == 'true' && 'config-tg' || 'topology-6u' }}
   tg-demo-tests:
-    if: ${{ inputs.tg-demo || needs.determine-tests.outputs.run-demo == 'true' }}
+    if: ${{ needs.determine-tests.outputs.run-demo == 'true' }}
     needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-demo-tests-impl.yaml
@@ -204,7 +204,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       topology: ${{ needs.determine-tests.outputs.is-config-tg == 'true' && 'config-tg' || 'topology-6u' }}
   tg-model-perf-tests:
-    if: ${{ inputs.tg-model-perf || needs.determine-tests.outputs.run-model-perf == 'true' }}
+    if: ${{ needs.determine-tests.outputs.run-model-perf == 'true' }}
     needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-model-perf-tests-impl.yaml
@@ -215,7 +215,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       topology: ${{ needs.determine-tests.outputs.is-config-tg == 'true' && 'config-tg' || 'topology-6u' }}
   tg-stress-test:
-    if: ${{ inputs.tg-stress || needs.determine-tests.outputs.run-stress == 'true' }}
+    if: ${{ needs.determine-tests.outputs.run-stress == 'true' }}
     needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-stress.yaml

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -3,6 +3,23 @@ name: "(TG) Choose your pipeline"
 on:
   workflow_dispatch:
     inputs:
+      model-selection:
+        description: "Select model to run tests on. ⚠️ If 'llama3_70b' is selected, all checkbox selections would be ignored."
+        required: true
+        type: choice
+        options:
+          - all
+          - llama3_70b
+      trigger_type:
+        description: "Select the type of trigger for the pipeline."
+        required: true
+        type: choice
+        options:
+          - manual
+          - model-pr
+          - op-pr
+          - nightly
+          - hw-self-test
       build-type:
         required: false
         type: choice

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -10,6 +10,7 @@ on:
         options:
           - all
           - llama3_70b
+        default: "all"
       trigger_type:
         description: "Select the type of trigger for the pipeline."
         required: true
@@ -20,6 +21,7 @@ on:
           - op-pr
           - nightly
           - hw-self-test
+        default: "manual"
       build-type:
         required: false
         type: choice
@@ -30,17 +32,11 @@ on:
           - ASan
           - TSan
         default: "Release"
-      topology:
-        required: false
-        type: choice
-        options:
-          - config-tg
-          - topology-6u
-        default: "config-tg"
-      extra-tag:
+      extra-tag: # set in-service and topology-6u by default
+        description: "Extra tag to add to the build. Can specify topology 'topology-6u' or 'config-tg'."
         required: true
         type: string
-        default: "in-service"
+        default: "in-service,config-tg"
       tg-quick:
         required: false
         type: boolean
@@ -59,11 +55,6 @@ on:
         default: false
       tg-model-perf:
         description: "tg-model-perf (Requires tracy build)"
-        required: false
-        type: boolean
-        default: false
-      tg-nightly:
-        description: "tg-nightly (Warning: Long running test! Do not choose this unless there is a specific need. Requires tracy build)"
         required: false
         type: boolean
         default: false
@@ -93,8 +84,9 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology-4u: ${{ inputs.topology == 'config-tg' }}
-      topology-6u: ${{ inputs.topology == 'topology-6u' }}
+      topology-4u: ${{ contains(inputs.extra-tag, 'config-tg') }}
+      topology-6u: ${{ contains(inputs.extra-tag, 'topology-6u') }}
+
   tg-unit-tests:
     if: ${{ inputs.tg-unit }}
     needs: build-artifact
@@ -105,7 +97,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology: ${{ inputs.topology }}
+      topology: ${{ contains(inputs.extra-tag, 'topology-6u') && 'topology-6u' || 'config-tg' }}
   tg-frequent-tests:
     if: ${{ inputs.tg-frequent }}
     needs: build-artifact
@@ -116,7 +108,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology: ${{ inputs.topology }}
+      topology: ${{ contains(inputs.extra-tag, 'topology-6u') && 'topology-6u' || 'config-tg' }}
   tg-demo-tests:
     if: ${{ inputs.tg-demo }}
     needs: build-artifact
@@ -127,7 +119,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology: ${{ inputs.topology }}
+      topology: ${{ contains(inputs.extra-tag, 'topology-6u') && 'topology-6u' || 'config-tg' }}
   tg-model-perf-tests:
     if: ${{ inputs.tg-model-perf }}
     needs: build-artifact
@@ -138,18 +130,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology: ${{ inputs.topology }}
-  tg-nightly-tests:
-    needs: build-artifact
-    if: ${{ inputs.tg-nightly }}
-    secrets: inherit
-    uses: ./.github/workflows/tg-nightly-tests-impl.yaml
-    with:
-      extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology: ${{ inputs.topology }}
+      topology: ${{ contains(inputs.extra-tag, 'topology-6u') && 'topology-6u' || 'config-tg' }}
   tg-stress-test:
     needs: build-artifact
     if: ${{ inputs.tg-stress }}
@@ -160,5 +141,5 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology-4u: ${{ inputs.topology == 'config-tg' }}
-      topology-6u: ${{ inputs.topology == 'topology-6u' }}
+      topology-4u: ${{ contains(inputs.extra-tag, 'config-tg') }}
+      topology-6u: ${{ contains(inputs.extra-tag, 'topology-6u') }}

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       model-selection:
-        description: "Select model to run tests on. ⚠️ If 'llama3_70b' is selected, all checkbox selections would be ignored."
+        description: "⚠️ If 'llama3_70b' is selected, all checkbox selections would be ignored.⚠️"
         required: true
         type: choice
         options:
@@ -12,7 +12,7 @@ on:
           - llama3_70b
         default: "all"
       trigger_type:
-        description: "Select the type of trigger for the pipeline."
+        description: "Select appropriate trigger."
         required: true
         type: choice
         options:
@@ -71,7 +71,7 @@ jobs:
     secrets: inherit
     with:
       build-type: ${{ inputs.build-type }}
-      tracy: ${{ inputs.tg-model-perf || inputs.tg-nightly }}
+      tracy: ${{ inputs.tg-model-perf }}
       build-wheel: true
       version: 22.04
   tg-quick:

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       model-selection:
-        description: "⚠️ If 'llama3_70b' is selected, all checkbox selections would be ignored.⚠️"
+        description: "Select model to run tests on."
         required: true
         type: choice
         options:
@@ -12,7 +12,7 @@ on:
           - llama3_70b
         default: "all"
       trigger_type:
-        description: "Select appropriate trigger."
+        description: "⚠️ If not 'manual', all checkbox selections will be ignored. ⚠️"
         required: true
         type: choice
         options:
@@ -64,6 +64,71 @@ on:
         default: false
 run-name: ${{ inputs.description }}
 jobs:
+  # Centralized logic to determine what should run
+  determine-tests:
+    runs-on: ubuntu-latest
+    outputs:
+      run-quick: ${{ steps.logic.outputs.run-quick }}
+      run-unit: ${{ steps.logic.outputs.run-unit }}
+      run-frequent: ${{ steps.logic.outputs.run-frequent }}
+      run-demo: ${{ steps.logic.outputs.run-demo }}
+      run-model-perf: ${{ steps.logic.outputs.run-model-perf }}
+      run-stress: ${{ steps.logic.outputs.run-stress }}
+    steps:
+      - name: Determine test execution
+        id: logic
+        # Skip all but tg-quick if trigger-type is not manual
+        run: |
+          case "${{ inputs.trigger_type }}" in
+            "manual")
+              echo "run-quick=${{ inputs.tg-quick }}" >> $GITHUB_OUTPUT
+              echo "run-unit=${{ inputs.tg-unit }}" >> $GITHUB_OUTPUT
+              echo "run-frequent=${{ inputs.tg-frequent }}" >> $GITHUB_OUTPUT
+              echo "run-demo=${{ inputs.tg-demo }}" >> $GITHUB_OUTPUT
+              echo "run-model-perf=${{ inputs.tg-model-perf }}" >> $GITHUB_OUTPUT
+              echo "run-stress=${{ inputs.tg-stress }}" >> $GITHUB_OUTPUT
+              ;;
+            "model-pr")
+              echo "run-quick=true" >> $GITHUB_OUTPUT
+              echo "run-unit=false" >> $GITHUB_OUTPUT
+              echo "run-frequent=false" >> $GITHUB_OUTPUT
+              echo "run-demo=false" >> $GITHUB_OUTPUT
+              echo "run-model-perf=false" >> $GITHUB_OUTPUT
+              echo "run-stress=false" >> $GITHUB_OUTPUT
+              ;;
+            "op-pr")
+              echo "run-quick=true" >> $GITHUB_OUTPUT
+              echo "run-unit=false" >> $GITHUB_OUTPUT
+              echo "run-frequent=false" >> $GITHUB_OUTPUT
+              echo "run-demo=false" >> $GITHUB_OUTPUT
+              echo "run-model-perf=false" >> $GITHUB_OUTPUT
+              echo "run-stress=false" >> $GITHUB_OUTPUT
+              ;;
+            "nightly")
+              echo "run-quick=true" >> $GITHUB_OUTPUT
+              echo "run-unit=false" >> $GITHUB_OUTPUT
+              echo "run-frequent=false" >> $GITHUB_OUTPUT
+              echo "run-demo=false" >> $GITHUB_OUTPUT
+              echo "run-model-perf=false" >> $GITHUB_OUTPUT
+              echo "run-stress=false" >> $GITHUB_OUTPUT
+              ;;
+            "hw-self-test")
+              echo "run-quick=true" >> $GITHUB_OUTPUT
+              echo "run-unit=false" >> $GITHUB_OUTPUT
+              echo "run-frequent=false" >> $GITHUB_OUTPUT
+              echo "run-demo=false" >> $GITHUB_OUTPUT
+              echo "run-model-perf=false" >> $GITHUB_OUTPUT
+              echo "run-stress=false" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "run-quick=true" >> $GITHUB_OUTPUT
+              echo "run-unit=false" >> $GITHUB_OUTPUT
+              echo "run-frequent=false" >> $GITHUB_OUTPUT
+              echo "run-demo=false" >> $GITHUB_OUTPUT
+              echo "run-model-perf=false" >> $GITHUB_OUTPUT
+              echo "run-stress=false" >> $GITHUB_OUTPUT
+              ;;
+          esac
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -75,8 +140,8 @@ jobs:
       build-wheel: true
       version: 22.04
   tg-quick:
-    if: ${{ inputs.tg-quick }}
-    needs: build-artifact
+    if: ${{ inputs.tg-quick || needs.determine-tests.outputs.run-quick == 'true' }}
+    needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-quick.yaml
     with:
@@ -88,8 +153,8 @@ jobs:
       topology-6u: ${{ contains(inputs.extra-tag, 'topology-6u') }}
 
   tg-unit-tests:
-    if: ${{ inputs.tg-unit }}
-    needs: build-artifact
+    if: ${{ inputs.tg-unit || needs.determine-tests.outputs.run-unit == 'true' }}
+    needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-unit-tests-impl.yaml
     with:
@@ -99,8 +164,8 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       topology: ${{ contains(inputs.extra-tag, 'topology-6u') && 'topology-6u' || 'config-tg' }}
   tg-frequent-tests:
-    if: ${{ inputs.tg-frequent }}
-    needs: build-artifact
+    if: ${{ inputs.tg-frequent || needs.determine-tests.outputs.run-frequent == 'true' }}
+    needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-frequent-tests-impl.yaml
     with:
@@ -110,8 +175,8 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       topology: ${{ contains(inputs.extra-tag, 'topology-6u') && 'topology-6u' || 'config-tg' }}
   tg-demo-tests:
-    if: ${{ inputs.tg-demo }}
-    needs: build-artifact
+    if: ${{ inputs.tg-demo || needs.determine-tests.outputs.run-demo == 'true' }}
+    needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-demo-tests-impl.yaml
     with:
@@ -121,8 +186,8 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       topology: ${{ contains(inputs.extra-tag, 'topology-6u') && 'topology-6u' || 'config-tg' }}
   tg-model-perf-tests:
-    if: ${{ inputs.tg-model-perf }}
-    needs: build-artifact
+    if: ${{ inputs.tg-model-perf || needs.determine-tests.outputs.run-model-perf == 'true' }}
+    needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-model-perf-tests-impl.yaml
     with:
@@ -132,8 +197,8 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       topology: ${{ contains(inputs.extra-tag, 'topology-6u') && 'topology-6u' || 'config-tg' }}
   tg-stress-test:
-    needs: build-artifact
-    if: ${{ inputs.tg-stress }}
+    if: ${{ inputs.tg-stress || needs.determine-tests.outputs.run-stress == 'true' }}
+    needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-stress.yaml
     with:

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       model-selection:
-        description: "Select model to run tests on."
+        description: "Selection ignored for now. "
         required: true
         type: choice
         options:
@@ -33,7 +33,7 @@ on:
           - TSan
         default: "Release"
       extra-tag: # set in-service and topology-6u by default
-        description: "Extra tag to add to the build. Can specify topology 'topology-6u' or 'config-tg'."
+        description: "You can specify topology with 'topology-6u' or 'config-tg' and specific machine."
         required: true
         type: string
         default: "in-service,config-tg"

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -74,11 +74,29 @@ jobs:
       run-demo: ${{ steps.logic.outputs.run-demo }}
       run-model-perf: ${{ steps.logic.outputs.run-model-perf }}
       run-stress: ${{ steps.logic.outputs.run-stress }}
+      clean-extra-tag: ${{ steps.logic.outputs.clean-extra-tag }}
+      is-config-tg: ${{ steps.logic.outputs.is-config-tg }}
     steps:
       - name: Determine test execution
         id: logic
         # Skip all but tg-quick if trigger-type is not manual
         run: |
+          EXTRA_TAG="${{ inputs.extra-tag }}"
+          # (remove both config-tg and topology-6u) from EXTRA_TAG
+          # and clean up any extra commas
+          # e.g. "config-tg,in-service" -> "in-service"
+          CLEANED=$(echo "$EXTRA_TAG" | sed -e 's/\bconfig-tg\b//g' -e 's/\btopology-6u\b//g' -e 's/,,/,/g' -e 's/^,//' -e 's/,$//')
+
+          # Check which tag is present
+          if [[ "$EXTRA_TAG" == *"topology-6u"* ]]; then
+            IS_CONFIG_TG=false
+          else
+            IS_CONFIG_TG=true  # set config-tg if topology-6u is not present
+          fi
+
+          echo "clean-extra-tag=$CLEANED" >> $GITHUB_OUTPUT
+          echo "is-config-tg=$IS_CONFIG_TG" >> $GITHUB_OUTPUT
+
           case "${{ inputs.trigger_type }}" in
             "manual")
               echo "run-quick=${{ inputs.tg-quick }}" >> $GITHUB_OUTPUT
@@ -145,12 +163,12 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-quick.yaml
     with:
-      extra-tag: ${{ inputs.extra-tag }}
+      extra-tag: ${{ needs.determine-tests.outputs.clean-extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology-4u: ${{ contains(inputs.extra-tag, 'config-tg') }}
-      topology-6u: ${{ contains(inputs.extra-tag, 'topology-6u') }}
+      topology-4u: ${{ needs.determine-tests.outputs.is-config-tg == 'true'}}
+      topology-6u: ${{ needs.determine-tests.outputs.is-config-tg == 'false'}}
 
   tg-unit-tests:
     if: ${{ inputs.tg-unit || needs.determine-tests.outputs.run-unit == 'true' }}
@@ -158,53 +176,53 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-unit-tests-impl.yaml
     with:
-      extra-tag: ${{ inputs.extra-tag }}
+      extra-tag: ${{ needs.determine-tests.outputs.clean-extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology: ${{ contains(inputs.extra-tag, 'topology-6u') && 'topology-6u' || 'config-tg' }}
+      topology: ${{ needs.determine-tests.outputs.is-config-tg == 'true' && 'config-tg' || 'topology-6u' }}
   tg-frequent-tests:
     if: ${{ inputs.tg-frequent || needs.determine-tests.outputs.run-frequent == 'true' }}
     needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-frequent-tests-impl.yaml
     with:
-      extra-tag: ${{ inputs.extra-tag }}
+      extra-tag: ${{ needs.determine-tests.outputs.clean-extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology: ${{ contains(inputs.extra-tag, 'topology-6u') && 'topology-6u' || 'config-tg' }}
+      topology: ${{ needs.determine-tests.outputs.is-config-tg == 'true' && 'config-tg' || 'topology-6u' }}
   tg-demo-tests:
     if: ${{ inputs.tg-demo || needs.determine-tests.outputs.run-demo == 'true' }}
     needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-demo-tests-impl.yaml
     with:
-      extra-tag: ${{ inputs.extra-tag }}
+      extra-tag: ${{ needs.determine-tests.outputs.clean-extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology: ${{ contains(inputs.extra-tag, 'topology-6u') && 'topology-6u' || 'config-tg' }}
+      topology: ${{ needs.determine-tests.outputs.is-config-tg == 'true' && 'config-tg' || 'topology-6u' }}
   tg-model-perf-tests:
     if: ${{ inputs.tg-model-perf || needs.determine-tests.outputs.run-model-perf == 'true' }}
     needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-model-perf-tests-impl.yaml
     with:
-      extra-tag: ${{ inputs.extra-tag }}
+      extra-tag: ${{ needs.determine-tests.outputs.clean-extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology: ${{ contains(inputs.extra-tag, 'topology-6u') && 'topology-6u' || 'config-tg' }}
+      topology: ${{ needs.determine-tests.outputs.is-config-tg == 'true' && 'config-tg' || 'topology-6u' }}
   tg-stress-test:
     if: ${{ inputs.tg-stress || needs.determine-tests.outputs.run-stress == 'true' }}
     needs: [build-artifact, determine-tests]
     secrets: inherit
     uses: ./.github/workflows/tg-stress.yaml
     with:
-      extra-tag: ${{ inputs.extra-tag }}
+      extra-tag: ${{ needs.determine-tests.outputs.clean-extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology-4u: ${{ contains(inputs.extra-tag, 'config-tg') }}
-      topology-6u: ${{ contains(inputs.extra-tag, 'topology-6u') }}
+      topology-4u: ${{ needs.determine-tests.outputs.is-config-tg == 'true'}}
+      topology-6u: ${{ needs.determine-tests.outputs.is-config-tg == 'false'}}

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       model-selection:
-        description: "Selection ignored for now. "
+        description: "Model selection ignored for now. "
         required: true
         type: choice
         options:
@@ -152,9 +152,10 @@ jobs:
     permissions:
       packages: write
     secrets: inherit
+    needs: determine-tests
     with:
       build-type: ${{ inputs.build-type }}
-      tracy: ${{ inputs.tg-model-perf }}
+      tracy: ${{ needs.determine-tests.outputs.run-model-perf == 'true' }}
       build-wheel: true
       version: 22.04
   tg-quick:

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -25,7 +25,7 @@ on:
           - TSan
         default: "Release"
       extra-tag: # set in-service and topology-6u by default
-        description: "You can specify topology with 'topology-6u' or 'config-tg' and specific machine."
+        description: "You can specify only one topology, 'topology-6u' or 'config-tg'. Default is config-tg."
         required: true
         type: string
         default: "in-service,config-tg"


### PR DESCRIPTION
### Problem description
Master issue: https://github.com/tenstorrent/tt-metal/issues/23408
#### Current problem
Choose Your Pipeline currently only supports running manually picked pipelines. 

### Solution
By adding trigger type we enable running relevant pipelines in different situations. Triggers we had in mind are:
- **model-pr** - run every time some Llama related PR is created
- **op-pr** - run when there is new op implemented
- **nightly** - runs all the tests every night (if too much workload on CI, it will be reduced)
- **hardware-self-test** - whenever new HW is brought up or fixed, run relevant tests to verify it's ready to use

### What's changed
- Added 2 select options
    - model-selection - currently placeholder, in the next PR I will add implementation for passing it to child pipelines
    - trigger-type - if it's 'manual' users regularly select pipelines they want. Otherwise, specific pipelines would be executed. Also it's currently configured to tg-quick only but will be modified once all the pipelines are present in workflow.
- Topology field is moved to extra-tag since we can't have more than 10 input fields (Github constraint)
- tg-nightly removed from input options due to input constraints and also it's anyways running every night and it's ~4hrs long. If someone really needs it then they will schedule it separately.
- determine-tests - quick job for determining which pipelines to run and to parse extra-tag

### Checklist
- [ ] [Choose your pipeline - manual run (tg-demo + tg-unit)](https://github.com/tenstorrent/tt-metal/actions/runs/15581783601)
- [ ] [Choose your pipeline - model-pr (runs only tg-quick) with topology-6u](https://github.com/tenstorrent/tt-metal/actions/runs/15581810121)
- [ ] [Choose your pipeline - manual run (tg-perf + tg-quick)](https://github.com/tenstorrent/tt-metal/actions/runs/15582161078)


@tt-rkim @ttmchiou @akirby-TT Let me know if you want me to run any other tests!