### PR TITLE
#22941: Pack/_untilize init cleanup - first pass

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -947,6 +947,7 @@ INPUT                  = tt_metal/hw/inc/compile_time_args.h \
                          tt_metal/include/compute_kernel_api/eltwise_binary.h \
                          tt_metal/include/compute_kernel_api/matmul.h \
                          tt_metal/include/compute_kernel_api/pack.h \
+                         tt_metal/include/compute_kernel_api/pack_untilize.h \
                          tt_metal/include/compute_kernel_api/quantization.h \
                          tt_metal/include/compute_kernel_api/reconfig_data_format.h \
                          tt_metal/include/compute_kernel_api/reduce.h \

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/pack_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/pack_tile.rst
@@ -1,5 +1,8 @@
 pack_tile
 =========
 
-.. doxygenfunction:: pack_tile(uint32_t idst, uint32_t cbid, std::uint32_t output_tile_index = 0)
-.. doxygenfunction:: matmul_pack_tile(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles)
+.. doxygenfunction:: pack_tile
+.. doxygenfunction:: pack_tile_block
+.. doxygenfunction:: pack_reconfig_data_format(const uint32_t new_operand)
+.. doxygenfunction:: pack_reconfig_data_format(const uint32_t old_operand, const uint32_t new_operand)
+.. doxygenfunction:: pack_reconfig_l1_acc

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/pack_untilize.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/pack_untilize.rst
@@ -1,0 +1,8 @@
+pack_untilize_block
+===================
+
+.. doxygenfunction:: pack_untilize_dest_init
+.. doxygenfunction:: pack_untilize_init
+.. doxygenfunction:: pack_untilize_block
+.. doxygenfunction:: pack_untilize_dest
+.. doxygenfunction:: pack_untilize_uninit

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/packing_apis.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/packing_apis.rst
@@ -5,4 +5,5 @@ Packing and Unpacking APIs allow reinterpreting or construct/reading of buffers 
 
 .. toctree::
     pack_tile
+    pack_untilize
     reconfig_data_format

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -200,7 +200,7 @@ void run_single_core_copy_block_matmul_partials(
 // ------------------------------------------------------------------------
 // These tests aim to cover usage of these API calls:
 // - copy_block_matmul_partials
-// - matmul_pack_tile
+// - pack_tile_block
 ////////////////////////////////////////////////////////////////////////////
 
 TEST_F(DeviceFixture, DISABLED_TensixComputeCopyBlockSingle) {

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -485,31 +485,6 @@ TEST_F(DeviceFixture, TensixComputePackUntilize) {
     }
 }
 
-TEST_F(DeviceFixture, TensixComputePackUntilizeShortInit) {
-    vector<vector<uint32_t>> num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}};
-    for (auto num_tile : num_tiles) {
-        for (bool fp32_dest_acc_en : {true, false}) {
-            // FP32 dest acc not possible for GS
-            if ((fp32_dest_acc_en) && (this->arch_ == tt::ARCH::GRAYSKULL)) {
-                continue;
-            }
-            for (bool dst_full_sync_en : {true, false}) {
-                unit_tests::compute::tilize::TestConfig test_config = {
-                    .short_init = true,
-                    .dst_full_sync_en = dst_full_sync_en,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .input_single_tile_size = 2 * 1024,
-                    .output_single_tile_size = 1024 * (fp32_dest_acc_en ? 4 : 2),
-                    .num_tiles_r = num_tile[0],
-                    .num_tiles_c = num_tile[1],
-                    .untilize_type = unit_tests::compute::tilize::UntilizeType::PACK,
-                    .golden_function = ::unit_tests::compute::gold_standard_untilize};
-                unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
-            }
-        }
-    }
-}
-
 TEST_F(DeviceFixture, TensixComputePackUntilizeDst) {
     vector<vector<uint32_t>> num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}};
     for (auto num_tile : num_tiles) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
@@ -72,7 +72,7 @@ void MAIN {
         cb_reserve_back(out_cb_id, out_block_num_tiles);
         tile_regs_wait();
         uint32_t start_dst_index = 0;
-        matmul_pack_tile(start_dst_index, out_cb_id, out_block_num_tiles);
+        pack_tile_block(start_dst_index, out_cb_id, out_block_num_tiles);
         tile_regs_release();
         cb_push_back(out_cb_id, out_block_num_tiles);
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
@@ -62,7 +62,7 @@ inline void reblock_and_untilize(
             }
             tile_regs_commit();
             tile_regs_wait();
-            pack_untilize_dst<out_subblock_w, out_block_w>(out_cb_id, 1, n);
+            pack_untilize_dest<out_subblock_w, out_block_w>(out_cb_id, 1, n);
             tile_regs_release();
             block_offset += out_subblock_num_tiles;
         }
@@ -223,7 +223,7 @@ void MAIN {
 #endif
 
                         uint32_t start_dst_index = 0;
-                        matmul_pack_tile(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
+                        pack_tile_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
 
                         tile_regs_release();
                         cb_push_back(mm_out_cb_id, out_subblock_num_tiles);
@@ -248,7 +248,7 @@ void MAIN {
 #endif
 
                         uint32_t start_dst_index = 0;
-                        matmul_pack_tile(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
+                        pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
 
                         tile_regs_release();
                         cb_push_back(mm_partials_cb_id, out_subblock_num_tiles);
@@ -359,7 +359,7 @@ void MAIN {
             PACK((llk_pack_reconfig_l1_acc(0)));
 #endif
 #endif  // FUSE_BIAS
-            pack_untilize_dst_init_short<out_subblock_w, out_block_w>(out_cb_id);
+            pack_untilize_dest_init<out_subblock_w, out_block_w>(out_cb_id);
             copy_tile_to_dst_init_short(mm_partials_cb_id);
             for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
                 reblock_and_untilize<out_subblock_w, out_block_w>(

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dst_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dst_untilize.cpp
@@ -16,9 +16,9 @@ void MAIN {
     constexpr uint32_t num_faces = get_compile_time_arg_val(2);
     constexpr uint32_t num_rows_per_face = get_compile_time_arg_val(3);
 
-    unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
     copy_tile_to_dst_init_short(tt::CBIndex::c_0);
-    pack_untilize_dst_init_short<per_core_block_tile_cnt>(tt::CBIndex::c_16, num_rows_per_face, num_faces);
+    pack_untilize_dest_init<per_core_block_tile_cnt>(tt::CBIndex::c_16, num_rows_per_face, num_faces);
 
     for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
         cb_wait_front(tt::CBIndex::c_0, per_core_block_tile_cnt);
@@ -31,7 +31,7 @@ void MAIN {
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_untilize_dst<per_core_block_tile_cnt>(tt::CBIndex::c_16, 1, 0, num_rows_per_face, num_faces);
+        pack_untilize_dest<per_core_block_tile_cnt>(tt::CBIndex::c_16, 1, 0, num_rows_per_face, num_faces);
         tile_regs_release();
 
         cb_push_back(tt::CBIndex::c_16, per_core_block_tile_cnt);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
@@ -32,7 +32,7 @@ void MAIN {
         // Copy num_single_transfer tiles from in_cb to DEST
         copy_block_matmul_partials(in_cb_id, 0, 0, num_single_transfer);
         // Pack num_single_transfer tiles to out_cb
-        matmul_pack_tile(0, out_cb_id, num_single_transfer);
+        pack_tile_block(0, out_cb_id, num_single_transfer);
 
         // Release DEST reg marking compute/pack complete
         release_dst();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp
@@ -32,14 +32,9 @@ void MAIN {
     constexpr uint32_t block_ct_dim = per_core_block_tile_cnt / num_blocks_per_col;
     constexpr uint32_t full_ct_dim = per_core_block_tile_cnt;
 
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
     pack_untilize_init<block_ct_dim, full_ct_dim>(tt::CBIndex::c_0, tt::CBIndex::c_16);
 
-#ifdef SHORT_INIT
-    unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
-    pack_untilize_init_short<block_ct_dim, full_ct_dim>(tt::CBIndex::c_0, tt::CBIndex::c_16);
-#else
-    pack_untilize_init<block_ct_dim, full_ct_dim>(tt::CBIndex::c_0, tt::CBIndex::c_16);
-#endif
 
     for (uint32_t r = 0; r < per_core_block_cnt; ++r) {
         cb_reserve_back(tt::CBIndex::c_16, full_ct_dim);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp
@@ -87,7 +87,7 @@ void MAIN {
         pack_reconfig_l1_acc(true);
 #endif
         // Configured already for CB_16, Bfp16_b
-        matmul_pack_tile(0, cb_out0, ublock_size_tiles);
+        pack_tile_block(0, cb_out0, ublock_size_tiles);
         // Reconfig for CB_17, Bfp8_b, then pack to CB_17
 #if (EXPLICIT_RECONFIG == 1)
         // Indices for old_output, new_output
@@ -99,7 +99,7 @@ void MAIN {
         // Not testing for L1 accumulation
         pack_reconfig_l1_acc(false);
 
-        matmul_pack_tile(0, cb_out1, ublock_size_tiles);
+        pack_tile_block(0, cb_out1, ublock_size_tiles);
         release_dst();
 
         cb_pop_front(cb_in0, ublock_size_tiles);

--- a/tt_metal/include/compute_kernel_api/pack.h
+++ b/tt_metal/include/compute_kernel_api/pack.h
@@ -10,13 +10,13 @@ namespace ckernel {
 
 // clang-format off
 /**
- * Copies a single tile from the DST register buffer at a specified index to a
+ * Copies a single tile from the DEST register buffer at a specified index to a
  * specified CB at a given index. For the out_tile_index to be valid for this
  * call, cb_reserve_back(n) has to be called first to reserve at least some
  * number n > 0 of tiles in the output CB. out_tile_index = 0 then references
  * the first tile in the reserved section of the CB, up to index n - 1, which will
  * then be visible to the consumer in the same order after a cb_push_back call.
- * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * The DEST register buffer must be in acquired state via *acquire_dst* call.
  * This call is blocking and is only available on the compute engine.
  *
  * Each subsequent pack call will increment the write pointer in the cb by single
@@ -27,17 +27,34 @@ namespace ckernel {
  *
  * A typical use case is first the producer ensures that there is a number of
  * tiles available in the buffer via cb_reserve_back, then the producer uses
- * the pack_tile call to copy a tile from one of DST slots to a slot in
+ * the pack_tile call to copy a tile from one of DEST slots to a slot in
  * reserved space and finally cb_push_back is called to announce visibility of
  * the reserved section of the circular buffer to the consumer.
  *
+ * When the `out_of_order_output` flag is set to true, `pack_tile` behaves like
+ * other APIs in that it writes the output tile to the tile index specified by
+ * the user in `output_tile_index` within the reserved region of the circular
+ * buffer, but relative to the position that might have been previously updated
+ * by `cb_push_back` function. If `out_of_order_output` is false (the default),
+ * `pack_tile` always operates sequentially: it writes to the next tile index
+ * starting from index 0, and the `output_tile_index` parameter is ignored. In
+ * this mode, each call to `pack_tile` advances the internal write pointer for
+ * the reserved region, which is reset after `cb_push_back` function.
+ *
+ * NOTE: pack_tile doesn't need explicit initialization function prior to its call. Other op-specific
+ * initialization functions (such as `tilize_init`, `reduce_init`, etc.) ensure proper initialization
+ * of the packer. The reason for this stems from the fact that MATH and PACK threads need to be explicitly
+ * synchronized in the kernels. To ensure this synchronization, tile packing is implemented as a separate
+ * API call.
+ *
  * Return value: None
  *
- * | Argument       | Description                                       | Type     | Valid Range                                         | Required |
- * |----------------|---------------------------------------------------|----------|-----------------------------------------------------|----------|
- * | ifrom_dst      | The index of the tile in the DST register         | uint32_t | Must be less than the size of the DST register (16) | True     |
- * | icb            | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31                                             | True     |
- * | icb_tile       | The index of the tile in the output CB to copy to | uint32_t | Must be less than the size of the CB                | True     |
+ * | Param Type | Name             | Description                                       | Type     | Valid Range                                          | Required |
+ * |------------|------------------|---------------------------------------------------|----------|------------------------------------------------------|----------|
+ * | Template   | out_of_order_output | Whether to allow out-of-order output           | bool     | true/false                                           | False    |
+ * | Function   | ifrom_dst        | The index of the tile in the DEST register        | uint32_t | Must be less than the size of the DEST register (16) | True     |
+ * | Function   | icb              | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31                                              | True     |
+ * | Function   | output_tile_index| The index of the tile in the output CB to copy to | uint32_t | Must be less than the size of the CB                 | False    |
  */
 // clang-format on
 template <bool out_of_order_output = false>
@@ -47,56 +64,106 @@ ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb, std::uint32_t output_tile_
 
 // clang-format off
 /**
- * Copies a block of tiles from the DST register buffer at a start index to a
- * specified CB at a given start index. cb_reserve_back(n) had to be called first
- * to reserve at least some number n>0 of tiles in the output CB. The out_tile_index = 0
- * then references the first tile in the reserved section of the CB, up to index n-1 that
- * will then be visible to the consumer in the same order after a cb_push_back call.
- * The DST register buffer must be in acquired state via *acquire_dst* call.
- * This call is blocking and is only available on the compute engine.
+ * Copies a block of tiles from the DEST register buffer starting at a specified index
+ * to a specified circular buffer (CB). The DEST register buffer must be in acquired
+ * state via *acquire_dst* call. This call is blocking and is only available on the
+ * compute engine. Before calling this function, cb_reserve_back(n) must be called to
+ * reserve at least n > 0 tiles in the output CB. Each call to `pack_tile_block` will
+ * copy `ntiles` tiles from the DEST register to the reserved region of the CB, starting
+ * from index 0. The internal write pointer in the CB is advanced by `ntiles` after each
+ * call, and is reset by another cb_push_back call. Operates in tandem with functions
+ * cb_reserve_back and cb_push_back.
  *
- * Each subsequent pack call will increment the write pointer in the cb by ntiles size.
- * The pointer is then again set to a valid position with space for n
- * reserved tiles by another cb_reserve_back call.
+ * A typical use case is for the producer to ensure that there are enough tiles available
+ * in the buffer via cb_reserve_back, then use pack_tile_block to copy a block of tiles
+ * from the DEST slots to the reserved space in the CB, and finally call cb_push_back to
+ * announce visibility of the reserved section of the circular buffer to the consumer.
  *
- * Operates in tandem with functions cb_reserve_back and cb_push_back.
- *
- * A typical use case is first the producer ensures that there is a number of
- * tiles available in the buffer via cb_reserve_back, then the producer uses
- * the matmul_pack_tile call to copy a block of tiles from the DST slots to the slots in
- * reserved space and finally cb_push_back is called to announce visibility of
- * the reserved section of the circular buffer to the consumer.
+ * NOTE: pack_tile_block doesn't need explicit initialization function prior to its call. Other op-specific
+ * initialization functions (such as `tilize_init`, `reduce_init`, etc.) ensure proper initialization
+ * of the packer. The reason for this stems from the fact that MATH and PACK threads need to be explicitly
+ * synchronized in the kernels. To ensure this synchronization, tile packing is implemented as a separate
+ * API call.
  *
  * Return value: None
  *
- * | Argument       | Description                                       | Type     | Valid Range                                         | Required |
- * |----------------|---------------------------------------------------|----------|-----------------------------------------------------|----------|
- * | ifrom_dst      | The index of the tile in the DST register         | uint32_t | Must be less than the size of the DST register (16) | True     |
- * | icb            | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31                                             | True     |
- * | ntiles         | The number of tiles to copy from DST to CB        | uint32_t | Must be less than the size of the CB                | True     |
+ * | Param Type | Name      | Description                                       | Type     | Valid Range                                          | Required |
+ * |------------|-----------|---------------------------------------------------|----------|------------------------------------------------------|----------|
+ * | Function   | ifrom_dst | The index of the first tile in the DEST register  | uint32_t | Must be less than the size of the DEST register (16) | True     |
+ * | Function   | icb       | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31                                              | True     |
+ * | Function   | ntiles    | The number of tiles to copy from DEST to CB       | uint32_t | Must be less than the size of the DEST register (16) | True     |
  */
 // clang-format on
-ALWI void matmul_pack_tile(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
+ALWI void pack_tile_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
     PACK((llk_matmul_pack<DST_ACCUM_MODE, false, false>(ifrom_dst, icb, ntiles)));
 }
 
+// clang-format off
 /**
- * Helper function to reconfigure packer output data format.
+ * Reconfigures the packer output data format by specifying the CB ID of the new operand. This function
+ * call will always perform the reconfiguration, regardless of the data format of the old operand.
+ * If the new CB ID is the same as the current one, reconfiguration will still occur.
+ *
+ * NOTE: Packer reconfiguration functions are used similarly to the initialization function, in a sense
+ * that they are called before the call to the packer function that uses the new configuration. It is
+ * recommended to call this function right after other op-specific initialization functions.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name       | Description                        | Type     | Valid Range | Required |
+ * |------------|------------|------------------------------------|----------|-------------|----------|
+ * | Function   | new_cb_id  | New data format operand value      | uint32_t | Any         | True     |
  */
-ALWI void pack_reconfig_data_format(const uint32_t new_operand) {
-    PACK((llk_pack_reconfig_data_format<DST_ACCUM_MODE>(new_operand)));
+// clang-format on
+ALWI void pack_reconfig_data_format(const uint32_t new_cb_id) {
+    PACK((llk_pack_reconfig_data_format<DST_ACCUM_MODE>(new_cb_id)));
 }
 
+// clang-format off
 /**
- * Helper function to reconfigure packer output data format.
+ * Reconfigures the packer output data format by specifying the CB IDs of the old and new operands.
+ * This function internally calls the reconfiguration function with the new CB ID, but before it does so,
+ * it checks if the old and new data formats are different. If they are the same, it does not perform
+ * the reconfiguration. This function is useful when you want to ensure that the packer only reconfigures
+ * when different data format is wanted, avoiding unnecessary reconfiguration overhead.
+ *
+ * NOTE: Packer reconfiguration functions are used similarly to the initialization function, in a sense
+ * that they are called before the call to the packer function that uses the new configuration. It is
+ * recommended to call this function right after other op-specific initialization functions.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name       | Description                        | Type     | Valid Range | Required |
+ * |------------|------------|------------------------------------|----------|-------------|----------|
+ * | Function   | old_cb_id  | Previous data format operand value | uint32_t | Any         | True     |
+ * | Function   | new_cb_id  | New data format operand value      | uint32_t | Any         | True     |
  */
-ALWI void pack_reconfig_data_format(const uint32_t old_operand, const uint32_t new_operand) {
-    PACK((llk_pack_reconfig_data_format<DST_ACCUM_MODE>(old_operand, new_operand)));
+// clang-format on
+ALWI void pack_reconfig_data_format(const uint32_t old_cb_id, const uint32_t new_cb_id) {
+    PACK((llk_pack_reconfig_data_format<DST_ACCUM_MODE>(old_cb_id, new_cb_id)));
 }
 
+// clang-format off
 /**
- * Helper function to reconfigure packer l1 accumulation flag
+ * Helper function to reconfigure the packer L1 accumulation flag. This function would ideally be called
+ * after other initialization functions that initialize the packer for a specific operation.
+ * This function configures the packer to accumulate the values it takes from DEST with the ones that
+ * are already in L1 at a given CB ID and tile index.
+ *
+ * The `l1_acc_en` parameter must be set to either 0 (disable accumulation) or 1 (enable accumulation).
+ * Other values are not valid.
+ *
+ * NOTE: Packer reconfiguration functions are used similarly to the initialization function, in a sense
+ * that they are called before the call to the packer function that uses the new configuration. It is
+ * recommended to call this function right after other op-specific initialization functions.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name      | Description                        | Type     | Valid Range | Required |
+ * |------------|-----------|------------------------------------|----------|-------------|----------|
+ * | Function   | l1_acc_en | L1 accumulation enable flag        | uint32_t | 0 or 1      | True     |
  */
+// clang-format on
 ALWI void pack_reconfig_l1_acc(const uint32_t l1_acc_en) { PACK((llk_pack_reconfig_l1_acc(l1_acc_en))); }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -14,38 +14,127 @@
 
 namespace ckernel {
 
+// clang-format off
 /**
- * Init function for untilize operations, to be used at the beginning of the kernel.
+ * Performs the necessary hardware and software initialization for the pack untilize operation. This initialization
+ * function should be used when the desired PACK input is already in DEST register - therefore, it doesn't
+ * configure UNPACK and MATH threads for transferring data from circular buffers to DEST register (this is done with
+ * `pack_untilize_init` function). Matching pack untilize operation for this initialization function is
+ * `pack_untilize_dest`. In order for this untilization to be performed correctly, some other function must
+ * place the tiles in the DEST register, e.g. `reduce_tile`, `copy_tile`, etc. This initialization function
+ * should, therefore, be called right after the op-specific initialization function (`reduce_init`, `copy_init`, etc.).
+ *
+ * Since pack untilize works on a block of tiles, the user should specify the width of a single block (block_ct_dim),
+ * and the width of the full block (`full_ct_dim`). It is not needed to provide the height of the block during the
+ * initialization, since `pack_untilize_block` will loop over the height of the block. Note that the maximum size
+ * of the block is limited by the size of the DEST and synchronization mode used. These are maximum sizes:
+ * - half-sync mode (16-bit mode): 8 tiles
+ * - half-sync mode (32-bit mode): 4 tiles
+ * - full-sync mode (16-bit mode): 16 tiles
+ * - full-sync mode (32-bit mode): 8 tiles
+ *
+ * NOTE: This function allows the user to specify `face_r_dim` and `num_faces` through function parameters. Setting these
+ * parameters results in an expensive MMIO write and cannot be avoided currently.
+ * This should be addressed more systematically within the issue tt-metal#22820, since these two values can be inferred
+ * from the circular buffer description, the same way as it is done in `llk_pack_hw_configure_disaggregated`. This
+ * would remove the need for `llk_pack_untilize_hw_configure_disaggregated` altogether and we would pay the price
+ * of the MMIO write only once, in `compute_kernel_hw_startup`.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name         | Description                              | Type      | Valid Range     | Required |
+ * |------------|--------------|------------------------------------------|-----------|-----------------|----------|
+ * | Template   | block_ct_dim | Width of a single block in tiles         | uint32_t  | 1 to max (see note) | False (default = 8) |
+ * | Template   | full_ct_dim  | Width of a full input in tiles           | uint32_t  | >= block_ct_dim | False    |
+ * | Template   | narrow_row   |  Whether the provided input is narrow    | bool      | true/false      | False    |
+ * | Template   | row_num_datums | Number of datums per row               | uint32_t  | >= 1            | False    |
+ * | Function   | ocb          | Output circular buffer identifier        | uint32_t  | 0 to 31         | True     |
+ * | Function   | face_r_dim   | Face height in rows                      | uint32_t  | 1, 8 or 16      | False (default = 16) |
+ * | Function   | num_faces    | Number of faces                          | uint32_t  | 1, 2 or 4       | False (default = 4) |
  */
-template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
-ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb) {
-    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
-        false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
-    MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated<true>(icb, icb)));
-
-    PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
-    PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim>(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, true>()));
-
-    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(icb)));
-    UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
-        false, false, icb)));  // init must be after configure
+// clang-format on
+template <
+    uint32_t block_ct_dim = 8,
+    uint32_t full_ct_dim = block_ct_dim,
+    bool narrow_row = false,
+    std::uint32_t row_num_datums = TILE_C_DIM>
+ALWI void pack_untilize_dest_init(uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4) {
+#ifdef ARCH_BLACKHOLE
+    // Needed for setting swizzle_32b:
+    MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
+#endif
+    // A workaround for tt-metal#17132. Should be addressed more systematically.
+    PACK(
+        (llk_pack_untilize_hw_configure_disaggregated<DST_ACCUM_MODE, false /*untilize*/>(ocb, face_r_dim, num_faces)));
+    PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim, false, narrow_row, row_num_datums>(
+        ocb, face_r_dim, num_faces)));
+    PACK((llk_init_packer_dest_offset_registers<true, false>()));
 }
 
 // clang-format off
 /**
- * Perform the untilize operation on a block of tiles. This simply loops over the provided block size.
- * Performs the untilize operation on a block of tiles. Loops over the provided block size.
+ * Performs the necessary hardware and software initialization for the pack untilize operation. Initializes all three
+ * threads: UNPACK, MATH, and PACK. This function should be used when the desired PACK input is not yet in DEST
+ * register. Internally, this function calls `pack_untilize_dest_init` to initialize the PACK thread.
  *
- * | Param Type | Name          | Description                                 | Type      | Valid Range     | Required |
- * |------------|---------------|---------------------------------------------|-----------|-----------------|----------|
- * | Template   | block_ct_dim  | Width of a single block in tiles            | uint32_t  | 1 to 8          | False    |
- * | Template   | full_ct_dim   | Width of a full input in tiles              | uint32_t  | >= block_ct_dim | False    |
- * | Function   | icb           | Input circular buffer identifier            | uint32_t  | 0 to 31         | True     |
- * | Function   | block_rt_dim  | Height of a single block in tiles           | uint32_t  | >= 1            | True     |
- * | Function   | ocb           | Output circular buffer identifier           | uint32_t  | 0 to 31         | True     |
- * | Function   | block_c_index | Index of the currently processed block      | uint32_t  | >= 0            | False    |
+ * Since pack untilize works on a block of tiles, the user should specify the width of a single block (block_ct_dim),
+ * and the width of the full block (`full_ct_dim`). It is not needed to provide the height of the block during the
+ * initialization, since `pack_untilize_block` will loop over the height of the block. Note that the maximum size
+ * of the block is limited by the size of the DEST and synchronization mode used. These are maximum sizes:
+ * - half-sync mode (16-bit mode): 8 tiles
+ * - half-sync mode (32-bit mode): 4 tiles
+ * - full-sync mode (16-bit mode): 16 tiles
+ * - full-sync mode (32-bit mode): 8 tiles
+ *
+ * NOTE: This function uses default `face_r_dim` and `num_faces` values (16 and 4, respectively). Setting these
+ * parameters results in an expensive MMIO write and cannot be avoided currently.
+ * This should be addressed more systematically within the issue tt-metal#22820, since these two values can be inferred
+ * from the circular buffer description, the same way as it is done in `llk_pack_hw_configure_disaggregated`. This
+ * would remove the need for `llk_pack_untilize_hw_configure_disaggregated` altogether and we would pay the price
+ * of the MMIO write only once, in `compute_kernel_hw_startup`.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name         | Description                                | Type      | Valid Range     | Required |
+ * |------------|--------------|--------------------------------------------|-----------|-----------------|----------|
+ * | Template   | block_ct_dim | Width of a single block in tiles           | uint32_t  | 1 to max (see note) | False (default = 8) |
+ * | Template   | full_ct_dim  | Width of a full input in tiles             | uint32_t  | >= block_ct_dim | False    |
+ * | Function   | icb          | Input circular buffer identifier           | uint32_t  | 0 to 31         | True     |
+ * | Function   | ocb          | Output circular buffer identifier          | uint32_t  | 0 to 31         | True     |
+ */
+// clang-format on
+template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
+ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb) {
+    UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
+        false, false, icb)));  // init must be after configure
+    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
+        false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
+    pack_untilize_dest_init<block_ct_dim, full_ct_dim>(ocb);
+}
+
+// clang-format off
+/**
+ * Performs the untilize operation on a block of tiles. Loops over the provided block size. The block is characterized
+ * by its width in tiles (block_ct_dim) and height in tiles (block_rt_dim). The width of the block has to be the same
+ * as the one provided during the initialization of the pack untilize operation (`pack_untilize_init`). It is not
+ * needed to provide the height of the block during the initialization, since `pack_untilize_block` will loop over the
+ * height of the block. Note that the maximum size of the block is limited by the size of the DEST and synchronization
+ * mode used. These are maximum sizes:
+ * - half-sync mode (16-bit mode): 8 tiles
+ * - half-sync mode (32-bit mode): 4 tiles
+ * - full-sync mode (16-bit mode): 16 tiles
+ * - full-sync mode (32-bit mode): 8 tiles
+ *
+ * Return value: None
+ *
+ * | Param Type | Name         | Description                                 | Type      | Valid Range     | Required |
+ * |------------|--------------|---------------------------------------------|-----------|-----------------|----------|
+ * | Template   | block_ct_dim | Width of a single block in tiles            | uint32_t  | 1 to max (see note) | False (default = 8) |
+ * | Template   | full_ct_dim  | Width of a full input in tiles              | uint32_t  | >= block_ct_dim | False    |
+ * | Function   | icb          | Input circular buffer identifier            | uint32_t  | 0 to 31         | True     |
+ * | Function   | block_rt_dim | Height of a single block in tiles           | uint32_t  | >= 1            | True     |
+ * | Function   | ocb          | Output circular buffer identifier           | uint32_t  | 0 to 31         | True     |
+ * | Function   | block_c_index | Index of the currently processed block     | uint32_t  | >= 0            | False    |
  */
 // clang-format on
 template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
@@ -66,41 +155,43 @@ ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb,
     }
 }
 
+// clang-format off
 /**
- * Uninitialize untilize operation, to allow initializing another operation.
+ * Performs the pack untilize operation when PACK input is already in DEST register. In order to properly initialize the operation,
+ * a call to `pack_untilize_dest_init` must be made before this function. The width of the block has to be the same
+ * as the one provided during the initialization of the pack untilize operation (`pack_untilize_dest_init`). In order for this
+ * untilization to be performed correctly, some other function must place the tiles in the DEST register, e.g. `reduce_tile`,
+ * `copy_tile`, etc. Similarly as `pack_untilize_block`, this function operates on a whole block that needs to be untilized.
+ * Note that the maximum size of the block is limited by the size of the DEST
+ * and synchronization mode used. These are maximum sizes:
+ * - half-sync mode (16-bit mode): 8 tiles
+ * - half-sync mode (32-bit mode): 4 tiles
+ * - full-sync mode (16-bit mode): 16 tiles
+ * - full-sync mode (32-bit mode): 8 tiles
+ *
+ * Return value: None
+ *
+ * | Param Type | Name           | Description                                                   | Type      | Valid Range     | Required |
+ * |------------|----------------|---------------------------------------------------------------|-----------|-----------------|----------|
+ * | Template   | block_ct_dim   | Width of a single block in tiles                              | uint32_t  | 1 to max (see note) | False (default = 8) |
+ * | Template   | full_ct_dim    | Width of a full input in tiles                                | uint32_t  | >= block_ct_dim | False    |
+ * | Template   | diagonal       | Whether to use diagonal packing                               | bool      | true/false      | False    |
+ * | Template   | narrow_row     | Whether the provided input is narrow                          | bool      | true/false      | False    |
+ * | Template   | row_num_datums | Number of datums per row                                      | uint32_t  | >= 1            | False    |
+ * | Function   | ocb            | Output circular buffer identifier                             | uint32_t  | 0 to 31         | True     |
+ * | Function   | block_rt_dim   | Height of a single block in tiles                             | uint32_t  | >= 1            | False (default=1) |
+ * | Function   | block_c_index  | Block column index (used when full_ct_dim > block_ct_dim)     | uint32_t  | >= 0            | False (default=0) |
+ * | Function   | face_r_dim     | Face height in rows                                           | uint32_t  | 1, 8 or 16      | False (default=16) |
+ * | Function   | num_faces      | Number of faces                                               | uint32_t  | 1, 2 or 4       | False (default=4) |
  */
-ALWI void pack_untilize_uninit(uint32_t ocb) {
-    PACK((llk_pack_init(ocb)));
-    PACK((llk_init_packer_dest_offset_registers<false>()));
-
-#ifdef ARCH_BLACKHOLE
-    PACK((llk_pack_untilize_uninit(ocb)));
-#endif
-}
-
+// clang-format on
 template <
     uint32_t block_ct_dim = 8,
     uint32_t full_ct_dim = block_ct_dim,
     bool diagonal = false,
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM>
-ALWI void pack_untilize_dst_init_short(uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4) {
-    // A workaround for tt-metal#17132. Should be addressed more systematically.
-    PACK((llk_pack_untilize_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb, face_r_dim, num_faces)));
-    PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
-        ocb, face_r_dim, num_faces)));
-    PACK((llk_init_packer_dest_offset_registers<true, diagonal>()));
-
-    MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
-}
-
-template <
-    uint32_t block_ct_dim = 8,
-    uint32_t full_ct_dim = block_ct_dim,
-    bool diagonal = false,
-    bool narrow_row = false,
-    std::uint32_t row_num_datums = TILE_C_DIM>
-ALWI void pack_untilize_dst(
+ALWI void pack_untilize_dest(
     uint32_t ocb,
     uint32_t block_rt_dim = 1,
     uint32_t block_c_index = 0 /* used when full_ct_dim > block_ct_dim*/,
@@ -110,13 +201,29 @@ ALWI void pack_untilize_dst(
         block_rt_dim, ocb, face_r_dim, num_faces, block_c_index)));
 }
 
-template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
-ALWI void pack_untilize_init_short(uint32_t icb, uint32_t ocb) {
-    UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
-        false, false, icb)));  // init must be after configure
-    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
-        false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
-    pack_untilize_dst_init_short<block_ct_dim, full_ct_dim>(ocb);
+// clang-format off
+/**
+ * Uninitializes the pack untilize operation, allowing another operations to be initialized. Needs to be
+ * called after the last call to `pack_untilize_dest` or `pack_untilize_block`, before initializing
+ * another operation.
+ *
+ * NOTE: This function is not in line with our programming model, and will be removed by the end of 2025
+ * as a part of tt-metal#22904.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name | Description                        | Type     | Valid Range | Required |
+ * |------------|------|------------------------------------|----------|-------------|----------|
+ * | Function   | ocb  | Output circular buffer identifier  | uint32_t | 0 to 31     | True     |
+ */
+// clang-format on
+ALWI void pack_untilize_uninit(uint32_t ocb) {
+    PACK((llk_pack_init(ocb)));
+    PACK((llk_init_packer_dest_offset_registers<false>()));
+
+#ifdef ARCH_BLACKHOLE
+    PACK((llk_pack_untilize_uninit(ocb)));
+#endif
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -58,7 +58,8 @@ ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
  * same dimension, this call can be omitted. If this function is not called, the packer will continue to use the edge masks set
  * by the latest reduce_init call, which may lead to incorrect packing behavior in subsequent operations.
  *
- * NOTE: This function is not in line with our programming model, and will be removed by the end of 2025.
+ * NOTE: This function is not in line with our programming model, and will be removed by the end of 2025
+ * as a part of tt-metal#22904.
  *
  * | Param Type | Name | Description                                      | Type | Valid Range | Required |
  * |------------|------|--------------------------------------------------|------|-------------|----------|

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -188,6 +188,9 @@ ALWI void unpack_tilizeA_B_block(
 /**
  * Uninitializes the tilize operation before re-initializing for another operation.
  *
+ * NOTE: This function is not in line with our programming model, and will be removed by the end of 2025
+ * as a part of tt-metal#22904.
+ *
  * Return value: None
  *
  * | Param Type | Name   | Description                              | Type     | Valid Range | Required |
@@ -206,6 +209,9 @@ ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {
 // clang-format off
 /**
  * Uninitializes the tilize operation and reconfigures the unpacker with CB data types.
+ *
+ * NOTE: This function is not in line with our programming model, and will be removed by the end of 2025
+ * as a part of tt-metal#22904.
  *
  * Return value: None
  *

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -56,7 +56,7 @@ inline void reblock_and_untilize(
             }
             tile_regs_commit();
             tile_regs_wait();
-            pack_untilize_dst<out_subblock_w, out_block_w>(out_cb_id, 1, n);
+            pack_untilize_dest<out_subblock_w, out_block_w>(out_cb_id, 1, n);
             tile_regs_release();
             block_offset += out_subblock_num_tiles;
         }
@@ -301,7 +301,7 @@ void MAIN {
 #endif
 
                         uint32_t start_dst_index = 0;
-                        matmul_pack_tile(start_dst_index, curr_matmul_out_cb, out_subblock_num_tiles);
+                        pack_tile_block(start_dst_index, curr_matmul_out_cb, out_subblock_num_tiles);
 
                         tile_regs_release();
                         cb_push_back(curr_matmul_out_cb, out_subblock_num_tiles);
@@ -436,7 +436,7 @@ void MAIN {
 #endif
 
 #ifdef PACKER_UNTILIZE
-                pack_untilize_dst_init_short<out_subblock_w, out_block_w>(out_cb_id);
+                pack_untilize_dest_init<out_subblock_w, out_block_w>(out_cb_id);
                 copy_tile_to_dst_init_short(matmul_partials_cb);
                 for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
                     reblock_and_untilize<out_subblock_w, out_block_w>(

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_rm_single_tile_size.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_rm_single_tile_size.cpp
@@ -40,7 +40,7 @@ void MAIN {
         // transpose input
         cb_wait_front(cb_tilize, 1);
         transpose_wh_init_short(cb_tilize);
-        pack_untilize_dst_init_short<1>(cb_out);
+        pack_untilize_dest_init<1>(cb_out);
 
         tile_regs_acquire();
         transpose_wh_tile(cb_tilize, 0, 0);  // transpose call
@@ -50,7 +50,7 @@ void MAIN {
         cb_reserve_back(cb_out, w_block_size);
 
         tile_regs_wait();
-        pack_untilize_dst<1>(cb_out);  // pack call
+        pack_untilize_dest<1>(cb_out);  // pack call
         tile_regs_release();
 
         cb_push_back(cb_out, w_block_size);

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_tiled.cpp
@@ -52,7 +52,7 @@ void MAIN {
         cb_wait_front(cb_tilize, 1);
 
         transpose_wh_init_short(cb_tilize);
-        pack_untilize_dst_init_short<1>(cb_out);
+        pack_untilize_dest_init<1>(cb_out);
 
         tile_regs_acquire();
         transpose_wh_tile(cb_tilize, 0, 0);  // transpose call
@@ -62,7 +62,7 @@ void MAIN {
         cb_reserve_back(cb_out, 1);
 
         tile_regs_wait();
-        pack_untilize_dst<1>(cb_out);  // pack call
+        pack_untilize_dest<1>(cb_out);  // pack call
         tile_regs_release();
 
         cb_push_back(cb_out, 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -52,7 +52,7 @@ ALWI void transpose_with_pack_untilize_narrow_row(uint32_t cb_tilize, uint32_t c
     uint32_t tile_idx = 0;
 
     transpose_wh_init_short(cb_tilize);
-    pack_untilize_dst_init_short<Ht, Ht, false, use_narrow_row, row_size>(cb_out);
+    pack_untilize_dest_init<Ht, Ht, use_narrow_row, row_size>(cb_out);
     for (uint32_t w = 0; w < Wt; ++w) {
         tile_regs_acquire();
         for (uint32_t h = 0; h < Ht; ++h) {
@@ -65,13 +65,13 @@ ALWI void transpose_with_pack_untilize_narrow_row(uint32_t cb_tilize, uint32_t c
         if (w == Wt - 1) {  // last row
             cb_reserve_back(cb_out, pack_num_pages_last_row_col);
             tile_regs_wait();
-            pack_untilize_dst<Ht, Ht, false, use_narrow_row, row_size>(cb_out);
+            pack_untilize_dest<Ht, Ht, false, use_narrow_row, row_size>(cb_out);
             tile_regs_release();
             cb_push_back(cb_out, pack_num_pages_last_row_col);
         } else {
             cb_reserve_back(cb_out, pack_num_pages_last_col);
             tile_regs_wait();
-            pack_untilize_dst<Ht, Ht, false, use_narrow_row, row_size>(cb_out);
+            pack_untilize_dest<Ht, Ht, false, use_narrow_row, row_size>(cb_out);
             tile_regs_release();
             cb_push_back(cb_out, pack_num_pages_last_col);
         }
@@ -85,7 +85,7 @@ ALWI void transpose_with_pack_untilize(uint32_t cb_tilize, uint32_t cb_out) {
     uint32_t tile_idx = 0;
 
     transpose_wh_init_short(cb_tilize);
-    pack_untilize_dst_init_short<Ht>(cb_out);
+    pack_untilize_dest_init<Ht>(cb_out);
     for (uint32_t w = 0; w < Wt; ++w) {
         tile_regs_acquire();
         for (uint32_t h = 0; h < Ht; ++h) {
@@ -96,7 +96,7 @@ ALWI void transpose_with_pack_untilize(uint32_t cb_tilize, uint32_t cb_out) {
 
         cb_reserve_back(cb_out, Ht);
         tile_regs_wait();
-        pack_untilize_dst<Ht>(cb_out);
+        pack_untilize_dest<Ht>(cb_out);
 
         tile_regs_release();
         cb_push_back(cb_out, Ht);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp
@@ -14,6 +14,7 @@ void MAIN {
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(2);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(3);
 
+    compute_kernel_hw_startup(src_cb_id, out_cb_id);
     pack_untilize_init<per_core_block_tile_cnt>(src_cb_id, out_cb_id);
 
     for (uint32_t b = 0; b < per_core_block_cnt; ++b) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize_variable_num_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize_variable_num_blocks.cpp
@@ -15,6 +15,7 @@ void MAIN {
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(1);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(2);
 
+    compute_kernel_hw_startup(src_cb_id, out_cb_id);
     pack_untilize_init<per_core_block_tile_cnt>(src_cb_id, out_cb_id);
 
     for (uint32_t b = 0; b < per_core_block_cnt; ++b) {

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
@@ -20,7 +20,7 @@ FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
 
     cb_reserve_back(cb_out, BATCH_SIZE);
     tile_regs_wait();
-    pack_untilize_dst<1>(cb_out, BATCH_SIZE);
+    pack_untilize_dest<1>(cb_out, BATCH_SIZE);
     tile_regs_release();
 
     cb_push_back(cb_out, BATCH_SIZE);
@@ -34,10 +34,11 @@ void MAIN {
     constexpr uint32_t cb_in = get_compile_time_arg_val(0);
     constexpr uint32_t cb_transpose_in = get_compile_time_arg_val(1);
 
+    compute_kernel_hw_startup(cb_in, cb_transpose_in);
     pack_untilize_init(cb_in, cb_transpose_in);
     transpose_wh_init(cb_in, cb_transpose_in);
 
-    pack_untilize_dst_init_short<1>(cb_transpose_in);
+    pack_untilize_dest_init<1>(cb_transpose_in);
 
     for (uint32_t i = 0; i < num_batches; i++) {
         transpose<BATCH_SIZE>(cb_in, cb_transpose_in);

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp
@@ -21,7 +21,7 @@ FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
     }
 
     cb_reserve_back(cb_out, BatchSize);
-    pack_untilize_dst<1>(cb_out, BatchSize);
+    pack_untilize_dest<1>(cb_out, BatchSize);
 
     tile_regs_commit();
     tile_regs_release();
@@ -62,7 +62,7 @@ void MAIN {
 
     pack_untilize_init(cb_in, cb_transpose_in0);
     transpose_wh_init(cb_in, cb_transpose_in0);
-    pack_untilize_dst_init_short<1>(cb_in);
+    pack_untilize_dest_init<1>(cb_in);
 
     for (uint32_t idx = 0; idx < total_tiles; idx++) {
         const uint32_t cb_transpose_in = idx % 2 == 0 ? cb_transpose_in0 : cb_transpose_in1;

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/compute/transformer_group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/compute/transformer_group_attn_matmul.cpp
@@ -76,7 +76,7 @@ void MAIN {
                         cb_pop_front(cb_in1, num_kv_heads_skip);
 
 			// This init changes DEST mapping, hence needs to be called before MATH does any processing, so that it has correct DEST mapping.
-                        pack_untilize_dst_init_short<intermediate_num_tiles>(cb_intermed0);
+                        pack_untilize_dest_init<intermediate_num_tiles>(cb_intermed0);
 
                         for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) { // TODO: Must be 1; need to review inner dim blocking and the untilizing
                             uint32_t in1_index_subblock_offset = 0;
@@ -140,7 +140,7 @@ void MAIN {
                         // This should normally be inside subblock loop and we pack out out_subblock_num_tiles
                         cb_reserve_back(cb_intermed0, intermediate_num_tiles);
                         tile_regs_wait();
-                        pack_untilize_dst<intermediate_num_tiles>(cb_intermed0);
+                        pack_untilize_dest<intermediate_num_tiles>(cb_intermed0);
                         pack_untilize_uninit(cb_intermed0);
 
                         tile_regs_release();

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/paged_fused_update_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/paged_fused_update_cache.cpp
@@ -32,6 +32,7 @@ void MAIN {
     constexpr uint32_t Wt = get_compile_time_arg_val(7);
     constexpr uint32_t num_heads = get_compile_time_arg_val(8);
 
+    compute_kernel_hw_startup(in_cb, untilized_in_cb);
     pack_untilize_init<Wt>(in_cb, untilized_in_cb);
 
     cb_wait_front(in_cb, Wt);
@@ -43,7 +44,7 @@ void MAIN {
     reconfig_data_format_srca(in_cb, cache_cb);
     pack_reconfig_data_format(untilized_in_cb, untilized_cache_cb);
     for (uint32_t cur_head = 0; cur_head < num_heads; ++cur_head) {
-        pack_untilize_init_short<Wt>(cache_cb, untilized_cache_cb);
+        pack_untilize_init<Wt>(cache_cb, untilized_cache_cb);
 
         // Untilize a block from the cache
         cb_wait_front(cache_cb, Wt);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/paged_row_major_fused_update_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/paged_row_major_fused_update_cache.cpp
@@ -31,10 +31,11 @@ void MAIN {
     constexpr uint32_t Wt = get_compile_time_arg_val(6);
     constexpr uint32_t num_heads = get_compile_time_arg_val(7);
 
+    compute_kernel_hw_startup(cache_cb, untilized_cache_cb);
     pack_untilize_init<Wt>(cache_cb, untilized_cache_cb);
 
     for (uint32_t cur_head = 0; cur_head < num_heads; ++cur_head) {
-        pack_untilize_init_short<Wt>(cache_cb, untilized_cache_cb);
+        pack_untilize_init<Wt>(cache_cb, untilized_cache_cb);
 
         // Untilize a block from the cache
         cb_wait_front(cache_cb, Wt);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/update_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/update_cache.cpp
@@ -37,6 +37,7 @@ void MAIN {
     constexpr uint32_t block_ct_dim = Wt / num_blocks_per_col;
     constexpr uint32_t full_ct_dim = Wt;
 
+    compute_kernel_hw_startup(in_cb, untilized_in_cb);
     pack_untilize_init<block_ct_dim, full_ct_dim>(in_cb, untilized_in_cb);
 
     cb_reserve_back(untilized_in_cb, Wt);
@@ -50,7 +51,7 @@ void MAIN {
     reconfig_data_format_srca(in_cb, cache_cb);
     pack_reconfig_data_format(untilized_in_cb, untilized_cache_cb);
     for (uint32_t cur_head = 0; cur_head < num_heads; ++cur_head) {
-        pack_untilize_init_short<block_ct_dim, full_ct_dim>(cache_cb, untilized_cache_cb);
+        pack_untilize_init<block_ct_dim, full_ct_dim>(cache_cb, untilized_cache_cb);
 
         // Untilize a block from the cache
         cb_reserve_back(untilized_cache_cb, Wt);

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/compute/update_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/compute/update_cache.cpp
@@ -21,6 +21,7 @@ void MAIN {
     constexpr uint32_t granularity = get_compile_time_arg_val(8);
     constexpr uint32_t u_count = get_compile_time_arg_val(9);
 
+    compute_kernel_hw_startup(in_cb, untilized_in_cb);
     pack_untilize_init<Wt>(in_cb, untilized_in_cb);
 
     for (uint32_t h = 0; h < num_batched_heads; ++h) {
@@ -32,7 +33,7 @@ void MAIN {
 
         reconfig_data_format_srca(in_cb, cache_cb);
         for (uint32_t u = 0; u < u_count; ++u) {
-            pack_untilize_init_short<Wt>(cache_cb, untilized_cache_cb);
+            pack_untilize_init<Wt>(cache_cb, untilized_cache_cb);
 
             for (uint32_t g = 0; g < granularity; ++g) {
                 // Untilize a block from the cache
@@ -62,7 +63,7 @@ void MAIN {
             pack_reconfig_data_format(out_cb, untilized_cache_cb);
         }
         reconfig_data_format_srca(cache_cb, in_cb);
-        pack_untilize_init_short<Wt>(in_cb, untilized_in_cb);
+        pack_untilize_init<Wt>(in_cb, untilized_in_cb);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -68,7 +68,7 @@ inline void reblock_and_untilize(
             }
             tile_regs_commit();
             tile_regs_wait();
-            pack_untilize_dst<out_subblock_w, out_block_w>(out_cb_id, 1, n);
+            pack_untilize_dest<out_subblock_w, out_block_w>(out_cb_id, 1, n);
             tile_regs_release();
             block_offset += out_subblock_num_tiles;
         }
@@ -244,7 +244,7 @@ void MAIN {
 #endif
 
                                 uint32_t start_dst_index = 0;
-                                matmul_pack_tile(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
+                                pack_tile_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
 
                                 tile_regs_release();
                                 cb_push_back(mm_out_cb_id, out_subblock_num_tiles);
@@ -270,7 +270,7 @@ void MAIN {
 #endif
 
                                 uint32_t start_dst_index = 0;
-                                matmul_pack_tile(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
+                                pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
 
                                 tile_regs_release();
                                 cb_push_back(mm_partials_cb_id, out_subblock_num_tiles);
@@ -384,7 +384,7 @@ void MAIN {
                     PACK((llk_pack_reconfig_l1_acc(0)));
 #endif
 #endif  // FUSE_BIAS
-                    pack_untilize_dst_init_short<out_subblock_w, out_block_w>(out_cb_id);
+                    pack_untilize_dest_init<out_subblock_w, out_block_w>(out_cb_id);
                     copy_tile_to_dst_init_short(mm_partials_cb_id);
                     for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
                         reblock_and_untilize<out_subblock_w, out_block_w>(

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -328,7 +328,7 @@ void MAIN {
                         }
 #endif
                         if constexpr (untilize_out) {
-                            pack_untilize_dst_init_short<out_subblock_num_tiles>(mm_out_cb_id);
+                            pack_untilize_dest_init<out_subblock_num_tiles>(mm_out_cb_id);
                         }
                         tile_regs_commit();
                         // Pack out to output buffer
@@ -346,9 +346,9 @@ void MAIN {
 
                         uint32_t start_dst_index = 0;
                         if constexpr (untilize_out) {
-                            pack_untilize_dst<out_subblock_num_tiles>(mm_out_cb_id);
+                            pack_untilize_dest<out_subblock_num_tiles>(mm_out_cb_id);
                         } else {
-                            matmul_pack_tile(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
+                            pack_tile_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
                         }
 
                         tile_regs_release();
@@ -372,7 +372,7 @@ void MAIN {
 #endif
 
                         uint32_t start_dst_index = 0;
-                        matmul_pack_tile(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
+                        pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
 
                         tile_regs_release();
                         cb_push_back(mm_partials_cb_id, out_subblock_num_tiles);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core.cpp
@@ -44,7 +44,7 @@ inline void reduce_h_fused(
     cb_pop_front(curr_in_cb_id, 1);
     tile_regs_wait();
     tile_regs_commit();
-    pack_untilize_dst<num_output_tiles>(
+    pack_untilize_dest<num_output_tiles>(
         out_cb_id, 1 /*out_subblock_h*/, 0, num_out_rows, num_output_faces); /* pack 1 row (1x16 or 1x32) */
     tile_regs_release();
     cb_push_back(out_cb_id, num_output_tiles);
@@ -97,7 +97,7 @@ void MAIN {
     constexpr uint32_t face_r_dim = window_size_hw > 16 ? 16 : window_size_hw;
     tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
         in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, out_cb_id, num_faces_in_tile, face_r_dim);
-    pack_untilize_dst_init_short<max_tiles_per_iter>(out_cb_id, num_out_rows, num_faces_in_tile);
+    pack_untilize_dest_init<max_tiles_per_iter>(out_cb_id, num_out_rows, num_faces_in_tile);
 
     // tilize reconfiguration is needed if we have more than one block and the number of tiles
     // is not a multiple of MAX_TILES_PER_REDUCTION

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core_large_kernel.cpp
@@ -42,7 +42,7 @@ inline void reduce_h_fused(
     }
     tile_regs_wait();
     tile_regs_commit();
-    pack_untilize_dst<num_output_tiles>(
+    pack_untilize_dest<num_output_tiles>(
         out_cb_id,
         1 /*out_subblock_h*/,
         output_row_index,
@@ -108,7 +108,7 @@ void MAIN {
     constexpr uint32_t face_r_dim = 16;
     tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
         in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, interm_cb_id, num_faces_in_input_tile, face_r_dim);
-    pack_untilize_dst_init_short<max_tiles_per_iter>(interm_cb_id, num_out_rows, num_faces_in_output_tile);
+    pack_untilize_dest_init<max_tiles_per_iter>(interm_cb_id, num_out_rows, num_faces_in_output_tile);
 
     constexpr uint32_t remaining_elems = window_size_hw % max_rows_for_reduction;
     constexpr uint32_t interm_reduction_chunks =

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
@@ -27,7 +27,7 @@ inline void reduce_h_fused(const uint32_t in_cb_id, const uint32_t in_scalar_cb_
 
     tile_regs_wait();
     tile_regs_commit();
-    pack_untilize_dst<tiles_per_reduction>(out_cb_id, 1, 0, 1, 2); /* pack 1 row (1x32) */
+    pack_untilize_dest<tiles_per_reduction>(out_cb_id, 1, 0, 1, 2); /* pack 1 row (1x32) */
     tile_regs_release();
 
     cb_push_back(out_cb_id, tiles_per_reduction);
@@ -57,7 +57,7 @@ void MAIN {
 
     constexpr uint32_t num_output_tiles = out_ntiles_c;  //* nblocks;
     tilizeA_B_reduce_init<false, true>(in_cb_id1, in_scalar_cb_id1, max_tiles_per_iter, out_cb_id, 2, 4);
-    pack_untilize_dst_init_short<max_tiles_per_iter>(out_cb_id, 1, 2); /* pack 1 row (1x32) */
+    pack_untilize_dest_init<max_tiles_per_iter>(out_cb_id, 1, 2); /* pack 1 row (1x32) */
     for (uint32_t i = 0; i < nsticks_per_core_by_nblocks; i++) {
         const uint32_t cb_id = (i % 2 == 0) ? in_cb_id1 : in_cb_id2;
         const uint32_t scalar_cb_id = (i % 2 == 0) ? in_scalar_cb_id1 : in_scalar_cb_id2;

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp
@@ -23,6 +23,8 @@ void MAIN {
     constexpr bool use_pack_untilize = tiles_per_row <= MAX_PACK_UNTILIZE_WIDTH;
 
     if constexpr (use_pack_untilize) {
+        // Will be moved above the if-else statement in untilize cleanup PR: tt-metal#23774.
+        compute_kernel_hw_startup(src_cb_id, out_cb_id0);
         pack_untilize_init<tiles_per_row>(src_cb_id, out_cb_id0);
     } else {
         untilize_init(src_cb_id, out_cb_id0);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -289,7 +289,7 @@ void MAIN {
 
             if constexpr (untilize_output) {
                 if constexpr (use_pack_untilize) {
-                    pack_untilize_init_short<out_chunk_tiles>(cb_out_accumulate_im, cb_out_final);
+                    pack_untilize_init<out_chunk_tiles>(cb_out_accumulate_im, cb_out_final);
                 } else {
                     untilize_init_short(cb_out_accumulate_im);
                 }


### PR DESCRIPTION
### Ticket
#22941  

### Problem description
Compute API currently has a lot of unused or redundant function arguments, and even unused functions. Furthermore, the programming model is violated at several places and the boundary between full and short inits is not clear. Lastly, some ops require calling an `_uninit`/`_revert` function, but not all, which introduces more confusion. We will do a series of PRs to fix these issues for all ops so that in the end Compute kernels look like this:
```
compute_kernel_hw_startup # called once at the start of the kernel
<op1>_init # called before op1
<op1>_tile / <op1>_block # We will add block ops where applicable
<op2>_init
<op2>_tile / <op2>_block
...
```

### What's changed
This PR addresses the mentioned drawbacks of Compute API for **pack** and **pack_untilize** ops. It is the initial PR that doesn't fix all the problems, but does the following:

* Uses `compute_kernel_hw_startup` function at kernel beginnings.
* `pack_untilize_init_short` renamed to `pack_untilize_init` and old full init removed. 
* `pack_untilize_dst_init_short` renamed to `pack_untilize_dst_init`. 
* Adapt API calls in all kernels to reflect the changes.
* Add documentation skeleton for functions that will remain in `pack.h` and `pack_untilize.h`at the end of the effort.

### Review Process Suggestion:
* Code owners should check their files and see whether all `pack_untilize_` init calls are modified. All `pack_untilize_init_short` calls should be swapped with `pack_untilize_init` calls.
* LLK team will review `pack.h` and `pack_untilize.h` for functional, structural and code documentation changes. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes -https://github.com/tenstorrent/tt-metal/actions/runs/16214937828
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) -https://github.com/tenstorrent/tt-metal/actions/runs/16214940892
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16221028693
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) 
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes