### PR TITLE
#23273: SDXL UNet matmul

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -280,14 +280,14 @@ def run_demo_inference(
                     negative_pooled_prompt_embed,
                     dtype=ttnn.bfloat16,
                     device=ttnn_device,
-                    layout=ttnn.TILE_LAYOUT,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 ),
                 ttnn.from_torch(
                     add_text_embed,
                     dtype=ttnn.bfloat16,
                     device=ttnn_device,
-                    layout=ttnn.TILE_LAYOUT,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 ),
             ]
@@ -337,7 +337,7 @@ def run_demo_inference(
                 add_text_embeds,
                 dtype=ttnn.bfloat16,
                 device=ttnn_device,
-                layout=ttnn.TILE_LAYOUT,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
         ]

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
@@ -26,7 +26,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
             20,
             1280,
             0,
-            0.965,
+            0.966,
         ),
         (
             (1, 1280, 64, 64),

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_feedforward.py
@@ -29,7 +29,6 @@ def test_feedforward(
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformermodel.py
@@ -18,7 +18,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
     "input_shape, encoder_shape, down_block_id, query_dim, num_attn_heads, out_dim, pcc",
     [
         ((1, 640, 64, 64), (1, 77, 2048), 1, 640, 10, 640, 0.999),
-        ((1, 1280, 32, 32), (1, 77, 2048), 2, 1280, 20, 1280, 0.996),
+        ((1, 1280, 32, 32), (1, 77, 2048), 2, 1280, 20, 1280, 0.997),
     ],
 )
 @pytest.mark.parametrize("transformer_weights_dtype", [ttnn.bfloat16])
@@ -39,7 +39,6 @@ def test_transformermodel(
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -60,18 +59,6 @@ def test_transformermodel(
 
     torch_output_tensor = torch_transformerblock(torch_input_tensor, encoder_hidden_states=torch_encoder_tensor).sample
 
-    ttnn_input_tensor = ttnn.from_torch(
-        torch_input_tensor,
-        dtype=ttnn.bfloat16,
-        device=device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.L1_MEMORY_CONFIG,
-    )
-    B, C, H, W = list(ttnn_input_tensor.shape)
-
-    ttnn_input_tensor = ttnn.permute(ttnn_input_tensor, (0, 2, 3, 1))
-    ttnn_input_tensor = ttnn.reshape(ttnn_input_tensor, (B, 1, H * W, C))
-
     ttnn_encoder_tensor = ttnn.from_torch(
         torch_encoder_tensor,
         dtype=ttnn.bfloat16,
@@ -79,6 +66,19 @@ def test_transformermodel(
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    B, C, H, W = list(ttnn_input_tensor.shape)
+
+    ttnn_input_tensor = ttnn.permute(ttnn_input_tensor, (0, 2, 3, 1))
+    ttnn_input_tensor = ttnn.reshape(ttnn_input_tensor, (B, 1, H * W, C))
+
     ttnn_output_tensor = tt_transformerblock.forward(ttnn_input_tensor, [B, C, H, W], None, ttnn_encoder_tensor)
     output_tensor = ttnn.to_torch(ttnn_output_tensor)
     output_tensor = output_tensor.reshape(B, H, W, C)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
@@ -18,17 +18,6 @@ def prepare_ttnn_tensors(
     device, torch_input_tensor, torch_timestep_tensor, torch_temb_tensor, torch_encoder_tensor, torch_time_ids
 ):
     torch.manual_seed(2025)
-    ttnn_input_tensor = ttnn.from_torch(
-        torch_input_tensor,
-        dtype=ttnn.bfloat16,
-        device=device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.L1_MEMORY_CONFIG,
-    )
-    B, C, H, W = list(ttnn_input_tensor.shape)
-
-    ttnn_input_tensor = ttnn.permute(ttnn_input_tensor, (0, 2, 3, 1))
-    ttnn_input_tensor = ttnn.reshape(ttnn_input_tensor, (B, 1, H * W, C))
 
     ttnn_timestep_tensor = ttnn.from_torch(
         torch_timestep_tensor,
@@ -49,7 +38,7 @@ def prepare_ttnn_tensors(
         torch_temb_tensor,
         dtype=ttnn.bfloat16,
         device=device,
-        layout=ttnn.TILE_LAYOUT,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
     ttnn_time_ids = ttnn.from_torch(
@@ -63,6 +52,18 @@ def prepare_ttnn_tensors(
         "text_embeds": ttnn_text_embeds,
         "time_ids": ttnn_time_ids,
     }
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    B, C, H, W = list(ttnn_input_tensor.shape)
+
+    ttnn_input_tensor = ttnn.permute(ttnn_input_tensor, (0, 2, 3, 1))
+    ttnn_input_tensor = ttnn.reshape(ttnn_input_tensor, (B, 1, H * W, C))
 
     return ttnn_input_tensor, [B, C, H, W], ttnn_timestep_tensor, ttnn_encoder_tensor, ttnn_added_cond_kwargs
 

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -13,7 +13,7 @@ def test_sdxl_unet_perf_device():
 
     inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
     post_processed_results = run_device_perf(command, subdir="sdxl_unet", num_iterations=3, cols=cols, batch_size=1)
-    expected_perf_cols = {inference_time_key: 464623492}
+    expected_perf_cols = {inference_time_key: 390001201}
     expected_results = check_device_perf(
         post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
     )

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -13,7 +13,7 @@ def test_sdxl_unet_perf_device():
 
     inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
     post_processed_results = run_device_perf(command, subdir="sdxl_unet", num_iterations=3, cols=cols, batch_size=1)
-    expected_perf_cols = {inference_time_key: 390001201}
+    expected_perf_cols = {inference_time_key: 387473640}
     expected_results = check_device_perf(
         post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
     )

--- a/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
@@ -416,6 +416,29 @@ class ModelOptimisations:
             fused_activation=None,
         )
 
+        self.matmul_configs["2D_GEGLU_LINEAR_640"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            in0_block_w=4,
+            per_core_M=16,
+            per_core_N=20,
+            out_subblock_h=1,
+            out_subblock_w=5,
+            transpose_mcast=False,
+            fused_activation=None,
+        )
+
+        self.matmul_configs["1D_GEGLU_LINEAR_1280"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=5,
+            per_core_M=32,
+            per_core_N=5,
+            fuse_batch=False,
+            fused_activation=None,
+            mcast_in0=True,
+        )
+
         self.compute_configs["DEFAULT_MM_COMPUTE_CONFIG"] = ttnn.WormholeComputeKernelConfig(
             math_fidelity=ttnn.MathFidelity.HiFi2,
             math_approx_mode=False,
@@ -434,6 +457,11 @@ class ModelOptimisations:
             return None
 
         if not ("decoder" in matmul_path):
+            if "net.0.proj" in matmul_path:
+                if "down_blocks.1" in matmul_path or "up_blocks.1" in matmul_path:
+                    return self.matmul_configs["2D_GEGLU_LINEAR_640"]
+                else:
+                    return self.matmul_configs["1D_GEGLU_LINEAR_1280"]
             # # # Down block 1 # # #
             pattern_downn_block_1_dense_out = re.compile(
                 r"down_blocks\.1\.attentions\.[01]\.transformer_blocks\.[01]\.attn[12]\.dense_out"

--- a/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
@@ -439,6 +439,28 @@ class ModelOptimisations:
             mcast_in0=True,
         )
 
+        self.matmul_configs["2D_TM_LINEAR_640"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            in0_block_w=2,
+            per_core_M=16,
+            per_core_N=3,
+            out_subblock_h=8,
+            out_subblock_w=1,
+            transpose_mcast=False,
+            fused_activation=None,
+        )
+
+        self.matmul_configs["2D_TM_LINEAR_1280"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            in0_block_w=5,
+            per_core_M=4,
+            per_core_N=5,
+            out_subblock_h=1,
+            out_subblock_w=5,
+            transpose_mcast=False,
+            fused_activation=None,
+        )
+
         self.compute_configs["DEFAULT_MM_COMPUTE_CONFIG"] = ttnn.WormholeComputeKernelConfig(
             math_fidelity=ttnn.MathFidelity.HiFi2,
             math_approx_mode=False,
@@ -457,11 +479,20 @@ class ModelOptimisations:
             return None
 
         if not ("decoder" in matmul_path):
+            # # # GEGLU # # #
             if "net.0.proj" in matmul_path:
                 if "down_blocks.1" in matmul_path or "up_blocks.1" in matmul_path:
                     return self.matmul_configs["2D_GEGLU_LINEAR_640"]
                 else:
                     return self.matmul_configs["1D_GEGLU_LINEAR_1280"]
+
+            # # # TM LINEAR # # #
+            if "proj_in" in matmul_path or "proj_out" in matmul_path:
+                if "down_blocks.1" in matmul_path or "up_blocks.1" in matmul_path:
+                    return self.matmul_configs["2D_TM_LINEAR_640"]
+                else:
+                    return self.matmul_configs["2D_TM_LINEAR_1280"]
+
             # # # Down block 1 # # #
             pattern_downn_block_1_dense_out = re.compile(
                 r"down_blocks\.1\.attentions\.[01]\.transformer_blocks\.[01]\.attn[12]\.dense_out"

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
@@ -21,7 +21,7 @@ class TtFeedForward(nn.Module):
         super().__init__()
 
         self.device = device
-        self.tt_geglu = TtGEGLU(device, state_dict, f"{module_path}.net.0", weights_dtype=weights_dtype)
+        self.tt_geglu = TtGEGLU(device, state_dict, f"{module_path}.net.0", model_config, weights_dtype=weights_dtype)
 
         weights = state_dict[f"{module_path}.net.2.weight"].unsqueeze(0).unsqueeze(0)
         bias = state_dict[f"{module_path}.net.2.bias"]

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_geglu.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_geglu.py
@@ -9,7 +9,7 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import prepare
 
 
 class TtGEGLU(nn.Module):
-    def __init__(self, device, state_dict, module_path, weights_dtype=ttnn.bfloat16):
+    def __init__(self, device, state_dict, module_path, model_config, weights_dtype=ttnn.bfloat16):
         super().__init__()
 
         self.device = device
@@ -17,17 +17,33 @@ class TtGEGLU(nn.Module):
         bias = state_dict[f"{module_path}.proj.bias"]
 
         self.tt_weights, self.tt_bias = prepare_linear_params(device, weights, bias, weights_dtype)
+        self.program_config = model_config.get_matmul_config(matmul_path=f"{module_path}.proj")
+        self.compute_config = model_config.get_mm_compute_config(f"{module_path}.proj")
 
-    def forward(self, hidden_states):
+    def forward(self, input_tensor):
+        output_memory_config = ttnn.create_sharded_memory_config(
+            (self.program_config.per_core_M * 32, self.program_config.per_core_N * 32),
+            core_grid=ttnn.CoreGrid(y=8, x=8),
+            strategy=ttnn.ShardStrategy.WIDTH if input_tensor.shape[-1] == 1280 else ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
         hidden_states = ttnn.linear(
-            hidden_states,
+            input_tensor,
             self.tt_weights,
             bias=self.tt_bias,
+            memory_config=output_memory_config,
+            program_config=self.program_config,
+            compute_kernel_config=self.compute_config,
         )
+        ttnn.deallocate(input_tensor)
+
+        hidden_states = ttnn.sharded_to_interleaved(hidden_states, ttnn.L1_MEMORY_CONFIG)
         gate = hidden_states[:, :, :, hidden_states.shape[3] // 2 :]
         hidden_states = hidden_states[:, :, :, : hidden_states.shape[3] // 2]
+        gate = ttnn.gelu(gate)
 
         # ttnn.split not working properly
         # hidden_states, gate = ttnn.split(hidden_states, ceil(hidden_states.shape[3] / 2), 3)
 
-        return ttnn.multiply(hidden_states, ttnn.gelu(gate))
+        return ttnn.multiply(hidden_states, gate)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -321,6 +321,7 @@ class TtResnetBlock2D(nn.Module):
         C = self.conv2_params["output_channels"]
 
         if self.tt_conv3_weights is not None:
+            input_tensor_pre_conv = input_tensor
             [input_tensor, [H, W], [self.tt_conv3_weights, self.tt_conv3_bias]] = ttnn.conv2d(
                 input_tensor=input_tensor,
                 weight_tensor=self.tt_conv3_weights,
@@ -342,6 +343,7 @@ class TtResnetBlock2D(nn.Module):
                 return_output_dim=True,
                 return_weights_and_bias=True,
             )
+            ttnn.deallocate(input_tensor_pre_conv)
             C = self.conv3_params["output_channels"]
             if input_tensor.is_sharded():
                 input_tensor = ttnn.sharded_to_interleaved(input_tensor, ttnn.L1_MEMORY_CONFIG)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
@@ -74,10 +74,11 @@ class TtBasicTransformerBlock(nn.Module):
             else None
         )
 
-    def forward(self, hidden_states, attention_mask=None, encoder_hidden_states=None):
-        attn_hidden_states = ttnn.layer_norm(hidden_states, weight=self.tt_norm1_weights, bias=self.tt_norm1_bias)
+    def forward(self, input_tensor, attention_mask=None, encoder_hidden_states=None):
+        attn_hidden_states = ttnn.layer_norm(input_tensor, weight=self.tt_norm1_weights, bias=self.tt_norm1_bias)
         attn_hidden_states = self.attn1(attn_hidden_states, attention_mask, None)
-        hidden_states = ttnn.add(hidden_states, attn_hidden_states)
+        hidden_states = ttnn.add(input_tensor, attn_hidden_states)
+        ttnn.deallocate(input_tensor)
 
         attn_hidden_states = ttnn.layer_norm(hidden_states, weight=self.tt_norm2_weights, bias=self.tt_norm2_bias)
         attn_hidden_states = self.attn2(attn_hidden_states, attention_mask, encoder_hidden_states)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
@@ -95,7 +95,7 @@ class TtTransformer2DModel(nn.Module):
             epsilon=self.norm_eps,
         )
 
-        hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
+        hidden_states = ttnn.to_memory_config(hidden_states, ttnn.L1_MEMORY_CONFIG)
 
         hidden_states = ttnn.to_layout(hidden_states, ttnn.TILE_LAYOUT)
         hidden_states = ttnn.linear(

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
@@ -90,7 +90,7 @@ class TtTransformer2DModel(nn.Module):
             epsilon=self.norm_eps,
         )
 
-        hidden_states = ttnn.to_memory_config(hidden_states, ttnn.L1_MEMORY_CONFIG)
+        hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
 
         hidden_states = ttnn.to_layout(hidden_states, ttnn.TILE_LAYOUT)
         hidden_states = ttnn.linear(

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
@@ -176,7 +176,6 @@ class TtUNet2DConditionModel(nn.Module):
         time_ids = added_cond_kwargs.get("time_ids")
         temb_add = self.add_time_proj.forward(time_ids)
         temb_add = ttnn.to_layout(temb_add, ttnn.ROW_MAJOR_LAYOUT)
-        text_embeds = ttnn.to_layout(text_embeds, ttnn.ROW_MAJOR_LAYOUT)
         temb_add = ttnn.reshape(temb_add, (text_embeds.shape[0], -1))
         temb_add = ttnn.concat([text_embeds, temb_add], -1)
         temb_add = ttnn.to_layout(temb_add, ttnn.TILE_LAYOUT)


### PR DESCRIPTION
#23273 
### What's changed
Defined program configs for matmuls in `TtTransformer2DModel` and `TtGEGLU`. Removed some fragmentation present in the UNet iteration.

New device perf: 387,473us

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15586352781) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15586358667) CI passes

Note: Device perf test run done locally as [pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) is in a bad state.