### PR TITLE
Excessive time and memory usage by scatter

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_scatter.py
@@ -94,18 +94,3 @@ def test_scatter_normal(input_shape, dim, index_and_source_shape, input_dtype, i
         assert torch_result_from_ttnn.shape == torch_result.shape
         assert torch_result_from_ttnn.dtype == torch_result.dtype
         torch.testing.assert_close(torch_result_from_ttnn, torch_result)
-
-        torch_output_preallocated = torch.zeros(torch_input.shape, dtype=torch_input.dtype)
-        ttnn_output_preallocated = ttnn.zeros(ttnn_input.shape, dtype=ttnn_input.dtype, device=device, layout=layout)
-
-        torch_preallocated_result = torch.scatter(
-            torch_input, dim, index=torch_index, src=torch_src, out=torch_output_preallocated
-        )
-        ttnn_preallocated_result = ttnn.experimental.scatter_(
-            ttnn_input, dim, index=ttnn_index, src=ttnn_src, out=ttnn_output_preallocated
-        )
-
-        torch_result_from_preallocated_ttnn = ttnn.to_torch(ttnn_preallocated_result)
-        assert torch_result_from_preallocated_ttnn.shape == torch_preallocated_result.shape
-        assert torch_result_from_preallocated_ttnn.dtype == torch_preallocated_result.dtype
-        torch.testing.assert_close(torch_result_from_preallocated_ttnn, torch_output_preallocated)

--- a/tests/ttnn/unit_tests/operations/test_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_scatter.py
@@ -14,40 +14,64 @@ def select_torch_dtype(ttnn_dtype):
         return torch.float32
     if ttnn_dtype is ttnn.uint8:
         return torch.uint8
+    if ttnn_dtype is ttnn.uint16:
+        return torch.int64
     if ttnn_dtype is ttnn.int32:
-        return (
-            torch.int64
-        )  # !!! there is a strict requirement for the index tensor in Torch to be int64, and there is no int64 in ttnn
+        return torch.int64
+    if ttnn_dtype is ttnn.uint32:
+        return torch.int64
 
 
 @pytest.mark.parametrize(
-    "input_shape, dim, index_and_source_shape, input_dtype",
+    "input_shape, dim, index_and_source_shape, input_dtype, index_dtype, layout",
     [
-        ([100], -1, [80], ttnn.float32),
-        ([50, 200], -1, [50, 100], ttnn.bfloat16),
-        ([2, 30, 200], -1, [2, 30, 200], ttnn.float32),
-        ([1, 1, 20, 20, 200], -1, [1, 1, 20, 20, 20], ttnn.bfloat16),
-        ([2, 2, 2, 2, 2, 2, 2, 2], -1, [2, 2, 2, 2, 2, 2, 2, 2], ttnn.float32),
-        ([10, 1, 10, 1, 10], -1, [10, 1, 10, 1, 1], ttnn.bfloat16),
-        ([10, 50, 10, 50, 10], -1, [10, 50, 10, 50, 10], ttnn.bfloat16),
-        ([10, 50, 10, 50, 100], -1, [10, 50, 10, 50, 100], ttnn.bfloat16),
-        ([700, 10, 30, 10], -1, [700, 10, 30, 10], ttnn.bfloat16),
-        ([700, 10, 30, 100], -1, [700, 10, 30, 10], ttnn.bfloat16),
+        ([100], -1, [80], ttnn.float32, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        # ([100], -1, [80], ttnn.float32, ttnn.uint16, ttnn.Layout.TILE), # to_layout precision issue #
+        ([50, 200], -1, [50, 100], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        ([2, 30, 200], -1, [2, 30, 200], ttnn.float32, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        ([1, 1, 20, 20, 200], -1, [1, 1, 20, 20, 20], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        ([2, 2, 2, 2, 2, 2, 2, 2], -1, [2, 2, 2, 2, 2, 2, 2, 2], ttnn.float32, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        ([10, 1, 10, 1, 10], -1, [10, 1, 10, 1, 1], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        ([10, 50, 10, 50, 10], -1, [10, 50, 10, 50, 10], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        ([10, 50, 10, 50, 100], -1, [10, 50, 10, 50, 100], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        ([700, 10, 30, 10], -1, [700, 10, 30, 10], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        ([700, 10, 30, 100], -1, [700, 10, 30, 10], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        ([1, 151936], -1, [1, 151936], ttnn.bfloat16, ttnn.int32, ttnn.Layout.ROW_MAJOR),
+        ([100, 151936], -1, [100, 151936], ttnn.float32, ttnn.int32, ttnn.Layout.ROW_MAJOR),
+        ([2, 10, 151936], -1, [2, 10, 151936], ttnn.bfloat16, ttnn.int32, ttnn.Layout.ROW_MAJOR),
+        ([1, 151936], -1, [1, 151936], ttnn.float32, ttnn.uint32, ttnn.Layout.ROW_MAJOR),
+        ([100, 151936], -1, [100, 151936], ttnn.bfloat16, ttnn.uint32, ttnn.Layout.ROW_MAJOR),
+        ([2, 10, 151936], -1, [2, 10, 151936], ttnn.float32, ttnn.uint32, ttnn.Layout.ROW_MAJOR),
+        ([10, 50, 10, 50, 100], -1, [10, 50, 10, 50, 100], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.TILE),
+        ([10, 50, 10, 50, 100], -1, [10, 50, 10, 50, 100], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
+        ([50, 200], -1, [50, 200], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.TILE),
+        ([50, 200], -1, [50, 200], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
+        # these cases fail due to the to_layout precision issue (fp32 tiled <-> row-major) : #23405
+        # ([10, 50, 10, 50, 100], -1, [10, 50, 10, 50, 100], ttnn.float32, ttnn.uint16, ttnn.Layout.TILE),
+        # ([2, 30, 200], -1, [2, 30, 200], ttnn.float32, ttnn.uint16, ttnn.Layout.TILE),
+        # these cases fail due to the to_layout integer issue (integer dtype size>256 tiled -> row-major): #23407
+        # ([1, 151936], -1, [1, 151936], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
+        # ([100, 151936], -1, [100, 151936], ttnn.float32, ttnn.int32, ttnn.Layout.TILE),
+        # ([2, 10, 151936], -1, [2, 10, 151936], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
+        # ([1, 151936], -1, [1, 151936], ttnn.float32, ttnn.uint32, ttnn.Layout.TILE),
+        # ([100, 151936], -1, [100, 151936], ttnn.bfloat16, ttnn.uint32, ttnn.Layout.TILE),
+        # ([2, 10, 151936], -1, [2, 10, 151936], ttnn.float32, ttnn.uint32, ttnn.Layout.TILE),
     ],
 )
-def test_scatter_normal(input_shape, dim, index_and_source_shape, input_dtype, device):
+def test_scatter_normal(input_shape, dim, index_and_source_shape, input_dtype, index_dtype, layout, device):
     torch.manual_seed(22052025)
     for _ in range(2):
         torch_dtype = select_torch_dtype(input_dtype)
+        torch_index_dtype = select_torch_dtype(index_dtype)
         ##
         torch_input = torch.randn(input_shape, dtype=torch_dtype)
-        ttnn_input = ttnn.from_torch(torch_input, dtype=input_dtype, layout=ttnn.Layout.TILE, device=device)
+        ttnn_input = ttnn.from_torch(torch_input, dtype=input_dtype, layout=layout, device=device)
 
-        torch_index = torch.randint(0, input_shape[dim], index_and_source_shape, dtype=torch.int64)
-        ttnn_index = ttnn.from_torch(torch_index, dtype=ttnn.int32, layout=ttnn.Layout.TILE, device=device)
+        torch_index = torch.randint(0, input_shape[dim], index_and_source_shape, dtype=torch_index_dtype)
+        ttnn_index = ttnn.from_torch(torch_index, dtype=index_dtype, layout=layout, device=device)
 
         torch_src = torch.randn(index_and_source_shape, dtype=torch_dtype)
-        ttnn_src = ttnn.from_torch(torch_src, dtype=input_dtype, layout=ttnn.Layout.TILE, device=device)
+        ttnn_src = ttnn.from_torch(torch_src, dtype=input_dtype, layout=layout, device=device)
 
         torch_result = torch.scatter(torch_input, dim, index=torch_index, src=torch_src)
         ttnn_result = ttnn.experimental.scatter_(ttnn_input, dim, ttnn_index, ttnn_src)
@@ -58,9 +82,7 @@ def test_scatter_normal(input_shape, dim, index_and_source_shape, input_dtype, d
         torch.testing.assert_close(torch_result_from_ttnn, torch_result)
 
         torch_output_preallocated = torch.zeros(torch_input.shape, dtype=torch_input.dtype)
-        ttnn_output_preallocated = ttnn.zeros(
-            ttnn_input.shape, dtype=ttnn_input.dtype, device=device, layout=ttnn.Layout.TILE
-        )
+        ttnn_output_preallocated = ttnn.zeros(ttnn_input.shape, dtype=ttnn_input.dtype, device=device, layout=layout)
 
         torch_preallocated_result = torch.scatter(
             torch_input, dim, index=torch_index, src=torch_src, out=torch_output_preallocated
@@ -72,4 +94,3 @@ def test_scatter_normal(input_shape, dim, index_and_source_shape, input_dtype, d
         torch_result_from_preallocated_ttnn = ttnn.to_torch(ttnn_preallocated_result)
         assert torch_result_from_preallocated_ttnn.shape == torch_preallocated_result.shape
         assert torch_result_from_preallocated_ttnn.dtype == torch_preallocated_result.dtype
-        torch.testing.assert_close(ttnn.to_torch(ttnn_output_preallocated), torch_output_preallocated)

--- a/tests/ttnn/unit_tests/operations/test_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_scatter.py
@@ -56,9 +56,7 @@ def select_torch_dtype(ttnn_dtype):
         ##################
         # these cases fail due to the int32 transpose issue
         # ([50, 200], 0, [50, 200], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
-        # ([10, 50, 10, 50, 100], 0, [10, 50, 10, 50, 100], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.TILE),
         # ([10, 50, 10, 50, 100], 0, [10, 50, 10, 50, 100], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
-        # ([50, 200], 0, [50, 200], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.TILE),
         # ([50, 200], 0, [50, 200], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
         ##################
         # these cases fail due to the to_layout precision issue (fp32 tiled <-> row-major) : #23405

--- a/tests/ttnn/unit_tests/operations/test_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_scatter.py
@@ -19,19 +19,20 @@ def select_torch_dtype(ttnn_dtype):
     if ttnn_dtype is ttnn.int32:
         return torch.int64
     if ttnn_dtype is ttnn.uint32:
-        return torch.int64
+        return (
+            torch.int64
+        )  # !!! there is a strict requirement for the index tensor in Torch to be int64, and there is no int64 in ttnn
 
 
 @pytest.mark.parametrize(
     "input_shape, dim, index_and_source_shape, input_dtype, index_dtype, layout",
     [
         ([100], -1, [80], ttnn.float32, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
-        # ([100], -1, [80], ttnn.float32, ttnn.uint16, ttnn.Layout.TILE), # to_layout precision issue #
-        ([50, 200], -1, [50, 100], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        ([50, 200], 0, [50, 200], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
         ([2, 30, 200], -1, [2, 30, 200], ttnn.float32, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
         ([1, 1, 20, 20, 200], -1, [1, 1, 20, 20, 20], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
         ([2, 2, 2, 2, 2, 2, 2, 2], -1, [2, 2, 2, 2, 2, 2, 2, 2], ttnn.float32, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
-        ([10, 1, 10, 1, 10], -1, [10, 1, 10, 1, 1], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        ([10, 1, 10, 1, 10], 0, [10, 1, 10, 1, 10], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
         ([10, 50, 10, 50, 10], -1, [10, 50, 10, 50, 10], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
         ([10, 50, 10, 50, 100], -1, [10, 50, 10, 50, 100], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
         ([700, 10, 30, 10], -1, [700, 10, 30, 10], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
@@ -42,13 +43,28 @@ def select_torch_dtype(ttnn_dtype):
         ([1, 151936], -1, [1, 151936], ttnn.float32, ttnn.uint32, ttnn.Layout.ROW_MAJOR),
         ([100, 151936], -1, [100, 151936], ttnn.bfloat16, ttnn.uint32, ttnn.Layout.ROW_MAJOR),
         ([2, 10, 151936], -1, [2, 10, 151936], ttnn.float32, ttnn.uint32, ttnn.Layout.ROW_MAJOR),
-        ([10, 50, 10, 50, 100], -1, [10, 50, 10, 50, 100], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.TILE),
+        ([1, 2, 3, 4, 5, 6, 7, 8], 1, [1, 2, 3, 4, 5, 6, 7, 8], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.TILE),
+        ([1, 2, 3, 4, 5, 6, 7, 8], 2, [1, 2, 3, 4, 5, 6, 7, 8], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        ([1, 2, 3, 4, 5, 6, 7, 8], 3, [1, 2, 3, 4, 5, 6, 7, 8], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.TILE),
+        ([1, 2, 3, 4, 5, 6, 7, 8], 4, [1, 2, 3, 4, 5, 6, 7, 8], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        ([1, 2, 3, 4, 5, 6, 7, 8], 5, [1, 2, 3, 4, 5, 6, 7, 8], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.TILE),
+        ([1, 2, 3, 4, 5, 6, 7, 8], 6, [1, 2, 3, 4, 5, 6, 7, 8], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
+        ([1, 2, 3, 4, 5, 6, 7, 8], 7, [1, 2, 3, 4, 5, 6, 7, 8], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.TILE),
+        ([1, 2, 3, 4, 5, 6, 7, 8], 0, [1, 2, 3, 4, 5, 6, 7, 8], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
         ([10, 50, 10, 50, 100], -1, [10, 50, 10, 50, 100], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
         ([50, 200], -1, [50, 200], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.TILE),
-        ([50, 200], -1, [50, 200], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
+        ##################
+        # these cases fail due to the int32 transpose issue
+        # ([50, 200], 0, [50, 200], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
+        # ([10, 50, 10, 50, 100], 0, [10, 50, 10, 50, 100], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.TILE),
+        # ([10, 50, 10, 50, 100], 0, [10, 50, 10, 50, 100], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
+        # ([50, 200], 0, [50, 200], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.TILE),
+        # ([50, 200], 0, [50, 200], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
+        ##################
         # these cases fail due to the to_layout precision issue (fp32 tiled <-> row-major) : #23405
         # ([10, 50, 10, 50, 100], -1, [10, 50, 10, 50, 100], ttnn.float32, ttnn.uint16, ttnn.Layout.TILE),
         # ([2, 30, 200], -1, [2, 30, 200], ttnn.float32, ttnn.uint16, ttnn.Layout.TILE),
+        ##################
         # these cases fail due to the to_layout integer issue (integer dtype size>256 tiled -> row-major): #23407
         # ([1, 151936], -1, [1, 151936], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
         # ([100, 151936], -1, [100, 151936], ttnn.float32, ttnn.int32, ttnn.Layout.TILE),
@@ -60,19 +76,19 @@ def select_torch_dtype(ttnn_dtype):
 )
 def test_scatter_normal(input_shape, dim, index_and_source_shape, input_dtype, index_dtype, layout, device):
     torch.manual_seed(22052025)
+    torch_dtype = select_torch_dtype(input_dtype)
+    torch_index_dtype = select_torch_dtype(index_dtype)
+    ##
+    torch_input = torch.randn(input_shape, dtype=torch_dtype)
+    ttnn_input = ttnn.from_torch(torch_input, dtype=input_dtype, layout=layout, device=device)
+
+    torch_index = torch.randint(0, input_shape[dim], index_and_source_shape, dtype=torch_index_dtype)
+    ttnn_index = ttnn.from_torch(torch_index, dtype=index_dtype, layout=layout, device=device)
+
+    torch_src = torch.randn(index_and_source_shape, dtype=torch_dtype)
+    ttnn_src = ttnn.from_torch(torch_src, dtype=input_dtype, layout=layout, device=device)
+
     for _ in range(2):
-        torch_dtype = select_torch_dtype(input_dtype)
-        torch_index_dtype = select_torch_dtype(index_dtype)
-        ##
-        torch_input = torch.randn(input_shape, dtype=torch_dtype)
-        ttnn_input = ttnn.from_torch(torch_input, dtype=input_dtype, layout=layout, device=device)
-
-        torch_index = torch.randint(0, input_shape[dim], index_and_source_shape, dtype=torch_index_dtype)
-        ttnn_index = ttnn.from_torch(torch_index, dtype=index_dtype, layout=layout, device=device)
-
-        torch_src = torch.randn(index_and_source_shape, dtype=torch_dtype)
-        ttnn_src = ttnn.from_torch(torch_src, dtype=input_dtype, layout=layout, device=device)
-
         torch_result = torch.scatter(torch_input, dim, index=torch_index, src=torch_src)
         ttnn_result = ttnn.experimental.scatter_(ttnn_input, dim, ttnn_index, ttnn_src)
 
@@ -94,3 +110,4 @@ def test_scatter_normal(input_shape, dim, index_and_source_shape, input_dtype, i
         torch_result_from_preallocated_ttnn = ttnn.to_torch(ttnn_preallocated_result)
         assert torch_result_from_preallocated_ttnn.shape == torch_preallocated_result.shape
         assert torch_result_from_preallocated_ttnn.dtype == torch_preallocated_result.dtype
+        torch.testing.assert_close(torch_result_from_preallocated_ttnn, torch_output_preallocated)

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/kernels/dataflow/reader_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/kernels/dataflow/reader_scatter.cpp
@@ -12,43 +12,41 @@ namespace {
 
 template <bool is_dram, typename AddrGen>
 FORCE_INLINE void load_to_cb(
-    const uint32_t& cb, const AddrGen& addr_gtor, const uint32_t& stick_size_bytes, const uint32_t& stick_id) {
-    cb_reserve_back(cb, ONE_PAGE);  // read a whole input row
+    const uint32_t& cb, const AddrGen& addr_gtor, const uint32_t& offset_bytes, const uint32_t& chunk_size_bytes, const uint32_t& stick_id) {
+    cb_reserve_back(cb, ONE_PAGE);
     const uint64_t source_noc_address = get_noc_addr(stick_id, addr_gtor);
     const uint32_t l1_write_address = get_write_ptr(cb);
 
-    noc_async_read(source_noc_address, l1_write_address, stick_size_bytes);
+    noc_async_read(source_noc_address + offset_bytes, l1_write_address, chunk_size_bytes);
     noc_async_read_barrier();
 
     cb_push_back(cb, ONE_PAGE);
 }
 
-FORCE_INLINE void prepare_cbs(
-    const uint32_t& input_cb, const uint32_t& index_cb, const uint32_t& source_cb, const uint32_t& output_cb) {
-    cb_wait_front(input_cb, ONE_PAGE);
-    cb_wait_front(index_cb, ONE_PAGE);
-    cb_wait_front(source_cb, ONE_PAGE);
-    cb_reserve_back(output_cb, ONE_PAGE);
-}
-
-FORCE_INLINE void recycle_input_and_push_result_row(
-    const uint32_t input_cb, const uint32_t& index_cb, const uint32_t& source_cb, const uint32_t& output_cb) {
-    cb_pop_front(input_cb, ONE_PAGE);
-    cb_pop_front(index_cb, ONE_PAGE);
-    cb_pop_front(source_cb, ONE_PAGE);
-    cb_push_back(output_cb, ONE_PAGE);
+template <typename number_type>
+FORCE_INLINE void copy_input_to_output(
+    const uint32_t& input_cb, const uint32_t& output_cb, const uint32_t& input_chunk_size) {
+    const uint32_t input_l1_read_addr = get_read_ptr(input_cb);
+    const uint32_t output_l1_write_addr = get_write_ptr(output_cb);
+    volatile tt_l1_ptr number_type* input_l1_read_ptr =
+        reinterpret_cast<volatile tt_l1_ptr number_type*>(input_l1_read_addr);
+    volatile tt_l1_ptr number_type* output_l1_write_ptr =
+        reinterpret_cast<volatile tt_l1_ptr number_type*>(output_l1_write_addr);
+    for (uint32_t index_in_input_chunk = 0; index_in_input_chunk < input_chunk_size; ++index_in_input_chunk) {
+        output_l1_write_ptr[index_in_input_chunk] = input_l1_read_ptr[index_in_input_chunk];
+    }
 }
 
 template <typename number_type, typename index_type>
-FORCE_INLINE void scatter_along_whole_axis(
+FORCE_INLINE void scatter_along_chunk(
     const uint32_t& input_cb,
     const uint32_t& index_cb,
     const uint32_t& source_cb,
     const uint32_t& output_cb,
     const uint32_t& input_stick_size,
-    const uint32_t& index_stick_size,
-    const uint32_t& source_stick_size,
-    const uint32_t& output_stick_size) {
+    const uint32_t& input_offset,
+    const uint32_t& input_chunk_size,
+    const uint32_t& index_chunk_size) {
     const uint32_t input_l1_read_addr = get_read_ptr(input_cb);
     const uint32_t index_l1_read_addr = get_read_ptr(index_cb);
     const uint32_t source_l1_read_addr = get_read_ptr(source_cb);
@@ -62,29 +60,21 @@ FORCE_INLINE void scatter_along_whole_axis(
     volatile tt_l1_ptr number_type* output_l1_write_ptr =
         reinterpret_cast<volatile tt_l1_ptr number_type*>(output_l1_write_addr);
 
-    for (uint32_t index_in_input_stick = 0; index_in_input_stick < input_stick_size; ++index_in_input_stick) {
-        // DPRINT << "INPUT " << input_l1_read_ptr[index_in_input_stick] << ENDL();
-        output_l1_write_ptr[index_in_input_stick] = input_l1_read_ptr[index_in_input_stick];
-    }
-
-    for (uint32_t index_in_index_stick = 0; index_in_index_stick < index_stick_size; ++index_in_index_stick) {
-        volatile index_type& index_value = index_l1_read_ptr[index_in_index_stick];
-        // DPRINT << "INDEX " << index_value << ENDL();
-        ASSERT(
-            index_value < index_stick_size,
-            "Index value {} is bigger than dimension size {}.",
-            index_value,
-            index_stick_size);
-        if (index_value >= index_stick_size) {
+    for (uint32_t index_in_index_chunk = 0; index_in_index_chunk < index_chunk_size; ++index_in_index_chunk) {
+        volatile index_type& index_value = index_l1_read_ptr[index_in_index_chunk];
+        if (index_value < input_offset || index_value >= input_offset + input_chunk_size) {
             continue;
         }
-        volatile number_type& source_value = source_l1_read_ptr[index_in_index_stick];
-        // DPRINT << "SOURCE " << source_value << ENDL();
-        output_l1_write_ptr[index_value] = source_value;
-    }
-
-    for (uint32_t i = 0; i < input_stick_size; ++i) {
-        DPRINT << i << " " << output_l1_write_ptr[i] << " " << ENDL();
+        ASSERT(
+            index_value < input_stick_size,
+            "Index value {} is bigger than input's dimension size {}.",
+            index_value,
+            input_stick_size);
+        if (index_value >= input_stick_size) {
+            continue;
+        }
+        volatile number_type& source_value = source_l1_read_ptr[index_in_index_chunk];
+        output_l1_write_ptr[index_value - input_offset] = source_value;
     }
 }
 
@@ -98,6 +88,8 @@ void kernel_main() {
     const uint32_t source_buffer_address = get_arg_val<uint32_t>(2);
     const uint32_t start_stick_id = get_arg_val<uint32_t>(3);
     const uint32_t sticks_for_core = get_arg_val<uint32_t>(4);
+    const uint32_t input_and_output_chunk_size = get_arg_val<uint32_t>(5);
+    const uint32_t index_and_source_chunk_size = get_arg_val<uint32_t>(6);
 
     const auto input_addr_gtor{
         get_interleaved_addr_gen<ctas.input_tensor_is_dram, ctas.is_input_stick_size_bytes_pow2_min_32>(
@@ -116,27 +108,56 @@ void kernel_main() {
     using source_addr_gtor_type = decltype(source_addr_gtor);
 
     for (uint32_t stick_id = start_stick_id; stick_id < start_stick_id + sticks_for_core; ++stick_id) {
-        // load input sticks (rows)
-        load_to_cb<ctas.input_tensor_is_dram, input_addr_gtor_type>(
-            ctas.input_cb, input_addr_gtor, ctas.input_stick_size_bytes, stick_id);
-        load_to_cb<ctas.index_tensor_is_dram, index_addr_gtor_type>(
-            ctas.index_cb, index_addr_gtor, ctas.index_stick_size_bytes, stick_id);
-        load_to_cb<ctas.source_tensor_is_dram, source_addr_gtor_type>(
-            ctas.source_cb, source_addr_gtor, ctas.source_stick_size_bytes, stick_id);
-        prepare_cbs(ctas.input_cb, ctas.index_cb, ctas.source_cb, ctas.output_cb);
+        // process input/output chunks sequentially
+        for (uint32_t input_offset = 0; input_offset < ctas.input_stick_size;
+             input_offset += input_and_output_chunk_size) {
+            const uint32_t input_chunk_length =
+                std::min(ctas.input_stick_size - input_offset, input_and_output_chunk_size);
 
-        // scatter glitter yayy
-        scatter_along_whole_axis<input_std_type, index_std_type>(
-            ctas.input_cb,
-            ctas.index_cb,
-            ctas.source_cb,
-            ctas.output_cb,
-            ctas.input_stick_size,
-            ctas.index_stick_size,
-            ctas.source_stick_size,
-            ctas.output_stick_size);
+            load_to_cb<ctas.input_tensor_is_dram, input_addr_gtor_type>(
+                ctas.input_cb,
+                input_addr_gtor,
+                input_offset * sizeof(input_std_type),
+                input_chunk_length * sizeof(input_std_type),
+                stick_id);
+            cb_wait_front(ctas.input_cb, ONE_PAGE);
+            cb_reserve_back(ctas.output_cb, ONE_PAGE);
 
-        // ecological and responsible
-        recycle_input_and_push_result_row(ctas.input_cb, ctas.index_cb, ctas.source_cb, ctas.output_cb);
+            copy_input_to_output<input_std_type>(ctas.input_cb, ctas.output_cb, input_chunk_length);
+
+            for (uint32_t index_offset = 0; index_offset < ctas.index_stick_size;
+                 index_offset += index_and_source_chunk_size) {
+                const uint32_t index_chunk_length =
+                    std::min(ctas.index_stick_size - index_offset, index_and_source_chunk_size);
+                load_to_cb<ctas.index_tensor_is_dram, index_addr_gtor_type>(
+                    ctas.index_cb,
+                    index_addr_gtor,
+                    index_offset * sizeof(index_std_type),
+                    index_chunk_length * sizeof(index_std_type),
+                    stick_id);
+                load_to_cb<ctas.source_tensor_is_dram, source_addr_gtor_type>(
+                    ctas.source_cb,
+                    source_addr_gtor,
+                    index_offset * sizeof(input_std_type),
+                    index_chunk_length * sizeof(input_std_type),
+                    stick_id);
+                cb_wait_front(ctas.index_cb, ONE_PAGE);
+                cb_wait_front(ctas.source_cb, ONE_PAGE);
+                scatter_along_chunk<input_std_type, index_std_type>(
+                    ctas.input_cb,
+                    ctas.index_cb,
+                    ctas.source_cb,
+                    ctas.output_cb,
+                    ctas.input_stick_size,
+                    input_offset,
+                    input_chunk_length,
+                    index_chunk_length);
+                cb_pop_front(ctas.source_cb, ONE_PAGE);
+                cb_pop_front(ctas.index_cb, ONE_PAGE);
+            }
+
+            cb_push_back(ctas.output_cb, ONE_PAGE);
+            cb_pop_front(ctas.input_cb, ONE_PAGE);
+        }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/kernels/dataflow/reader_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/kernels/dataflow/reader_scatter.cpp
@@ -10,142 +10,81 @@
 
 namespace {
 
-template <bool is_dram>
-FORCE_INLINE void read_nth_tile_in_Wt_tiles(
-    IAGF<is_dram> addr_gtor,
-    const uint32_t& cb,
-    const uint32_t& Wt_tiles,
-    const uint32_t& ht_offset,
-    const uint32_t& tile_num_in_row) {
-    cb_reserve_back(cb, ONE_TILE);
-    const uint32_t l1_addr = get_write_ptr(cb);
-    noc_async_read_tile(ht_offset * Wt_tiles + tile_num_in_row, addr_gtor, l1_addr);
+template <bool is_dram, typename AddrGen>
+FORCE_INLINE void load_to_cb(
+    const uint32_t& cb, const AddrGen& addr_gtor, const uint32_t& stick_size_bytes, const uint32_t& stick_id) {
+    cb_reserve_back(cb, ONE_PAGE);  // read a whole input row
+    const uint64_t source_noc_address = get_noc_addr(stick_id, addr_gtor);
+    const uint32_t l1_write_address = get_write_ptr(cb);
+
+    noc_async_read(source_noc_address, l1_write_address, stick_size_bytes);
     noc_async_read_barrier();
-    cb_push_back(cb, ONE_TILE);
+
+    cb_push_back(cb, ONE_PAGE);
 }
 
-// several comments on the algorithm
-// computational complexity: O(input_shape[scatter_axis] * index_shape[scatter_axis])
-// memory complexity: O(3 * tile_size(input_cb) + tile_size(index_cb)) -> O(1)
-// this algorithm courses through each tile along the whole scatter axis (index_shape[scatter_axis]) in the index tensor
-// (and source tensor on parallel) for each input tile along the whole scatter axis (input_shape[scatter_axis])
-template <
-    typename number_type,
-    typename index_type,
-    bool input_tensor_is_dram,
-    bool index_tensor_is_dram,
-    bool source_tensor_is_dram>
+FORCE_INLINE void prepare_cbs(
+    const uint32_t& input_cb, const uint32_t& index_cb, const uint32_t& source_cb, const uint32_t& output_cb) {
+    cb_wait_front(input_cb, ONE_PAGE);
+    cb_wait_front(index_cb, ONE_PAGE);
+    cb_wait_front(source_cb, ONE_PAGE);
+    cb_reserve_back(output_cb, ONE_PAGE);
+}
+
+FORCE_INLINE void recycle_input_and_push_result_row(
+    const uint32_t input_cb, const uint32_t& index_cb, const uint32_t& source_cb, const uint32_t& output_cb) {
+    cb_pop_front(input_cb, ONE_PAGE);
+    cb_pop_front(index_cb, ONE_PAGE);
+    cb_pop_front(source_cb, ONE_PAGE);
+    cb_push_back(output_cb, ONE_PAGE);
+}
+
+template <typename number_type, typename index_type>
 FORCE_INLINE void scatter_along_whole_axis(
-    const uint32_t& ht_offset,
-    const uint32_t& Wt_input,
-    const uint32_t& logical_index_width,
-    const uint32_t& logical_index_height,
-    const uint32_t& Wt_index,
-    const uint32_t& counter,
-    const uint32_t& pad_scalar_offset,
-    const uint32_t& tile_height,
-    const uint32_t& tile_width,
-    const uint32_t& face_height,
-    const uint32_t& face_width,
-    const uint32_t& face_num_x,
-    const uint32_t& face_num_y,
     const uint32_t& input_cb,
     const uint32_t& index_cb,
     const uint32_t& source_cb,
     const uint32_t& output_cb,
-    const IAGF<input_tensor_is_dram>& input_addr_gtor,
-    const IAGF<index_tensor_is_dram>& index_addr_gtor,
-    const IAGF<source_tensor_is_dram>& source_addr_gtor) {
-    // for each tile along the scatter axis (Wt_input, or input_shape[scatter_axis]) in the input tensor...
-    const uint32_t tile_width_mask = tile_width - 1;
-    const uint32_t tile_height_mask = tile_height - 1;
-    const uint32_t tile_width_divisor = __builtin_ctz(tile_width);
-    const uint32_t tile_height_divisor = __builtin_ctz(tile_height);
-    const uint32_t ht_pad = ((pad_scalar_offset + tile_height_mask) >> tile_height_divisor);
-    const uint32_t residue_rows = (pad_scalar_offset & tile_height_mask);
-    const uint32_t tile_hw = tile_height * tile_width;
-    const uint32_t face_hw = face_height * face_width;
-    for (uint32_t tile_input = 0; tile_input < Wt_input; ++tile_input) {
-        cb_reserve_back(output_cb, ONE_TILE);
-        // read an input tile + get fresh pointers
-        read_nth_tile_in_Wt_tiles<input_tensor_is_dram>(input_addr_gtor, input_cb, Wt_input, ht_offset, tile_input);
-        const uint32_t input_l1_read_addr = get_read_ptr(input_cb);
-        const uint32_t output_l1_write_addr = get_write_ptr(output_cb);
-        volatile tt_l1_ptr number_type* input_l1_ptr =
-            reinterpret_cast<volatile tt_l1_ptr number_type*>(input_l1_read_addr);
-        volatile tt_l1_ptr number_type* output_l1_ptr =
-            reinterpret_cast<volatile tt_l1_ptr number_type*>(output_l1_write_addr);
+    const uint32_t& input_stick_size,
+    const uint32_t& index_stick_size,
+    const uint32_t& source_stick_size,
+    const uint32_t& output_stick_size) {
+    const uint32_t input_l1_read_addr = get_read_ptr(input_cb);
+    const uint32_t index_l1_read_addr = get_read_ptr(index_cb);
+    const uint32_t source_l1_read_addr = get_read_ptr(source_cb);
+    const uint32_t output_l1_write_addr = get_write_ptr(output_cb);
+    volatile tt_l1_ptr number_type* input_l1_read_ptr =
+        reinterpret_cast<volatile tt_l1_ptr number_type*>(input_l1_read_addr);
+    volatile tt_l1_ptr index_type* index_l1_read_ptr =
+        reinterpret_cast<volatile tt_l1_ptr index_type*>(index_l1_read_addr);
+    volatile tt_l1_ptr number_type* source_l1_read_ptr =
+        reinterpret_cast<volatile tt_l1_ptr number_type*>(source_l1_read_addr);
+    volatile tt_l1_ptr number_type* output_l1_write_ptr =
+        reinterpret_cast<volatile tt_l1_ptr number_type*>(output_l1_write_addr);
 
-        // copy WIP input tile into output (memcpy?)
-        for (uint32_t tile_input_inner = 0; tile_input_inner < tile_hw; ++tile_input_inner) {
-            output_l1_ptr[tile_input_inner] = input_l1_ptr[tile_input_inner];
+    for (uint32_t index_in_input_stick = 0; index_in_input_stick < input_stick_size; ++index_in_input_stick) {
+        // DPRINT << "INPUT " << input_l1_read_ptr[index_in_input_stick] << ENDL();
+        output_l1_write_ptr[index_in_input_stick] = input_l1_read_ptr[index_in_input_stick];
+    }
+
+    for (uint32_t index_in_index_stick = 0; index_in_index_stick < index_stick_size; ++index_in_index_stick) {
+        volatile index_type& index_value = index_l1_read_ptr[index_in_index_stick];
+        // DPRINT << "INDEX " << index_value << ENDL();
+        ASSERT(
+            index_value < index_stick_size,
+            "Index value {} is bigger than dimension size {}.",
+            index_value,
+            index_stick_size);
+        if (index_value >= index_stick_size) {
+            continue;
         }
-        // ...scatter Wt_tiles (index_shape[scatter_axis]) tiles onto ONE_TILE from Wt_input
-        for (uint32_t tile_index_w = 0; tile_index_w < Wt_index; ++tile_index_w) {
-            // read index and source tiles + get fresh pointers
-            read_nth_tile_in_Wt_tiles<index_tensor_is_dram>(
-                index_addr_gtor, index_cb, Wt_index, ht_offset, tile_index_w);
-            read_nth_tile_in_Wt_tiles<source_tensor_is_dram>(
-                source_addr_gtor, source_cb, Wt_index, ht_offset, tile_index_w);
-            const uint32_t index_l1_read_addr = get_read_ptr(index_cb);
-            const uint32_t source_l1_read_addr = get_read_ptr(source_cb);
-            volatile tt_l1_ptr index_type* index_l1_ptr =
-                reinterpret_cast<volatile tt_l1_ptr index_type*>(index_l1_read_addr);
-            volatile tt_l1_ptr number_type* source_l1_ptr =
-                reinterpret_cast<volatile tt_l1_ptr number_type*>(source_l1_read_addr);
-            // gut the tiles
-            for (uint32_t face_x = 0; face_x < face_num_x; ++face_x) {
-                for (uint32_t face_y = 0; face_y < face_num_y; ++face_y) {
-                    for (uint32_t scalar_x = 0; scalar_x < face_width; ++scalar_x) {
-                        const uint32_t width_scalar_index =
-                            get_width_scalar_index(tile_index_w, face_x, scalar_x, tile_width, face_width);
-                        // break sooner if the pointer went past logical width
-                        if (width_scalar_index >= logical_index_width) {
-                            break;
-                        }
-                        for (uint32_t scalar_y = 0; scalar_y < face_height; ++scalar_y) {
-                            // get global coords + assert
-                            // break sooner if the pointer went past logical height
-                            if (counter == ht_pad - 1) {
-                                const uint32_t height_scalar_index =
-                                    get_height_scalar_index_inside_tile(face_y, scalar_y, face_height);
-                                if (height_scalar_index >= residue_rows) {
-                                    break;
-                                }
-                            }
+        volatile number_type& source_value = source_l1_read_ptr[index_in_index_stick];
+        // DPRINT << "SOURCE " << source_value << ENDL();
+        output_l1_write_ptr[index_value] = source_value;
+    }
 
-                            // get scatter info
-                            volatile index_type& index_value = tile_guts<index_type>(
-                                index_l1_ptr, face_x, face_y, scalar_x, scalar_y, face_hw, face_width);
-                            // check if index value targets currently chosen input tile (tile_input)
-                            const uint32_t dest_tile_id_in_row = index_value >> tile_width_divisor;
-                            ASSERT(dest_tile_id_in_row < Wt_input);
-                            if (dest_tile_id_in_row != tile_input) {
-                                continue;
-                            }
-                            volatile number_type& source_value = tile_guts<number_type>(
-                                source_l1_ptr, face_x, face_y, scalar_x, scalar_y, face_hw, face_width);
-                            const uint32_t x_index_in_tile = index_value & tile_width_mask;
-                            const uint32_t dest_scalar_x =
-                                (x_index_in_tile < face_width) ? x_index_in_tile : (x_index_in_tile - face_width);
-                            const uint32_t dest_face_id_x = (x_index_in_tile < face_width) ? 0 : 1;
-
-                            // scatter the value
-                            tile_guts<number_type>(
-                                output_l1_ptr, dest_face_id_x, face_y, dest_scalar_x, scalar_y, face_hw, face_width) =
-                                source_value;
-                        }
-                    }
-                }
-            }
-            // release index and source tiles
-            cb_pop_front(index_cb, ONE_TILE);
-            cb_pop_front(source_cb, ONE_TILE);
-        }
-
-        // release input tile + push resulting tile to the output
-        cb_push_back(output_cb, ONE_TILE);
-        cb_pop_front(input_cb, ONE_TILE);
+    for (uint32_t i = 0; i < input_stick_size; ++i) {
+        DPRINT << i << " " << output_l1_write_ptr[i] << " " << ENDL();
     }
 }
 
@@ -154,55 +93,50 @@ FORCE_INLINE void scatter_along_whole_axis(
 void kernel_main() {
     constexpr auto ctas{get_ctas()};
 
-    const DataFormat input_data_format{get_dataformat(ctas.input_tensor_cb)};
+    const uint32_t input_buffer_address = get_arg_val<uint32_t>(0);
+    const uint32_t index_buffer_address = get_arg_val<uint32_t>(1);
+    const uint32_t source_buffer_address = get_arg_val<uint32_t>(2);
+    const uint32_t start_stick_id = get_arg_val<uint32_t>(3);
+    const uint32_t sticks_for_core = get_arg_val<uint32_t>(4);
 
-    const auto input_addr_gtor{make_addr_gtor<ctas.input_tensor_is_dram>(ctas.input_tensor_cb, ctas.input_tensor_addr)};
-    const auto index_addr_gtor{make_addr_gtor<ctas.index_tensor_is_dram>(ctas.index_tensor_cb, ctas.index_tensor_addr)};
+    const auto input_addr_gtor{
+        get_interleaved_addr_gen<ctas.input_tensor_is_dram, ctas.is_input_stick_size_bytes_pow2_min_32>(
+            input_buffer_address, ctas.input_stick_size_bytes, ctas.input_stick_size_bytes_log2)};
+    const auto index_addr_gtor{
+        get_interleaved_addr_gen<ctas.index_tensor_is_dram, ctas.is_index_stick_size_bytes_pow2_min_32>(
+            index_buffer_address, ctas.index_stick_size_bytes, ctas.index_stick_size_bytes_log2)};
     const auto source_addr_gtor{
-        make_addr_gtor<ctas.source_tensor_is_dram>(ctas.source_tensor_cb, ctas.source_tensor_addr)};
+        get_interleaved_addr_gen<ctas.source_tensor_is_dram, ctas.is_source_stick_size_bytes_pow2_min_32>(
+            source_buffer_address, ctas.source_stick_size_bytes, ctas.source_stick_size_bytes_log2)};
 
-    const uint32_t start_ht_id = get_arg_val<uint32_t>(0);
-    const uint32_t ht_per_core = get_arg_val<uint32_t>(1);
+    using input_std_type = std_type_t<get_dataformat(ctas.input_cb)>;
+    using index_std_type = std_type_t<get_dataformat(ctas.index_cb)>;
+    using input_addr_gtor_type = decltype(input_addr_gtor);
+    using index_addr_gtor_type = decltype(index_addr_gtor);
+    using source_addr_gtor_type = decltype(source_addr_gtor);
 
-    using input_std_type = std_type_t<get_dataformat(ctas.input_tensor_cb)>;
-    using index_std_type = std_type_t<get_dataformat(ctas.index_tensor_cb)>;
+    for (uint32_t stick_id = start_stick_id; stick_id < start_stick_id + sticks_for_core; ++stick_id) {
+        // load input sticks (rows)
+        load_to_cb<ctas.input_tensor_is_dram, input_addr_gtor_type>(
+            ctas.input_cb, input_addr_gtor, ctas.input_stick_size_bytes, stick_id);
+        load_to_cb<ctas.index_tensor_is_dram, index_addr_gtor_type>(
+            ctas.index_cb, index_addr_gtor, ctas.index_stick_size_bytes, stick_id);
+        load_to_cb<ctas.source_tensor_is_dram, source_addr_gtor_type>(
+            ctas.source_cb, source_addr_gtor, ctas.source_stick_size_bytes, stick_id);
+        prepare_cbs(ctas.input_cb, ctas.index_cb, ctas.source_cb, ctas.output_cb);
 
-    uint32_t counter = get_arg_val<uint32_t>(2);
+        // scatter glitter yayy
+        scatter_along_whole_axis<input_std_type, index_std_type>(
+            ctas.input_cb,
+            ctas.index_cb,
+            ctas.source_cb,
+            ctas.output_cb,
+            ctas.input_stick_size,
+            ctas.index_stick_size,
+            ctas.source_stick_size,
+            ctas.output_stick_size);
 
-    const uint32_t tile_height_mask = ctas.tile_height - 1;
-    const uint32_t tile_height_divisor = __builtin_ctz(ctas.tile_height);
-    constexpr uint32_t ht_pad = ((ctas.pad_scalar_offset + tile_height_mask) >> tile_height_divisor);
-
-    for (uint32_t ht = start_ht_id; ht < start_ht_id + ht_per_core; ++ht) {
-        if (counter == ht_pad) {
-            counter = 0;
-        }
-        scatter_along_whole_axis<
-            input_std_type,
-            index_std_type,
-            ctas.input_tensor_is_dram,
-            ctas.index_tensor_is_dram,
-            ctas.source_tensor_is_dram>(
-            ht,
-            ctas.Wt_input,
-            ctas.logical_index_width,
-            ctas.logical_index_height,
-            ctas.Wt_index,
-            counter,
-            ctas.pad_scalar_offset,
-            ctas.tile_height,
-            ctas.tile_width,
-            ctas.face_height,
-            ctas.face_width,
-            ctas.face_num_x,
-            ctas.face_num_y,
-            ctas.input_tensor_cb,
-            ctas.index_tensor_cb,
-            ctas.source_tensor_cb,
-            ctas.output_tensor_cb,
-            input_addr_gtor,
-            index_addr_gtor,
-            source_addr_gtor);
-        ++counter;
+        // ecological and responsible
+        recycle_input_and_push_result_row(ctas.input_cb, ctas.index_cb, ctas.source_cb, ctas.output_cb);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/kernels/dataflow/writer_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/kernels/dataflow/writer_scatter.cpp
@@ -10,12 +10,12 @@ namespace {
 
 template <bool is_dram, typename AddrGen>
 FORCE_INLINE void write_to_output(
-    const uint32_t& cb, const AddrGen& addr_gtor, const uint32_t& stick_size_bytes, const uint32_t& stick_id) {
-    cb_wait_front(cb, ONE_PAGE);  // read a whole input row
+    const uint32_t& cb, const AddrGen& addr_gtor, const uint32_t& offset_bytes, const uint32_t& chunk_size_bytes, const uint32_t& stick_id) {
+    cb_wait_front(cb, ONE_PAGE);
     const uint64_t destination_noc_address = get_noc_addr(stick_id, addr_gtor);
     const uint32_t l1_read_address = get_read_ptr(cb);
 
-    noc_async_write(destination_noc_address, l1_read_address, stick_size_bytes);
+    noc_async_write(l1_read_address, destination_noc_address + offset_bytes, chunk_size_bytes);
     noc_async_write_barrier();
 
     cb_pop_front(cb, ONE_PAGE);
@@ -35,8 +35,16 @@ void kernel_main() {
             output_buffer_address, ctas.output_stick_size_bytes, ctas.output_stick_size_bytes_log2)};
     using output_addr_gtor_type = decltype(output_addr_gtor);
 
+    using output_std_type = std_type_t<get_dataformat(ctas.output_cb)>;
+
+    const uint32_t input_and_output_chunk_size = get_arg_val<uint32_t>(3);
+
     for (uint32_t stick_id = start_stick_id; stick_id < start_stick_id + sticks_for_core; ++stick_id) {
-        write_to_output<ctas.output_tensor_is_dram, output_addr_gtor_type>(
-            ctas.output_cb, output_addr_gtor, ctas.output_stick_size_bytes, stick_id);
+        for (uint32_t offset_bytes = 0; offset_bytes < ctas.output_stick_size_bytes; offset_bytes += input_and_output_chunk_size * sizeof(output_std_type)) {
+            const uint32_t chunk_write_bytes = std::min(
+                ctas.output_stick_size_bytes - offset_bytes, input_and_output_chunk_size * sizeof(output_std_type));
+            write_to_output<ctas.output_tensor_is_dram, output_addr_gtor_type>(
+                ctas.output_cb, output_addr_gtor, offset_bytes, chunk_write_bytes, stick_id);
+        }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/kernels/dataflow/writer_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/kernels/dataflow/writer_scatter.cpp
@@ -8,16 +8,17 @@
 
 namespace {
 
-template <bool is_dram>
-FORCE_INLINE void write_wt_tiles(
-    IAGF<is_dram> addr_gtor, const uint32_t& cb, const uint32_t Wt_input, const uint32_t& ht_offset = 0) {
-    for (uint32_t tile_num_in_row = 0; tile_num_in_row < Wt_input; ++tile_num_in_row) {
-        cb_wait_front(cb, ONE_TILE);
-        const uint32_t l1_addr = get_read_ptr(cb);
-        noc_async_write_tile(ht_offset * Wt_input + tile_num_in_row, addr_gtor, l1_addr);
-        noc_async_write_barrier();
-        cb_pop_front(cb, ONE_TILE);
-    }
+template <bool is_dram, typename AddrGen>
+FORCE_INLINE void write_to_output(
+    const uint32_t& cb, const AddrGen& addr_gtor, const uint32_t& stick_size_bytes, const uint32_t& stick_id) {
+    cb_wait_front(cb, ONE_PAGE);  // read a whole input row
+    const uint64_t destination_noc_address = get_noc_addr(stick_id, addr_gtor);
+    const uint32_t l1_read_address = get_read_ptr(cb);
+
+    noc_async_write(destination_noc_address, l1_read_address, stick_size_bytes);
+    noc_async_write_barrier();
+
+    cb_pop_front(cb, ONE_PAGE);
 }
 
 }  // namespace
@@ -25,15 +26,17 @@ FORCE_INLINE void write_wt_tiles(
 void kernel_main() {
     constexpr auto ctas{get_ctas()};
 
+    const uint32_t output_buffer_address = get_arg_val<uint32_t>(0);
+    const uint32_t start_stick_id = get_arg_val<uint32_t>(1);
+    const uint32_t sticks_for_core = get_arg_val<uint32_t>(2);
+
     const auto output_addr_gtor{
-        make_addr_gtor<ctas.output_tensor_is_dram>(ctas.output_tensor_cb, ctas.output_tensor_addr)};
+        get_interleaved_addr_gen<ctas.output_tensor_is_dram, ctas.is_output_stick_size_bytes_pow2_min_32>(
+            output_buffer_address, ctas.output_stick_size_bytes, ctas.output_stick_size_bytes_log2)};
+    using output_addr_gtor_type = decltype(output_addr_gtor);
 
-    const uint32_t start_ht_id = get_arg_val<uint32_t>(0);
-    const uint32_t ht_per_core = get_arg_val<uint32_t>(1);
-
-    for (uint32_t h = start_ht_id; h < start_ht_id + ht_per_core; ++h) {
-        // simply read the output_tensor_cb and write to the NoC
-        // this writes tile-by-tile as soon as a single tile becomes available in the output CB
-        write_wt_tiles<ctas.output_tensor_is_dram>(output_addr_gtor, ctas.output_tensor_cb, ctas.Wt_input, h);
+    for (uint32_t stick_id = start_stick_id; stick_id < start_stick_id + sticks_for_core; ++stick_id) {
+        write_to_output<ctas.output_tensor_is_dram, output_addr_gtor_type>(
+            ctas.output_cb, output_addr_gtor, ctas.output_stick_size_bytes, stick_id);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/kernels/scatter_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/kernels/scatter_common.hpp
@@ -8,11 +8,7 @@
 
 #include <tt-metalium/constants.hpp>
 
-constexpr uint32_t ONE_TILE = 1;
-constexpr uint32_t FIRST_TILE = 0;
-
-template <bool is_dram>
-using IAGF = InterleavedAddrGenFast<is_dram>;
+constexpr uint32_t ONE_PAGE = 1;
 
 template <DataFormat df>
 struct df_to_std {
@@ -52,57 +48,6 @@ struct df_to_std<DataFormat::UInt8> {
 template <DataFormat df>
 using std_type_t = typename df_to_std<df>::std_type;
 
-FORCE_INLINE uint32_t calc_offset_inside_tile(
-    const uint32_t& face_x,
-    const uint32_t& face_y,
-    const uint32_t& scalar_x,
-    const uint32_t& scalar_y,
-    const uint32_t& face_hw,
-    const uint32_t& face_width) {
-    // pick the face
-    const uint32_t face_multiplier = ((face_y << 1) | (face_x));
-    uint32_t offset = face_hw * face_multiplier;
-
-    // pick the value inside face
-    offset += scalar_y * face_width + scalar_x;
-
-    return offset;
-}
-
-template <typename T>
-FORCE_INLINE volatile T& tile_guts(
-    volatile tt_l1_ptr T* l1_ptr,
-    const uint32_t& face_x,
-    const uint32_t& face_y,
-    const uint32_t& scalar_x,
-    const uint32_t& scalar_y,
-    const uint32_t& face_hw,
-    const uint32_t& face_width) {
-    return l1_ptr[calc_offset_inside_tile(face_x, face_y, scalar_x, scalar_y, face_hw, face_width)];
-}
-
-FORCE_INLINE uint32_t get_width_scalar_index(
-    const uint32_t& tile_id,
-    const uint32_t& face_x,
-    const uint32_t& scalar_x,
-    const uint32_t& tile_width,
-    const uint32_t& face_width) {
-    return tile_id * tile_width + face_x * face_width + scalar_x;
-}
-
-FORCE_INLINE uint32_t
-get_height_scalar_index_inside_tile(const uint32_t& face_y, const uint32_t& scalar_y, const uint32_t& face_height) {
-    return face_y * face_height + scalar_y;
-}
-
-template <bool is_dram>
-FORCE_INLINE IAGF<is_dram> make_addr_gtor(const uint32_t& cb, const uint32_t& base_addr) {
-    return {
-        .bank_base_address = base_addr,
-        .page_size = static_cast<uint32_t>(get_tile_size(cb)),
-        .data_format = get_dataformat(cb)};
-}
-
 struct ScatterCTAs {
     const bool input_tensor_is_dram;
     const bool index_tensor_is_dram;
@@ -112,34 +57,37 @@ struct ScatterCTAs {
     const uint32_t index_tensor_addr;
     const uint32_t source_tensor_addr;
     const uint32_t output_tensor_addr;
-    const uint32_t input_tensor_cb;
-    const uint32_t index_tensor_cb;
-    const uint32_t source_tensor_cb;
-    const uint32_t output_tensor_cb;
-    const uint32_t Wt_input;
-    const uint32_t logical_index_width;
-    const uint32_t logical_index_height;
-    const uint32_t face_num_x;
-    const uint32_t face_num_y;
-    const uint32_t Wt_index;
-    const uint32_t pad_scalar_offset;
-    const uint32_t Ht;
-    const uint32_t total_number_of_cores;
-    const uint32_t compute_with_storage_grid_size_x;
-    const uint32_t tile_height;
-    const uint32_t tile_width;
-    const uint32_t face_height;
-    const uint32_t face_width;
+    const uint32_t input_cb;
+    const uint32_t index_cb;
+    const uint32_t source_cb;
+    const uint32_t output_cb;
+    const uint32_t input_stick_size;
+    const uint32_t index_stick_size;
+    const uint32_t source_stick_size;
+    const uint32_t output_stick_size;
+    const uint32_t input_stick_size_bytes;
+    const uint32_t index_stick_size_bytes;
+    const uint32_t source_stick_size_bytes;
+    const uint32_t output_stick_size_bytes;
+    const uint32_t input_stick_size_bytes_log2;
+    const uint32_t index_stick_size_bytes_log2;
+    const uint32_t source_stick_size_bytes_log2;
+    const uint32_t output_stick_size_bytes_log2;
+    const bool is_input_stick_size_bytes_pow2_min_32;
+    const bool is_index_stick_size_bytes_pow2_min_32;
+    const bool is_source_stick_size_bytes_pow2_min_32;
+    const bool is_output_stick_size_bytes_pow2_min_32;
 };
 
 FORCE_INLINE constexpr ScatterCTAs get_ctas() {
-    return {get_compile_time_arg_val(0) == 1, get_compile_time_arg_val(1) == 1, get_compile_time_arg_val(2) == 1,
-            get_compile_time_arg_val(3) == 1, get_compile_time_arg_val(4),      get_compile_time_arg_val(5),
-            get_compile_time_arg_val(6),      get_compile_time_arg_val(7),      get_compile_time_arg_val(8),
-            get_compile_time_arg_val(9),      get_compile_time_arg_val(10),     get_compile_time_arg_val(11),
-            get_compile_time_arg_val(12),     get_compile_time_arg_val(13),     get_compile_time_arg_val(14),
-            get_compile_time_arg_val(15),     get_compile_time_arg_val(16),     get_compile_time_arg_val(17),
-            get_compile_time_arg_val(18),     get_compile_time_arg_val(19),     get_compile_time_arg_val(20),
-            get_compile_time_arg_val(21),     get_compile_time_arg_val(22),     get_compile_time_arg_val(23),
-            get_compile_time_arg_val(24),     get_compile_time_arg_val(25)};
+    return {get_compile_time_arg_val(0) == 1,  get_compile_time_arg_val(1) == 1,  get_compile_time_arg_val(2) == 1,
+            get_compile_time_arg_val(3) == 1,  get_compile_time_arg_val(4),       get_compile_time_arg_val(5),
+            get_compile_time_arg_val(6),       get_compile_time_arg_val(7),       get_compile_time_arg_val(8),
+            get_compile_time_arg_val(9),       get_compile_time_arg_val(10),      get_compile_time_arg_val(11),
+            get_compile_time_arg_val(12),      get_compile_time_arg_val(13),      get_compile_time_arg_val(14),
+            get_compile_time_arg_val(15),      get_compile_time_arg_val(16),      get_compile_time_arg_val(17),
+            get_compile_time_arg_val(18),      get_compile_time_arg_val(19),      get_compile_time_arg_val(20),
+            get_compile_time_arg_val(21),      get_compile_time_arg_val(22),      get_compile_time_arg_val(23),
+            get_compile_time_arg_val(24) == 1, get_compile_time_arg_val(25) == 1, get_compile_time_arg_val(26) == 1,
+            get_compile_time_arg_val(27) == 1};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.cpp
@@ -35,49 +35,6 @@ void ScatterDeviceOperation::validate_on_program_cache_miss(
     const uint32_t src_rank{src_shape.rank()};
 
     TT_FATAL(
-        args.dim < static_cast<int32_t>(input_rank) && -static_cast<int32_t>(input_rank) <= args.dim,
-        "dim must follow the condition -input_rank <= dim < input_rank (dim: {}, rank: {}).",
-        args.dim,
-        static_cast<int32_t>(input_rank));
-
-    if (tensor_args.opt_output.has_value()) {
-        const auto& output_tensor{tensor_args.opt_output.value()};
-        const auto& output_shape{output_tensor.logical_shape()};
-        const auto& output_rank{output_shape.rank()};
-        const auto& output_dtype{output_tensor.dtype()};
-
-        TT_FATAL(
-            input_shape == output_shape,
-            "The shapes of input and output tensors must be equal (input_shape: {}, output_shape: {}).",
-            input_shape,
-            output_shape);
-
-        TT_FATAL(
-            input_dtype == output_dtype,
-            "input_dtype and output_dtype must be the same (input_dtype: {}, output_dtype: {})",
-            magic_enum::enum_name(input_dtype),
-            magic_enum::enum_name(output_dtype));
-
-        TT_FATAL(
-            static_cast<int32_t>(args.dim) >= -static_cast<int32_t>(output_rank),
-            "dim cannot be lower than output shape's negative rank (dim: {}, rank: {}).",
-            args.dim,
-            -static_cast<int32_t>(output_rank));
-        TT_FATAL(
-            static_cast<int32_t>(args.dim) < static_cast<int32_t>(output_rank),
-            "dim must be lower than output shape's positive rank (dim: {}, rank: {}).",
-            args.dim,
-            static_cast<int32_t>(output_rank));
-
-        TT_FATAL(
-            output_tensor.get_layout() == Layout::ROW_MAJOR,
-            "Output tensor doesn't have a row-major layout - only row-major layout is supported.");
-        TT_FATAL(output_tensor.buffer() != nullptr, "Output tensor's buffer is null.");
-        TT_FATAL(output_tensor.storage_type() == StorageType::DEVICE, "Output tensor must be allocated on a device.");
-        TT_FATAL(!output_tensor.is_sharded(), "Sharded tensors are not supported - output_tensor is sharded.");
-    }
-
-    TT_FATAL(
         index_shape == src_shape,
         "index_shape must be the same as src_shape (index_shape: {}, src_shape: {}).",
         index_shape,
@@ -101,21 +58,6 @@ void ScatterDeviceOperation::validate_on_program_cache_miss(
         "index_dtype is not integer, it is {}.",
         magic_enum::enum_name(index_dtype));
 
-    const int32_t dim{(args.dim < 0) ? (args.dim + input_tensor.padded_shape().rank()) : args.dim};
-
-    for (uint32_t probe_dim = 0; probe_dim < input_shape.rank(); ++probe_dim) {
-        if (probe_dim != dim) {
-            TT_FATAL(
-                index_shape[probe_dim] == input_shape[probe_dim],
-                "Index tensor has other dimension {}'s length than input shape's (index dimension: {}, "
-                "input_dimension: "
-                "{}).",
-                probe_dim,
-                index_shape[probe_dim],
-                input_shape[probe_dim]);
-        }
-    }
-
     TT_FATAL(!input_tensor.is_sharded(), "Sharded tensors are not supported - input_tensor is sharded.");
     TT_FATAL(!index_tensor.is_sharded(), "Sharded tensors are not supported - index_tensor is sharded.");
     TT_FATAL(!src_tensor.is_sharded(), "Sharded tensors are not supported - src_tensor is sharded.");
@@ -132,10 +74,6 @@ void ScatterDeviceOperation::validate_on_program_cache_miss(
 ScatterDeviceOperation::spec_return_value_t ScatterDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     using namespace tt::tt_metal;
-    if (tensor_args.opt_output.has_value()) {
-        return tensor_args.opt_output.value().tensor_spec();
-    }
-
     return TensorSpec{
         tensor_args.input_tensor.get_logical_shape(),
         TensorLayout{tensor_args.input_tensor.get_dtype(), PageConfig{Layout::ROW_MAJOR}, args.output_memory_config}};
@@ -143,10 +81,6 @@ ScatterDeviceOperation::spec_return_value_t ScatterDeviceOperation::compute_outp
 
 ScatterDeviceOperation::tensor_return_value_t ScatterDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    if (tensor_args.opt_output.has_value()) {
-        return *tensor_args.opt_output;
-    }
-
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.cpp
@@ -70,8 +70,8 @@ void ScatterDeviceOperation::validate_on_program_cache_miss(
             static_cast<int32_t>(output_rank));
 
         TT_FATAL(
-            output_tensor.layout() == Layout::TILE,
-            "Output tensor doesn't have a tile layout - only tile layout is supported.");
+            output_tensor.get_layout() == Layout::ROW_MAJOR,
+            "Output tensor doesn't have a row-major layout - only row-major layout is supported.");
         TT_FATAL(output_tensor.buffer() != nullptr, "Output tensor's buffer is null.");
         TT_FATAL(output_tensor.storage_type() == StorageType::DEVICE, "Output tensor must be allocated on a device.");
         TT_FATAL(!output_tensor.is_sharded(), "Sharded tensors are not supported - output_tensor is sharded.");
@@ -121,13 +121,14 @@ void ScatterDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(!src_tensor.is_sharded(), "Sharded tensors are not supported - src_tensor is sharded.");
 
     TT_FATAL(
-        input_tensor.layout() == Layout::TILE,
-        "Input tensor doesn't have a tile layout - only tile layout is supported.");
+        input_tensor.get_layout() == Layout::ROW_MAJOR,
+        "Input tensor doesn't have a row-major layout - only row-major layout is supported.");
     TT_FATAL(
-        index_tensor.layout() == Layout::TILE,
-        "Index tensor doesn't have a tile layout - only tile layout is supported.");
+        index_tensor.get_layout() == Layout::ROW_MAJOR,
+        "Index tensor doesn't have a row-major layout - only row-major layout is supported.");
     TT_FATAL(
-        src_tensor.layout() == Layout::TILE, "Src tensor doesn't have a tile layout - only tile layout is supported.");
+        src_tensor.get_layout() == Layout::ROW_MAJOR,
+        "Src tensor doesn't have a row-major layout - only row-major layout is supported.");
 
     TT_FATAL(input_tensor.buffer() != nullptr, "Input tensor's buffer is null.");
     TT_FATAL(index_tensor.buffer() != nullptr, "Index tensor's buffer is null.");
@@ -146,8 +147,8 @@ ScatterDeviceOperation::spec_return_value_t ScatterDeviceOperation::compute_outp
     }
 
     return TensorSpec{
-        tensor_args.input_tensor.logical_shape(),
-        TensorLayout{tensor_args.input_tensor.dtype(), PageConfig{Layout::TILE}, args.output_memory_config}};
+        tensor_args.input_tensor.get_logical_shape(),
+        TensorLayout{tensor_args.input_tensor.get_dtype(), PageConfig{Layout::ROW_MAJOR}, args.output_memory_config}};
 }
 
 ScatterDeviceOperation::tensor_return_value_t ScatterDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.cpp
@@ -120,16 +120,6 @@ void ScatterDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(!index_tensor.is_sharded(), "Sharded tensors are not supported - index_tensor is sharded.");
     TT_FATAL(!src_tensor.is_sharded(), "Sharded tensors are not supported - src_tensor is sharded.");
 
-    TT_FATAL(
-        input_tensor.get_layout() == Layout::ROW_MAJOR,
-        "Input tensor doesn't have a row-major layout - only row-major layout is supported.");
-    TT_FATAL(
-        index_tensor.get_layout() == Layout::ROW_MAJOR,
-        "Index tensor doesn't have a row-major layout - only row-major layout is supported.");
-    TT_FATAL(
-        src_tensor.get_layout() == Layout::ROW_MAJOR,
-        "Src tensor doesn't have a row-major layout - only row-major layout is supported.");
-
     TT_FATAL(input_tensor.buffer() != nullptr, "Input tensor's buffer is null.");
     TT_FATAL(index_tensor.buffer() != nullptr, "Index tensor's buffer is null.");
     TT_FATAL(src_tensor.buffer() != nullptr, "Src tensor's buffer is null.");

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.cpp
@@ -91,11 +91,10 @@ ScatterDeviceOperation::invocation_result_t ScatterDeviceOperation::invoke(
     const Tensor& source_tensor,
     const MemoryConfig& output_memory_config,
     const std::optional<ScatterReductionType>& opt_reduction,
-    std::optional<Tensor>& opt_output,
     const QueueId& queue_id) {
     return {
         operation_attributes_t{dim, output_memory_config, opt_reduction},
-        tensor_args_t{input_tensor, index_tensor, source_tensor, opt_output}};
+        tensor_args_t{input_tensor, index_tensor, source_tensor}};
 }
 
 }  // namespace ttnn::operations::experimental::scatter

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.hpp
@@ -45,7 +45,6 @@ struct ScatterDeviceOperation {
         const Tensor& source_tensor,
         const MemoryConfig& output_memory_config,
         const std::optional<ScatterReductionType>& opt_reduction,
-        std::optional<Tensor>& opt_output,
         const QueueId& queue_id = DefaultQueueId);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation_types.hpp
@@ -20,7 +20,6 @@ struct tensor_args_t {
     const Tensor& input_tensor;
     const Tensor& index_tensor;
     const Tensor& src_tensor;
-    std::optional<Tensor> opt_output;
 };
 
 using spec_return_value_t = TensorSpec;

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_program_factory.cpp
@@ -201,10 +201,12 @@ void ScatterProgramFactory::override_runtime_arguments(
     auto source_buffer_address = tensor_args.src_tensor.buffer()->address();
     auto output_buffer_address = output_tensor.buffer()->address();
     for (const auto& core : cores) {
-        GetRuntimeArgs(program, reader_kernel_id, core)[0] = input_buffer_address;
-        GetRuntimeArgs(program, reader_kernel_id, core)[1] = index_buffer_address;
-        GetRuntimeArgs(program, reader_kernel_id, core)[2] = source_buffer_address;
-        GetRuntimeArgs(program, writer_kernel_id, core)[0] = output_buffer_address;
+        auto& reader_runtime_args  = GetRuntimeArgs(program, reader_kernel_id, core);
+        auto& writer_runtime_args  = GetRuntimeArgs(program, reader_kernel_id, core);
+        reader_runtime_args[0] = input_buffer_address;
+        reader_runtime_args[1] = index_buffer_address;
+        reader_runtime_args[2] = source_buffer_address;
+        writer_runtime_args[0] = output_buffer_address;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_program_factory.cpp
@@ -12,6 +12,16 @@
 
 namespace ttnn::operations::experimental::scatter {
 
+namespace {
+constexpr uint32_t BIT_MASK_32 = 32 - 1;
+
+uint32_t ceil32(const uint32_t& number) {
+    return ((number & BIT_MASK_32) == 0) ? number : ((number | BIT_MASK_32) + 1);
+}
+
+bool is_pow2_min32(const uint32_t& number) { return ((number & (number - 1)) == 0) && number >= 32; }
+}  // namespace
+
 ScatterProgramFactory::cached_program_t ScatterProgramFactory::create(
     const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {
     using namespace tt::tt_metal;
@@ -20,24 +30,20 @@ ScatterProgramFactory::cached_program_t ScatterProgramFactory::create(
     Program program{};
 
     const auto& input_tensor{tensor_args.input_tensor};
-    const auto& input_shape{input_tensor.padded_shape()};
+    const auto& input_shape{input_tensor.logical_shape()};
     const auto& input_rank{input_shape.rank()};
     const auto& index_tensor{tensor_args.index_tensor};
-    const auto& index_shape{index_tensor.padded_shape()};
+    const auto& index_shape{index_tensor.logical_shape()};
     const auto& index_rank{index_shape.rank()};
     const auto& src_tensor{tensor_args.src_tensor};
-    const auto& src_shape{src_tensor.padded_shape()};
+    const auto& src_shape{src_tensor.logical_shape()};
     const auto& src_rank{src_shape.rank()};
+    const auto& output_shape{output_tensor.logical_shape()};
 
     const tt::DataFormat input_tensor_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     const tt::DataFormat index_tensor_cb_data_format = datatype_to_dataformat_converter(index_tensor.dtype());
     const tt::DataFormat src_tensor_cb_data_format = datatype_to_dataformat_converter(src_tensor.dtype());
     const tt::DataFormat output_tensor_cb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
-
-    const uint32_t input_tensor_tile_size = tile_size(input_tensor_cb_data_format);
-    const uint32_t index_tensor_tile_size = tile_size(index_tensor_cb_data_format);
-    const uint32_t src_tensor_tile_size = tile_size(src_tensor_cb_data_format);
-    const uint32_t output_tensor_tile_size = tile_size(output_tensor_cb_data_format);
 
     auto input_buffer = input_tensor.buffer();
     auto index_buffer = index_tensor.buffer();
@@ -49,51 +55,62 @@ ScatterProgramFactory::cached_program_t ScatterProgramFactory::create(
     const uint32_t src_tensor_is_dram = src_buffer->buffer_type() == BufferType::DRAM;
     const uint32_t output_tensor_is_dram = output_buffer->buffer_type() == BufferType::DRAM;
 
-    const uint32_t num_input_tiles = input_tensor.physical_volume() / TILE_HW;
-    const uint32_t num_index_tiles = index_tensor.physical_volume() / TILE_HW;
-    const uint32_t num_src_tiles = src_tensor.physical_volume() / TILE_HW;
-    const uint32_t num_output_tiles = output_tensor.physical_volume() / TILE_HW;
-
-    const uint32_t logical_index_height = index_shape[0] * index_shape[1] * index_shape[2];
-    const uint32_t Ht = (input_shape[0] * input_shape[1] * input_shape[2]) / TILE_HEIGHT;
-    const uint32_t Wt_input = input_shape[3] / TILE_WIDTH;
-    const uint32_t Wt_index = index_shape[3] / TILE_WIDTH;
-
     const int32_t dim{(args.dim >= 0) ? args.dim : (input_rank + args.dim)};
 
     auto device = input_tensor.device();
     const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     const uint32_t total_number_of_cores = compute_with_storage_grid_size.y * compute_with_storage_grid_size.x;
 
-    const uint32_t all_core_utilization_loop_count = Ht / total_number_of_cores;
-    const uint32_t all_core_utilization_loop_remainder = Ht % total_number_of_cores;
+    const uint32_t& input_stick_size = input_shape[-1];
+    const uint32_t& index_stick_size = index_shape[-1];
+    const uint32_t& source_stick_size = src_shape[-1];
+    const uint32_t& output_stick_size = output_shape[-1];
 
-    const CoreCoord core{0, 0};
-
-    auto grid{device->compute_with_storage_grid_size()};
+    // TODO(jbbieniekTT): logical or padded volume?
+    const uint32_t work_units = input_tensor.logical_volume() / input_stick_size;
     const auto
-        [num_cores, all_cores, core_group_1, core_group_2, num_cols_per_core_group_1, num_cols_per_core_group_2] =
-            tt::tt_metal::split_work_to_cores(grid, Ht);
+        [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, work_units);
 
-    constexpr uint32_t NUM_CB_TILE_UNITS = 2;
-    constexpr uint32_t ONE_TILE = 1;
+    const uint32_t& input_datum_size = input_tensor.element_size();
+    const uint32_t& index_datum_size = index_tensor.element_size();
+    const uint32_t& source_datum_size = src_tensor.element_size();
+    const uint32_t& output_datum_size = output_tensor.element_size();
 
-    const uint32_t input_tiles = NUM_CB_TILE_UNITS * ONE_TILE;
-    const uint32_t index_tiles = NUM_CB_TILE_UNITS * ONE_TILE;
-    const uint32_t src_tiles = NUM_CB_TILE_UNITS * ONE_TILE;
-    const uint32_t out_tiles = NUM_CB_TILE_UNITS * ONE_TILE;
+    const uint32_t& input_stick_size_bytes = input_shape[-1] * input_datum_size;
+    const uint32_t& index_stick_size_bytes = index_shape[-1] * index_datum_size;
+    const uint32_t& source_stick_size_bytes = src_shape[-1] * source_datum_size;
+    const uint32_t& output_stick_size_bytes = output_shape[-1] * output_datum_size;
 
-    auto cb_input{create_cb(program, input_tensor.dtype(), ScatterCB::INPUT, all_cores, input_tiles)};
-    auto cb_index{create_cb(program, index_tensor.dtype(), ScatterCB::INDEX, all_cores, index_tiles)};
-    auto cb_src{create_cb(program, src_tensor.dtype(), ScatterCB::SRC, all_cores, src_tiles)};
-    auto cb_dst{create_cb(program, output_tensor.dtype(), ScatterCB::DST, all_cores, out_tiles)};
+    // pad pages to 32
+    const uint32_t input_page_size_bytes = ceil32(input_stick_size) * input_datum_size;
+    const uint32_t index_page_size_bytes = ceil32(index_stick_size) * index_datum_size;
+    const uint32_t source_page_size_bytes = ceil32(source_stick_size) * source_datum_size;
+    const uint32_t output_page_size_bytes = ceil32(output_stick_size) * output_datum_size;
+
+    const uint32_t is_input_stick_size_bytes_pow2_min_32 = is_pow2_min32(input_stick_size_bytes);
+    const uint32_t is_index_stick_size_bytes_pow2_min_32 = is_pow2_min32(index_stick_size_bytes);
+    const uint32_t is_source_stick_size_bytes_pow2_min_32 = is_pow2_min32(source_stick_size_bytes);
+    const uint32_t is_output_stick_size_bytes_pow2_min_32 = is_pow2_min32(output_stick_size_bytes);
+
+    const uint32_t input_stick_size_bytes_log2 =
+        is_input_stick_size_bytes_pow2_min_32 ? std::log2(input_stick_size_bytes) : 0;
+    const uint32_t index_stick_size_bytes_log2 =
+        is_index_stick_size_bytes_pow2_min_32 ? std::log2(index_stick_size_bytes) : 0;
+    const uint32_t source_stick_size_bytes_log2 =
+        is_source_stick_size_bytes_pow2_min_32 ? std::log2(source_stick_size_bytes) : 0;
+    const uint32_t output_stick_size_bytes_log2 =
+        is_output_stick_size_bytes_pow2_min_32 ? std::log2(output_stick_size_bytes) : 0;
+
+    auto cb_input{create_cb(program, input_tensor.get_dtype(), ScatterCB::INPUT, all_cores, input_page_size_bytes)};
+    auto cb_index{create_cb(program, index_tensor.get_dtype(), ScatterCB::INDEX, all_cores, index_page_size_bytes)};
+    auto cb_src{create_cb(program, src_tensor.get_dtype(), ScatterCB::SRC, all_cores, source_page_size_bytes)};
+    auto cb_dst{create_cb(program, output_tensor.get_dtype(), ScatterCB::DST, all_cores, output_page_size_bytes)};
 
     constexpr const char* reader_kernel_path =
         "ttnn/cpp/ttnn/operations/experimental/scatter/device/kernels/dataflow/reader_scatter.cpp";
     constexpr const char* writer_kernel_path =
         "ttnn/cpp/ttnn/operations/experimental/scatter/device/kernels/dataflow/writer_scatter.cpp";
-
-    const auto& tile_spec = input_tensor.tensor_spec().tile();
 
     const std::vector<uint32_t> compile_time_args{
         {input_tensor_is_dram,
@@ -108,68 +125,91 @@ ScatterProgramFactory::cached_program_t ScatterProgramFactory::create(
          static_cast<uint32_t>(ScatterCB::INDEX),
          static_cast<uint32_t>(ScatterCB::SRC),
          static_cast<uint32_t>(ScatterCB::DST),
-         Wt_input,
-         index_tensor.logical_shape()[-1],
-         logical_index_height,
-         tile_spec.get_width() / tile_spec.get_face_shape()[1],
-         tile_spec.get_height() / tile_spec.get_face_shape()[0],
-         Wt_index,
-         input_tensor.logical_shape()[-2],
-         Ht,
-         total_number_of_cores,
-         compute_with_storage_grid_size.x,
-         tile_spec.get_height(),
-         tile_spec.get_width(),
-         tile_spec.get_face_shape()[0],
-         tile_spec.get_face_shape()[1]}};
+         input_stick_size,
+         index_stick_size,
+         source_stick_size,
+         output_stick_size,
+         input_stick_size_bytes,
+         index_stick_size_bytes,
+         source_stick_size_bytes,
+         output_stick_size_bytes,
+         input_stick_size_bytes_log2,
+         index_stick_size_bytes_log2,
+         source_stick_size_bytes_log2,
+         output_stick_size_bytes_log2,
+         is_input_stick_size_bytes_pow2_min_32,
+         is_index_stick_size_bytes_pow2_min_32,
+         is_source_stick_size_bytes_pow2_min_32,
+         is_output_stick_size_bytes_pow2_min_32}};
 
     auto reader_kernel =
         create_kernel(program, reader_kernel_path, all_cores, ReaderDataMovementConfig{compile_time_args});
     auto writer_kernel =
         create_kernel(program, writer_kernel_path, all_cores, WriterDataMovementConfig{compile_time_args});
 
+    const uint32_t& num_cores_x = compute_with_storage_grid_size.x;
     const uint32_t& num_cores_y = compute_with_storage_grid_size.y;
-    uint32_t tile_offset = 0;
+    auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y);
+    uint32_t stick_offset = 0;
     for (uint32_t i = 0; i < num_cores; ++i) {
         CoreCoord core{i / num_cores_y, i % num_cores_y};
 
-        uint32_t ht_per_core;
+        uint32_t sticks_per_core;
         if (core_group_1.contains(core)) {
-            ht_per_core = num_cols_per_core_group_1;
+            sticks_per_core = num_sticks_per_core_group_1;
         } else if (core_group_2.contains(core)) {
-            ht_per_core = num_cols_per_core_group_2;
+            sticks_per_core = num_sticks_per_core_group_2;
         } else {
             TT_THROW("Core not in any predefined core range.");
         }
 
-        SetRuntimeArgs(program, reader_kernel, core, {tile_offset, ht_per_core, tile_offset % total_number_of_cores});
+        SetRuntimeArgs(
+            program,
+            reader_kernel,
+            core,
+            {input_buffer->address(), index_buffer->address(), src_buffer->address(), stick_offset, sticks_per_core});
 
-        SetRuntimeArgs(program, writer_kernel, core, {tile_offset, ht_per_core});
+        SetRuntimeArgs(program, writer_kernel, core, {output_buffer->address(), stick_offset, sticks_per_core});
 
-        tile_offset += ht_per_core;
+        stick_offset += sticks_per_core;
     }
 
-    return {std::move(program), {reader_kernel, writer_kernel, compute_with_storage_grid_size}};
+    return {std::move(program), {reader_kernel, writer_kernel, cores}};
 }
 
+// TODO(jbbieniekTT): do this now and merge issues or do it separately?
 void ScatterProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& args,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {}
+    tensor_return_value_t& output_tensor) {
+    const auto& program = cached_program.program;
+    const auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
+    const auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
+    const auto& cores = cached_program.shared_variables.cores;
+
+    auto input_buffer_address = tensor_args.input_tensor.buffer()->address();
+    auto index_buffer_address = tensor_args.index_tensor.buffer()->address();
+    auto source_buffer_address = tensor_args.src_tensor.buffer()->address();
+    auto output_buffer_address = output_tensor.buffer()->address();
+    for (const auto& core : cores) {
+        GetRuntimeArgs(program, reader_kernel_id, core)[0] = input_buffer_address;
+        GetRuntimeArgs(program, reader_kernel_id, core)[1] = index_buffer_address;
+        GetRuntimeArgs(program, reader_kernel_id, core)[2] = source_buffer_address;
+        GetRuntimeArgs(program, writer_kernel_id, core)[0] = output_buffer_address;
+    }
+}
 
 CBHandle ScatterProgramFactory::create_cb(
     Program& program,
     const DataType& dtype,
     const ScatterCB& scatter_cb,
     const CoreRangeSet& core_range_set,
-    const uint32_t& num_tiles) {
-    using tt::tt_metal::detail::TileSize;
+    const uint32_t& page_size_bytes) {
     const uint32_t cb_id{static_cast<uint32_t>(scatter_cb)};
     const auto cb_data_format{datatype_to_dataformat_converter(dtype)};
-    const uint32_t single_tile_size{TileSize(cb_data_format)};
-    const auto cb_config{CircularBufferConfig{num_tiles * single_tile_size, {{cb_id, cb_data_format}}}.set_page_size(
-        cb_id, single_tile_size)};
+    const auto cb_config{
+        CircularBufferConfig{2 * page_size_bytes, {{cb_id, cb_data_format}}}.set_page_size(cb_id, page_size_bytes)};
     return CreateCircularBuffer(program, core_range_set, cb_config);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_program_factory.hpp
@@ -30,7 +30,7 @@ struct ScatterProgramFactory {
     struct shared_variables_t {
         KernelHandle reader_kernel_id;
         KernelHandle writer_kernel_id;
-        CoreCoord storage_grid_size;
+        std::vector<CoreCoord> cores;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.cpp
@@ -20,39 +20,12 @@ namespace ttnn::operations::experimental {
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 
-void check_if_bad_dim_or_shape(
+void validate_inputs(
     const Tensor& input_tensor,
     const Tensor& index_tensor,
     const Tensor& source_tensor,
     const int32_t& dim,
     const std::optional<Tensor>& output_tensor) {
-    // if (tensor_args.opt_output.has_value()) {
-    //     const auto& output_tensor{tensor_args.opt_output.value()};
-    //     const auto& output_shape{output_tensor.logical_shape()};
-    //     const auto& output_rank{output_shape.rank()};
-    //     const auto& output_dtype{output_tensor.dtype()};
-
-    //     TT_FATAL(
-    //         input_shape == output_shape,
-    //         "The shapes of input and output tensors must be equal (input_shape: {}, output_shape: {}).",
-    //         input_shape,
-    //         output_shape);
-
-    //     TT_FATAL(
-    //         input_dtype == output_dtype,
-    //         "input_dtype and output_dtype must be the same (input_dtype: {}, output_dtype: {})",
-    //         magic_enum::enum_name(input_dtype),
-    //         magic_enum::enum_name(output_dtype));
-
-    //     TT_FATAL(
-    //         output_tensor.get_layout() == input_tensor.get_layout(),
-    //         "Output tensor's and input tensor's layouts must be the same.");
-    //     TT_FATAL(output_tensor.buffer() != nullptr, "Output tensor's buffer is null.");
-    //     TT_FATAL(output_tensor.storage_type() == StorageType::DEVICE, "Output tensor must be allocated on a
-    //     device."); TT_FATAL(!output_tensor.is_sharded(), "Sharded tensors are not supported - output_tensor is
-    //     sharded.");
-    // }
-
     const int32_t normalized_dim{(dim < 0) ? (dim + input_tensor.padded_shape().rank()) : dim};
 
     const auto& input_dtype{input_tensor.dtype()};
@@ -226,7 +199,7 @@ Tensor ScatterOperation::invoke(
     const ttnn::Shape original_input_tensor_lshape = input_tensor.logical_shape();
     const auto input_tensor_rank = input_tensor.padded_shape().rank();
 
-    CMAKE_UNIQUE_NAMESPACE::check_if_bad_dim_or_shape(input_tensor, index_tensor, source_tensor, dim, opt_output);
+    CMAKE_UNIQUE_NAMESPACE::validate_inputs(input_tensor, index_tensor, source_tensor, dim, opt_output);
 
     const auto original_index_tensor_lshape = index_tensor.logical_shape();
     if (original_input_tensor_lshape == ttnn::Shape{} || original_index_tensor_lshape == ttnn::Shape{}) {

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.cpp
@@ -20,6 +20,80 @@ namespace ttnn::operations::experimental {
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 
+void check_if_bad_dim_or_shape(
+    const Tensor& input_tensor,
+    const Tensor& index_tensor,
+    const Tensor& source_tensor,
+    const int32_t& dim,
+    const std::optional<Tensor>& output_tensor) {
+    // if (tensor_args.opt_output.has_value()) {
+    //     const auto& output_tensor{tensor_args.opt_output.value()};
+    //     const auto& output_shape{output_tensor.logical_shape()};
+    //     const auto& output_rank{output_shape.rank()};
+    //     const auto& output_dtype{output_tensor.dtype()};
+
+    //     TT_FATAL(
+    //         input_shape == output_shape,
+    //         "The shapes of input and output tensors must be equal (input_shape: {}, output_shape: {}).",
+    //         input_shape,
+    //         output_shape);
+
+    //     TT_FATAL(
+    //         input_dtype == output_dtype,
+    //         "input_dtype and output_dtype must be the same (input_dtype: {}, output_dtype: {})",
+    //         magic_enum::enum_name(input_dtype),
+    //         magic_enum::enum_name(output_dtype));
+
+    //     TT_FATAL(
+    //         output_tensor.get_layout() == input_tensor.get_layout(),
+    //         "Output tensor's and input tensor's layouts must be the same.");
+    //     TT_FATAL(output_tensor.buffer() != nullptr, "Output tensor's buffer is null.");
+    //     TT_FATAL(output_tensor.storage_type() == StorageType::DEVICE, "Output tensor must be allocated on a
+    //     device."); TT_FATAL(!output_tensor.is_sharded(), "Sharded tensors are not supported - output_tensor is
+    //     sharded.");
+    // }
+
+    const int32_t normalized_dim{(dim < 0) ? (dim + input_tensor.padded_shape().rank()) : dim};
+
+    const auto& input_dtype{input_tensor.dtype()};
+    const auto& index_dtype{index_tensor.dtype()};
+    const auto& src_dtype{source_tensor.dtype()};
+    const auto& input_shape{input_tensor.logical_shape()};
+    const auto& index_shape{index_tensor.logical_shape()};
+    const auto& src_shape{source_tensor.logical_shape()};
+    const uint32_t input_rank{input_shape.rank()};
+    const uint32_t index_rank{index_shape.rank()};
+    const uint32_t src_rank{src_shape.rank()};
+
+    TT_FATAL(
+        dim < static_cast<int32_t>(input_rank) && -static_cast<int32_t>(input_rank) <= dim,
+        "dim must follow the condition -input_rank <= dim < input_rank (dim: {}, rank: {}).",
+        dim,
+        static_cast<int32_t>(input_rank));
+
+    for (uint32_t probe_dim = 0; probe_dim < input_tensor.logical_shape().rank(); ++probe_dim) {
+        if (probe_dim != normalized_dim) {
+            TT_FATAL(
+                index_shape[probe_dim] == input_shape[probe_dim],
+                "Index tensor has other dimension {}'s length than input shape's (index dimension: {}, "
+                "input_dimension: "
+                "{}).",
+                probe_dim,
+                index_shape[probe_dim],
+                input_shape[probe_dim]);
+        }
+    }
+
+    if (output_tensor.has_value()) {
+        TT_FATAL(
+            input_shape == output_tensor->logical_shape(),
+            "Provided output tensor's logical shape is different from input tensor's (input shape: {}, output shape: "
+            "{})",
+            input_shape,
+            output_tensor->logical_shape());
+    }
+}
+
 Tensor pre_scatter_transform_tensor(
     const Tensor& input_tensor, const int8_t dim, const bool is_dim_last_idx, const bool is_rank_le_4d) {
     if (input_tensor.logical_shape() == ttnn::Shape{1} || input_tensor.logical_shape() == ttnn::Shape{0}) {
@@ -34,6 +108,30 @@ Tensor pre_scatter_transform_tensor(
     }
     // transposing a row-major tensor here
     processed_tensor = reduction_common::perform_transpose(processed_tensor, is_dim_last_idx, dim, -1);
+    processed_tensor = reduction_common::transform_to_4d_tensor(processed_tensor, is_rank_le_4d);
+
+    return processed_tensor;
+}
+
+Tensor pre_scatter_transform_tensor(
+    const Tensor& input_tensor,
+    Shape& after_transpose_shape,
+    const int8_t dim,
+    const bool is_dim_last_idx,
+    const bool is_rank_le_4d) {
+    if (input_tensor.logical_shape() == ttnn::Shape{1} || input_tensor.logical_shape() == ttnn::Shape{0}) {
+        return input_tensor;
+    }
+
+    Tensor processed_tensor = input_tensor;
+    // if layout is tile, convert to row-major first - this allows for minimized memory usage by transpose (no padding)
+    if (processed_tensor.layout() != Layout::ROW_MAJOR) {
+        processed_tensor =
+            ttnn::to_layout(input_tensor, Layout::ROW_MAJOR, std::nullopt, std::nullopt, input_tensor.device());
+    }
+    // transposing a row-major tensor here
+    processed_tensor = reduction_common::perform_transpose(processed_tensor, is_dim_last_idx, dim, -1);
+    after_transpose_shape = processed_tensor.logical_shape();
     processed_tensor = reduction_common::transform_to_4d_tensor(processed_tensor, is_rank_le_4d);
 
     return processed_tensor;
@@ -76,6 +174,43 @@ Tensor post_scatter_transform_tensor(
     return output_tensor;
 }
 
+Tensor post_scatter_transform_tensor(
+    Tensor& output_tensor,
+    const Shape& after_transpose_shape,
+    const int32_t dim,
+    const bool is_dim_last_idx,
+    const Shape& original_logical_shape,
+    const Layout& original_layout) {
+    const auto orig_rank = original_logical_shape.rank();
+
+    if (orig_rank == 1) {
+        output_tensor = ttnn::reshape(output_tensor, original_logical_shape);
+    } else if (orig_rank < 4) {
+        output_tensor = ttnn::squeeze_from_4D(output_tensor, orig_rank);
+    } else if (orig_rank > 4) {
+        output_tensor = ttnn::reshape(output_tensor, after_transpose_shape);
+    }
+
+    // transposing a row-major tensor here
+    if (!is_dim_last_idx) {
+        output_tensor = ttnn::transpose(output_tensor, dim, -1, output_tensor.memory_config());
+    }
+
+    TT_FATAL(
+        output_tensor.get_logical_shape() == original_logical_shape,
+        "Output tensor transformation did not create correct output shape! Got: {}, expected: {}",
+        output_tensor.get_logical_shape(),
+        original_logical_shape);
+
+    // if the output tensor's original layout is not row-major, convert the output tensor back
+    if (original_layout != Layout::ROW_MAJOR) {
+        output_tensor =
+            ttnn::to_layout(output_tensor, original_layout, std::nullopt, std::nullopt, output_tensor.device());
+    }
+
+    return output_tensor;
+}
+
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
@@ -91,6 +226,8 @@ Tensor ScatterOperation::invoke(
     const ttnn::Shape original_input_tensor_lshape = input_tensor.logical_shape();
     const auto input_tensor_rank = input_tensor.padded_shape().rank();
 
+    CMAKE_UNIQUE_NAMESPACE::check_if_bad_dim_or_shape(input_tensor, index_tensor, source_tensor, dim, opt_output);
+
     const auto original_index_tensor_lshape = index_tensor.logical_shape();
     if (original_input_tensor_lshape == ttnn::Shape{} || original_index_tensor_lshape == ttnn::Shape{}) {
         return input_tensor;
@@ -101,21 +238,15 @@ Tensor ScatterOperation::invoke(
     const bool input_tensor_is_dim_last_idx = (dim == -1 || dim == input_tensor_rank - 1);
     const bool input_tensor_is_rank_le_4d = input_tensor_rank <= 4;
 
+    Shape after_transpose_shape;
+    Tensor transformed_input_tensor = CMAKE_UNIQUE_NAMESPACE::pre_scatter_transform_tensor(
+        input_tensor, after_transpose_shape, dim, input_tensor_is_dim_last_idx, input_tensor_is_rank_le_4d);
+
     Tensor transformed_index_tensor = CMAKE_UNIQUE_NAMESPACE::pre_scatter_transform_tensor(
         index_tensor, dim, input_tensor_is_dim_last_idx, input_tensor_is_rank_le_4d);
 
     Tensor transformed_source_tensor = CMAKE_UNIQUE_NAMESPACE::pre_scatter_transform_tensor(
         source_tensor, dim, input_tensor_is_dim_last_idx, input_tensor_is_rank_le_4d);
-
-    Tensor transformed_input_tensor = CMAKE_UNIQUE_NAMESPACE::pre_scatter_transform_tensor(
-        input_tensor, dim, input_tensor_is_dim_last_idx, input_tensor_is_rank_le_4d);
-
-    Layout original_output_layout;
-    if (opt_output.has_value()) {
-        original_output_layout = opt_output.value().layout();
-        *opt_output = CMAKE_UNIQUE_NAMESPACE::pre_scatter_transform_tensor(
-            *opt_output, dim, input_tensor_is_dim_last_idx, input_tensor_is_rank_le_4d);
-    }
 
     const MemoryConfig final_memory_config{
         output_memory_config.has_value()
@@ -131,14 +262,17 @@ Tensor ScatterOperation::invoke(
         std::nullopt,
         opt_output,
         queue_id);
+    output = CMAKE_UNIQUE_NAMESPACE::post_scatter_transform_tensor(
+        output,
+        after_transpose_shape,
+        dim,
+        input_tensor_is_dim_last_idx,
+        original_input_tensor_lshape,
+        original_layout);
     if (opt_output.has_value()) {
         ttnn::copy(output, *opt_output);
-        *opt_output = CMAKE_UNIQUE_NAMESPACE::post_scatter_transform_tensor(
-            *opt_output, dim, input_tensor_is_dim_last_idx, original_input_tensor_lshape, original_output_layout);
-        return *opt_output;
     }
-    return CMAKE_UNIQUE_NAMESPACE::post_scatter_transform_tensor(
-        output, dim, input_tensor_is_dim_last_idx, original_input_tensor_lshape, original_layout);
+    return output;
 }
 
 }  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.hpp
@@ -22,8 +22,7 @@ struct ScatterOperation {
         const Tensor& index_tensor,
         const Tensor& source_tensor,
         const std::optional<MemoryConfig>& opt_out_memory_config,
-        const std::optional<scatter::ScatterReductionType>& opt_reduction,
-        std::optional<Tensor>& opt_output);
+        const std::optional<scatter::ScatterReductionType>& opt_reduction);
 };
 
 }  // namespace operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter_enums.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter_enums.hpp
@@ -16,4 +16,9 @@ using namespace tt;
 
 enum class ScatterReductionType : uint8_t { ADD, MULTIPLY, AMIN, AMAX };
 
+enum class ProcessingMode : uint8_t {
+    FULL_ROW_PROCESSING,
+    SPLIT_ROW_PROCESSING
+};
+
 }  // namespace ttnn::operations::experimental::scatter

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter_enums.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter_enums.hpp
@@ -16,9 +16,4 @@ using namespace tt;
 
 enum class ScatterReductionType : uint8_t { ADD, MULTIPLY, AMIN, AMAX };
 
-enum class ProcessingMode : uint8_t {
-    FULL_ROW_PROCESSING,
-    SPLIT_ROW_PROCESSING
-};
-
 }  // namespace ttnn::operations::experimental::scatter

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter_pybind.cpp
@@ -27,7 +27,6 @@ void bind_scatter_operation(py::module& module) {
             Keyword Arguments:
                 * `reduce` (ScatterReductionType, optional): currently not supported - this is the option to reduce numbers going to the same destination in output with a function like `amax`, `amin`, `sum`, etc.
                 * `memory_config` (MemoryConfig, optional): Specifies the memory configuration for the output tensor. Defaults to `None`.
-                * `out` (Tensor, optional): Preallocated output tensor where scatter result should go to (should be the same shape as the input tensor). Defaults to `None`.
 
             Additional info:
                 * Up until this time, no reductions have been implemented.
@@ -69,7 +68,6 @@ void bind_scatter_operation(py::module& module) {
                const ttnn::Tensor& source_tensor,
                const std::optional<tt::tt_metal::MemoryConfig>& opt_out_memory_config,
                const std::optional<experimental::scatter::ScatterReductionType>& opt_reduction,
-               std::optional<ttnn::Tensor>& opt_output,
                const QueueId& queue_id = DefaultQueueId) -> Tensor {
                 return self(
                     queue_id,
@@ -78,8 +76,7 @@ void bind_scatter_operation(py::module& module) {
                     index_tensor,
                     source_tensor,
                     opt_out_memory_config,
-                    opt_reduction,
-                    opt_output);
+                    opt_reduction);
             },
             py::arg("input").noconvert(),
             py::arg("dim"),
@@ -88,7 +85,6 @@ void bind_scatter_operation(py::module& module) {
             py::kw_only(),
             py::arg("reduce") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("out") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
 


### PR DESCRIPTION
### Ticket
#22926

### Problem description
`ttnn.experimental.scatter_` takes way too much time/memory for pre-/post-processing

### What's changed
- converting input tensors into row-major
- suited kernels
- improved test cases

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes