### PR TITLE
[DM]: Reintroducing BH profiler quick push

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -837,6 +837,7 @@ inline void noc_async_write_multicast(
         noc_async_write_multicast_one_packet(src_local_l1_addr, dst_noc_addr_multicast, size, num_dests, linked);
     } else {
         WAYPOINT("NMWW");
+        NOC_TRACE_QUICK_PUSH_IF_LINKED(write_cmd_buf, linked);
         DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size);
         ncrisc_noc_fast_write_any_len<noc_mode>(
             noc,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22578)

### Problem description
The quick push fix, introduced [here](https://github.com/tenstorrent/tt-metal/pull/23349), for the BH profiler hang was removed in this PR: https://github.com/tenstorrent/tt-metal/pull/23076

### What's changed
This PR reintroduces the quick push.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15589134879) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15589137212) CI with demo tests passes (if applicable)