### PR TITLE
Improve CNN model device performance test times

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -21,16 +21,7 @@ from models.experimental.functional_unet.tests.common import (
 )
 
 
-@pytest.mark.parametrize("batch", [1])
-@pytest.mark.parametrize("groups", [4])
-@pytest.mark.parametrize("device_params", [{"l1_small_size": UNET_L1_SMALL_REGION_SIZE}], indirect=True)
-def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
-    if (
-        not is_wormhole_b0(device)
-        and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 110
-    ):
-        pytest.skip(f"Shallow UNet only support 110 cores on BH (was {device.compute_with_storage_grid_size()})")
-
+def run_unet_model(batch, groups, device, iterations=1):
     torch_input, ttnn_input = create_unet_input_tensors(
         batch,
         groups,
@@ -46,7 +37,7 @@ def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
 
     torch_output_tensor = model(torch_input)
-    output_tensor = ttnn_model(ttnn_input, move_input_tensor_to_device=False)
+    output_tensor = ttnn_model(ttnn_input, move_input_tensor_to_device=False, deallocate_input_activation=True).cpu()
 
     B, C, H, W = torch_output_tensor.shape
     ttnn_output_tensor = ttnn.to_torch(output_tensor).reshape(B, C, H, W)
@@ -55,3 +46,28 @@ def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
         ttnn_output_tensor,
         UNET_FULL_MODEL_PCC if is_wormhole_b0(device) else UNET_FULL_MODEL_PCC_BH,
     )
+
+    for _ in range(iterations - 1):
+        _, ttnn_input = create_unet_input_tensors(
+            batch,
+            groups,
+            channel_order="first",
+            pad=False,
+            fold=True,
+            device=device,
+            memory_config=unet_shallow_ttnn.UNet.input_sharded_memory_config,
+        )
+        ttnn_model(ttnn_input, move_input_tensor_to_device=False, deallocate_input_activation=True).cpu()
+        ttnn.DumpDeviceProfiler(device)
+
+
+@pytest.mark.parametrize("batch", [1])
+@pytest.mark.parametrize("groups", [4])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": UNET_L1_SMALL_REGION_SIZE}], indirect=True)
+def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
+    if (
+        not is_wormhole_b0(device)
+        and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 110
+    ):
+        pytest.skip(f"Shallow UNet only support 110 cores on BH (was {device.compute_with_storage_grid_size()})")
+    run_unet_model(batch, groups, device)

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -15,27 +15,43 @@ from models.utility_functions import (
 )
 
 from models.experimental.functional_unet.tests.common import UNET_TRACE_REGION_SIZE, UNET_L1_SMALL_REGION_SIZE
+from models.experimental.functional_unet.tests.test_unet_model import run_unet_model
+
+UNET_DEVICE_TEST_TOTAL_ITERATIONS = 8
+
+
+@pytest.mark.parametrize("batch", [1])
+@pytest.mark.parametrize("groups", [4])
+@pytest.mark.parametrize("iterations", [UNET_DEVICE_TEST_TOTAL_ITERATIONS])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": UNET_L1_SMALL_REGION_SIZE}], indirect=True)
+def test_unet_model(batch, groups, device, iterations, use_program_cache, reset_seeds):
+    if (
+        not is_wormhole_b0(device)
+        and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 110
+    ):
+        pytest.skip(f"Shallow UNet only support 110 cores on BH (was {device.compute_with_storage_grid_size()})")
+    run_unet_model(batch, groups, device, iterations)
 
 
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1420.0),),
+    ((1, 4, 1410.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
-    command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"
+    command = f"pytest models/experimental/functional_unet/tests/test_unet_perf.py::test_unet_model"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
-    total_batch = groups * batch
+    total_batch = groups * batch * UNET_DEVICE_TEST_TOTAL_ITERATIONS
 
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
     post_processed_results = run_device_perf(
-        command, subdir="unet_shallow", num_iterations=3, cols=cols, batch_size=total_batch
+        command, subdir="unet_shallow", num_iterations=1, cols=cols, batch_size=total_batch
     )
     expected_perf_cols = {inference_time_key: expected_device_perf_fps}
     expected_results = check_device_perf(
-        post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
+        post_processed_results, margin=0.005, expected_perf_cols=expected_perf_cols, assert_on_fail=True
     )
     prep_device_perf_report(
         model_name=f"unet-shallow_batch-{batch}_groups-{groups}",

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
@@ -68,26 +68,16 @@ def prepare_ttnn_tensors(
     return ttnn_input_tensor, [B, C, H, W], ttnn_timestep_tensor, ttnn_encoder_tensor, ttnn_added_cond_kwargs
 
 
-@pytest.mark.parametrize(
-    "input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape",
-    [
-        ((1, 4, 128, 128), (1,), (1, 77, 2048), (1, 1280), (1, 6)),
-    ],
-)
-@pytest.mark.parametrize("conv_weights_dtype", [ttnn.bfloat16])
-@pytest.mark.parametrize("transformer_weights_dtype", [ttnn.bfloat16])
-@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_unet(
+def run_unet_model(
     device,
     input_shape,
     timestep_shape,
     encoder_shape,
     temb_shape,
     time_ids_shape,
-    use_program_cache,
-    reset_seeds,
     conv_weights_dtype,
     transformer_weights_dtype,
+    iterations=1,
 ):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
@@ -132,7 +122,6 @@ def test_unet(
     ) = prepare_ttnn_tensors(
         device, torch_input_tensor, torch_timestep_tensor, torch_temb_tensor, torch_encoder_tensor, torch_time_ids
     )
-
     ttnn_output_tensor, output_shape = tt_unet.forward(
         ttnn_input_tensor,
         [B, C, H, W],
@@ -141,12 +130,76 @@ def test_unet(
         added_cond_kwargs=ttnn_added_cond_kwargs,
     )
 
-    output_tensor = ttnn.to_torch(ttnn_output_tensor)
+    output_tensor = ttnn.to_torch(ttnn_output_tensor.cpu())
     output_tensor = output_tensor.reshape(B, output_shape[1], output_shape[2], output_shape[0])
     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    ttnn.deallocate(ttnn_input_tensor)
+    ttnn.deallocate(ttnn_output_tensor)
+    ttnn.deallocate(ttnn_timestep_tensor)
+    ttnn.deallocate(ttnn_encoder_tensor)
+
+    ttnn.DumpDeviceProfiler(device)
+
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.995)
+    logger.info(f"PCC of first iteration is: {pcc_message}")
+
+    for _ in range(iterations - 1):
+        (
+            ttnn_input_tensor,
+            [B, C, H, W],
+            ttnn_timestep_tensor,
+            ttnn_encoder_tensor,
+            ttnn_added_cond_kwargs,
+        ) = prepare_ttnn_tensors(
+            device, torch_input_tensor, torch_timestep_tensor, torch_temb_tensor, torch_encoder_tensor, torch_time_ids
+        )
+        ttnn_output_tensor, output_shape = tt_unet.forward(
+            ttnn_input_tensor,
+            [B, C, H, W],
+            timestep=ttnn_timestep_tensor,
+            encoder_hidden_states=ttnn_encoder_tensor,
+            added_cond_kwargs=ttnn_added_cond_kwargs,
+        )
+        ttnn.deallocate(ttnn_input_tensor)
+        ttnn.deallocate(ttnn_output_tensor)
+        ttnn.deallocate(ttnn_timestep_tensor)
+        ttnn.deallocate(ttnn_encoder_tensor)
+
+        ttnn.DumpDeviceProfiler(device)
 
     del unet
     gc.collect()
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.995)
-    logger.info(f"PCC is: {pcc_message}")
+
+@pytest.mark.parametrize(
+    "input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape",
+    [
+        ((1, 4, 128, 128), (1,), (1, 77, 2048), (1, 1280), (1, 6)),
+    ],
+)
+@pytest.mark.parametrize("conv_weights_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("transformer_weights_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+def test_unet(
+    device,
+    input_shape,
+    timestep_shape,
+    encoder_shape,
+    temb_shape,
+    time_ids_shape,
+    conv_weights_dtype,
+    transformer_weights_dtype,
+    use_program_cache,
+    reset_seeds,
+):
+    run_unet_model(
+        device,
+        input_shape,
+        timestep_shape,
+        encoder_shape,
+        temb_shape,
+        time_ids_shape,
+        conv_weights_dtype,
+        transformer_weights_dtype,
+    )

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -51,7 +51,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_fps = 2.15
+    expected_device_perf_cycles_per_iteration = 387473640
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
@@ -59,11 +59,13 @@ def test_sdxl_unet_perf_device():
     batch_size = 1
     total_batch_size = batch_size * UNET_DEVICE_TEST_TOTAL_ITERATIONS
 
-    inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
+    inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
     post_processed_results = run_device_perf(
         command, subdir="sdxl_unet", num_iterations=1, cols=cols, batch_size=total_batch_size
     )
-    expected_perf_cols = {inference_time_key: expected_device_perf_fps}
+    expected_perf_cols = {
+        inference_time_key: expected_device_perf_cycles_per_iteration * UNET_DEVICE_TEST_TOTAL_ITERATIONS
+    }
     expected_results = check_device_perf(
         post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
     )

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -3,24 +3,74 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+import ttnn
+
 from models.perf.device_perf_utils import run_device_perf, check_device_perf, prep_device_perf_report
+
+from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
+from models.experimental.stable_diffusion_xl_base.tests.pcc.test_module_tt_unet import run_unet_model
+
+UNET_DEVICE_TEST_TOTAL_ITERATIONS = 3
+
+
+@pytest.mark.parametrize(
+    "input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape",
+    [
+        ((1, 4, 128, 128), (1,), (1, 77, 2048), (1, 1280), (1, 6)),
+    ],
+)
+@pytest.mark.parametrize("conv_weights_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("transformer_weights_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+@pytest.mark.parametrize("iterations", [UNET_DEVICE_TEST_TOTAL_ITERATIONS])
+def test_unet(
+    device,
+    input_shape,
+    timestep_shape,
+    encoder_shape,
+    temb_shape,
+    time_ids_shape,
+    conv_weights_dtype,
+    transformer_weights_dtype,
+    iterations,
+    use_program_cache,
+    reset_seeds,
+):
+    run_unet_model(
+        device,
+        input_shape,
+        timestep_shape,
+        encoder_shape,
+        temb_shape,
+        time_ids_shape,
+        conv_weights_dtype,
+        transformer_weights_dtype,
+        iterations=iterations,
+    )
 
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    command = f"pytest tests/nightly/single_card/stable_diffusion_xl_base/test_module_tt_unet.py::test_unet[device_params0-transformer_weights_dtype0-conv_weights_dtype0-input_shape0-timestep_shape0-encoder_shape0-temb_shape0-time_ids_shape0]"
+    expected_device_perf_fps = 2.15
+
+    command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
-    inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
-    post_processed_results = run_device_perf(command, subdir="sdxl_unet", num_iterations=3, cols=cols, batch_size=1)
-    expected_perf_cols = {inference_time_key: 387473640}
+    batch_size = 1
+    total_batch_size = batch_size * UNET_DEVICE_TEST_TOTAL_ITERATIONS
+
+    inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
+    post_processed_results = run_device_perf(
+        command, subdir="sdxl_unet", num_iterations=1, cols=cols, batch_size=total_batch_size
+    )
+    expected_perf_cols = {inference_time_key: expected_device_perf_fps}
     expected_results = check_device_perf(
         post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
     )
     prep_device_perf_report(
-        model_name=f"sdxl_unet_single_iter",
-        batch_size=1,
+        model_name=f"sdxl_unet",
+        batch_size=total_batch_size,
         post_processed_results=post_processed_results,
         expected_results=expected_results,
-        comments="",
+        comments=f"iterations={UNET_DEVICE_TEST_TOTAL_ITERATIONS}",
     )


### PR DESCRIPTION
### Summary
The device performance pipeline was getting slow. This change updates Shallow UNet and SDXL tests to run iterations within the same process to eliminate the setup and teardown cost between model runs.

Shallow UNet: before=2min, after=1min
SDXL: before=13min, after=9min

### Checklist
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/15590926732