### PR TITLE
Cleanup command queue

### DIFF
--- a/tt_metal/api/tt-metalium/command_queue.hpp
+++ b/tt_metal/api/tt-metalium/command_queue.hpp
@@ -18,36 +18,19 @@ namespace tt::tt_metal {
 class Event;
 class Program;
 class Kernel;
-class SystemMemoryManager;
-class WorkerConfigBufferMgr;
 class TraceDescriptor;
+class HWCommandQueue;
 
 class CommandQueue {
 public:
     virtual ~CommandQueue() = default;
 
-    virtual const CoreCoord& virtual_enqueue_program_dispatch_core() const = 0;
-
     virtual void record_begin(const uint32_t tid, const std::shared_ptr<TraceDescriptor>& ctx) = 0;
     virtual void record_end() = 0;
 
-    virtual void reset_worker_state(
-        bool reset_launch_msg_state, uint32_t num_sub_devices, const vector_aligned<uint32_t>& go_signal_noc_data) = 0;
-
-    virtual void set_go_signal_noc_data_and_dispatch_sems(
-        uint32_t num_dispatch_sems, const vector_aligned<uint32_t>& noc_mcast_unicast_data) = 0;
-
     virtual uint32_t id() const = 0;
-    virtual std::optional<uint32_t> tid() const = 0;
-
-    virtual SystemMemoryManager& sysmem_manager() = 0;
-
-    virtual void terminate() = 0;
 
     virtual IDevice* device() = 0;
-
-    // This function is temporarily needed since MeshCommandQueue relies on the CommandQueue object
-    virtual WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) = 0;
 
     virtual void enqueue_trace(const uint32_t trace_id, bool blocking) = 0;
 
@@ -73,6 +56,11 @@ public:
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
 
     virtual void finish(tt::stl::Span<const SubDeviceId> sub_device_ids) = 0;
+
+private:
+    // Ensure only HWCommandQueue can inherit from CommandQueue.
+    CommandQueue() = default;
+    friend class HWCommandQueue;
 };
 
 struct ReadBufferDescriptor;

--- a/tt_metal/api/tt-metalium/program.hpp
+++ b/tt_metal/api/tt-metalium/program.hpp
@@ -127,8 +127,6 @@ public:
     uint32_t get_cb_base_addr(IDevice* device, CoreCoord logical_core, CoreType core_type);
     uint32_t get_sem_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const;
     uint32_t get_cb_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const;
-    void set_last_used_command_queue_for_testing(CommandQueue* queue);
-    CommandQueue* get_last_used_command_queue() const;
     const std::vector<SubDeviceId>& determine_sub_device_ids(const IDevice* device);
     void set_kernels_bin_buffer(const std::shared_ptr<Buffer>& buffer);
     uint32_t get_cb_memory_size() const;

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -24,6 +24,7 @@ class go_msg_t;
 class launch_msg_t;
 namespace tt::tt_metal {
 class SubDeviceManagerTracker;
+class HWCommandQueue;
 
 // A physical PCIexpress Tenstorrent device
 class Device : public IDevice {
@@ -244,7 +245,7 @@ private:
     uint8_t num_hw_cqs_ = 1;
 
     // SystemMemoryManager is the interface to the hardware command queue
-    std::vector<std::unique_ptr<CommandQueue>> command_queues_;
+    std::vector<std::unique_ptr<HWCommandQueue>> command_queues_;
 
     std::set<CoreCoord> compute_cores_;
     std::set<CoreCoord> storage_only_cores_;

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -38,6 +38,7 @@
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/dispatch/system_memory_manager.hpp"
 #include <umd/device/tt_core_coordinates.h>
+#include "dispatch/hardware_command_queue.hpp"
 
 using namespace tt::tt_metal;
 
@@ -636,7 +637,7 @@ void DevicePool::teardown_fd(const std::unordered_set<chip_id_t>& devices_to_clo
         }
 
         for (int cq_id = 0; cq_id < dev->num_hw_cqs(); cq_id++) {
-            auto& cq = dev->command_queue(cq_id);
+            auto& cq = HWCommandQueue::from(dev->command_queue(cq_id));
             if (cq.sysmem_manager().get_bypass_mode()) {
                 cq.record_end();
             }

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -447,7 +447,7 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
     // Values in these commands will get updated based on kernel config ring
     // buffer state at runtime.
     program.generate_dispatch_commands(device_);
-    program.set_last_used_command_queue_for_testing(this);
+    program.impl().set_last_used_command_queue_for_testing(this);
 
     if (this->manager_.get_bypass_mode()) {
         this->trace_nodes_.push_back(program_dispatch::create_trace_node(program.impl(), device_));

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -55,7 +55,7 @@ public:
 
     ~HWCommandQueue() override;
 
-    const CoreCoord& virtual_enqueue_program_dispatch_core() const override;
+    const CoreCoord& virtual_enqueue_program_dispatch_core() const;
 
     void record_begin(const uint32_t tid, const std::shared_ptr<TraceDescriptor>& ctx) override;
     void record_end() override;
@@ -63,20 +63,19 @@ public:
     void reset_worker_state(
         bool reset_launch_msg_state,
         uint32_t num_sub_devices,
-        const vector_aligned<uint32_t>& go_signal_noc_data) override;
+        const vector_aligned<uint32_t>& go_signal_noc_data);
 
     void set_go_signal_noc_data_and_dispatch_sems(
-        uint32_t num_dispatch_sems, const vector_aligned<uint32_t>& noc_mcast_unicast_data) override;
+        uint32_t num_dispatch_sems, const vector_aligned<uint32_t>& noc_mcast_unicast_data);
 
     uint32_t id() const override;
-    std::optional<uint32_t> tid() const override;
+    std::optional<uint32_t> tid() const;
 
-    SystemMemoryManager& sysmem_manager() override;
+    SystemMemoryManager& sysmem_manager();
 
-    void terminate() override;
+    void terminate();
 
-    // This function is temporarily needed since MeshCommandQueue relies on the CommandQueue object
-    WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) override;
+    WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index);
 
     void enqueue_trace(const uint32_t trace_id, bool blocking) override;
     void enqueue_program(Program& program, bool blocking) override;
@@ -117,6 +116,18 @@ public:
     void finish(tt::stl::Span<const SubDeviceId> sub_device_ids) override;
 
     IDevice* device() override;
+
+    static HWCommandQueue& from(CommandQueue& command_queue) {
+        // HWCommandQueue is the only implementation of CommandQueue.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        return static_cast<HWCommandQueue&>(command_queue);
+    }
+
+    static const HWCommandQueue& from(const CommandQueue& command_queue) {
+        // HWCommandQueue is the only implementation of CommandQueue.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        return static_cast<const HWCommandQueue&>(command_queue);
+    }
 
 private:
     uint32_t id_;

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
@@ -16,6 +16,7 @@
 #include "flatbuffer/base_types_to_flatbuffer.hpp"
 #include "flatbuffer/program_types_to_flatbuffer.hpp"
 #include "flatbuffer/buffer_types_to_flatbuffer.hpp"
+#include "dispatch/hardware_command_queue.hpp"
 
 namespace tt::tt_metal {
 
@@ -291,7 +292,7 @@ void CaptureEnqueueProgram(CommandQueue& cq, Program& program, bool blocking) {
     auto& ctx = LightMetalCaptureContext::get();
 
     // When Metal Trace is enabled, skip EnqueueProgram capture (replaced with LoadTrace + ReplayTrace)
-    if (cq.sysmem_manager().get_bypass_mode()) {
+    if (HWCommandQueue::from(cq).sysmem_manager().get_bypass_mode()) {
         return;
     }
 

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -63,6 +63,7 @@
 #include "dispatch/worker_config_buffer.hpp"
 #include "tt_metal/distributed/mesh_workload_impl.hpp"
 #include "kernels/kernel_impl.hpp"
+#include "dispatch/hardware_command_queue.hpp"
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1491,19 +1491,13 @@ uint32_t Program::get_cb_base_addr(IDevice* device, CoreCoord /*logical_core*/, 
                            .cb_offset;
 }
 
-void detail::ProgramImpl::set_last_used_command_queue_for_testing(CommandQueue* queue) {
+void detail::ProgramImpl::set_last_used_command_queue_for_testing(HWCommandQueue* queue) {
     this->last_used_command_queue_for_testing = queue;
 }
 
-CommandQueue* detail::ProgramImpl::get_last_used_command_queue() const {
+HWCommandQueue* detail::ProgramImpl::get_last_used_command_queue() const {
     return this->last_used_command_queue_for_testing;
 }
-
-void Program::set_last_used_command_queue_for_testing(CommandQueue* queue) {
-    internal_->set_last_used_command_queue_for_testing(queue);
-}
-
-CommandQueue* Program::get_last_used_command_queue() const { return internal_->get_last_used_command_queue(); }
 
 uint32_t detail::ProgramImpl::get_sem_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const {
     CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -43,6 +43,7 @@ namespace tt_metal {
 class CircularBufferConfig;
 class IDevice;
 class JitBuildOptions;
+class HWCommandQueue;
 
 namespace experimental {
 class GlobalCircularBuffer;
@@ -192,8 +193,8 @@ public:
     // debug/test
     uint32_t get_sem_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const;
     uint32_t get_cb_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const;
-    void set_last_used_command_queue_for_testing(CommandQueue* queue);
-    CommandQueue* get_last_used_command_queue() const;
+    void set_last_used_command_queue_for_testing(HWCommandQueue* queue);
+    HWCommandQueue* get_last_used_command_queue() const;
     void populate_dispatch_data(IDevice* device);
 
     void finalize_offsets(IDevice* device);
@@ -209,7 +210,7 @@ public:
     std::vector<uint32_t>& get_program_config_sizes() noexcept { return program_config_sizes_; }
 
 private:
-    CommandQueue* last_used_command_queue_for_testing = nullptr;
+    HWCommandQueue* last_used_command_queue_for_testing = nullptr;
 
     // Buffers temporarily owned by the program
     std::vector<std::shared_ptr<Buffer>> owned_buffer_pool = {};

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -30,6 +30,7 @@
 #include <tt_stl/strong_type.hpp>
 #include "tt_metal/impl/sub_device/sub_device_manager.hpp"
 #include "sub_device/sub_device_manager_tracker.hpp"
+#include "dispatch/hardware_command_queue.hpp"
 
 namespace tt::tt_metal {
 
@@ -81,7 +82,7 @@ void SubDeviceManagerTracker::reset_sub_device_state(const std::unique_ptr<SubDe
             true, num_sub_devices, sub_device_manager->noc_mcast_unicast_data());
     } else {
         for (uint8_t cq_id = 0; cq_id < device_->num_hw_cqs(); ++cq_id) {
-            auto& hw_cq = device_->command_queue(cq_id);
+            auto& hw_cq = HWCommandQueue::from(device_->command_queue(cq_id));
             // Only need to reset launch messages once, so reset on cq 0
             hw_cq.reset_worker_state(cq_id == 0, num_sub_devices, sub_device_manager->noc_mcast_unicast_data());
         }


### PR DESCRIPTION
### Problem description
CommandQueue has several methods that shouldn't be called by API consumers

### What's changed
Remove them from CommandQueue. There's only only implementation of CommandQueue (HWCommandQueue), so code that needs to call them can cast to HWCommandQueue first. To make clear that that's safe, enforce that CommandQueue has only one implementer, and add some static methods to help with the cast.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes