### PR TITLE
Delay reporting core init complete until all cores ready

### DIFF
--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -249,7 +249,7 @@ void device_setup() {
 
 inline void deassert_ncrisc_trisc() {
     // Below sets ncrisc to go so we can wait until it is cleared on first iteration
-    mailboxes->subordinate_sync.all = RUN_SYNC_MSG_ALL_SUBORDINATES_DONE;
+    mailboxes->subordinate_sync.all = RUN_SYNC_MSG_ALL_INIT;
 
     // Bring ncrisc/triscs out of reset
     deassert_all_reset();

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -341,9 +341,10 @@ int main() {
 
     // Set ncrisc's resume address to 0 so we know when ncrisc has overwritten it
     mailboxes->ncrisc_halt.resume_addr = 0;
-    mailboxes->subordinate_sync.dm1 = RUN_SYNC_MSG_GO;
     deassert_ncrisc_trisc();
 
+    // Wait for all cores to be finished initializing before reporting initialization done.
+    wait_ncrisc_trisc();
     mailboxes->go_message.signal = RUN_MSG_DONE;
 
     // Initialize the NoCs to a safe state

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -118,6 +118,7 @@ int main() {
     risc_init();
 
     mailboxes->subordinate_sync.all = RUN_SYNC_MSG_ALL_SUBORDINATES_DONE;
+    mailboxes->subordinate_sync.dm1 = RUN_SYNC_MSG_INIT;
     set_deassert_addresses();
     //device_setup();
 
@@ -127,6 +128,8 @@ int main() {
     }
 
     deassert_all_reset(); // Bring all riscs on eth cores out of reset
+    // Wait for all subordinate ERISCs to be ready before reporting the core is done initializing.
+    wait_subordinate_eriscs(heartbeat);
     mailboxes->go_message.signal = RUN_MSG_DONE;
     mailboxes->launch_msg_rd_ptr = 0; // Initialize the rdptr to 0
     // Cleanup profiler buffer incase we never get the go message

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -118,7 +118,9 @@ int main() {
     risc_init();
 
     mailboxes->subordinate_sync.all = RUN_SYNC_MSG_ALL_SUBORDINATES_DONE;
+#ifdef ARCH_BLACKHOLE
     mailboxes->subordinate_sync.dm1 = RUN_SYNC_MSG_INIT;
+#endif
     set_deassert_addresses();
     //device_setup();
 

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -109,6 +109,8 @@ int main(int argc, char *argv[]) {
     my_logical_x_ = mailboxes->core_info.absolute_logical_x;
     my_logical_y_ = mailboxes->core_info.absolute_logical_y;
 
+    signal_ncrisc_completion();
+
     // Cleanup profiler buffer incase we never get the go message
     while (1) {
         WAYPOINT("W");

--- a/tt_metal/hw/firmware/src/subordinate_idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/subordinate_idle_erisc.cc
@@ -73,6 +73,7 @@ int main(int argc, char *argv[]) {
     my_logical_x_ = mailboxes->core_info.absolute_logical_x;
     my_logical_y_ = mailboxes->core_info.absolute_logical_y;
     risc_init();
+    signal_subordinate_idle_erisc_completion();
 
     // Cleanup profiler buffer incase we never get the go message
     while (1) {

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -106,6 +106,7 @@ int main(int argc, char *argv[]) {
 
     my_logical_x_ = mailboxes->core_info.absolute_logical_x;
     my_logical_y_ = mailboxes->core_info.absolute_logical_y;
+    *trisc_run = RUN_SYNC_MSG_DONE;
 
     // Cleanup profiler buffer incase we never get the go message
     while (1) {

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -64,6 +64,7 @@ constexpr uint32_t RUN_SYNC_MSG_WAITING_FOR_RESET = 0x2;
 constexpr uint32_t RUN_SYNC_MSG_INIT_SYNC_REGISTERS = 0x3;
 constexpr uint32_t RUN_SYNC_MSG_DONE = 0;
 constexpr uint32_t RUN_SYNC_MSG_ALL_GO = 0x80808080;
+constexpr uint32_t RUN_SYNC_MSG_ALL_INIT = 0x40404040;
 constexpr uint32_t RUN_SYNC_MSG_ALL_SUBORDINATES_DONE = 0;
 
 struct ncrisc_halt_msg_t {


### PR DESCRIPTION
### Problem description
Currently BRISC changes the go message signal from RUN_MSG_INIT to RUN_MSG_DONE when it's complete initializing, not when the other RISCs are finished.

### What's changed
Wait for all subordinate cores to report done before reporting RUN_MSG_DONE.

Also do this on idle_erisc - this requires modifying subordinate_idle_erisc to report when done.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes