### PR TITLE
Bump UMD

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -106,6 +106,8 @@ void MetalContext::teardown() {
     }
     dispatch_query_manager_.reset();
     dispatch_core_manager_.reset();
+    cluster_.reset();
+    hal_.reset();
 }
 
 MetalContext& MetalContext::instance() {
@@ -120,10 +122,7 @@ MetalContext::MetalContext() {
     cluster_ = std::make_unique<Cluster>(rtoptions_, *hal_);
 }
 
-MetalContext::~MetalContext() {
-    cluster_.reset();
-    hal_.reset();
-}
+MetalContext::~MetalContext() {}
 
 llrt::RunTimeOptions& MetalContext::rtoptions() { return rtoptions_; }
 

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -73,6 +73,7 @@ public:
 private:
     friend class tt::stl::Indestructible<MetalContext>;
     MetalContext();
+    // Note: The destructor won't be called ever.
     ~MetalContext();
     void teardown();
 


### PR DESCRIPTION
### Ticket

### Problem description
Regular UMD bump bringing in new features

### What's changed
- Minor nanobind skeleton around UMD's Cluster
- Harvesting masks are now reported as logical in cluster descriptor
- New sysmem buffers now have different behavior for buffers not aligned to a Page
- Don't allow two users to start_device the same devices, guaranteed through a lock

### Checklist
All runs on brosko/bumpumd1106 :
- [ ] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15736002735
- [ ] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15736005308
- [ ] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/15736008059
- [ ] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/15736010945
- [ ] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15736013738
- [ ] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/15736016583
- [ ] (TG) TG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15736019343
- [ ] (TG) TG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/15736022003
- [ ] Galaxy Quick : https://github.com/tenstorrent/tt-metal/actions/runs/15736024709