### PR TITLE
Only generate kernel duration for device perf CI tests

### DIFF
--- a/models/perf/device_perf_utils.py
+++ b/models/perf/device_perf_utils.py
@@ -115,7 +115,7 @@ def run_device_perf_detailed(command, subdir, cols, op_name="", has_signposts=Fa
         results[f"MAX {d_col}"] = -float("inf")
         results[f"STD {d_col}"] = 0
 
-    run_device_profiler(command, subdir)
+    run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
     r = post_process_ops_log_detailed(
         subdir, duration_cols, op_name=op_name, has_signposts=has_signposts, detailed=True, warmup_iters=warmup_iters
     )

--- a/tt_metal/tools/profiler/process_model_log.py
+++ b/tt_metal/tools/profiler/process_model_log.py
@@ -50,12 +50,16 @@ def post_process_ops_log(output_logs_subdir, columns=None, sum_vals=True, op_nam
     return results
 
 
-def run_device_profiler(command, output_logs_subdir, check_test_return_code=True):
+def run_device_profiler(command, output_logs_subdir, check_test_return_code=True, device_analysis_types=[]):
     output_profiler_dir = get_profiler_folder(output_logs_subdir)
     check_return_code = ""
+    device_analysis_opt = ""
     if check_test_return_code:
         check_return_code = "--check-exit-code"
-    profiler_cmd = f"python3 -m tracy -p -r -o {output_profiler_dir} {check_return_code} -t 5000 -m {command}"
+    if device_analysis_types:
+        assert type(device_analysis_types) == list
+        device_analysis_opt = [f" -a {analysis}" for analysis in device_analysis_types]
+    profiler_cmd = f"python3 -m tracy -p -r -o {output_profiler_dir} {check_return_code} {device_analysis_opt} -t 5000 -m {command}"
     subprocess.run([profiler_cmd], shell=True, check=True)
 
 

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -279,7 +279,7 @@ def extract_dispatch_op_id(dispatchOps):
 
 
 # Append device data to device ops and return the list of mapped device op ref list
-def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces):
+def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces, device_analysis_types):
     traceReplayCounts = {}
     for deviceID in traceReplays:
         traceReplayCounts[deviceID] = {}
@@ -291,6 +291,14 @@ def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces):
     traceOps = {}
     if os.path.isfile(deviceTimesLog):
         setup = device_post_proc_config.default_setup()
+        if device_analysis_types:
+            allAnalysis = setup.timerAnalysis
+            pickedAnalysis = {}
+            for analysis in device_analysis_types:
+                assert analysis in allAnalysis.keys(), f" {analysis} is not calculated in device analysis"
+                pickedAnalysis[analysis] = allAnalysis[analysis]
+
+            setup.timerAnalysis = pickedAnalysis
         setup.deviceInputLog = deviceTimesLog
         deviceData = import_log_run_stats(setup)
         freq = deviceData["deviceInfo"]["freq"]
@@ -434,7 +442,7 @@ def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces):
 
 
 def get_device_data_generate_report(
-    logFolder, outputFolder, date, nameAppend, export_csv=True, cleanup_device_log=False
+    logFolder, outputFolder, date, nameAppend, export_csv=True, cleanup_device_log=False, device_analysis_types=[]
 ):
     deviceTimesLog = os.path.join(logFolder, PROFILER_DEVICE_SIDE_LOG)
     devicePreOpTime = {}
@@ -475,6 +483,14 @@ def get_device_data_generate_report(
     if os.path.isfile(deviceTimesLog):
         logger.info(f"Getting device only ops data")
         setup = device_post_proc_config.default_setup()
+        if device_analysis_types:
+            allAnalysis = setup.timerAnalysis
+            pickedAnalysis = {}
+            for analysis in device_analysis_types:
+                assert analysis in allAnalysis.keys(), f" {analysis} is not calculated in device analysis"
+                pickedAnalysis[analysis] = allAnalysis[analysis]
+
+            setup.timerAnalysis = pickedAnalysis
         setup.deviceInputLog = deviceTimesLog
         deviceData = import_log_run_stats(setup)
         logger.info(f"Generating device op report ...")
@@ -904,7 +920,9 @@ def analyzeNoCTraces(logFolder):
         return None
 
 
-def process_ops(output_folder, name_append, date, device_only=False, analyze_noc_traces=False):
+def process_ops(
+    output_folder, name_append, date, device_only=False, analyze_noc_traces=False, device_analysis_types=[]
+):
     if not output_folder:
         output_folder = PROFILER_ARTIFACTS_DIR
     logFolder = generate_logs_folder(output_folder)
@@ -913,10 +931,14 @@ def process_ops(output_folder, name_append, date, device_only=False, analyze_noc
     ops, signposts, traceReplays = import_tracy_op_logs(logFolder)
 
     if ops and not device_only:
-        deviceOps, traceOps = append_device_data(ops, traceReplays, logFolder, analyze_noc_traces)
+        deviceOps, traceOps = append_device_data(
+            ops, traceReplays, logFolder, analyze_noc_traces, device_analysis_types
+        )
         generate_reports(ops, deviceOps, traceOps, signposts, logFolder, reportFolder, date, name_append)
     else:
-        deviceOps = get_device_data_generate_report(logFolder, reportFolder, date, name_append)
+        deviceOps = get_device_data_generate_report(
+            logFolder, reportFolder, date, name_append, device_analysis_types=device_analysis_types
+        )
 
 
 @click.command()
@@ -927,10 +949,11 @@ def process_ops(output_folder, name_append, date, device_only=False, analyze_noc
 @click.option(
     "--analyze-noc-traces", is_flag=True, help="Use tt-npe to analyze profiler noc event trace files (if available)"
 )
-def main(output_folder, name_append, date, device_only, analyze_noc_traces):
+@click.option("-a", "--device-analysis-types", multiple=True, help="Subset of analysis types to be performed on device")
+def main(output_folder, name_append, date, device_only, analyze_noc_traces, device_analysis_types):
     if output_folder:
         output_folder = Path(output_folder)
-    process_ops(output_folder, name_append, date, device_only, analyze_noc_traces)
+    process_ops(output_folder, name_append, date, device_only, analyze_noc_traces, device_analysis_types)
 
 
 if __name__ == "__main__":

--- a/ttnn/tracy/__init__.py
+++ b/ttnn/tracy/__init__.py
@@ -120,7 +120,7 @@ def run_report_setup(verbose, outputFolder, port):
     return toolsReady, captureProcess
 
 
-def generate_report(outputFolder, nameAppend, childCalls, collect_noc_traces=False):
+def generate_report(outputFolder, nameAppend, childCalls, collect_noc_traces=False, device_analysis_types=[]):
     logsFolder = generate_logs_folder(outputFolder)
     tracyOutFile = logsFolder / TRACY_FILE_NAME
     timeOut = 15
@@ -164,7 +164,14 @@ def generate_report(outputFolder, nameAppend, childCalls, collect_noc_traces=Fal
 
     logger.info(f"Host side ops data report generated at {logsFolder / TRACY_OPS_DATA_FILE_NAME}")
 
-    process_ops(outputFolder, nameAppend, True, device_only=False, analyze_noc_traces=collect_noc_traces)
+    process_ops(
+        outputFolder,
+        nameAppend,
+        True,
+        device_only=False,
+        analyze_noc_traces=collect_noc_traces,
+        device_analysis_types=device_analysis_types,
+    )
 
 
 def get_available_port():

--- a/ttnn/tracy/__main__.py
+++ b/ttnn/tracy/__main__.py
@@ -91,6 +91,13 @@ def main():
         help="Exit the run and do not attempt post processing if the test command fails",
         default=False,
     )
+    parser.add_option(
+        "--device-analysis-types",
+        dest="device_analysis_types",
+        action="append",
+        help="List of device analysis types",
+        default=[],
+    )
 
     if not sys.argv[1:]:
         parser.print_usage()
@@ -227,7 +234,13 @@ def main():
 
             try:
                 captureProcess.communicate(timeout=15)
-                generate_report(outputFolder, options.name_append, options.child_functions, options.collect_noc_traces)
+                generate_report(
+                    outputFolder,
+                    options.name_append,
+                    options.child_functions,
+                    options.collect_noc_traces,
+                    options.device_analysis_types,
+                )
             except subprocess.TimeoutExpired as e:
                 captureProcess.terminate()
                 captureProcess.communicate()


### PR DESCRIPTION
### Ticket
#23445 

### Problem description
Device perf only uses kernel duration to test  for any device side regressions. None of the other device perf columns are used in this tests so they should not be generated as their generation takes up a considerable time.

### What's changed
Only generate kernel duration for each op in the report

### Checklist
- [x] [Device Perf](https://github.com/tenstorrent/tt-metal/actions/runs/15681945142)
- [x] [T3K Profiler](https://github.com/tenstorrent/tt-metal/actions/runs/15596843878)
- [x] [Profiler Post commit ](https://github.com/tenstorrent/tt-metal/actions/workflows/run-profiler-regression-wrapper.yaml)