### PR TITLE
#23426: Enforce no network runs in WH 6U image because that's a requirement for it

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -172,10 +172,10 @@ jobs:
         env:
           SOURCE_LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct
           LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct
-        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $SOURCE_LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
+        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $SOURCE_LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10
-        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
+        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
   test-bh-llmbox-image:
     needs:
       - get-image-tags

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -81,11 +81,13 @@ jobs:
             hw-topology: wh_6u
             build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
             wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+            techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
             test-command: tests/scripts/wh_6u/run_wh_6u_upstream_profiler_tests.sh
             hw-topology: wh_6u
             build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
             wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+            techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -152,6 +154,8 @@ jobs:
           push: true
           tags: ${{ matrix.image-config.image-tag }}
           context: ${{ github.workspace }}
+          build-args: |
+            TECHDEBT_INSTALL_TTT_REQS=${{ matrix.image-config.techdebt-install-ttt-reqs && 'true' || 'false' }}
   test-wh-6u-image:
     needs:
       - get-image-tags

--- a/dockerfile/upstream_test_images/Dockerfile.template
+++ b/dockerfile/upstream_test_images/Dockerfile.template
@@ -2,6 +2,9 @@ FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:${TT_METAL_
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Build argument to control whether to install tt_transformers requirements
+ARG TECHDEBT_INSTALL_TTT_REQS="false"
+
 LABEL org.opencontainers.image.source=https://github.com/tenstorrent/tt-metal
 LABEL org.opencontainers.image.description="Run upstream smoke tests"
 LABEL org.opencontainers.image.licenses=MIT
@@ -33,7 +36,7 @@ RUN pip3 install $(ls -1 *.whl)
 # TODO: Clean up later and ensure these requirements are incorporated into the regular
 # requirements files/dependencies, as this is here because we don't have network access
 # for 6U
-RUN pip3 install -r models/tt_transformers/requirements.txt
+RUN bash -c 'if [ "$TECHDEBT_INSTALL_TTT_REQS" = "true" ]; then pip3 install -r models/tt_transformers/requirements.txt; fi'
 
 RUN TRACY_NO_INVARIANT_CHECK=1 TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites" --gtest_list_tests
 RUN TRACY_NO_INVARIANT_CHECK=1 python3 -c 'import ttnn'

--- a/dockerfile/upstream_test_images/Dockerfile.template
+++ b/dockerfile/upstream_test_images/Dockerfile.template
@@ -30,6 +30,10 @@ COPY _tt-metal/runtime/ ./runtime/
 COPY ttnn-*.whl ./
 
 RUN pip3 install $(ls -1 *.whl)
+# TODO: Clean up later and ensure these requirements are incorporated into the regular
+# requirements files/dependencies, as this is here because we don't have network access
+# for 6U
+RUN pip3 install -r models/tt_transformers/requirements.txt
 
 RUN TRACY_NO_INVARIANT_CHECK=1 TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites" --gtest_list_tests
 RUN TRACY_NO_INVARIANT_CHECK=1 python3 -c 'import ttnn'

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -106,8 +106,6 @@ test_suite_wh_6u_llama_demo_tests() {
 
     verify_llama_dir_
 
-    # TODO: to remove...
-    pip install -r models/tt_transformers/requirements.txt
     pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick"
     pytest models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
     pytest models/demos/llama3_subdevices/demo/text_demo.py -k "repeat"
@@ -123,8 +121,6 @@ test_suite_wh_6u_llama_long_stress_tests() {
 
     verify_llama_dir_
 
-    # TODO: to remove...
-    pip install -r models/tt_transformers/requirements.txt
     # This will take almost 3 hours. Ensure that the tensors are cached in the LLAMA_DIR.
     pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "stress-test and not mini-stress-test"
 }


### PR DESCRIPTION
### Ticket

#23426 

### Problem description


Can't run with the interwebs !!!

### What's changed

- Cut off internet access for container run
- Move any dependencies that need internet into container build

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes