### PR TITLE
#23353: Use madvise to lazily free mmapped pages

### DIFF
--- a/tests/ttnn/benchmark/cpp/host_alloc_on_tensor_readback.cpp
+++ b/tests/ttnn/benchmark/cpp/host_alloc_on_tensor_readback.cpp
@@ -37,28 +37,8 @@ void BM_host_alloc_on_tensor_readback(benchmark::State& state) {
 
 BENCHMARK(BM_host_alloc_on_tensor_readback)
     ->Unit(benchmark::kMicrosecond)
-    ->Iterations(5)
-    ->Arg(1 << 10)    // 1KB
-    ->Arg(2 << 10)    // 2KB
-    ->Arg(4 << 10)    // 4KB
-    ->Arg(8 << 10)    // 8KB
-    ->Arg(16 << 10)   // 16KB
-    ->Arg(32 << 10)   // 32KB
-    ->Arg(64 << 10)   // 64KB
-    ->Arg(128 << 10)  // 128KB
-    ->Arg(256 << 10)  // 256KB
-    ->Arg(512 << 10)  // 512KB
-    ->Arg(1 << 20)    // 1MB
-    ->Arg(2 << 20)    // 2MB
-    ->Arg(4 << 20)    // 4MB
-    ->Arg(8 << 20)    // 8MB
-    ->Arg(16 << 20)   // 16MB
-    ->Arg(32 << 20)   // 32MB
-    ->Arg(64 << 20)   // 64MB
-    ->Arg(128 << 20)  // 128MB
-    ->Arg(256 << 20)  // 256MB
-    ->Arg(512 << 20)  // 512MB
-    ->Arg(1 << 30);   // 1GB
+    ->RangeMultiplier(2)
+    ->Range(1 << 10, 1 << 30);  // 1KB to 1GB, powers of 2
 
 }  // namespace
 

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -33,7 +33,7 @@ namespace {
 
 // Threshold for switch for mmap-based allocations to regular allocations.
 // Determined empirically using a microbenchmark; see https://github.com/tenstorrent/tt-metal/pull/22959 for details.
-constexpr size_t kMmapThresholdBytes = 1 << 20;  // 1MB
+constexpr size_t kMmapThresholdBytes = 1 << 20;
 
 // Allocates memory on the host in batch; using either mmap for large allocations or std::vector for small allocations.
 using SharedMemoryPtr = std::shared_ptr<void>;
@@ -42,7 +42,7 @@ SharedMemoryPtr allocate_host_data(size_t size_bytes) {
         ZoneScopedN("AllocateBufferMmap");
         void* ptr = mmap(nullptr, size_bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         TT_FATAL(ptr != MAP_FAILED, "Failed to allocate {} bytes of memory", size_bytes);
-        return SharedMemoryPtr(ptr, [size_bytes](void* p) { munmap(p, size_bytes); });
+        return SharedMemoryPtr(ptr, [size_bytes](void* p) { madvise(p, size_bytes, MADV_FREE); });
     } else {
         auto vec = std::make_shared<std::vector<std::byte>>(size_bytes);
         return SharedMemoryPtr(vec, vec->data());


### PR DESCRIPTION
### Ticket
#23353

### Problem description
mmap-based allocation on the read path introduced perf regression in several host-bound models. See #23353.

### What's changed
Instead of munmap, use madvise with MADV_FREE to lazily mark allocated pages as free. This gives roughly 10% perf improvement on falcon 7B on T3K (~9500 -> ~10500 prefill tps). This is consistent with microbenchmarks, which show 5-20% improvement across different allocation sizes.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15595968577)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15595971379)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15595982910)
- [x] New/Existing tests provide coverage for changes