### PR TITLE
Remove min from dataflow_api.h

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1720,9 +1720,6 @@ inline void RISC_POST_HEARTBEAT(uint32_t& heartbeat) {
     ptr[0] = 0xAABB0000 | (heartbeat & 0xFFFF);
 }
 
-FORCE_INLINE
-uint32_t min(uint32_t a, uint32_t b) { return (a < b) ? a : b; }
-
 template <bool use_vc>
 FORCE_INLINE uint32_t noc_async_read_tile_dram_sharded_set_state(
     uint32_t bank_base_address,

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <algorithm>
 #include "dataflow_api.h"
 
 void kernel_main() {
@@ -69,11 +70,11 @@ void kernel_main() {
 
         // Compute X block boundaries
         uint32_t x_start = x_block * x_block_size;
-        uint32_t x_end = min(x_start + x_block_size, X);
+        uint32_t x_end = std::min(x_start + x_block_size, X);
 
         // Compute W block boundaries
         uint32_t w_start = w_block * w_block_size;
-        uint32_t w_end = min(w_start + w_block_size, input_shape[N - 1]);
+        uint32_t w_end = std::min(w_start + w_block_size, input_shape[N - 1]);
         uint32_t w_offset = w_start * element_size;
 
         uint32_t w_read_size_bytes = (w_end - w_start) * element_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <algorithm>
 #include "dataflow_api.h"
 #include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 
@@ -98,10 +99,10 @@ void kernel_main() {
 
         // Compute start/end boundaries for the current X and W blocks
         const uint32_t x_start = x_block * x_block_size;
-        const uint32_t x_end = min(x_start + x_block_size, X);
+        const uint32_t x_end = std::min(x_start + x_block_size, X);
 
         const uint32_t w_start = w_block * w_block_size;
-        const uint32_t w_end = min(w_start + w_block_size, W);
+        const uint32_t w_end = std::min(w_start + w_block_size, W);
 
         // Compute the read size for the X dimension
         const uint32_t x_read_size_bytes = (x_end - x_start) * element_size;

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <algorithm>
 #include "dataflow_api.h"
 
 void kernel_main() {
@@ -34,7 +35,7 @@ void kernel_main() {
     constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
 
     const InterleavedAddrGen<dst0_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = output_stick_size};
-    const uint32_t noc_write_size = min(output_stick_size, input_stick_size);
+    const uint32_t noc_write_size = std::min(output_stick_size, input_stick_size);
     uint32_t dst_stick_id = start_id;
     uint32_t sticks_read = 0;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/reader_moreh_getitem_tilize_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/reader_moreh_getitem_tilize_w.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include "dataflow_api.h"
 #include "cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/common.hpp"
 
@@ -140,7 +141,7 @@ void kernel_main() {
         uint32_t index_w_index = i % num_alignment_width;
         uint32_t index_off = index_w_index * num_elements_per_alignment;
         uint32_t index_start = index_off;
-        uint32_t index_end = min(index_off + num_elements_per_alignment, index_size_w);
+        uint32_t index_end = std::min(index_off + num_elements_per_alignment, index_size_w);
 
         uint32_t j = 0;
         for (uint32_t index_index = index_start; index_index < index_end; index_index++, j++) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/writer_moreh_getitem_tilize_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/writer_moreh_getitem_tilize_w.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include "dataflow_api.h"
 #include "cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_kernels/common.hpp"
 
@@ -49,7 +50,7 @@ void kernel_main() {
         uint32_t output_stick_w = i % num_alignment_width;
         uint32_t w_off = output_stick_w * num_elements_per_alignment;
         uint32_t w_start = w_off;
-        uint32_t w_end = min(w_off + num_elements_per_alignment, output_size_w_without_padding);
+        uint32_t w_end = std::min(w_off + num_elements_per_alignment, output_size_w_without_padding);
 
         uint32_t stick_y = (i / num_alignment_width);
         uint32_t stick_x = w_start / FACE_WIDTH;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_2d.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include "cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
 
 void kernel_main() {
@@ -72,7 +73,7 @@ void kernel_main() {
     for (uint32_t i = start_id; i < end_id; ++i) {
         // loop from n_start to n_end
         uint32_t n_start = i * TILE_HEIGHT;
-        uint32_t n_end = min(i * TILE_HEIGHT + TILE_HEIGHT, N);
+        uint32_t n_end = std::min(i * TILE_HEIGHT + TILE_HEIGHT, N);
         uint32_t nt = i;
 
         // target: (1, N)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_3d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/reader_moreh_nll_loss_step2_3d.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include "cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
 
 void kernel_main() {
@@ -105,7 +106,7 @@ void kernel_main() {
         auto tmp_input_l1_ptr = get_write_ptr<FP32_DEST_ACC_FTYPE>(cb_tmp_input);
         auto target_l1_ptr = get_read_ptr<int32_t>(cb_target);
 
-        uint32_t idx_max = min(w + FACE_WIDTH, W);
+        uint32_t idx_max = std::min(w + FACE_WIDTH, W);
         for (uint32_t idx = 0; idx < idx_max; idx++) {
             int32_t target_val = target_l1_ptr[idx];
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
+#include <algorithm>
 #include "cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
 
 #define ALWI inline __attribute__((always_inline))
@@ -78,10 +79,10 @@ void kernel_main() {
 
                 uint32_t x1 = int(x);
                 uint32_t y1 = int(y);
-                uint32_t x2 = min(x1 + 1, in_w - 1);
+                uint32_t x2 = std::min(x1 + 1, in_w - 1);
                 uint32_t y2 = y1 + 1;
                 if (is_last_row) {
-                    y2 = min(y2, in_image_rows_per_core);  // if last row, y2 should be in_image_rows_per_core
+                    y2 = std::min(y2, in_image_rows_per_core);  // if last row, y2 should be in_image_rows_per_core
                 }
 
                 fill_four_val(

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <algorithm>
 
 #include "dataflow_api.h"
 #include "utils/bfloat16.h"
@@ -64,7 +65,7 @@ inline void find_argmax_for_core(
                 max_val = val;
             } else if (val == max_val) {
                 auto full_idx = outer_idx * inner_dim_units * red_dim_units + j * red_dim_units + i;
-                max_idx = reduce_all ? min(max_idx, full_idx) : min(max_idx, i);
+                max_idx = reduce_all ? std::min(max_idx, full_idx) : std::min(max_idx, i);
             }
         }
 


### PR DESCRIPTION
### Ticket
#18872

### Problem description
dataflow_api.h should not define `min`.

### What's changed
Deleted `min`.  Changed affected kernels to use `std::min` instead.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15597989329/) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15597890233) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes