### PR TITLE
Improve yolov4 perf

### DIFF
--- a/models/demos/yolov4/tests/perf/test_perf.py
+++ b/models/demos/yolov4/tests/perf/test_perf.py
@@ -101,7 +101,7 @@ def test_yolov4(
 @pytest.mark.parametrize(
     "batch_size, model_name, expected_perf",
     [
-        (1, "yolov4", 82),
+        (1, "yolov4", 87.8),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov4/tt/common.py
+++ b/models/demos/yolov4/tt/common.py
@@ -26,8 +26,8 @@ class Conv:
             shard_layout=conv_param.shard_layout,
             reshard_if_not_optimal=conv_param.reshard_if_not_optimal,
             deallocate_activation=conv_param.deallocate_activation,
-            enable_act_double_buffer=conv_param.enable_act_double_buffer,
-            enable_split_reader=conv_param.enable_split_reader,
+            enable_act_double_buffer=True,
+            enable_split_reader=True if conv_param.shard_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED else False,
             output_layout=ttnn.TILE_LAYOUT,
         )
         config_override = None

--- a/models/demos/yolov4/tt/model_preprocessing.py
+++ b/models/demos/yolov4/tt/model_preprocessing.py
@@ -159,14 +159,14 @@ def _create_ds1_model_parameters(conv_args, resolution):
         conv_args.c1["enable_act_double_buffer"] = False
         conv_args.c1["deallocate_activation"] = True
         conv_args.c1["reshard_if_not_optimal"] = False
-        conv_args.c1["shard_layout"] = None
+        conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
 
-        conv_args.c2["act_block_h"] = None
+        conv_args.c2["act_block_h"] = 320
         conv_args.c2["enable_split_reader"] = False
         conv_args.c2["enable_act_double_buffer"] = False
         conv_args.c2["deallocate_activation"] = True
         conv_args.c2["reshard_if_not_optimal"] = False
-        conv_args.c2["shard_layout"] = None
+        conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
 
         conv_args.c3["act_block_h"] = None
         conv_args.c3["enable_split_reader"] = True


### PR DESCRIPTION
Enable split reader for hs convs
Enable act double buffering or hs convs

Device perf 82->87.8

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15589750698)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15582593811)
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15582582045