### PR TITLE
Logits remain 1D when using perm_table_tensor

### DIFF
--- a/models/demos/llama3_subdevices/tt/generator.py
+++ b/models/demos/llama3_subdevices/tt/generator.py
@@ -486,7 +486,7 @@ class Generator:
     def read_decode_output(self, tt_logits, unpadded_batch, is_tokens=True):
         logits = self.model.process_output_decode(tt_logits, B=unpadded_batch, S=1)
         if self.perm_table_tensor is not None:
-            logits = logits[self.perm_table_tensor, :]
+            logits = logits[self.perm_table_tensor]
         return logits
 
     def chat_completion(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23473

### Problem description
vLLM test is failing due to dimensions mismatch:
https://github.com/tenstorrent/tt-metal/actions/runs/15587180530/job/43897211104#step:12:495

### What's changed
Logits are now explicitly 1D

### Checklist
- [ ✅ ] [vLLM test](https://github.com/tenstorrent/tt-metal/actions/runs/15607249514/job/43960026598)