### PR TITLE
Fix `tt-inference-server` passing incorrect `CACHE_PATH`

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -5,6 +5,7 @@
 import json
 import math
 import os
+import re
 from enum import Enum, auto
 from pathlib import Path
 from typing import Tuple
@@ -483,6 +484,13 @@ class ModelArgs:
             self.TOKENIZER_PATH = LLAMA_DIR
             if not self.CACHE_PATH:
                 self.CACHE_PATH = os.path.join(LLAMA_DIR, self.device_name)
+            else:
+                # tt-inference-server currently incorrectly sets cache path so we first need to strip the device name
+                # TODO: Remove this once tt-inference-server is fixed
+                regex = r"/(CPU|TG|T3K|N150x4|N300|N150|P150x4|P300|P150|P100)$"
+                self.CACHE_PATH = re.sub(regex, "", self.CACHE_PATH)
+                self.CACHE_PATH = os.path.join(self.CACHE_PATH, self.device_name)
+
             self.model_name = os.path.basename(LLAMA_DIR.strip("/"))  # May be overridden by config
         elif HF_MODEL:
             self.CKPT_DIR = HF_MODEL


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Running data-parallel configurations with `tt-inference-server` encounters a problem where the server incorrectly sets a cache path based on the entire machine name instead of being aware of the division into appropriate submeshes.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes