### PR TITLE
Disable gcc-12 debug build in APC, due to OOM

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -238,11 +238,11 @@ jobs:
             build-type: "Release"
             publish-artifact: false
             skip-tt-train: true
-          - version: "22.04"
-            toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
-            build-type: "Debug"
-            publish-artifact: false
-            skip-tt-train: true
+          #- version: "22.04"
+          #  toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
+          #  build-type: "Debug"
+          #  publish-artifact: false
+          #  skip-tt-train: true
           - version: "24.04"
             toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
             build-type: "Release"


### PR DESCRIPTION
### Ticket
NA

### Problem description
Seeing some OOM errors in APC for this build job.

### What's changed
Temporarily disable this, until we figure this out.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15614451413) CI passes (Good enough)
- [x] New/Existing tests provide coverage for changes