### PR TITLE
 Add demo with trace for Resnet50

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -28,6 +28,7 @@ jobs:
           { name: "bert_tiny", runner-label: "N150", performance: false, cmd: run_bert_tiny_func, owner_id: U024A4EFV6U}, # Brian Liu
           { name: "bert", runner-label: "N150", performance: false, cmd: run_bert_func, owner_id: U024A4EFV6U}, # Brian Liu
           { name: "resnet", runner-label: "N150", performance: false, cmd: run_resnet_func, owner_id: U0837MYG788}, # Marko Radosavljevic
+          { name: "ttnn_resnet", runner-label: "N150", performance: false, cmd: run_resnet_perf, owner_id: U0837MYG788}, # Marko Radosavljevic
           { name: "distilbert", runner-label: "N150", performance: false, cmd: run_distilbert_func, owner_id: U013121KDH9}, # Austin Ho
           { name: "covnet_mnist", runner-label: "N150", performance: false, cmd: run_covnet_mnist_func, owner_id: U06LRK6JDGB}, # Saad Jameel
           { name: "mnist", runner-label: "N150", performance: false, cmd: run_mnist_func, owner_id: U06ECNVR0EN}, # Evan Smal
@@ -73,6 +74,8 @@ jobs:
           { name: "vgg_unet", runner-label: "N300", performance: false, cmd: run_vgg_unet_demo, owner_id: U045U3DEKM4}, # Mohamed Bahnas (keerthana-r-mcw)
           { name: "yolov4", runner-label: "N300", performance: false, cmd: run_yolov4_perf, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Sudhanshu Singhal)
           { name: "yolov10x", runner-label: "N300", performance: false, cmd: run_yolov10x_demo, owner_id: U056BK5U81E}, # Dalar Vartanians
+          { name: "ttnn_resnet", runner-label: "N300", performance: false, cmd: run_resnet_perf, owner_id: U0837MYG788}, # Marko Radosavljevic
+
           # Moved to t3k tests until OOM on single card runners resolved
           # { name: "qwen7b", runner-label: "N300", performance: false, cmd: run_qwen7b_func, owner_id: U03PUAKE719}, # Mark O'Connor
         ]

--- a/models/demos/ttnn_resnet/tests/resnet50_performant_imagenet.py
+++ b/models/demos/ttnn_resnet/tests/resnet50_performant_imagenet.py
@@ -16,6 +16,7 @@ class ResNet50Trace2CQ:
         device_batch_size=1,
         act_dtype=ttnn.bfloat16,
         weight_dtype=ttnn.bfloat16,
+        model_location_generator=None,
     ):
         self.test_infra = create_test_infra(
             device,
@@ -26,6 +27,7 @@ class ResNet50Trace2CQ:
             True,
             dealloc_input=True,
             final_output_mem_config=ttnn.L1_MEMORY_CONFIG,
+            model_location_generator=model_location_generator,
         )
         self.device = device
         self.tt_inputs_host, sharded_mem_config_DRAM, self.input_mem_config = self.test_infra.setup_dram_sharded_input(

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -102,6 +102,13 @@ run_resnet_func() {
 
 }
 
+run_resnet_perf(){
+
+   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/ttnn_resnet/demo/demo.py
+
+}
+
+
 run_sdxl_func() {
   pytest --disable-warnings models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py --start-from=0 --num-prompts=2
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem Description
The model/demos/ttnn_resnet directory does not currently include a demo utilizing trace_2cqs.

### What's Changed
Added a demo that uses trace_2cqs for both the ImageNet dataset and single image inference in model/demos/ttnn_resnet/demo.py.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes