### PR TITLE
[tt-train] Enable program cache in MNIST example

### DIFF
--- a/tt-train/configs/training_mnist_mlp.yaml
+++ b/tt-train/configs/training_mnist_mlp.yaml
@@ -10,5 +10,5 @@ training_config:
   model_path: "/tmp/mnist_mlp.msgpack"
   mlp_config:
     input_features: 784
-    hidden_features: [128]
+    hidden_features: [128, 128]
     output_features: 10

--- a/tt-train/sources/examples/mnist_mlp/main.cpp
+++ b/tt-train/sources/examples/mnist_mlp/main.cpp
@@ -5,6 +5,7 @@
 #include <yaml-cpp/node/node.h>
 
 #include <CLI/CLI.hpp>
+#include <chrono>
 #include <core/ttnn_all_includes.hpp>
 #include <cstdint>
 #include <functional>
@@ -170,6 +171,7 @@ int main(int argc, char **argv) {
         dataset.test_images, dataset.test_labels);
 
     auto *device = &ttml::autograd::ctx().get_device();
+    device->enable_program_cache();
     std::function<BatchType(std::vector<DatasetSample> && samples)> collate_fn =
         [num_features, num_targets, device](std::vector<DatasetSample> &&samples) {
             const uint32_t batch_size = samples.size();
@@ -250,6 +252,8 @@ int main(int argc, char **argv) {
     };
 
     for (size_t epoch = 0; epoch < config.num_epochs; ++epoch) {
+        auto start_time = std::chrono::steady_clock::now();
+        uint32_t num_steps_in_epoch = 0;
         for (const auto &[data, target] : train_dataloader) {
             optimizer.zero_grad();
             auto output = run_model(model, data);
@@ -268,7 +272,12 @@ int main(int argc, char **argv) {
             optimizer.step();
             ttml::autograd::ctx().reset_graph();
             training_step++;
+            num_steps_in_epoch++;
         }
+
+        auto end_time = std::chrono::steady_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+        fmt::println("per step ms: {} ms", duration.count() / num_steps_in_epoch);
 
         const float test_accuracy = evaluate(test_dataloader, model, num_targets);
         fmt::print(


### PR DESCRIPTION
### Problem description
I've decided to take a look of current performance of the MNIST example. It appeared that it takes 115 ms per step which is unrealistic. After short investigation I've realized that example is missing enabled program cache.

### What's changed
* enable program cache in MNIST demo
* add code to measure time per iteration 
* 115 ms -> 3 ms 

### Checklist
- [x] New/Existing tests provide coverage for changes