### PR TITLE
Bump timeout for slow tests in smoke suite because we're seeing slowdowns because of disk speeds

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -15,7 +15,10 @@ on:
       per-test-timeout:
         required: false
         type: string
-        default: 3.5
+        # We want to eventually bump this back down to 3.5, but because of
+        # https://github.com/tenstorrent/github-ci-infra/issues/876 tests
+        # are taking longer on host than we'd like on CIv2
+        default: 4.5
       product:
         required: true
         type: string # tt-metalium or tt-nn


### PR DESCRIPTION
…

### Ticket

N/A , on CIv2 side https://github.com/tenstorrent/github-ci-infra/issues/876

### Problem description

Recent slow write speeds seem to be causing our usual smoke tests to keep bumping against the threshold for slow tests in the smoke suite.

### What's changed

Bump it for now, with a comment explaining we want to bump it down later once write speeds are investigated.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes