### PR TITLE
[skip ci] Relax the Smoke threshold until CIv2's slow disks get resolved

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -15,7 +15,7 @@ on:
       per-test-timeout:
         required: false
         type: string
-        default: 3.5
+        default: 4.0 # Was 3.5, but CIv2 is experiencing slow disks; until that's resolved, relax this threshold
       product:
         required: true
         type: string # tt-metalium or tt-nn

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -15,7 +15,7 @@ on:
       per-test-timeout:
         required: false
         type: string
-        default: 4.0 # Was 3.5, but CIv2 is experiencing slow disks; until that's resolved, relax this threshold
+        default: 4.0 # TODO: Drop back to 3.5 when https://github.com/tenstorrent/github-ci-infra/issues/876 is resolved.
       product:
         required: true
         type: string # tt-metalium or tt-nn


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Occasionally we've seen some Smoke tests exceed the guardrail with no change.  CIv2 has also been observed with low performing disks.  Occam's Razor suggests those could be connected.  Bump the threshold for now while the disk performance is investigated.

### What's changed
Bump the threshold