### PR TITLE
[skip ci] Tighten up the critical section

### DIFF
--- a/.github/workflows/docs-latest-public.yaml
+++ b/.github/workflows/docs-latest-public.yaml
@@ -16,13 +16,6 @@ on:
       build-artifact-name:
         required: true
         type: string
-concurrency:
-  # Note that people may spam the post-commit pipeline on their branch, and
-  # we have this docs pipeline in the post-commit pipeline, then people
-  # would have to wait until the previous one fully completes. That may be
-  # ok because each post-commit pipeline definitely takes more than 30 min
-  group: "pages-${{ github.ref }}"
-  cancel-in-progress: false
 
 jobs:
   build-docs:
@@ -85,7 +78,15 @@ jobs:
 
   deploy-docs:
     needs: build-docs
+    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases/v') }}
     runs-on: ubuntu-latest
+    concurrency:
+      # Note that people may spam the post-commit pipeline on their branch, and
+      # we have this docs pipeline in the post-commit pipeline, then people
+      # would have to wait until the previous one fully completes. That may be
+      # ok because each post-commit pipeline definitely takes more than 30 min
+      group: "pages-${{ github.ref }}"
+      cancel-in-progress: false # WARNING: This will only queue a single job; all else will still be cancelled!
     defaults:
       run:
         shell: bash
@@ -100,7 +101,6 @@ jobs:
           name: gh_pages_${{ inputs.version }}
           path: gh_pages/${{ inputs.version }}
       - name: Deploy to GitHub Pages
-        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases/v') }}
         uses: JamesIves/github-pages-deploy-action@v4
         id: deployment
         with:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
* GH can't queue for the life of them
* The critical section was larger than it needed to be
* Combine the above and we've got cancelled builds that shouldn't be cancelled

### What's changed
* Shrink the critical section
* Avoid running the entire Job if we're not actually going to DO anything in it

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [runs without syntax errors](https://github.com/tenstorrent/tt-metal/actions/runs/15616043120)