### PR TITLE
Restore noc registers after profiler L1 to DRAM noc writes 

### DIFF
--- a/tt_metal/hw/inc/tt-1xx/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/tt-1xx/wormhole/dev_mem_map.h
@@ -55,7 +55,7 @@
 
 /////////////
 // Firmware/kernel code holes
-#define MEM_BRISC_FIRMWARE_SIZE (5 * 1024 + 512)
+#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024)
 // TODO: perhaps put NCRISC FW in the scratch area and free 1.5K after init (GS/WH)
 #define MEM_NCRISC_FIRMWARE_SIZE 2048
 #define MEM_TRISC0_FIRMWARE_SIZE 1536


### PR DESCRIPTION
### Ticket
Inspired by #23175 

### Problem description
We are not restoring all the necessary registers before initiating noc transfers on profiler 

### What's changed
Save and restore them after the write

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18595440995)
- [ ] https://github.com/tenstorrent/tt-metal/actions/runs/18410067221
- [x] [T3K profiler](https://github.com/tenstorrent/tt-metal/actions/runs/18595450574)
- [x] [bh post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18595445879)