### PR TITLE
#22169: Use distributed host buffer on the tensor read path

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -25,9 +25,11 @@
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/cpp/ttnn/operations/creation.hpp"
 #include "ttnn/decorators.hpp"
+#include "ttnn/distributed/api.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/moreh/moreh_sum/moreh_sum.hpp"
 #include "ttnn/tensor/enum_types.hpp"
+#include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/layout/page_config.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
@@ -65,8 +67,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
     ttnn::SmallVector<int64_t> reduce_dims = {3};
     Tensor np_out = ttnn::moreh_sum(np_tensor, reduce_dims, false, std::nullopt, std::nullopt, std::nullopt);
     Tensor np_out_host = np_out.cpu();
-    auto buffer = std::get<MultiDeviceHostStorage>(np_out_host.get_storage()).get_shard_at_origin();
-    const auto golden_output = buffer->view_as<bfloat16>();
+    const Tensor reference_tensor = ttnn::distributed::get_device_tensors(np_out_host).front();
+    auto golden_output = host_buffer::get_as<bfloat16>(reference_tensor);
     // Events for host - device synchronization
     // Running sum-reduce with preallocated output
     // Preallocate Input and Output Tensors on Device

--- a/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
@@ -84,10 +84,12 @@ private:
     DistributedHostBuffer(
         distributed::MeshShape global_shape,
         distributed::MeshCoordinate local_offset,
-        distributed::MeshContainer<Shard> local_shards) :
+        distributed::MeshContainer<Shard> local_shards,
+        std::set<distributed::MeshCoordinate> populated_shards) :
         global_shape_(std::move(global_shape)),
         local_offset_(std::move(local_offset)),
-        local_shards_(std::move(local_shards)) {}
+        local_shards_(std::move(local_shards)),
+        populated_shards_(std::move(populated_shards)) {}
 
     distributed::MeshShape global_shape_;
     distributed::MeshCoordinate local_offset_;

--- a/tt_metal/distributed/distributed_host_buffer.cpp
+++ b/tt_metal/distributed/distributed_host_buffer.cpp
@@ -41,7 +41,10 @@ DistributedHostBuffer DistributedHostBuffer::create(
             global_shape[dim]);
     }
     return DistributedHostBuffer(
-        global_shape, local_offset, distributed::MeshContainer<Shard>(local_shape, Shard{.is_populated = false}));
+        global_shape,
+        local_offset,
+        distributed::MeshContainer<Shard>(local_shape, Shard{.is_populated = false}),
+        /*populated_shards=*/std::set<distributed::MeshCoordinate>{});
 }
 
 DistributedHostBuffer DistributedHostBuffer::create(const distributed::MeshShape& shape) {
@@ -121,7 +124,8 @@ DistributedHostBuffer DistributedHostBuffer::transform(
     return DistributedHostBuffer(
         global_shape_,
         local_offset_,
-        distributed::MeshContainer<Shard>(local_shards_.shape(), std::move(transformed_shards)));
+        distributed::MeshContainer<Shard>(local_shards_.shape(), std::move(transformed_shards)),
+        populated_shards_);
 }
 
 void DistributedHostBuffer::apply(const ApplyFn& fn, ProcessShardExecutionPolicy policy) const {

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -50,9 +50,6 @@ struct DeviceStorage {
 
 class MultiDeviceHostStorage {
 public:
-    // TODO: #15840 - Remove this once `HostStorage` and `MultiDeviceHostStorage` are unified.
-    std::optional<HostBuffer> get_shard_at_origin() const;
-
     // Constructor that creates a linearized distributed host buffer from a vector of host buffers.
     // The buffer is re-shaped upon a write to device, to fit the actual shape of the device.
     // TODO: #22169 - Remove this once there are no more usages of this constructor.

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -99,8 +99,8 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
             const auto& host_storage = std::get<tt::tt_metal::HostStorage>(storage);
             buffer_size = host_storage.buffer.view_bytes().size();
         } else {
-            const auto buffer = std::get<tt::tt_metal::MultiDeviceHostStorage>(storage).get_shard_at_origin();
-            buffer_size = buffer->view_bytes().size();
+            std::get<tt::tt_metal::MultiDeviceHostStorage>(storage).distributed_buffer().apply(
+                [&buffer_size](const tt::tt_metal::HostBuffer& shard) { buffer_size = shard.view_bytes().size(); });
         }
 
         auto inline_storage = ttnn::flatbuffer::InlineFileStorage(/*offset=*/0, buffer_size);

--- a/ttnn/core/tensor/host_buffer/functions.cpp
+++ b/ttnn/core/tensor/host_buffer/functions.cpp
@@ -20,7 +20,10 @@ HostBuffer get_host_buffer(const Tensor& tensor) {
             [](const MultiDeviceHostStorage& storage) {
                 std::vector<HostBuffer> buffers;
                 storage.distributed_buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
-                TT_FATAL(buffers.size() == 1, "Can't get a single buffer from multi device host storage");
+                TT_FATAL(
+                    buffers.size() == 1,
+                    "Can't get a single buffer from multi device host storage of size: {}",
+                    buffers.size());
                 return buffers.front();
             },
             [](const auto&) -> HostBuffer { TT_THROW("Tensor must have HostStorage or MultiDeviceHostStorage"); },

--- a/ttnn/core/tensor/host_buffer/functions.cpp
+++ b/ttnn/core/tensor/host_buffer/functions.cpp
@@ -18,10 +18,10 @@ HostBuffer get_host_buffer(const Tensor& tensor) {
         tt::stl::overloaded{
             [](const HostStorage& storage) { return storage.buffer; },
             [](const MultiDeviceHostStorage& storage) {
-                TT_FATAL(
-                    storage.distributed_buffer().shape().mesh_size() == 1,
-                    "Can't get a single buffer from multi device host storage");
-                return *storage.get_shard_at_origin();
+                std::vector<HostBuffer> buffers;
+                storage.distributed_buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
+                TT_FATAL(buffers.size() == 1, "Can't get a single buffer from multi device host storage");
+                return buffers.front();
             },
             [](const auto&) -> HostBuffer { TT_THROW("Tensor must have HostStorage or MultiDeviceHostStorage"); },
         },

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -52,11 +52,6 @@ bool DeviceStorage::is_uniform_storage() const {
     return coords.size() == mesh_buffer->device()->num_devices();
 }
 
-std::optional<HostBuffer> MultiDeviceHostStorage::get_shard_at_origin() const {
-    return distributed_buffer_.get_shard(
-        distributed::MeshCoordinate::zero_coordinate(distributed_buffer_.shape().dims()));
-}
-
 const DistributedHostBuffer& MultiDeviceHostStorage::distributed_buffer() const { return distributed_buffer_; }
 
 MultiDeviceHostStorage::MultiDeviceHostStorage(std::vector<HostBuffer> buffers) :

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -765,10 +765,11 @@ void write_tensor(const Tensor& host_tensor, Tensor device_tensor, QueueId cq_id
                             return host_storage.buffer.view_bytes().data();
                         },
                         [](const MultiDeviceHostStorage& host_storage) -> const void* {
-                            TT_ASSERT(
-                                host_storage.distributed_buffer().shape().mesh_size() == 1,
-                                "Cannot copy multi-buffer host storage to a single device");
-                            return host_storage.get_shard_at_origin()->view_bytes().data();
+                            std::vector<HostBuffer> buffers;
+                            host_storage.distributed_buffer().apply(
+                                [&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
+                            TT_FATAL(buffers.size() == 1, "Can't get a single buffer from multi device host storage");
+                            return buffers.front().view_bytes().data();
                         },
                         [](auto&&) -> const void* { TT_THROW("Unreachable"); },
                     },

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -768,7 +768,10 @@ void write_tensor(const Tensor& host_tensor, Tensor device_tensor, QueueId cq_id
                             std::vector<HostBuffer> buffers;
                             host_storage.distributed_buffer().apply(
                                 [&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
-                            TT_FATAL(buffers.size() == 1, "Can't get a single buffer from multi device host storage");
+                            TT_FATAL(
+                                buffers.size() == 1,
+                                "Can't get a single buffer from multi device host storage of size: {}",
+                                buffers.size());
                             return buffers.front().view_bytes().data();
                         },
                         [](auto&&) -> const void* { TT_THROW("Unreachable"); },

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -468,10 +468,10 @@ HostBuffer get_host_buffer_from_tensor(const Tensor& tt_tensor, const bool padde
         tt::stl::overloaded{
             [](const HostStorage& storage) { return storage.buffer; },
             [](const MultiDeviceHostStorage& storage) {
-                TT_FATAL(
-                    storage.distributed_buffer().shape().mesh_size() == 1,
-                    "Can't get a single buffer from multi device host storage");
-                return *storage.get_shard_at_origin();
+                std::vector<HostBuffer> buffers;
+                storage.distributed_buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
+                TT_FATAL(buffers.size() == 1, "Can't get a single buffer from multi device host storage");
+                return buffers.front();
             },
             [&tt_tensor](auto&&) -> HostBuffer {
                 TT_THROW(

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -470,7 +470,10 @@ HostBuffer get_host_buffer_from_tensor(const Tensor& tt_tensor, const bool padde
             [](const MultiDeviceHostStorage& storage) {
                 std::vector<HostBuffer> buffers;
                 storage.distributed_buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
-                TT_FATAL(buffers.size() == 1, "Can't get a single buffer from multi device host storage");
+                TT_FATAL(
+                    buffers.size() == 1,
+                    "Can't get a single buffer from multi device host storage of size: {}",
+                    buffers.size());
                 return buffers.front();
             },
             [&tt_tensor](auto&&) -> HostBuffer {


### PR DESCRIPTION
### Ticket
#22169

### Problem description
Adopting read API for distributed host buffer.

### What's changed
1. Removing `MultiDeviceHostStorage::get_shard_at_origin` API because we can. "Unwrapping" local shards with `apply` is more scalable and doesn't introduce new public functions. 
2. On the read path, due to performance regression introduced in https://github.com/tenstorrent/tt-metal/pull/22959, switching back to multi-threaded allocations, however now relying on `DistributedHostBuffer` mechanism based on Taskflow for each, instead of `MeshDevice` thread pool. This restores perf on [falcon7b](https://github.com/tenstorrent/tt-metal/actions/runs/15619625788/job/44001709428) and [whisper](https://github.com/tenstorrent/tt-metal/actions/runs/15619653371/job/44001909455).

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15621558320)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15619653371/job/44001909455)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15619625788/job/44001709428)
- [x] New/Existing tests provide coverage for changes