### PR TITLE
add support for variable routing plane count based on live ethernet link count

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -413,6 +413,7 @@ def mesh_device(request, silicon_arch_name, device_params):
 
     updated_device_params = get_updated_device_params(device_params)
     fabric_config = updated_device_params.pop("fabric_config", None)
+    reliability_mode = updated_device_params.pop("reliability_mode", None)
     set_fabric(fabric_config)
     mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, **updated_device_params)
 

--- a/conftest.py
+++ b/conftest.py
@@ -473,6 +473,7 @@ def pcie_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
 
     updated_device_params = get_updated_device_params(device_params)
     fabric_config = updated_device_params.pop("fabric_config", None)
+    reliability_mode = updated_device_params.pop("reliability_mode", None)
     set_fabric(fabric_config)
     mesh_device = ttnn.open_mesh_device(
         mesh_shape=ttnn.MeshShape(2, 2),
@@ -501,6 +502,7 @@ def n300_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
 
     updated_device_params = get_updated_device_params(device_params)
     fabric_config = updated_device_params.pop("fabric_config", None)
+    reliability_mode = updated_device_params.pop("reliability_mode", None)
     set_fabric(fabric_config)
     mesh_device = ttnn.open_mesh_device(
         mesh_shape=ttnn.MeshShape(1, 2),
@@ -528,6 +530,7 @@ def t3k_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device
     request.node.pci_ids = ttnn.get_pcie_device_ids()
     updated_device_params = get_updated_device_params(device_params)
     fabric_config = updated_device_params.pop("fabric_config", None)
+    reliability_mode = updated_device_params.pop("reliability_mode", None)
     set_fabric(fabric_config)
     mesh_device = ttnn.open_mesh_device(
         mesh_shape=ttnn.MeshShape(1, 8),

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -60,7 +60,8 @@ public:
         for (unsigned int id = 0; id < num_devices; id++) {
             ids.push_back(id);
         }
-        tt::tt_metal::detail::SetFabricConfig(fabric_config, num_routing_planes);
+        tt::tt_metal::detail::SetFabricConfig(
+            fabric_config, tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, num_routing_planes);
         devices_map_ = tt::tt_metal::detail::CreateDevices(ids);
         for (auto& [id, device] : devices_map_) {
             devices_.push_back(device);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -34,7 +34,10 @@ TEST_F(ControlPlaneFixture, TestTGControlPlaneInit) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(tg_mesh_graph_desc_path.string());
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
+    control_plane->initialize_fabric_context(
+        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
+        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
 }
 
 TEST_F(ControlPlaneFixture, TestTGMeshAPIs) {
@@ -54,7 +57,10 @@ TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(tg_mesh_graph_desc_path.string());
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
+    control_plane->initialize_fabric_context(
+        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
+        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 1);
     EXPECT_GT(valid_chans.size(), 0);
     for (auto chan : valid_chans) {
@@ -75,7 +81,10 @@ TEST_F(ControlPlaneFixture, TestT3kControlPlaneInit) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(t3k_mesh_graph_desc_path.string());
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
+    control_plane->initialize_fabric_context(
+        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
+        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
 }
 
 TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
@@ -83,7 +92,10 @@ TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(t3k_mesh_graph_desc_path.string());
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
+    control_plane->initialize_fabric_context(
+        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
+        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 0);
     EXPECT_GT(valid_chans.size(), 0);
     for (auto chan : valid_chans) {
@@ -114,9 +126,13 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kControlPlaneInit) {
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
     auto global_control_plane = std::make_unique<GlobalControlPlane>(
-        t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
+        t3k_mesh_graph_desc_path.string(),
+        get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
     auto& control_plane = global_control_plane->get_local_node_control_plane();
-    control_plane.configure_routing_tables_for_fabric_ethernet_channels();
+    control_plane.initialize_fabric_context(
+        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
+        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    control_plane.configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
 }
 
 TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
@@ -125,9 +141,13 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
     auto global_control_plane = std::make_unique<GlobalControlPlane>(
-        t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
+        t3k_mesh_graph_desc_path.string(),
+        get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
     auto& control_plane = global_control_plane->get_local_node_control_plane();
-    control_plane.configure_routing_tables_for_fabric_ethernet_channels();
+    control_plane.initialize_fabric_context(
+        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
+        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    control_plane.configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
     for (const auto& src_mesh : control_plane.get_user_physical_mesh_ids()) {
         for (const auto& dst_mesh : control_plane.get_user_physical_mesh_ids()) {
             auto src_mesh_shape = control_plane.get_physical_mesh_shape(src_mesh);
@@ -153,7 +173,10 @@ TEST_F(ControlPlaneFixture, TestT3kDisjointFabricRoutes) {
     auto global_control_plane = std::make_unique<GlobalControlPlane>(
         t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
     auto& control_plane = global_control_plane->get_local_node_control_plane();
-    control_plane.configure_routing_tables_for_fabric_ethernet_channels();
+    control_plane.initialize_fabric_context(
+        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
+        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    control_plane.configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
     auto valid_chans = control_plane.get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 0);
     EXPECT_GT(valid_chans.size(), 0);
     for (auto chan : valid_chans) {
@@ -186,7 +209,10 @@ TEST_F(ControlPlaneFixture, TestQuantaGalaxyControlPlaneInit) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/quanta_galaxy_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(quanta_galaxy_mesh_graph_desc_path.string());
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
+    control_plane->initialize_fabric_context(
+        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
+        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
 }
 
 TEST_F(ControlPlaneFixture, TestQuantaGalaxyMeshAPIs) {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -172,14 +172,7 @@ public:
     std::shared_ptr<MeshDevice> mesh_device_;
 
     // Gets the appropriate mesh shape based on device configuration
-    MeshShape GetDeterminedMeshShape() const {
-        return SystemMesh::instance().get_shape();
-        // if (num_devices_ == TG_NUM_DEVICES || num_devices_ == GALAXY_6U_NUM_DEVICES) {
-        //     return MeshShape{8, 4};
-        // } else {
-        //     return MeshShape{2, 4};
-        // }
-    }
+    MeshShape GetDeterminedMeshShape() const { return SystemMesh::instance().get_shape(); }
 
     // Validates environment and hardware for tests
     void ValidateEnvironment() {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -173,11 +173,12 @@ public:
 
     // Gets the appropriate mesh shape based on device configuration
     MeshShape GetDeterminedMeshShape() const {
-        if (num_devices_ == TG_NUM_DEVICES || num_devices_ == GALAXY_6U_NUM_DEVICES) {
-            return MeshShape{8, 4};
-        } else {
-            return MeshShape{2, 4};
-        }
+        return SystemMesh::instance().get_shape();
+        // if (num_devices_ == TG_NUM_DEVICES || num_devices_ == GALAXY_6U_NUM_DEVICES) {
+        //     return MeshShape{8, 4};
+        // } else {
+        //     return MeshShape{2, 4};
+        // }
     }
 
     // Validates environment and hardware for tests
@@ -3696,13 +3697,13 @@ size_t get_number_of_links_for_ring_deadlock_stability_test(
     size_t num_links = num_links_opt.value_or(0);
     if (num_links == 0) {
         if (cluster_type == ClusterType::GALAXY) {
-            for (size_t i = 0; i < 8; i++) {
+            for (size_t i = 0; i < mesh_device.shape()[0]; i++) {
                 size_t cluster_axis = 1;
                 auto nl =
                     tt::tt_fabric::experimental::get_number_of_available_routing_planes(mesh_device, cluster_axis, i);
                 log_debug(tt::LogTest, "Number of links for Galaxy cluster_axis 0, row {}: {}", i, nl);
             }
-            for (size_t i = 0; i < 4; i++) {
+            for (size_t i = 0; i < mesh_device.shape()[1]; i++) {
                 size_t cluster_axis = 0;
                 auto nl =
                     tt::tt_fabric::experimental::get_number_of_available_routing_planes(mesh_device, cluster_axis, i);

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -107,8 +107,8 @@ protected:
 public:
     BaseFabricFixture() : device_open(false) {}
 
-    BaseFabricFixture(tt::tt_metal::FabricConfig fabric_config) : device_open(false) {
-        tt::tt_metal::detail::SetFabricConfig(fabric_config);
+    BaseFabricFixture(tt::tt_metal::FabricConfig fabric_config, tt::tt_metal::FabricReliabilityMode reliability_mode = tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) : device_open(false) {
+        tt::tt_metal::detail::SetFabricConfig(fabric_config, reliability_mode);
     }
 
     virtual ~BaseFabricFixture() { tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED); }
@@ -148,11 +148,86 @@ public:
 
     Fabric1DFixture() : BaseFabricFixture() { this->SetupDevices(); }
 
-    Fabric1DFixture(tt::tt_metal::FabricConfig fabric_config) : BaseFabricFixture(fabric_config) {
+    Fabric1DFixture(
+        tt::tt_metal::FabricConfig fabric_config,
+        tt::tt_metal::FabricReliabilityMode reliability_mode =
+            tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) :
+        BaseFabricFixture(fabric_config, reliability_mode) {
         this->SetupDevices();
     }
 
     ~Fabric1DFixture() override { TearDown(); }
+};
+
+class Fabric1DDeviceInitFixture {
+public:
+    tt::ARCH arch_;
+    std::size_t num_devices_;
+    bool device_open = false;
+
+    // Common constants for both fixtures
+    static constexpr size_t TG_NUM_DEVICES = 36;
+    static constexpr size_t GALAXY_6U_NUM_DEVICES = 32;
+
+    std::shared_ptr<MeshDevice> mesh_device_;
+
+    // Gets the appropriate mesh shape based on device configuration
+    MeshShape GetDeterminedMeshShape() const {
+        if (num_devices_ == TG_NUM_DEVICES || num_devices_ == GALAXY_6U_NUM_DEVICES) {
+            return MeshShape{8, 4};
+        } else {
+            return MeshShape{2, 4};
+        }
+    }
+
+    // Validates environment and hardware for tests
+    void ValidateEnvironment() {
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (slow_dispatch) {
+            TT_THROW("This suite can only be run without TT_METAL_SLOW_DISPATCH_MODE set");
+        }
+
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        num_devices_ = tt::tt_metal::GetNumAvailableDevices();
+
+        if (!(arch_ == tt::ARCH::WORMHOLE_B0 && num_devices_ >= 8 &&
+              (tt::tt_metal::GetNumPCIeDevices() == 4 || tt::tt_metal::GetNumPCIeDevices() == GALAXY_6U_NUM_DEVICES))) {
+            TT_THROW("This suite can only be run on T3000 or TG Wormhole devices");
+        }
+    }
+
+    void SetupDevices() {
+        ValidateEnvironment();
+
+        const MeshShape cluster_shape = GetDeterminedMeshShape();
+        const auto& physical_device_ids = SystemMesh::instance().get_mapped_physical_device_ids(cluster_shape);
+
+        mesh_device_ = MeshDevice::create(MeshDeviceConfig(cluster_shape));
+        device_open = true;
+    }
+
+    void TearDown() {
+        if (device_open) {
+            mesh_device_->close();
+            device_open = false;
+        }
+    }
+
+    Fabric1DDeviceInitFixture() : device_open(false) { this->SetupDevices(); }
+
+    Fabric1DDeviceInitFixture(
+        tt::tt_metal::FabricConfig fabric_config,
+        tt::tt_metal::FabricReliabilityMode reliability_mode =
+            tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) :
+        device_open(false) {
+        tt::tt_metal::detail::SetFabricConfig(fabric_config, reliability_mode);
+        this->SetupDevices();
+    }
+
+    ~Fabric1DDeviceInitFixture() {
+        TearDown();
+        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+    }
 };
 
 class MeshFabric1DFixture : public BaseFabricFixture {
@@ -174,7 +249,11 @@ public:
 
     MeshFabric1DFixture() : BaseFabricFixture() { this->SetupDevices(); }
 
-    MeshFabric1DFixture(tt::tt_metal::FabricConfig fabric_config) : BaseFabricFixture(fabric_config) {
+    MeshFabric1DFixture(
+        tt::tt_metal::FabricConfig fabric_config,
+        tt::tt_metal::FabricReliabilityMode reliability_mode =
+            tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) :
+        BaseFabricFixture(fabric_config, reliability_mode) {
         this->SetupDevices();
     }
 
@@ -193,6 +272,20 @@ public:
 class Fabric1DRingDeviceInitFixture : public Fabric1DFixture {
 public:
     Fabric1DRingDeviceInitFixture() : Fabric1DFixture(tt::tt_metal::FabricConfig::FABRIC_1D_RING) {}
+};
+class Fabric1DRingStrictDeviceInitFixture : public Fabric1DDeviceInitFixture {
+public:
+    Fabric1DRingStrictDeviceInitFixture() :
+        Fabric1DDeviceInitFixture(
+            tt::tt_metal::FabricConfig::FABRIC_1D_RING,
+            tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) {}
+};
+class Fabric1DRingRelaxedDeviceInitFixture : public Fabric1DDeviceInitFixture {
+public:
+    Fabric1DRingRelaxedDeviceInitFixture() :
+        Fabric1DDeviceInitFixture(
+            tt::tt_metal::FabricConfig::FABRIC_1D_RING,
+            tt::tt_metal::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE) {}
 };
 
 class MeshFabric1DLineDeviceInitFixture : public MeshFabric1DFixture {
@@ -3594,29 +3687,115 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
     Run1DFabricPacketSendTest(test_fixture, test_specs, params_copy, 0);
 }
 
+size_t get_number_of_links_for_ring_deadlock_stability_test(
+    const MeshDevice& mesh_device,
+    ClusterType cluster_type,
+    std::optional<size_t> num_links_opt,
+    size_t num_devices,
+    std::optional<size_t> row_or_col) {
+    size_t num_links = num_links_opt.value_or(0);
+    if (num_links == 0) {
+        if (cluster_type == ClusterType::GALAXY) {
+            for (size_t i = 0; i < 8; i++) {
+                size_t cluster_axis = 1;
+                auto nl =
+                    tt::tt_fabric::experimental::get_number_of_available_routing_planes(mesh_device, cluster_axis, i);
+                log_debug(tt::LogTest, "Number of links for Galaxy cluster_axis 0, row {}: {}", i, nl);
+            }
+            for (size_t i = 0; i < 4; i++) {
+                size_t cluster_axis = 0;
+                auto nl =
+                    tt::tt_fabric::experimental::get_number_of_available_routing_planes(mesh_device, cluster_axis, i);
+                log_debug(tt::LogTest, "Number of links for Galaxy cluster_axis 1, row {}: {}", i, nl);
+            }
+
+            bool is_long_edge = num_devices == 8;
+            size_t cluster_axis = !is_long_edge ? 1 : 0;
+            num_links = tt::tt_fabric::experimental::get_number_of_available_routing_planes(
+                mesh_device, cluster_axis, row_or_col.value());
+        } else {
+            TT_THROW("This test can only be run on 4 or 8 chips on Galaxy devices");
+        }
+    }
+
+    return num_links;
+}
+
+std::vector<IDevice*> get_devices_for_ring_deadlock_stability_test(
+    const MeshDeviceView& view, ClusterType cluster_type, size_t num_devices, std::optional<size_t> row_or_col) {
+    std::vector<IDevice*> devices_;
+    log_debug(tt::LogTest, "Getting devices for ring deadlock stability test. Row or col: {}", row_or_col.value_or(0));
+
+    if (cluster_type == ClusterType::GALAXY) {
+        if (num_devices == 4) {
+            log_debug(
+                tt::LogTest,
+                "Getting 4 devices for ring deadlock stability test. Row or col: {}",
+                row_or_col.value_or(0));
+            devices_ = {
+                view.get_device(MeshCoordinate(row_or_col.value_or(0), 0)),
+                view.get_device(MeshCoordinate(row_or_col.value_or(0), 1)),
+                view.get_device(MeshCoordinate(row_or_col.value_or(0), 2)),
+                view.get_device(MeshCoordinate(row_or_col.value_or(0), 3))};
+        } else if (num_devices == 8) {
+            log_debug(
+                tt::LogTest,
+                "Getting 8 devices for ring deadlock stability test. Row or col: {}",
+                row_or_col.value_or(0));
+            devices_ = {
+                view.get_device(MeshCoordinate(0, row_or_col.value_or(0))),
+                view.get_device(MeshCoordinate(1, row_or_col.value_or(0))),
+                view.get_device(MeshCoordinate(2, row_or_col.value_or(0))),
+                view.get_device(MeshCoordinate(3, row_or_col.value_or(0))),
+                view.get_device(MeshCoordinate(4, row_or_col.value_or(0))),
+                view.get_device(MeshCoordinate(5, row_or_col.value_or(0))),
+                view.get_device(MeshCoordinate(6, row_or_col.value_or(0))),
+                view.get_device(MeshCoordinate(7, row_or_col.value_or(0)))};
+        }
+    } else {
+        log_debug(
+            tt::LogTest, "Getting 8 devices for ring deadlock stability test. Row or col: {}", row_or_col.value_or(0));
+        TT_FATAL(!row_or_col.has_value(), "Row or col must be provided for T3000 devices");
+        devices_ = {
+            view.get_device(MeshCoordinate(0, 0)),
+            view.get_device(MeshCoordinate(0, 1)),
+            view.get_device(MeshCoordinate(0, 2)),
+            view.get_device(MeshCoordinate(0, 3)),
+            view.get_device(MeshCoordinate(1, 3)),
+            view.get_device(MeshCoordinate(1, 2)),
+            view.get_device(MeshCoordinate(1, 1)),
+            view.get_device(MeshCoordinate(1, 0))};
+    }
+    return devices_;
+}
+
+template <typename DeviceInitFixture = Fabric1DRingStrictDeviceInitFixture>
 void RunRingDeadlockStabilityTestWithPersistentFabric(
     size_t num_mcasts,
-    size_t num_links,
+    std::optional<size_t> num_links_opt,
     size_t num_devices,
     size_t num_op_invocations,
     bool has_forward_connection,
     bool has_backward_connection,
-    size_t packet_payload_size_bytes = tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes) {
+    size_t packet_payload_size_bytes = tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes,
+    std::optional<size_t> row_or_col = std::nullopt) {
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+
     auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
     switch (cluster_type) {
         case ClusterType::T3K:
             if (num_devices != 8) {
-                log_info(tt::LogTest, "This test can only be run 8 chips on T3000 devices");
+                log_debug(tt::LogTest, "This test can only be run 8 chips on T3000 devices");
                 return;
             }
             break;
         case ClusterType::GALAXY:
             if (num_devices != 4 && num_devices != 8) {
-                log_info(tt::LogTest, "This test can only be run on 4 or 8 chips on Galaxy devices");
+                log_debug(tt::LogTest, "This test can only be run on 4 or 8 chips on Galaxy devices");
                 return;
             }
             break;
-        default: log_info(tt::LogTest, "This test can only be run on T3000 or Galaxy devices"); return;
+        default: log_debug(tt::LogTest, "This test can only be run on T3000 or Galaxy devices"); return;
     }
 
     using namespace ttnn::ccl;
@@ -3635,47 +3814,19 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
     size_t dest_buffer_size = packet_payload_size_bytes * 4;
     static constexpr tt::DataFormat cb_df = tt::DataFormat::Bfp8;
 
-    Fabric1DRingDeviceInitFixture test_fixture;
-    auto view = *(test_fixture.view_);
+    DeviceInitFixture test_fixture;
+    auto view = test_fixture.mesh_device_->get_view();
 
-    std::vector<IDevice*> devices_;
-
-    if (cluster_type == ClusterType::GALAXY) {
-        if (num_devices == 4) {
-            devices_ = {
-                view.get_device(MeshCoordinate(0, 0)),
-                view.get_device(MeshCoordinate(0, 1)),
-                view.get_device(MeshCoordinate(0, 2)),
-                view.get_device(MeshCoordinate(0, 3))};
-        } else if (num_devices == 8) {
-            devices_ = {
-                view.get_device(MeshCoordinate(0, 0)),
-                view.get_device(MeshCoordinate(1, 0)),
-                view.get_device(MeshCoordinate(2, 0)),
-                view.get_device(MeshCoordinate(3, 0)),
-                view.get_device(MeshCoordinate(4, 0)),
-                view.get_device(MeshCoordinate(5, 0)),
-                view.get_device(MeshCoordinate(6, 0)),
-                view.get_device(MeshCoordinate(7, 0))};
-        }
-    } else {
-        devices_ = {
-            view.get_device(MeshCoordinate(0, 0)),
-            view.get_device(MeshCoordinate(0, 1)),
-            view.get_device(MeshCoordinate(0, 2)),
-            view.get_device(MeshCoordinate(0, 3)),
-            view.get_device(MeshCoordinate(1, 3)),
-            view.get_device(MeshCoordinate(1, 2)),
-            view.get_device(MeshCoordinate(1, 1)),
-            view.get_device(MeshCoordinate(1, 0))};
-    }
+    std::vector<IDevice*> devices_ =
+        get_devices_for_ring_deadlock_stability_test(view, cluster_type, num_devices, row_or_col);
+    size_t num_links = get_number_of_links_for_ring_deadlock_stability_test(
+        *test_fixture.mesh_device_.get(), cluster_type, num_links_opt, num_devices, row_or_col);
 
     std::vector<IDevice*> devices;
     devices.reserve(line_size);
     for (size_t i = 0; i < line_size; i++) {
         devices.push_back(devices_[i]);
     }
-    // build the mesh device
 
     // Other boiler plate setup
     CoreRangeSet worker_cores = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(num_links - 1, 0)));
@@ -3690,6 +3841,7 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
     ttnn::SmallVector<std::shared_ptr<Buffer>> device_dest_buffers;
     device_dest_buffers.reserve(line_size);
     for (auto* d : devices) {
+        TT_FATAL(d != nullptr, "Device is nullptr");
         auto local_input_buffer =
             CreateBuffer(InterleavedBufferConfig{d, dest_buffer_size, dest_buffer_size, BufferType::L1});
         device_dest_buffers.push_back(local_input_buffer);
@@ -3707,13 +3859,11 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
     global_semaphore_addrs.reserve(line_size + 1);
     std::vector<ttnn::global_semaphore::MultiDeviceGlobalSemaphore> global_semaphore_handles;
     for (size_t i = 0; i < line_size * 4; i++) {
-        auto global_semaphores = ttnn::global_semaphore::create_global_semaphore_with_same_address(
+        auto global_semaphores = ttnn::global_semaphore::create_global_semaphore(
             devices_,
             devices_[0]->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
-            0,                             // initial value
-            tt::tt_metal::BufferType::L1,  // buffer type
-            1000                           // attempts
-        );
+            0,                              // initial value
+            tt::tt_metal::BufferType::L1);  //,  // buffer type
         global_semaphore_handles.push_back(global_semaphores);
         auto global_semaphore_addr =
             ttnn::global_semaphore::get_global_semaphore_address(global_semaphores.global_semaphores.at(0));
@@ -3735,6 +3885,7 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
     std::vector<KernelHandle> worker_kernel_ids;
     std::vector<size_t> per_device_global_sem_addr_rt_arg;
     uint32_t num_dirs = (uint32_t)has_forward_connection + (uint32_t)has_backward_connection;
+    log_debug(tt::LogTest, "Initializing worker programs");
     for (size_t i = 0; i < num_devices_with_workers; i++) {
         const size_t line_index = i;
         auto& program = programs[i];

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -1297,15 +1297,15 @@ TEST(EdmFabric, RingDeadlockStabilityTest) {
     constexpr size_t num_op_invocations = 5;
     constexpr bool line_sync = true;
     size_t num_links = 1;
-    std::vector<size_t> num_devices;
+    std::vector<size_t> num_devices_vec;
     auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
     if (cluster_type == tt::ClusterType::GALAXY) {
-        num_devices = {4, 8};
+        num_devices_vec = {4, 8};
         num_links = 4;
     } else {
-        num_devices = {8};
+        num_devices_vec = {8};
     }
-    for (const auto& num_devices : num_devices) {
+    for (const auto& num_devices : num_devices_vec) {
         log_trace(
             tt::LogTest, "Running RingDeadlockStabilityTest with forward mcast only with {} devices", num_devices);
         RunRingDeadlockStabilityTestWithPersistentFabric(
@@ -1320,5 +1320,42 @@ TEST(EdmFabric, RingDeadlockStabilityTest) {
             num_devices);
         RunRingDeadlockStabilityTestWithPersistentFabric(
             num_mcasts, num_links, num_devices, num_op_invocations, true, true);
+    }
+}
+
+TEST(EdmFabric, RingDeadlockStabilityTest_RelaxedFabricStrictness) {
+    constexpr size_t num_mcasts = 200000;
+    constexpr size_t num_op_invocations = 5;
+    constexpr bool line_sync = true;
+    // Set to however many links are available
+    std::optional<size_t> num_links = std::nullopt;
+    std::vector<size_t> num_devices;
+    auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+
+    if (cluster_type != tt::ClusterType::GALAXY) {
+        return;
+    }
+    num_devices = {4, 8};
+    for (size_t offset = 0; offset < num_devices[1]; offset++) {
+        RunRingDeadlockStabilityTestWithPersistentFabric<Fabric1DRingRelaxedDeviceInitFixture>(
+            num_mcasts,
+            num_links,
+            num_devices[0],
+            num_op_invocations,
+            true,
+            false,
+            tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes,
+            offset);
+    }
+    for (size_t offset = 0; offset < num_devices[0]; offset++) {
+        RunRingDeadlockStabilityTestWithPersistentFabric<Fabric1DRingRelaxedDeviceInitFixture>(
+            num_mcasts,
+            num_links,
+            num_devices[1],
+            num_op_invocations,
+            true,
+            false,
+            tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes,
+            offset);
     }
 }

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -122,9 +122,6 @@ public:
     // If the ethernet core is an intermesh link, probe to see if it is trained
     bool is_intermesh_eth_link_trained(chip_id_t chip_id, CoreCoord eth_core) const;
 
-    // Calculate number of active routing planes for each mesh
-    size_t get_num_active_routing_planes(const IntraMeshConnectivity& intra_mesh_connectivity);
-
 private:
     uint16_t routing_mode_ = 0;  // ROUTING_MODE_UNDEFINED
     // TODO: remove this from local node control plane. Can get it from the global control plane

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -11,6 +11,11 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/fabric_types.hpp>
 
+#include <map>
+#include <unordered_map>
+#include <memory>
+#include <vector>
+
 namespace tt::tt_fabric {
 
 class FabricContext;
@@ -26,9 +31,11 @@ public:
     // Printing functions
     void print_routing_tables() const;
     void print_ethernet_channels() const;
+    void print_active_ethernet_connections() const;
+    void print_all_ethernet_connections() const;
 
     // Converts chip level routing tables to per ethernet channel
-    void configure_routing_tables_for_fabric_ethernet_channels();
+    void configure_routing_tables_for_fabric_ethernet_channels(tt_metal::FabricReliabilityMode reliability_mode);
     void write_routing_tables_to_all_chips() const;
 
     // Return mesh_id, chip_id from physical chip id
@@ -67,7 +74,15 @@ public:
 
     size_t get_num_active_fabric_routers(FabricNodeId fabric_node_id) const;
 
+    // Number of active ethernet channels, but these may not be participating in active routing planes
+    // (in other words, they are not participating in fabric traffic)
     std::vector<chan_id_t> get_active_fabric_eth_channels_in_direction(
+        FabricNodeId fabric_node_id, RoutingDirection routing_direction) const;
+    // Return the active routing planes in a given direction.
+    std::vector<chan_id_t> get_active_fabric_eth_routing_planes_in_direction(
+        FabricNodeId fabric_node_id, RoutingDirection routing_direction) const;
+
+    size_t get_num_available_routing_planes_in_direction(
         FabricNodeId fabric_node_id, RoutingDirection routing_direction) const;
 
     std::set<std::pair<chan_id_t, eth_chan_directions>> get_active_fabric_eth_channels(
@@ -80,7 +95,7 @@ public:
     void set_routing_mode(uint16_t mode);
     uint16_t get_routing_mode() const;
 
-    void initialize_fabric_context(tt_metal::FabricConfig fabric_config);
+    void initialize_fabric_context(tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode);
 
     FabricContext& get_fabric_context() const;
 
@@ -107,6 +122,9 @@ public:
     // If the ethernet core is an intermesh link, probe to see if it is trained
     bool is_intermesh_eth_link_trained(chip_id_t chip_id, CoreCoord eth_core) const;
 
+    // Calculate number of active routing planes for each mesh
+    size_t get_num_active_routing_planes(const IntraMeshConnectivity& intra_mesh_connectivity);
+
 private:
     uint16_t routing_mode_ = 0;  // ROUTING_MODE_UNDEFINED
     // TODO: remove this from local node control plane. Can get it from the global control plane
@@ -116,6 +134,9 @@ private:
     // map[mesh_fabric_id][direction] has a vector of ethernet channels in that direction
     std::map<FabricNodeId, std::unordered_map<RoutingDirection, std::vector<chan_id_t>>>
         router_port_directions_to_physical_eth_chan_map_;
+    // map[mesh_fabric_id][direction] has the number of live routing planes in that direction
+    std::map<FabricNodeId, std::unordered_map<RoutingDirection, size_t>>
+        router_port_directions_to_num_routing_planes_map_;
     // tables[mesh_fabric_id][eth_chan]
     std::map<FabricNodeId, std::vector<std::vector<chan_id_t>>>
         intra_mesh_routing_tables_;  // table that will be written to each ethernet core
@@ -142,6 +163,10 @@ private:
 
     void load_physical_chip_mapping(
         const std::map<FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping);
+    size_t get_num_live_routing_planes(FabricNodeId fabric_node_id, RoutingDirection routing_direction) const;
+    void initialize_dynamic_routing_plane_counts(
+        const IntraMeshConnectivity& intra_mesh_connectivity, tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode);
+    void trim_ethernet_channels_not_mapped_to_live_routing_planes();
 
     void validate_mesh_connections(MeshId mesh_id) const;
     void validate_mesh_connections() const;

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -18,6 +18,10 @@ class Program;
 }  // namespace tt_metal
 }  // namespace tt
 
+namespace tt::tt_metal::distributed {
+class MeshDevice;
+}  // namespace tt::tt_metal::distributed
+
 namespace tt::tt_fabric {
 
 size_t get_tt_fabric_channel_buffer_size_bytes();
@@ -53,5 +57,10 @@ void append_fabric_connection_rt_args(
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
     CoreType core_type = CoreType::WORKER);
+
+namespace experimental {
+size_t get_number_of_available_routing_planes(
+    const tt::tt_metal::distributed::MeshDevice& mesh_device, size_t cluster_axis, size_t row_or_col);
+}
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/api/tt-metalium/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/fabric_types.hpp
@@ -7,6 +7,7 @@
 #include <tt_stl/strong_type.hpp>
 
 namespace tt::tt_metal {
+
 enum class FabricConfig : uint32_t {
     DISABLED = 0,
     FABRIC_1D = 1,          // Instatiates fabric with 1D routing and no deadlock avoidance
@@ -15,6 +16,21 @@ enum class FabricConfig : uint32_t {
     FABRIC_2D_TORUS = 4,    // Instatiates fabric with 2D routing and with deadlock avoidance using datelines
     FABRIC_2D_DYNAMIC = 5,  // Instatiates fabric with 2D routing with dynamic routing
     CUSTOM = 6
+};
+
+enum class FabricReliabilityMode : uint32_t {
+
+    // When fabric is initialized, user expects live links/devices to exactly match the mesh graph descriptor.
+    // Any downed devices/links will result in some sort of error condition being reported.
+    STRICT_SYSTEM_HEALTH_SETUP_MODE = 0,
+
+    // When fabric is initialized, user is flexible towards downed links/devices. This mode specifies that fabric
+    // can be initialized with fewer routing planes than are in the mesh graph descriptor, according to the number
+    // of live links in the system
+    RELAXED_SYSTEM_HEALTH_SETUP_MODE = 1,
+
+    // Unsupported - fabric can be setup at runtime. Placeholder
+    DYNAMIC_RECONFIGURATION_SETUP_MODE = 2,
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -28,6 +28,7 @@
 namespace tt {
 namespace tt_metal {
 enum class FabricConfig : uint32_t;
+enum class FabricReliabilityMode : uint32_t;
 }  // namespace tt_metal
 }  // namespace tt
 
@@ -55,7 +56,10 @@ bool DispatchStateCheck(bool isFastDispatch);
  * | fabric_config      | Fabric config to set                | FabricConfig      |             | Yes      |
  * | num_routing_planes | Number of routing planes for fabric | optional<uint8_t> |             | No       |
  */
-void SetFabricConfig(FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt);
+void SetFabricConfig(
+    FabricConfig fabric_config,
+    FabricReliabilityMode reliability_mode = FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+    std::optional<uint8_t> num_routing_planes = std::nullopt);
 
 std::map<chip_id_t, IDevice*> CreateDevices(
     // TODO: delete this in favour of DevicePool

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -245,7 +245,7 @@ void write_socket_configs(
     }
 }
 
-uint32_t get_physical_mesh_id(MeshDevice* mesh_device, const MeshCoordinate& coord) {
+uint32_t get_physical_mesh_id(const MeshDevice* mesh_device, const MeshCoordinate& coord) {
     auto physical_device_id = mesh_device->get_device(coord)->id();
     auto global_coord = SystemMesh::instance().get_global_device_coordinate(physical_device_id);
     return SystemMesh::instance().get_physical_mesh_id(global_coord);

--- a/tt_metal/distributed/mesh_socket_utils.hpp
+++ b/tt_metal/distributed/mesh_socket_utils.hpp
@@ -30,6 +30,6 @@ void write_socket_configs(
 //  =============== Additional utility functions  ===============
 
 // Given a MeshDevice and a logical device coordinate, determine the device's physical mesh id
-uint32_t get_physical_mesh_id(MeshDevice* mesh_device, const MeshCoordinate& coord);
+uint32_t get_physical_mesh_id(const MeshDevice* mesh_device, const MeshCoordinate& coord);
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -149,7 +149,7 @@ void ControlPlane::initialize_dynamic_routing_plane_counts(
     size_t min_routing_planes = std::numeric_limits<size_t>::max();
 
     auto apply_min =
-        [this, reliability_mode](
+        [this](
             const std::unordered_map<tt::tt_fabric::RoutingDirection, std::vector<tt::tt_fabric::chan_id_t>>&
                 port_direction_eth_chans,
             tt::tt_fabric::RoutingDirection direction,
@@ -1425,7 +1425,7 @@ uint16_t ControlPlane::get_routing_mode() const { return this->routing_mode_; }
 void ControlPlane::initialize_fabric_context(tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode) {
     TT_FATAL(this->fabric_context_ == nullptr, "Trying to re-initialize fabric context");
     tt::tt_metal::MetalContext::instance().set_fabric_config(fabric_config, reliability_mode);
-    this->fabric_context_ = std::make_unique<FabricContext>(fabric_config);//, reliability_mode);
+    this->fabric_context_ = std::make_unique<FabricContext>(fabric_config);
 }
 
 FabricContext& ControlPlane::get_fabric_context() const {

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -116,6 +116,148 @@ bool is_chip_on_corner_of_mesh(
     }
 }
 
+template <typename CONNECTIVITY_MAP_T>
+static void build_golden_link_counts(
+    CONNECTIVITY_MAP_T const& golden_connectivity_map,
+    std::unordered_map<MeshId, std::unordered_map<chip_id_t, std::unordered_map<RoutingDirection, size_t>>>&
+        golden_link_counts_out) {
+    static_assert(
+        std::is_same_v<CONNECTIVITY_MAP_T, IntraMeshConnectivity> ||
+            std::is_same_v<CONNECTIVITY_MAP_T, InterMeshConnectivity>,
+        "Invalid connectivity map type");
+    for (std::uint32_t mesh_id = 0; mesh_id < golden_connectivity_map.size(); mesh_id++) {
+        for (std::uint32_t chip_id = 0; chip_id < golden_connectivity_map[mesh_id].size(); chip_id++) {
+            for (const auto& [remote_connected_id, router_edge] : golden_connectivity_map[mesh_id][chip_id]) {
+                TT_FATAL(
+                    golden_link_counts_out[MeshId{mesh_id}][chip_id][router_edge.port_direction] == 0,
+                    "Golden link counts already set for chip {} in mesh {}",
+                    chip_id,
+                    mesh_id);
+                golden_link_counts_out[MeshId{mesh_id}][chip_id][router_edge.port_direction] =
+                    router_edge.connected_chip_ids.size();
+            }
+        }
+    }
+};
+
+void ControlPlane::initialize_dynamic_routing_plane_counts(
+    const IntraMeshConnectivity& intra_mesh_connectivity, tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode) {
+    if (fabric_config == tt_metal::FabricConfig::CUSTOM) {
+        return;
+    }
+    auto topology = FabricContext::get_topology_from_config(fabric_config);
+    size_t min_routing_planes = std::numeric_limits<size_t>::max();
+
+    auto apply_min =
+        [this, reliability_mode](
+            const std::unordered_map<tt::tt_fabric::RoutingDirection, std::vector<tt::tt_fabric::chan_id_t>>&
+                port_direction_eth_chans,
+            tt::tt_fabric::RoutingDirection direction,
+            const std::unordered_map<tt::tt_fabric::RoutingDirection, size_t>& golden_link_counts,
+            size_t& val) {
+            if (auto it = port_direction_eth_chans.find(direction); it != port_direction_eth_chans.end()) {
+                val = std::min(val, it->second.size());
+            }
+        };
+
+    auto get_chip_coord = [this](FabricNodeId fabric_node_id) -> MeshCoordinate {
+        auto mesh_id = fabric_node_id.mesh_id;
+        auto chip_id = fabric_node_id.chip_id;
+
+        // Get mesh dimensions from the mesh graph descriptor
+        auto mesh_ew_size = this->routing_table_generator_->mesh_graph->get_mesh_shape(mesh_id)[1];
+        auto mesh_ns_size = this->routing_table_generator_->mesh_graph->get_mesh_shape(mesh_id)[0];
+
+        // Convert linear chip_id to 2D mesh coordinates
+        auto coord_y = chip_id / mesh_ew_size;
+        auto coord_x = chip_id % mesh_ew_size;
+
+        return MeshCoordinate(coord_x, coord_y);
+    };
+
+    // For each mesh in the system
+    auto user_meshes = this->get_user_physical_mesh_ids();
+    if (reliability_mode == tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) {
+        for (auto mesh_id : user_meshes) {
+            size_t num_chips_in_mesh = intra_mesh_connectivity[mesh_id.get()].size();
+            for (std::uint32_t chip_id = 0; chip_id < num_chips_in_mesh; chip_id++) {
+                const auto fabric_node_id = FabricNodeId(MeshId{mesh_id}, chip_id);
+                for (const auto& [direction, eth_chans] :
+                     this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)) {
+                    this->router_port_directions_to_num_routing_planes_map_[fabric_node_id][direction] =
+                        eth_chans.size();
+                }
+            }
+        }
+    }
+
+    std::unordered_map<MeshId, std::unordered_map<chip_id_t, std::unordered_map<RoutingDirection, size_t>>>
+        golden_link_counts;
+    TT_FATAL(
+        this->routing_table_generator_ != nullptr && this->routing_table_generator_->mesh_graph != nullptr,
+        "Routing table generator not initialized");
+    build_golden_link_counts(
+        this->routing_table_generator_->mesh_graph->get_intra_mesh_connectivity(), golden_link_counts);
+    build_golden_link_counts(
+        this->routing_table_generator_->mesh_graph->get_inter_mesh_connectivity(), golden_link_counts);
+
+    // For each mesh in the system
+    for (auto mesh_id : user_meshes) {
+        const auto& mesh_shape = this->get_physical_mesh_shape(MeshId{mesh_id});
+        TT_FATAL(mesh_shape.dims() == 2, "ControlPlane: Only 2D meshes are supported");
+        TT_FATAL(mesh_shape[0] > 0, "ControlPlane: Mesh width must be greater than 0");
+        TT_FATAL(mesh_shape[1] > 0, "ControlPlane: Mesh height must be greater than 0");
+
+        std::vector<size_t> row_min_planes(mesh_shape[0], std::numeric_limits<size_t>::max());
+        std::vector<size_t> col_min_planes(mesh_shape[1], std::numeric_limits<size_t>::max());
+
+        // First pass: Calculate minimums for each row/column
+        size_t num_chips_in_mesh = intra_mesh_connectivity[mesh_id.get()].size();
+        bool is_single_chip = num_chips_in_mesh == 1 && user_meshes.size() == 1;
+        bool may_have_intra_mesh_connectivity = !is_single_chip;
+        if (may_have_intra_mesh_connectivity) {
+            for (std::uint32_t chip_id = 0; chip_id < num_chips_in_mesh; chip_id++) {
+                const auto fabric_node_id = FabricNodeId(MeshId{mesh_id}, chip_id);
+                const auto chip_coord = get_chip_coord(fabric_node_id);
+                auto chip_coord_x = chip_coord[0];
+                auto chip_coord_y = chip_coord[1];
+
+                const auto& port_directions = this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id);
+
+                const auto& golden_counts = golden_link_counts.at(MeshId{mesh_id}).at(chip_id);
+                apply_min(port_directions, RoutingDirection::E, golden_counts, row_min_planes.at(chip_coord_y));
+                apply_min(port_directions, RoutingDirection::W, golden_counts, row_min_planes.at(chip_coord_y));
+                apply_min(port_directions, RoutingDirection::N, golden_counts, col_min_planes.at(chip_coord_x));
+                apply_min(port_directions, RoutingDirection::S, golden_counts, col_min_planes.at(chip_coord_x));
+            }
+
+            // TODO: specialize by topology for better perf
+            if (topology == Topology::Mesh || topology == Topology::Torus) {
+                const auto rows_min = std::min_element(row_min_planes.begin(), row_min_planes.end());
+                const auto cols_min = std::min_element(col_min_planes.begin(), col_min_planes.end());
+                const auto mesh_min = std::min(*rows_min, *cols_min);
+                std::fill(row_min_planes.begin(), row_min_planes.end(), mesh_min);
+                std::fill(col_min_planes.begin(), col_min_planes.end(), mesh_min);
+            }
+
+            // Second pass: Apply minimums to each device
+            for (std::uint32_t chip_id = 0; chip_id < num_chips_in_mesh; chip_id++) {
+                const auto fabric_node_id = FabricNodeId(MeshId{mesh_id}, chip_id);
+                const auto chip_coord = get_chip_coord(fabric_node_id);
+                auto chip_coord_x = chip_coord[0];
+                auto chip_coord_y = chip_coord[1];
+
+                this->router_port_directions_to_num_routing_planes_map_[fabric_node_id] = {
+                    {RoutingDirection::E, row_min_planes.at(chip_coord_y)},
+                    {RoutingDirection::W, row_min_planes.at(chip_coord_y)},
+                    {RoutingDirection::N, col_min_planes.at(chip_coord_x)},
+                    {RoutingDirection::S, col_min_planes.at(chip_coord_x)},
+                };
+            }
+        }
+    }
+}
+
 ControlPlane::ControlPlane(const std::string& mesh_graph_desc_file) {
     this->routing_table_generator_ = std::make_unique<RoutingTableGenerator>(mesh_graph_desc_file);
     // Printing, only enabled with log_debug
@@ -646,7 +788,75 @@ void ControlPlane::order_ethernet_channels() {
     }
 }
 
-void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
+void ControlPlane::trim_ethernet_channels_not_mapped_to_live_routing_planes() {
+    auto user_mesh_ids = this->get_user_physical_mesh_ids();
+    std::unordered_set<MeshId> user_mesh_ids_set(user_mesh_ids.begin(), user_mesh_ids.end());
+    if (tt::tt_metal::MetalContext::instance().get_fabric_config() != tt_metal::FabricConfig::CUSTOM) {
+        for (auto& [fabric_node_id, directional_eth_chans] : this->router_port_directions_to_physical_eth_chan_map_) {
+            if (user_mesh_ids_set.count(fabric_node_id.mesh_id) == 0) {
+                continue;
+            }
+            for (auto direction :
+                 {RoutingDirection::N, RoutingDirection::S, RoutingDirection::E, RoutingDirection::W}) {
+                if (directional_eth_chans.find(direction) != directional_eth_chans.end()) {
+                    size_t num_available_routing_planes = this->get_num_live_routing_planes(fabric_node_id, direction);
+                    TT_FATAL(
+                        directional_eth_chans.at(direction).size() >= num_available_routing_planes,
+                        "Expected {} eth channels on M{}D{} in direction {}, but got {}",
+                        num_available_routing_planes,
+                        fabric_node_id.mesh_id,
+                        fabric_node_id.chip_id,
+                        direction,
+                        directional_eth_chans.at(direction).size());
+                    TT_FATAL(
+                        num_available_routing_planes <= 4,
+                        "Expected at most 4 routing planes for M{}D{} in direction {}",
+                        fabric_node_id.mesh_id,
+                        fabric_node_id.chip_id,
+                        direction);
+                    bool trim = directional_eth_chans.at(direction).size() > num_available_routing_planes;
+                    auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
+                    if (trim) {
+                        log_warning(
+                            tt::LogFabric,
+                            "phys {} M{}D{} in direction {} has {} eth channels, but only {} routing planes are "
+                            "available",
+                            physical_chip_id,
+                            fabric_node_id.mesh_id,
+                            fabric_node_id.chip_id,
+                            direction,
+                            directional_eth_chans.at(direction).size(),
+                            num_available_routing_planes);
+                    }
+                    directional_eth_chans.at(direction).resize(num_available_routing_planes);
+                }
+            }
+        }
+    }
+}
+
+size_t ControlPlane::get_num_live_routing_planes(
+    FabricNodeId fabric_node_id, RoutingDirection routing_direction) const {
+    TT_FATAL(
+        this->router_port_directions_to_num_routing_planes_map_.find(fabric_node_id) !=
+            this->router_port_directions_to_num_routing_planes_map_.end(),
+        "Fabric node id (mesh={}, chip={}) not found in router port directions to num routing planes map",
+        fabric_node_id.mesh_id,
+        fabric_node_id.chip_id);
+    TT_FATAL(
+        this->router_port_directions_to_num_routing_planes_map_.at(fabric_node_id).find(routing_direction) !=
+            this->router_port_directions_to_num_routing_planes_map_.at(fabric_node_id).end(),
+        "Routing direction {} not found in router port directions to num routing planes map for fabric node id "
+        "(mesh={}, chip={})",
+        routing_direction,
+        fabric_node_id.mesh_id,
+        fabric_node_id.chip_id);
+    return this->router_port_directions_to_num_routing_planes_map_.at(fabric_node_id).at(routing_direction);
+}
+
+// Only builds the routing table representation, does not actually populate the routing tables in memory of the
+// fabric routers on device
+void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(tt_metal::FabricReliabilityMode reliability_mode) {
     this->intra_mesh_routing_tables_.clear();
     this->inter_mesh_routing_tables_.clear();
     this->router_port_directions_to_physical_eth_chan_map_.clear();
@@ -685,21 +895,37 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
 
     for (std::uint32_t mesh_id = 0; mesh_id < intra_mesh_connectivity.size(); mesh_id++) {
         for (std::uint32_t chip_id = 0; chip_id < intra_mesh_connectivity[mesh_id].size(); chip_id++) {
-            auto physical_chip_id =
-                this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(FabricNodeId(MeshId{mesh_id}, chip_id));
+            const auto fabric_node_id = FabricNodeId(MeshId{mesh_id}, chip_id);
+            auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
             const auto& connected_chips_and_eth_cores =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_cores_grouped_by_connected_chips(
                     physical_chip_id);
             for (const auto& [logical_connected_chip_id, edge] : intra_mesh_connectivity[mesh_id][chip_id]) {
                 const auto& physical_connected_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(
                     FabricNodeId(MeshId{mesh_id}, logical_connected_chip_id));
-                const auto& connected_eth_cores = connected_chips_and_eth_cores.at(physical_connected_chip_id);
+
+                bool connections_exist = connected_chips_and_eth_cores.find(physical_connected_chip_id) !=
+                                         connected_chips_and_eth_cores.end();
                 TT_FATAL(
-                    connected_eth_cores.size() >= edge.connected_chip_ids.size(),
-                    "Expected {} eth links from physical chip {} to physical chip {}",
-                    edge.connected_chip_ids.size(),
-                    physical_chip_id,
-                    physical_connected_chip_id);
+                    connections_exist || reliability_mode !=
+                                             tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+                    "Expected connections to exist for M{}D{} to D{}",
+                    mesh_id,
+                    chip_id,
+                    logical_connected_chip_id);
+                if (!connections_exist) {
+                    continue;
+                }
+
+                const auto& connected_eth_cores = connected_chips_and_eth_cores.at(physical_connected_chip_id);
+                if (reliability_mode == tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) {
+                    TT_FATAL(
+                        connected_eth_cores.size() >= edge.connected_chip_ids.size(),
+                        "Expected {} eth links from physical chip {} to physical chip {}",
+                        edge.connected_chip_ids.size(),
+                        physical_chip_id,
+                        physical_connected_chip_id);
+                }
 
                 for (const auto& eth_core : connected_eth_cores) {
                     // There could be an optimization here to create entry for both chips here, assuming links are
@@ -711,8 +937,8 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
     }
     for (std::uint32_t mesh_id = 0; mesh_id < inter_mesh_connectivity.size(); mesh_id++) {
         for (std::uint32_t chip_id = 0; chip_id < inter_mesh_connectivity[mesh_id].size(); chip_id++) {
-            auto physical_chip_id =
-                this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(FabricNodeId(MeshId{mesh_id}, chip_id));
+            const auto fabric_node_id = FabricNodeId(MeshId{mesh_id}, chip_id);
+            auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
             const auto& connected_chips_and_eth_cores =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_cores_grouped_by_connected_chips(
                     physical_chip_id);
@@ -738,7 +964,16 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
         }
     }
 
+    this->initialize_dynamic_routing_plane_counts(
+        intra_mesh_connectivity, tt::tt_metal::MetalContext::instance().get_fabric_config(), reliability_mode);
+
+    // Order the ethernet channels so that when we use them for deciding connections, indexing into ports per direction
+    // is consistent for each each neighbouring chip.
     this->order_ethernet_channels();
+
+    // Trim the ethernet channels that don't map to live fabric routing planes.
+    // NOTE: This MUST be called after ordering ethernet channels
+    this->trim_ethernet_channels_not_mapped_to_live_routing_planes();
 
     this->convert_fabric_routing_table_to_chip_routing_table();
 }
@@ -1071,6 +1306,29 @@ std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_channels_in_direction
     return {};
 }
 
+std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_routing_planes_in_direction(
+    FabricNodeId fabric_node_id, RoutingDirection routing_direction) const {
+    auto eth_chans = get_active_fabric_eth_channels_in_direction(fabric_node_id, routing_direction);
+    size_t num_routing_planes = 0;
+    if (this->router_port_directions_to_num_routing_planes_map_.contains(fabric_node_id) &&
+        this->router_port_directions_to_num_routing_planes_map_.at(fabric_node_id).contains(routing_direction)) {
+        num_routing_planes =
+            this->router_port_directions_to_num_routing_planes_map_.at(fabric_node_id).at(routing_direction);
+    }
+    TT_FATAL(eth_chans.size() >= num_routing_planes, "Not enough active fabric eth channels in direction");
+    eth_chans.resize(num_routing_planes);
+    return eth_chans;
+}
+
+size_t ControlPlane::get_num_available_routing_planes_in_direction(
+    FabricNodeId fabric_node_id, RoutingDirection routing_direction) const {
+    if (this->router_port_directions_to_num_routing_planes_map_.contains(fabric_node_id) &&
+        this->router_port_directions_to_num_routing_planes_map_.at(fabric_node_id).contains(routing_direction)) {
+        return this->router_port_directions_to_num_routing_planes_map_.at(fabric_node_id).at(routing_direction);
+    }
+    return 0;
+}
+
 void ControlPlane::write_routing_tables_to_all_chips() const {
     // Configure the routing tables on the chips
     TT_ASSERT(
@@ -1164,9 +1422,10 @@ void ControlPlane::set_routing_mode(uint16_t mode) {
 
 uint16_t ControlPlane::get_routing_mode() const { return this->routing_mode_; }
 
-void ControlPlane::initialize_fabric_context(tt_metal::FabricConfig fabric_config) {
+void ControlPlane::initialize_fabric_context(tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode) {
     TT_FATAL(this->fabric_context_ == nullptr, "Trying to re-initialize fabric context");
-    this->fabric_context_ = std::make_unique<FabricContext>(fabric_config);
+    tt::tt_metal::MetalContext::instance().set_fabric_config(fabric_config, reliability_mode);
+    this->fabric_context_ = std::make_unique<FabricContext>(fabric_config);//, reliability_mode);
 }
 
 FabricContext& ControlPlane::get_fabric_context() const {
@@ -1281,7 +1540,8 @@ ControlPlane::get_all_intermesh_eth_links() const {
 
 ControlPlane::~ControlPlane() = default;
 
-GlobalControlPlane::GlobalControlPlane(const std::string& mesh_graph_desc_file) {
+GlobalControlPlane::GlobalControlPlane(
+    const std::string& mesh_graph_desc_file) {
     mesh_graph_desc_file_ = mesh_graph_desc_file;
     // Initialize host mappings
     this->initialize_host_mapping();
@@ -1293,8 +1553,8 @@ GlobalControlPlane::GlobalControlPlane(
     const std::map<FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
     mesh_graph_desc_file_ = mesh_graph_desc_file;
     this->initialize_host_mapping();
-    control_plane_ =
-        std::make_unique<ControlPlane>(mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
+    control_plane_ = std::make_unique<ControlPlane>(
+        mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
 }
 
 void GlobalControlPlane::initialize_host_mapping() {

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -12,11 +12,14 @@
 #include <tt-metalium/assert.hpp>
 #include <tt-metalium/control_plane.hpp>
 #include <tt-metalium/metal_soc_descriptor.h>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/device.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
 #include <optional>
 #include <set>
 #include <vector>
 
+#include "distributed/mesh_socket_utils.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.h>
 
@@ -176,5 +179,43 @@ void append_fabric_connection_rt_args(
         worker_buffer_index_semaphore_id,
         worker_args);
 }
+
+namespace experimental {
+
+size_t get_number_of_available_routing_planes(
+    const tt::tt_metal::distributed::MeshDevice& mesh_device, size_t cluster_axis, size_t row_or_col) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    // Get any device from the cluster to determine fabric node
+    // For now, use chip 0 as a representative device
+
+    size_t row_idx = cluster_axis == 0 ? 0 : row_or_col;
+    size_t col_idx = cluster_axis == 0 ? row_or_col : 0;
+    auto* first_chip = mesh_device.get_device(row_idx, col_idx);
+    chip_id_t first_chip_id = mesh_device.get_device(row_idx, col_idx)->id();
+    auto mesh_id = tt::tt_metal::distributed::get_physical_mesh_id(&mesh_device, MeshCoordinate{row_idx, col_idx});
+    auto fabric_node_in_row_or_col = FabricNodeId{MeshId{mesh_id}, first_chip_id};
+
+    // Map cluster axis to routing directions
+    constexpr std::array<std::array<RoutingDirection, 2>, 2> cluster_axis_directions_to_check = {
+        std::array<RoutingDirection, 2>{RoutingDirection::N, RoutingDirection::S},
+        std::array<RoutingDirection, 2>{RoutingDirection::E, RoutingDirection::W}};
+
+    TT_FATAL(
+        cluster_axis < cluster_axis_directions_to_check.size(),
+        "Invalid cluster axis {}. Must be less than {}",
+        cluster_axis,
+        cluster_axis_directions_to_check.size());
+    const auto& directions_to_check = cluster_axis_directions_to_check[cluster_axis];
+
+    size_t planes_dir0 =
+        control_plane.get_num_available_routing_planes_in_direction(fabric_node_in_row_or_col, directions_to_check[0]);
+    size_t planes_dir1 =
+        control_plane.get_num_available_routing_planes_in_direction(fabric_node_in_row_or_col, directions_to_check[1]);
+    TT_FATAL(planes_dir0 == planes_dir1, "Routing planes are not equal");
+    return planes_dir0;
+}
+
+}  // namespace experimental
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -43,8 +43,8 @@ std::unordered_map<MeshId, bool> FabricContext::check_for_wrap_around_mesh() con
     return wrap_around_mesh;
 }
 
-tt::tt_fabric::Topology FabricContext::get_topology() const {
-    switch (this->fabric_config_) {
+tt::tt_fabric::Topology FabricContext::get_topology_from_config(tt::tt_metal::FabricConfig fabric_config) {
+    switch (fabric_config) {
         case tt::tt_metal::FabricConfig::FABRIC_1D: return tt::tt_fabric::Topology::Linear;
         case tt::tt_metal::FabricConfig::FABRIC_1D_RING: return tt::tt_fabric::Topology::Ring;
         case tt::tt_metal::FabricConfig::FABRIC_2D: return tt::tt_fabric::Topology::Mesh;
@@ -52,7 +52,7 @@ tt::tt_fabric::Topology FabricContext::get_topology() const {
         case tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC: return tt::tt_fabric::Topology::Mesh;
         case tt::tt_metal::FabricConfig::DISABLED:
         case tt::tt_metal::FabricConfig::CUSTOM:
-            TT_THROW("Unsupported fabric config: {}", magic_enum::enum_name(this->fabric_config_));
+            TT_THROW("Unsupported fabric config: {}", magic_enum::enum_name(fabric_config));
     }
     return tt::tt_fabric::Topology::Linear;
 }
@@ -105,7 +105,7 @@ FabricContext::FabricContext(tt::tt_metal::FabricConfig fabric_config) {
     this->fabric_config_ = fabric_config;
 
     this->wrap_around_mesh_ = this->check_for_wrap_around_mesh();
-    this->topology_ = this->get_topology();
+    this->topology_ = this->get_topology_from_config(fabric_config);
 
     this->packet_header_size_bytes_ = this->get_packet_header_size_bytes();
     this->max_payload_size_bytes_ = this->get_max_payload_size_bytes();

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -25,7 +25,10 @@ public:
 
     bool is_wrap_around_mesh(MeshId mesh_id) const;
 
+    static tt::tt_fabric::Topology get_topology_from_config(tt::tt_metal::FabricConfig fabric_config);
+
     tt::tt_fabric::Topology get_fabric_topology() const;
+    tt::tt_metal::FabricConfig get_fabric_config() const { return fabric_config_; }
 
     size_t get_fabric_packet_header_size_bytes() const;
     size_t get_fabric_max_payload_size_bytes() const;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -256,7 +256,7 @@ void MetalContext::set_custom_control_plane_mesh_graph(
 
     global_control_plane_ = std::make_unique<tt::tt_fabric::GlobalControlPlane>(
         mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
-    this->set_fabric_config(fabric_config_);
+    this->set_fabric_config(fabric_config_, tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
 }
 
 void MetalContext::set_default_control_plane_mesh_graph() {
@@ -264,7 +264,7 @@ void MetalContext::set_default_control_plane_mesh_graph() {
         !DevicePool::is_initialized() || DevicePool::instance().get_all_active_devices().size() == 0,
         "Modifying control plane requires no devices to be active");
     global_control_plane_.reset();
-    this->set_fabric_config(fabric_config_);
+    this->set_fabric_config(fabric_config_, tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
 }
 
 void MetalContext::teardown_fabric_config() {
@@ -273,9 +273,12 @@ void MetalContext::teardown_fabric_config() {
 }
 
 void MetalContext::set_fabric_config(
-    const tt_metal::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes) {
+    const tt_metal::FabricConfig fabric_config,
+    tt_metal::FabricReliabilityMode reliability_mode,
+    std::optional<uint8_t> num_routing_planes) {
     if (this->fabric_config_ == tt_metal::FabricConfig::DISABLED || fabric_config == tt_metal::FabricConfig::DISABLED) {
         this->fabric_config_ = fabric_config;
+        this->fabric_reliability_mode_ = reliability_mode;
     } else {
         TT_FATAL(
             this->fabric_config_ == fabric_config,
@@ -327,9 +330,9 @@ void MetalContext::initialize_fabric_config() {
         this->fabric_config_, this->num_fabric_active_routing_planes_);
     auto& control_plane = this->get_control_plane();
     if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
-        control_plane.initialize_fabric_context(this->fabric_config_);
+        control_plane.initialize_fabric_context(this->fabric_config_, this->fabric_reliability_mode_);
     }
-    control_plane.configure_routing_tables_for_fabric_ethernet_channels();
+    control_plane.configure_routing_tables_for_fabric_ethernet_channels(this->fabric_reliability_mode_);
 }
 
 tt_metal::FabricConfig MetalContext::get_fabric_config() const {
@@ -365,7 +368,8 @@ void MetalContext::initialize_control_plane() {
     const std::filesystem::path mesh_graph_desc_path = std::filesystem::path(rtoptions_.get_root_dir()) /
                                                        "tt_metal/fabric/mesh_graph_descriptors" / mesh_graph_descriptor;
 
-    global_control_plane_ = std::make_unique<tt::tt_fabric::GlobalControlPlane>(mesh_graph_desc_path.string());
+    global_control_plane_ = std::make_unique<tt::tt_fabric::GlobalControlPlane>(
+        mesh_graph_desc_path.string());
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -68,7 +68,10 @@ public:
         const std::map<tt_fabric::FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping);
     void set_default_control_plane_mesh_graph();
     void set_fabric_config(
-        tt_metal::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt);
+        tt_metal::FabricConfig fabric_config,
+        tt_metal::FabricReliabilityMode reliability_mode =
+            tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+        std::optional<uint8_t> num_routing_planes = std::nullopt);
     void initialize_fabric_config();
     tt_metal::FabricConfig get_fabric_config() const;
 
@@ -104,6 +107,12 @@ private:
     std::array<std::unique_ptr<DispatchMemMap>, magic_enum::enum_count<CoreType>()> dispatch_mem_map_;
     std::unique_ptr<tt::tt_fabric::GlobalControlPlane> global_control_plane_;
     tt_metal::FabricConfig fabric_config_ = tt_metal::FabricConfig::DISABLED;
+
+    // Strict system health mode requires (expects) all links/devices to be live. When enabled, it
+    // is expected that any downed devices/links will result in some sort of error condition being
+    // reported. When set to false, the control plane is free to instantiate fewer routing planes
+    // according to which links are available.
+    tt_metal::FabricReliabilityMode fabric_reliability_mode_ = tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
     uint8_t num_fabric_active_routing_planes_ = 0;
 };
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -308,6 +308,9 @@ public:
     void configure_ethernet_cores_for_fabric_routers(
         tt_metal::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt);
 
+    void initialize_fabric_config(
+        tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode);
+
     // Returns whether we are running on Galaxy.
     bool is_galaxy_cluster() const;
 
@@ -363,7 +366,6 @@ private:
     // Disable ethernet cores that retrain
     // This should be removed when we handle retraining or dropped links in control plane properly
     void disable_ethernet_cores_with_retrain();
-
 
     // Set tunnels from mmio
     void set_tunnels_from_mmio_device();

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -375,8 +375,9 @@ bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t 
     return true;
 }
 
-void SetFabricConfig(FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes) {
-    tt::tt_metal::MetalContext::instance().set_fabric_config(fabric_config, num_routing_planes);
+void SetFabricConfig(
+    FabricConfig fabric_config, FabricReliabilityMode reliability_mode, std::optional<uint8_t> num_routing_planes) {
+    tt::tt_metal::MetalContext::instance().set_fabric_config(fabric_config, reliability_mode, num_routing_planes);
 }
 
 std::map<chip_id_t, IDevice*> CreateDevices(

--- a/ttnn/cpp/ttnn-pybind/fabric.cpp
+++ b/ttnn/cpp/ttnn-pybind/fabric.cpp
@@ -19,11 +19,22 @@ void py_bind_fabric_api(py::module& module) {
         .value("FABRIC_1D_RING", tt::tt_metal::FabricConfig::FABRIC_1D_RING)
         .value("FABRIC_2D", tt::tt_metal::FabricConfig::FABRIC_2D)
         .value("CUSTOM", tt::tt_metal::FabricConfig::CUSTOM);  // DISABLED = 0, FABRIC_1D = 1, FABRIC_2D = 2, CUSTOM = 4
+    py::enum_<tt::tt_metal::FabricReliabilityMode>(module, "FabricReliabilityMode", R"(
+        Specifies how the fabric initialization handles system health and configuration.
+        Values:
+            STRICT_INIT: Initialize fabric such that the live links/devices must exactly match the mesh graph descriptor. Any downed devices/links will result in errors.
+            RELAXED_INIT: Initialize the fabric with flexibility towards downed links/devices. The fabric will initialize with fewer routing planes than in mesh graph descriptor, based on live links.
+            DYNAMIC_RECONFIG: [Unsupported] Placeholder for dynamic (runtime) reconfiguration based on live system events (such as hardware failures).
+        )")
+        .value("STRICT_INIT", tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE)
+        .value("RELAXED_INIT", tt::tt_metal::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE)
+        .value("DYNAMIC_RECONFIG", tt::tt_metal::FabricReliabilityMode::DYNAMIC_RECONFIGURATION_SETUP_MODE);
 
     module.def(
         "set_fabric_config",
         &tt::tt_metal::detail::SetFabricConfig,
         py::arg("config"),
+        py::arg("reliability_mode") = tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
         py::arg("num_planes") = std::nullopt);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -4,6 +4,7 @@
 
 #include "cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.hpp"
 #include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/fabric.hpp>
 #include "ttnn/global_semaphore.hpp"
 
 #include <ranges>
@@ -153,6 +154,20 @@ operation::ProgramWithCallbacks ReduceScatterAsync::create_program_at(
         devices = this->devices;
     }
 
+    std::optional<size_t> num_links = this->num_links_preferred;
+
+    if (!num_links.has_value()) {
+        if (this->cluster_axis.has_value()) {
+            auto row_or_col = this->cluster_axis.value() == 0 ? coord[1] : coord[0];
+            num_links = tt::tt_fabric::experimental::get_number_of_available_routing_planes(
+                *mesh_device, this->cluster_axis.value(), row_or_col);
+        } else {
+            TT_FATAL(
+                false,
+                "Reduce scatter with undefined number of links and non-cluster axis API is currently not supported");
+        }
+    }
+
     auto target_device =
         input_tensors[0].mesh_device() ? input_tensors[0].mesh_device()->get_device(coord) : input_tensors[0].device();
 
@@ -199,7 +214,7 @@ operation::ProgramWithCallbacks ReduceScatterAsync::create_program_at(
         this->ring_size,
         config.device_index,
         this->topology,
-        this->num_links_preferred,
+        num_links,
         this->from_remote_sem,
         this->to_remote_sem,
         this->sub_device_id);
@@ -463,4 +478,4 @@ std::vector<Tensor> reduce_scatter(
 }  // namespace experimental
 }  // namespace operations
 
-};  // namespace ttnn
+}  // namespace ttnn

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -133,7 +133,7 @@ from ttnn._ttnn.global_circular_buffer import (
     create_global_circular_buffer,
 )
 
-from ttnn._ttnn.fabric import FabricConfig, set_fabric_config
+from ttnn._ttnn.fabric import FabricConfig, FabricReliabilityMode, set_fabric_config
 
 from ttnn._ttnn.global_semaphore import (
     create_global_semaphore,


### PR DESCRIPTION
### Problem description
Current implementation of fabric initiailization does not reliably handle systems where ethernet links are unreliable/disconnected.

### What's changed
On control plane/fabric initialization, support is added to instantiate only as many routing planes as there are live links available. The general policy is as follows:
1) For 1D topologies, rows/columns are evaluated independently
  - The full row/column of devices is traversed and the narrowest step of the traversal is applied as the number of routing planes
  - For example, if there are 4 hops, and the link counts per hop are {2, 3, 4, 4}, then 2 routing planes will be instantiated for this 1D topology. Different rows/columns of the device will have different routing planes depending on live link counts
2) For 2D topologies, the minimal number of routing planes across all hops is applied to the full fabric.

The implementation for reducing the number of routing planes is to trim the number of active ethernet links as a post process step after discovering all links. This is done before routing tables are generated. As a more robust implementation would have a separate datastructure (or set of fields) to differentiate between routing plane ethernet cores and active ethernet cores. With that approach, control plane could understand remaining cores available if it wants to reprogram routing planes during long running workloads

- Build reference cluster connectivity (same as before)
- Compute number of routing planes per row and column (for 1D topologies) or for all rows/cols collectively (for mesh).
- Trim active ethernet cores according to the maximum number of routing planes, for full rows and columns

## Visual Example

Consider a healthy 4-chip line topology with 4 routing planes:

```                                                                                                                           
 ┌───────────────────┐             ┌───────────────────┐             ┌───────────────────┐             ┌───────────────────┐ 
 │                   │    RP 0     │                   │    RP 0     │                   │    RP 0     │                   │ 
 │                   │=============│                   │=============│                   │=============│                   │ 
 │                   │             │                   │             │                   │             │                   │ 
 │                   │             │                   │             │                   │             │                   │ 
 │                   │    RP 1     │                   │    RP 1     │                   │    RP 1     │                   │ 
 │                   │=============│                   │=============│                   │=============│                   │ 
 │                   │             │                   │             │                   │             │                   │ 
 │                   │             │                   │             │                   │             │                   │ 
 │                   │    RP 2     │                   │    RP 2     │                   │    RP 2     │                   │ 
 │                   │=============│                   │=============│                   │=============│                   │ 
 │                   │             │                   │             │                   │             │                   │ 
 │                   │             │                   │             │                   │             │                   │ 
 │                   │    RP 3     │                   │    RP 3     │                   │    RP 3     │                   │ 
 │                   │=============│                   │=============│                   │=============│                   │ 
 │                   │             │                   │             │                   │             │                   │ 
 │                   │             │                   │             │                   │             │                   │ 
 └───────────────────┘             └───────────────────┘             └───────────────────┘             └───────────────────┘ 
```

The (chip) internal router-to-router connections would look something like this:
```
         Chip 0                           Chip 1                           Chip 2                             Chip 3          
  ┌───────────────────┐             ┌───────────────────┐             ┌───────────────────┐             ┌───────────────────┐ 
  │                   │    RP 0     │                   │    RP 0     │                   │    RP 0     │                   │ 
  │                   │=============│<----------------->│=============│<----------------->│=============│                   │ 
  │                   │             │                   │             │                   │             │                   │ 
  │                   │             │                   │             │                   │             │                   │ 
  │                   │    RP 1     │                   │    RP 1     │                   │    RP 1     │                   │ 
  │                   │=============│<----------------->│=============│<----------------->│=============│                   │ 
  │                   │             │                   │             │                   │             │                   │ 
  │                   │             │                   │             │                   │             │                   │ 
  │                   │    RP 2     │                   │    RP 2     │                   │    RP 2     │                   │ 
  │                   │=============│<----------------->│=============│<----------------->│=============│                   │ 
  │                   │             │                   │             │                   │             │                   │ 
  │                   │             │                   │             │                   │             │                   │ 
  │                   │    RP 3     │                   │    RP 3     │                   │    RP 3     │                   │ 
  │                   │=============│<----------------->│=============│<----------------->│=============│                   │ 
  │                   │             │                   │             │                   │             │                   │ 
  │                   │             │                   │             │                   │             │                   │ 
  └───────────────────┘             └───────────────────┘             └───────────────────┘             └───────────────────┘
```

However, for an unhealthy system, some links may not be active or live. In those cases, the control plane must build fabric differently. In this example, consider the first link dead for the first edge and the last link dead for the last edge. In that scenario, the routing planes could be configured as shown. One of the edges still has 4 live links, but only 3 would participate in that fabric as routing planes.

```
         Chip 0                           Chip 1                           Chip 2                             Chip 3          
  ┌───────────────────┐             ┌───────────────────┐             ┌───────────────────┐             ┌───────────────────┐ 
  │                   │             │                   │   RP 0      │                   │   RP 0      │                   │ 
  │                   │==X       X==│           /------>│=============│<----------------->│=============│                   │ 
  │                   │             │          /        │             │                   │             │                   │ 
  │                   │             │         /         │             │                   │             │                   │ 
  │                   │   RP 0      │        /          │   RP 1      │                   │   RP 1      │                   │ 
  │                   │=============│<------/   /------>│=============│<----------------->│=============│                   │ 
  │                   │             │          /        │             │                   │             │                   │ 
  │                   │             │         /         │             │                   │             │                   │ 
  │                   │   RP 1      │        /          │   RP 2      │                   │   RP 2      │                   │ 
  │                   │=============│<------/   /------>│=============│<----------------->│=============│                   │ 
  │                   │             │          /        │             │                   │             │                   │ 
  │                   │             │         /         │             │                   │             │                   │ 
  │                   │   RP 2      │        /          │  INACTIVE   │                   │             │                   │ 
  │                   │=============│<------/           │=============│                   │==X       X==│                   │ 
  │                   │             │                   │             │                   │             │                   │ 
  │                   │             │                   │             │                   │             │                   │ 
  └───────────────────┘             └───────────────────┘             └───────────────────┘             └───────────────────┘ 
```


## User Facing APIs
Added a new user facing kernel to determine the number of live routing planes, given a cluster axis and direction in the mesh of devices:

`tt::tt_fabric::experimental::get_number_of_available_routing_planes()`

An example of how this API may be used at op level for CCLs:

```
    std::optional<size_t> num_links = this->num_links_preferred;

    if (!num_links.has_value()) {
        if (this->cluster_axis.has_value()) {
            auto row_or_col = this->cluster_axis.value() == 0 ? coord[1] : coord[0];
            num_links = tt::tt_fabric::experimental::get_number_of_available_routing_planes(
                *mesh_device, this->cluster_axis.value(), row_or_col);
        } else {
            TT_FATAL(
                false,
                "Reduce scatter with undefined number of links and non-cluster axis API is currently not supported");
        }
    }
``` 

## Future Work
- Add more extensive testing where a test harness manually disables links and runs fabric tests
- Add downshifting from ring down to mesh topologies in cases where all links are down between pairs of chips

### Ticket
https://github.com/tenstorrent/tt-metal/issues/23189

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/15716594434
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes: https://github.com/tenstorrent/tt-metal/actions/runs/15721262254
- [x] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/15716598314
- [x] TG: https://github.com/tenstorrent/tt-metal/actions/runs/15716603009
- [x] New/Existing tests provide coverage for changes
