### PR TITLE
Remove redundant print_vec definitions

### DIFF
--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -530,7 +530,7 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(tt_metal::IDevice* device)
                 convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
 
             // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
-            // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
+            // print_vec_of_bfloat16(result_flat_layout, 1, "Result - tile#" + std::to_string(tile_id));
             pass &= (golden_tile == result_flat_layout);
         }
     }

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
@@ -447,7 +447,7 @@ bool matmul_multi_core_multi_dram_inX_mcast(tt_metal::IDevice* device, int in1_o
                 convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
 
             // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
-            // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
+            // print_vec_of_bfloat16(result_flat_layout, 1, "Result - tile#" + std::to_string(tile_id));
             pass &= (golden_tile == result_flat_layout);
         }
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -1420,19 +1420,6 @@ std::vector<T> get_col_slice(std::vector<T> data, int start_col_index, int num_c
     return result;
 }
 
-void print_vec(const std::vector<float>& data, int rows, int cols, const string& name) {
-    std::cout << name << ": " << std::endl;
-    int index = 0;
-    for (int i = 0; i < rows; i++) {
-        for (int j = 0; j < cols; j++) {
-            std::cout << data.at(index) << " ";
-            index++;
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-}
-
 void prepare_inputs(
     tt_metal::IDevice* device,
     CoreCoord core_range,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
@@ -125,19 +125,6 @@ std::vector<T> slice(std::vector<T> const& v, int m, int n) {
     return vec;
 }
 
-void print_vec(const std::vector<bfloat16>& data, int rows, int cols, const std::string& name) {
-    std::cout << name << ": " << std::endl;
-    int index = 0;
-    for (int i = 0; i < rows; i++) {
-        for (int j = 0; j < cols; j++) {
-            std::cout << data.at(index).to_float() << " ";
-            index++;
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-}
-
 int main(int argc, char** argv) {
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
         TT_THROW("Test not supported w/ slow dispatch, exiting");
@@ -246,8 +233,8 @@ int main(int argc, char** argv) {
         auto identity = create_identity_matrix(Kt * 32, Nt * 32, std::min(Kt, Nt) * 32);  // bflaot16 identity
 
         if (print_tensor) {
-            print_vec(tensor.get_values(), 2, Kt * 32, std::string("Activation first row"));
-            print_vec(identity, 2, Nt * 32, std::string("Weights first row"));
+            print_vec_of_bfloat16(tensor.get_values(), 1, "Activation first row");
+            print_vec_of_bfloat16(identity, 1, "Weights first row");
         }
 
         log_info(LogTest, "Slicing input tensors and copying them to L1");
@@ -363,11 +350,8 @@ int main(int argc, char** argv) {
                     auto result_untilized = untilize_swizzled(result_flat_layout, per_core_Mt * 32, per_core_Nt * 32);
 
                     if (print_tensor) {
-                        print_vec(
-                            result_untilized,
-                            2,
-                            Nt * 32,
-                            std::string("result_untilized" + std::to_string(r) + " " + std::to_string(c)));
+                        print_vec_of_bfloat16(
+                            result_untilized, 1, "result_untilized" + std::to_string(r) + " " + std::to_string(c));
                     }
 
                     if (!(per_core_golden == result_untilized)) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -52,19 +52,6 @@ std::vector<T> slice_vec(std::vector<T> const& v, int m, int n) {
     return vec;
 }
 
-void print_vec(const std::vector<bfloat16>& data, int rows, int cols, const std::string& name) {
-    std::cout << name << ": " << std::endl;
-    int index = 0;
-    for (int i = 0; i < rows; i++) {
-        for (int j = 0; j < cols; j++) {
-            std::cout << data.at(index).to_float() << " ";
-            index++;
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-}
-
 int main(int argc, char** argv) {
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
         TT_THROW("Test not supported w/ slow dispatch, exiting");
@@ -159,11 +146,10 @@ int main(int argc, char** argv) {
         if (print_tensor) {
             for (int r = 0; r < num_cores_r; ++r) {
                 for (int c = 0; c < num_cores_c; ++c) {
-                    print_vec(
+                    print_vec_of_bfloat16(
                         tensors[r * num_cores_c + c].get_values(),
                         1,
-                        32,
-                        std::string("input tensor " + std::to_string(r) + " " + std::to_string(c)));
+                        "input tensor " + std::to_string(r) + " " + std::to_string(c));
                     if (single_read || one_buffer_share) {
                         break;
                     }
@@ -250,16 +236,12 @@ int main(int argc, char** argv) {
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
 
                 if (print_tensor) {
-                    print_vec(
-                        result_bfp16,
-                        1,
-                        32,
-                        std::string("from l1 buffer " + std::to_string(r) + " " + std::to_string(c)));
-                    print_vec(
+                    print_vec_of_bfloat16(
+                        result_bfp16, 1, "from l1 buffer " + std::to_string(r) + " " + std::to_string(c));
+                    print_vec_of_bfloat16(
                         tensors[r * num_cores_c + c].get_values(),
                         1,
-                        32,
-                        std::string("tensor " + std::to_string(r) + " " + std::to_string(c)));
+                        "tensor " + std::to_string(r) + " " + std::to_string(c));
                 }
                 if (!(tensors[r * num_cores_c + c].get_values() == result_bfp16)) {
                     log_error(
@@ -343,19 +325,11 @@ int main(int argc, char** argv) {
                         slice_vec(tensors[tensors_idx].get_values(), (index - cb_tiles) * 1024, index * 1024 - 1);
 
                     if (print_tensor) {
-                        print_vec(
-                            result_bfp16,
-                            32,
-                            32,
-                            std::string("result_bfp16 " + std::to_string(r) + " " + std::to_string(c)));
-
-                        print_vec(
-                            sliced_tensor,
-                            32,
-                            32,
-                            std::string("sliced_tensor " + std::to_string(r) + " " + std::to_string(c)));
+                        print_vec_of_bfloat16(
+                            result_bfp16, 1, "result_bfp16 " + std::to_string(r) + " " + std::to_string(c));
+                        print_vec_of_bfloat16(
+                            sliced_tensor, 1, "sliced_tensor " + std::to_string(r) + " " + std::to_string(c));
                     }
-
                     if (sliced_tensor != result_bfp16) {
                         log_error(LogTest, "{}/{} - comparision failed ", r, c);
                         pass = false;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
@@ -49,19 +49,6 @@ std::vector<T> slice_vec(std::vector<T> const& v, int m, int n) {
     return vec;
 }
 
-void print_vec(const std::vector<bfloat16>& data, int rows, int cols, const std::string& name) {
-    std::cout << name << ": " << std::endl;
-    int index = 0;
-    for (int i = 0; i < rows; i++) {
-        for (int j = 0; j < cols; j++) {
-            std::cout << data.at(index).to_float() << " ";
-            index++;
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-}
-
 int main(int argc, char** argv) {
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
         TT_THROW("Test not supported w/ slow dispatch, exiting");
@@ -138,10 +125,9 @@ int main(int argc, char** argv) {
         if (print_tensor) {
             for (int r = 0; r < num_cores_r; ++r) {
                 for (int c = 0; c < num_cores_c; ++c) {
-                    print_vec(
+                    print_vec_of_bfloat16(
                         tensors[r * num_cores_c + c].get_values(),
                         1,
-                        32,
                         std::string("input tensor " + std::to_string(r) + " " + std::to_string(c)));
                 }
             }
@@ -262,16 +248,13 @@ int main(int argc, char** argv) {
                         slice_vec(tensors[r * num_cores_c + c].get_values(), (Nt - cb_tiles) * 1024, Nt * 1024 - 1);
 
                     if (print_tensor) {
-                        print_vec(
+                        print_vec_of_bfloat16(
                             result_bfp16,
-                            32,
-                            32,
+                            1,
                             std::string("result_bfp16 " + std::to_string(r) + " " + std::to_string(c)));
-
-                        print_vec(
+                        print_vec_of_bfloat16(
                             sliced_tensor,
-                            32,
-                            32,
+                            1,
                             std::string("sliced_tensor " + std::to_string(r) + " " + std::to_string(c)));
                     }
 

--- a/tests/tt_metal/tt_metal/test_datacopy_multi_core_multi_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_multi_core_multi_dram.cpp
@@ -17,19 +17,6 @@
 //////////////////////////////////////////////////////////////////////////////////////////
 using namespace tt;
 
-void print_vec(const std::vector<bfloat16>& data, int rows, int cols, string name) {
-    std::cout << name << ": " << std::endl;
-    int index = 0;
-    for (int i = 0; i < rows; i++) {
-        for (int j = 0; j < cols; j++) {
-            std::cout << data.at(index).to_float() << ", ";
-            index++;
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-}
-
 std::vector<bfloat16> select_columns(std::vector<bfloat16> data, int M, int K, int N) {
     if (N == K) {
         return data;
@@ -415,10 +402,11 @@ int main(int argc, char** argv) {
                 tt_metal::detail::ReadFromDeviceDRAMChannel(
                     device, dram_bank, dram_address, single_tile_size, result_vec);
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-                auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
+                auto result_flat_layout =
+                    convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
 
                 // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
-                // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
+                // print_vec_of_bfloat16(result_flat_layout, 1, "Result " + std::to_string(tile_id));
                 pass &= (golden_tile == result_flat_layout);
             }
         }

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -75,19 +75,6 @@ std::vector<std::uint32_t> transpose_tiles(
     return result;
 }
 
-void print_vec(const std::vector<bfloat16>& data, int rows, int cols, const std::string& name) {
-    std::cout << name << ": " << std::endl;
-    int index = 0;
-    for (int i = 0; i < rows; i++) {
-        for (int j = 0; j < cols; j++) {
-            std::cout << data.at(index).to_float() << ", ";
-            index++;
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-}
-
 void print_faces(std::vector<bfloat16> data, const std::string& name) {
     std::cout << name << ": " << std::endl;
     int index = 0;
@@ -342,13 +329,13 @@ int main(int argc, char** argv) {
         auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
         auto result_untilized = untilize_swizzled(result_flat_layout, M * 32, N * 32);
 
-        // print_vec(result_bfp16, 128, 128, "Result bfp16");
+        // print_vec_of_bfloat16(result_bfp16, 16, "Result bfp16");
         // print_faces(unpack_uint32_vec_into_bfloat16_vec(activations_tile_transposed), "Activations tile transpose");
         // print_faces(unpack_uint32_vec_into_bfloat16_vec(weights), "Weights tile transposed");
         // print_faces(result_bfp16, "Result bfp16");
         // print_vec_of_uint32_as_packed_bfloat16(weights, 16, "weights tile transposed");
-        // print_vec(result_untilized, M*32, N*32, "Result");
-        // print_vec(tensor.get_values(), 128, 128, "Golden");
+        // print_vec_of_bfloat16(result_untilized, M*N, "Result");
+        // print_vec_of_bfloat16(tensor.get_values(), 16, "Golden");
 
         pass &= (tensor.get_values() == result_untilized);
         pass &= tt_metal::CloseDevice(device);

--- a/tests/tt_metal/tt_metal/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_large_block.cpp
@@ -372,8 +372,9 @@ bool test_matmul_large_block(tt_metal::IDevice* device, bool activations_rm, boo
                 print_faces(result_bfp16, "Result");
             }
         } else {
-            auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
-            auto result_untilized = untilize(result_flat_layout, M * 32, N * 32);
+            auto result_flat_layout =
+                convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
+            auto result_untilized = untilize_swizzled(result_flat_layout, M * 32, N * 32);
             pass &= (tensor.get_values() == result_untilized);
             if (not pass) {
                 print_faces(result_untilized, "Result");

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram.cpp
@@ -22,19 +22,6 @@ using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
-void print_vec(const std::vector<bfloat16>& data, int rows, int cols, string name) {
-    std::cout << name << ": " << std::endl;
-    int index = 0;
-    for (int i = 0; i < rows; i++) {
-        for (int j = 0; j < cols; j++) {
-            std::cout << data.at(index).to_float() << ", ";
-            index++;
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-}
-
 std::vector<bfloat16> select_columns(std::vector<bfloat16> data, int M, int K, int N) {
     if (N == K) {
         return data;
@@ -432,7 +419,8 @@ int main(int argc, char** argv) {
                 result_vec.insert(result_vec.end(), result_iter, result_iter + 512);
                 result_iter += 512;
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-                auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
+                auto result_flat_layout =
+                    convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
 
                 pass &= (golden_tile == result_flat_layout);
             }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast.cpp
@@ -19,19 +19,6 @@
 using std::vector;
 using namespace tt;
 
-void print_vec(const std::vector<bfloat16>& data, int rows, int cols, string name) {
-    std::cout << name << ": " << std::endl;
-    int index = 0;
-    for (int i = 0; i < rows; i++) {
-        for (int j = 0; j < cols; j++) {
-            std::cout << data.at(index).to_float() << ", ";
-            index++;
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-}
-
 std::vector<bfloat16> select_columns(std::vector<bfloat16> data, int M, int K, int N) {
     if (N == K) {
         return data;
@@ -490,10 +477,11 @@ int main(int argc, char** argv) {
                 tt_metal::detail::ReadFromDeviceDRAMChannel(
                     device, dram_bank, dram_address, single_tile_size, result_vec);
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-                auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
+                auto result_flat_layout =
+                    convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
 
                 // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
-                // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
+                // print_vec_of_bfloat16(result_flat_layout, 1, "Result - tile#" + std::to_string(tile_id));
                 pass &= (golden_tile == result_flat_layout);
             }
         }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -19,19 +19,6 @@
 using std::vector;
 using namespace tt;
 
-void print_vec(const std::vector<bfloat16>& data, int rows, int cols, string name) {
-    std::cout << name << ": " << std::endl;
-    int index = 0;
-    for (int i = 0; i < rows; i++) {
-        for (int j = 0; j < cols; j++) {
-            std::cout << data.at(index).to_float() << ", ";
-            index++;
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-}
-
 std::vector<bfloat16> select_columns(std::vector<bfloat16> data, int M, int K, int N) {
     if (N == K) {
         return data;
@@ -585,10 +572,11 @@ int main(int argc, char** argv) {
                 tt_metal::detail::ReadFromDeviceDRAMChannel(
                     device, dram_bank, dram_address, single_tile_size, result_vec);
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-                auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
+                auto result_flat_layout =
+                    convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
 
                 // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
-                // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
+                // print_vec_of_bfloat16(result_flat_layout, 1, "Result - tile#" + std::to_string(tile_id));
                 pass &= (golden_tile == result_flat_layout);
             }
         }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in1_mcast.cpp
@@ -19,19 +19,6 @@
 using std::vector;
 using namespace tt;
 
-void print_vec(const std::vector<bfloat16>& data, int rows, int cols, string name) {
-    std::cout << name << ": " << std::endl;
-    int index = 0;
-    for (int i = 0; i < rows; i++) {
-        for (int j = 0; j < cols; j++) {
-            std::cout << data.at(index).to_float() << ", ";
-            index++;
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-}
-
 std::vector<bfloat16> select_columns(std::vector<bfloat16> data, int M, int K, int N) {
     if (N == K) {
         return data;
@@ -484,10 +471,11 @@ int main(int argc, char** argv) {
                 tt_metal::detail::ReadFromDeviceDRAMChannel(
                     device, dram_bank, dram_address, single_tile_size, result_vec);
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-                auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
+                auto result_flat_layout =
+                    convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
 
                 // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
-                // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
+                // print_vec_of_bfloat16(result_flat_layout, 1, "Result - tile#" + std::to_string(tile_id));
                 pass &= (golden_tile == result_flat_layout);
             }
         }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_single_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_single_dram.cpp
@@ -39,19 +39,6 @@ std::vector<std::uint32_t> transpose_tiles(
     return result;
 }
 
-void print_vec(const std::vector<bfloat16>& data, int rows, int cols, string name) {
-    std::cout << name << ": " << std::endl;
-    int index = 0;
-    for (int i = 0; i < rows; i++) {
-        for (int j = 0; j < cols; j++) {
-            std::cout << data.at(index).to_float() << ", ";
-            index++;
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-}
-
 void print_faces(std::vector<bfloat16> data, string name) {
     std::cout << name << ": " << std::endl;
     int index = 0;
@@ -398,8 +385,9 @@ int main(int argc, char** argv) {
                     per_core_M * per_core_N * single_tile_size,
                     result_vec);
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-                auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
-                auto result_untilized = untilize(result_flat_layout, per_core_M * 32, per_core_N * 32);
+                auto result_flat_layout =
+                    convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
+                auto result_untilized = untilize_swizzled(result_flat_layout, per_core_M * 32, per_core_N * 32);
                 pass &= (per_core_golden == result_untilized);
             }
         }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_tile.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_tile.cpp
@@ -235,8 +235,8 @@ bool run_matmul(const tt::ARCH& arch, const bool with_bias) {
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
         auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-        auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
-        auto result_untilized = untilize(result_flat_layout, M * 32, N * 32);
+        auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
+        auto result_untilized = untilize_swizzled(result_flat_layout, M * 32, N * 32);
 
         pass &= (tensor.get_values() == result_untilized);
 

--- a/tests/tt_metal/tt_metal/test_matmul_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_core.cpp
@@ -39,19 +39,6 @@ std::vector<std::uint32_t> transpose_tiles(
     return result;
 }
 
-void print_vec(const std::vector<bfloat16>& data, int rows, int cols, string name) {
-    std::cout << name << ": " << std::endl;
-    int index = 0;
-    for (int i = 0; i < rows; i++) {
-        for (int j = 0; j < cols; j++) {
-            std::cout << data.at(index).to_float() << ", ";
-            index++;
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-}
-
 void print_faces(std::vector<bfloat16> data, string name) {
     std::cout << name << ": " << std::endl;
     int index = 0;
@@ -304,15 +291,15 @@ int main(int argc, char** argv) {
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
         auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-        auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
-        auto result_untilized = untilize(result_flat_layout, M * 32, N * 32);
-        // print_vec(result_bfp16, 128, 128, "Result bfp16");
+        auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
+        auto result_untilized = untilize_swizzled(result_flat_layout, M * 32, N * 32);
+        // print_vec_of_bfloat16(result_bfp16, 16, "Result bfp16");
         // print_faces(unpack_uint32_vec_into_bfloat16_vec(activations_tile_transposed), "Activations tile transpose");
         // print_faces(unpack_uint32_vec_into_bfloat16_vec(weights), "Weights tile transposed");
         // print_faces(result_bfp16, "Result bfp16");
         // print_vec_of_uint32_as_packed_bfloat16(weights, 16, "weights tile transposed");
-        // print_vec(result_untilized, M*32, N*32, "Result");
-        // print_vec(tensor.get_values(), 128, 128, "Golden");
+        // print_vec_of_bfloat16(result_untilized, M*N, "Result");
+        // print_vec_of_bfloat16(tensor.get_values(), 16, "Golden");
         auto golden = select_columns(tensor.get_values(), M, K, std::min(K, N));
         // auto golden = tensor.get_values();
         pass &= (golden == result_untilized);

--- a/tests/tt_metal/tt_metal/test_matmul_single_core_small.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_core_small.cpp
@@ -40,19 +40,6 @@ std::vector<std::uint32_t> transpose_tiles(
     return result;
 }
 
-void print_vec(const std::vector<bfloat16>& data, int rows, int cols, string name) {
-    std::cout << name << ": " << std::endl;
-    int index = 0;
-    for (int i = 0; i < rows; i++) {
-        for (int j = 0; j < cols; j++) {
-            std::cout << data.at(index).to_float() << ", ";
-            index++;
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-}
-
 void print_faces(std::vector<bfloat16> data, string name) {
     std::cout << name << ": " << std::endl;
     int index = 0;
@@ -306,15 +293,16 @@ int main(int argc, char** argv) {
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
         auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-        auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
-        auto result_untilized = untilize(result_flat_layout, M * 32, N * 32);
-        // print_vec(result_bfp16, 128, 128, "Result bfp16");
+        auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
+        auto result_untilized = untilize_swizzled(result_flat_layout, M * 32, N * 32);
+
+        // print_vec_of_bfloat16(result_bfp16, 16, "Result bfp16");
         // print_faces(unpack_uint32_vec_into_bfloat16_vec(activations_tile_transposed), "Activations tile transpose");
         // print_faces(unpack_uint32_vec_into_bfloat16_vec(weights), "Weights tile transposed");
         // print_faces(result_bfp16, "Result bfp16");
         // print_vec_of_uint32_as_packed_bfloat16(weights, 16, "weights tile transposed");
-        // print_vec(result_untilized, M*32, N*32, "Result");
-        // print_vec(tensor.get_values(), 128, 128, "Golden");
+        // print_vec_of_bfloat16(result_untilized, M * N, "Result bfloat16");
+        // print_vec_of_bfloat16(tensor.get_values(), 16, "Golden");
         auto golden = select_columns(tensor.get_values(), M, K, std::min(K, N));
         // auto golden = tensor.get_values();
         pass &= tt::test_utils::is_close_vectors<bfloat16>(

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile.cpp
@@ -153,7 +153,7 @@ int main(int argc, char** argv) {
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
         auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-        auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
+        auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
         pass &= (tensor.get_values() == result_flat_layout);  // src1 is all 0's
         pass &= tt_metal::CloseDevice(device);
 


### PR DESCRIPTION
### Ticket
[Same print function is defined 13 times](https://github.com/tenstorrent/tt-metal/issues/19721)

### Problem description
Function print_vec() was defined multiple times across different files.

tests/tt_metal/tt_metal/test_datacopy_multi_core_multi_dram.cpp
tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in1_mcast.cpp
tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram.cpp
tests/tt_metal/tt_metal/test_matmul_multi_core_single_dram.cpp
tests/tt_metal/tt_metal/test_matmul_single_core_small.cpp
tests/tt_metal/tt_metal/test_matmul_single_core.cpp
tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp

### What's changed
Removed redundant declarations and substituted their calls by print_vec_of_bfloat16() defined in bfloat16.hpp

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15620341877) CI passes
- [x] New/Existing tests provide coverage for changes