### PR TITLE
Add support for L1 profiler buffer reads using fast dispatch

### DIFF
--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -183,7 +183,7 @@ void DeviceProfiler::issueFastDispatchReadFromL1DataBuffer(IDevice* device, cons
                 distributed::DeviceMemoryAddress{
                     device_coord, worker_core, reinterpret_cast<DeviceAddr>(profiler_msg->buffer)},
                 core_l1_data_buffers[worker_core].data(),
-                kernel_profiler::PROFILER_L1_VECTOR_SIZE * PROFILER_RISC_COUNT,
+                kernel_profiler::PROFILER_L1_BUFFER_SIZE * PROFILER_RISC_COUNT,
                 true);
     } else {
         dynamic_cast<HWCommandQueue&>(device->command_queue())
@@ -191,7 +191,7 @@ void DeviceProfiler::issueFastDispatchReadFromL1DataBuffer(IDevice* device, cons
                 worker_core,
                 core_l1_data_buffers[worker_core].data(),
                 reinterpret_cast<DeviceAddr>(profiler_msg->buffer),
-                kernel_profiler::PROFILER_L1_VECTOR_SIZE * PROFILER_RISC_COUNT,
+                kernel_profiler::PROFILER_L1_BUFFER_SIZE * PROFILER_RISC_COUNT,
                 true);
     }
 }

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -168,41 +168,45 @@ void DeviceProfiler::issueSlowDispatchReadFromProfilerBuffer(IDevice* device) {
     }
 }
 
-void DeviceProfiler::issueFastDispatchReadFromL1DataBuffer(IDevice* device, const CoreCoord& worker_core) {
+std::vector<uint32_t> DeviceProfiler::issueFastDispatchReadFromL1DataBuffer(
+    IDevice* device, const CoreCoord& worker_core) {
     ZoneScoped;
     TT_ASSERT(tt::DevicePool::instance().is_dispatch_firmware_active());
     const chip_id_t device_id = device->id();
     const HalProgrammableCoreType core_type = tt::llrt::get_core_type(device_id, worker_core);
     profiler_msg_t* profiler_msg =
         MetalContext::instance().hal().get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
-    core_l1_data_buffers[worker_core].resize(kernel_profiler::PROFILER_L1_VECTOR_SIZE * PROFILER_RISC_COUNT);
+    std::vector<uint32_t> data_buffer(kernel_profiler::PROFILER_L1_VECTOR_SIZE * PROFILER_RISC_COUNT);
     if (auto mesh_device = device->get_mesh_device()) {
         const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device_id);
         dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue())
             .enqueue_read_shard_from_core(
                 distributed::DeviceMemoryAddress{
                     device_coord, worker_core, reinterpret_cast<DeviceAddr>(profiler_msg->buffer)},
-                core_l1_data_buffers[worker_core].data(),
+                data_buffer.data(),
                 kernel_profiler::PROFILER_L1_BUFFER_SIZE * PROFILER_RISC_COUNT,
                 true);
     } else {
         dynamic_cast<HWCommandQueue&>(device->command_queue())
             .enqueue_read_from_core(
                 worker_core,
-                core_l1_data_buffers[worker_core].data(),
+                data_buffer.data(),
                 reinterpret_cast<DeviceAddr>(profiler_msg->buffer),
                 kernel_profiler::PROFILER_L1_BUFFER_SIZE * PROFILER_RISC_COUNT,
                 true);
     }
+
+    return data_buffer;
 }
 
-void DeviceProfiler::issueSlowDispatchReadFromL1DataBuffer(IDevice* device, const CoreCoord& worker_core) {
+std::vector<uint32_t> DeviceProfiler::issueSlowDispatchReadFromL1DataBuffer(
+    IDevice* device, const CoreCoord& worker_core) {
     ZoneScoped;
     const chip_id_t device_id = device->id();
     const HalProgrammableCoreType core_type = tt::llrt::get_core_type(device_id, worker_core);
     profiler_msg_t* profiler_msg =
         MetalContext::instance().hal().get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
-    core_l1_data_buffers[worker_core] = tt::llrt::read_hex_vec_from_core(
+    return tt::llrt::read_hex_vec_from_core(
         device_id,
         worker_core,
         reinterpret_cast<uint64_t>(profiler_msg->buffer),
@@ -240,14 +244,12 @@ void DeviceProfiler::readRiscProfilerResults(
     IDevice* device,
     const CoreCoord& worker_core,
     const ProfilerDumpState state,
+    const std::vector<uint32_t>& data_buffer,
     const ProfilerDataBufferSource data_source,
     const std::optional<ProfilerOptionalMetadata>& metadata,
     std::ofstream& log_file_ofs,
     nlohmann::ordered_json& noc_trace_json_log) {
     ZoneScoped;
-
-    const std::vector<uint32_t>& data_buffer =
-        (data_source == ProfilerDataBufferSource::L1) ? core_l1_data_buffers.at(worker_core) : profile_buffer;
 
     std::vector<uint32_t> control_buffer = core_control_buffers.at(worker_core);
 
@@ -1187,20 +1189,22 @@ void DeviceProfiler::dumpResults(
                 readControlBuffers(device, worker_core, state);
                 resetControlBuffers(device, worker_core, state);
 
+                std::vector<uint32_t> core_l1_data_buffer;
                 if (tt::DevicePool::instance().is_dispatch_firmware_active()) {
                     if (rtoptions.get_profiler_do_dispatch_cores() || state == ProfilerDumpState::FORCE_UMD_READ) {
-                        issueSlowDispatchReadFromL1DataBuffer(device, worker_core);
+                        core_l1_data_buffer = issueSlowDispatchReadFromL1DataBuffer(device, worker_core);
                     } else {
-                        issueFastDispatchReadFromL1DataBuffer(device, worker_core);
+                        core_l1_data_buffer = issueFastDispatchReadFromL1DataBuffer(device, worker_core);
                     }
                 } else {
-                    issueSlowDispatchReadFromL1DataBuffer(device, worker_core);
+                    core_l1_data_buffer = issueSlowDispatchReadFromL1DataBuffer(device, worker_core);
                 }
 
                 readRiscProfilerResults(
                     device,
                     worker_core,
                     state,
+                    core_l1_data_buffer,
                     ProfilerDataBufferSource::L1,
                     metadata,
                     log_file_ofs,
@@ -1210,6 +1214,7 @@ void DeviceProfiler::dumpResults(
                     device,
                     worker_core,
                     state,
+                    profile_buffer,
                     ProfilerDataBufferSource::DRAM,
                     metadata,
                     log_file_ofs,

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -207,6 +207,7 @@ private:
         IDevice* device,
         const CoreCoord& worker_core,
         const ProfilerDumpState state,
+        const std::vector<uint32_t>& data_buffer,
         const ProfilerDataBufferSource data_source,
         const std::optional<ProfilerOptionalMetadata>& metadata,
         std::ofstream& log_file_ofs,
@@ -232,9 +233,6 @@ public:
 
     // DRAM Vector
     std::vector<uint32_t> profile_buffer;
-
-    // Data stored in L1 for each core
-    std::unordered_map<CoreCoord, std::vector<uint32_t>> core_l1_data_buffers;
 
     // Number of bytes reserved in each DRAM bank for storing device profiling data
     uint32_t profile_buffer_bank_size_bytes;
@@ -285,10 +283,10 @@ public:
     void issueSlowDispatchReadFromProfilerBuffer(IDevice* device);
 
     // Read data from L1 data buffer using fast dispatch
-    void issueFastDispatchReadFromL1DataBuffer(IDevice* device, const CoreCoord& worker_core);
+    std::vector<uint32_t> issueFastDispatchReadFromL1DataBuffer(IDevice* device, const CoreCoord& worker_core);
 
     // Read data from L1 data buffer using slow dispatch
-    void issueSlowDispatchReadFromL1DataBuffer(IDevice* device, const CoreCoord& worker_core);
+    std::vector<uint32_t> issueSlowDispatchReadFromL1DataBuffer(IDevice* device, const CoreCoord& worker_core);
 };
 
 void write_control_buffer_to_core(

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -207,7 +207,6 @@ private:
         IDevice* device,
         const CoreCoord& worker_core,
         const ProfilerDumpState state,
-        const std::vector<uint32_t>& data_buffer,
         const ProfilerDataBufferSource data_source,
         const std::optional<ProfilerOptionalMetadata>& metadata,
         std::ofstream& log_file_ofs,

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -234,6 +234,9 @@ public:
     // DRAM Vector
     std::vector<uint32_t> profile_buffer;
 
+    // Data stored in L1 for each core
+    std::unordered_map<CoreCoord, std::vector<uint32_t>> core_l1_data_buffers;
+
     // Number of bytes reserved in each DRAM bank for storing device profiling data
     uint32_t profile_buffer_bank_size_bytes;
 
@@ -281,6 +284,12 @@ public:
 
     // Read data from profiler buffer using slow dispatch
     void issueSlowDispatchReadFromProfilerBuffer(IDevice* device);
+
+    // Read data from L1 data buffer using fast dispatch
+    void issueFastDispatchReadFromL1DataBuffer(IDevice* device, const CoreCoord& worker_core);
+
+    // Read data from L1 data buffer using slow dispatch
+    void issueSlowDispatchReadFromL1DataBuffer(IDevice* device, const CoreCoord& worker_core);
 };
 
 void write_control_buffer_to_core(


### PR DESCRIPTION
#23435 

This PR modifies L1 profiler buffer reads to use FD when able to do so.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15640551743)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/15640555721)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15640575205)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15640579453)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15590674815)
- [x] [T3K Profiler] (https://github.com/tenstorrent/tt-metal/actions/runs/15640564380)
- [x] [Metal Microbenchmarks] (https://github.com/tenstorrent/tt-metal/actions/runs/15640569810)
- [x] New/Existing tests provide coverage for changes