### PR TITLE
Adjust is_using_noc_coords for WH vs BH

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp
@@ -14,7 +14,13 @@
 static constexpr size_t VIRTUAL_COORDS_START_X = 16;
 static constexpr size_t VIRTUAL_COORDS_START_Y = 16;
 FORCE_INLINE bool is_using_noc_coords(uint16_t noc_x, uint16_t noc_y) {
-    return !(bool)COORDINATE_VIRTUALIZATION_ENABLED;
+#ifdef ARCH_WORMHOLE
+    return noc_x < VIRTUAL_COORDS_START_X && noc_y < VIRTUAL_COORDS_START_Y;
+#elif defined(COORDINATE_VIRTUALIZATION_ENABLED) && COORDINATE_VIRTUALIZATION_ENABLED == 1
+    return false;
+#else
+    return true;
+#endif
 }
 
 FORCE_INLINE uint64_t


### PR DESCRIPTION
### Ticket
N/A

### Problem description
I broke llama on TG with my pr to support Fabric on BH

### What's changed
ifdef whether coordinate is virtualized based on arch

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [TG quick](https://github.com/tenstorrent/tt-metal/actions/runs/15625337476)
- [ ] [TG unit](https://github.com/tenstorrent/tt-metal/actions/runs/15629353997)
- [ ] https://github.com/tenstorrent/tt-metal/actions/runs/15629473690