### PR TITLE
Enable folding with pad for conv2d folds.

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3612,11 +3612,24 @@ def test_segformer_channel_padding(device, enable_act_double_buffer, enable_spli
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize("input_channels", [3, 320])
-@pytest.mark.parametrize("output_channels", [32])
-@pytest.mark.parametrize("input_height,input_width", [(224, 224), (512, 672)])
-@pytest.mark.parametrize("kernel_height,kernel_width", [(16, 16), (32, 32)])
-@pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize(
+    "input_channels, output_channels, input_height, input_width, kernel_height, kernel_width, stride_height, stride_width",
+    [
+        (3, 32, 224, 224, 16, 16, 16, 16),
+        (3, 32, 224, 224, 32, 32, 32, 32),
+        (3, 32, 224, 224, 16, 16, 2, 2),
+        (3, 32, 224, 224, 7, 7, 2, 2),
+        (3, 32, 224, 224, 6, 6, 2, 2),
+        (3, 32, 1280, 1280, 6, 6, 2, 2),
+        (3, 32, 512, 672, 16, 16, 16, 16),
+        (3, 32, 512, 672, 32, 32, 32, 32),
+        (320, 32, 224, 224, 16, 16, 16, 16),
+        (320, 32, 224, 224, 32, 32, 32, 32),
+        (320, 32, 512, 672, 16, 16, 16, 16),
+        (320, 32, 512, 672, 32, 32, 32, 32),
+    ]
+)
+@pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("has_bias", [True, False])
 def test_conv2d_with_fold(
     device,
@@ -3628,6 +3641,8 @@ def test_conv2d_with_fold(
     input_width,
     kernel_height,
     kernel_width,
+    stride_height,
+    stride_width,
     input_layout,
     has_bias,
 ):
@@ -3645,8 +3660,8 @@ def test_conv2d_with_fold(
         input_width=input_width,
         filter_height=kernel_height,
         filter_width=kernel_width,
-        stride_h=kernel_height,
-        stride_w=kernel_width,
+        stride_h=stride_height,
+        stride_w=stride_width,
         padding=(0, 0),
         config_override=None,
         input_layout=input_layout,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -439,7 +439,7 @@ Result conv2d_L1(
     if (conv_config.enable_kernel_stride_folding) {
         auto folding_result = compute_kernel_stride_folding_params(
             input_height, input_width, in_channels, kernel_size, stride, padding_n4, conv_config);
-        input_tensor = fold_tensor(input_tensor, device, stride, kernel_size, padding_n4, conv_config.dtype);
+        input_tensor = fold_tensor(input_tensor, device, stride, kernel_size, padding_n4);
         if (conv_config.deallocate_activation) {
             Tensor input_tensor_pre_folded = input_tensor_;
             input_tensor_pre_folded.deallocate(true);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -439,7 +439,7 @@ Result conv2d_L1(
     if (conv_config.enable_kernel_stride_folding) {
         auto folding_result = compute_kernel_stride_folding_params(
             input_height, input_width, in_channels, kernel_size, stride, padding_n4, conv_config);
-        input_tensor = fold_tensor(input_tensor, device, stride, kernel_size, padding_n4, output_dtype, false);
+        input_tensor = fold_tensor(input_tensor, device, stride, kernel_size, padding_n4, conv_config.dtype);
         if (conv_config.deallocate_activation) {
             Tensor input_tensor_pre_folded = input_tensor_;
             input_tensor_pre_folded.deallocate(true);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1052,6 +1052,8 @@ ttnn::Tensor fold_tensor(
         dtype = tensor.dtype();
     }
     TT_FATAL(dtype.value() != tt_metal::DataType::BFLOAT8_B, "Conv2D DRAM folding currently doesn't support BFLOAT8_B");
+    TT_FATAL(
+        stride[0] <= kernel_size[0] && stride[1] <= kernel_size[1], "Stride must be less than or equal to kernel size");
 
     // Move to device if needed
     ttnn::Tensor tensor_on_device = tensor;
@@ -1081,8 +1083,8 @@ KernelStrideFoldingResult compute_kernel_stride_folding_params(
     input_width = input_width / stride[1];
     in_channels = in_channels * stride[0] * stride[1];
 
-    auto kernel_h = (kernel_size[0] + kernel_size[0] % stride[0]) / stride[0];
-    auto kernel_w = (kernel_size[1] + kernel_size[1] % stride[1]) / stride[1];
+    auto kernel_h = tt::div_up(kernel_size[0], stride[0]);
+    auto kernel_w = tt::div_up(kernel_size[1], stride[1]);
 
     return KernelStrideFoldingResult{
         .input_height = input_height,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1041,19 +1041,20 @@ ttnn::Tensor fold_tensor(
     T* device,
     std::array<uint32_t, 2> stride,
     std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 4> padding_n4,
-    std::optional<DataType> dtype) {
+    std::array<uint32_t, 4> padding_n4) {
     // Validation checks
-    TT_FATAL(!tensor.memory_config().is_l1(), "Input tensor must not be in L1 memory for folding");
+    TT_FATAL(
+        !tensor.memory_config().is_l1(),
+        "Conv2D kernel stride folding: Input tensor must not be in L1 memory for folding");
     TT_FATAL(
         padding_n4[0] == 0 && padding_n4[1] == 0 && padding_n4[2] == 0 && padding_n4[3] == 0,
-        "Padding must be 0 for folding");
-    if (!dtype.has_value()) {
-        dtype = tensor.dtype();
-    }
-    TT_FATAL(dtype.value() != tt_metal::DataType::BFLOAT8_B, "Conv2D DRAM folding currently doesn't support BFLOAT8_B");
+        "Conv2D kernel stride folding: Padding must be 0 for folding");
     TT_FATAL(
-        stride[0] <= kernel_size[0] && stride[1] <= kernel_size[1], "Stride must be less than or equal to kernel size");
+        tensor.dtype() != tt_metal::DataType::BFLOAT8_B,
+        "Conv2D kernel stride folding: Currently doesn't support BFLOAT8_B");
+    TT_FATAL(
+        stride[0] <= kernel_size[0] && stride[1] <= kernel_size[1],
+        "Conv2D kernel stride folding: Stride must be less than or equal to kernel size");
 
     // Move to device if needed
     ttnn::Tensor tensor_on_device = tensor;
@@ -1171,16 +1172,14 @@ template ttnn::Tensor fold_tensor<IDevice>(
     tt::tt_metal::IDevice* device,
     std::array<uint32_t, 2> stride,
     std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 4> padding_n4,
-    std::optional<DataType> dtype);
+    std::array<uint32_t, 4> padding_n4);
 
 template ttnn::Tensor fold_tensor<MeshDevice>(
     const ttnn::Tensor& tensor,
     tt::tt_metal::distributed::MeshDevice* device,
     std::array<uint32_t, 2> stride,
     std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 4> padding_n4,
-    std::optional<DataType> dtype);
+    std::array<uint32_t, 4> padding_n4);
 
 std::ostream& operator<<(std::ostream& os, const Conv2dConfig& config) {
     tt::stl::reflection::operator<<(os, config);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -191,8 +191,7 @@ ttnn::Tensor fold_tensor(
     T* device,
     std::array<uint32_t, 2> stride,
     std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 4> padding_n4,
-    std::optional<DataType> dtype);
+    std::array<uint32_t, 4> padding_n4);
 
 struct KernelStrideFoldingResult {
     uint32_t input_height;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -192,8 +192,7 @@ ttnn::Tensor fold_tensor(
     std::array<uint32_t, 2> stride,
     std::array<uint32_t, 2> kernel_size,
     std::array<uint32_t, 4> padding_n4,
-    std::optional<DataType> dtype,
-    bool is_weight_tensor = false);
+    std::optional<DataType> dtype);
 
 struct KernelStrideFoldingResult {
     uint32_t input_height;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -495,10 +495,7 @@ Tensor convert_conv_weight_tensor_to_depthwise_layout(
 }
 
 static Tensor to_folded_weight_layout(
-    const Tensor& conv_weight_tensor,
-    std::array<uint32_t, 2> stride,
-    std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 4> padding) {
+    const Tensor& conv_weight_tensor, std::array<uint32_t, 2> stride, std::array<uint32_t, 2> kernel_size) {
     auto w_shape = conv_weight_tensor.padded_shape();
     uint32_t out_channels = w_shape[0];
     uint32_t in_channels = w_shape[1];
@@ -508,22 +505,47 @@ static Tensor to_folded_weight_layout(
     // Get input data type
     auto dtype = conv_weight_tensor.dtype();
 
-    ttnn::Shape output_shape = ttnn::Shape({w_shape[0], w_shape[1] * kernel_h * kernel_w, 1, 1});
+    auto pad_h = kernel_size[0] % stride[0];
+    auto pad_w = kernel_size[1] % stride[1];
+
+    auto padded_kernel_h = kernel_h + pad_h;
+    auto padded_kernel_w = kernel_w + pad_w;
+
+    ttnn::Shape output_shape = ttnn::Shape(
+        {out_channels, in_channels * stride[0] * stride[1], padded_kernel_h / stride[0], padded_kernel_w / stride[1]});
     auto storage = std::get<tt::tt_metal::HostStorage>(conv_weight_tensor.storage()).buffer;
 
     auto fold_weights = [&](auto input_buffer) {
         using T = std::decay_t<decltype(input_buffer[0])>;
-        std::vector<T> output_buffer(output_shape.volume());
 
-        uint32_t patch_size = kernel_h * kernel_w * in_channels;
+        std::vector<T> output_buffer(output_shape.volume(), T(0));
+        int new_h = padded_kernel_h / stride[0];
+        int new_w = padded_kernel_w / stride[1];
+
         for (auto oc = 0; oc < out_channels; oc++) {
-            uint32_t dst_offset = oc * patch_size;
-            uint32_t dst_idx = 0;
-            for (auto kh = 0; kh < kernel_h; kh++) {
-                for (auto kw = 0; kw < kernel_w; kw++) {
-                    for (auto ic = 0; ic < in_channels; ic++) {
+            for (auto ic = 0; ic < in_channels; ic++) {
+                for (auto kh = 0; kh < kernel_h; kh++) {
+                    for (auto kw = 0; kw < kernel_w; kw++) {
                         uint32_t src_idx = ((((oc * in_channels + ic) * kernel_h) + kh) * kernel_w) + kw;
-                        output_buffer[dst_offset + dst_idx++] = input_buffer[src_idx];
+
+                        int sh = kh % stride[0];
+                        int sw = kw % stride[1];
+
+                        // Calculate new y,x coordinates
+                        int y = kh / stride[0];
+                        int x = kw / stride[1];
+
+                        if (y < new_h && x < new_w) {
+                            // Calculate folded input channel index
+                            int folded_ic_idx = (sh * stride[1] + sw) * in_channels + ic;
+
+                            // Calculate final destination index
+                            int dst_idx = oc * in_channels * stride[0] * stride[1] * new_h * new_w +
+                                          folded_ic_idx * new_h * new_w + y * new_w + x;
+
+                            // Direct copy from input to output
+                            output_buffer[dst_idx] = input_buffer[src_idx];
+                        }
                     }
                 }
             }
@@ -917,7 +939,7 @@ static ttnn::Tensor prepare_conv_weights_internal(
     }
     if (params.enable_kernel_stride_folding) {
         weight_tensor_ = to_folded_weight_layout(
-            weight_tensor_, params.stride, {original_weights_window_h, original_weights_window_w}, params.padding_n4);
+            weight_tensor_, params.stride, {original_weights_window_h, original_weights_window_w});
     }
     const auto& weights_shape = weight_tensor_.logical_shape();
     uint32_t out_channels = weights_shape[0];


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22378

### Problem description
The existing Conv2D implementation in TTNN only supported convolution via matmul operations. Direct strided convolution with folded weights was not implemented.

### What's changed
This PR implements the kernel stride folding functionality for when enable_kernel_stride_folding=true and stride != kernel:

- Weight Folding Implementation: Added the actual implementation to support folded convolution which transforms weights to match the stride pattern, improving computation efficiency.



### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16133542858) CI Passes
- [X] Nightly tt-metal L2 testsCI passes [BH](https://github.com/tenstorrent/tt-metal/actions/runs/16133540723) [WH](https://github.com/tenstorrent/tt-metal/actions/runs/16067207487)
- [X] [Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI same as main [Link](https://github.com/tenstorrent/tt-metal/actions/runs/16067215136)