### PR TITLE
Make assert_with_ulp() robust to empty tensors, NaN and Inf values

### DIFF
--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -604,7 +604,7 @@ def ulp(x: Union[ttnn.Tensor, torch.Tensor]) -> Union[ttnn.Tensor, torch.Tensor]
     return ulp_value
 
 
-def comp_ulp(golden, calculated, ulp_threshold):
+def comp_ulp(golden, calculated, ulp_threshold, allow_nonfinite=False):
     """
     Compute absolute error between two tensors in Units of Least Precision (ULP)
     """
@@ -613,9 +613,11 @@ def comp_ulp(golden, calculated, ulp_threshold):
     if torch.numel(golden) == 0 and torch.numel(calculated) == 0:
         return True, "Both tensors are empty"
 
+    if not allow_nonfinite and not torch.all(torch.isfinite(calculated)):
+        return False, "Calculated tensor contains non-finite values"
+
     if not _comp_finite(golden, calculated):
         return False, "Tensors are not finite at the same positions"
-
     # nonfinite elments can intefere with ULP error calculation
     # To avoid this, replace nan, +inf, -inf with 0
     # (we have already checked that both tensors have the same nonfinite elements)

--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -488,10 +488,10 @@ def is_close(a, b, rtol=1e-2, atol=1e-2, max_mag=2.0, max_mag_fraction=0.02):
     return torch.all(or_abs_rel)
 
 
-def _comp_finite(golden, calculated):
+def _comp_nonfinite(golden, calculated):
     """
-    Check whether two tensors are nonfinite (nan, inf, -inf) at the same positions.
-    If they are, then check whether nonfinite elements are the same.
+    Returns True if tensors contain the same non-finite values (nan, inf, -inf) at the same positions. Also returns True if all elements are finite.
+    Returns False if non-finite values differ between both tensors.
     """
 
     # torch.equal(['nan'], ['nan']] => False
@@ -616,7 +616,7 @@ def comp_ulp(golden, calculated, ulp_threshold, allow_nonfinite=False):
     if not allow_nonfinite and not torch.all(torch.isfinite(calculated)):
         return False, "Calculated tensor contains non-finite values"
 
-    if not _comp_finite(golden, calculated):
+    if not _comp_nonfinite(golden, calculated):
         return False, "Tensors are not finite at the same positions"
     # nonfinite elments can intefere with ULP error calculation
     # To avoid this, replace nan, +inf, -inf with 0

--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -488,6 +488,28 @@ def is_close(a, b, rtol=1e-2, atol=1e-2, max_mag=2.0, max_mag_fraction=0.02):
     return torch.all(or_abs_rel)
 
 
+def _comp_finite(golden, calculated):
+    """
+    Check whether two tensors are nonfinite (nan, inf, -inf) at the same positions.
+    If they are, then check whether nonfinite elements are the same.
+    """
+
+    # torch.equal(['nan'], ['nan']] => False
+    # For this reason, we check for nan and inf separately
+    if torch.not_equal(torch.isnan(golden), torch.isnan(calculated)).any():
+        return False
+
+    golden_inf_mask = torch.isinf(golden)
+    calculated_inf_mask = torch.isinf(calculated)
+
+    if torch.not_equal(golden_inf_mask, calculated_inf_mask).any():
+        return False
+
+    golden_inf = golden[golden_inf_mask]
+    calculated_inf = calculated[calculated_inf_mask]
+    return torch.equal(golden_inf, calculated_inf)
+
+
 def comp_allclose(golden, calculated, rtol=1e-05, atol=1e-08):
     if golden.dtype != calculated.dtype:
         calculated = calculated.type(golden.dtype)
@@ -587,13 +609,28 @@ def comp_ulp(golden, calculated, ulp_threshold):
     Compute absolute error between two tensors in Units of Least Precision (ULP)
     """
 
+    # If both tensors are empty, then we can return True
+    if torch.numel(golden) == 0 and torch.numel(calculated) == 0:
+        return True, "Both tensors are empty"
+
+    if not _comp_finite(golden, calculated):
+        return False, "Tensors are not finite at the same positions"
+
+    # nonfinite elments can intefere with ULP error calculation
+    # To avoid this, replace nan, +inf, -inf with 0
+    # (we have already checked that both tensors have the same nonfinite elements)
+    mask_finite = ~torch.isfinite(golden)
+    golden = golden.clone()
+    calculated = calculated.clone()
+    golden[mask_finite] = 0
+    calculated[mask_finite] = 0
+
     # ULP is measured according to the golden tensor
     # In most cases, data type of golden tensor should be the same as calculated tensor.
     # However, in some cases, we may want to measure < 1 ULP differences, which requires golden tensor
     # to have higher precision than calculated tensor.
     # If we passed golden tensor to ulp() as is, we would get ULP of higher precision.
     # e.g. ulp of float32 rather bfloat16 calculation, which would give us a wrong value.
-
     ulp_value = ulp(golden.type(calculated.dtype))
 
     if golden.dtype != calculated.dtype:  # Note: assumes that golden has higher precision than calculated tensor

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -142,7 +142,7 @@ def assert_with_ulp(
         expected_result (Union[ttnn.Tensor, torch.Tensor]): The expected reference tensor
         actual_result (Union[ttnn.Tensor, torch.Tensor]): The actual tensor to compare against the reference
         ulp_threshold (float, optional): Maximum tolerated ULP distance. Defaults to 10.
-        allow_nonfinite (bool, optional): If disabled, any non-finite value (NaN, +inf, -inf) will trigger assertion. If enabled, it will also compare NaNs, +inf and inf.
+        allow_nonfinite (bool, optional): If disabled, any non-finite value (NaN, +inf, -inf) will trigger an assertion. If enabled, differences between non-finite values at the same positions will trigger an assertion.
 
     Note:
         The length of a single ULP is measured using the difference between two consecutive floating point numbers.

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -122,7 +122,10 @@ def assert_allclose(
 
 
 def assert_with_ulp(
-    expected_result: Union[ttnn.Tensor, torch.Tensor], actual_result: Union[ttnn.Tensor, torch.Tensor], ulp_threshold=10
+    expected_result: Union[ttnn.Tensor, torch.Tensor],
+    actual_result: Union[ttnn.Tensor, torch.Tensor],
+    ulp_threshold=10,
+    allow_nonfinite=False,
 ):
     """
     Assert that two tensors are similar within a given distance expressed in Units of Least Precision (ULP)
@@ -139,6 +142,7 @@ def assert_with_ulp(
         expected_result (Union[ttnn.Tensor, torch.Tensor]): The expected reference tensor
         actual_result (Union[ttnn.Tensor, torch.Tensor]): The actual tensor to compare against the reference
         ulp_threshold (float, optional): Maximum tolerated ULP distance. Defaults to 10.
+        allow_nonfinite (bool, optional): If disabled, any non-finite value (NaN, +inf, -inf) will trigger assertion. If enabled, it will also compare NaNs, +inf and inf.
 
     Note:
         The length of a single ULP is measured using the difference between two consecutive floating point numbers.
@@ -160,7 +164,7 @@ def assert_with_ulp(
         actual_result.shape
     ), f"list(expected_result.shape)={list(expected_result.shape)} vs list(actual_result.shape)={list(actual_result.shape)}"
 
-    ulp_passed, ulp_message = comp_ulp(expected_result, actual_result, ulp_threshold)
+    ulp_passed, ulp_message = comp_ulp(expected_result, actual_result, ulp_threshold, allow_nonfinite)
     assert ulp_passed, ulp_message
     return ulp_passed, ulp_message
 


### PR DESCRIPTION
### Ticket
#23532 

### Problem description

`assert_with_ulp()` currently throws on some specific values:

```
assert_with_ulp([], []) => FAIL
assert_with_ulp(torch.full('nan'), torch.full('nan')) => FAIL
assert_with_ulp(torch.full('inf'), torch.full('inf')) => FAIL
```

For correctness and convenience purposes, we would like to make it pass these configurations (i.e. as opposed to checking manually outside the function). 

Indeed, even if it does not make much sense to compute the ULP of 'nan' or 'inf', if `golden(x) = inf` then we also want `f(x) = inf`.
 Ideally, `assert_with_ulp()` should be used on the useful range, where we typically shouldn't have these special outputs. But testing against these can make `assert_with_ulp()` usage more convenient (request from @mouliraj-mcw ). 

### What's changed

This PR ensures that:

```
assert_with_ulp([], []) => PASS
assert_with_ulp(torch.full('nan'), torch.full('nan')) => PASS
assert_with_ulp(torch.full('inf'), torch.full('inf')) => PASS
```

`assert_with_ulp()` will also throw if there are *any* mismatched element (e.g. if comparing `nan` and `1`; `nan` and `inf`; ... ).

To achieve this, I added a `_comp_finite(golden, calculated)` function in `models.utility_functions.py`. 
(For now, it's only used by `comp_ulp()`)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes