### PR TITLE
[skip ci] Bump timeout

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -140,7 +140,7 @@ jobs:
   build-artifact:
     name: "🛠️ Build ${{ inputs.build-type }} ${{ inputs.distro }} ${{ inputs.version }}"
     needs: build-docker-image
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: tt-beta-ubuntu-2204-large
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     outputs:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Saw an instance where the compile took 23m and the overall job slammed headfirst against the 30m timeout.
It shouldn't take that long even with 0% cache misses.  But we're still investigating degraded performance on the CPU runners (slow disk) and the CPU is known to be oversubscribed.  Better to not fail the jobs.

### What's changed
Bump the timeout.