### PR TITLE
Calcuate tsu threshold and failures based on decode_iteration in demo decode

### DIFF
--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -419,7 +419,7 @@ def run_llama3_demo(
     # Tracks the number of iterations where throughput falls below `tsu_threshold`
     tsu_failures = 0
     all_tokens_per_second_per_user = []
-
+    failed_tokens_per_second_per_user = []
     read_events = []
     tt_out_toks_cpu = []
     iteration_time_start = time()
@@ -508,6 +508,7 @@ def run_llama3_demo(
                         or tokens_per_second_per_user > tsu_thresholds["max"]
                     ):
                         tsu_failures += 1
+                        failed_tokens_per_second_per_user.append((decode_iteration, tokens_per_second_per_user))
 
                 iteration_time_start = time()
 
@@ -566,13 +567,9 @@ def run_llama3_demo(
         if tsu_failures > tsu_perf_drop_limit:
             logger.info(out_of_targets_msg)
             logger.info(f"Failing iterations sorted by t/s/u")
-            sorted_tokens_per_second_per_user = sorted(all_tokens_per_second_per_user)
-            for i in range(len(sorted_tokens_per_second_per_user)):
-                if (
-                    sorted_tokens_per_second_per_user[i] < tsu_thresholds["min"]
-                    or sorted_tokens_per_second_per_user[i] > tsu_thresholds["max"]
-                ):
-                    logger.info(f"Iteration {i}: {sorted_tokens_per_second_per_user[i]}")
+            sorted_tokens_per_second_per_user = sorted(failed_tokens_per_second_per_user, key=lambda x: x[1])
+            for iteration, tsu in sorted_tokens_per_second_per_user:
+                logger.info(f"Iteration {iteration}: {tsu}")
         # Assert at the end of test to check if the throughput recuperated
         assert tsu_failures <= tsu_perf_drop_limit, out_of_targets_msg
 

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -503,7 +503,7 @@ def run_llama3_demo(
 
                 if not stress_test:
                     # Increment failure count if throughput is too low
-                    if iteration < 200 and (
+                    if decode_iteration < 200 and (
                         tokens_per_second_per_user < tsu_thresholds["min"]
                         or tokens_per_second_per_user > tsu_thresholds["max"]
                     ):
@@ -562,7 +562,7 @@ def run_llama3_demo(
 
         # print before assertion
         out_of_targets_msg = f"Throughput is out of targets {tsu_thresholds['min']} - {tsu_thresholds['max']} t/s/u in {tsu_failures} iterations"
-        tsu_perf_drop_limit = TSU_PERF_DROP_LIMIT_PERCENT * iteration / 100
+        tsu_perf_drop_limit = TSU_PERF_DROP_LIMIT_PERCENT * decode_iteration / 100
         if tsu_failures > tsu_perf_drop_limit:
             logger.info(out_of_targets_msg)
             logger.info(f"Failing iterations sorted by t/s/u")

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -503,7 +503,7 @@ def run_llama3_demo(
 
                 if not stress_test:
                     # Increment failure count if throughput is too low
-                    if decode_iteration < 200 and (
+                    if decode_iteration in range(1, 200) and (
                         tokens_per_second_per_user < tsu_thresholds["min"]
                         or tokens_per_second_per_user > tsu_thresholds["max"]
                     ):


### PR DESCRIPTION
### Problem description
Calculate the tsu threshold and failures count based on decode_iteration not iteration

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes