### PR TITLE
#22090: Adopt `x0...xn` notation in mesh shape / coord constructors

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -21,6 +21,7 @@ public:
     using ShapeBase::operator[];
 
     // Shorthands for constructing 1D, 2D and 3D shapes.
+    // The values s0...sn are assumed to be supplied in row-major order (from outer dim to inner dim).
     explicit MeshShape(uint32_t s);
     MeshShape(uint32_t s0, uint32_t s1);
     MeshShape(uint32_t s0, uint32_t s1, uint32_t s2);
@@ -62,6 +63,7 @@ bool is_line_topology(const MeshShape& shape);
 class MeshCoordinate {
 public:
     // Shorthands for constructing 1D, 2D and 3D coordinates.
+    // The values c0...cn are assumed to be supplied in row-major order (from outer dim to inner dim).
     explicit MeshCoordinate(uint32_t c);
     MeshCoordinate(uint32_t c0, uint32_t c1);
     MeshCoordinate(uint32_t c0, uint32_t c1, uint32_t c2);

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -21,9 +21,9 @@ public:
     using ShapeBase::operator[];
 
     // Shorthands for constructing 1D, 2D and 3D shapes.
-    explicit MeshShape(uint32_t x);
-    MeshShape(uint32_t x, uint32_t y);
-    MeshShape(uint32_t x, uint32_t y, uint32_t z);
+    explicit MeshShape(uint32_t s);
+    MeshShape(uint32_t s0, uint32_t s1);
+    MeshShape(uint32_t s0, uint32_t s1, uint32_t s2);
 
     explicit MeshShape(const tt::stl::SmallVector<uint32_t>& shape);
     explicit MeshShape(tt::stl::SmallVector<uint32_t>&& shape);
@@ -62,9 +62,9 @@ bool is_line_topology(const MeshShape& shape);
 class MeshCoordinate {
 public:
     // Shorthands for constructing 1D, 2D and 3D coordinates.
-    explicit MeshCoordinate(uint32_t x);
-    MeshCoordinate(uint32_t x, uint32_t y);
-    MeshCoordinate(uint32_t x, uint32_t y, uint32_t z);
+    explicit MeshCoordinate(uint32_t c);
+    MeshCoordinate(uint32_t c0, uint32_t c1);
+    MeshCoordinate(uint32_t c0, uint32_t c1, uint32_t c2);
 
     // Constructs a generic N-dimensional coordinate.
     explicit MeshCoordinate(tt::stl::Span<const uint32_t> coords);

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -67,9 +67,9 @@ bool check_mergeable(const MeshCoordinateRange& a, const MeshCoordinateRange& b)
 
 }  // namespace
 
-MeshShape::MeshShape(uint32_t x) : MeshShape({x}) {}
-MeshShape::MeshShape(uint32_t x, uint32_t y) : MeshShape({x, y}) {}
-MeshShape::MeshShape(uint32_t x, uint32_t y, uint32_t z) : MeshShape({x, y, z}) {}
+MeshShape::MeshShape(uint32_t s) : MeshShape({s}) {}
+MeshShape::MeshShape(uint32_t s0, uint32_t s1) : MeshShape({s0, s1}) {}
+MeshShape::MeshShape(uint32_t s0, uint32_t s1, uint32_t s2) : MeshShape({s0, s1, s2}) {}
 
 MeshShape::MeshShape(const tt::stl::SmallVector<uint32_t>& shape) : ShapeBase(shape) { compute_strides(); }
 MeshShape::MeshShape(tt::stl::SmallVector<uint32_t>&& shape) : ShapeBase(std::move(shape)) { compute_strides(); }
@@ -112,9 +112,9 @@ bool is_line_topology(const MeshShape& shape) {
     return std::count_if(shape.cbegin(), shape.cend(), [](size_t dim) { return dim != 1; }) <= 1;
 }
 
-MeshCoordinate::MeshCoordinate(uint32_t x) : value_({x}) {}
-MeshCoordinate::MeshCoordinate(uint32_t x, uint32_t y) : value_({x, y}) {}
-MeshCoordinate::MeshCoordinate(uint32_t x, uint32_t y, uint32_t z) : value_({x, y, z}) {}
+MeshCoordinate::MeshCoordinate(uint32_t c) : value_({c}) {}
+MeshCoordinate::MeshCoordinate(uint32_t c0, uint32_t c1) : value_({c0, c1}) {}
+MeshCoordinate::MeshCoordinate(uint32_t c0, uint32_t c1, uint32_t c2) : value_({c0, c1, c2}) {}
 
 MeshCoordinate::MeshCoordinate(tt::stl::Span<const uint32_t> coords) : value_(coords.begin(), coords.end()) {}
 

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -60,7 +60,7 @@ void py_module(py::module& module) {
             "Constructor with the specified 3D shape.",
             py::arg("s0"),
             py::arg("s1"),
-            py::arg("n3"))
+            py::arg("s2"))
         .def(
             py::init([](const std::vector<uint32_t>& shape) { return MeshShape(shape); }),
             "Constructor with the specified ND shape.",

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -49,19 +49,18 @@ void py_module_types(py::module& module) {
 }
 
 void py_module(py::module& module) {
-    // TODO: #17477 - Remove overloads that accept 'row' and 'col'. Instead, use generic ND terms.
     static_cast<py::class_<MeshShape>>(module.attr("MeshShape"))
         .def(
-            py::init([](size_t num_rows, size_t num_cols) { return MeshShape(num_rows, num_cols); }),
-            "Constructor with the specified number of rows and columns.",
-            py::arg("num_rows"),
-            py::arg("num_cols"))
+            py::init([](size_t s0, size_t s1) { return MeshShape(s0, s1); }),
+            "Constructor with the specified 2D shape.",
+            py::arg("s0"),
+            py::arg("s1"))
         .def(
-            py::init([](size_t x, size_t y, size_t z) { return MeshShape(x, y, z); }),
+            py::init([](size_t s0, size_t s1, size_t s2) { return MeshShape(s0, s1, s2); }),
             "Constructor with the specified 3D shape.",
-            py::arg("x"),
-            py::arg("y"),
-            py::arg("z"))
+            py::arg("s0"),
+            py::arg("s1"),
+            py::arg("n3"))
         .def(
             py::init([](const std::vector<uint32_t>& shape) { return MeshShape(shape); }),
             "Constructor with the specified ND shape.",
@@ -79,16 +78,16 @@ void py_module(py::module& module) {
             py::keep_alive<0, 1>());
     static_cast<py::class_<MeshCoordinate>>(module.attr("MeshCoordinate"))
         .def(
-            py::init([](size_t row, size_t col) { return MeshCoordinate(row, col); }),
-            "Constructor with specified row and column offsets.",
-            py::arg("row"),
-            py::arg("col"))
+            py::init([](size_t c0, size_t c1) { return MeshCoordinate(c0, c1); }),
+            "Constructor with specified 2D coordinate.",
+            py::arg("c0"),
+            py::arg("c1"))
         .def(
-            py::init([](size_t x, size_t y, size_t z) { return MeshCoordinate(x, y, z); }),
+            py::init([](size_t c0, size_t c1, size_t c2) { return MeshCoordinate(c0, c1, c2); }),
             "Constructor with the specified 3D coordinate.",
-            py::arg("x"),
-            py::arg("y"),
-            py::arg("z"))
+            py::arg("c0"),
+            py::arg("c1"),
+            py::arg("c2"))
         .def(
             py::init([](const std::vector<uint32_t>& coords) { return MeshCoordinate(coords); }),
             "Constructor with the specified ND coordinate.",

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -52,18 +52,20 @@ void py_module(py::module& module) {
     static_cast<py::class_<MeshShape>>(module.attr("MeshShape"))
         .def(
             py::init([](size_t s0, size_t s1) { return MeshShape(s0, s1); }),
-            "Constructor with the specified 2D shape.",
+            "Constructor with the specified 2D shape. The value s0 is assumed to be the outer dimension.",
             py::arg("s0"),
             py::arg("s1"))
         .def(
             py::init([](size_t s0, size_t s1, size_t s2) { return MeshShape(s0, s1, s2); }),
-            "Constructor with the specified 3D shape.",
+            "Constructor with the specified 3D shape. The values s0...s2 are assumed to be supplied in row-major order "
+            "(from outer dim to inner dim).",
             py::arg("s0"),
             py::arg("s1"),
             py::arg("s2"))
         .def(
             py::init([](const std::vector<uint32_t>& shape) { return MeshShape(shape); }),
-            "Constructor with the specified ND shape.",
+            "Constructor with the specified ND shape. The values s0...sn are assumed to be supplied in row-major order "
+            "(from outer dim to inner dim).",
             py::arg("shape"))
         .def(
             "__repr__",
@@ -79,18 +81,20 @@ void py_module(py::module& module) {
     static_cast<py::class_<MeshCoordinate>>(module.attr("MeshCoordinate"))
         .def(
             py::init([](size_t c0, size_t c1) { return MeshCoordinate(c0, c1); }),
-            "Constructor with specified 2D coordinate.",
+            "Constructor with the specified 2D coordinate. The value c0 is assumed to be the outer dimension.",
             py::arg("c0"),
             py::arg("c1"))
         .def(
             py::init([](size_t c0, size_t c1, size_t c2) { return MeshCoordinate(c0, c1, c2); }),
-            "Constructor with the specified 3D coordinate.",
+            "Constructor with the specified 3D coordinate. The values c0...c2 are assumed to be supplied in row-major "
+            "order (from outer dim to inner dim).",
             py::arg("c0"),
             py::arg("c1"),
             py::arg("c2"))
         .def(
             py::init([](const std::vector<uint32_t>& coords) { return MeshCoordinate(coords); }),
-            "Constructor with the specified ND coordinate.",
+            "Constructor with the specified ND coordinate. The values c0...cn are assumed to be supplied in row-major "
+            "order (from outer dim to inner dim).",
             py::arg("coords"))
         .def(
             "__repr__",


### PR DESCRIPTION
### Ticket
#22090

### Problem description
`x, y, z` is confusing because parts of code base use the reverse ordering notation.

### What's changed
Rename to `s0...sn` for shape components and `c0...cn` for coordinate components, staying agnostic to `x y z` ordering.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15654992144)
- [X] New/Existing tests provide coverage for changes
