### PR TITLE
#0: Eliminate unnecessary copying when creating tensor data

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_sharding.cpp
@@ -137,7 +137,7 @@ TEST_P(ShardWithAlignmentTests, LogicalToPhysical) {
     const auto& expected_physical_data = params.expected.physical_data;
 
     // Convert output physical data to row major (if necessary) for testing
-    auto physical_data = tensor_impl::encode_tensor_data(std::move(logical_data), tensor_spec);
+    auto physical_data = tensor_impl::encode_tensor_data(tt::stl::make_const_span(logical_data), tensor_spec);
     if (tensor_spec.layout() == Layout::TILE) {
         // TODO: Fix convert_layout_tile_to_row_major to take in vector instead of buffer?
         physical_data = tensor_impl::convert_layout_tile_to_row_major(
@@ -193,7 +193,7 @@ TEST_P(ShardWithAlignmentTests, PhysicalToLogical) {
         physical_data = tensor_impl::convert_layout_row_major_to_tile(
             physical_shape, tensor_spec.tile(), tt::stl::make_const_span(physical_data));
     }
-    auto logical_data = tensor_impl::decode_tensor_data(std::move(physical_data), tensor_spec);
+    auto logical_data = tensor_impl::decode_tensor_data(tt::stl::make_const_span(physical_data), tensor_spec);
 
     // auto shape_2d = tensor_spec.logical_2d_shape();
     // pretty_print_data_as_shards(params.expected.physical_data, physical_shape, physical_shard_shape);

--- a/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
+++ b/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
@@ -6,6 +6,7 @@
 
 #include <tt_stl/overloaded.hpp>
 #include <tt_stl/reflection.hpp>
+#include <type_traits>
 
 #include "ttnn/tensor/tensor.hpp"
 
@@ -14,24 +15,25 @@ namespace host_buffer {
 
 template <typename T>
 void validate_datatype(const Tensor& tensor) {
-    if constexpr (std::is_same_v<T, uint32_t>) {
+    using BaseType = std::remove_const_t<T>;
+    if constexpr (std::is_same_v<BaseType, uint32_t>) {
         TT_FATAL(
             tensor.dtype() == DataType::UINT32 or tensor.dtype() == DataType::BFLOAT8_B or
                 tensor.dtype() == DataType::BFLOAT4_B,
             "Incorrect data type {}",
             tensor.dtype());
-    } else if constexpr (std::is_same_v<T, int32_t>) {
+    } else if constexpr (std::is_same_v<BaseType, int32_t>) {
         TT_FATAL(tensor.dtype() == DataType::INT32, "Incorrect data type {}", tensor.dtype());
-    } else if constexpr (std::is_same_v<T, float>) {
+    } else if constexpr (std::is_same_v<BaseType, float>) {
         TT_FATAL(tensor.dtype() == DataType::FLOAT32, "Incorrect data type {}", tensor.dtype());
-    } else if constexpr (std::is_same_v<T, bfloat16>) {
+    } else if constexpr (std::is_same_v<BaseType, bfloat16>) {
         TT_FATAL(tensor.dtype() == DataType::BFLOAT16, "Incorrect data type {}", tensor.dtype());
-    } else if constexpr (std::is_same_v<T, uint16_t>) {
+    } else if constexpr (std::is_same_v<BaseType, uint16_t>) {
         TT_FATAL(tensor.dtype() == DataType::UINT16, "Incorrect data type {}", tensor.dtype());
-    } else if constexpr (std::is_same_v<T, uint8_t>) {
+    } else if constexpr (std::is_same_v<BaseType, uint8_t>) {
         TT_FATAL(tensor.dtype() == DataType::UINT8, "Incorrect data type {}", tensor.dtype());
     } else {
-        static_assert(tt::stl::concepts::always_false_v<T>, "Unsupported DataType");
+        static_assert(tt::stl::concepts::always_false_v<BaseType>, "Unsupported DataType");
     }
 }
 

--- a/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
+++ b/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
@@ -15,7 +15,7 @@ namespace host_buffer {
 
 template <typename T>
 void validate_datatype(const Tensor& tensor) {
-    using BaseType = std::remove_const_t<T>;
+    using BaseType = std::remove_cvref_t<T>;
     if constexpr (std::is_same_v<BaseType, uint32_t>) {
         TT_FATAL(
             tensor.dtype() == DataType::UINT32 or tensor.dtype() == DataType::BFLOAT8_B or

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -85,7 +85,7 @@ public:
     // Elements in the buffer are assumed to be stored in row-major order. The size of the buffer and the type of the
     // elements have to match `spec`; block float formats such as BFLOAT8_B and BFLOAT4_B require `T` equal `float`.
     //
-    // The data in the buffer is copied into a tensor with an owned storage.
+    // The data in the buffer is copied into a tensor with host storage.
     template <typename T>
     static Tensor from_span(
         tt::stl::Span<const T> buffer,

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -160,7 +160,10 @@ std::vector<T> encode_tensor_data(tt::stl::Span<const T> logical_data, const Ten
 template <typename T>
 std::vector<T> decode_tensor_data(tt::stl::Span<const T> physical_data, const TensorSpec& tensor_spec);
 
-// Returns true if the logical tensor data matches the physical tensor data. Used for optimizing conversion operations.
+// Returns true if the logical tensor data matches the physical tensor data:
+// 1. Row major layout is used.
+// 2. Logical 2D shape matches physical shape.
+// Used for optimizing conversion operations.
 bool logical_matches_physical(const TensorSpec& tensor_spec);
 
 // ===============================================================================================================================================

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -148,7 +148,7 @@ std::vector<T> convert_layout_tile_to_row_major(
 //     ** For the last shard, we only align to nearest page instead of full shard size for partial shards
 //   * After conversion, size of physical data will match 2D physical size indicated by tensor_spec.physical_shape()
 template <typename T>
-std::vector<T> encode_tensor_data(std::vector<T>&& logical_data, const TensorSpec& tensor_spec, T pad_value = 0);
+std::vector<T> encode_tensor_data(tt::stl::Span<const T> logical_data, const TensorSpec& tensor_spec, T pad_value = 0);
 
 // Converts physical data into logical data based on tensor spec (see encode_tensor_data for details)
 // - Physical data: Flat container of physical data corresponding to tensor spec
@@ -158,7 +158,10 @@ std::vector<T> encode_tensor_data(std::vector<T>&& logical_data, const TensorSpe
 //   * To get logical data, perform the exact inverse process of encode_tensor_data
 //   * Resulting data is safe to be converted to python tensors or general consumption with just a ND logical shape
 template <typename T>
-std::vector<T> decode_tensor_data(std::vector<T>&& physical_data, const TensorSpec& tensor_spec);
+std::vector<T> decode_tensor_data(tt::stl::Span<const T> physical_data, const TensorSpec& tensor_spec);
+
+// Returns true if the logical tensor data matches the physical tensor data. Used for optimizing conversion operations.
+bool logical_matches_physical(const TensorSpec& tensor_spec);
 
 // ===============================================================================================================================================
 //                                                              High Level APIs

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -107,7 +107,7 @@ Tensor create_typed_tt_tensor_from_py_data(
         return output;
     } else {
         return Tensor::from_span(
-            tt::stl::Span<const T>(pydata_span), tensor_spec, device, cq_id, static_cast<T>(pad_value));
+            tt::stl::make_const_span(pydata_span), tensor_spec, device, cq_id, static_cast<T>(pad_value));
     }
 }
 
@@ -406,16 +406,12 @@ HostBuffer create_row_major_host_buffer(
     }
 
     // No modifications needed; direclty return buffer
-    if (tensor_spec.layout() == Layout::ROW_MAJOR and tensor_spec.logical_2d_shape() == tensor_spec.physical_shape()) {
+    if (tensor_impl::logical_matches_physical(tensor_spec)) {
         return host_buffer;
     }
 
-    // TODO: Switch to use span in decode_tensor_data and avoid data copy here
-    auto typed_view = host_buffer::get_as<T>(host_buffer);
-    std::vector<T> physical_data(typed_view.begin(), typed_view.end());
-
-    // See implementation for documentation
-    auto logical_data = tensor_impl::decode_tensor_data(std::move(physical_data), tensor_spec);
+    auto typed_view = host_buffer::get_as<const T>(host_buffer);
+    auto logical_data = tensor_impl::decode_tensor_data(typed_view, tensor_spec);
 
     return HostBuffer(std::move(logical_data));
 }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
There are a couple of unnecessary copies done on the tensor conversion path. See comments inline.

### What's changed
* Implement `encode_tensor_data` / `decode_tensor_data` in terms of const span. 
* Add an explicit `logical_matches_physical` so that the client code can check if logical data matches physical data.
* This allows for more general and flexible approach when creating tensors, as the input data may or may not be owned. `tt::stl::Span<const T>` works always. See inline comments on where the copies were made.

### Perf report
Running `pytest tests/ttnn/benchmark/python/benchmark_from_torch.py` on T3K:
* `test_benchmark_from_torch_one_copy` actually made 2 copies; perf went up from 6.7091 QPS to 12.3692 QPS.
* `test_benchmark_from_torch_two_copy` actually made 3 copies; perf went up from 4.6528 QPS to 6.7870 QPS
* `test_benchmark_from_torch_zero_copy` actually made 0 copies. Perf remains the same.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15656043173)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15656044452)
- [x] New/Existing tests provide coverage for changes