### PR TITLE
Fix unused local typedef warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,6 @@ add_compile_options(
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-mismatched-tags>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-reorder-ctor>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-lambda-capture>"
-    "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-local-typedef>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-private-field>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unknown-pragmas>"
     "$<$<CXX_COMPILER_ID:Clang>:SHELL:-Xclang -fno-pch-timestamp>" # ccache-friendly PCH flag

--- a/tests/tt_metal/multihost/common/multihost_test_tools.hpp
+++ b/tests/tt_metal/multihost/common/multihost_test_tools.hpp
@@ -96,8 +96,6 @@ inline void barrier(const ContextPtr& ctx) { ctx->barrier(); }
 // ----------------------------------------------------------------------
 inline int multihost_main(int argc, char** argv) {
     tt::tt_metal::distributed::multihost::DistributedContext::create(argc, argv);
-    using Rank = tt::tt_metal::distributed::multihost::Rank;
-    using Tag = tt::tt_metal::distributed::multihost::Tag;
 
     ::testing::InitGoogleTest(&argc, argv);
 

--- a/tests/tt_metal/multihost/single_host_mp_tests/test_context.cpp
+++ b/tests/tt_metal/multihost/single_host_mp_tests/test_context.cpp
@@ -54,9 +54,6 @@ TEST(DistributedContextTest, AllReduceInt) {
     // assuming context is already initialized in main with argc, argv
     // in this case we will just get a world context
     auto context = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
-    using Rank = tt::tt_metal::distributed::multihost::Rank;
-    using Tag = tt::tt_metal::distributed::multihost::Tag;
-    using Size = tt::tt_metal::distributed::multihost::Size;
 
     auto size = context->size();
 

--- a/ttnn/api/ttnn/run_operation.hpp
+++ b/ttnn/api/ttnn/run_operation.hpp
@@ -80,7 +80,6 @@ inline auto run_with_autoformat(
     const std::vector<std::optional<Tensor>>& optional_output_tensors = {},
     const float pad_value = 0,
     ttnn::QueueId cq_id = ttnn::DefaultQueueId) -> Tensors {
-    using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
     auto operation = DeviceOperation<Tensors>(concrete_op);
     return run_with_autoformat(
         std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors, pad_value, cq_id);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -65,7 +65,6 @@ ttnn::Tensor pad_impl(
         }
         using ShardStrategy = ttnn::operations::data_movement::ShardStrategy;
         using ShardOrientation = tt::tt_metal::ShardOrientation;
-        using Layout = tt::tt_metal::Layout;
 
         auto output_memory_config = memory_config_arg.value_or(input_tensor.memory_config());
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
@@ -1209,7 +1209,6 @@ static void populate_partial_reduce_rt_args(
     std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& reader_rt_args_overrider_map,
     std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& writer_rt_args_overrider_map) {
     using namespace ttnn::ccl::worker_detail;
-    using Direction = ttnn::ccl::LineDirection;
 
     auto const& all_tensors = builder_config.all_tensors.get();
     auto const& kernel_ids = builder_config.kernel_ids.get();
@@ -1526,7 +1525,6 @@ static void create_end_of_line_worker_runtime_args(
     std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& writer_rt_args_overrider_map) {
     using namespace ttnn::ccl::worker_detail;
     using namespace ttnn::ccl::cmd;
-    using Direction = ttnn::ccl::LineDirection;
     Program& program = builder_config.program.get();
     IDevice* device = builder_config.device;
     ProgramTensorsBundle const& all_tensors = builder_config.all_tensors.get();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_op.cpp
@@ -320,7 +320,6 @@ tt::tt_metal::operation::ProgramWithCallbacks RMSAllGather::create_program_at(
             } else {
                 TT_FATAL(false, "Program Config does not match");
 
-                using ProgramConfigType = std::decay_t<decltype(program_config)>;
                 uint32_t num_cores_x = 1;
                 uint32_t num_cores_y = 1;
                 CoreCoord grid_size = CoreCoord(num_cores_x, num_cores_y);

--- a/ttnn/cpp/ttnn/operations/full/full_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/full/full_pybind.cpp
@@ -39,7 +39,6 @@ void bind_full_operation(py::module& module) {
         )doc",
         ttnn::moreh_full.base_name());
 
-    using FullType = decltype(ttnn::moreh_full);
     bind_registered_operation(
         module,
         ttnn::moreh_full,

--- a/ttnn/cpp/ttnn/operations/pool/upsample/upsample_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/upsample_pybind.cpp
@@ -38,7 +38,6 @@ void bind_upsample(py::module& module) {
 
         )doc";
 
-    using OperationType = decltype(ttnn::upsample);
     ttnn::bind_registered_operation(
         module,
         ttnn::upsample,


### PR DESCRIPTION
### Ticket
#23444 

### Problem description
The warning is disabled.

### What's changed
Enable the warning, and remove the dead code that was hiding.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15674953514) CI passes
- [x] New/Existing tests provide coverage for changes