### PR TITLE
Modify Galaxy quick to use 2D Torus for healthcheck machine validation

### DIFF
--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -115,7 +115,7 @@ jobs:
         # NOTE: These tests do not automatically get added to upstream tests. Please refer to dockerfile/upstream_test_images/.
         # TODO #23350: This should use TORUS_2D topology not MESH since there are tests that depend on ring here.
         run: |
-          ./build/test/tt_metal/tt_fabric/test_system_health --system-topology MESH
+          ./build/test/tt_metal/tt_fabric/test_system_health --system-topology TORUS_2D
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardFixture.*";
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardProgramFixture.*";
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites";
@@ -167,7 +167,7 @@ jobs:
         timeout-minutes: 20
         # NOTE: These tests do not automatically get added to upstream tests. Please refer to dockerfile/upstream_test_images/.
         run: |
-          ./build/test/tt_metal/tt_fabric/test_system_health --system-topology MESH
+          ./build/test/tt_metal/tt_fabric/test_system_health --system-topology TORUS_2D
           pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick";
           pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "quick";
           pytest models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py;


### PR DESCRIPTION
Modify Health Check to validate 6U for 2D torus instead of mesh.

### Problem description
There are lots of QSFP links intermittently going down. For further development of Llama and majority of models we want to utilise 2D torus topology instead of mesh. 

### What's changed
Galaxy Quick uses TORUS_2D instead of MESH as argument for validating system healthcheck. 

### Checklist
- [ ] [Galaxy Quick](https://github.com/tenstorrent/tt-metal/actions/runs/15680703017)