### PR TITLE
22447: ttnn.experimental.tosa_scatter + scatter_->scatter

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_scatter.py
@@ -88,7 +88,7 @@ def test_scatter_normal(input_shape, dim, index_and_source_shape, input_dtype, i
 
     for _ in range(2):
         torch_result = torch.scatter(torch_input, dim, index=torch_index, src=torch_src)
-        ttnn_result = ttnn.experimental.scatter_(ttnn_input, dim, ttnn_index, ttnn_src)
+        ttnn_result = ttnn.experimental.scatter(ttnn_input, dim, ttnn_index, ttnn_src)
 
         torch_result_from_ttnn = ttnn.to_torch(ttnn_result)
         assert torch_result_from_ttnn.shape == torch_result.shape

--- a/tests/ttnn/unit_tests/operations/test_tosa_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_tosa_scatter.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+
+def select_torch_dtype(ttnn_dtype):
+    if ttnn_dtype is ttnn.bfloat16:
+        return torch.bfloat16
+    if ttnn_dtype is ttnn.float32:
+        return torch.float32
+    if ttnn_dtype is ttnn.uint8:
+        return torch.uint8
+    if ttnn_dtype is ttnn.int32:
+        return (
+            torch.int64
+        )  # !!! there is a strict requirement for the index tensor in Torch to be int64, and there is no int64 in ttnn
+
+
+@pytest.mark.parametrize(
+    "N, K, W, C, input_dtype, index_dtype, input_layout",
+    [
+        (32, 32, 32, 32, ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR)
+    ]
+)
+def test_tosa_scatter_normal(N, K, W, C, input_dtype, index_dtype, input_layout, device):
+    input_torch_dtype = select_torch_dtype(input_dtype)
+
+    input_shape = [N, K, C]
+    index_shape = [N, W]
+    source_shape = [N, W, C]
+
+    torch_input = torch.randn(input_shape, dtype=input_torch_dtype)
+    ttnn_input = ttnn.from_torch(torch_input, dtype=input_dtype, layout=input_layout, device=device)
+    torch_index = torch.randint(0, K, index_shape, dtype=torch.int64)
+    ttnn_index = ttnn.from_torch(torch_index, dtype=index_dtype, layout=input_layout, device=device)
+    torch_source = torch.randn(source_shape, dtype=input_torch_dtype)
+    ttnn_source = ttnn.from_torch(torch_source, dtype=input_dtype, layout=input_layout, device=device)
+
+    # adapt torch_index (expand [N, W] into [N, W, C])
+    dim = 1
+    torch_index = torch_index.unsqueeze(-1).expand([N, W, C])
+    torch_output = torch.scatter(torch_input, dim=dim, index=torch_index, src=torch_source)
+    ttnn_output = ttnn.experimental.tosa_scatter(ttnn_input, ttnn_index, ttnn_source)
+    assert ttnn_output.shape == ttnn_input.shape
+    assert ttnn_output.dtype == ttnn_input.dtype
+    torch.testing.assert_close(ttnn.to_torch(ttnn_output), torch_output)
+

--- a/tests/ttnn/unit_tests/operations/test_tosa_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_tosa_scatter.py
@@ -22,7 +22,13 @@ def select_torch_dtype(ttnn_dtype):
 
 @pytest.mark.parametrize(
     "N, K, W, C, input_dtype, index_dtype, input_layout",
-    [(32, 32, 32, 32, ttnn.bfloat16, ttnn.uint32, ttnn.Layout.ROW_MAJOR)],
+    [
+        (32, 32, 32, 32, ttnn.bfloat16, ttnn.uint32, ttnn.Layout.TILE),
+        (3, 2, 2, 3, ttnn.bfloat16, ttnn.uint32, ttnn.Layout.ROW_MAJOR),
+        (1, 1, 1, 1, ttnn.bfloat16, ttnn.uint32, ttnn.Layout.TILE),
+        (20, 40, 40, 10, ttnn.bfloat16, ttnn.uint32, ttnn.Layout.ROW_MAJOR),
+        (20, 40, 30, 10, ttnn.bfloat16, ttnn.uint32, ttnn.Layout.TILE),
+    ],
 )
 def test_tosa_scatter_normal(N, K, W, C, input_dtype, index_dtype, input_layout, device):
     input_torch_dtype = select_torch_dtype(input_dtype)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -178,7 +178,6 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/paged_cache/paged_cache_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/plusone/plusone_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/argmax/argmax_${PY_BINDING}.cpp
-    # ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/scatter/scatter_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/cumprod/cumprod_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/cumsum/cumsum_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_${PY_BINDING}.cpp
@@ -293,6 +292,7 @@ set(CCL_EXPERIMENTAL_TTNN_SRCS_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/scatter/scatter_${PY_BINDING}.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/sort/sort_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/gather/gather_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/gather/tosa/gather_tosa_${PY_BINDING}.cpp
@@ -465,6 +465,7 @@ target_link_libraries(
         TTNN::Ops::Experimental::Reshape
         TTNN::Ops::Experimental::Scatter
         TTNN::Ops::Experimental::SSM
+        TTNN::Ops::Experimental::TOSAScatter
         TTNN::Ops::Experimental::Transformer
         TTNN::Ops::Experimental::UnaryBackward
         TTNN::Ops::Full
@@ -607,6 +608,7 @@ add_subdirectory(cpp/ttnn/operations/experimental/plusone)
 add_subdirectory(cpp/ttnn/operations/experimental/reduction)
 add_subdirectory(cpp/ttnn/operations/experimental/reshape)
 add_subdirectory(cpp/ttnn/operations/experimental/scatter)
+add_subdirectory(cpp/ttnn/operations/experimental/scatter/tosa)
 add_subdirectory(cpp/ttnn/operations/experimental/ssm)
 add_subdirectory(cpp/ttnn/operations/experimental/transformer)
 add_subdirectory(cpp/ttnn/operations/experimental/unary_backward)

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
@@ -46,6 +46,7 @@
 #include "ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/all_reduce_create_qkv_heads_pybind.hpp"
 #include "ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward_pybind.hpp"
 #include "ttnn/operations/experimental/scatter/scatter_pybind.hpp"
+#include "ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.hpp"
 #include "ttnn/operations/experimental/reduction/sort/sort_pybind.hpp"
 #include "ttnn/operations/experimental/gather/gather_pybind.hpp"
 #include "ttnn/operations/experimental/gather/tosa/gather_tosa_pybind.hpp"
@@ -106,6 +107,7 @@ void py_module(py::module& module) {
     gelu_backward::detail::bind_experimental_gelu_backward_operation(module);
 
     scatter::detail::bind_scatter_operation(module);
+    tosa_scatter::detail::bind_tosa_scatter_operation(module);
 
     reduction::sort::detail::bind_reduction_sort_operation(module);
 

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.hpp
@@ -51,6 +51,6 @@ struct ScatterDeviceOperation {
 }  // namespace ttnn::operations::experimental::scatter
 
 namespace ttnn::prim {
-constexpr auto scatter_ =
-    ttnn::register_operation<"ttnn::prim::scatter_", ttnn::operations::experimental::scatter::ScatterDeviceOperation>();
+constexpr auto scatter =
+    ttnn::register_operation<"ttnn::prim::scatter", ttnn::operations::experimental::scatter::ScatterDeviceOperation>();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation_types.hpp
@@ -14,6 +14,7 @@ struct operation_attributes_t {
     const int32_t dim;
     const tt::tt_metal::MemoryConfig output_memory_config;
     const std::optional<ScatterReductionType> opt_reduction;
+    const bool duplicates_allowed;
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation_types.hpp
@@ -14,7 +14,6 @@ struct operation_attributes_t {
     const int32_t dim;
     const tt::tt_metal::MemoryConfig output_memory_config;
     const std::optional<ScatterReductionType> opt_reduction;
-    const bool duplicates_allowed;
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.cpp
@@ -295,7 +295,7 @@ Tensor ScatterOperation::invoke(
             ? output_memory_config.value()
             : input_tensor.memory_config()};
 
-    Tensor output = ttnn::prim::scatter_(
+    Tensor output = ttnn::prim::scatter(
         transformed_input_tensor,
         dim,
         transformed_index_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.hpp
@@ -29,7 +29,7 @@ struct ScatterOperation {
 
 namespace experimental {
 constexpr auto scatter_ =
-    ttnn::register_operation<"ttnn::experimental::scatter_", ttnn::operations::experimental::ScatterOperation>();
+    ttnn::register_operation<"ttnn::experimental::scatter", ttnn::operations::experimental::ScatterOperation>();
 }  // namespace experimental
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.hpp
@@ -28,7 +28,7 @@ struct ScatterOperation {
 }  // namespace operations::experimental
 
 namespace experimental {
-constexpr auto scatter_ =
+constexpr auto scatter =
     ttnn::register_operation<"ttnn::experimental::scatter", ttnn::operations::experimental::ScatterOperation>();
 }  // namespace experimental
 

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter_pybind.cpp
@@ -55,10 +55,10 @@ void bind_scatter_operation(py::module& module) {
                 another_output = ttnn.experimental.scatter_(input_ttnn, dim, index_ttnn, source_ttnn, out=output_preallocated)
         )doc";
 
-    using OperationType = decltype(ttnn::experimental::scatter_);
+    using OperationType = decltype(ttnn::experimental::scatter);
     bind_registered_operation(
         module,
-        ttnn::experimental::scatter_,
+        ttnn::experimental::scatter,
         doc,
         ttnn::pybind_overload_t{
             [](const OperationType& self,

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter_pybind.cpp
@@ -49,10 +49,7 @@ void bind_scatter_operation(py::module& module) {
                 source_ttnn = ttnn.from_torch(source_torch, dtype=ttnn.float32, device=device, layout=ttnn.Layout.TILE)
                 dim = -1
 
-                output = ttnn.experimental.scatter_(input_ttnn, dim, index_ttnn, source_ttnn)
-
-                output_preallocated = ttnn.zeros_like(input_ttnn)
-                another_output = ttnn.experimental.scatter_(input_ttnn, dim, index_ttnn, source_ttnn, out=output_preallocated)
+                output = ttnn.experimental.scatter(input_ttnn, dim, index_ttnn, source_ttnn)
         )doc";
 
     using OperationType = decltype(ttnn::experimental::scatter);

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_library(ttnn_op_experimental_tosa_scatter ${LIB_TYPE})
+add_library(TTNN::Ops::Experimental::TOSAScatter ALIAS ttnn_op_experimental_tosa_scatter)
+
+target_precompile_headers(ttnn_op_experimental_tosa_scatter REUSE_FROM TT::CommonPCH)
+
+target_sources(
+    ttnn_op_experimental_tosa_scatter
+    PRIVATE
+        ../device/scatter_device_operation.cpp
+        ../device/scatter_program_factory.cpp
+        tosa_scatter.cpp
+)
+
+target_include_directories(ttnn_op_experimental_tosa_scatter PRIVATE ${FixmeOpIncDirs})
+target_link_libraries(
+    ttnn_op_experimental_tosa_scatter
+    PRIVATE
+        TT::Metalium
+        TTNN::Core
+)
+
+install(TARGETS ttnn_op_experimental_tosa_scatter LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter.cpp
@@ -130,18 +130,11 @@ Tensor TOSAScatterOperation::invoke(
     const Tensor& index_tensor,
     const Tensor& source_tensor,
     const std::optional<MemoryConfig>& output_memory_config) {
-    CMAKE_UNIQUE_NAMESPACE::validate_tensors(input_tensor.get_logical_shape(), index_tensor.get_logical_shape(), source_tensor.get_logical_shape());
-
-    const ttnn::Shape original_input_tensor_lshape = input_tensor.logical_shape();
-    const auto input_tensor_rank = input_tensor.padded_shape().rank();
-
-    const auto original_index_tensor_lshape = index_tensor.logical_shape();
-    if (original_input_tensor_lshape == ttnn::Shape{} || original_index_tensor_lshape == ttnn::Shape{}) {
-        return input_tensor;
-    }
-
     const auto& input_shape{input_tensor.get_logical_shape()};
     const auto& index_shape{index_tensor.get_logical_shape()};
+    const auto& source_shape{source_tensor.get_logical_shape()};
+
+    CMAKE_UNIQUE_NAMESPACE::validate_tensors(input_shape, index_shape, source_shape);
 
     const uint32_t N = input_shape[0];
     const uint32_t K = input_shape[1];

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter.cpp
@@ -155,15 +155,13 @@ Tensor TOSAScatterOperation::invoke(
             : (opt_output.has_value() ? opt_output.value().memory_config()
                                                         : input_tensor.memory_config())};
 
-    Tensor output = ttnn::prim::scatter_(
+    Tensor output = ttnn::prim::scatter(
         processed_input_tensor,
         LAST_DIMENSION,
         processed_index_tensor,
         processed_source_tensor,
         final_memory_config,
         std::nullopt,
-        opt_output,
-        false,
         queue_id);
     return CMAKE_UNIQUE_NAMESPACE::post_tosa_scatter_transform_tensor(output, N, K, W, C, input_tensor.layout());
 }

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/reduction/reduction_common/reduction_common.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include "ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
 
 namespace ttnn::operations::experimental {
 namespace {
@@ -34,7 +35,8 @@ Tensor expand_tensor(const Tensor& tensor, const uint32_t& N, const uint32_t& K,
         }
 
         case InputTensorType::INDEX: {
-            return ttnn::unsqueeze_to_4D(ttnn::expand(ttnn::reshape(tensor, Shape{N, W, 1}), SmallVector<int32_t>{N, W, C}, tensor.memory_config()));
+            return ttnn::unsqueeze_to_4D(
+                ttnn::expand(ttnn::unsqueeze(tensor, -1), SmallVector<int32_t>{N, W, C}, tensor.memory_config()));
         }
 
         case InputTensorType::SOURCE: {

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter.cpp
@@ -113,6 +113,12 @@ void validate_tensors(
         input_shape,
         index_shape
     );
+
+    TT_FATAL(
+        index_shape[1] == source_shape[1],
+        "Index shape has a different dimension W than source shape (index shape: {}, source shape: {}).",
+        index_shape,
+        source_shape);
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter.cpp
@@ -31,11 +31,13 @@ enum class InputTensorType : uint8_t {
 
 namespace CMAKE_UNIQUE_NAMESPACE {
 
-Tensor pre_tosa_scatter_transform_tensor(const Tensor& tensor, const uint32_t& N, const uint32_t& K, const uint32_t& W, const uint32_t& C, const InputTensorType& input_tensor_type) {
-    if (tensor.logical_shape() == ttnn::Shape{1} || tensor.logical_shape() == ttnn::Shape{0}) {
-        return tensor;
-    }
-
+Tensor pre_tosa_scatter_transform_tensor(
+    const Tensor& tensor,
+    const uint32_t& N,
+    const uint32_t& K,
+    const uint32_t& W,
+    const uint32_t& C,
+    const InputTensorType& input_tensor_type) {
     Tensor processed_tensor = tensor;
     if (input_tensor_type == InputTensorType::INDEX) {
         processed_tensor =
@@ -60,7 +62,7 @@ Tensor pre_tosa_scatter_transform_tensor(const Tensor& tensor, const uint32_t& N
 Tensor post_tosa_scatter_transform_tensor(
     Tensor& output_tensor, const uint32_t& N, const uint32_t& K, const uint32_t& W, const uint32_t& C, const Layout& original_layout) {
     Tensor processed_tensor = ttnn::transpose(output_tensor, W_DIMENSION, LAST_DIMENSION);
-    processed_tensor = ttnn::squeeze_from_4D(processed_tensor, 3);
+    processed_tensor = ttnn::squeeze_from_4D(processed_tensor, INPUT_RANK_CONSTRAINT);
     if (original_layout != Layout::ROW_MAJOR) {
         processed_tensor = ttnn::to_layout(processed_tensor, original_layout, std::nullopt, std::nullopt, processed_tensor.device());
     }

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter.hpp
@@ -18,8 +18,7 @@ struct TOSAScatterOperation {
         const Tensor& input_tensor,
         const Tensor& index_tensor,
         const Tensor& source_tensor,
-        const std::optional<MemoryConfig>& opt_out_memory_config,
-        std::optional<Tensor>& opt_output);
+        const std::optional<MemoryConfig>& opt_out_memory_config);
 };
 
 }  // namespace operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include "ttnn/decorators.hpp"
+
+namespace ttnn {
+
+namespace operations::experimental {
+
+struct TOSAScatterOperation {
+    static Tensor invoke(
+        const QueueId& queue_id,
+        const Tensor& input_tensor,
+        const Tensor& index_tensor,
+        const Tensor& source_tensor,
+        const std::optional<MemoryConfig>& opt_out_memory_config,
+        std::optional<Tensor>& opt_output);
+};
+
+}  // namespace operations::experimental
+
+namespace experimental {
+constexpr auto tosa_scatter =
+    ttnn::register_operation<"ttnn::experimental::tosa_scatter", ttnn::operations::experimental::TOSAScatterOperation>();
+}  // namespace experimental
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.cpp
@@ -18,9 +18,9 @@ void bind_tosa_scatter_operation(py::module& module) {
             to the index tensor.
 
             Parameters:
-                * `input` (Tensor): The input tensor to scatter values onto.
-                * `index` (Tensor): The tensor specifying indices where values from the source tensor must go to.
-                * `src` (Tensor): The tensor containing the source values to be scattered onto input.
+                * `input` (Tensor): The input tensor to scatter values onto. Must be of rank 3.
+                * `index` (Tensor): The tensor specifying indices where values from the source tensor must go to. Must be of rank 2.
+                * `src` (Tensor): The tensor containing the source values to be scattered onto input. Must be of rank 3.
 
             Keyword Arguments:
                 * `memory_config` (MemoryConfig, optional): Specifies the memory configuration for the output tensor. Defaults to `None`.

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.cpp
@@ -11,7 +11,7 @@
 
 namespace ttnn::operations::experimental::tosa_scatter::detail {
 
-void bind_scatter_operation(py::module& module) {
+void bind_tosa_scatter_operation(py::module& module) {
     auto doc =
         R"doc(
             Scatters the source tensor's values along a given dimension according

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.cpp
@@ -60,22 +60,14 @@ void bind_tosa_scatter_operation(py::module& module) {
                const ttnn::Tensor& index_tensor,
                const ttnn::Tensor& source_tensor,
                const std::optional<tt::tt_metal::MemoryConfig>& opt_out_memory_config,
-               std::optional<ttnn::Tensor>& opt_output,
                const QueueId& queue_id = DefaultQueueId) -> Tensor {
-                return self(
-                    queue_id,
-                    input_tensor,
-                    index_tensor,
-                    source_tensor,
-                    opt_out_memory_config,
-                    opt_output);
+                return self(queue_id, input_tensor, index_tensor, source_tensor, opt_out_memory_config);
             },
             py::arg("input").noconvert(),
             py::arg("index").noconvert(),
             py::arg("src").noconvert(),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("out") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.cpp
@@ -44,9 +44,6 @@ void bind_tosa_scatter_operation(py::module& module) {
                 source_ttnn = ttnn.from_torch(source_torch, dtype=ttnn.float32, device=device, layout=ttnn.Layout.TILE)
 
                 output = ttnn.experimental.tosa_scatter(input_ttnn, index_ttnn, source_ttnn)
-
-                output_preallocated = ttnn.zeros_like(input_ttnn)
-                another_output = ttnn.experimental.scatter_(input_ttnn, dim, index_ttnn, source_ttnn, out=output_preallocated)
         )doc";
 
     using OperationType = decltype(ttnn::experimental::tosa_scatter);

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tosa_scatter_pybind.hpp"
+
+#include "ttnn-pybind/decorators.hpp"
+
+#include "tosa_scatter.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::tosa_scatter::detail {
+
+void bind_scatter_operation(py::module& module) {
+    auto doc =
+        R"doc(
+            Scatters the source tensor's values along a given dimension according
+            to the index tensor.
+
+            Parameters:
+                * `input` (Tensor): The input tensor to scatter values onto.
+                * `index` (Tensor): The tensor specifying indices where values from the source tensor must go to.
+                * `src` (Tensor): The tensor containing the source values to be scattered onto input.
+
+            Keyword Arguments:
+                * `memory_config` (MemoryConfig, optional): Specifies the memory configuration for the output tensor. Defaults to `None`.
+                * `out` (Tensor, optional): Preallocated output tensor where scatter result should go to (should be the same shape as the input tensor). Defaults to `None`.
+
+            Example:
+
+            .. code-block:: python
+
+                import ttnn
+                import torch
+
+                input_torch = torch.randn([10,20,30,20,10], dtype=torch.float32)
+                index_torch = torch.randint(0, 10, [10,20,30,20,5], dtype=torch.int64)
+                source_torch = torch.randn([10,20,30,20,10], dtype=input_torch.dtype)
+
+                device = ttnn.open_device(device_id=0)
+                # input tensors must be interleaved and on device
+                input_ttnn = ttnn.from_torch(input_torch, dtype=ttnn.float32, device=device, layout=ttnn.Layout.TILE)
+                index_ttnn = ttnn.from_torch(index_torch, dtype=ttnn.int32, device=device, layout=ttnn.Layout.TILE)
+                source_ttnn = ttnn.from_torch(source_torch, dtype=ttnn.float32, device=device, layout=ttnn.Layout.TILE)
+
+                output = ttnn.experimental.tosa_scatter(input_ttnn, index_ttnn, source_ttnn)
+
+                output_preallocated = ttnn.zeros_like(input_ttnn)
+                another_output = ttnn.experimental.scatter_(input_ttnn, dim, index_ttnn, source_ttnn, out=output_preallocated)
+        )doc";
+
+    using OperationType = decltype(ttnn::experimental::tosa_scatter);
+    bind_registered_operation(
+        module,
+        ttnn::experimental::tosa_scatter,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               const ttnn::Tensor& input_tensor,
+               const ttnn::Tensor& index_tensor,
+               const ttnn::Tensor& source_tensor,
+               const std::optional<tt::tt_metal::MemoryConfig>& opt_out_memory_config,
+               std::optional<ttnn::Tensor>& opt_output,
+               const QueueId& queue_id = DefaultQueueId) -> Tensor {
+                return self(
+                    queue_id,
+                    input_tensor,
+                    index_tensor,
+                    source_tensor,
+                    opt_out_memory_config,
+                    opt_output);
+            },
+            py::arg("input").noconvert(),
+            py::arg("index").noconvert(),
+            py::arg("src").noconvert(),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("out") = std::nullopt,
+            py::arg("queue_id") = DefaultQueueId});
+}
+
+}  // namespace ttnn::operations::experimental::scatter::detail

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-pybind/pybind_fwd.hpp"
+
+namespace ttnn::operations::experimental::tosa_scatter::detail {
+
+namespace py = pybind11;
+void bind_scatter_operation(py::module& module);
+
+}  // namespace ttnn::operations::experimental::scatter::detail

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/tosa/tosa_scatter_pybind.hpp
@@ -9,6 +9,6 @@
 namespace ttnn::operations::experimental::tosa_scatter::detail {
 
 namespace py = pybind11;
-void bind_scatter_operation(py::module& module);
+void bind_tosa_scatter_operation(py::module& module);
 
 }  // namespace ttnn::operations::experimental::scatter::detail


### PR DESCRIPTION
Add `ttnn.experimental.tosa_scatter`
Rename `scatter_` to `scatter`

### Ticket
#22447
#21757
#16942

### Problem description
Add TOSA-compliant version of `ttnn.experimental.scatter`

### What's changed
`ttnn.experimental.tosa_scatter ` has been added
`ttnn.experimental.scatter_` -> `ttnn.experimental.scatter`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes