### PR TITLE
SDXL: UNet layer_norm compute_kernel_config

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
@@ -19,7 +19,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
     "input_shape, temb_shape, encoder_shape, query_dim, num_attn_heads, out_dim, down_block_id, pcc",
     [
         ((1, 320, 64, 64), (1, 1280), (1, 77, 2048), 640, 10, 640, 1, 0.997),
-        ((1, 640, 32, 32), (1, 1280), (1, 77, 2048), 1280, 20, 1280, 2, 0.994),
+        ((1, 640, 32, 32), (1, 1280), (1, 77, 2048), 1280, 20, 1280, 2, 0.995),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
@@ -101,5 +101,5 @@ def test_crossattnmid(
     del unet, tt_crosattn
     gc.collect()
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.988)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.989)
     logger.info(f"PCC is: {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
@@ -26,7 +26,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
             20,
             1280,
             0,
-            0.966,
+            0.973,
         ),
         (
             (1, 1280, 64, 64),
@@ -37,7 +37,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
             10,
             640,
             1,
-            0.986,
+            0.987,
         ),
     ],
 )

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
@@ -74,17 +74,43 @@ class TtBasicTransformerBlock(nn.Module):
             else None
         )
 
+        self.ln_eps = 1e-5
+        self.ln_compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+
     def forward(self, input_tensor, attention_mask=None, encoder_hidden_states=None):
-        attn_hidden_states = ttnn.layer_norm(input_tensor, weight=self.tt_norm1_weights, bias=self.tt_norm1_bias)
+        attn_hidden_states = ttnn.layer_norm(
+            input_tensor,
+            weight=self.tt_norm1_weights,
+            bias=self.tt_norm1_bias,
+            epsilon=self.ln_eps,
+            compute_kernel_config=self.ln_compute_kernel_config,
+        )
         attn_hidden_states = self.attn1(attn_hidden_states, attention_mask, None)
         hidden_states = ttnn.add(input_tensor, attn_hidden_states)
         ttnn.deallocate(input_tensor)
 
-        attn_hidden_states = ttnn.layer_norm(hidden_states, weight=self.tt_norm2_weights, bias=self.tt_norm2_bias)
+        attn_hidden_states = ttnn.layer_norm(
+            hidden_states,
+            weight=self.tt_norm2_weights,
+            bias=self.tt_norm2_bias,
+            epsilon=self.ln_eps,
+            compute_kernel_config=self.ln_compute_kernel_config,
+        )
         attn_hidden_states = self.attn2(attn_hidden_states, attention_mask, encoder_hidden_states)
         hidden_states = ttnn.add(hidden_states, attn_hidden_states)
 
-        attn_hidden_states = ttnn.layer_norm(hidden_states, weight=self.tt_norm3_weights, bias=self.tt_norm3_bias)
+        attn_hidden_states = ttnn.layer_norm(
+            hidden_states,
+            weight=self.tt_norm3_weights,
+            bias=self.tt_norm3_bias,
+            epsilon=self.ln_eps,
+            compute_kernel_config=self.ln_compute_kernel_config,
+        )
         attn_hidden_states = self.ff(attn_hidden_states)
         hidden_states = ttnn.add(hidden_states, attn_hidden_states)
 


### PR DESCRIPTION
### What's changed
Defined `compute_kernel_config` and `epsilon` for `ttnn.layer_norm` to increase pcc.

New FID and CLIP scores:

- FID score: 189.33256780051818
- Average CLIP Score: 30.704025998711586 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15680272723) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15677917020) CI passes
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/15677925068) CI passes