### PR TITLE
Read dataset from cache downloaded and saved from Hugging Face

### DIFF
--- a/models/datasets/dataset_squadv2.py
+++ b/models/datasets/dataset_squadv2.py
@@ -5,7 +5,7 @@
 
 from typing import Any
 
-from datasets import load_dataset
+from datasets import load_from_disk
 from loguru import logger
 from torch.utils.data import Dataset
 
@@ -97,7 +97,8 @@ def squad_divide_chunks(dataset_question, dataset_context, dataset_reference, ba
 
 
 def squadv2_1K_samples_input(tokenizer, seq_len, attention_mask, token_type_ids, microbatch=8):
-    squadv2_dataset = load_dataset("squad_v2", use_auth_token=False, streaming=True)["validation"]
+    squadv2_dataset = load_from_disk("/mnt/MLPerf/tt_dnn-models/squad_v2")
+    # squadv2_dataset = load_dataset("squad_v2", use_auth_token=False, streaming=True)["validation"]
     # squadv2_dataset = load_dataset("squad_v2", use_auth_token=True, streaming=True)["validation"]
 
     dataset_iter = iter(squadv2_dataset)


### PR DESCRIPTION
### Ticket
[Create huggingface cache and re-mount as :ro for single-card demos](https://github.com/tenstorrent/tt-metal/issues/21762)

### Problem description
Hitting a rate limit when requesting model weights and dataset from Hugging Face

### What's changed
Downloaded Datasets from Hugging Face and saved it in cache location: "/mnt/MLPerf/tt_dnn-models/squad_v2"

### Checklist
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/15685150448) CI passes
- [Y] New/Existing tests provide coverage for changes