### PR TITLE
#22258: Add multi-device / multi-host creation API in terms of `tt::stl::Span<const T>`

### DIFF
--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -72,7 +72,17 @@ public:
         const MeshMapperConfig& config,
         const std::optional<ttnn::MeshShape>& shape = std::nullopt);
 
+    // Distributes a tensor onto a mesh.
     Tensor operator()(const Tensor& tensor) const;
+
+    // Overload that takes in a span of logical data; used in situations where the tensor object might not be
+    // materialized.
+    template <typename T>
+    Tensor operator()(
+        tt::stl::Span<const T> buffer,
+        const ttnn::Shape& shape,
+        const tt::tt_metal::TensorLayout& layout,
+        T pad_value = 0) const;
 
     tt::tt_metal::DistributedTensorConfig config() const;
 
@@ -147,7 +157,18 @@ std::unique_ptr<MeshToTensor> concat_mesh_to_tensor_composer(MeshDevice& mesh_de
 Tensor distribute_tensor(
     const Tensor& tensor,
     const TensorToMesh& mapper,
-    std::optional<std::reference_wrapper<MeshDevice>> mesh_device = std::nullopt);
+    std::optional<std::reference_wrapper<MeshDevice>> mesh_device = std::nullopt,
+    ttnn::QueueId cq_id = ttnn::DefaultQueueId);
+
+// Creates a distributed tensor from a span of logical data specified in `buffer`.
+template <typename T>
+Tensor create_distributed_tensor(
+    tt::stl::Span<const T> buffer,
+    const TensorSpec& spec,
+    const TensorToMesh& mapper,
+    std::optional<std::reference_wrapper<MeshDevice>> mesh_device = std::nullopt,
+    ttnn::QueueId cq_id = ttnn::DefaultQueueId,
+    T pad_value = 0);
 
 // Aggregates a multi-device tensor into a host tensor according to the `composer`.
 Tensor aggregate_tensor(const Tensor& tensor, const MeshToTensor& composer);


### PR DESCRIPTION
### Ticket
#22258

### Problem description
Need a convenient creation API that doesn't require the use of `Tensor`, for the data that might not be fully materialized (in context of multi-host tensors).

### What's changed
Add `create_distributed_tensor` API and adapt C++ sharding code to be able to handle this case.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15689662430)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15689666364)
- [x] New/Existing tests provide coverage for changes