### PR TITLE
#0: fix prefetcher race condition in global cb

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -895,6 +895,10 @@ FORCE_INLINE void noc_async_write_one_packet_with_state(
             inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
             inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, 1);
         }
+    } else {
+        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
+        }
     }
     WAYPOINT("NWPW");
     while (!noc_cmd_buf_ready(noc, write_cmd_buf));
@@ -911,6 +915,10 @@ FORCE_INLINE void noc_async_write_one_packet_with_state(
         if constexpr (noc_mode == DM_DEDICATED_NOC) {
             noc_nonposted_writes_num_issued[noc] += 1;
             noc_nonposted_writes_acked[noc] += 1;  // num_dests
+        }
+    } else {
+        if constexpr (noc_mode == DM_DEDICATED_NOC) {
+            noc_posted_writes_num_issued[noc] += 1;
         }
     }
 }

--- a/tt_metal/hw/inc/remote_circular_buffer_api.h
+++ b/tt_metal/hw/inc/remote_circular_buffer_api.h
@@ -170,6 +170,21 @@ FORCE_INLINE void resize_remote_receiver_cb_interface(
             aligned_page_adjustment = (next_fifo_rd_ptr - fifo_rd_ptr) / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
         }
         if (aligned_page_adjustment != 0) {
+            // wait for sender to send the credits first so ack ptr never go faster than sent ptr.
+            uint32_t pages_acked = 0;
+            uint32_t pages_sent = 0;
+            uint32_t num_pages_recv = 0;
+            volatile tt_l1_ptr uint32_t* pages_acked_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_cb_interface.aligned_pages_acked_ptr);
+            volatile tt_l1_ptr uint32_t* pages_sent_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                receiver_cb_interface.aligned_pages_acked_ptr - L1_ALIGNMENT);
+            do {
+                invalidate_l1_cache();
+                pages_acked = *pages_acked_ptr;
+                pages_sent = *pages_sent_ptr;
+                num_pages_recv = pages_sent - pages_acked;
+            } while (num_pages_recv < aligned_page_adjustment);
+
             if (nm == DM_DYNAMIC_NOC) {
                 detail::update_pages_acked<DM_DYNAMIC_NOC>(
                     receiver_cb_interface, aligned_page_adjustment, noc, posted, cmd_buf);
@@ -240,8 +255,8 @@ FORCE_INLINE void remote_cb_reserve_back(uint32_t cb_id, uint32_t num_pages) {
     uint32_t fifo_limit_page_aligned = remote_cb.fifo_limit_page_aligned;
     uint32_t fifo_start_addr = remote_cb.fifo_start_addr;
     uint32_t fifo_wr_ptr = remote_cb.fifo_wr_ptr;
+    uint32_t fifo_size = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.config_ptr)[3];
     if (fifo_wr_ptr + len_bytes >= fifo_limit_page_aligned) {
-        uint32_t fifo_size = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.config_ptr)[3];
         len_bytes += fifo_start_addr + fifo_size - fifo_limit_page_aligned;
     }
     uint32_t num_pages_wait = len_bytes / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
@@ -253,8 +268,7 @@ FORCE_INLINE void remote_cb_reserve_back(uint32_t cb_id, uint32_t num_pages) {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.aligned_pages_sent_ptr + L1_ALIGNMENT);
 
     uint32_t num_receivers = remote_cb.num_receivers;
-    uint32_t fifo_aligned_num_pages =
-        (fifo_limit_page_aligned - fifo_start_addr) / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
+    uint32_t fifo_aligned_num_pages = fifo_size / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
 
     for (uint32_t i = 0; i < num_receivers; ++i) {
         do {
@@ -262,7 +276,7 @@ FORCE_INLINE void remote_cb_reserve_back(uint32_t cb_id, uint32_t num_pages) {
             uint32_t pages_acked = *pages_acked_ptr;
             uint32_t pages_sent = *pages_sent_ptr;
             uint32_t sent_minus_ack = pages_sent - pages_acked;
-            free_pages = fifo_aligned_num_pages >= sent_minus_ack ? (fifo_aligned_num_pages - sent_minus_ack) : 0;
+            free_pages = fifo_aligned_num_pages - sent_minus_ack;
         } while (free_pages < num_pages_wait);
         pages_acked_ptr += 2 * L1_ALIGNMENT / sizeof(uint32_t);
         pages_sent_ptr += 2 * L1_ALIGNMENT / sizeof(uint32_t);

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
@@ -19,7 +19,8 @@ void kernel_main() {
     constexpr uint32_t max_block_size = get_compile_time_arg_val(5);
     constexpr uint32_t cb_id = get_compile_time_arg_val(6);
     constexpr uint32_t addrs_cb_id = get_compile_time_arg_val(7);
-    constexpr bool skip_ptr_update = get_compile_time_arg_val(8);
+    constexpr uint32_t sync_cb_id = get_compile_time_arg_val(8);
+    constexpr bool skip_ptr_update = get_compile_time_arg_val(9);
 
     // Runtime args
     uint32_t rt_args_idx = 0;
@@ -106,5 +107,16 @@ void kernel_main() {
             noc_async_read_barrier_with_trid(block_trid_to_wait);
             cb_push_back(cb_id, max_block_num_tiles);
         }
+    }
+
+    // wait for signal to exit, since reader cannot exit early due to the ongoing traffic on the same noc.
+    cb_wait_front(sync_cb_id, 1);
+    cb_pop_front(sync_cb_id, 1);
+
+    // reset noc counters here because we didn't properly update ptrs for better perf.
+    if (noc_mode == DM_DEDICATED_NOC) {
+        ncrisc_noc_counters_init();
+    } else {
+        dynamic_noc_local_state_init();
     }
 }

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/writer_l1.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/writer_l1.cpp
@@ -23,7 +23,8 @@ void kernel_main() {
     constexpr uint32_t max_block_num_tiles = get_compile_time_arg_val(4);
     constexpr uint32_t local_cb_id = get_compile_time_arg_val(5);
     constexpr uint32_t remote_cb_id = get_compile_time_arg_val(6);
-    constexpr bool skip_ptr_update = get_compile_time_arg_val(7);
+    constexpr uint32_t sync_cb_id = get_compile_time_arg_val(7);
+    constexpr bool skip_ptr_update = get_compile_time_arg_val(8);
 
     // Runtime args
     // Note: Coalesced sizes -> wrt to receiver cores, sizes -> wrt to dram reader cores
@@ -47,11 +48,11 @@ void kernel_main() {
             uint32_t curr_block_size_per_receiver = curr_block_size / num_receivers;
 
             experimental::resize_remote_sender_cb_interface<true>(remote_cb_id, curr_block_size_per_receiver, noc);
-            experimental::remote_cb_reserve_back(remote_cb_id, num_blocks);
 
             for (uint32_t block = 0; block < num_blocks; ++block) {
                 {
                     cb_wait_front(local_cb_id, max_block_num_tiles);
+                    experimental::remote_cb_reserve_back(remote_cb_id, 1);
 
                     uint32_t local_cb_addr = get_read_ptr(local_cb_id);
                     experimental::remote_cb_push_back_and_write_pages<skip_ptr_update>(
@@ -63,22 +64,24 @@ void kernel_main() {
                         curr_coalesced_page_size,
                         noc);
 
+                    noc_async_posted_writes_flushed();
+
                     cb_pop_front(local_cb_id, max_block_num_tiles);
                 }
             }
         }
     }
 
-    experimental::remote_cb_sender_barrier(remote_cb_id);
-
     experimental::update_remote_cb_config_in_l1(remote_cb_id);
 
     // reset noc counters here because we didn't properly update ptrs for better perf.
-    if constexpr (skip_ptr_update) {
-        if (noc_mode == DM_DEDICATED_NOC) {
-            ncrisc_noc_counters_init();
-        } else {
-            dynamic_noc_local_state_init();
-        }
+    if (noc_mode == DM_DEDICATED_NOC) {
+        ncrisc_noc_counters_init();
+    } else {
+        dynamic_noc_local_state_init();
     }
+
+    // signal reader can exit, since reader cannot exit early due to the ongoing traffic on the same noc.
+    cb_reserve_back(sync_cb_id, 1);
+    cb_push_back(sync_cb_id, 1);
 }


### PR DESCRIPTION
### Problem description
There's a race condition in the global cb resize function, in the case sender hasn't send the credits to receiver, and receiver already ack and move to next layer cb resize function, then ack ptr can go faster than send ptr. 
There's missing flush in the sender side, might cause reader to overwrite.

### What's changed
Fix race by explicitly wait on sender in global cb resize function.
use dedicated noc mode, so that flush is not that expensive.
Explicitly sync between reader/writer kernel, so that reader doesn't exit early. 
Change to reserve by block in global cb, for better perf.
latest perf: 65.4t/u/s on 6U

### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/15690872330
- [x] BH https://github.com/tenstorrent/tt-metal/actions/runs/15690920994
- [x] TG https://github.com/tenstorrent/tt-metal/actions/runs/15690862143
