### PR TITLE
#21997: [skip ci] Fix typo with Fabric1D tests, add ttnn stress test to BH nightly QB tests

### DIFF
--- a/.github/workflows/blackhole-llmbox-fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/blackhole-llmbox-fabric-build-and-unit-tests.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {name: fabric 1D unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D.*" },
+          {name: fabric 1D unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*" },
           {name: fabric 2D fixture unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*" },
           {name: fabric system health tests, cmd: ./build/test/tt_metal/tt_fabric/test_system_health },
           # {name: t3000 fast fabric tests, cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests" },

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -101,3 +101,14 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  blackhole-llmbox-ttnn-stress-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/ttnn-stress-tests-impl.yaml
+    with:
+      arch: blackhole
+      runner-label: BH-LLMBox
+      timeout: 45
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Ticket
#21997 

### Problem description
Fix typo for Fabric1D tests
Add more test coverage (ttnn stress test)

### What's changed
Add ttnn stress tests and run the correct Fabric1D tests on BH quietbox.

### Checklist
- [x] New/Existing tests provide coverage for changes https://github.com/tenstorrent/tt-metal/actions/runs/15646803753/job/44085790904