### PR TITLE
Add API to Pass Neighbour Chip using FabricNodeId to FabricEriscDatamoverBuilder

### DIFF
--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -13,7 +13,7 @@
 #include <tt-metalium/fabric_edm_types.hpp>
 #include <tt-metalium/fabric_edm_packet_header.hpp>
 #include <tt-metalium/edm_fabric_counters.hpp>
-
+#include <tt-metalium/routing_table_generator.hpp>  // for FabricNodeId
 #include <unordered_map>
 #include <optional>
 #include <cstdint>
@@ -299,8 +299,8 @@ public:
         const CoreCoord& my_eth_core_logical,
         size_t my_noc_x,
         size_t my_noc_y,
-        size_t my_chip_id,
-        size_t peer_chip_id,
+        const FabricNodeId& local_fabric_node_id,
+        const FabricNodeId& peer_fabric_node_id,
 
         const std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>&
             receiver_channels_downstream_flow_control_semaphore_id,
@@ -322,8 +322,19 @@ public:
         tt::tt_metal::IDevice* device,
         tt::tt_metal::Program& program,
         const CoreCoord& ethernet_core,
-        chip_id_t local_chip_id,
-        chip_id_t peer_chip_id,
+        const FabricNodeId& local_fabric_node_id,
+        const FabricNodeId& peer_fabric_node_id,
+        const FabricEriscDatamoverConfig& config,
+        bool build_in_worker_connection_mode = false,
+        bool dateline_connection = false,
+        eth_chan_directions direction = eth_chan_directions::EAST);
+
+    static FabricEriscDatamoverBuilder build(
+        tt::tt_metal::IDevice* device,
+        tt::tt_metal::Program& program,
+        const CoreCoord& ethernet_core,
+        chip_id_t local_physical_chip_id,
+        chip_id_t peer_physical_chip_id,
         const FabricEriscDatamoverConfig& config,
         bool build_in_worker_connection_mode = false,
         bool dateline_connection = false,
@@ -363,8 +374,8 @@ public:
 
     FabricEriscDatamoverConfig config;
 
-    size_t my_chip_id = 0;
-    size_t peer_chip_id = 0;
+    FabricNodeId local_fabric_node_id = FabricNodeId(MeshId{0}, 0);
+    FabricNodeId peer_fabric_node_id = FabricNodeId(MeshId{0}, 0);
     size_t handshake_address = 0;
     size_t channel_buffer_size = 0;
 

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -194,8 +194,9 @@ void get_optimal_noc_for_edm(
     }
     log_debug(
         tt::LogTest,
-        "device {} edm_builder1 {} {} is connecting to edm_builder2 {} {} num links {}",
-        edm_builder1.my_chip_id,
+        "Fabric MeshId {} ChipId {} edm_builder1 {} {} is connecting to edm_builder2 {} {} num links {}",
+        *(edm_builder1.local_fabric_node_id.mesh_id),
+        edm_builder1.local_fabric_node_id.chip_id,
         edm_builder1.my_noc_x,
         edm_builder1.my_noc_y,
         edm_builder2.my_noc_x,

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
@@ -301,8 +301,9 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
                     if (edm_fwd.my_noc_x < edm_bwd.my_noc_x) {
                         log_info(
                             tt::LogOp,
-                            "device {} edm_fwd {} {} is connecting to edm_bwd {} {} on link {}",
-                            edm_fwd.my_chip_id,
+                            "Fabric MeshId {} ChipId {} edm_fwd {} {} is connecting to edm_bwd {} {} on link {}",
+                            *(edm_fwd.local_fabric_node_id.mesh_id),
+                            edm_fwd.local_fabric_node_id.chip_id,
                             edm_fwd.my_noc_x,
                             edm_fwd.my_noc_y,
                             edm_bwd.my_noc_x,
@@ -323,8 +324,9 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
                     } else if (edm_fwd.my_noc_x > edm_bwd.my_noc_x) {
                         log_info(
                             tt::LogOp,
-                            "device {} edm_fwd {} {} is connecting to edm_bwd {} {} on link {}",
-                            edm_fwd.my_chip_id,
+                            "Fabric MeshId {} ChipId {} edm_fwd {} {} is connecting to edm_bwd {} {} on link {}",
+                            *(edm_fwd.local_fabric_node_id.mesh_id),
+                            edm_fwd.local_fabric_node_id.chip_id,
                             edm_fwd.my_noc_x,
                             edm_fwd.my_noc_y,
                             edm_bwd.my_noc_x,


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
`FabricEriscDatamoverBuilder` currently accepts physical ids for src and neighbour chips. These ids are used for determining the handshake initiator.

In multi-host/multi-mesh setups, we may not have access to the physical ids of all neighbours -> this mechanism breaks down.

### What's changed
- Add variant of `FabricEriscDatamoverBuilder::build` API accepting src and neighbour Fabric Node Ids
- Preserve the original `FabricEriscDatamoverBuilder::build` API, accepting physical ids, since control plane and `FabricNodeId` are currently not properly exposed to TTNN. We should (will need to ) phase this out eventually as we write multi-host aware ops
- Modify handshake tie break to use `FabricNodeId`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes