### PR TITLE
BH eth ring gather tests invalidate cache

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_direct_ring_gather_utils.h
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_direct_ring_gather_utils.h
@@ -43,6 +43,7 @@ FORCE_INLINE void eth_wait_for_remote_receiver_done_and_get_local_receiver_data(
     }
     noc_semaphore_inc(receiver_semaphore_noc_addr, 1);
     while (erisc_info->channels[0].bytes_sent != 0) {
+        invalidate_l1_cache();
         internal_::risc_context_switch();
     }
 }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Missing cache invalidation in a test eth kernel was causing BH QB CI to hang


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15698004888) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15693009743) CI on QB (still under debug , this pr doesn't address all issues)