### PR TITLE
Restore Tensor Logging in debug mode for clang builds

### DIFF
--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -199,8 +199,9 @@ auto get_operation_name(const typename device_operation_t::operation_attributes_
     }
 }
 
-// GCC 12 has a bug that causes a segfault when using reflection to log tensors.
-#if !defined(NDEBUG) && !defined(__GNUC__)
+// GCC 12 has a bug that causes a segfault when using reflection to log tensors in debug mode.
+// If building with clang, allow this to be compiled
+#if !defined(NDEBUG) && defined(__clang__)
 
 template <typename device_operation_t>
 inline void log_operation(


### PR DESCRIPTION
### Ticket
NA

### Problem description
These log statements were disabled to support building in gcc-12 in debug mode.
However, I accidentally disabled them for both clang and gcc.

### What's changed
Correct the logic to work as intended.
Building this code in clang is okay.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15699920220) CI passes
- [x] New/Existing tests provide coverage for changes