### PR TITLE
23050: add hash computation to ttnn.experimental.scatter

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_scatter.py
@@ -76,8 +76,6 @@ def test_scatter_normal(
     input_shape, dim, index_and_source_shape, input_dtype, index_dtype, layout, device, use_program_cache
 ):
     torch.manual_seed(22052025)
-    if use_program_cache:
-        device.enable_program_cache()
     torch_dtype = select_torch_dtype(input_dtype)
     torch_index_dtype = select_torch_dtype(index_dtype)
     ##

--- a/tests/ttnn/unit_tests/operations/test_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_scatter.py
@@ -72,9 +72,12 @@ def select_torch_dtype(ttnn_dtype):
         # ([2, 10, 151936], -1, [2, 10, 151936], ttnn.float32, ttnn.uint32, ttnn.Layout.TILE),
     ],
 )
-def test_scatter_normal(input_shape, dim, index_and_source_shape, input_dtype, index_dtype, layout, device):
+def test_scatter_normal(
+    input_shape, dim, index_and_source_shape, input_dtype, index_dtype, layout, device, use_program_cache
+):
     torch.manual_seed(22052025)
-    device.enable_program_cache()
+    if use_program_cache:
+        device.enable_program_cache()
     torch_dtype = select_torch_dtype(input_dtype)
     torch_index_dtype = select_torch_dtype(index_dtype)
     ##

--- a/tests/ttnn/unit_tests/operations/test_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_scatter.py
@@ -74,6 +74,7 @@ def select_torch_dtype(ttnn_dtype):
 )
 def test_scatter_normal(input_shape, dim, index_and_source_shape, input_dtype, index_dtype, layout, device):
     torch.manual_seed(22052025)
+    device.enable_program_cache()
     torch_dtype = select_torch_dtype(input_dtype)
     torch_index_dtype = select_torch_dtype(index_dtype)
     ##

--- a/tests/ttnn/unit_tests/operations/test_tosa_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_tosa_scatter.py
@@ -30,7 +30,7 @@ def select_torch_dtype(ttnn_dtype):
         (20, 40, 30, 10, ttnn.bfloat16, ttnn.uint32, ttnn.Layout.TILE),
     ],
 )
-def test_tosa_scatter_normal(N, K, W, C, input_dtype, index_dtype, input_layout, device):
+def test_tosa_scatter_normal(N, K, W, C, input_dtype, index_dtype, input_layout, device, use_program_cache):
     input_torch_dtype = select_torch_dtype(input_dtype)
 
     input_shape = [N, K, C]
@@ -49,7 +49,8 @@ def test_tosa_scatter_normal(N, K, W, C, input_dtype, index_dtype, input_layout,
     torch_index = torch_index.unsqueeze(-1).expand([N, W, C])
 
     torch_output = torch.scatter(torch_input, dim=dim, index=torch_index, src=torch_source)
-    device.enable_program_cache()
+    if use_program_cache:
+        device.enable_program_cache()
     for _ in range(2):
         ttnn_output = ttnn.experimental.tosa_scatter(ttnn_input, ttnn_index, ttnn_source)
         assert ttnn_output.shape == ttnn_input.shape

--- a/tests/ttnn/unit_tests/operations/test_tosa_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_tosa_scatter.py
@@ -49,8 +49,6 @@ def test_tosa_scatter_normal(N, K, W, C, input_dtype, index_dtype, input_layout,
     torch_index = torch_index.unsqueeze(-1).expand([N, W, C])
 
     torch_output = torch.scatter(torch_input, dim=dim, index=torch_index, src=torch_source)
-    if use_program_cache:
-        device.enable_program_cache()
     for _ in range(2):
         ttnn_output = ttnn.experimental.tosa_scatter(ttnn_input, ttnn_index, ttnn_source)
         assert ttnn_output.shape == ttnn_input.shape

--- a/tests/ttnn/unit_tests/operations/test_tosa_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_tosa_scatter.py
@@ -49,7 +49,9 @@ def test_tosa_scatter_normal(N, K, W, C, input_dtype, index_dtype, input_layout,
     torch_index = torch_index.unsqueeze(-1).expand([N, W, C])
 
     torch_output = torch.scatter(torch_input, dim=dim, index=torch_index, src=torch_source)
-    ttnn_output = ttnn.experimental.tosa_scatter(ttnn_input, ttnn_index, ttnn_source)
-    assert ttnn_output.shape == ttnn_input.shape
-    assert ttnn_output.dtype == ttnn_input.dtype
-    torch.testing.assert_close(ttnn.to_torch(ttnn_output), torch_output)
+    device.enable_program_cache()
+    for _ in range(2):
+        ttnn_output = ttnn.experimental.tosa_scatter(ttnn_input, ttnn_index, ttnn_source)
+        assert ttnn_output.shape == ttnn_input.shape
+        assert ttnn_output.dtype == ttnn_input.dtype
+        torch.testing.assert_close(ttnn.to_torch(ttnn_output), torch_output)

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.cpp
@@ -115,13 +115,7 @@ operation::Hash ScatterDeviceOperation::compute_program_hash(
         tensor_args.src_tensor.memory_config(),
         tensor_args.input_tensor.layout(),
         tensor_args.index_tensor.layout(),
-        tensor_args.src_tensor.layout(),
-        tensor_args.input_tensor.device_storage(),
-        tensor_args.index_tensor.device_storage(),
-        tensor_args.src_tensor.device_storage(),
-        tensor_args.input_tensor.device(),
-        tensor_args.index_tensor.device(),
-        tensor_args.src_tensor.device());
+        tensor_args.src_tensor.layout());
 }
 
 }  // namespace ttnn::operations::experimental::scatter

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.cpp
@@ -97,4 +97,31 @@ ScatterDeviceOperation::invocation_result_t ScatterDeviceOperation::invoke(
         tensor_args_t{input_tensor, index_tensor, source_tensor}};
 }
 
+operation::Hash ScatterDeviceOperation::compute_program_hash(
+    const operation_attributes_t& op_args, const tensor_args_t& tensor_args) {
+    return operation::hash_operation<ScatterDeviceOperation>(
+        select_program_factory(op_args, tensor_args).index(),
+        op_args.dim,
+        op_args.opt_reduction,
+        op_args.output_memory_config,
+        tensor_args.input_tensor.logical_shape(),
+        tensor_args.index_tensor.logical_shape(),
+        tensor_args.src_tensor.logical_shape(),
+        tensor_args.input_tensor.dtype(),
+        tensor_args.index_tensor.dtype(),
+        tensor_args.src_tensor.dtype(),
+        tensor_args.input_tensor.memory_config(),
+        tensor_args.index_tensor.memory_config(),
+        tensor_args.src_tensor.memory_config(),
+        tensor_args.input_tensor.layout(),
+        tensor_args.index_tensor.layout(),
+        tensor_args.src_tensor.layout(),
+        tensor_args.input_tensor.device_storage(),
+        tensor_args.index_tensor.device_storage(),
+        tensor_args.src_tensor.device_storage(),
+        tensor_args.input_tensor.device(),
+        tensor_args.index_tensor.device(),
+        tensor_args.src_tensor.device());
+}
+
 }  // namespace ttnn::operations::experimental::scatter

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_device_operation.hpp
@@ -34,6 +34,8 @@ struct ScatterDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 
+    static operation::Hash compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     using invocation_result_t = std::tuple<operation_attributes_t, tensor_args_t>;

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/device/scatter_program_factory.cpp
@@ -202,7 +202,7 @@ void ScatterProgramFactory::override_runtime_arguments(
     auto output_buffer_address = output_tensor.buffer()->address();
     for (const auto& core : cores) {
         auto& reader_runtime_args  = GetRuntimeArgs(program, reader_kernel_id, core);
-        auto& writer_runtime_args  = GetRuntimeArgs(program, reader_kernel_id, core);
+        auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
         reader_runtime_args[0] = input_buffer_address;
         reader_runtime_args[1] = index_buffer_address;
         reader_runtime_args[2] = source_buffer_address;


### PR DESCRIPTION
Add hash computation for ttnn.experimental.scatter

### Ticket
#23050

### Problem description
Add `ScatterDeviceOperation::compute_program_hash`

### What's changed
Added `ScatterDeviceOperation::compute_program_hash`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes