### PR TITLE
#0: use ifdef to not have matmul benchmark gtest in pipelines

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_matmul_benchmark.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_matmul_benchmark.cpp
@@ -133,6 +133,11 @@ public:
         ttnn::TTNNFixtureWithDevice(/*trace_region_size=*/65536, /*l1_small_size=*/200000) {}
 };
 
+// Benchmark is not intended to be run or instantiated as part of CI.
+// Uncomment the define and comment out the GTEST_SKIP to run locally.
+// #define MM_BENCHMARK_INSTANTIATION
+
+#ifdef MM_BENCHMARK_INSTANTIATION
 TEST_P(Matmul2DHostPerfTestFixture, Matmul2DHostPerfTest) {
     GTEST_SKIP() << "Benchmark is not intended to be run as part of CI and can be manually run locally";
 
@@ -786,3 +791,4 @@ INSTANTIATE_TEST_SUITE_P(
              /*in0_block_w_div=*/4,
              /*num_out_blocks_h=*/4,
              /*num_out_blocks_w=*/4}})));
+#endif


### PR DESCRIPTION
### Ticket
Link to Github Issue N/A

### Problem description
The matmul benchmark C++ gtest is in ttnn-smoke-tests. It is designed to be skipped in the pipelines. However, the number of tests instantiated results in just skipping the test taking too long.

### What's changed
Remove the test and its instantiation by default as well (left in the skip to keep that layer of protection from running the test on pipelines).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). N/A
- [ ] New/Existing tests provide coverage for changes N/A