### PR TITLE
Revert "#0: [skip ci] Use TTBOT_DOCS_ACCESS token for produce_data pi…

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -100,13 +100,13 @@ jobs:
           echo "::notice title=target-workflow-link::The workflow being analyzed is available at https://github.com/tenstorrent/tt-metal/actions/runs/$run_id/attempts/$attempt_number"
       - name: Get API rate limit status
         env:
-          GH_TOKEN: ${{ secrets.TTBOT_DOCS_ACCESS }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "[Info] Grabbing API rate limit status"
           gh api rate_limit
       - name: Output auxiliary values
         env:
-          GH_TOKEN: ${{ secrets.TTBOT_DOCS_ACCESS }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "Sleeping for 60 seconds for github to fully sync the workflow run before calling the API"
           sleep 60
@@ -120,7 +120,7 @@ jobs:
       - name: Collect workflow artifact and job logs
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.TTBOT_DOCS_ACCESS }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           ./infra/data_collection/github/download_cicd_logs_and_artifacts.sh --workflow-run-id ${{ steps.get-run-id-and-attempt.outputs.run-id }} --attempt-number ${{ steps.get-run-id-and-attempt.outputs.attempt-number }}
           find generated/cicd/ -type f


### PR DESCRIPTION
…peline (#22032)"

This reverts commit 1e830973dd799161e930cf084b0cd08305939064.

### Ticket
Link to Github Issue

### Problem description
Looks like the TTBOT_DOCS_ACCESS token got deauthorized, reverting back to github.token as a workaround fix for now

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes
