### PR TITLE
[DM] Directly Write to/Read from L1 for Test Preparation and Checking (Test: One To All)

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -10,7 +10,7 @@ This test suite addresses the functionality and performance (i.e. bandwidth) of 
 | One to One           | 4, 50      | Write transactions between two Tensix cores.                                         |
 | One From One         | 5, 51      | Read transactions between two Tensix cores.                                          |
 | One to all           | 6-8        | Writes transaction from one core to all cores.                                       |
-| One to all Multicast | 9-14, 52-54| Writes transaction from one core to all cores using multicast.                       |
+| One to all Multicast | 9-14, 52   | Writes transaction from one core to all cores using multicast.                       |
 | One From All         | 15, 30     | Read transactions between one gatherer Tensix core and multiple sender Tensix cores. |
 | Loopback             | 16         | Does a loopback operation where one cores writes to itself.                          |
 | Reshard Hardcoded    | 17-20      | Uses existing reshard tests to analyse their bandwidth and latency.                  |

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -9,8 +9,8 @@ This test suite addresses the functionality and performance (i.e. bandwidth) of 
 | DRAM Unary           | 0-3        | Transactions between DRAM and a single Tensix core.                                  |
 | One to One           | 4, 50      | Write transactions between two Tensix cores.                                         |
 | One From One         | 5, 51      | Read transactions between two Tensix cores.                                          |
-| One to all           | 6-8, 52    | Writes transaction from one core to all cores.                                       |
-| One to all Multicast | 9-14       | Writes transaction from one core to all cores using multicast.                       |
+| One to all           | 6-8        | Writes transaction from one core to all cores.                                       |
+| One to all Multicast | 9-14, 52-54| Writes transaction from one core to all cores using multicast.                       |
 | One From All         | 15, 30     | Read transactions between one gatherer Tensix core and multiple sender Tensix cores. |
 | Loopback             | 16         | Does a loopback operation where one cores writes to itself.                          |
 | Reshard Hardcoded    | 17-20      | Uses existing reshard tests to analyse their bandwidth and latency.                  |

--- a/tests/tt_metal/tt_metal/data_movement/documentation/ideal_performance.md
+++ b/tests/tt_metal/tt_metal/data_movement/documentation/ideal_performance.md
@@ -9,5 +9,5 @@ Units are **Bytes/cycle**.
 | DRAM Write                        | 21            | 34        |
 | One To One                        | 29            | 60        |
 | One From One                      | 28            | 60        |
-| One To All (Multicast + Linked)   | 22            | 40        |
+| One To All (Multicast + Linked)   | 22            | 42        |
 | One From All                      | 30            | 60        |

--- a/tests/tt_metal/tt_metal/data_movement/documentation/ideal_performance.md
+++ b/tests/tt_metal/tt_metal/data_movement/documentation/ideal_performance.md
@@ -9,5 +9,5 @@ Units are **Bytes/cycle**.
 | DRAM Write                        | 21            | 34        |
 | One To One                        | 29            | 60        |
 | One From One                      | 28            | 60        |
-| One To All (Multicast + Linked)   | 19            | 34        |
+| One To All (Multicast + Linked)   | 22            | 40        |
 | One From All                      | 30            | 60        |

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/README.md
@@ -3,7 +3,7 @@
 This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between Tensix cores.
 
 ## Test Flow
-Sharded L1 buffers are created on all Tensix cores: one sender and multiple receiver cores getting the same data. Data is written into the L1 buffer on the sender core. The sender kernel issues NOC transactions to transfer this data into the L1 buffer on the receiver core. Once data is transferred, the sender kernel signals to the receiver kernel that it is done by incrementing a semaphore. Receiver kernel waits on/polls this semaphore and completes its execution when it is incremented.
+Data is written directly into the L1 memory on the sender Tensix core. The sender kernel issues NOC transactions to transfer this data into the L1 memory of each receiver core in a grid. Once data is transferred, the sender kernel signals to the receiver kernel that it is done by incrementing a semaphore. Receiver kernel waits on/polls this semaphore and completes its execution when it is incremented.
 
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
@@ -39,4 +39,6 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
 7. One to All Multicast Linked 2x2 Packet Sizes: Tests one to all linked multicast on a 2x2 grid.
 8. One to All Multicast Linked 5x5 Packet Sizes: Tests one to all linked multicast on a 5x5 grid.
 9. One to All Multicast Linked 11x10 Packet Sizes: Tests one to all linked multicast on a 11x10 grid.
-10. One to All Directed Ideal: Tests the most optimal one to all linked multicast data movement setup. A high number of transactions is performed to amortize initialization overhead.
+10. One to All Directed Ideal: Tests the most optimal one to all linked multicast data movement setup. Large transaction size and high number of transactions amortizes initialization overhead and maximizes bandwidth utilization.
+11. One to All 2x2 Directed Ideal: Tests the most optimal one to all linked multicast data movement setup, but on a smaller grid (2x2). Large transaction size and high number of transactions amortizes initialization overhead and maximizes bandwidth utilization.
+10. One to All 4x4 Directed Ideal: Tests the most optimal one to all linked multicast data movement setup, but on a smaller grid (4x4). Large transaction size and high number of transactions amortizes initialization overhead and maximizes bandwidth utilization.

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/README.md
@@ -40,5 +40,3 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
 8. One to All Multicast Linked 5x5 Packet Sizes: Tests one to all linked multicast on a 5x5 grid.
 9. One to All Multicast Linked 11x10 Packet Sizes: Tests one to all linked multicast on a 11x10 grid.
 10. One to All Directed Ideal: Tests the most optimal one to all linked multicast data movement setup. Large transaction size and high number of transactions amortizes initialization overhead and maximizes bandwidth utilization.
-11. One to All 2x2 Directed Ideal: Tests the most optimal one to all linked multicast data movement setup, but on a smaller grid (2x2). Large transaction size and high number of transactions amortizes initialization overhead and maximizes bandwidth utilization.
-10. One to All 4x4 Directed Ideal: Tests the most optimal one to all linked multicast data movement setup, but on a smaller grid (4x4). Large transaction size and high number of transactions amortizes initialization overhead and maximizes bandwidth utilization.

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Note: The sender kernels in One To All write the same transaction_size_bytes amount of data to the same location
+// num_of_transactions times
+
 #include "device_fixture.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
@@ -56,6 +59,11 @@ bool run_dm(IDevice* device, const OneToAllConfig& test_config) {
     // Sharded L1 buffers
     const uint32_t transaction_size_bytes = test_config.transaction_size_pages * test_config.page_size_bytes;
 
+    if (test_config.loopback && (test_config.num_of_transactions * transaction_size_bytes > 1024 * 1024 / 2)) {
+        log_error(tt::LogTest, "Not enough memory for master core using loopback");
+        return false;
+    }
+
     CoreRangeSet master_core_set({CoreRange(test_config.master_core_coord)});
     CoreRangeSet subordinate_core_set(
         {CoreRange(CoreCoord(0, 0), CoreCoord(test_config.grid_size.x - 1, test_config.grid_size.y - 1))});
@@ -68,8 +76,7 @@ bool run_dm(IDevice* device, const OneToAllConfig& test_config) {
     uint32_t num_subordinates = subordinate_core_set.num_cores();
     uint32_t total_sender_size_bytes =
         test_config.transaction_size_pages * test_config.page_size_bytes * num_subordinates;
-    uint32_t total_sender_size_pages = test_config.transaction_size_pages * num_subordinates;
-
+    /*
     auto master_shard_parameters = ShardSpecBuffer(
         master_core_set,
         {1, transaction_size_bytes / 2},
@@ -84,8 +91,36 @@ bool run_dm(IDevice* device, const OneToAllConfig& test_config) {
         .buffer_layout = TensorMemoryLayout::WIDTH_SHARDED,
         .shard_parameters = std::move(master_shard_parameters),
     });
-    uint32_t master_l1_byte_address = master_l1_buffer->address();
+    */
 
+    // Obtain L1 Address for Storing Data
+    // NOTE: We don't know if the whole block of memory is actually available.
+    //       This is something that could probably be checked
+    L1AddressInfo master_l1_info =
+        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.master_core_coord);
+
+    auto sub_core_list = corerange_to_cores(subordinate_core_set);
+    for (auto& core : sub_core_list) {
+        L1AddressInfo subordinate_l1_info = tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, core);
+        // Checks that both master and subordinate cores have the same L1 base address and size
+        if (master_l1_info.base_address != subordinate_l1_info.base_address ||
+            master_l1_info.size != subordinate_l1_info.size) {
+            log_error(tt::LogTest, "Mismatch in L1 address or size between master and subordinate cores");
+            return false;
+        }
+    }
+    // Check if the L1 size is sufficient for the test configuration
+    if (master_l1_info.size < test_config.num_of_transactions * transaction_size_bytes) {
+        log_error(tt::LogTest, "Insufficient L1 size for the test configuration");
+        return false;
+    }
+
+    uint32_t subordinate_l1_byte_address = master_l1_info.base_address;
+    uint32_t master_l1_byte_address =
+        test_config.loopback ? subordinate_l1_byte_address + (test_config.num_of_transactions * transaction_size_bytes)
+                             : subordinate_l1_byte_address;
+
+    /*
     auto subordinate_shard_parameters = ShardSpecBuffer(
         subordinate_core_set,
         {1, transaction_size_bytes / 2},
@@ -100,7 +135,7 @@ bool run_dm(IDevice* device, const OneToAllConfig& test_config) {
         .buffer_layout = TensorMemoryLayout::WIDTH_SHARDED,
         .shard_parameters = std::move(subordinate_shard_parameters),
     });
-    uint32_t subordinate_l1_byte_address = subordinate_l1_buffer->address();
+    */
 
     // Compile-time arguments for kernels
     vector<uint32_t> sender_compile_args = {
@@ -139,7 +174,7 @@ bool run_dm(IDevice* device, const OneToAllConfig& test_config) {
 
     // Runtime Arguments
     std::vector<uint32_t> master_run_args = {sem_id, start_coord.x, start_coord.y, end_coord.x, end_coord.y};
-    for (auto& core : corerange_to_cores(subordinate_core_set)) {
+    for (auto& core : sub_core_list) {
         if (!test_config.loopback &&
             (core.x == test_config.master_core_coord.x && core.y == test_config.master_core_coord.y)) {
             continue;
@@ -163,28 +198,33 @@ bool run_dm(IDevice* device, const OneToAllConfig& test_config) {
 
     // Golden output
     vector<uint32_t> packed_golden = packed_input;
+    /*
     for (uint32_t i = 1; i < num_subordinates; i++) {
         packed_golden.insert(packed_golden.end(), packed_input.begin(), packed_input.end());
     }
+        */
 
     // Launch program and record outputs
-    detail::WriteToBuffer(master_l1_buffer, packed_input);
+    detail::WriteToDeviceL1(device, test_config.master_core_coord, master_l1_byte_address, packed_input);
     MetalContext::instance().get_cluster().l1_barrier(device->id());
     detail::LaunchProgram(device, program);
 
     vector<uint32_t> packed_output;
-    detail::ReadFromBuffer(subordinate_l1_buffer, packed_output);
-    // Results comparison
-    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
-        packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
-    if (!pcc) {
-        log_error(tt::LogTest, "PCC Check failed");
-        log_info(tt::LogTest, "Golden vector");
-        print_vector<uint32_t>(packed_golden);
-        log_info(tt::LogTest, "Output vector");
-        print_vector<uint32_t>(packed_output);
+    for (auto& core : sub_core_list) {
+        detail::ReadFromDeviceL1(device, core, subordinate_l1_byte_address, transaction_size_bytes, packed_output);
+        // Results comparison
+        bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
+            packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+        if (!pcc) {
+            log_error(tt::LogTest, "PCC Check failed");
+            log_info(tt::LogTest, "Golden vector");
+            print_vector<uint32_t>(packed_golden);
+            log_info(tt::LogTest, "Output vector");
+            print_vector<uint32_t>(packed_output);
+            return false;
+        }
     }
-    return pcc;
+    return true;
 }
 }  // namespace unit_tests::dm::core_to_all
 
@@ -196,30 +236,34 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAll2x2PacketSizes) {
     uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
     CoreCoord master_core_coord = {0, 0};
     CoreCoord grid_size = {2, 2};
-    bool loopback = true;
     NOC noc_id = NOC::NOC_0;
+    for (uint32_t l = 0; l < 2; l++) {
+        bool loopback = (l == 1);  // fully test loopback = false, then loopback = true
+        if (loopback) {
+            max_transactions /= 2;
+        }
+        for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
+            for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
+                 transaction_size_pages *= 2) {
+                // Test config
+                unit_tests::dm::core_to_all::OneToAllConfig test_config = {
+                    .test_id = unit_tests::dm::core_to_all::START_ID + 0,
+                    .master_core_coord = master_core_coord,
+                    .grid_size = grid_size,
+                    .num_of_transactions = num_of_transactions,
+                    .transaction_size_pages = transaction_size_pages,
+                    .page_size_bytes = page_size_bytes,
+                    .l1_data_format = DataFormat::Float16_b,
+                    .loopback = loopback,
+                    .noc_id = noc_id,
+                    .is_multicast = false,
+                    .is_linked = false,
+                };
 
-    for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
-        for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
-             transaction_size_pages *= 2) {
-            // Test config
-            unit_tests::dm::core_to_all::OneToAllConfig test_config = {
-                .test_id = unit_tests::dm::core_to_all::START_ID + 0,
-                .master_core_coord = master_core_coord,
-                .grid_size = grid_size,
-                .num_of_transactions = num_of_transactions,
-                .transaction_size_pages = transaction_size_pages,
-                .page_size_bytes = page_size_bytes,
-                .l1_data_format = DataFormat::Float16_b,
-                .loopback = loopback,
-                .noc_id = noc_id,
-                .is_multicast = false,
-                .is_linked = false,
-            };
-
-            // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+                // Run
+                for (unsigned int id = 0; id < num_devices_; id++) {
+                    EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+                }
             }
         }
     }
@@ -233,30 +277,34 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAll4x4PacketSizes) {
     uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
     CoreCoord master_core_coord = {0, 0};
     CoreCoord grid_size = {4, 4};
-    bool loopback = true;
     NOC noc_id = NOC::NOC_0;
+    for (uint32_t l = 0; l < 2; l++) {
+        bool loopback = (l == 1);  // fully test loopback = false, then loopback = true
+        if (loopback) {
+            max_transactions /= 2;
+        }
+        for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
+            for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
+                 transaction_size_pages *= 2) {
+                // Test config
+                unit_tests::dm::core_to_all::OneToAllConfig test_config = {
+                    .test_id = unit_tests::dm::core_to_all::START_ID + 1,
+                    .master_core_coord = master_core_coord,
+                    .grid_size = grid_size,
+                    .num_of_transactions = num_of_transactions,
+                    .transaction_size_pages = transaction_size_pages,
+                    .page_size_bytes = page_size_bytes,
+                    .l1_data_format = DataFormat::Float16_b,
+                    .loopback = loopback,
+                    .noc_id = noc_id,
+                    .is_multicast = false,
+                    .is_linked = false,
+                };
 
-    for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
-        for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
-             transaction_size_pages *= 2) {
-            // Test config
-            unit_tests::dm::core_to_all::OneToAllConfig test_config = {
-                .test_id = unit_tests::dm::core_to_all::START_ID + 1,
-                .master_core_coord = master_core_coord,
-                .grid_size = grid_size,
-                .num_of_transactions = num_of_transactions,
-                .transaction_size_pages = transaction_size_pages,
-                .page_size_bytes = page_size_bytes,
-                .l1_data_format = DataFormat::Float16_b,
-                .loopback = loopback,
-                .noc_id = noc_id,
-                .is_multicast = false,
-                .is_linked = false,
-            };
-
-            // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+                // Run
+                for (unsigned int id = 0; id < num_devices_; id++) {
+                    EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+                }
             }
         }
     }
@@ -269,7 +317,6 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAll10x10PacketSizes) {
     uint32_t max_transaction_size_pages = 64;
     uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
     CoreCoord master_core_coord = {0, 0};
-    bool loopback = true;
     NOC noc_id = NOC::NOC_0;
 
     CoreCoord cs_grid_size = {
@@ -282,28 +329,33 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAll10x10PacketSizes) {
         uint32_t smaller_dim = grid_size.x > grid_size.y ? grid_size.y : grid_size.x;
         grid_size = {smaller_dim, smaller_dim};
     }
+    for (uint32_t l = 0; l < 2; l++) {
+        bool loopback = (l == 1);  // fully test loopback = false, then loopback = true
+        if (loopback) {
+            max_transactions /= 2;
+        }
+        for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
+            for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
+                 transaction_size_pages *= 2) {
+                // Test config
+                unit_tests::dm::core_to_all::OneToAllConfig test_config = {
+                    .test_id = unit_tests::dm::core_to_all::START_ID + 2,
+                    .master_core_coord = master_core_coord,
+                    .grid_size = grid_size,
+                    .num_of_transactions = num_of_transactions,
+                    .transaction_size_pages = transaction_size_pages,
+                    .page_size_bytes = page_size_bytes,
+                    .l1_data_format = DataFormat::Float16_b,
+                    .loopback = loopback,
+                    .noc_id = noc_id,
+                    .is_multicast = false,
+                    .is_linked = false,
+                };
 
-    for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
-        for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
-             transaction_size_pages *= 2) {
-            // Test config
-            unit_tests::dm::core_to_all::OneToAllConfig test_config = {
-                .test_id = unit_tests::dm::core_to_all::START_ID + 2,
-                .master_core_coord = master_core_coord,
-                .grid_size = grid_size,
-                .num_of_transactions = num_of_transactions,
-                .transaction_size_pages = transaction_size_pages,
-                .page_size_bytes = page_size_bytes,
-                .l1_data_format = DataFormat::Float16_b,
-                .loopback = loopback,
-                .noc_id = noc_id,
-                .is_multicast = false,
-                .is_linked = false,
-            };
-
-            // Run
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+                // Run
+                for (unsigned int id = 0; id < num_devices_; id++) {
+                    EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+                }
             }
         }
     }
@@ -312,7 +364,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAll10x10PacketSizes) {
 /* ========== Test case for one to all multicast data movement; ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticast2x2PacketSizes) {
     // Parameters
-    uint32_t max_transactions = 256;
+    uint32_t max_transactions = 128;
     uint32_t max_transaction_size_pages = 64;
     uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
     CoreCoord master_core_coord = {0, 0};
@@ -349,7 +401,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticast2x2PacketSizes) {
 /* ========== Test case for one to all multicast data movement; ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticast5x5PacketSizes) {
     // Parameters
-    uint32_t max_transactions = 256;
+    uint32_t max_transactions = 128;
     uint32_t max_transaction_size_pages = 64;
     uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
     CoreCoord master_core_coord = {0, 0};
@@ -386,7 +438,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticast5x5PacketSizes) {
 /* ========== Test case for one to all multicast data movement; ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticast11x10PacketSizes) {
     // Parameters
-    uint32_t max_transactions = 256;
+    uint32_t max_transactions = 128;
     uint32_t max_transaction_size_pages = 64;
     uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
     CoreCoord master_core_coord = {0, 0};
@@ -430,7 +482,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticast11x10PacketSizes) {
 /* ========== Test case for one to all multicast data movement; ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastLinked2x2PacketSizes) {
     // Parameters
-    uint32_t max_transactions = 256;
+    uint32_t max_transactions = 128;
     uint32_t max_transaction_size_pages = 64;
     uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
     CoreCoord master_core_coord = {0, 0};
@@ -467,7 +519,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastLinked2x2PacketSizes) {
 /* ========== Test case for one to all multicast data movement; ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastLinked5x5PacketSizes) {
     // Parameters
-    uint32_t max_transactions = 256;
+    uint32_t max_transactions = 128;
     uint32_t max_transaction_size_pages = 64;
     uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
     CoreCoord master_core_coord = {0, 0};
@@ -504,7 +556,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastLinked5x5PacketSizes) {
 /* ========== Test case for one to all multicast data movement; ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastLinked11x10PacketSizes) {
     // Parameters
-    uint32_t max_transactions = 256;
+    uint32_t max_transactions = 128;
     uint32_t max_transaction_size_pages = 64;
     uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
     CoreCoord master_core_coord = {0, 0};
@@ -549,38 +601,101 @@ TEST_F(DeviceFixture, TensixDataMovementOneToAllMulticastLinked11x10PacketSizes)
 TEST_F(DeviceFixture, TensixDataMovementOneToAllDirectedIdeal) {
     uint32_t test_id = 52;  // Arbitrary test id
 
+    // Physical Constraints
+    auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+
     // Parameters
-    /*
-        L1 Capacity: 1.5 MB (I think, might be wrong)
-        - Max transaction size
-            = 4 * 32 pages
-            = 128 pages * 32 (or 64) bytes/page
-            = 4096 bytes for WH; 8192 bytes for BH
-        - Max total transaction size
-            = 128 transactions * 4096 bytes
-            = 524,288 Bytes
-            < 1.25 MB ~= L1 buffer capacity (.25 MB is allocated for the kernel code and other overheads)
-    */
-    uint32_t page_size_bytes, num_of_transactions;
-    uint32_t transaction_size_pages = 4 * 32;
-    if (arch_ == tt::ARCH::BLACKHOLE) {
-        page_size_bytes = 64;  // (=flit size): 64 bytes for BH
-        num_of_transactions = 64;
-    } else {
-        page_size_bytes = 32;  // (=flit size): 32 bytes for WH
-        num_of_transactions = 128;
-    }
+    // Ideal: Less transactions, more data per transaction
+    uint32_t num_of_transactions = 32;
+    uint32_t transaction_size_pages = 256;
+
     CoreCoord master_core_coord = {0, 0};
     CoreCoord grid_size = {
         devices_.at(0)->compute_with_storage_grid_size().x, devices_.at(0)->compute_with_storage_grid_size().y};
     NOC noc_id = NOC::NOC_0;
-    bool is_linked = true;  // True or False?
+    bool is_linked = true;
 
     // Limit the grid size to 100 cores because the max allowed kernel args is 256
     if (grid_size.x * grid_size.y > 100) {
         uint32_t smaller_dim = grid_size.x > grid_size.y ? grid_size.y : grid_size.x;
         grid_size = {smaller_dim, smaller_dim};
     }
+
+    unit_tests::dm::core_to_all::OneToAllConfig test_config = {
+        .test_id = test_id,
+        .master_core_coord = master_core_coord,
+        .grid_size = grid_size,
+        .num_of_transactions = num_of_transactions,
+        .transaction_size_pages = transaction_size_pages,
+        .page_size_bytes = page_size_bytes,
+        .l1_data_format = DataFormat::Float16_b,
+        .loopback = true,
+        .noc_id = noc_id,
+        .is_multicast = true,
+        .is_linked = is_linked,
+    };
+
+    // Run
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    }
+}
+
+/* ========== Test case for one to all multicast data movement; ========== */
+TEST_F(DeviceFixture, TensixDataMovementOneToAll2x2DirectedIdeal) {
+    uint32_t test_id = 53;  // Arbitrary test id
+
+    // Physical Constraints
+    auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+
+    // Parameters
+    uint32_t num_of_transactions = 32;
+    uint32_t transaction_size_pages = 256;
+
+    CoreCoord master_core_coord = {0, 0};
+    CoreCoord grid_size = {2, 2};
+    NOC noc_id = NOC::NOC_0;
+    bool is_linked = true;
+
+    unit_tests::dm::core_to_all::OneToAllConfig test_config = {
+        .test_id = test_id,
+        .master_core_coord = master_core_coord,
+        .grid_size = grid_size,
+        .num_of_transactions = num_of_transactions,
+        .transaction_size_pages = transaction_size_pages,
+        .page_size_bytes = page_size_bytes,
+        .l1_data_format = DataFormat::Float16_b,
+        .loopback = true,
+        .noc_id = noc_id,
+        .is_multicast = true,
+        .is_linked = is_linked,
+    };
+
+    // Run
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    }
+}
+
+/* ========== Test case for one to all multicast data movement; ========== */
+TEST_F(DeviceFixture, TensixDataMovementOneToAll4x4DirectedIdeal) {
+    uint32_t test_id = 54;  // Arbitrary test id
+
+    // Physical Constraints
+    auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(arch_, devices_.at(0));
+
+    // Parameters
+    // Ideal: Less transactions, more data per transaction
+    uint32_t num_of_transactions = 32;
+    uint32_t transaction_size_pages = 256;
+
+    CoreCoord master_core_coord = {0, 0};
+    CoreCoord grid_size = {4, 4};
+    NOC noc_id = NOC::NOC_0;
+    bool is_linked = true;
 
     unit_tests::dm::core_to_all::OneToAllConfig test_config = {
         .test_id = test_id,

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -99,6 +99,7 @@ bool run_dm(IDevice* device, const OneToAllConfig& test_config) {
     }
 
     uint32_t subordinate_l1_byte_address = master_l1_info.base_address;
+    // Offset the address for loopback to avoid data race when master writes to self
     uint32_t master_l1_byte_address =
         test_config.loopback ? subordinate_l1_byte_address + transaction_size_bytes : subordinate_l1_byte_address;
 

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -216,13 +216,7 @@ test_bounds = {
             "riscv_1": {"latency": {"lower": 32700, "upper": 37500}, "bandwidth": 28},  # 18596, 28.2
         },
         52: {  # One to All Directed Ideal
-            "riscv_0": {"latency": {"lower": 11000, "upper": 12000}, "bandwidth": 22},
-        },
-        53: {  # One to All 2x2 Directed Ideal
-            "riscv_0": {"latency": {"lower": 8500, "upper": 9500}, "bandwidth": 28},
-        },
-        54: {  # One to All 4x4 Directed Ideal
-            "riscv_0": {"latency": {"lower": 9000, "upper": 10000}, "bandwidth": 27},
+            "riscv_0": {"latency": {"lower": 86000, "upper": 91000}, "bandwidth": 23},
         },
         17: {
             "riscv_1": {"latency": {"lower": 50, "upper": 700}, "bandwidth": 3},
@@ -330,13 +324,7 @@ test_bounds = {
             "riscv_1": {"latency": {"lower": 16000, "upper": 17800}, "bandwidth": 59},  # 8730, 60.1
         },
         52: {  # One to All Directed Ideal
-            "riscv_0": {"latency": {"lower": 12000, "upper": 13000}, "bandwidth": 40},
-        },
-        53: {  # One to All 2x2 Directed Ideal
-            "riscv_0": {"latency": {"lower": 8500, "upper": 9500}, "bandwidth": 56},
-        },
-        54: {  # One to All 4x4 Directed Ideal
-            "riscv_0": {"latency": {"lower": 9000, "upper": 10000}, "bandwidth": 54},
+            "riscv_0": {"latency": {"lower": 96000, "upper": 100000}, "bandwidth": 42},
         },
         17: {
             "riscv_1": {"latency": {"lower": 50, "upper": 700}, "bandwidth": 7},

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -173,33 +173,33 @@ test_bounds = {
         5: {
             "riscv_1": {"latency": {"lower": 200, "upper": 19000}, "bandwidth": 0.1},
         },
-        6: {
-            "riscv_0": {"latency": {"lower": 400, "upper": 70000}, "bandwidth": 0.3},
-        },
-        7: {
-            "riscv_0": {"latency": {"lower": 800, "upper": 300000}, "bandwidth": 0.6},
-        },
-        8: {
-            "riscv_0": {"latency": {"lower": 1900, "upper": 900000}, "bandwidth": 0.8},
-        },
-        9: {
-            "riscv_0": {"latency": {"lower": 300, "upper": 30000}, "bandwidth": 0.09},
-        },
-        10: {
-            "riscv_0": {"latency": {"lower": 400, "upper": 60000}, "bandwidth": 0.07},
-        },
-        11: {
-            "riscv_0": {"latency": {"lower": 500, "upper": 90000}, "bandwidth": 0.04},
-        },
-        12: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 20000}, "bandwidth": 0.09},
-        },
-        13: {
-            "riscv_0": {"latency": {"lower": 400, "upper": 30000}, "bandwidth": 0.07},
-        },
-        14: {
-            "riscv_0": {"latency": {"lower": 500, "upper": 40000}, "bandwidth": 0.04},
-        },
+        # 6: {
+        #     "riscv_0": {"latency": {"lower": 400, "upper": 70000}, "bandwidth": 0.3},
+        # },
+        # 7: {
+        #     "riscv_0": {"latency": {"lower": 800, "upper": 300000}, "bandwidth": 0.6},
+        # },
+        # 8: {
+        #     "riscv_0": {"latency": {"lower": 1900, "upper": 900000}, "bandwidth": 0.8},
+        # },
+        # 9: {
+        #     "riscv_0": {"latency": {"lower": 300, "upper": 30000}, "bandwidth": 0.09},
+        # },
+        # 10: {
+        #     "riscv_0": {"latency": {"lower": 400, "upper": 60000}, "bandwidth": 0.07},
+        # },
+        # 11: {
+        #     "riscv_0": {"latency": {"lower": 500, "upper": 90000}, "bandwidth": 0.04},
+        # },
+        # 12: {
+        #     "riscv_0": {"latency": {"lower": 200, "upper": 20000}, "bandwidth": 0.09},
+        # },
+        # 13: {
+        #     "riscv_0": {"latency": {"lower": 400, "upper": 30000}, "bandwidth": 0.07},
+        # },
+        # 14: {
+        #     "riscv_0": {"latency": {"lower": 500, "upper": 40000}, "bandwidth": 0.04},
+        # },
         15: {
             "riscv_1": {"latency": {"lower": 700, "upper": 85000}, "bandwidth": 0.71},
         },
@@ -216,7 +216,13 @@ test_bounds = {
             "riscv_1": {"latency": {"lower": 32700, "upper": 37500}, "bandwidth": 28},  # 18596, 28.2
         },
         52: {  # One to All Directed Ideal
-            "riscv_0": {"latency": {"lower": 24000, "upper": 28000}, "bandwidth": 19},  # 26966, 19.4
+            "riscv_0": {"latency": {"lower": 11000, "upper": 12000}, "bandwidth": 22},
+        },
+        53: {  # One to All 2x2 Directed Ideal
+            "riscv_0": {"latency": {"lower": 8500, "upper": 9500}, "bandwidth": 28},
+        },
+        54: {  # One to All 4x4 Directed Ideal
+            "riscv_0": {"latency": {"lower": 9000, "upper": 10000}, "bandwidth": 27},
         },
         17: {
             "riscv_1": {"latency": {"lower": 50, "upper": 700}, "bandwidth": 3},
@@ -281,33 +287,33 @@ test_bounds = {
         5: {
             "riscv_1": {"latency": {"lower": 300, "upper": 18000}, "bandwidth": 0.17},
         },
-        6: {
-            "riscv_0": {"latency": {"lower": 400, "upper": 70000}, "bandwidth": 0.5},
-        },
-        7: {
-            "riscv_0": {"latency": {"lower": 900, "upper": 275000}, "bandwidth": 1.00},
-        },
-        8: {
-            "riscv_0": {"latency": {"lower": 3800, "upper": 1700000}, "bandwidth": 1.65},
-        },
-        9: {
-            "riscv_0": {"latency": {"lower": 300, "upper": 30000}, "bandwidth": 0.16},
-        },
-        10: {
-            "riscv_0": {"latency": {"lower": 450, "upper": 70000}, "bandwidth": 0.12},
-        },
-        11: {
-            "riscv_0": {"latency": {"lower": 700, "upper": 115000}, "bandwidth": 0.08},
-        },
-        12: {
-            "riscv_0": {"latency": {"lower": 300, "upper": 20000}, "bandwidth": 0.16},
-        },
-        13: {
-            "riscv_0": {"latency": {"lower": 500, "upper": 24000}, "bandwidth": 0.12},
-        },
-        14: {
-            "riscv_0": {"latency": {"lower": 700, "upper": 46000}, "bandwidth": 0.08},
-        },
+        # 6: {
+        #     "riscv_0": {"latency": {"lower": 400, "upper": 70000}, "bandwidth": 0.5},
+        # },
+        # 7: {
+        #     "riscv_0": {"latency": {"lower": 900, "upper": 275000}, "bandwidth": 1.00},
+        # },
+        # 8: {
+        #     "riscv_0": {"latency": {"lower": 3800, "upper": 1700000}, "bandwidth": 1.65},
+        # },
+        # 9: {
+        #     "riscv_0": {"latency": {"lower": 300, "upper": 30000}, "bandwidth": 0.16},
+        # },
+        # 10: {
+        #     "riscv_0": {"latency": {"lower": 450, "upper": 70000}, "bandwidth": 0.12},
+        # },
+        # 11: {
+        #     "riscv_0": {"latency": {"lower": 700, "upper": 115000}, "bandwidth": 0.08},
+        # },
+        # 12: {
+        #     "riscv_0": {"latency": {"lower": 300, "upper": 20000}, "bandwidth": 0.16},
+        # },
+        # 13: {
+        #     "riscv_0": {"latency": {"lower": 500, "upper": 24000}, "bandwidth": 0.12},
+        # },
+        # 14: {
+        #     "riscv_0": {"latency": {"lower": 700, "upper": 46000}, "bandwidth": 0.08},
+        # },
         15: {
             "riscv_1": {"latency": {"lower": 800, "upper": 87000}, "bandwidth": 1.19},
         },
@@ -324,7 +330,13 @@ test_bounds = {
             "riscv_1": {"latency": {"lower": 16000, "upper": 17800}, "bandwidth": 59},  # 8730, 60.1
         },
         52: {  # One to All Directed Ideal
-            "riscv_0": {"latency": {"lower": 10000, "upper": 17000}, "bandwidth": 30},  # 15322, 34.2
+            "riscv_0": {"latency": {"lower": 12000, "upper": 13000}, "bandwidth": 40},
+        },
+        53: {  # One to All 2x2 Directed Ideal
+            "riscv_0": {"latency": {"lower": 8500, "upper": 9500}, "bandwidth": 56},
+        },
+        54: {  # One to All 4x4 Directed Ideal
+            "riscv_0": {"latency": {"lower": 9000, "upper": 10000}, "bandwidth": 54},
         },
         17: {
             "riscv_1": {"latency": {"lower": 50, "upper": 700}, "bandwidth": 7},

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -294,7 +294,7 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 300, "upper": 30000}, "bandwidth": 0.16},
         },
         10: {
-            "riscv_0": {"latency": {"lower": 500, "upper": 70000}, "bandwidth": 0.12},
+            "riscv_0": {"latency": {"lower": 450, "upper": 70000}, "bandwidth": 0.12},
         },
         11: {
             "riscv_0": {"latency": {"lower": 700, "upper": 115000}, "bandwidth": 0.08},

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -216,7 +216,7 @@ test_bounds = {
             "riscv_1": {"latency": {"lower": 32700, "upper": 37500}, "bandwidth": 28},  # 18596, 28.2
         },
         52: {  # One to All Directed Ideal
-            "riscv_0": {"latency": {"lower": 86000, "upper": 91000}, "bandwidth": 23},
+            "riscv_0": {"latency": {"lower": 70000, "upper": 91000}, "bandwidth": 23},
         },
         17: {
             "riscv_1": {"latency": {"lower": 50, "upper": 700}, "bandwidth": 3},


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22803)

### Problem description
The use of sharded buffers for allocating space on the master and subordinate cores limited the ability of the tests to make use of the entire available L1 spaces on each core. In the case of the One to All tests, this restricted the movement of data amounting to more than half of the available L1 space since a master buffer and a subordinate buffer were each being allocated for all cores, including the master and subordinate cores involved in the transactions.

### What's changed
This has been fixed for the One to All tests. Instead of using sharded buffers, the test now uses the `WriteToDeviceL1()` and `ReadFromDeviceL1()` APIs to set up the master's L1 data and check the subordinates' L1 data respectively.

Additionally, the tests that use loopback have been corrected so that when the master core writes to itself, it does so in a different memory address such that the original data is not overwritten. The directed ideal tests (which use multicast) now send a transaction size of a full packet and a large number of transactions to maximize bandwidth utilization and the benefits derived from linking.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes