### PR TITLE
Fix executor.hpp

### DIFF
--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -9,19 +9,19 @@
 #include <stdexcept>
 
 namespace tt::tt_metal::detail {
-static const size_t EXECUTOR_NTHREADS = std::getenv("TT_METAL_THREADCOUNT")
-                                            ? std::stoi(std::getenv("TT_METAL_THREADCOUNT"))
-                                            : std::thread::hardware_concurrency();
+inline static const size_t EXECUTOR_NTHREADS = std::getenv("TT_METAL_THREADCOUNT")
+                                                   ? std::stoi(std::getenv("TT_METAL_THREADCOUNT"))
+                                                   : std::thread::hardware_concurrency();
 
 using Executor = tf::Executor;
 using ExecTask = tf::Task;
 
-static Executor& GetExecutor() {
+inline Executor& GetExecutor() {
     static Executor exec(EXECUTOR_NTHREADS);
     return exec;
 }
 
-static std::mutex& GetExecutorMutex() {
+inline std::mutex& GetExecutorMutex() {
     static std::mutex exec_mutex;
     return exec_mutex;
 }


### PR DESCRIPTION
### Ticket
NA

### Problem description
Once more compiler warnings are turned on, we will see:
```
In file included from /workspace/tt_metal/distributed/distributed_host_buffer.cpp:15:
/workspace/tt_metal/common/executor.hpp:24:20: error: 'static' function 'GetExecutorMutex' declared in header file should be declared 'static inline' [-Werror,-Wunneeded-internal-declaration]
   24 | static std::mutex& GetExecutorMutex() {
      |                    ^~~~~~~~~~~~~~~~
1 error generated.
```

### What's changed
Define the variables and functions as inline so that there is only one instance per TU.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15712274420) CI passes
- [x] New/Existing tests provide coverage for changes