### PR TITLE
#22258: Expose richer ND multi-device sharding APIs to Python

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -183,8 +183,8 @@ TEST_P(TensorDistributionT3000Test2D, FullyReplicated) {
         *mesh_device_,
         MeshMapperConfig{
             .placements = {MeshMapperConfig::Replicate{}, MeshMapperConfig::Replicate{}},
-        },
-        MeshShape(num_rows, num_cols));
+            .mesh_shape_override = MeshShape(num_rows, num_cols),
+        });
     Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
 
     std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
@@ -218,8 +218,8 @@ TEST_P(TensorDistributionT3000Test2D, ReplicateDim) {
         *mesh_device_,
         MeshMapperConfig{
             .placements = {MeshMapperConfig::Shard{1}, MeshMapperConfig::Replicate{}},
-        },
-        MeshShape(num_rows, num_cols));
+            .mesh_shape_override = MeshShape(num_rows, num_cols),
+        });
     Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
 
     std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
@@ -252,8 +252,8 @@ TEST_P(TensorDistributionT3000Test2D, ShardDims) {
         *mesh_device_,
         MeshMapperConfig{
             .placements = {MeshMapperConfig::Shard{1}, MeshMapperConfig::Shard{2}},
-        },
-        MeshShape(num_rows, num_cols));
+            .mesh_shape_override = MeshShape(num_rows, num_cols),
+        });
     Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
 
     std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
@@ -266,8 +266,8 @@ TEST_P(TensorDistributionT3000Test2D, ShardDims) {
         *mesh_device_,
         MeshComposerConfig{
             .dims = {0, 2},
-        },
-        MeshShape(num_rows, num_cols));
+            .mesh_shape_override = MeshShape(num_rows, num_cols),
+        });
     Tensor concatenated_tensor = aggregate_tensor(sharded_tensor, *composer);
 
     Tensor expected_tensor =
@@ -285,8 +285,8 @@ TEST_F(TensorDistributionT3000Test, NdMapperInvalidShape) {
         *mesh_device_,
         MeshMapperConfig{
             .placements = {MeshMapperConfig::Replicate{}},
-        },
-        MeshShape{1, 9}));
+            .mesh_shape_override = MeshShape{1, 9},
+        }));
 }
 
 TEST_F(TensorDistributionT3000Test, NdMapperUnevenSharding) {
@@ -331,8 +331,8 @@ TEST_F(TensorDistributionT3000Test, NdComposerInvalidShape) {
         *mesh_device_,
         MeshComposerConfig{
             .dims = {0, 1, 2},
-        },
-        MeshShape{1, 9}));
+            .mesh_shape_override = MeshShape{1, 9},
+        }));
 }
 
 TEST_F(TensorDistributionT3000Test, NdComposerInvalidDims) {
@@ -355,8 +355,8 @@ TEST_F(TensorDistributionT3000Test, NdComposerUnevenComposition) {
         *mesh_device_,
         MeshComposerConfig{
             .dims = {0, 1},
-        },
-        MeshShape(2, 3));
+            .mesh_shape_override = MeshShape(2, 3),
+        });
 
     EXPECT_ANY_THROW({ Tensor aggregated_tensor = aggregate_tensor(replicated_tensor, *composer); });
 }
@@ -384,8 +384,8 @@ TEST_F(TensorDistributionT3000Test, NdMapperShard3D) {
                     MeshMapperConfig::Shard{2},
                     MeshMapperConfig::Shard{1},
                 },
-        },
-        MeshShape(2, 2, 2));
+            .mesh_shape_override = MeshShape(2, 2, 2),
+        });
     Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
 
     std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
@@ -404,8 +404,8 @@ TEST_F(TensorDistributionT3000Test, NdMapperShard3D) {
         *mesh_device_,
         MeshComposerConfig{
             .dims = {0, 2, 1},
-        },
-        MeshShape(2, 2, 2));
+            .mesh_shape_override = MeshShape(2, 2, 2),
+        });
     Tensor aggregated_tensor = aggregate_tensor(sharded_tensor, *composer);
     EXPECT_EQ(aggregated_tensor.logical_shape(), ttnn::Shape({2 * kOuterDim, kNumRows, kNumCols, kInnerDim}));
     EXPECT_THAT(aggregated_tensor.to_vector<float>(), Pointwise(FloatEq(), expected_data));

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -317,8 +317,9 @@ auto get_mesh_tensor_write_test_params() {
                                 {
                                     MeshMapperConfig::Replicate(),
                                     MeshMapperConfig::Shard(1),
-                                }},
-                        MeshShape(2, 3));
+                                },
+                            .mesh_shape_override = MeshShape(2, 3),
+                        });
                 },
         },
     };

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
@@ -165,8 +165,8 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard2DTensorRoundtrip) {
         ttnn::distributed::MeshMapperConfig{
             .placements =
                 {ttnn::distributed::MeshMapperConfig::Shard{1}, ttnn::distributed::MeshMapperConfig::Shard{2}},
-        },
-        ttnn::distributed::MeshShape(kNumRows, kNumCols));
+            .mesh_shape_override = ttnn::distributed::MeshShape(kNumRows, kNumCols),
+        });
 
     Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);
 
@@ -251,8 +251,8 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard2x3SubmeshRoundtrip) {
         ttnn::distributed::MeshMapperConfig{
             .placements =
                 {ttnn::distributed::MeshMapperConfig::Shard{1}, ttnn::distributed::MeshMapperConfig::Shard{2}},
-        },
-        ttnn::distributed::MeshShape(kNumRows, kNumCols));
+            .mesh_shape_override = ttnn::distributed::MeshShape(kNumRows, kNumCols),
+        });
 
     Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);
 

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -43,17 +43,21 @@ struct MeshMapperConfig {
     //
     // Distributed Tensor on Mesh (placements = {Replicate{}, Shard{1}}):
     //
-    // +-------------------------------------+---------------------------------------+
-    // |  (0,0)                              |  (0,1)                                |
-    // | +---+---+---+---+---+---+----+----+ | +---+---+---+---+----+----+----+----+ |
-    // | | 0 | 1 | 2 | 3 | 8 | 9 | 10 | 11 | | | 4 | 5 | 6 | 7 | 12 | 13 | 14 | 15 | |
-    // | +---+---+---+---+---+---+----+----+ | +---+---+---+---+----+----+----+----+ |
-    // +-------------------------------------+---------------------------------------+
-    // |  (1,0)                              |  (1,1)                                |
-    // | +---+---+---+---+---+---+----+----+ | +---+---+---+---+----+----+----+----+ |
-    // | | 0 | 1 | 2 | 3 | 8 | 9 | 10 | 11 | | | 4 | 5 | 6 | 7 | 12 | 13 | 14 | 15 | |
-    // | +---+---+---+---+---+---+----+----+ | +---+---+---+---+----+----+----+----+ |
-    // +-------------------------------------+---------------------------------------+
+    // +-----------------------------+-----------------------------+
+    // |     (0,0)                   |     (0,1)                   |
+    // |    +----+----+----+----+    |    +----+----+----+----+    |
+    // |    |  0 |  1 |  2 |  3 |    |    |  4 |  5 |  6 |  7 |    |
+    // |    +----+----+----+----+    |    +----+----+----+----+    |
+    // |    |  8 |  9 | 10 | 11 |    |    | 12 | 13 | 14 | 15 |    |
+    // |    +----+----+----+----+    |    +----+----+----+----+    |
+    // +-----------------------------+-----------------------------+
+    // |     (1,0)                   |     (1,1)                   |
+    // |    +----+----+----+----+    |    +----+----+----+----+    |
+    // |    |  0 |  1 |  2 |  3 |    |    |  4 |  5 |  6 |  7 |    |
+    // |    +----+----+----+----+    |    +----+----+----+----+    |
+    // |    |  8 |  9 | 10 | 11 |    |    | 12 | 13 | 14 | 15 |    |
+    // |    +----+----+----+----+    |    +----+----+----+----+    |
+    // +-----------------------------+-----------------------------+
     //
 
     using Placement = std::variant<Replicate, Shard>;
@@ -102,8 +106,6 @@ private:
 };
 
 // Creates an ND mesh mapper that distributes a tensor according to the `config`.
-// If `shape` is not provided, the shape of `mesh_device` is used.
-// Otherwise, the size of the shape must be smaller than the mesh device shape.
 std::unique_ptr<TensorToMesh> create_mesh_mapper(MeshDevice& mesh_device, const MeshMapperConfig& config);
 
 // Creates a mapper that replicates a tensor across all devices.
@@ -149,8 +151,6 @@ private:
 };
 
 // Creates an ND mesh composer that aggregates a tensor according to the `config`.
-// If `shape` is not provided, the shape of `mesh_device` is used.
-// Otherwise, the size of the shape must match the size of the mesh device shape.
 std::unique_ptr<MeshToTensor> create_mesh_composer(MeshDevice& mesh_device, const MeshComposerConfig& config);
 
 // Creates a composer that concatenates a tensor across a single dimension.

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -55,8 +55,18 @@ struct MeshMapperConfig {
     // | +---+---+---+---+---+---+----+----+ | +---+---+---+---+----+----+----+----+ |
     // +-------------------------------------+---------------------------------------+
     //
-    tt::stl::SmallVector<std::variant<Replicate, Shard>> placements;
+
+    using Placement = std::variant<Replicate, Shard>;
+    tt::stl::SmallVector<Placement> placements;
+
+    // If provided, the sharding will be performed according to this shape, but re-mapped to the mesh device shape in
+    // either row-major order, or preserving the original coordinates (if the shape fits within the mesh device
+    // entirely).
+    std::optional<ttnn::MeshShape> mesh_shape_override = std::nullopt;
 };
+
+std::ostream& operator<<(std::ostream& os, const MeshMapperConfig::Placement& placement);
+std::ostream& operator<<(std::ostream& os, const MeshMapperConfig& config);
 
 // Distributes a host tensor onto a multi-device configuration.
 class TensorToMesh {
@@ -67,10 +77,7 @@ public:
     TensorToMesh(const TensorToMesh&) = delete;
     TensorToMesh& operator=(const TensorToMesh&) = delete;
 
-    static TensorToMesh create(
-        const MeshDevice& mesh_device,
-        const MeshMapperConfig& config,
-        const std::optional<ttnn::MeshShape>& shape = std::nullopt);
+    static TensorToMesh create(const MeshDevice& mesh_device, const MeshMapperConfig& config);
 
     // Distributes a tensor onto a mesh.
     Tensor operator()(const Tensor& tensor) const;
@@ -97,10 +104,7 @@ private:
 // Creates an ND mesh mapper that distributes a tensor according to the `config`.
 // If `shape` is not provided, the shape of `mesh_device` is used.
 // Otherwise, the size of the shape must be smaller than the mesh device shape.
-std::unique_ptr<TensorToMesh> create_mesh_mapper(
-    MeshDevice& mesh_device,
-    const MeshMapperConfig& config,
-    const std::optional<ttnn::MeshShape>& shape = std::nullopt);
+std::unique_ptr<TensorToMesh> create_mesh_mapper(MeshDevice& mesh_device, const MeshMapperConfig& config);
 
 // Creates a mapper that replicates a tensor across all devices.
 // Shorthand for specifying a MeshMapperConfig that replicates the tensor over the entire mesh.
@@ -113,8 +117,15 @@ std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_devic
 
 struct MeshComposerConfig {
     // Specifies dimension of the tensor to concatenate.
-    std::vector<int> dims;
+    tt::stl::SmallVector<int> dims;
+
+    // If provided, the concatenation will be performed according to this shape, but re-mapped to the mesh device shape
+    // in either row-major order, or preserving the original coordinates (if the shape fits within the mesh device
+    // entirely).
+    std::optional<ttnn::MeshShape> mesh_shape_override = std::nullopt;
 };
+
+std::ostream& operator<<(std::ostream& os, const MeshComposerConfig& config);
 
 // Composer interface that aggregates a multi-device tensor into a host tensor.
 class MeshToTensor {
@@ -125,10 +136,7 @@ public:
     MeshToTensor(const MeshToTensor&) = delete;
     MeshToTensor& operator=(const MeshToTensor&) = delete;
 
-    static MeshToTensor create(
-        const MeshDevice& mesh_device,
-        const MeshComposerConfig& config,
-        const std::optional<ttnn::MeshShape>& shape = std::nullopt);
+    static MeshToTensor create(const MeshDevice& mesh_device, const MeshComposerConfig& config);
 
     Tensor compose(const std::vector<Tensor>& tensors) const;
 
@@ -143,10 +151,7 @@ private:
 // Creates an ND mesh composer that aggregates a tensor according to the `config`.
 // If `shape` is not provided, the shape of `mesh_device` is used.
 // Otherwise, the size of the shape must match the size of the mesh device shape.
-std::unique_ptr<MeshToTensor> create_mesh_composer(
-    MeshDevice& mesh_device,
-    const MeshComposerConfig& config,
-    const std::optional<ttnn::MeshShape>& shape = std::nullopt);
+std::unique_ptr<MeshToTensor> create_mesh_composer(MeshDevice& mesh_device, const MeshComposerConfig& config);
 
 // Creates a composer that concatenates a tensor across a single dimension.
 // Shorthand for specifying a MeshComposerConfig with 1D mesh shape, and concatenating the tensor across a single

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/sub_device.hpp>
+#include "ttnn-pybind/small_vector_caster.hpp"  // NOLINT - for pybind11 SmallVector binding support.
 #include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/distributed/types.hpp"
@@ -39,6 +40,8 @@ void py_module_types(py::module& module) {
 
     py::class_<MeshMapperConfig>(module, "MeshMapperConfig");
     py::class_<MeshComposerConfig>(module, "MeshComposerConfig");
+    py::class_<MeshMapperConfig::Replicate>(module, "PlacementReplicate");
+    py::class_<MeshMapperConfig::Shard>(module, "PlacementShard");
 
     py::class_<MeshDevice, std::shared_ptr<MeshDevice>>(module, "MeshDevice");
     py::class_<MeshShape>(module, "MeshShape", "Shape of a mesh device.");
@@ -422,24 +425,103 @@ void py_module(py::module& module) {
         py::arg("worker_l1_size") = DEFAULT_WORKER_L1_SIZE);
     module.def("close_mesh_device", &close_mesh_device, py::arg("mesh_device"), py::kw_only());
 
-    // TODO: #22258 - make this more flexible and useful.
+    auto py_placement_shard = static_cast<py::class_<MeshMapperConfig::Shard>>(module.attr("PlacementShard"));
+    py_placement_shard.def(py::init([](size_t dim) { return MeshMapperConfig::Shard{dim}; }));
+    auto py_placement_replicate =
+        static_cast<py::class_<MeshMapperConfig::Replicate>>(module.attr("PlacementReplicate"));
+    py_placement_replicate.def(py::init([]() { return MeshMapperConfig::Replicate{}; }));
     auto py_mesh_mapper_config = static_cast<py::class_<MeshMapperConfig>>(module.attr("MeshMapperConfig"));
-    py_mesh_mapper_config.def(
-        py::init([](size_t row_dim, size_t col_dim) {
-            MeshMapperConfig config;
-            config.placements.push_back(MeshMapperConfig::Shard{row_dim});
-            config.placements.push_back(MeshMapperConfig::Shard{col_dim});
-            return config;
-        }),
-        py::arg("row_dim"),
-        py::arg("col_dim"));
+
+    py_mesh_mapper_config
+        .def(
+            py::init([](tt::stl::SmallVector<MeshMapperConfig::Placement> placements,
+                        const std::optional<MeshShape>& mesh_shape_override) {
+                return MeshMapperConfig{
+                    .placements = std::move(placements), .mesh_shape_override = mesh_shape_override};
+            }),
+            py::arg("placements"),
+            py::arg("mesh_shape_override") = std::nullopt,
+            R"doc(
+           Creates a MeshMapperConfig object with the given placements and mesh shape override.
+
+           Args:
+               placements (List[Placement]): A set of placements to use for the mapper.
+               mesh_shape_override (MeshShape): If provided, overrides distribution shape of the mesh device.
+               Used for distributing a tensor over ND shape that doesn't match the shape of the mesh device:
+               when the shape fits within a mesh device, the tensor shards are distributed within the submesh
+               region. Otherwise, the tensor shards are distributed across mesh in row-major order.
+           )doc")
+        .def(
+            py::init([](std::optional<size_t> row_dim,
+                        std::optional<size_t> col_dim,
+                        const std::optional<MeshShape>& mesh_shape_override) {
+                MeshMapperConfig config;
+                config.placements.push_back(
+                    row_dim ? MeshMapperConfig::Placement{MeshMapperConfig::Shard{*row_dim}}
+                            : MeshMapperConfig::Placement{MeshMapperConfig::Replicate{}});
+                config.placements.push_back(
+                    col_dim ? MeshMapperConfig::Placement{MeshMapperConfig::Shard{*col_dim}}
+                            : MeshMapperConfig::Placement{MeshMapperConfig::Replicate{}});
+                return config;
+            }),
+            py::arg("row_dim"),
+            py::arg("col_dim"),
+            py::arg("mesh_shape_override") = std::nullopt,
+            R"doc(
+           Creates a 2D MeshMapperConfig with the given placements and mesh shape override.
+
+           Placements are supplied as optional integers: when set to None, the mapper will replicate over the dimension.
+           Otherwise, the mapper will shard over the dimension.
+
+           Args:
+               row_dim Optional[int]: The row dimension to shard / replicate over.
+               col_dim Optional[int]: The column dimension to shard / replicate over.
+               mesh_shape_override Optional[MeshShape]: If provided, overrides distribution shape of the mesh device.
+               )doc")
+        .def("__repr__", [](const MeshMapperConfig& config) {
+            std::ostringstream str;
+            str << config;
+            return str.str();
+        });
     auto py_mesh_composer_config = static_cast<py::class_<MeshComposerConfig>>(module.attr("MeshComposerConfig"));
-    py_mesh_composer_config.def(py::init([](size_t row_dim, size_t col_dim) {
-        MeshComposerConfig config;
-        config.dims.push_back(row_dim);
-        config.dims.push_back(col_dim);
-        return config;
-    }));
+    py_mesh_composer_config
+        .def(
+            py::init([](tt::stl::SmallVector<int> dims, const std::optional<MeshShape>& mesh_shape_override) {
+                return MeshComposerConfig{.dims = std::move(dims), .mesh_shape_override = mesh_shape_override};
+            }),
+            py::arg("dims"),
+            py::arg("mesh_shape_override") = std::nullopt,
+            R"doc(
+           Creates a MeshComposerConfig object with the given dimensions.
+
+           Args:
+               dims (List[int]): The dimensions to concat over.
+               mesh_shape_override Optional[MeshShape]: If provided, overrides distribution shape of the mesh device.
+           )doc")
+        .def(
+            py::init([](size_t row_dim, size_t col_dim, const std::optional<MeshShape>& mesh_shape_override) {
+                MeshComposerConfig config;
+                config.dims.push_back(row_dim);
+                config.dims.push_back(col_dim);
+                config.mesh_shape_override = mesh_shape_override;
+                return config;
+            }),
+            py::arg("row_dim"),
+            py::arg("col_dim"),
+            py::arg("mesh_shape_override") = std::nullopt,
+            R"doc(
+           Creates a 2D MeshComposerConfig object with the given dimensions.
+
+           Args:
+               row_dim (int): The dimension to concat over.
+               col_dim (int): The dimension to concat over.
+               mesh_shape_override Optional[MeshShape]: If provided, overrides distribution shape of the mesh device.
+           )doc")
+        .def("__repr__", [](const MeshComposerConfig& config) {
+            std::ostringstream str;
+            str << config;
+            return str.str();
+        });
 
     module.def(
         "get_device_tensors",
@@ -490,23 +572,17 @@ void py_module(py::module& module) {
    )doc");
     module.def(
         "create_mesh_mapper",
-        [](MeshDevice& mesh_device,
-           const MeshMapperConfig& config,
-           const std::optional<MeshShape>& mesh_shape = std::nullopt) -> std::unique_ptr<TensorToMesh> {
-            return create_mesh_mapper(mesh_device, config, mesh_shape);
+        [](MeshDevice& mesh_device, const MeshMapperConfig& config) -> std::unique_ptr<TensorToMesh> {
+            return create_mesh_mapper(mesh_device, config);
         },
         py::arg("mesh_device"),
         py::arg("config"),
-        py::arg("mesh_shape") = std::nullopt,
         R"doc(
        Returns an ND mapper for sharding and replicating a tensor over the given dimensions for the given mesh.
 
        Args:
            mesh_device (MeshDevice): The mesh to create the mapper for.
            config (MeshMapperConfig): A config object representing a set of placements.
-           mesh_shape (MeshShape): If provided, provides overrides the logical shape for the mapper.
-            Useful for distributing a tensor over ND shape that exceeds the number of physical dimensions
-            in the mesh device.
 
        Returns:
            TensorToMesh: A mapper providing the desired sharding.
@@ -520,11 +596,11 @@ void py_module(py::module& module) {
         py::arg("dim"));
     module.def(
         "create_mesh_composer",
-        [](MeshDevice& mesh_device, const MeshComposerConfig& config, const std::optional<MeshShape>& shape)
-            -> std::unique_ptr<MeshToTensor> { return create_mesh_composer(mesh_device, config, shape); },
+        [](MeshDevice& mesh_device, const MeshComposerConfig& config) -> std::unique_ptr<MeshToTensor> {
+            return create_mesh_composer(mesh_device, config);
+        },
         py::arg("mesh_device"),
         py::arg("config"),
-        py::arg("shape") = std::nullopt,
         R"doc(
             Returns an ND composer that concatenates a tensor across the given dimensions.
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -97,6 +97,8 @@ def manage_config(name, value):
 from ttnn._ttnn.multi_device import (
     CppMeshToTensor,
     CppTensorToMesh,
+    PlacementReplicate,
+    PlacementShard,
     MeshMapperConfig,
     MeshComposerConfig,
     get_device_tensors,


### PR DESCRIPTION
### Ticket
#22258

### Problem description
Migrating pytorch-based sharding APIs to C++ to enable multi-host sharding requires better binding.

### What's changed
Propagated all config knobs from C++ APIs to Python.

Moved "mesh shape override" inside of config objects, for simplicity. Example of the API use:
```python
import torch, ttnn

torch_tensor = torch.arange(16).reshape(2,8)
tt_tensor = ttnn.from_torch(torch_tensor)
device = ttnn.open_mesh_device(ttnn.MeshShape(2,2))

mesh_mapper = ttnn.create_mesh_mapper(device, ttnn.MeshMapperConfig([ttnn.PlacementReplicate(), ttnn.PlacementShard(1)]))

tt_tensor = ttnn.distribute_tensor(tt_tensor, mesh_mapper)

print(tt_tensor)
```

Output:
```
ttnn.Tensor([[    0,     1,     2,     3],
             [    8,     9,    10,    11]], shape=Shape([2, 4]), dtype=DataType::UINT32, layout=Layout::ROW_MAJOR)
ttnn.Tensor([[    4,     5,     6,     7],
             [   12,    13,    14,    15]], shape=Shape([2, 4]), dtype=DataType::UINT32, layout=Layout::ROW_MAJOR)
ttnn.Tensor([[    0,     1,     2,     3],
             [    8,     9,    10,    11]], shape=Shape([2, 4]), dtype=DataType::UINT32, layout=Layout::ROW_MAJOR)
ttnn.Tensor([[    4,     5,     6,     7],
             [   12,    13,    14,    15]], shape=Shape([2, 4]), dtype=DataType::UINT32, layout=Layout::ROW_MAJOR)
```

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15717397826)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15717401516)
- [x] New/Existing tests provide coverage for changes