### PR TITLE
Cleanup test fixtures

### DIFF
--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -23,7 +23,9 @@ class CommandQueueFixture : public DispatchFixture {
 protected:
     tt::tt_metal::IDevice* device_;
     void SetUp() override {
-        this->validate_dispatch_mode();
+        if (!this->validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         this->create_device();
     }
@@ -34,14 +36,15 @@ protected:
         }
     }
 
-    void validate_dispatch_mode() {
+    bool validate_dispatch_mode() {
         this->slow_dispatch_ = false;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch) {
             log_info(tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
             this->slow_dispatch_ = true;
-            GTEST_SKIP();
+            return false;
         }
+        return true;
     }
 
     void create_device(const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
@@ -62,7 +65,9 @@ class CommandQueueProgramFixture : public CommandQueueFixture {};
 class CommandQueueTraceFixture : public CommandQueueFixture {
 protected:
     void SetUp() override {
-        this->validate_dispatch_mode();
+        if (!this->validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     }
 
@@ -72,21 +77,28 @@ protected:
 class CommandQueueSingleCardFixture : virtual public DispatchFixture {
 protected:
     void SetUp() override {
-        this->validate_dispatch_mode();
+        if (!this->validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         this->create_devices();
     }
 
-    void TearDown() override { tt::tt_metal::detail::CloseDevices(reserved_devices_); }
+    void TearDown() override {
+        if (!reserved_devices_.empty()) {
+            tt::tt_metal::detail::CloseDevices(reserved_devices_);
+        }
+    }
 
-    void validate_dispatch_mode() {
+    bool validate_dispatch_mode() {
         this->slow_dispatch_ = false;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch) {
             log_info(tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
             this->slow_dispatch_ = false;
-            GTEST_SKIP();
+            return false;
         }
+        return true;
     }
 
     void create_devices(const std::size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
@@ -124,7 +136,9 @@ class CommandQueueSingleCardBufferFixture : public CommandQueueSingleCardFixture
 class CommandQueueSingleCardTraceFixture : virtual public CommandQueueSingleCardFixture {
 protected:
     void SetUp() override {
-        this->validate_dispatch_mode();
+        if (!this->validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         this->create_devices(90000000);
     }

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -17,9 +17,15 @@
 namespace tt::tt_metal {
 
 class DeviceFixture : public DispatchFixture {
+private:
+    std::map<chip_id_t, tt::tt_metal::IDevice*> id_to_device_;
+
 protected:
     void SetUp() override {
-        this->validate_dispatch_mode();
+        // Save time. Don't do any setup if invalid dispatch mode
+        if (!this->validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         // Some CI machines have lots of cards, running all tests on all cards is slow
@@ -36,21 +42,37 @@ protected:
         this->create_devices(ids);
     }
 
-    void validate_dispatch_mode() {
+    void TearDown() override {
+        // Device not initialized if skipped
+        if (!id_to_device_.empty()) {
+            tt::tt_metal::detail::CloseDevices(id_to_device_);
+        }
+    }
+
+    bool validate_dispatch_mode() {
         this->slow_dispatch_ = true;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (!slow_dispatch) {
             log_info(tt::LogTest, "This suite can only be run with slow dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
             this->slow_dispatch_ = false;
-            GTEST_SKIP();
+            return false;
         }
+        return true;
     }
 
     void create_devices(const std::vector<chip_id_t>& device_ids) {
         const auto& dispatch_core_config =
             tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
-        tt::DevicePool::initialize(device_ids, 1, l1_small_size_, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
-        this->devices_ = tt::DevicePool::instance().get_all_active_devices();
+        id_to_device_ = tt::tt_metal::detail::CreateDevices(
+            device_ids,
+            tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs(),
+            l1_small_size_,
+            DEFAULT_TRACE_REGION_SIZE,
+            dispatch_core_config);
+        devices_.clear();
+        for (auto [device_id, device] : id_to_device_) {
+            devices_.push_back(device);
+        }
         this->num_devices_ = this->devices_.size();
     }
 
@@ -81,21 +103,28 @@ public:
 class DeviceSingleCardFixture : public DispatchFixture {
 protected:
     void SetUp() override {
-        this->validate_dispatch_mode();
+        if (!this->validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         this->create_devices();
     }
 
-    void TearDown() override { tt::tt_metal::detail::CloseDevices(reserved_devices_); }
+    void TearDown() override {
+        if (!reserved_devices_.empty()) {
+            tt::tt_metal::detail::CloseDevices(reserved_devices_);
+        }
+    }
 
-    virtual void validate_dispatch_mode() {
+    virtual bool validate_dispatch_mode() {
         this->slow_dispatch_ = true;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (!slow_dispatch) {
             log_info(tt::LogTest, "This suite can only be run with slow dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
             this->slow_dispatch_ = false;
-            GTEST_SKIP();
+            return false;
         }
+        return true;
     }
 
     void create_devices() {
@@ -116,7 +145,9 @@ class DeviceSingleCardBufferFixture : public DeviceSingleCardFixture {};
 class BlackholeSingleCardFixture : public DeviceSingleCardFixture {
 protected:
     void SetUp() override {
-        this->validate_dispatch_mode();
+        if (!this->validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         if (this->arch_ != tt::ARCH::BLACKHOLE) {
             GTEST_SKIP();
@@ -127,13 +158,14 @@ protected:
 
 class DeviceSingleCardFastSlowDispatchFixture : public DeviceSingleCardFixture {
    protected:
-    void validate_dispatch_mode() override {
-        this->slow_dispatch_ = true;
-        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        if (!slow_dispatch) {
-            this->slow_dispatch_ = false;
-        }
-    }
+       bool validate_dispatch_mode() override {
+           this->slow_dispatch_ = true;
+           auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+           if (!slow_dispatch) {
+               this->slow_dispatch_ = false;
+           }
+           return true;
+       }
 };
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
@@ -4,9 +4,12 @@
 
 #pragma once
 
+#include <umd/device/types/cluster_descriptor_types.h>
 #include "gtest/gtest.h"
+#include <map>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "hostdevcommon/common_values.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/command_queue.hpp>
@@ -18,6 +21,9 @@ namespace tt::tt_metal {
 
 // A dispatch-agnostic test fixture
 class DispatchFixture : public ::testing::Test {
+private:
+    std::map<chip_id_t, tt::tt_metal::IDevice*> id_to_device_;
+
 public:
     // A function to run a program, according to which dispatch mode is set.
     void RunProgram(tt::tt_metal::IDevice* device, tt::tt_metal::Program& program, const bool skip_finish = false) {
@@ -74,54 +80,38 @@ protected:
 
     void SetUp() override {
         this->DetectDispatchMode();
-        // Set up all available devices
+        // Must set up all available devices
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         auto num_devices = tt::tt_metal::GetNumAvailableDevices();
         std::vector<chip_id_t> ids;
         for (unsigned int id = 0; id < num_devices; id++) {
-            if (SkipTest(id)) {
-                continue;
-            }
             ids.push_back(id);
         }
         const auto& dispatch_core_config =
             tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
-        tt::DevicePool::initialize(
+        id_to_device_ = tt::tt_metal::detail::CreateDevices(
             ids,
             tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs(),
             l1_small_size_,
             DEFAULT_TRACE_REGION_SIZE,
             dispatch_core_config);
-        devices_ = tt::DevicePool::instance().get_all_active_devices();
+        devices_.clear();
+        for (auto [device_id, device] : id_to_device_) {
+            devices_.push_back(device);
+        }
     }
 
     void TearDown() override {
-        tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(false);
-        // Close all opened devices
-        for (unsigned int id = 0; id < devices_.size(); id++) {
-            // The test may ahve closed the device already, so only close if active.
-            if (devices_.at(id)->is_initialized()) {
-                tt::tt_metal::CloseDevice(devices_.at(id));
-            }
+        // Checking if devices are empty because DPrintFixture.TensixTestPrintFinish already
+        // closed all devices
+        if (!id_to_device_.empty()) {
+            tt::tt_metal::detail::CloseDevices(id_to_device_);
+            id_to_device_.clear();
+            devices_.clear();
         }
-    }
-
-    bool SkipTest(unsigned int device_id) {
-        // Also skip all devices after device 0 for grayskull. This to match all other tests
-        // targetting device 0 by default (and to not cause issues with BMs that have E300s).
-        // TODO: when we can detect only supported devices, this check can be removed.
-        if (this->arch_ == tt::ARCH::GRAYSKULL && device_id > 0) {
-            log_info(tt::LogTest, "Skipping test on device {} due to unsupported E300", device_id);
-            return true;
-        }
-
-        return false;
     }
 
     void RunTestOnDevice(const std::function<void()>& run_function, tt::tt_metal::IDevice* device) {
-        if (SkipTest(device->id())) {
-            return;
-        }
         log_info(tt::LogTest, "Running test on device {}.", device->id());
         run_function();
         log_info(tt::LogTest, "Finished running test on device {}.", device->id());

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_before_finish.cpp
@@ -44,7 +44,7 @@ static void RunTest(DPrintFixture* fixture, IDevice* device) {
 
     // Run the program, use a large delay for the last print to emulate a long-running kernel.
     uint32_t clk_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device->id());
-    uint32_t delay_cycles = clk_mhz * 2000000; // 2 seconds
+    uint32_t delay_cycles = clk_mhz * 4000000;  // 4 seconds
     for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
         for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
             const std::vector<uint32_t> args = { delay_cycles, x, y };
@@ -57,8 +57,8 @@ static void RunTest(DPrintFixture* fixture, IDevice* device) {
         }
     }
     fixture->RunProgram(device, program);
-    // Close the device instantly after running to attempt to cut off prints.
-    tt::tt_metal::CloseDevice(device);
+    // Close system instantly after running to attempt to cut off prints.
+    fixture->TearDownTestSuite();
 
     // Check the print log against expected output.
     vector<string> expected_output;

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
@@ -72,8 +72,6 @@ TEST_F(WatcherFixture, ActiveEthTestWatcherEthLinkCheck) {
     }
 
     // Close devices to trigger watcher check on teardown.
-    for (IDevice* device : this->devices_) {
-        tt::tt_metal::CloseDevice(device);
-    }
+    TearDown();
     EXPECT_TRUE(FileContainsAllStrings(this->log_file_name, expected_strings));
 }

--- a/tests/tt_metal/tt_metal/device/galaxy_fixture.hpp
+++ b/tests/tt_metal/tt_metal/device/galaxy_fixture.hpp
@@ -9,40 +9,26 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/device_pool.hpp>
-#include "multi_device_fixture.hpp"
+#include "dispatch_fixture.hpp"
 
 namespace tt::tt_metal {
 
-class GalaxyFixture : public MultiDeviceFixture {
+class GalaxyFixture : public DispatchFixture {
 protected:
-    void SkipTestSuiteIfNotGalaxyMotherboard() {
+    bool SkipTestSuiteIfNotGalaxyMotherboard() {
         const size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
         if (!(this->arch_ == tt::ARCH::WORMHOLE_B0 && num_devices >= 32)) {
-            GTEST_SKIP();
+            return true;
         }
-    }
-
-    void InitializeDevices() {
-        const size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
-        std::vector<chip_id_t> ids;
-        for (uint32_t id = 0; id < num_devices; id++) {
-            ids.push_back(id);
-        }
-        this->device_ids_to_devices_ = tt::tt_metal::detail::CreateDevices(ids);
-        this->devices_ = tt::DevicePool::instance().get_all_active_devices();
+        return false;
     }
 
     void SetUp() override {
-        MultiDeviceFixture::SetUp();
         this->DetectDispatchMode();
-        this->SkipTestSuiteIfNotGalaxyMotherboard();
-        this->InitializeDevices();
-    }
-
-    void TearDown() override {
-        tt::tt_metal::detail::CloseDevices(this->device_ids_to_devices_);
-        this->device_ids_to_devices_.clear();
-        this->devices_.clear();
+        if (this->SkipTestSuiteIfNotGalaxyMotherboard()) {
+            GTEST_SKIP() << "Not a galaxy mobo";
+        }
+        DispatchFixture::SetUp();
     }
 
 private:
@@ -52,38 +38,28 @@ private:
 class TGFixture : public GalaxyFixture {
 protected:
     void SkipTestSuiteIfNotTG() {
-        this->SkipTestSuiteIfNotGalaxyMotherboard();
+        if (this->SkipTestSuiteIfNotGalaxyMotherboard()) {
+            GTEST_SKIP() << "Not a galaxy mobo";
+        }
         const size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
         const size_t num_pcie_devices = tt::tt_metal::GetNumPCIeDevices();
         if (!(num_devices == 32 && num_pcie_devices == 4)) {
-            GTEST_SKIP();
+            GTEST_SKIP() << "This test can only run on TG";
         }
-    }
-
-    void SetUp() override {
-        MultiDeviceFixture::SetUp();
-        this->DetectDispatchMode();
-        this->SkipTestSuiteIfNotTG();
-        this->InitializeDevices();
     }
 };
 
 class TGGFixture : public GalaxyFixture {
 protected:
     void SkipTestSuiteIfNotTGG() {
-        this->SkipTestSuiteIfNotGalaxyMotherboard();
+        if (this->SkipTestSuiteIfNotGalaxyMotherboard()) {
+            GTEST_SKIP() << "Not a galaxy mobo";
+        }
         const size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
         const size_t num_pcie_devices = tt::tt_metal::GetNumPCIeDevices();
         if (!(num_devices == 64 && num_pcie_devices == 8)) {
-            GTEST_SKIP();
+            GTEST_SKIP() << "This test can only run on TGG";
         }
-    }
-
-    void SetUp() override {
-        MultiDeviceFixture::SetUp();
-        this->DetectDispatchMode();
-        this->SkipTestSuiteIfNotTGG();
-        this->InitializeDevices();
     }
 };
 

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -234,7 +234,7 @@ TEST_F(DeviceFixture, TensixValidateKernelDoesNotTargetHarvestedCores) {
             uint32_t read_address =
                 l1_address + this->devices_.at(id)->allocator()->get_bank_offset(BufferType::L1, bank_id);
             tt_metal::detail::ReadFromDeviceL1(this->devices_.at(id), logical_core, read_address, size_bytes, output);
-            ASSERT_TRUE(output.size() == host_input.size());
+            ASSERT_EQ(output.size(), host_input.size());
             uint32_t expected_value =
                 bank_id_to_value.at(bank_id) + 1;  // ping_legal_l1s kernel increments each value it reads
             ASSERT_TRUE(output.at(0) == expected_value) << "Logical core " + logical_core.str() + " should have " +

--- a/tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp
@@ -159,14 +159,15 @@ TEST_F(N300DeviceFixture, ActiveEthValidateEthernetSockets) {
     std::vector<CoreCoord> device_0_sockets = device_0->get_ethernet_sockets(1);
     std::vector<CoreCoord> device_1_sockets = device_1->get_ethernet_sockets(0);
 
-    ASSERT_TRUE(device_0_sockets.size() == 2);
-    ASSERT_TRUE(device_1_sockets.size() == 2);
-    ASSERT_TRUE(
-        device_0->get_connected_ethernet_core(device_0_sockets.at(0)) ==
+    // There are 2 in total. But expecting 1 because 1 is used for dispatching to remote device.
+    ASSERT_EQ(device_0_sockets.size(), 1);
+    ASSERT_EQ(device_1_sockets.size(), 1);
+    ASSERT_EQ(
+        device_0->get_connected_ethernet_core(device_0_sockets.at(0)),
         std::make_tuple(device_1->id(), device_1_sockets.at(0)));
-    ASSERT_TRUE(
-        device_0->get_connected_ethernet_core(device_0_sockets.at(1)) ==
-        std::make_tuple(device_1->id(), device_1_sockets.at(1)));
+    ASSERT_EQ(
+        device_0->get_connected_ethernet_core(device_0_sockets.at(0)),
+        std::make_tuple(device_1->id(), device_1_sockets.at(0)));
     EXPECT_ANY_THROW(device_0->get_ethernet_sockets(2));
 }
 }  // namespace unit_tests::multichip::cluster

--- a/tests/tt_metal/tt_metal/device/test_device_pool.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_pool.cpp
@@ -26,8 +26,8 @@ TEST(DevicePool, DevicePoolOpenClose) {
     DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     auto devices = DevicePool::instance().get_all_active_devices();
     for (const auto& dev : devices) {
-        ASSERT_TRUE((int)(dev->allocator()->get_config().l1_small_size) == l1_small_size);
-        ASSERT_TRUE((int)(dev->num_hw_cqs()) == num_hw_cqs);
+        ASSERT_EQ((int)(dev->allocator()->get_config().l1_small_size), l1_small_size);
+        ASSERT_EQ((int)(dev->num_hw_cqs()), num_hw_cqs);
         ASSERT_TRUE(dev->is_initialized());
     }
 
@@ -37,8 +37,8 @@ TEST(DevicePool, DevicePoolOpenClose) {
     }
     devices = DevicePool::instance().get_all_active_devices();
     for (const auto& dev : devices) {
-        ASSERT_TRUE((int)(dev->allocator()->get_config().l1_small_size) == l1_small_size);
-        ASSERT_TRUE((int)(dev->num_hw_cqs()) == num_hw_cqs);
+        ASSERT_EQ((int)(dev->allocator()->get_config().l1_small_size), l1_small_size);
+        ASSERT_EQ((int)(dev->num_hw_cqs()), num_hw_cqs);
         ASSERT_TRUE(dev->is_initialized());
     }
     for (const auto& dev : devices) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/program_with_kernel_created_from_string_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/program_with_kernel_created_from_string_fixture.hpp
@@ -19,8 +19,6 @@ protected:
         }
     }
 
-    void TearDown() override { detail::CloseDevices(this->device_ids_to_devices_); }
-
 private:
     std::map<chip_id_t, IDevice*> device_ids_to_devices_;
 };

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -224,9 +224,8 @@ bool cb_config_successful(IDevice* device, Program& program, const DummyProgramM
     return pass;
 }
 
-bool test_dummy_EnqueueProgram_with_runtime_args(IDevice* device, const CoreCoord& eth_core_coord) {
+void test_dummy_EnqueueProgram_with_runtime_args(IDevice* device, const CoreCoord& eth_core_coord) {
     Program program;
-    bool pass = true;
     auto eth_noc_xy = device->ethernet_core_from_logical_core(eth_core_coord);
 
     constexpr uint32_t num_runtime_args0 = 9;
@@ -257,9 +256,7 @@ bool test_dummy_EnqueueProgram_with_runtime_args(IDevice* device, const CoreCoor
             tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED),
         dummy_kernel0_args.size() * sizeof(uint32_t));
 
-    pass &= (dummy_kernel0_args == dummy_kernel0_args_readback);
-
-    return pass;
+    ASSERT_EQ(dummy_kernel0_args, dummy_kernel0_args_readback);
 }
 
 bool test_dummy_EnqueueProgram_with_cbs(IDevice* device, CommandQueue& cq, DummyProgramMultiCBConfig& program_config) {
@@ -1185,7 +1182,7 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixSetCommonRuntimeArgsMultipleC
 TEST_F(CommandQueueSingleCardProgramFixture, ActiveEthEnqueueDummyProgram) {
     for (const auto& device : devices_) {
         for (const auto& eth_core : device->get_active_ethernet_cores(true)) {
-            ASSERT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(device, eth_core));
+            local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(device, eth_core);
         }
     }
 }
@@ -1876,7 +1873,7 @@ TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TensixTestRandomizedProgram)
             if (i % 10 == 0) {
                 log_debug(
                     tt::LogTest,
-                    "Enqueueing {} programs on cq {} for iter: {}/{} now.",
+                    "Enqueuing {} programs on cq {} for iter: {}/{} now.",
                     programs.size(),
                     (uint32_t)cq_id,
                     i + 1,
@@ -2145,8 +2142,7 @@ TEST_F(CommandQueueProgramFixture, TensixTestRandomizedProgram) {
         auto rng = std::default_random_engine{};
         std::shuffle(std::begin(programs), std::end(programs), rng);
         if (i % 50 == 0) {
-            log_info(
-                tt::LogTest, "Enqueueing {} programs for iter: {}/{} now.", programs.size(), i + 1, NUM_ITERATIONS);
+            log_info(tt::LogTest, "Enqueuing {} programs for iter: {}/{} now.", programs.size(), i + 1, NUM_ITERATIONS);
         }
         for (Program& program : programs) {
             EnqueueProgram(this->device_->command_queue(), program, false);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
@@ -160,7 +160,7 @@ TEST_P(RingbufferCacheRandomizedTestsFixture, RandomizedQueries) {
                 << ", pgm_size: " << pgm_size << ", offset: " << result->offset
                 << ", next_block_offset: " << get_next_block_offset() << std::endl;
         }
-        ASSERT_TRUE(get_manager_entry_size() >= std::min(params.initial_manager_size, params.cache_size_blocks))
+        ASSERT_GE(get_manager_entry_size(), std::min(params.initial_manager_size, params.cache_size_blocks))
             << "Manager size: " << get_manager_entry_size() << ", cache size: " << params.cache_size_blocks
             << ", initial manager size: " << params.initial_manager_size << ", oldest_idx: " << get_oldest_idx()
             << ", next_index: " << get_next_idx() << ", oldest_block_offset: " << get_oldest_block_offset()
@@ -172,7 +172,7 @@ TEST_P(RingbufferCacheRandomizedTestsFixture, RandomizedQueries) {
     auto end_rbcache = std::chrono::high_resolution_clock::now();
     auto duration_rbcache = std::chrono::duration_cast<std::chrono::milliseconds>(end_rbcache - start_rbcache).count();
     std::cout << "Ringbuffer cache runtime: " << duration_rbcache << " ms, hits: " << hits_count << std::endl;
-    ASSERT_TRUE(get_manager_entry_size() <= params.cache_size_blocks)
+    ASSERT_LE(get_manager_entry_size(), params.cache_size_blocks)
         << "Manager size: " << get_manager_entry_size() << ", cache size: " << params.cache_size_blocks << std::endl;
     std::cout << "Cache size: " << params.cache_size_blocks << ", initial manager size: " << params.initial_manager_size
               << ", final manager size: " << get_manager_entry_size() << std::endl;

--- a/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
@@ -9,10 +9,10 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <gtest/gtest.h>
 #include <tt-metalium/circular_buffer_constants.h>
 #include <tt-metalium/kernel.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "impl/context/metal_context.hpp"
 #include "dispatch_test_utils.hpp"
 
 namespace tt::tt_metal {
@@ -71,8 +71,11 @@ protected:
 
     void SetUp() override {
         CommandQueueSingleCardProgramFixture::SetUp();
-        this->device_ = this->devices_[0];
-        this->initialize_seed();
+        if (!::testing::Test::IsSkipped()) {
+            // Parent may have skipped
+            this->device_ = this->devices_[0];
+            this->initialize_seed();
+        }
     }
 
     void initialize_seed() {
@@ -364,8 +367,11 @@ protected:
 
     void SetUp() override {
         CommandQueueSingleCardTraceFixture::SetUp();
-        this->device_ = this->devices_[0];
-        this->initialize_seed();
+        if (!::testing::Test::IsSkipped()) {
+            // Parent may have skipped
+            this->device_ = this->devices_[0];
+            this->initialize_seed();
+        }
     }
 
     uint32_t trace_programs() {

--- a/tests/tt_metal/tt_metal/lightmetal/lightmetal_fixture.hpp
+++ b/tests/tt_metal/tt_metal/lightmetal/lightmetal_fixture.hpp
@@ -28,9 +28,10 @@ protected:
     size_t trace_region_size_;
 
     void SetUp() override {
-        this->validate_dispatch_mode();
+        if (!this->validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-        TT_FATAL(!this->IsSlowDispatch(), "Test is running in slow dispatch mode, which is not supported.");
     }
 
     void CreateDeviceAndBeginCapture(

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -33,11 +33,12 @@ protected:
     size_t num_devices_ = 0;
 
 public:
-    void check_slow_dispatch() {
+    bool check_dispatch_mode() {
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch) {
-            GTEST_SKIP() << "Skipping test, since it can only be run in Fast Dispatch Mode.";
+            return false;
         }
+        return true;
     }
 
 public:
@@ -75,7 +76,9 @@ protected:
     std::shared_ptr<tt::tt_metal::distributed::MeshDevice> device_holder_;
 
     void SetUp() override {
-        check_slow_dispatch();
+        if (!check_dispatch_mode()) {
+            GTEST_SKIP() << "Skipping test, since it can only be run in Fast Dispatch Mode.";
+        }
 
         DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER;
         if (arch_ == tt::ARCH::WORMHOLE_B0 and num_devices_ != 1) {
@@ -95,7 +98,9 @@ protected:
     std::map<chip_id_t, std::shared_ptr<tt::tt_metal::distributed::MeshDevice>> devs;
 
     void SetUp() override {
-        check_slow_dispatch();
+        if (!check_dispatch_mode()) {
+            GTEST_SKIP() << "Skipping test, since it can only be run in Fast Dispatch Mode.";
+        }
 
         if (num_devices_ < 8 or arch_ != tt::ARCH::WORMHOLE_B0) {
             GTEST_SKIP() << "Skipping T3K Multi CQ test suite on non T3K machine.";


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18726

### Problem description
- GTEST_SKIP was being used outside of SetUp() during setup. This made the remainder of setup continue and also teardown when it wasn't needed
- Some tests fail but don't show which values were wrong

### What's changed
- GTEST_SKIP needs to be called inside the actual test function or in SetUp() otherwise undefined behavior
- Removed some duplicate logic. Consolidated fixture logic to top level fixtures such as DispatchFixture
- Use the CloseDevices API instead of calling close on individual devices which has missing steps
- Replaced ASSERT_TRUE with ASSERT_EQ where it might be useful to see the different results
- Deleted the MultiDeviceFixture. This was doing the same thing as DispatchFixture

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15719231138

T3K
https://github.com/tenstorrent/tt-metal/actions/runs/15719758306

BH
https://github.com/tenstorrent/tt-metal/actions/runs/15719227040/job/44296844522

TG
https://github.com/tenstorrent/tt-metal/actions/runs/15719760804