### PR TITLE
#22258: Migrate Pytorch sharding to C++

### DIFF
--- a/models/experimental/stable_diffusion_35_large/tt/linear.py
+++ b/models/experimental/stable_diffusion_35_large/tt/linear.py
@@ -73,7 +73,13 @@ class TtLinearParameters:
             bias = bias.unsqueeze(0)
 
         if shard_dim in [0, -2]:
-            bias_mm = _ShardBias(device)
+            # Shard the bias of a linear operation on the first dimension.
+            # A single device receive the bias as is, while the other ones receive zero tensors of the same
+            # shape so that the bias is not added multiple times after gathering.
+            mesh_height, mesh_width = device.shape
+            zeros = torch.zeros_like(bias)
+            bias = torch.cat([bias] + [zeros] * (mesh_width - 1), dim=0)
+            bias_mm = ttnn.ShardTensor2dMesh(device, mesh_shape=(mesh_height, mesh_width), dims=(None, 0))
         elif shard_dim in [1, -1]:
             bias_mm = ttnn.ShardTensorToMesh(device, 1)
         else:
@@ -298,30 +304,3 @@ class TtLinear:
             output = output.reshape([output.shape[0], 1, 1, output.shape[-1]])
 
         return output
-
-
-class _ShardBias(ttnn.TensorToMesh):
-    """A mesh mapper for sharding the bias of a linear operation.
-
-    This mesh mapper is intended for sharding the bias of a linear operation on the first dimension.
-    A single device receive the bias as is, while the other ones receive zero tensors of the same
-    shape so that the bias is not added multiple times after gathering.
-    """
-
-    def __init__(self, mesh_device: ttnn.MeshDevice) -> None:
-        super().__init__(mesh_device)
-
-    def map(self, tensor: torch.Tensor) -> dict[int, ttnn.Tensor]:
-        mesh_height, mesh_width = self.mesh_device.shape
-
-        zeros = torch.zeros_like(tensor)
-        return ([tensor] + [zeros] * (mesh_width - 1)) * mesh_height
-
-    def config(self) -> dict[str, str]:
-        mesh_height, mesh_width = self.mesh_device.shape
-
-        return {
-            "strategy": "shard_2d",
-            "mesh_shape_y": str(mesh_height),
-            "mesh_shape_x": str(mesh_width),
-        }

--- a/tests/sweep_framework/sweeps/ccl/all_gather_n300.py
+++ b/tests/sweep_framework/sweeps/ccl/all_gather_n300.py
@@ -98,7 +98,7 @@ def run(
     input_tensors = torch.chunk(input_tensor, num_devices, dim)
     tt_input_tensors = []
     for i, t in enumerate(input_tensors):
-        tt_input_tensors.append(ttnn.Tensor(t, input_dtype, {}, ttnn.Tile(tile)).to(layout))
+        tt_input_tensors.append(ttnn.Tensor(tensor=t, data_type=input_dtype, tile=ttnn.Tile(tile)).to(layout))
 
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(device, mem_config)
     for i in range(num_iters):

--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include "host_buffer.hpp"
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
 
 #include "ttnn/distributed/api.hpp"
@@ -23,6 +24,15 @@ using ::testing::Pointwise;
 
 TensorSpec get_tensor_spec(const ttnn::Shape& shape, DataType dtype) {
     return TensorSpec(shape, TensorLayout(dtype, Layout::ROW_MAJOR, MemoryConfig{}));
+}
+
+// Returns the number of unique buffers in host-side multi-device tensor.
+int count_unique_buffers(const Tensor& tensor) {
+    const auto& storage = std::get<tt::tt_metal::MultiDeviceHostStorage>(tensor.storage());
+    std::unordered_set<const void*> buffer_addresses;
+    storage.distributed_buffer().apply(
+        [&buffer_addresses](const HostBuffer& buffer) { buffer_addresses.insert(buffer.view_bytes().data()); });
+    return buffer_addresses.size();
 }
 
 class AggregateTensorTest : public GenericMeshDeviceFixture,
@@ -123,7 +133,9 @@ TEST_F(TensorDistributionT3000Test, Shard1DFewerShardsThanDevices) {
         Tensor::from_vector(test_data, get_tensor_spec(ttnn::Shape{1, num_devices - 1, 3, 1}, DataType::FLOAT32));
 
     auto mapper = shard_tensor_to_mesh_mapper(*mesh_device_, 1);
-    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
+    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    EXPECT_EQ(count_unique_buffers(sharded_tensor), mesh_device_->num_devices() - 1);
 
     std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
     EXPECT_EQ(device_tensors.size(), mesh_device_->num_devices() - 1);
@@ -166,7 +178,9 @@ TEST_F(TensorDistributionT3000Test, Shard1D) {
         Tensor::from_vector(test_data, get_tensor_spec(ttnn::Shape{1, num_devices, 3, 1}, DataType::FLOAT32));
 
     auto mapper = shard_tensor_to_mesh_mapper(*mesh_device_, 1);
-    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
+    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    EXPECT_EQ(count_unique_buffers(sharded_tensor), mesh_device_->num_devices());
 
     std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
     EXPECT_EQ(device_tensors.size(), mesh_device_->num_devices());
@@ -202,7 +216,9 @@ TEST_P(TensorDistributionT3000Test2D, FullyReplicated) {
             .placements = {MeshMapperConfig::Replicate{}, MeshMapperConfig::Replicate{}},
             .mesh_shape_override = MeshShape(num_rows, num_cols),
         });
-    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
+    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    EXPECT_EQ(count_unique_buffers(sharded_tensor), 1);
 
     std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
     EXPECT_EQ(device_tensors.size(), num_devices);
@@ -237,7 +253,9 @@ TEST_P(TensorDistributionT3000Test2D, ReplicateDim) {
             .placements = {MeshMapperConfig::Shard{1}, MeshMapperConfig::Replicate{}},
             .mesh_shape_override = MeshShape(num_rows, num_cols),
         });
-    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
+    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    EXPECT_EQ(count_unique_buffers(sharded_tensor), num_rows);
 
     std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
     EXPECT_EQ(device_tensors.size(), num_devices);
@@ -271,7 +289,9 @@ TEST_P(TensorDistributionT3000Test2D, ShardDims) {
             .placements = {MeshMapperConfig::Shard{1}, MeshMapperConfig::Shard{2}},
             .mesh_shape_override = MeshShape(num_rows, num_cols),
         });
-    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
+    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    EXPECT_EQ(count_unique_buffers(sharded_tensor), num_rows * num_cols);
 
     std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
     EXPECT_EQ(device_tensors.size(), num_devices);
@@ -403,7 +423,9 @@ TEST_F(TensorDistributionT3000Test, NdMapperShard3D) {
                 },
             .mesh_shape_override = MeshShape(2, 2, 2),
         });
-    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
+    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    EXPECT_EQ(count_unique_buffers(sharded_tensor), 2 * 2);
 
     std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
     EXPECT_EQ(device_tensors.size(), mesh_device_->num_devices());

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather.py
@@ -1176,7 +1176,7 @@ def run_all_gather_sharded(
 
     tt_input_tensors = []
     for i, t in enumerate(input_tensors):
-        tt_input_tensors.append(ttnn.Tensor(t, input_dtype, {}, ttnn.Tile(tile)).to(tensor_layout))
+        tt_input_tensors.append(ttnn.Tensor(tensor=t, data_type=input_dtype, tile=ttnn.Tile(tile)).to(tensor_layout))
 
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(mesh_device, input_mem_config)
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_matmul.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_matmul.py
@@ -59,7 +59,7 @@ def run_all_gather_matmul_on_t3000_impl(
     input_tensors = torch.chunk(input_tensor, num_devices, dim)
     tt_input_tensors = []
     for i, t in enumerate(input_tensors):
-        tt_input_tensors.append(ttnn.Tensor(t, ag_input_dtype, {}, ttnn.Tile(tile)).to(layout))
+        tt_input_tensors.append(ttnn.Tensor(tensor=t, data_type=ag_input_dtype, tile=ttnn.Tile(tile)).to(layout))
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(t3k_mesh_device, mem_config_input)
 
     ##### Create the weight matrix for the matmul #####

--- a/tt_metal/api/tt-metalium/host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/host_buffer.hpp
@@ -62,6 +62,9 @@ public:
     template <typename T>
     tt::stl::Span<const T> view_as() const&& = delete;
 
+    // Returns the memory pin of the host buffer.
+    MemoryPin pin() const { return pin_; }
+
 private:
     MemoryPin pin_;
     tt::stl::Span<std::byte> view_;

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include <tt_stl/small_vector.hpp>
+#include <tt-metalium/memory_pin.hpp>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/distributed/types.hpp"
@@ -90,8 +91,9 @@ public:
     // materialized.
     template <typename T>
     Tensor operator()(
-        tt::stl::Span<const T> buffer,
+        tt::stl::Span<T> buffer,
         const ttnn::Shape& shape,
+        const tt::tt_metal::MemoryPin& buffer_pin,
         const tt::tt_metal::TensorLayout& layout,
         T pad_value = 0) const;
 
@@ -167,11 +169,13 @@ Tensor distribute_tensor(
 
 // Creates a distributed tensor from a span of logical data specified in `buffer`.
 // `global_shape` must match the size of `buffer`; shapes of shards will be derived automatically based on the `mapper`,
-// and the `shard_layout` will be applied subsequently.
+// and the `shard_layout` will be applied subsequently. `buffer` may be re-used to create tensors directly, taking
+// `buffer_pin` as the RAII to retain reference count to the object.
 template <typename T>
 Tensor create_distributed_tensor(
-    tt::stl::Span<const T> buffer,
+    tt::stl::Span<T> buffer,
     const ttnn::Shape& global_shape,
+    const tt::tt_metal::MemoryPin& buffer_pin,
     const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device = std::nullopt,

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -166,10 +166,13 @@ Tensor distribute_tensor(
     ttnn::QueueId cq_id = ttnn::DefaultQueueId);
 
 // Creates a distributed tensor from a span of logical data specified in `buffer`.
+// `global_shape` must match the size of `buffer`; shapes of shards will be derived automatically based on the `mapper`,
+// and the `shard_layout` will be applied subsequently.
 template <typename T>
 Tensor create_distributed_tensor(
     tt::stl::Span<const T> buffer,
-    const TensorSpec& spec,
+    const ttnn::Shape& global_shape,
+    const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device = std::nullopt,
     ttnn::QueueId cq_id = ttnn::DefaultQueueId,

--- a/ttnn/api/ttnn/tensor/serialization.hpp
+++ b/ttnn/api/ttnn/tensor/serialization.hpp
@@ -11,8 +11,7 @@
 
 namespace tt::tt_metal {
 
-void dump_tensor(
-    const std::string& file_name, const Tensor& tensor, const std::unordered_map<std::string, std::string>& strategy);
+void dump_tensor(const std::string& file_name, const Tensor& tensor);
 
 Tensor load_tensor(const std::string& file_name, distributed::MeshDevice* device = nullptr);
 

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -112,6 +112,16 @@ public:
         const ttnn::Shape& shape,
         const std::function<void()>& on_creation_callback,
         const std::function<void()>& on_destruction_callback,
+        const std::optional<Tile>& tile = std::nullopt) {
+        return from_borrowed_data(buffer, shape, MemoryPin(on_creation_callback, on_destruction_callback), tile);
+    }
+
+    // Overload that takes a memory pin.
+    template <typename T>
+    [[nodiscard]] static Tensor from_borrowed_data(
+        tt::stl::Span<T> buffer,
+        const ttnn::Shape& shape,
+        tt::tt_metal::MemoryPin buffer_pin,
         const std::optional<Tile>& tile = std::nullopt);
 
     // Same as `from_span`, but operates on a vector instead.

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -426,10 +426,20 @@ void py_module(py::module& module) {
     module.def("close_mesh_device", &close_mesh_device, py::arg("mesh_device"), py::kw_only());
 
     auto py_placement_shard = static_cast<py::class_<MeshMapperConfig::Shard>>(module.attr("PlacementShard"));
-    py_placement_shard.def(py::init([](size_t dim) { return MeshMapperConfig::Shard{dim}; }));
+    py_placement_shard.def(py::init([](int dim) { return MeshMapperConfig::Shard{dim}; }))
+        .def("__repr__", [](const MeshMapperConfig::Shard& shard) {
+            std::ostringstream str;
+            str << shard;
+            return str.str();
+        });
     auto py_placement_replicate =
         static_cast<py::class_<MeshMapperConfig::Replicate>>(module.attr("PlacementReplicate"));
-    py_placement_replicate.def(py::init([]() { return MeshMapperConfig::Replicate{}; }));
+    py_placement_replicate.def(py::init([]() { return MeshMapperConfig::Replicate{}; }))
+        .def("__repr__", [](const MeshMapperConfig::Replicate& replicate) {
+            std::ostringstream str;
+            str << replicate;
+            return str.str();
+        });
     auto py_mesh_mapper_config = static_cast<py::class_<MeshMapperConfig>>(module.attr("MeshMapperConfig"));
 
     py_mesh_mapper_config

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -513,48 +513,42 @@ Tensor create_distributed_tensor(
 }
 
 // Explicit instantiation of `create_distributed_tensor` for supported data types.
-template <>
-Tensor create_distributed_tensor<bfloat16>(
+template Tensor create_distributed_tensor<bfloat16>(
     tt::stl::Span<const bfloat16> buffer,
     const TensorSpec& spec,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     bfloat16 pad_value);
-template <>
-Tensor create_distributed_tensor<float>(
+template Tensor create_distributed_tensor<float>(
     tt::stl::Span<const float> buffer,
     const TensorSpec& spec,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     float pad_value);
-template <>
-Tensor create_distributed_tensor<int32_t>(
+template Tensor create_distributed_tensor<int32_t>(
     tt::stl::Span<const int32_t> buffer,
     const TensorSpec& spec,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     int32_t pad_value);
-template <>
-Tensor create_distributed_tensor<uint8_t>(
+template Tensor create_distributed_tensor<uint8_t>(
     tt::stl::Span<const uint8_t> buffer,
     const TensorSpec& spec,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     uint8_t pad_value);
-template <>
-Tensor create_distributed_tensor<uint16_t>(
+template Tensor create_distributed_tensor<uint16_t>(
     tt::stl::Span<const uint16_t> buffer,
     const TensorSpec& spec,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     uint16_t pad_value);
-template <>
-Tensor create_distributed_tensor<uint32_t>(
+template Tensor create_distributed_tensor<uint32_t>(
     tt::stl::Span<const uint32_t> buffer,
     const TensorSpec& spec,
     const TensorToMesh& mapper,

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -68,8 +68,8 @@ TensorSpec compute_tensor_spec_for_shards(
 std::ostream& operator<<(std::ostream& os, const MeshMapperConfig::Placement& placement) {
     std::visit(
         tt::stl::overloaded{
-            [&](const MeshMapperConfig::Replicate& replicate) { os << "Replicate()"; },
-            [&](const MeshMapperConfig::Shard& shard) { os << "Shard(" << shard.dim << ")"; },
+            [&](const MeshMapperConfig::Replicate& replicate) { os << "PlacementReplicate()"; },
+            [&](const MeshMapperConfig::Shard& shard) { os << "PlacementShard(" << shard.dim << ")"; },
         },
         placement);
     return os;

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -506,12 +506,13 @@ Tensor distribute_tensor(
 template <typename T>
 Tensor create_distributed_tensor(
     tt::stl::Span<const T> buffer,
-    const TensorSpec& spec,
+    const ttnn::Shape& global_shape,
+    const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     T pad_value) {
-    Tensor output = mapper(buffer, spec.logical_shape(), spec.tensor_layout(), pad_value);
+    Tensor output = mapper(buffer, global_shape, shard_layout, pad_value);
     if (mesh_device.has_value()) {
         return output.to_device(&(mesh_device->get()), output.memory_config(), cq_id);
     }
@@ -521,42 +522,48 @@ Tensor create_distributed_tensor(
 // Explicit instantiation of `create_distributed_tensor` for supported data types.
 template Tensor create_distributed_tensor<bfloat16>(
     tt::stl::Span<const bfloat16> buffer,
-    const TensorSpec& spec,
+    const ttnn::Shape& global_shape,
+    const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     bfloat16 pad_value);
 template Tensor create_distributed_tensor<float>(
     tt::stl::Span<const float> buffer,
-    const TensorSpec& spec,
+    const ttnn::Shape& global_shape,
+    const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     float pad_value);
 template Tensor create_distributed_tensor<int32_t>(
     tt::stl::Span<const int32_t> buffer,
-    const TensorSpec& spec,
+    const ttnn::Shape& global_shape,
+    const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     int32_t pad_value);
 template Tensor create_distributed_tensor<uint8_t>(
     tt::stl::Span<const uint8_t> buffer,
-    const TensorSpec& spec,
+    const ttnn::Shape& global_shape,
+    const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     uint8_t pad_value);
 template Tensor create_distributed_tensor<uint16_t>(
     tt::stl::Span<const uint16_t> buffer,
-    const TensorSpec& spec,
+    const ttnn::Shape& global_shape,
+    const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     uint16_t pad_value);
 template Tensor create_distributed_tensor<uint32_t>(
     tt::stl::Span<const uint32_t> buffer,
-    const TensorSpec& spec,
+    const ttnn::Shape& global_shape,
+    const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -122,6 +122,19 @@ public:
         SUBMESH,
     };
 
+    // Returns a function that remaps a mesh coordinate from the mesh mapper shape ("distribution_shape") to the
+    // device shape ("global_shape").
+    static auto get_remap_fn(DistributionMode distribution_mode, const MeshCoordinateRange* global_range) {
+        return [distribution_mode, global_range, row_major_dst = global_range->begin()](
+                   const MeshCoordinate& src_coord) mutable {
+            switch (distribution_mode) {
+                case DistributionMode::ROW_MAJOR: return *(row_major_dst++);
+                case DistributionMode::SUBMESH: return src_coord;
+            }
+            TT_THROW("Unreachable");
+        };
+    }
+
     Impl(
         const MeshDevice& mesh_device,
         DistributionMode distribution_mode,
@@ -129,6 +142,7 @@ public:
         const MeshMapperConfig& config,
         const tt::tt_metal::DistributedTensorConfig& distributed_tensor_config) :
         global_shape_(mesh_device.shape()),
+        global_range_(global_shape_),
         local_shape_(mesh_device.shape()),
         local_offset_(MeshCoordinate::zero_coordinate(mesh_device.shape().dims())),
         distribution_mode_(distribution_mode),
@@ -138,21 +152,15 @@ public:
 
     Tensor operator()(const Tensor& tensor) const {
         auto extract_logical_data = [this]<typename T>(const tt::tt_metal::Tensor& tensor) -> Tensor {
-            std::vector<T> logical_data;
-            auto data_span = [&]() {
-                const bool data_viewable =
-                    tensor.tensor_spec().layout() == tt::tt_metal::Layout::ROW_MAJOR &&
-                    tensor.tensor_spec().physical_shape() == tensor.tensor_spec().logical_2d_shape();
-                if (data_viewable) {
-                    tt::tt_metal::HostBuffer buffer = tt::tt_metal::host_buffer::get_host_buffer(tensor);
-                    return buffer.view_as<const T>();
-                } else {
-                    logical_data = tensor.to_vector<T>();
-                    return tt::stl::make_const_span(logical_data);
-                }
-            }();
-
-            return (*this)(data_span, tensor.tensor_spec().logical_shape(), tensor.tensor_spec().tensor_layout());
+            const bool data_viewable = tensor.tensor_spec().layout() == tt::tt_metal::Layout::ROW_MAJOR &&
+                                       tensor.tensor_spec().physical_shape() == tensor.tensor_spec().logical_2d_shape();
+            tt::tt_metal::HostBuffer host_buffer = data_viewable ? tt::tt_metal::host_buffer::get_host_buffer(tensor)
+                                                                 : tt::tt_metal::HostBuffer(tensor.to_vector<T>());
+            return (*this)(
+                host_buffer.view_as<T>(),
+                tensor.tensor_spec().logical_shape(),
+                host_buffer.pin(),
+                tensor.tensor_spec().tensor_layout());
         };
 
         switch (tensor.tensor_spec().data_type()) {
@@ -171,16 +179,14 @@ public:
 
     template <typename T>
     Tensor operator()(
-        tt::stl::Span<const T> span,
+        tt::stl::Span<T> span,
         const Shape& shape,
+        const tt::tt_metal::MemoryPin& buffer_pin,
         const tt::tt_metal::TensorLayout& layout,
         T pad_value = 0) const {
         size_t volume = shape.volume();
         TT_FATAL(
             span.size() == volume, "Current buffer size is {} different from shape volume {}", span.size(), volume);
-
-        std::vector<size_t> shape_vec(shape.cbegin(), shape.cend());
-        auto input_xtensor = xt::adapt(span.data(), span.size(), xt::no_ownership(), shape_vec);
 
         // Perform sharding, followed by replication.
         tt::stl::SmallVector<size_t> shard_dims;
@@ -199,6 +205,31 @@ public:
                 replicate_dims.push_back(mesh_dim_idx);
             }
         }
+
+        // Optimize a fully replicated path, which can use the same buffer for all shards.
+        if (shard_dims.empty()) {
+            const TensorSpec tensor_spec(shape, layout);
+            tt::tt_metal::HostBuffer replicated_buffer;
+            if (const bool pydata_borrowable = tensor_spec.layout() == tt::tt_metal::Layout::ROW_MAJOR &&
+                                               tensor_spec.physical_shape() == tensor_spec.logical_2d_shape() &&
+                                               tensor_spec.data_type() == tt::tt_metal::convert_to_data_type<T>()) {
+                replicated_buffer = tt::tt_metal::HostBuffer(span, buffer_pin);
+            } else {
+                replicated_buffer = tt::tt_metal::host_buffer::get_host_buffer(Tensor::from_span(
+                    tt::stl::make_const_span(span), tensor_spec, /*device=*/nullptr, ttnn::DefaultQueueId, pad_value));
+            }
+            auto distributed_buffer =
+                tt::tt_metal::DistributedHostBuffer::create(global_shape_, local_shape_, local_offset_);
+            auto remap_fn = get_remap_fn(distribution_mode_, &global_range_);
+            for (const auto& coord : MeshCoordinateRange(distribution_shape_)) {
+                distributed_buffer.emplace_shard(remap_fn(coord), [&b = replicated_buffer]() { return b; });
+            }
+            return Tensor(tt::tt_metal::MultiDeviceHostStorage(std::move(distributed_buffer)), tensor_spec, config());
+        }
+
+        // Otherwise, use xtensor to chunk the data into shards.
+        std::vector<size_t> shape_vec(shape.cbegin(), shape.cend());
+        auto input_xtensor = xt::adapt(span.data(), span.size(), xt::no_ownership(), shape_vec);
 
         auto chunks = experimental::xtensor::chunk_ndim(input_xtensor, num_chunks_per_dim, tensor_dims);
         TT_FATAL(chunks.size() >= 1, "No chunks were produced");
@@ -266,15 +297,7 @@ private:
 
         auto distributed_buffer =
             tt::tt_metal::DistributedHostBuffer::create(global_shape_, local_shape_, local_offset_);
-        const auto global_range = MeshCoordinateRange(global_shape_);
-
-        auto get_dst_coord = [this, row_major_dst = global_range.begin()](const MeshCoordinate& src_coord) mutable {
-            switch (distribution_mode_) {
-                case DistributionMode::ROW_MAJOR: return *(row_major_dst++);
-                case DistributionMode::SUBMESH: return src_coord;
-            }
-            TT_THROW("Unreachable");
-        };
+        auto remap_fn = get_remap_fn(distribution_mode_, &global_range_);
 
         // Deduplicate processing of replicated buffers, by keeping a cache of already converted buffers.
         using XTensorViewKey = decltype(&sharded_xtensor_views.values().front()->get());
@@ -283,7 +306,7 @@ private:
         for (const auto& [coord, xtensor_view] : sharded_xtensor_views) {
             if (xtensor_view.has_value()) {
                 distributed_buffer.emplace_shard(
-                    get_dst_coord(coord), [&converted_buffers, &xtensor_view, &shard_spec, &coord, pad_value]() {
+                    remap_fn(coord), [&converted_buffers, &xtensor_view, &shard_spec, &coord, pad_value]() {
                         // The callable makes a copy from the strided xtensor view to a vector; on multi-host systems,
                         // executed only for shards that are local to this host.
 
@@ -310,6 +333,7 @@ private:
 
     // MeshDevice parameters.
     MeshShape global_shape_;
+    MeshCoordinateRange global_range_;
     MeshShape local_shape_;
     MeshCoordinate local_offset_;
     DistributionMode distribution_mode_ = DistributionMode::ROW_MAJOR;
@@ -373,11 +397,12 @@ Tensor TensorToMesh::operator()(const Tensor& tensor) const { return (*impl_)(te
 
 template <typename T>
 Tensor TensorToMesh::operator()(
-    tt::stl::Span<const T> buffer,
+    tt::stl::Span<T> buffer,
     const ttnn::Shape& shape,
+    const tt::tt_metal::MemoryPin& buffer_pin,
     const tt::tt_metal::TensorLayout& layout,
     T pad_value) const {
-    return (*impl_)(buffer, shape, layout, pad_value);
+    return (*impl_)(buffer, shape, buffer_pin, layout, pad_value);
 }
 
 tt::tt_metal::DistributedTensorConfig TensorToMesh::config() const { return impl_->config(); }
@@ -505,14 +530,15 @@ Tensor distribute_tensor(
 
 template <typename T>
 Tensor create_distributed_tensor(
-    tt::stl::Span<const T> buffer,
+    tt::stl::Span<T> buffer,
     const ttnn::Shape& global_shape,
+    const tt::tt_metal::MemoryPin& buffer_pin,
     const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     T pad_value) {
-    Tensor output = mapper(buffer, global_shape, shard_layout, pad_value);
+    Tensor output = mapper(buffer, global_shape, buffer_pin, shard_layout, pad_value);
     if (mesh_device.has_value()) {
         return output.to_device(&(mesh_device->get()), output.memory_config(), cq_id);
     }
@@ -521,48 +547,54 @@ Tensor create_distributed_tensor(
 
 // Explicit instantiation of `create_distributed_tensor` for supported data types.
 template Tensor create_distributed_tensor<bfloat16>(
-    tt::stl::Span<const bfloat16> buffer,
+    tt::stl::Span<bfloat16> buffer,
     const ttnn::Shape& global_shape,
+    const tt::tt_metal::MemoryPin& buffer_pin,
     const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     bfloat16 pad_value);
 template Tensor create_distributed_tensor<float>(
-    tt::stl::Span<const float> buffer,
+    tt::stl::Span<float> buffer,
     const ttnn::Shape& global_shape,
+    const tt::tt_metal::MemoryPin& buffer_pin,
     const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     float pad_value);
 template Tensor create_distributed_tensor<int32_t>(
-    tt::stl::Span<const int32_t> buffer,
+    tt::stl::Span<int32_t> buffer,
     const ttnn::Shape& global_shape,
+    const tt::tt_metal::MemoryPin& buffer_pin,
     const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     int32_t pad_value);
 template Tensor create_distributed_tensor<uint8_t>(
-    tt::stl::Span<const uint8_t> buffer,
+    tt::stl::Span<uint8_t> buffer,
     const ttnn::Shape& global_shape,
+    const tt::tt_metal::MemoryPin& buffer_pin,
     const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     uint8_t pad_value);
 template Tensor create_distributed_tensor<uint16_t>(
-    tt::stl::Span<const uint16_t> buffer,
+    tt::stl::Span<uint16_t> buffer,
     const ttnn::Shape& global_shape,
+    const tt::tt_metal::MemoryPin& buffer_pin,
     const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
     uint16_t pad_value);
 template Tensor create_distributed_tensor<uint32_t>(
-    tt::stl::Span<const uint32_t> buffer,
+    tt::stl::Span<uint32_t> buffer,
     const ttnn::Shape& global_shape,
+    const tt::tt_metal::MemoryPin& buffer_pin,
     const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -283,8 +283,7 @@ Tensor load_tensor(const std::string& file_name, MeshDevice* device) {
     return tensor;
 }
 
-void dump_tensor(
-    const std::string& file_name, const Tensor& tensor, const std::unordered_map<std::string, std::string>& strategy) {
+void dump_tensor(const std::string& file_name, const Tensor& tensor) {
     FILE* output_file = fopen(file_name.c_str(), "wb");
     if (not output_file) {
         TT_THROW("Cannot open \"{}\"", file_name);
@@ -313,9 +312,9 @@ void dump_tensor(
             [output_file, dtype = tensor.dtype()](const DeviceStorage& storage) {
                 TT_THROW("Device storage isn't supported");
             },
-            [output_file, &strategy, &tensor_spec = tensor.tensor_spec()](const MultiDeviceHostStorage& storage) {
-                auto distribute_config = get_distributed_tensor_config(strategy);
-                dump_multi_device_host_storage(output_file, storage, distribute_config, tensor_spec);
+            [output_file, &tensor](const MultiDeviceHostStorage& storage) {
+                dump_multi_device_host_storage(
+                    output_file, storage, tensor.distributed_tensor_config(), tensor.tensor_spec());
             },
         },
         tensor_to_dump.storage());

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -390,38 +390,32 @@ template Tensor Tensor::from_span<uint32_t>(
 template Tensor Tensor::from_borrowed_data<float>(
     tt::stl::Span<float> buffer,
     const ttnn::Shape& shape,
-    const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback,
+    tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<bfloat16>(
     tt::stl::Span<bfloat16> buffer,
     const ttnn::Shape& shape,
-    const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback,
+    tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<int32_t>(
     tt::stl::Span<int32_t> buffer,
     const ttnn::Shape& shape,
-    const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback,
+    tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<uint8_t>(
     tt::stl::Span<uint8_t> buffer,
     const ttnn::Shape& shape,
-    const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback,
+    tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<uint16_t>(
     tt::stl::Span<uint16_t> buffer,
     const ttnn::Shape& shape,
-    const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback,
+    tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<uint32_t>(
     tt::stl::Span<uint32_t> buffer,
     const ttnn::Shape& shape,
-    const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback,
+    tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile);
 template Tensor Tensor::from_vector<bfloat16>(
     std::vector<bfloat16>&& buffer,

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -258,14 +258,12 @@ template <typename T>
 Tensor Tensor::from_borrowed_data(
     tt::stl::Span<T> buffer,
     const ttnn::Shape& shape,
-    const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback,
+    tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile) {
     size_t volume = shape.volume();
     TT_FATAL(
         buffer.size() == volume, "Current buffer size is {} different from shape volume {}", buffer.size(), volume);
-    HostBuffer data_buffer(buffer, MemoryPin(on_creation_callback, on_destruction_callback));
-    return Tensor(std::move(data_buffer), shape, convert_to_data_type<T>(), Layout::ROW_MAJOR, tile);
+    return Tensor(HostBuffer(buffer, std::move(buffer_pin)), shape, convert_to_data_type<T>(), Layout::ROW_MAJOR, tile);
 }
 
 template <>

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -887,7 +887,7 @@ void pytensor_module(py::module& m_tensor) {
                 +--------------+--------------------------------+
                 | data_type    | TT Tensor data type (optional) |
                 +--------------+--------------------------------+
-                | mesh_mapper  | TTNN Mesh Mapper (optional)    |
+                | mesh_mapper  | TT-NN Mesh Mapper (optional)    |
                 +--------------+--------------------------------+
                 | tile         | TT Tile Spec (optional)        |
                 +--------------+--------------------------------+

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -42,10 +42,8 @@
 using namespace tt::tt_metal;
 
 namespace ttnn::tensor {
-
-using tt::tt_metal::CoreCoord;
-
-namespace detail {
+namespace CMAKE_UNIQUE_NAMESPACE {
+namespace {
 
 #ifdef DEBUG
 
@@ -594,7 +592,8 @@ auto parse_external_operation(
     return std::make_tuple(operation, input_tensors);
 }
 
-}  // namespace detail
+}  // namespace
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 
 void pytensor_module_types(py::module& m_tensor) {
     // Tensor constructors that accept device and .to_device() function use keep alive call policy to communicate that
@@ -644,9 +643,9 @@ void pytensor_module(py::module& m_tensor) {
                 std::function([function, function_name](const py::args& args, const py::kwargs& kwargs) {
                     ZoneScopedN("TT_DNN_FALLBACK_OP");
                     auto [operation, input_tensors] =
-                        detail::parse_external_operation(function, args, kwargs, function_name);
+                        CMAKE_UNIQUE_NAMESPACE::parse_external_operation(function, args, kwargs, function_name);
                     GraphTracker::instance().track_function_start(operation.get_type_name(), args, kwargs);
-                    detail::log_external_operation(operation, input_tensors);
+                    CMAKE_UNIQUE_NAMESPACE::log_external_operation(operation, input_tensors);
                     auto output = function(*args, **kwargs);
                     TracyOpTTNNExternal(
                         operation, input_tensors, ttnn::CoreIDs::instance().fetch_and_increment_device_operation_id());
@@ -860,7 +859,7 @@ void pytensor_module(py::module& m_tensor) {
                           std::optional<Layout> optional_layout,
                           const std::optional<MemoryConfig>& optional_memory_config,
                           std::optional<float> pad_value) {
-                return detail::convert_python_tensor_to_tt_tensor(
+                return CMAKE_UNIQUE_NAMESPACE::convert_python_tensor_to_tt_tensor(
                     tensor,
                     data_type,
                     optional_layout,
@@ -914,7 +913,7 @@ void pytensor_module(py::module& m_tensor) {
                           const std::optional<Tile>& tile,
                           ttnn::QueueId cq_id,
                           std::optional<float> pad_value) {
-                return detail::convert_python_tensor_to_tt_tensor(
+                return CMAKE_UNIQUE_NAMESPACE::convert_python_tensor_to_tt_tensor(
                     python_tensor,
                     data_type,
                     layout,
@@ -1448,7 +1447,9 @@ void pytensor_module(py::module& m_tensor) {
             py::return_value_policy::reference)
         .def(
             "to_torch_with_padded_shape",
-            [](const Tensor& self) -> py::object { return detail::convert_tt_tensor_to_torch_tensor(self, true); },
+            [](const Tensor& self) -> py::object {
+                return CMAKE_UNIQUE_NAMESPACE::convert_tt_tensor_to_torch_tensor(self, true);
+            },
             R"doc(
             Convert tensor to torch tensor using legacy padded shape.
             WARNING: Will be deprecated soon!
@@ -1462,7 +1463,9 @@ void pytensor_module(py::module& m_tensor) {
         )doc")
         .def(
             "to_torch",
-            [](const Tensor& self) -> py::object { return detail::convert_tt_tensor_to_torch_tensor(self); },
+            [](const Tensor& self) -> py::object {
+                return CMAKE_UNIQUE_NAMESPACE::convert_tt_tensor_to_torch_tensor(self);
+            },
             R"doc(
             Convert tensor to torch tensor.
 
@@ -1475,7 +1478,9 @@ void pytensor_module(py::module& m_tensor) {
         )doc")
         .def(
             "to_numpy",
-            [](const Tensor& self) -> py::object { return detail::convert_tt_tensor_to_numpy_tensor(self); },
+            [](const Tensor& self) -> py::object {
+                return CMAKE_UNIQUE_NAMESPACE::convert_tt_tensor_to_numpy_tensor(self);
+            },
             R"doc(
             Convert tensor to numpy tensor.
 

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -917,7 +917,7 @@ void pytensor_module(py::module& m_tensor) {
                 return detail::convert_python_tensor_to_tt_tensor(
                     python_tensor,
                     data_type,
-                    layout.value_or(Layout::ROW_MAJOR),
+                    layout,
                     tile,
                     mem_config.value_or(MemoryConfig{}),
                     device.value_or(nullptr),
@@ -928,7 +928,7 @@ void pytensor_module(py::module& m_tensor) {
             py::arg("tensor"),
             py::arg("data_type") = std::nullopt,
             py::arg("device") = std::nullopt,
-            py::arg("layout").noconvert() = Layout::ROW_MAJOR,
+            py::arg("layout").noconvert() = std::nullopt,
             py::arg("mem_config").noconvert() = std::nullopt,
             py::arg("tile").noconvert() = std::nullopt,
             py::arg("cq_id") = ttnn::DefaultQueueId,

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -26,6 +26,7 @@
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/core.hpp"
 #include "ttnn/distributed/api.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -80,20 +81,28 @@ Tensor create_typed_tt_tensor_from_py_data(
     MeshDevice* device,
     const std::function<void()>& on_creation_callback,
     const std::function<void()>& on_destruction_callback,
-    const bool force_disable_borrow,
     ttnn::QueueId cq_id,
-    float pad_value) {
+    float pad_value,
+    const distributed::TensorToMesh* mesh_mapper) {
     TT_FATAL(
         !tensor_spec.memory_config().is_sharded() || tensor_spec.memory_config().shard_spec().has_value() ||
             tensor_spec.memory_config().nd_shard_spec().has_value(),
         "Sharded tensors must have a shard spec when converting to tt tensors!");
 
-    const bool pydata_borrowable = tensor_spec.layout() == Layout::ROW_MAJOR &&
-                                   tensor_spec.physical_shape() == tensor_spec.logical_2d_shape() &&
-                                   tensor_spec.data_type() == convert_to_data_type<T>();
-
     tt::stl::Span<T> pydata_span(reinterpret_cast<T*>(py_data_ptr), tensor_spec.logical_shape().volume());
-    if (pydata_borrowable && !force_disable_borrow) {
+
+    if (mesh_mapper != nullptr) {
+        return ttnn::distributed::create_distributed_tensor(
+            tt::stl::make_const_span(pydata_span),
+            tensor_spec,
+            *mesh_mapper,
+            device != nullptr ? std::make_optional(std::ref(*device)) : std::nullopt,
+            cq_id,
+            static_cast<T>(pad_value));
+    } else if (const bool pydata_borrowable = tensor_spec.layout() == Layout::ROW_MAJOR &&
+                                              tensor_spec.physical_shape() == tensor_spec.logical_2d_shape() &&
+                                              tensor_spec.data_type() == convert_to_data_type<T>();
+               pydata_borrowable) {
         auto output = Tensor::from_borrowed_data(
             pydata_span,
             tensor_spec.logical_shape(),
@@ -114,11 +123,11 @@ Tensor create_tt_tensor_from_py_data(
     std::size_t py_data_ptr,
     const TensorSpec& tensor_spec,
     MeshDevice* device,
-    const bool force_disable_borrow,
     const std::function<void()>& on_creation_callback,
     const std::function<void()>& on_destruction_callback,
     ttnn::QueueId cq_id,
-    float pad_value) {
+    float pad_value,
+    const distributed::TensorToMesh* mesh_mapper) {
     auto create_concrete = [&]<typename T>() {
         return create_typed_tt_tensor_from_py_data<T>(
             py_data_ptr,
@@ -126,9 +135,9 @@ Tensor create_tt_tensor_from_py_data(
             device,
             on_creation_callback,
             on_destruction_callback,
-            force_disable_borrow,
             cq_id,
-            pad_value);
+            pad_value,
+            mesh_mapper);
     };
     switch (tensor_spec.data_type()) {
         case DataType::UINT8: return create_concrete.operator()<uint8_t>();
@@ -136,9 +145,7 @@ Tensor create_tt_tensor_from_py_data(
         case DataType::INT32: return create_concrete.operator()<int32_t>();
         case DataType::UINT32: return create_concrete.operator()<uint32_t>();
         case DataType::FLOAT32: return create_concrete.operator()<float>();
-        // TODO: This is not supported for numpy
         case DataType::BFLOAT16: return create_concrete.operator()<bfloat16>();
-
         case DataType::BFLOAT8_B:
         case DataType::BFLOAT4_B: {
             return create_concrete.operator()<float>();
@@ -151,40 +158,19 @@ Tensor create_tt_tensor_from_py_data(
     TT_THROW("Unsupported DataType: {}", tensor_spec.data_type());
 }
 
-Tensor convert_python_tensor_to_tt_tensor(
-    const py::handle& py_tensor,
-    std::optional<DataType> optional_data_type,
-    std::optional<Layout> optional_layout,
-    const std::optional<Tile>& optional_tile,
-    const MemoryConfig& memory_config,
-    MeshDevice* device,
-    ttnn::QueueId cq_id,
-    float pad_value,
-    const bool force_disable_borrow = false) {
-    GraphTracker::instance().track_function_start(
-        "tt::tt_metal::detail::convert_python_tensor_to_tt_tensor",
-        py_tensor,
-        optional_data_type,
-        optional_layout,
-        optional_tile,
-        memory_config,
-        device,
-        cq_id,
-        pad_value,
-        force_disable_borrow);
-    py::object torch = py::module_::import("torch");
-    py::object np = py::module_::import("numpy");
-
-    auto py_dtype = py_tensor.attr("dtype");
-    auto shape = ttnn::Shape(py::cast<ttnn::SmallVector<uint32_t>>(py_tensor.attr("shape")));
-
-    DataType data_type;
-
+// Preprocess the python tensor, optionally performing dtype conversion.
+struct PreprocessedPyTensor {
+    DataType data_type = DataType::INVALID;
     py::object contiguous_py_tensor;
-    size_t num_elements = 0;
-    size_t py_data_ptr = 0;
-    if (py::isinstance(py_tensor, torch.attr("Tensor"))) {
-        contiguous_py_tensor = py_tensor.attr("contiguous")();
+    std::size_t num_elements = 0;
+    std::size_t py_data_ptr = 0;
+};
+
+PreprocessedPyTensor parse_py_tensor(const py::handle& py_tensor, std::optional<DataType> optional_data_type) {
+    const auto py_dtype = py_tensor.attr("dtype");
+    if (py::object torch = py::module_::import("torch"); py::isinstance(py_tensor, torch.attr("Tensor"))) {
+        py::object contiguous_py_tensor = py_tensor.attr("contiguous")();
+        DataType data_type = DataType::INVALID;
 
         // Override the data type if there is a user-provided one
         // Otherwise, figure it out from torch dtype
@@ -197,12 +183,10 @@ Tensor convert_python_tensor_to_tt_tensor(
         } else if (py_dtype.equal(torch.attr("bfloat16"))) {
             data_type = DataType::BFLOAT16;
         } else if (py_dtype.equal(torch.attr("int64"))) {
-            // TODO: add DataType::INT64?
             data_type = DataType::UINT32;
         } else if (py_dtype.equal(torch.attr("int32"))) {
             data_type = DataType::INT32;
         } else if (py_dtype.equal(torch.attr("int16"))) {
-            // TODO: add DataType::INT16?
             data_type = DataType::UINT16;
         } else if (py_dtype.equal(torch.attr("uint8"))) {
             data_type = DataType::UINT8;
@@ -245,12 +229,15 @@ Tensor convert_python_tensor_to_tt_tensor(
             }
         }
 
-        num_elements = py::cast<std::size_t>(contiguous_py_tensor.attr("numel")());
-        py_data_ptr = py::cast<std::size_t>(contiguous_py_tensor.attr("data_ptr")());
-    } else if (py::isinstance(py_tensor, np.attr("ndarray"))) {
-        TT_FATAL(!force_disable_borrow, "Disabling borrowed buffers for numpy tensors is untested!");
-
-        contiguous_py_tensor = np.attr("ascontiguousarray")(py_tensor);
+        return PreprocessedPyTensor{
+            .data_type = data_type,
+            .contiguous_py_tensor = contiguous_py_tensor,
+            .num_elements = py::cast<std::size_t>(contiguous_py_tensor.attr("numel")()),
+            .py_data_ptr = py::cast<std::size_t>(contiguous_py_tensor.attr("data_ptr")()),
+        };
+    } else if (py::object np = py::module_::import("numpy"); py::isinstance(py_tensor, np.attr("ndarray"))) {
+        py::object contiguous_py_tensor = np.attr("ascontiguousarray")(py_tensor);
+        DataType data_type = DataType::INVALID;
 
         // Override the data type if there is a user-provided one
         // Otherwise, figure it out from numpy dtype
@@ -304,24 +291,54 @@ Tensor convert_python_tensor_to_tt_tensor(
             }
         }
 
-        num_elements = py::cast<std::size_t>(contiguous_py_tensor.attr("size"));
-        py_data_ptr = py::cast<std::size_t>(py::cast<py::tuple>(
-            py::cast<py::dict>(contiguous_py_tensor.attr("__array_interface__"))[py::str("data")])[0]);
+        return PreprocessedPyTensor{
+            .data_type = data_type,
+            .contiguous_py_tensor = contiguous_py_tensor,
+            .num_elements = py::cast<std::size_t>(contiguous_py_tensor.attr("size")),
+            .py_data_ptr = py::cast<std::size_t>(py::cast<py::tuple>(
+                py::cast<py::dict>(contiguous_py_tensor.attr("__array_interface__"))[py::str("data")])[0]),
+        };
     } else {
         TT_THROW("The argument must be of type torch.Tensor or numpy.ndarray!");
     }
+}
 
-    // TODO: Remove check of num_elements from python against volume of ttnn::Shape
+Tensor convert_python_tensor_to_tt_tensor(
+    const py::handle& py_tensor,
+    std::optional<DataType> optional_data_type,
+    std::optional<Layout> optional_layout,
+    const std::optional<Tile>& optional_tile,
+    const MemoryConfig& memory_config,
+    MeshDevice* device,
+    ttnn::QueueId cq_id,
+    float pad_value,
+    const distributed::TensorToMesh* mesh_mapper) {
+    GraphTracker::instance().track_function_start(
+        "tt::tt_metal::detail::convert_python_tensor_to_tt_tensor",
+        py_tensor,
+        optional_data_type,
+        optional_layout,
+        optional_tile,
+        memory_config,
+        device,
+        cq_id,
+        pad_value,
+        mesh_mapper);
+
+    auto preprocessed_py_tensor = parse_py_tensor(py_tensor, optional_data_type);
+    const auto shape = ttnn::Shape(py::cast<ttnn::SmallVector<uint32_t>>(py_tensor.attr("shape")));
+
     TT_FATAL(
-        num_elements == shape.volume(),
+        preprocessed_py_tensor.num_elements == shape.volume(),
         "Number of elements from python tensor {} must match volume of shape {}!",
-        num_elements,
+        preprocessed_py_tensor.num_elements,
         shape.volume());
 
     const Layout layout = [&]() {
         // Block float types require tile layout.
         // Choose tile by default and disallow overriding to anything else.
-        if (data_type == DataType::BFLOAT8_B or data_type == DataType::BFLOAT4_B) {
+        if (preprocessed_py_tensor.data_type == DataType::BFLOAT8_B ||
+            preprocessed_py_tensor.data_type == DataType::BFLOAT4_B) {
             TT_FATAL(
                 !optional_layout.has_value() or *optional_layout == Layout::TILE,
                 "Tile layout is required for tensor of type bfloat8_b or bfloat4_b; got {}.",
@@ -332,56 +349,20 @@ Tensor convert_python_tensor_to_tt_tensor(
         }
     }();
 
-    auto tensor_spec = TensorSpec(shape, TensorLayout(data_type, PageConfig(layout, optional_tile), memory_config));
-    auto on_creation_callback = [tensor = contiguous_py_tensor] { tensor.inc_ref(); };
-    auto on_destruction_callback = [tensor = contiguous_py_tensor] { tensor.dec_ref(); };
+    auto tensor_spec = TensorSpec(
+        shape, TensorLayout(preprocessed_py_tensor.data_type, PageConfig(layout, optional_tile), memory_config));
+    auto on_creation_callback = [t = preprocessed_py_tensor.contiguous_py_tensor] { t.inc_ref(); };
+    auto on_destruction_callback = [t = preprocessed_py_tensor.contiguous_py_tensor] { t.dec_ref(); };
     auto output = create_tt_tensor_from_py_data(
-        py_data_ptr,
+        preprocessed_py_tensor.py_data_ptr,
         tensor_spec,
         device,
-        force_disable_borrow,
         on_creation_callback,
         on_destruction_callback,
         cq_id,
-        pad_value);
-
-    output = tt::tt_metal::set_tensor_id(output);
-    GraphTracker::instance().track_function_end(output);
-    return output;
-}
-
-Tensor convert_python_tensors_to_tt_tensors(
-    py::list tensor_shards,
-    std::optional<DataType> data_type,
-    std::optional<Layout> optional_layout,
-    const std::optional<Tile>& optional_tile,
-    const MemoryConfig& memory_config,
-    ttnn::QueueId cq_id,
-    float pad_value,
-    const std::unordered_map<std::string, std::string>& strategy) {
-    GraphTracker::instance().track_function_start(
-        "tt::tt_metal::detail::convert_python_tensors_to_tt_tensors",
-        tensor_shards,
-        data_type,
-        optional_layout,
-        optional_tile,
-        memory_config,
         pad_value,
-        strategy);
-    std::vector<Tensor> tt_shards;
-    for (const auto& shard : tensor_shards) {
-        tt_shards.push_back(detail::convert_python_tensor_to_tt_tensor(
-            shard,
-            data_type,
-            optional_layout,
-            optional_tile,
-            memory_config,
-            /*device=*/nullptr,
-            cq_id,
-            pad_value,
-            /*force_disable_borrow=*/true));
-    }
-    auto output = distributed::aggregate_as_tensor(tt_shards, get_distributed_tensor_config(strategy));
+        mesh_mapper);
+
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
@@ -874,22 +855,11 @@ void pytensor_module(py::module& m_tensor) {
         .def(
             py::init<>([](const py::object& tensor,
                           std::optional<DataType> data_type,
-                          const std::unordered_map<std::string, std::string>& strategy,
+                          const distributed::TensorToMesh* mesh_mapper,
                           const std::optional<Tile>& optional_tile,
                           std::optional<Layout> optional_layout,
                           const std::optional<MemoryConfig>& optional_memory_config,
                           std::optional<float> pad_value) {
-                if (py::isinstance<py::list>(tensor)) {
-                    return detail::convert_python_tensors_to_tt_tensors(
-                        tensor,
-                        data_type,
-                        optional_layout,
-                        optional_tile,
-                        optional_memory_config.value_or(MemoryConfig{}),
-                        ttnn::DefaultQueueId,
-                        pad_value.value_or(0.0f),
-                        strategy);
-                }
                 return detail::convert_python_tensor_to_tt_tensor(
                     tensor,
                     data_type,
@@ -898,11 +868,12 @@ void pytensor_module(py::module& m_tensor) {
                     optional_memory_config.value_or(MemoryConfig{}),
                     /*device=*/nullptr,
                     ttnn::DefaultQueueId,
-                    pad_value.value_or(0.0f));
+                    pad_value.value_or(0.0f),
+                    mesh_mapper);
             }),
             py::arg("tensor"),
             py::arg("data_type") = std::nullopt,
-            py::arg("strategy") = std::unordered_map<std::string, std::string>(),
+            py::arg("mesh_mapper") = nullptr,
             py::arg("tile") = std::nullopt,
             py::arg("layout") = std::nullopt,
             py::arg("mem_config") = std::nullopt,
@@ -916,7 +887,7 @@ void pytensor_module(py::module& m_tensor) {
                 +--------------+--------------------------------+
                 | data_type    | TT Tensor data type (optional) |
                 +--------------+--------------------------------+
-                | strategy     | TT Strategy (optional)         |
+                | mesh_mapper  | TTNN Mesh Mapper (optional)    |
                 +--------------+--------------------------------+
                 | tile         | TT Tile Spec (optional)        |
                 +--------------+--------------------------------+
@@ -951,7 +922,8 @@ void pytensor_module(py::module& m_tensor) {
                     mem_config.value_or(MemoryConfig{}),
                     device.value_or(nullptr),
                     cq_id,
-                    pad_value.value_or(0.0f));
+                    pad_value.value_or(0.0f),
+                    /*mesh_mapper=*/nullptr);
             }),
             py::arg("tensor"),
             py::arg("data_type") = std::nullopt,
@@ -1431,7 +1403,6 @@ void pytensor_module(py::module& m_tensor) {
 
         )doc")
         .def(
-            // TODO: Rename to volume
             "logical_volume",
             [](const Tensor& self) { return self.logical_volume(); },
             R"doc(

--- a/ttnn/cpp/ttnn-pybind/tensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/tensor.cpp
@@ -288,7 +288,6 @@ void tensor_mem_config_module(py::module& m_tensor) {
         &dump_tensor,
         py::arg("filename"),
         py::arg("tensor"),
-        py::arg("strategy") = std::unordered_map<std::string, std::string>{},
         R"doc(
             Dump tensor to file
         )doc");

--- a/ttnn/ttnn/distributed/__init__.py
+++ b/ttnn/ttnn/distributed/__init__.py
@@ -9,6 +9,7 @@ from .distributed import (
     MeshToTensor,
     TensorToMesh,
     ReplicateTensorToMesh,
+    ReplicateTensorToMeshWrapper,
     ShardTensorToMesh,
     ShardTensor2dMesh,
     ConcatMeshToTensor,

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -199,18 +199,27 @@ def create_mesh_device(*args, **kwargs):
 TensorToMesh = ttnn.CppTensorToMesh
 
 
+# Deprecated. Prefer to use `ttnn.replicate_tensor_to_mesh_mapper` directly.
 def ReplicateTensorToMesh(mesh_device: MeshDevice):
     return ttnn.replicate_tensor_to_mesh_mapper(mesh_device)
 
 
+# Deprecated. Prefer to use `ttnn.shard_tensor_to_mesh_mapper` directly.
 def ShardTensorToMesh(mesh_device: MeshDevice, dim: int):
     return ttnn.shard_tensor_to_mesh_mapper(mesh_device, dim)
 
 
+# Deprecated. Prefer to create `ttnn.MeshMapperConfig` directly.
 def ShardTensor2dMesh(mesh_device: MeshDevice, mesh_shape: Tuple[int, int], dims: Tuple[Optional[int], Optional[int]]):
     return ttnn.create_mesh_mapper(
         mesh_device,
-        ttnn.MeshMapperConfig(shard_dim[0], shard_dim[1], ttnn.MeshShape(mesh_shape[0], mesh_shape[1])),
+        ttnn.MeshMapperConfig(
+            [
+                ttnn.PlacementShard(dims[0]) if dims[0] else ttnn.PlacementReplicate(),
+                ttnn.PlacementShard(dims[1]) if dims[1] else ttnn.PlacementReplicate(),
+            ],
+            ttnn.MeshShape(mesh_shape[0], mesh_shape[1]),
+        ),
     )
 
 

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -199,9 +199,19 @@ def create_mesh_device(*args, **kwargs):
 TensorToMesh = ttnn.CppTensorToMesh
 
 
+# Workaround needed to differentiate mappers created by `ReplicateTensorToMesh`, which use a different file name used for caching.
+class ReplicateTensorToMeshWrapper:
+    def __init__(self, mapper: ttnn.CppTensorToMesh):
+        self._mapper = mapper
+
+    def unwrap(self):
+        return self._mapper
+
+
 # Deprecated. Prefer to use `ttnn.replicate_tensor_to_mesh_mapper` directly.
 def ReplicateTensorToMesh(mesh_device: MeshDevice):
-    return ttnn.replicate_tensor_to_mesh_mapper(mesh_device)
+    mapper = ttnn.replicate_tensor_to_mesh_mapper(mesh_device)
+    return ReplicateTensorToMeshWrapper(mapper)
 
 
 # Deprecated. Prefer to use `ttnn.shard_tensor_to_mesh_mapper` directly.

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -325,7 +325,7 @@ class ConcatMeshToTensor(MeshToTensor):
 
 
 @contextlib.contextmanager
-def distribute(default: Union[TensorToMesh, MeshToTensor]):
+def distribute(default: Union[ttnn.CppTensorToMesh, ReplicateTensorToMeshWrapper, MeshToTensor]):
     """
     Context manager to temporarily modify the behavior of ttnn.from_torch and ttnn.to_torch to use the specified
     mesh_mapper or mesh_composer for tensor distribution and composition to/from MeshDevice.
@@ -333,7 +333,7 @@ def distribute(default: Union[TensorToMesh, MeshToTensor]):
     Invocations of ttnn.to_torch(..) will use the mesh_composer as defined by the default in ttnn.distribute.
 
     Args:
-        mesh_mapper_or_composer (Union[TensorToMesh, MeshToTensor]): An instance of either TensorToMesh or MeshToTensor
+        mesh_mapper_or_composer (Union[ttnn.CppTensorToMesh, ReplicateTensorToMeshWrapper, MeshToTensor]): An instance of either TensorToMesh or MeshToTensor
             used to map tensors to a mesh or compose tensors from a mesh.
 
     Example:
@@ -348,7 +348,7 @@ def distribute(default: Union[TensorToMesh, MeshToTensor]):
     _original_from_torch = ttnn.from_torch
 
     try:
-        if isinstance(default, TensorToMesh):
+        if isinstance(default, ttnn.CppTensorToMesh) or isinstance(default, ReplicateTensorToMeshWrapper):
             ttnn.from_torch = functools.partial(_original_from_torch, mesh_mapper=default)
         elif isinstance(default, MeshToTensor):
             ttnn.to_torch = functools.partial(_original_to_torch, mesh_composer=default)

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -215,8 +215,8 @@ def ShardTensor2dMesh(mesh_device: MeshDevice, mesh_shape: Tuple[int, int], dims
         mesh_device,
         ttnn.MeshMapperConfig(
             [
-                ttnn.PlacementShard(dims[0]) if dims[0] else ttnn.PlacementReplicate(),
-                ttnn.PlacementShard(dims[1]) if dims[1] else ttnn.PlacementReplicate(),
+                ttnn.PlacementReplicate() if dims[0] is None else ttnn.PlacementShard(dims[0]),
+                ttnn.PlacementReplicate() if dims[1] is None else ttnn.PlacementShard(dims[1]),
             ],
             ttnn.MeshShape(mesh_shape[0], mesh_shape[1]),
         ),

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -194,20 +194,24 @@ def create_mesh_device(*args, **kwargs):
         close_mesh_device(mesh_device)
 
 
-class TensorToMesh:
-    """
-    Defines the mapping of a torch.Tensor to a device mesh: e.g. Shard/Replicate.
-    You can also "Bring your own TensorToMesh" based on your custom mapping.
-    """
+# TODO: #22258 - Temporary stubs to accomodate migration of Python-based sharding to C++.
+# Remove once migration is complete.
+TensorToMesh = ttnn.CppTensorToMesh
 
-    def __init__(self, mesh_device):
-        self.mesh_device = mesh_device
 
-    def map(self, tensor: "torch.Tensor"):
-        raise NotImplementedError("Subclasses must implement this method")
+def ReplicateTensorToMesh(mesh_device: MeshDevice):
+    return ttnn.replicate_tensor_to_mesh_mapper(mesh_device)
 
-    def config(self):
-        raise NotImplementedError("Subclasses must implement this method")
+
+def ShardTensorToMesh(mesh_device: MeshDevice, dim: int):
+    return ttnn.shard_tensor_to_mesh_mapper(mesh_device, dim)
+
+
+def ShardTensor2dMesh(mesh_device: MeshDevice, mesh_shape: Tuple[int, int], dims: Tuple[Optional[int], Optional[int]]):
+    return ttnn.create_mesh_mapper(
+        mesh_device,
+        ttnn.MeshMapperConfig(shard_dim[0], shard_dim[1], ttnn.MeshShape(mesh_shape[0], mesh_shape[1])),
+    )
 
 
 class MeshToTensor:
@@ -221,117 +225,6 @@ class MeshToTensor:
 
     def compose(self, tensor: ttnn.Tensor):
         raise NotImplementedError("Subclasses must implement this method")
-
-
-class ShardTensorToMesh(TensorToMesh):
-    def __init__(self, mesh_device, dim):
-        super().__init__(mesh_device)
-        self.shard_dim = dim
-
-    def map(self, tensor: "torch.Tensor") -> Dict[int, ttnn.Tensor]:
-        import torch
-
-        sliced_tensors = torch.chunk(tensor, self.mesh_device.get_num_devices(), dim=self.shard_dim)
-        return list(sliced_tensors)
-
-    def config(self):
-        return {
-            "strategy": "shard",
-            "shard_dim": f"{self.shard_dim}",
-        }
-
-
-class ShardTensor2dMesh(TensorToMesh):
-    """
-    Shard a tensor across a 2D mesh of devices.
-
-    This class implements a strategy for distributing a tensor across a 2D grid of devices,
-    allowing for efficient parallel processing in distributed computing environments.
-    """
-
-    def __init__(self, mesh_device: MeshDevice, mesh_shape: Tuple[int, int], dims: Tuple[Optional[int], Optional[int]]):
-        """
-        Initialize the ShardTensor2dMesh.
-
-        Args:
-            mesh_device: The target device mesh for distributing the tensor.
-            mesh_shape: The shape of the 2D mesh as (rows, cols).
-            dims: The dimensions to shard along, specified as (row_dim, col_dim).
-
-        The `dims` tuple determines how the tensor is sharded across the 2D mesh:
-        - row_dim: The dimension to shard across mesh rows (or None for replication).
-        - col_dim: The dimension to shard across mesh columns (or None for replication).
-
-        Examples:
-        1. dims=(2, 3) for a tensor of shape (A, B, C, D):
-           - Shard along dimension 2 (C) across mesh rows
-           - Shard along dimension 3 (D) across mesh columns
-
-        2. dims=(None, 3):
-           - Replicate across mesh rows
-           - Shard along dimension 3 (D) across mesh columns
-
-        3. dims=(None, None):
-           - Fully replicate the tensor across all devices
-        """
-        super().__init__(mesh_device)
-        self.mesh_shape: Tuple[int, int] = mesh_shape
-        self.dims: Tuple[Optional[int], Optional[int]] = dims
-
-        mesh_device_rows, mesh_device_cols = self.mesh_device.shape
-        if mesh_shape[0] > mesh_device_rows or mesh_shape[1] > mesh_device_cols:
-            raise ValueError("ShardTensor2dMesh: Device mesh shape does not match the provided mesh shape.")
-
-    def map(self, tensor: "torch.Tensor") -> List["torch.Tensor"]:
-        """
-        Map the input tensor to a list of sharded tensors.
-
-        Args:
-            tensor: The input tensor to be sharded.
-
-        Returns:
-            A list of sharded tensors, one for each device in the mesh.
-
-        Raises:
-            ValueError: If the number of sharding dimensions is not 2.
-        """
-        import torch
-
-        if len(self.dims) != 2:
-            raise ValueError("ShardTensor2dMesh only supports 2D shard dimensions")
-
-        rows, cols = self.mesh_shape
-        row_dim, col_dim = self.dims
-
-        # Shard along rows
-        row_tensors = (
-            [tensor.clone() for _ in range(rows)] if row_dim is None else torch.chunk(tensor, rows, dim=row_dim)
-        )
-
-        # Shard along columns
-        if col_dim is None:
-            return [t.clone() for t in row_tensors for _ in range(cols)]
-        tensor_shards = [tt for t in row_tensors for tt in torch.chunk(t, cols, dim=col_dim)]
-
-        if len(tensor_shards) != rows * cols:
-            raise ValueError(
-                f"ShardTensor2dMesh: Sharding failed. Number of shards should match the product of the mesh dimensions. Got {len(tensor_shards)} shards but expected {rows * cols} ({rows} rows * {cols} cols)."
-            )
-
-        return tensor_shards
-
-    def config(self) -> Dict[str, str]:
-        """
-        Provide the configuration of the sharding strategy.
-
-        Returns:
-            A dictionary containing the sharding strategy and dimensions.
-        """
-        return {
-            "strategy": "shard_2d",
-            "mesh_shape_y": str(self.mesh_shape[0]),
-            "mesh_shape_x": str(self.mesh_shape[1]),
-        }
 
 
 class ConcatMesh2dToTensor(MeshToTensor):
@@ -396,20 +289,6 @@ class ConcatMesh2dToTensor(MeshToTensor):
 
         # Then concatenate the resulting tensors along rows
         return torch.cat(row_concatenated, dim=row_dim)
-
-
-class ReplicateTensorToMesh(TensorToMesh):
-    def __init__(self, mesh_device: MeshDevice):
-        super().__init__(mesh_device)
-
-    def map(self, tensor: "torch.Tensor"):
-        return [tensor for i in range(self.mesh_device.get_num_devices())]
-
-    def config(self):
-        return {
-            "strategy": "replicate",
-            "replication_factor": str(self.mesh_device.get_num_devices()),
-        }
 
 
 class ConcatMeshToTensor(MeshToTensor):

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -537,14 +537,13 @@ def load_tensor(file_name: Union[str, pathlib.Path], *, device: ttnn.MeshDevice 
 
 
 @ttnn.register_python_operation(name="ttnn.dump_tensor")
-def dump_tensor(file_name: Union[str, pathlib.Path], tensor: ttnn.Tensor, distribute: Dict[str, str] = None) -> None:
+def dump_tensor(file_name: Union[str, pathlib.Path], tensor: ttnn.Tensor) -> None:
     """
     Dump tensor to a file.
 
     Args:
         file_name (str | pathlib.Path): The file name.
         tensor (ttnn.Tensor): the tensor to be dumped.
-        distribute (Dict[str, str], optional): The distributed strategy. Only applicable to multi-device tensors. Defaults to `None`.
 
     Returns:
         `None`: tensor saved to a specified file.
@@ -556,7 +555,7 @@ def dump_tensor(file_name: Union[str, pathlib.Path], tensor: ttnn.Tensor, distri
     if distribute is None:
         distribute = dict()
     file_name = pathlib.Path(file_name)
-    ttnn._ttnn.tensor.dump_tensor(str(file_name), tensor, distribute)
+    ttnn._ttnn.tensor.dump_tensor(str(file_name), tensor)
 
 
 @ttnn.register_python_operation(name="ttnn.as_tensor")
@@ -661,8 +660,7 @@ def as_tensor(
                 f"Generating cache for {cache_file_name} of shape {tensor.shape}, dtype {dtype_name}, layout {layout_name}"
             )
             pathlib.Path(cache_file_name).parent.mkdir(parents=True, exist_ok=True)
-            distributed_config = mesh_mapper.config() if mesh_mapper else dict()
-            ttnn._ttnn.tensor.dump_tensor(cache_file_name, tensor, distributed_config)
+            ttnn._ttnn.tensor.dump_tensor(cache_file_name, tensor)
             return tensor
 
         if isinstance(mesh_mapper, ttnn.ReplicateTensorToMesh):

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -552,8 +552,6 @@ def dump_tensor(file_name: Union[str, pathlib.Path], tensor: ttnn.Tensor) -> Non
         >>> tensor = ttnn.ones([2, 3], bfloat16, ttnn.ROW_MAJOR_LAYOUT)
         >>> dump_tensor(file_name=str(tensor.bin), tensor=tensor)
     """
-    if distribute is None:
-        distribute = dict()
     file_name = pathlib.Path(file_name)
     ttnn._ttnn.tensor.dump_tensor(str(file_name), tensor)
 

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -242,7 +242,7 @@ def from_torch(
     layout: Optional[ttnn.Layout] = ttnn.ROW_MAJOR_LAYOUT,
     device: Optional[ttnn.MeshDevice] = None,
     memory_config: Optional[ttnn.MemoryConfig] = None,
-    mesh_mapper: Optional[ttnn.TensorToMesh] = None,
+    mesh_mapper: Optional[ttnn.CppTensorToMesh] = None,
     cq_id: Optional[int] = ttnn.DefaultQueueId,
 ) -> ttnn.Tensor:
     """
@@ -286,8 +286,8 @@ def from_torch(
             raise RuntimeError("ttnn.from_torch: device must be specified when memory_config is specified")
 
     if mesh_mapper:
-        shards = mesh_mapper.map(tensor)
-        tensor = ttnn.Tensor(shards, dtype, mesh_mapper.config(), tile, layout, memory_config, pad_value)
+        # TODO: #22258 - supply device to pytensor constructor directly.
+        tensor = ttnn.Tensor(tensor, dtype, mesh_mapper, tile, layout, memory_config, pad_value)
         if device is not None:
             tensor = ttnn.to_device(tensor, device, memory_config=memory_config, cq_id=cq_id)
         return tensor
@@ -569,7 +569,7 @@ def as_tensor(
     memory_config: Optional[ttnn.MemoryConfig] = None,
     cache_file_name: Optional[Union[str, pathlib.Path]] = None,
     preprocess: Optional[Callable[[ttnn.Tensor], ttnn.Tensor]] = None,
-    mesh_mapper: Optional[ttnn.TensorToMesh] = None,
+    mesh_mapper: Optional[ttnn.CppTensorToMesh] = None,
     use_device_tilizer: bool = False,
 ) -> ttnn.Tensor:
     """
@@ -585,7 +585,7 @@ def as_tensor(
         memory_config (ttnn.MemoryConfig, optional): The `ttnn` memory configuration. Defaults to `None`.
         cache_file_name (str | pathlib.Path, optional): The cache file name. Defaults to `None`.
         preprocess (Callable[[ttnn.Tensor], ttnn.Tensor], optional): The function to preprocess the tensor before serializing/converting to ttnn. Defaults to `None`.
-        mesh_mapper (ttnn.TensorToMesh, optional): The TensorToMesh to define the mapping from torch to multi-device. Defaults to `None`.
+        mesh_mapper (ttnn.CppTensorToMesh, optional): The TensorToMesh to define the mapping from torch to multi-device. Defaults to `None`.
         use_device_tilizer (bool, optional): The flag that toggles whether to use host vs. device tilizer. Defaults to `False`.
 
             - For Grayskull, the on-device tilizer will truncate mantissa bits for bfp* formats.
@@ -621,7 +621,7 @@ def as_tensor(
         layout: Optional[ttnn.Layout],
         device: Optional[ttnn.MeshDevice],
         memory_config: Optional[ttnn.MemoryConfig],
-        mesh_mapper: Optional[ttnn.TensorToMesh],
+        mesh_mapper: Optional[ttnn.CppTensorToMesh],
     ):
         if preprocess:
             tensor = preprocess(tensor)
@@ -654,7 +654,7 @@ def as_tensor(
             dtype: Optional[ttnn.DataType],
             layout: Optional[ttnn.Layout],
             cache_file_name: str,
-            mesh_mapper: Optional[ttnn.TensorToMesh],
+            mesh_mapper: Optional[ttnn.CppTensorToMesh],
         ):
             tensor = torch_to_ttnn(tensor, dtype, layout, device, memory_config, mesh_mapper)
             logger.debug(

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -661,12 +661,7 @@ def as_tensor(
             ttnn._ttnn.tensor.dump_tensor(cache_file_name, tensor)
             return tensor
 
-        if isinstance(mesh_mapper, ttnn.ReplicateTensorToMesh):
-            storage_type = f"_multi_device" if mesh_mapper else ""
-        elif mesh_mapper:
-            storage_type = f"_multi_device_{device.get_num_devices()}"
-        else:
-            storage_type = ""
+        storage_type = f"_multi_device" if mesh_mapper else ""
 
         cache_file_name = f"{cache_file_name}{storage_type}_dtype_{dtype_name}_layout_{layout_name}.bin"
 


### PR DESCRIPTION
### Ticket
#22258

### Problem description
Migrate Pytorch-based sharding APIs to C++ to onboard multi-host aware sharding, deduplicate code, and provide much more efficient implementation that doesn't excessively copy.

### What's changed
* Refactor pytensor to accommodate the change.
* Redirect python sharding APIs to C++ impl, to avoid disrupting clients.
* `ReplicateTensorToMeshWrapper` is used to distinguish between mappers created in `ReplicateTensorToMesh` function, which is used to differentiate tensor cache filename in `as_tensor` function. 



### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15839615905)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15789213964)
- [X] [Single card tests](https://github.com/tenstorrent/tt-metal/actions/runs/15786648986)
- [X] [TG tests](https://github.com/tenstorrent/tt-metal/actions/runs/15814492043)
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15833376724)
- [X] New/Existing tests provide coverage for changes