### PR TITLE
Remove xfail tag after resolution of the underlying issue 21803

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -271,9 +271,7 @@ def test_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
 @pytest.mark.parametrize("dim", [3, 4])
 @pytest.mark.parametrize("k", [17, 32, 64])
 @pytest.mark.parametrize("largest", [True])
-@pytest.mark.parametrize(
-    "dtype", [ttnn.bfloat16, pytest.param(ttnn.bfloat8_b, marks=pytest.mark.xfail(reason="Issue #21438"))]
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_5d_topk(device, dim1, dim2, dim3, dim4, dim5, dim, k, largest, dtype):
     torch.manual_seed(2005)
     shape = [dim1, dim2, dim3, dim4, dim5]

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -25,7 +25,6 @@ void bind_reduction_topk_operation(py::module& module) {
             Input tensor must have BFLOAT8 or BFLOAT16 data type and TILE_LAYOUT layout.
 
             Output value tensor will have the same data type as input tensor and output index tensor will have UINT16 data type.
-            Note that when using BFLOAT8, a different set of elements than in the input may share the same exponent, causing some values to be rounded up or down.
 
             Equivalent pytorch code:
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21438
https://github.com/tenstorrent/tt-metal/issues/21803

Refer to the linked issue for complete details.
Tests run on 200 different seeds, confirmed passing.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15720369300
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/15720378899
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes