### PR TITLE
Adjust pytest wrappers to account for roofline numbers

### DIFF
--- a/tests/sweep_framework/sweep_utils/reduction_common.py
+++ b/tests/sweep_framework/sweep_utils/reduction_common.py
@@ -32,9 +32,6 @@ def run_sum(
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
 
-    if input_a_dtype == ttnn.float32 and ttnn.device.is_grayskull(device):
-        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
-
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
@@ -72,9 +69,6 @@ def run_prod(
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
-
-    if input_a_dtype == ttnn.float32 and ttnn.device.is_grayskull(device):
-        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
 
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype

--- a/tests/sweep_framework/sweeps/normalization/batch_norm/batch_norm.py
+++ b/tests/sweep_framework/sweeps/normalization/batch_norm/batch_norm.py
@@ -65,9 +65,6 @@ def run_batch_norm(
         input_shape, 5, 10, device, is_input=True, testing_dtype=dtype_names, memory_config=input_memory_config
     )
 
-    if input_dtype == ttnn.float32 and ttnn.device.is_grayskull(device):
-        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
-
     mean_data, mean_tensor = (
         data_gen_with_range_batch_norm(
             input_shape, 4, 10, device, testing_dtype=dtype_names, memory_config=input_memory_config

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
@@ -15,6 +15,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
+from loguru import logger
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -186,7 +187,7 @@ def test_argmax(
     result, reason = invalidate_vector(test_vector)
     if result:
         pytest.skip(reason)
-    result, msg, _perf = run_argmax(
+    (result, msg), e2e_perf = run_argmax(
         input_shape,
         dim,
         keepdim,
@@ -197,4 +198,7 @@ def test_argmax(
         device=device,
     )
     if not result:
-        assert False, msg
+        assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
@@ -197,8 +197,7 @@ def test_argmax(
         output_memory_config,
         device=device,
     )
-    if not result:
-        assert result, msg
+    assert result, msg
     logger.info(msg)
     if e2e_perf:
         logger.info(f"E2E Performance: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax_output.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax_output.py
@@ -123,8 +123,7 @@ def test_nightly(device, params):
 
     (result, msg), e2e_perf = run_argmax(**params, device=device)
 
-    if not result:
-        assert result, msg
+    assert result, msg
     logger.info(msg)
     if e2e_perf:
         logger.info(f"E2E Performance: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax_output.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax_output.py
@@ -14,6 +14,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
+from loguru import logger
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -120,9 +121,13 @@ def test_nightly(device, params):
     if invalidated:
         pytest.skip(output_str)
 
-    res, _ = run_argmax(**params, device=device)
+    (result, msg), e2e_perf = run_argmax(**params, device=device)
 
-    assert res[0], res[1]
+    if not result:
+        assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")
 
 
 # This is the run instructions for the test, defined by the developer.

--- a/tests/sweep_framework/sweeps/reduction/backward/prod_bw/prod_bw.py
+++ b/tests/sweep_framework/sweeps/reduction/backward/prod_bw/prod_bw.py
@@ -110,9 +110,6 @@ def run(
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
 
-    if (input_a_dtype == ttnn.float32 or grad_dtype == ttnn.float32) and ttnn.device.is_grayskull(device):
-        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
-
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=0, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)

--- a/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
+++ b/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
@@ -119,8 +119,7 @@ def test_reduction(
         op,
         dtype,
     )
-    if not result:
-        assert result, msg
+    assert result, msg
     logger.info(msg)
     if e2e_perf:
         logger.info(f"E2E Performance: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
+++ b/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
@@ -9,6 +9,7 @@ import random
 import sys
 import torch
 import ttnn
+from loguru import logger
 
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
@@ -110,7 +111,7 @@ def test_reduction(
     op,
     dtype,
 ):
-    result, msg = run_reduction(
+    (result, msg), e2e_perf = run_reduction(
         device,
         tensor_shape,
         dim,
@@ -118,7 +119,11 @@ def test_reduction(
         op,
         dtype,
     )
-    assert result, msg
+    if not result:
+        assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")
 
 
 def run(

--- a/tests/sweep_framework/sweeps/reduction/mean/mean.py
+++ b/tests/sweep_framework/sweeps/reduction/mean/mean.py
@@ -100,9 +100,6 @@ def run(
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
 
-    if input_a_dtype == ttnn.float32 and ttnn.device.is_grayskull(device):
-        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
-
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)
 

--- a/tests/sweep_framework/sweeps/reduction/prod.py
+++ b/tests/sweep_framework/sweeps/reduction/prod.py
@@ -128,8 +128,7 @@ def test_reduction_prod_localrun_fail_only(device, input_shape, dim, keepdim):
         input_shape, dim, keepdim, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, device
     )
 
-    if not result:
-        assert result, msg
+    assert result, msg
     logger.info(msg)
     if e2e_perf:
         logger.info(f"E2E Performance: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/prod.py
+++ b/tests/sweep_framework/sweeps/reduction/prod.py
@@ -10,6 +10,7 @@ import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+from loguru import logger
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
@@ -123,6 +124,12 @@ import pytest
     ],
 )
 def test_reduction_prod_localrun_fail_only(device, input_shape, dim, keepdim):
-    run_prod(
+    (result, msg), e2e_perf = run_prod(
         input_shape, dim, keepdim, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, device
     )
+
+    if not result:
+        assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/std/std.py
+++ b/tests/sweep_framework/sweeps/reduction/std/std.py
@@ -100,9 +100,6 @@ def run(
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
 
-    if input_a_dtype == ttnn.float32 and ttnn.device.is_grayskull(device):
-        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
-
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)
 

--- a/tests/sweep_framework/sweeps/reduction/sum.py
+++ b/tests/sweep_framework/sweeps/reduction/sum.py
@@ -10,6 +10,7 @@ import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+from loguru import logger
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
@@ -110,6 +111,12 @@ import pytest
 def test_reduction_sum_localrun_fail_only(
     device, input_shape, dim, keepdim, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config
 ):
-    run_sum(
+    (result, msg), e2e_perf = run_sum(
         input_shape, dim, keepdim, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config, device
     )
+
+    if not result:
+        assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/sum.py
+++ b/tests/sweep_framework/sweeps/reduction/sum.py
@@ -115,8 +115,7 @@ def test_reduction_sum_localrun_fail_only(
         input_shape, dim, keepdim, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config, device
     )
 
-    if not result:
-        assert result, msg
+    assert result, msg
     logger.info(msg)
     if e2e_perf:
         logger.info(f"E2E Performance: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/topk/topk.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk.py
@@ -134,9 +134,6 @@ def run(
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
 
-    if input_a_dtype == ttnn.float32 and ttnn.device.is_grayskull(device):
-        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
-
     input_shape = sanitize_shape(input_shape, "topk")
 
     torch_input_tensor_a = gen_func_with_cast_tt(

--- a/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
@@ -144,8 +144,7 @@ def test_nightly(device, params):
 
     (result, msg), e2e_perf = run_topk(**params, device=device)
 
-    if not result:
-        assert result, msg
+    assert result, msg
     logger.info(msg)
     if e2e_perf:
         logger.info(f"E2E Performance: {e2e_perf}")
@@ -161,8 +160,7 @@ def test_nightly(device, params):
 
     (result, msg), e2e_perf = run_topk(**params, device=device)
 
-    if not result:
-        assert result, msg
+    assert result, msg
     logger.info(msg)
     if e2e_perf:
         logger.info(f"E2E Performance: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
@@ -15,6 +15,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
+from loguru import logger
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -141,9 +142,13 @@ def test_nightly(device, params):
     if invalidated:
         pytest.skip(output_str)
 
-    res, _ = run_topk(**params, device=device)
+    (result, msg), e2e_perf = run_topk(**params, device=device)
 
-    assert res[0], res[1]
+    if not result:
+        assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")
 
 
 @pytest.mark.xfail
@@ -154,9 +159,13 @@ def test_nightly(device, params):
     if invalidated:
         pytest.skip(output_str)
 
-    res, _ = run_topk(**params, device=device)
+    (result, msg), e2e_perf = run_topk(**params, device=device)
 
-    assert res[0], res[1]
+    if not result:
+        assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")
 
 
 # This is the run instructions for the test, defined by the developer.

--- a/tests/sweep_framework/sweeps/reduction/traces/argmax_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/argmax_traces.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 import ttnn
+from loguru import logger
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
@@ -46,7 +47,12 @@ def run_argmax(device, height, width, dim, dtype, layout):
 @pytest.mark.parametrize("dtype", parameters["pytorch"]["dtype"])
 @pytest.mark.parametrize("layout", parameters["pytorch"]["layout"])
 def test_pytorch(device, height, width, dim, dtype, layout):
-    run_argmax(device, height, width, dim, dtype, layout)
+    (result, msg), e2e_perf = run_argmax(device, height, width, dim, dtype, layout)
+    if not result:
+        assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")
 
 
 def run(

--- a/tests/sweep_framework/sweeps/reduction/traces/argmax_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/argmax_traces.py
@@ -48,8 +48,7 @@ def run_argmax(device, height, width, dim, dtype, layout):
 @pytest.mark.parametrize("layout", parameters["pytorch"]["layout"])
 def test_pytorch(device, height, width, dim, dtype, layout):
     (result, msg), e2e_perf = run_argmax(device, height, width, dim, dtype, layout)
-    if not result:
-        assert result, msg
+    assert result, msg
     logger.info(msg)
     if e2e_perf:
         logger.info(f"E2E Performance: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/traces/max_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/max_traces.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 import ttnn
+from loguru import logger
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
@@ -371,14 +372,24 @@ def run_max(device, params, dtype, layout):
 @pytest.mark.parametrize("dtype", parameters["pytorch"]["dtype"])
 @pytest.mark.parametrize("layout", parameters["pytorch"]["layout"])
 def test_pytorch(device, params, dtype, layout):
-    run_max(device, params, dtype, layout)
+    (result, msg), e2e_perf = run_max(device, params, dtype, layout)
+    if not result:
+        assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")
 
 
 @pytest.mark.parametrize("params", parameters["forge"]["params"])
 @pytest.mark.parametrize("dtype", parameters["forge"]["dtype"])
 @pytest.mark.parametrize("layout", parameters["forge"]["layout"])
 def test_forge(device, params, dtype, layout):
-    run_max(device, params, dtype, layout)
+    (result, msg), e2e_perf = run_max(device, params, dtype, layout)
+    if not result:
+        assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")
 
 
 def run(

--- a/tests/sweep_framework/sweeps/reduction/traces/max_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/max_traces.py
@@ -373,8 +373,7 @@ def run_max(device, params, dtype, layout):
 @pytest.mark.parametrize("layout", parameters["pytorch"]["layout"])
 def test_pytorch(device, params, dtype, layout):
     (result, msg), e2e_perf = run_max(device, params, dtype, layout)
-    if not result:
-        assert result, msg
+    assert result, msg
     logger.info(msg)
     if e2e_perf:
         logger.info(f"E2E Performance: {e2e_perf}")
@@ -385,8 +384,7 @@ def test_pytorch(device, params, dtype, layout):
 @pytest.mark.parametrize("layout", parameters["forge"]["layout"])
 def test_forge(device, params, dtype, layout):
     (result, msg), e2e_perf = run_max(device, params, dtype, layout)
-    if not result:
-        assert result, msg
+    assert result, msg
     logger.info(msg)
     if e2e_perf:
         logger.info(f"E2E Performance: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/traces/mean_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/mean_traces.py
@@ -129,8 +129,7 @@ def run_mean(device, params):
 @pytest.mark.parametrize("params", parameters["pytorch"]["params"])
 def test_pytorch(device, params):
     (result, msg), e2e_perf = run_mean(device, params)
-    if not result:
-        assert result, msg
+    assert result, msg
     logger.info(msg)
     if e2e_perf:
         logger.info(f"E2E Performance: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/traces/mean_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/mean_traces.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 import ttnn
+from loguru import logger
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
@@ -127,7 +128,12 @@ def run_mean(device, params):
 
 @pytest.mark.parametrize("params", parameters["pytorch"]["params"])
 def test_pytorch(device, params):
-    run_mean(device, params)
+    (result, msg), e2e_perf = run_mean(device, params)
+    if not result:
+        assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")
 
 
 def run(

--- a/tests/sweep_framework/sweeps/reduction/traces/sum_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/sum_traces.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 import ttnn
+from loguru import logger
 
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 from tests.ttnn.utils_for_testing import start_measuring_time, stop_measuring_time
@@ -646,12 +647,22 @@ def run_sum(device, params):
 
 @pytest.mark.parametrize("params", parameters["pytorch"]["params"])
 def test_pytorch(device, params):
-    run_sum(device, params)
+    (result, msg), e2e_perf = run_sum(device, params)
+    if not result:
+        assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")
 
 
 @pytest.mark.parametrize("params", parameters["forge"]["params"])
 def test_forge(device, params):
-    run_sum(device, params)
+    (result, msg), e2e_perf = run_sum(device, params)
+    if not result:
+        assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")
 
 
 def run(

--- a/tests/sweep_framework/sweeps/reduction/traces/sum_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/sum_traces.py
@@ -648,8 +648,7 @@ def run_sum(device, params):
 @pytest.mark.parametrize("params", parameters["pytorch"]["params"])
 def test_pytorch(device, params):
     (result, msg), e2e_perf = run_sum(device, params)
-    if not result:
-        assert result, msg
+    assert result, msg
     logger.info(msg)
     if e2e_perf:
         logger.info(f"E2E Performance: {e2e_perf}")
@@ -658,8 +657,7 @@ def test_pytorch(device, params):
 @pytest.mark.parametrize("params", parameters["forge"]["params"])
 def test_forge(device, params):
     (result, msg), e2e_perf = run_sum(device, params)
-    if not result:
-        assert result, msg
+    assert result, msg
     logger.info(msg)
     if e2e_perf:
         logger.info(f"E2E Performance: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/traces/topk_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/topk_traces.py
@@ -46,8 +46,7 @@ def run_topk(device, params):
 @pytest.mark.parametrize("params", parameters["pytorch"]["params"])
 def test_pytorch(device, params):
     (result, msg), e2e_perf = run_topk(device, params)
-    if not result:
-        assert result, msg
+    assert result, msg
     logger.info(msg)
     if e2e_perf:
         logger.info(f"E2E Performance: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/traces/topk_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/topk_traces.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 import ttnn
+from loguru import logger
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
@@ -44,7 +45,12 @@ def run_topk(device, params):
 
 @pytest.mark.parametrize("params", parameters["pytorch"]["params"])
 def test_pytorch(device, params):
-    run_topk(device, params)
+    (result, msg), e2e_perf = run_topk(device, params)
+    if not result:
+        assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")
 
 
 def run(

--- a/tests/sweep_framework/sweeps/reduction/var/var.py
+++ b/tests/sweep_framework/sweeps/reduction/var/var.py
@@ -103,9 +103,6 @@ def run(
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
 
-    if input_a_dtype == ttnn.float32 and ttnn.device.is_grayskull(device):
-        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
-
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23037

### Problem description
The return values in sweeps come in two flavors:
1. When there is no perf, the return value is a tuple with 2 entries (result and msg)
2. When there is perf, the return value is a list with two entries. The first entry is a tuple (same as (1)) and the second entry is the e2e perf.
So pytest will need to check return type and assert on the first entry or the first entry's first entry.
### What's changed
1. Unpack return values correctly
2. Log roofline and e2e perf if test passed. Assert with correct messages if not.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15720372951
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) Smoke test taking longer is known issue: https://github.com/tenstorrent/tt-metal/issues/23667
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes