### PR TITLE
#23571: Add --without-distributed option to build_metal.sh

### DIFF
--- a/build_metal.sh
+++ b/build_metal.sh
@@ -40,7 +40,7 @@ show_help() {
     echo "  --toolchain-path                 Set path to CMake toolchain file."
     echo "  --configure-only                 Only configure the project, do not build."
     echo "  --enable-coverage                Instrument the binaries for code coverage."
-    echo "  --enable-distributed             Enable distributed compute support (OpenMPI)."
+    echo "  --without-distributed            Disable distributed compute support (OpenMPI dependency). Enabled by default."
     echo "  --without-python-bindings        Disable Python bindings (ttnncpp will be available as standalone library, otherwise ttnn will include the cpp backend and the python bindings), Enabled by default"
 }
 
@@ -121,7 +121,7 @@ ttnn-shared-sub-libs
 toolchain-path:
 configure-only
 enable-coverage
-enable-distributed
+without-distributed
 without-python-bindings
 "
 
@@ -150,8 +150,8 @@ while true; do
             enable_time_trace="ON";;
         --enable-coverage)
             enable_coverage="ON";;
-        --enable-distributed)
-            enable_distributed="ON";;
+        --without-distributed)
+            enable_distributed="OFF";;
 	--build-dir)
             build_dir="$2";shift;;
         -b|--build-type)


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/23571)

### Problem description
`build_metal.sh` script doesn't allow buillding without OpenMPI dependency. This is because build_metal.sh script only has `--enable-distributed`, but we already have it enabled by default.

### What's changed
Adds the ability to disable OpenMPI support during build by using the --without-distributed flag. The default remains enabled. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/15721044076