### PR TITLE
Move get_active_ethernet_cores and get_inactive_ethernet_cores to Control Plane

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_intermesh_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_intermesh_apis.cpp
@@ -72,7 +72,6 @@ TEST(IntermeshAPIs, ConsistencyChecks) {
 }
 
 TEST(IntermeshAPIs, IntermeshLinksAreDistinctFromEthernetLinks) {
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     if (!control_plane.system_has_intermesh_links()) {
@@ -85,8 +84,8 @@ TEST(IntermeshAPIs, IntermeshLinksAreDistinctFromEthernetLinks) {
     auto all_intermesh_links = control_plane.get_all_intermesh_eth_links();
 
     for (const auto& [chip_id, intermesh_links] : all_intermesh_links) {
-        auto active_eth_cores = cluster.get_active_ethernet_cores(chip_id);
-        auto inactive_eth_cores = cluster.get_inactive_ethernet_cores(chip_id);
+        auto active_eth_cores = control_plane.get_active_ethernet_cores(chip_id);
+        auto inactive_eth_cores = control_plane.get_inactive_ethernet_cores(chip_id);
 
         // Verify no overlap between intermesh links and active ethernet cores
         for (const auto& [eth_core, channel] : intermesh_links) {

--- a/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
@@ -43,7 +43,7 @@ is updated with this option, we can call that over this function.
 std::unordered_set<chip_id_t> get_ethernet_connected_device_ids(const chip_id_t device_id) {
     std::unordered_set<chip_id_t> connected_device_ids;
     const std::unordered_set<CoreCoord>& active_ethernet_cores =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id);
+        tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id);
     for (const CoreCoord& ethernet_core : active_ethernet_cores) {
         if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_id, ethernet_core)) {
             continue;
@@ -68,7 +68,7 @@ TEST_F(TGFixture, ActiveEthValidateNumLinksBetweenAdjacentGalaxyChips) {
         if (is_galaxy_device(device_id)) {
             std::unordered_map<chip_id_t, uint32_t> connected_devices_to_num_links_found;
             const std::unordered_set<CoreCoord>& active_ethernet_cores =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id);
+                tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id);
             for (const CoreCoord& ethernet_core : active_ethernet_cores) {
                 if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
                         device_id, ethernet_core)) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -265,7 +265,7 @@ private:
 
         for (auto sender_chip_id : sender_chips) {
             auto non_tunneling_eth_cores =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(
+                tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(
                     sender_chip_id, !slow_dispath_mode);
             for (auto logical_active_eth : non_tunneling_eth_cores) {
                 if (!tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <unordered_set>
+
 #include <tt_stl/span.hpp>
 #include <tt-metalium/routing_table_generator.hpp>
 #include <tt-metalium/fabric_host_interface.h>
@@ -113,14 +115,21 @@ public:
 
     // Get all intermesh ethernet links in the system
     // Returns: map of chip_id -> vector of (eth_core, channel)
-    const std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, chan_id_t>>>& get_all_intermesh_eth_links()
-        const;
+    const std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, chan_id_t>>>& get_all_intermesh_eth_links() const;
 
     // Check if a specific ethernet core is an intermesh link
     bool is_intermesh_eth_link(chip_id_t chip_id, CoreCoord eth_core) const;
 
     // If the ethernet core is an intermesh link, probe to see if it is trained
     bool is_intermesh_eth_link_trained(chip_id_t chip_id, CoreCoord eth_core) const;
+
+    // Returns set of logical active ethernet coordinates on chip
+    // If skip_reserved_cores is true, will return cores that dispatch is not using,
+    // intended for users to grab available eth cores for testing
+    // `skip_reserved_cores` is ignored on BH because there are no ethernet cores used for Fast Dispatch
+    // tunneling
+    std::unordered_set<CoreCoord> get_active_ethernet_cores(chip_id_t chip_id, bool skip_reserved_cores = false) const;
+    std::unordered_set<CoreCoord> get_inactive_ethernet_cores(chip_id_t chip_id) const;
 
 private:
     uint16_t routing_mode_ = 0;  // ROUTING_MODE_UNDEFINED

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1544,6 +1544,87 @@ ControlPlane::get_all_intermesh_eth_links() const {
     return intermesh_eth_links_;
 }
 
+std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(
+    chip_id_t chip_id, bool skip_reserved_cores) const {
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+
+    std::unordered_set<CoreCoord> active_ethernet_cores;
+    const auto& cluster_desc = cluster.get_cluster_desc();
+    const auto& soc_desc = cluster.get_soc_desc(chip_id);
+    if (cluster.arch() == ARCH::BLACKHOLE) {
+        // Can't just use `get_ethernet_cores_grouped_by_connected_chips` because there are some active ethernet cores
+        // without links. Only risc1 on these cores is available for Metal and should not be classified as idle
+        // to ensure that Metal does not try to program both riscs.
+        std::set<uint32_t> logical_active_eth_channels = cluster_desc->get_active_eth_channels(chip_id);
+        for (auto logical_active_eth_channel : logical_active_eth_channels) {
+            tt::umd::CoreCoord logical_active_eth =
+                soc_desc.get_eth_core_for_channel(logical_active_eth_channel, CoordSystem::LOGICAL);
+            active_ethernet_cores.insert(CoreCoord(logical_active_eth.x, logical_active_eth.y));
+        }
+    } else {
+        std::set<uint32_t> logical_active_eth_channels = cluster_desc->get_active_eth_channels(chip_id);
+        const auto& freq_retrain_eth_cores = cluster.get_eth_cores_with_frequent_retraining(chip_id);
+        const auto& eth_routing_info = cluster.get_eth_routing_info(chip_id);
+        for (const auto& eth_channel : logical_active_eth_channels) {
+            tt::umd::CoreCoord eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
+            const auto& routing_info = eth_routing_info.at(eth_core);
+            if ((routing_info == EthRouterMode::BI_DIR_TUNNELING or routing_info == EthRouterMode::FABRIC_ROUTER) and
+                skip_reserved_cores) {
+                continue;
+            }
+            if (freq_retrain_eth_cores.find(eth_core) != freq_retrain_eth_cores.end()) {
+                continue;
+            }
+
+            active_ethernet_cores.insert(eth_core);
+        }
+        // WH has a special case where mmio chips with remote connections must always have certain channels active
+        if (cluster.arch() == tt::ARCH::WORMHOLE_B0 && cluster_desc->is_chip_mmio_capable(chip_id) &&
+            cluster.get_tunnels_from_mmio_device(chip_id).size() > 0) {
+            // UMD routing FW uses these cores for base routing
+            // channel 15 is used by syseng tools
+            std::unordered_set<int> channels_to_skip = {};
+            if (cluster.is_galaxy_cluster()) {
+                // TODO: This may need to change, if we need additional eth cores for dispatch on Galaxy
+                channels_to_skip = {0, 1, 2, 3, 15};
+            } else {
+                channels_to_skip = {15};
+            }
+            for (const auto& eth_channel : channels_to_skip) {
+                if (logical_active_eth_channels.find(eth_channel) == logical_active_eth_channels.end()) {
+                    tt::umd::CoreCoord eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
+                    active_ethernet_cores.insert(eth_core);
+                }
+            }
+        }
+
+        if (cluster.get_board_type(chip_id) != BoardType::UBB) {
+            // For Non-UBB Wormhole systems, intermesh links must also be marked as active ethernet cores
+            // These cores are not seen by UMD or the cluster descriptor as active. Control Plane is
+            // responsible for querying this information.
+            // Note: On UBB systems, intermesh links are already identified as active by UMD, so control
+            // plane does not need to do this.
+            auto intermesh_links = this->get_intermesh_eth_links(chip_id);
+            for (const auto& [eth_coord, eth_chan] : intermesh_links) {
+                active_ethernet_cores.insert(eth_coord);
+            }
+        }
+    }
+    return active_ethernet_cores;
+}
+
+std::unordered_set<CoreCoord> ControlPlane::get_inactive_ethernet_cores(chip_id_t chip_id) const {
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    std::unordered_set<CoreCoord> active_ethernet_cores = this->get_active_ethernet_cores(chip_id);
+    std::unordered_set<CoreCoord> inactive_ethernet_cores;
+    for (const auto& [eth_core, chan] : cluster.get_soc_desc(chip_id).logical_eth_core_to_chan_map) {
+        if (active_ethernet_cores.find(eth_core) == active_ethernet_cores.end()) {
+            inactive_ethernet_cores.insert(eth_core);
+        }
+    }
+    return inactive_ethernet_cores;
+}
+
 ControlPlane::~ControlPlane() = default;
 
 GlobalControlPlane::GlobalControlPlane(

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -182,7 +182,7 @@ void MetalContext::clear_l1_state(chip_id_t device_id) {
     }
 
     // Clear erisc unreserved L1
-    for (const auto& eth_core : cluster_->get_active_ethernet_cores(device_id)) {
+    for (const auto& eth_core : this->get_control_plane().get_active_ethernet_cores(device_id)) {
         static uint32_t zero_vec_size = tt::tt_metal::hal::get_erisc_l1_unreserved_size();
         auto zero_vec_addr = tt::tt_metal::hal::get_erisc_l1_unreserved_base();
 
@@ -232,10 +232,10 @@ void MetalContext::clear_launch_messages_on_eth_cores(chip_id_t device_id) {
             &go_msg, sizeof(go_msg_t), tt_cxy_pair(device_id, virtual_eth_core), go_addr);
     };
 
-    for (const auto& eth_core : cluster_->get_active_ethernet_cores(device_id)) {
+    for (const auto& eth_core : this->get_control_plane().get_active_ethernet_cores(device_id)) {
         clear_ethernet_core(eth_core);
     }
-    for (const auto& eth_core : cluster_->get_inactive_ethernet_cores(device_id)) {
+    for (const auto& eth_core : this->get_control_plane().get_inactive_ethernet_cores(device_id)) {
         clear_ethernet_core(eth_core);
     }
 }

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -7,6 +7,7 @@
 #include <set>
 
 #include "dev_msgs.h"
+#include <tt-metalium/control_plane.hpp>
 #include <tt-metalium/core_descriptor.hpp>
 #include "hostdevcommon/dprint_common.h"
 #include "impl/context/metal_context.hpp"
@@ -37,11 +38,11 @@ static CoreDescriptorSet GetAllCores(chip_id_t device_id) {
         }
     }
     for (const auto& logical_core :
-         tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id)) {
+         tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id)) {
         all_cores.insert({logical_core, CoreType::ETH});
     }
     for (const auto& logical_core :
-         tt::tt_metal::MetalContext::instance().get_cluster().get_inactive_ethernet_cores(device_id)) {
+         tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(device_id)) {
         all_cores.insert({logical_core, CoreType::ETH});
     }
 
@@ -74,7 +75,7 @@ static tt::tt_metal::HalProgrammableCoreType get_programmable_core_type(CoreCoor
         tt::tt_metal::MetalContext::instance().get_cluster().get_logical_ethernet_core_from_virtual(
             device_id, virtual_core);
     auto active_ethernet_cores =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id);
+        tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id);
     if (active_ethernet_cores.find(logical_core) != active_ethernet_cores.end()) {
         return tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH;
     }
@@ -97,7 +98,7 @@ inline int GetNumRiscs(chip_id_t device_id, const CoreDescriptor& core) {
         if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE) {
             // TODO: Update this to be `DPRINT_NRISCVS_ETH + 1` when active erisc0 is running Metal FW
             auto logical_active_eths =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id);
+                tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id);
             CoreCoord logical_eth(core.coord.x, core.coord.y);
             return (logical_active_eths.find(logical_eth) != logical_active_eths.end()) ? DPRINT_NRISCVS_ETH
                                                                                         : DPRINT_NRISCVS_ETH + 1;

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -191,7 +191,7 @@ WatcherDeviceReader::WatcherDeviceReader(
         tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
         std::vector<uint32_t> read_data;
         for (const CoreCoord& eth_core :
-             tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id)) {
+             tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id)) {
             CoreCoord virtual_core =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
                     device_id, eth_core, CoreType::ETH);
@@ -212,7 +212,7 @@ WatcherDeviceReader::~WatcherDeviceReader() {
         tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
         std::vector<uint32_t> read_data;
         for (const CoreCoord& eth_core :
-             tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id)) {
+             tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id)) {
             CoreCoord virtual_core =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
                     device_id, eth_core, CoreType::ETH);
@@ -281,12 +281,12 @@ void WatcherDeviceReader::Dump(FILE* file) {
 
     // Dump eth cores
     for (const CoreCoord& eth_core :
-         tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id)) {
+         tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id)) {
         CoreDescriptor logical_core = {eth_core, CoreType::ETH};
         DumpCore(logical_core, true);
     }
     for (const CoreCoord& eth_core :
-         tt::tt_metal::MetalContext::instance().get_cluster().get_inactive_ethernet_cores(device_id)) {
+         tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(device_id)) {
         CoreDescriptor logical_core = {eth_core, CoreType::ETH};
         DumpCore(logical_core, false);
     }

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -414,11 +414,11 @@ void watcher_init(chip_id_t device_id) {
             is_active_eth_core ? GET_WATCHER_ERISC_DEV_ADDR() : GET_WATCHER_IERISC_DEV_ADDR());
     };
     for (const CoreCoord& active_eth_core :
-         tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id)) {
+         tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id)) {
         init_eth_debug_values(active_eth_core, true);
     }
     for (const CoreCoord& inactive_eth_core :
-         tt::tt_metal::MetalContext::instance().get_cluster().get_inactive_ethernet_cores(device_id)) {
+         tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(device_id)) {
         init_eth_debug_values(inactive_eth_core, false);
     }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -75,6 +75,7 @@
 #include "sub_device/sub_device_manager_tracker.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/tools/profiler/tt_metal_tracy.hpp"
+#include <tt-metalium/control_plane.hpp>
 #include <umd/device/coordinate_manager.h>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_silicon_driver_common.hpp>
@@ -156,7 +157,7 @@ Device::Device(
 }
 
 std::unordered_set<CoreCoord> Device::get_active_ethernet_cores(bool skip_reserved_tunnel_cores) const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(
+    return tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(
         this->id_, skip_reserved_tunnel_cores);
 }
 
@@ -166,12 +167,12 @@ bool Device::is_active_ethernet_core(CoreCoord logical_core, bool skip_reserved_
 }
 
 std::unordered_set<CoreCoord> Device::get_inactive_ethernet_cores() const {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_inactive_ethernet_cores(this->id_);
+    return tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(this->id_);
 }
 
 bool Device::is_inactive_ethernet_core(CoreCoord logical_core) const {
     auto inactive_ethernet_cores =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_inactive_ethernet_cores(this->id_);
+        tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(this->id_);
     return inactive_ethernet_cores.find(logical_core) != inactive_ethernet_cores.end();
 }
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -569,8 +569,8 @@ std::size_t DevicePool::get_max_num_eth_cores_across_all_devices() const {
     for (const auto& device : this->devices) {
         max_eth_core_count = std::max(
             MetalContext::instance()
-                .get_cluster()
-                .get_active_ethernet_cores(device->id(), /*skip_reserved_tunnel_cores*/ true)
+                .get_control_plane()
+                .get_active_ethernet_cores(device->id(), /*skip_reserved_cores*/ true)
                 .size(),
             max_eth_core_count);
     }

--- a/tt_metal/impl/dispatch/dispatch_core_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.cpp
@@ -14,6 +14,7 @@
 #include "core_descriptor.hpp"
 #include "dispatch_core_common.hpp"
 #include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/control_plane.hpp>
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.h>
 
@@ -299,7 +300,7 @@ void dispatch_core_manager::reset_dispatch_core_manager(
         // Infer the remaining dispatch cores from the idle eth core list (this is device dependent).
         if (dispatch_core_config.get_core_type() == CoreType::ETH) {
             for (const auto& idle_eth_core :
-                 tt::tt_metal::MetalContext::instance().get_cluster().get_inactive_ethernet_cores(device_id)) {
+                 tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(device_id)) {
                 add_dispatch_core_to_device(device_id, idle_eth_core);
             }
         }

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -424,7 +424,7 @@ void DispatchKernel::CreateKernel() {
     uint32_t num_virtual_active_eth_cores = tt::DevicePool::instance().get_max_num_eth_cores_across_all_devices();
     uint32_t num_physical_active_eth_cores =
         MetalContext::instance()
-            .get_cluster()
+            .get_control_plane()
             .get_active_ethernet_cores(device_->id(), /*skip_reserved_tunnel_cores*/ true)
             .size();
     bool virtualize_num_eth_cores = num_virtual_active_eth_cores > num_physical_active_eth_cores;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -97,7 +97,7 @@ void DispatchSKernel::CreateKernel() {
     uint32_t num_virtual_active_eth_cores = tt::DevicePool::instance().get_max_num_eth_cores_across_all_devices();
     uint32_t num_physical_active_eth_cores =
         MetalContext::instance()
-            .get_cluster()
+            .get_control_plane()
             .get_active_ethernet_cores(device_->id(), /*skip_reserved_tunnel_cores*/ true)
             .size();
     bool virtualize_num_eth_cores = num_virtual_active_eth_cores > num_physical_active_eth_cores;

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -26,6 +26,7 @@
 #include "impl/context/metal_context.hpp"
 #include "trace/trace.hpp"
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
+#include <tt-metalium/control_plane.hpp>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/xy_pair.h>
 #include "vector_aligned.hpp"
@@ -208,7 +209,7 @@ void SubDeviceManager::validate_sub_devices() const {
             const auto& eth_cores = sub_device.cores(HalProgrammableCoreType::ACTIVE_ETH);
             uint32_t num_eth_cores = 0;
             const auto& device_eth_cores =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_->id());
+                tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_->id());
             for (const auto& dev_eth_core : device_eth_cores) {
                 if (eth_cores.contains(dev_eth_core)) {
                     num_eth_cores++;

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -20,6 +20,7 @@
 #include "metal_soc_descriptor.h"
 #include "tt_backend_api_types.hpp"
 #include "impl/context/metal_context.hpp"
+#include <tt-metalium/control_plane.hpp>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/arch.h>
 #include <umd/device/types/cluster_descriptor_types.h>
@@ -171,7 +172,7 @@ const core_descriptor_t& get_core_descriptor_config(
     CoreCoord grid_size =
         tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
     auto logical_active_eth_cores =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id);
+        tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id);
 
     for (const auto& core_node : desc_yaml[dispatch_cores_string]) {
         RelativeCoreCoord coord = {};

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -24,6 +24,7 @@
 #include <unordered_set>
 
 #include "impl/context/metal_context.hpp"
+#include <tt-metalium/control_plane.hpp>
 #include "hal_types.hpp"
 #include "llrt.hpp"
 #include "metal_soc_descriptor.h"
@@ -103,9 +104,10 @@ tt_metal::HalProgrammableCoreType get_core_type(chip_id_t chip_id, const CoreCoo
 
     // Determine whether an ethernet core is active or idle. Their host handshake interfaces are different.
     if (is_eth_core) {
-        auto active_eth_cores = tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(chip_id);
+        auto active_eth_cores =
+            tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(chip_id);
         auto inactive_eth_cores =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_inactive_ethernet_cores(chip_id);
+            tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(chip_id);
         is_active_eth_core =
             active_eth_cores.find(logical_core_from_ethernet_core(chip_id, virtual_core)) != active_eth_cores.end();
         is_inactive_eth_core =
@@ -213,7 +215,8 @@ CoreCoord get_core_for_dram_channel(int dram_channel_id, chip_id_t chip_id) {
 namespace internal_ {
 
 bool is_active_eth_core(chip_id_t chip_id, const CoreCoord& core) {
-    auto active_eth_cores = tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(chip_id);
+    auto active_eth_cores =
+        tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(chip_id);
     return active_eth_cores.find(logical_core_from_ethernet_core(chip_id, core)) != active_eth_cores.end();
 }
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1106,59 +1106,6 @@ std::unordered_set<chip_id_t> Cluster::get_ethernet_connected_device_ids(chip_id
     return device_ids;
 }
 
-std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
-    chip_id_t chip_id, bool skip_reserved_tunnel_cores) const {
-    std::unordered_set<CoreCoord> active_ethernet_cores;
-    const auto& soc_desc = get_soc_desc(chip_id);
-    if (arch_ == ARCH::BLACKHOLE) {
-        // Can't just use `get_ethernet_cores_grouped_by_connected_chips` because there are some active ethernet cores
-        // without links. Only risc1 on these cores is available for Metal and should not be classified as idle
-        // to ensure that Metal does not try to program both riscs.
-        std::set<uint32_t> logical_active_eth_channels = cluster_desc_->get_active_eth_channels(chip_id);
-        for (auto logical_active_eth_channel : logical_active_eth_channels) {
-            tt::umd::CoreCoord logical_active_eth =
-                soc_desc.get_eth_core_for_channel(logical_active_eth_channel, CoordSystem::LOGICAL);
-            active_ethernet_cores.insert(CoreCoord(logical_active_eth.x, logical_active_eth.y));
-        }
-    } else {
-        std::set<uint32_t> logical_active_eth_channels = cluster_desc_->get_active_eth_channels(chip_id);
-        for (const auto& eth_channel : logical_active_eth_channels) {
-            tt::umd::CoreCoord eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
-            const auto& routing_info = this->device_eth_routing_info_.at(chip_id).at(eth_core);
-            if ((routing_info == EthRouterMode::BI_DIR_TUNNELING or routing_info == EthRouterMode::FABRIC_ROUTER) and
-                skip_reserved_tunnel_cores) {
-                continue;
-            }
-            if (this->frequent_retrain_cores_.at(chip_id).find(eth_core) !=
-                this->frequent_retrain_cores_.at(chip_id).end()) {
-                continue;
-            }
-
-            active_ethernet_cores.insert(eth_core);
-        }
-        // WH has a special case where mmio chips with remote connections must always have certain channels active
-        if (this->arch_ == tt::ARCH::WORMHOLE_B0 && this->cluster_desc_->is_chip_mmio_capable(chip_id) &&
-            this->get_tunnels_from_mmio_device(chip_id).size() > 0) {
-            // UMD routing FW uses these cores for base routing
-            // channel 15 is used by syseng tools
-            std::unordered_set<int> channels_to_skip = {};
-            if (this->is_galaxy_cluster()) {
-                // TODO: This may need to change, if we need additional eth cores for dispatch on Galaxy
-                channels_to_skip = {0, 1, 2, 3, 15};
-            } else {
-                channels_to_skip = {15};
-            }
-            for (const auto& eth_channel : channels_to_skip) {
-                if (logical_active_eth_channels.find(eth_channel) == logical_active_eth_channels.end()) {
-                    tt::umd::CoreCoord eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
-                    active_ethernet_cores.insert(eth_core);
-                }
-            }
-        }
-    }
-    return active_ethernet_cores;
-}
-
 void Cluster::configure_ethernet_cores_for_fabric_routers(
     tt_metal::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes) {
     if (fabric_config != tt_metal::FabricConfig::DISABLED) {
@@ -1248,7 +1195,8 @@ void Cluster::release_ethernet_cores_for_fabric_routers() {
 
 std::set<tt_fabric::chan_id_t> Cluster::get_fabric_ethernet_channels(chip_id_t chip_id) const {
     std::set<tt_fabric::chan_id_t> fabric_ethernet_channels;
-    const auto& active_eth_cores = this->get_active_ethernet_cores(chip_id, false);
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& active_eth_cores = control_plane.get_active_ethernet_cores(chip_id, false);
     for (const auto& eth_core : active_eth_cores) {
         if (!this->is_ethernet_link_up(chip_id, eth_core)) {
             continue;
@@ -1275,17 +1223,6 @@ std::vector<CoreCoord> Cluster::get_fabric_ethernet_routers_between_src_and_dest
         }
     }
     return fabric_ethernet_channels;
-}
-
-std::unordered_set<CoreCoord> Cluster::get_inactive_ethernet_cores(chip_id_t chip_id) const {
-    std::unordered_set<CoreCoord> active_ethernet_cores = this->get_active_ethernet_cores(chip_id);
-    std::unordered_set<CoreCoord> inactive_ethernet_cores;
-    for (const auto& [eth_core, chan] : get_soc_desc(chip_id).logical_eth_core_to_chan_map) {
-        if (active_ethernet_cores.find(eth_core) == active_ethernet_cores.end()) {
-            inactive_ethernet_cores.insert(eth_core);
-        }
-    }
-    return inactive_ethernet_cores;
 }
 
 bool Cluster::is_ethernet_link_up(chip_id_t chip_id, const CoreCoord& logical_core) const {
@@ -1413,7 +1350,7 @@ void Cluster::set_internal_routing_info_for_ethernet_cores(bool enable_internal_
     for (auto chip_id : this->driver_->get_target_remote_device_ids()) {
         non_mmio_devices.emplace_back(chip_id);
     }
-
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     if (enable_internal_routing) {
         const routing_info_t routing_info_enabled = {
             .routing_enabled = 1,
@@ -1421,14 +1358,14 @@ void Cluster::set_internal_routing_info_for_ethernet_cores(bool enable_internal_
             .dst_acked_valid_cmd = 0,
         };
         for (const auto &chip_id : non_mmio_devices) {
-            for (const auto& eth_core : this->get_active_ethernet_cores(chip_id, false)) {
+            for (const auto& eth_core : control_plane.get_active_ethernet_cores(chip_id, false)) {
                 tt_cxy_pair virtual_eth_core(chip_id, get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
                 // Enable internal ethernet routing for non-mmio devices
                 write_core((void*)&routing_info_enabled, sizeof(routing_info_t), virtual_eth_core, routing_info_addr_);
             }
         }
         for (const auto &chip_id : mmio_devices) {
-            for (const auto& eth_core : this->get_active_ethernet_cores(chip_id, false)) {
+            for (const auto& eth_core : control_plane.get_active_ethernet_cores(chip_id, false)) {
                 tt_cxy_pair virtual_eth_core(chip_id, get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
                 // Enable internal ethernet routing for mmio devices
                 write_core((void*)&routing_info_enabled, sizeof(routing_info_t), virtual_eth_core, routing_info_addr_);
@@ -1441,14 +1378,14 @@ void Cluster::set_internal_routing_info_for_ethernet_cores(bool enable_internal_
             .dst_acked_valid_cmd = 0,
         };
         for (const auto &chip_id : mmio_devices) {
-            for (const auto& eth_core : this->get_active_ethernet_cores(chip_id, false)) {
+            for (const auto& eth_core : control_plane.get_active_ethernet_cores(chip_id, false)) {
                 tt_cxy_pair virtual_eth_core(chip_id, get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
                 // Disable internal ethernet routing for mmio devices
                 write_core((void*)&routing_info_disabled, sizeof(routing_info_t), virtual_eth_core, routing_info_addr_);
             }
         }
         for (const auto &chip_id : non_mmio_devices) {
-            for (const auto& eth_core : this->get_active_ethernet_cores(chip_id, false)) {
+            for (const auto& eth_core : control_plane.get_active_ethernet_cores(chip_id, false)) {
                 tt_cxy_pair virtual_eth_core(chip_id, get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
                 // Disable internal ethernet routing for non-mmio devices
                 write_core((void*)&routing_info_disabled, sizeof(routing_info_t), virtual_eth_core, routing_info_addr_);

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -115,6 +115,11 @@ public:
 
     std::set<chip_id_t> all_pci_chip_ids() const { return this->driver_->get_target_mmio_device_ids(); }
 
+    tt_ClusterDescriptor* get_cluster_desc() const {
+        TT_FATAL(this->cluster_desc_ != nullptr, "Cluster descriptor is not initialized.");
+        return this->cluster_desc_;
+    }
+
     // TODO: UMD will eventually consolidate ethernet coordinates and unique ids, we can remove the ethernet coord
     // getter after that change is in
     const std::unordered_map<chip_id_t, uint64_t>& get_unique_chip_ids() const {
@@ -210,17 +215,6 @@ public:
     // Ethernet cluster api
     // Returns set of device ids connected via ethernet
     std::unordered_set<chip_id_t> get_ethernet_connected_device_ids(chip_id_t chip_id) const;
-
-    // Returns set of logical active ethernet coordinates on chip
-    // If skip_reserved_tunnel_cores is true, will return cores that dispatch is not using,
-    // intended for users to grab available eth cores for testing
-    // `skip_reserved_tunnel_cores` is ignored on BH because there are no ethernet cores used for Fast Dispatch
-    // tunneling
-    std::unordered_set<CoreCoord> get_active_ethernet_cores(
-        chip_id_t chip_id, bool skip_reserved_tunnel_cores = false) const;
-
-    // Returns set of logical inactive ethernet coordinates on chip
-    std::unordered_set<CoreCoord> get_inactive_ethernet_cores(chip_id_t chip_id) const;
 
     // Returns whether `logical_core` has an eth link to a core on a connected chip
     // Cores that connect to another cluster will show up as connected
@@ -344,6 +338,14 @@ public:
     // TODO: move to separate system descriptor class
     // return enum for connection type, Internal, QSFP, Other, Unknown
     bool is_external_cable(chip_id_t physical_chip_id, CoreCoord eth_core) const;
+
+    const std::unordered_set<CoreCoord>& get_eth_cores_with_frequent_retraining(chip_id_t chip_id) const {
+        return this->frequent_retrain_cores_.at(chip_id);
+    }
+
+    const std::unordered_map<CoreCoord, EthRouterMode>& get_eth_routing_info(chip_id_t chip_id) const {
+        return this->device_eth_routing_info_.at(chip_id);
+    }
 
 private:
     void detect_arch_and_target();


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- For Multi-Mesh workloads, the active ethernet cores list needs to account for ethernet cores backing intermesh links.
- These links are hidden from UMD, and hence aren't visible in the cluster descriptor
- These need to be queried by runtime using the `*intermesh_eth*` APIs added to Control Plane
- It thus makes sense to move these query APIs from Cluster into Control Plane

### What's changed
- Account for intermesh eth cores in the `ControlPlane::get_active_ethernet_cores` query
- Move active and inactive eth core queries to Control Plane

### Future Cleanup on the Schedule
- There are multiple utility functions in `tt_cluster` tracking ethernet core state. Some are related to fabric, ethernet core retraining, ethernet core usage, etc.
- These functions likely also need to be moved to control plane
- Some `tt_cluster` functions needed by control plane to generate the active ethernet core list are exposed as public APIs by cluster. These will be moved.
- This is a first step that is part of a larger effort to separate the responsibilities between `tt_cluster` and Control Plane, where the former serves as a wrapper around UMD and the latter serves as a physical resource management and query layer for Meshes (currently limited to Ethernet and Fabric related concepts).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes