### PR TITLE
Add automatic MPI context initialization in MetalContext

### DIFF
--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(distributed_unit_tests)
 target_sources(
     distributed_unit_tests
     PRIVATE
+        test_auto_mpi_init.cpp
         test_end_to_end_eltwise.cpp
         test_distributed_host_buffer.cpp
         test_mesh_buffer.cpp

--- a/tests/tt_metal/distributed/test_auto_mpi_init.cpp
+++ b/tests/tt_metal/distributed/test_auto_mpi_init.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <tt-metalium/distributed_context.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/device.hpp>
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
+
+namespace tt::tt_metal::distributed {
+namespace {
+
+// If MeshDevice is initialized, the distributed context is initialized through MetalContext
+using MeshDeviceAutoInitDistributedContextTest = GenericMeshDeviceFixture;
+
+// Test that MetalContext constructor automatically initializes the distributed context
+TEST_F(MeshDeviceAutoInitDistributedContextTest, MetalContextInitializesDistributedContext) {
+    EXPECT_TRUE(multihost::DistributedContext::is_initialized());
+    auto world_context = multihost::DistributedContext::get_current_world();
+    EXPECT_NE(world_context, nullptr);
+    EXPECT_EQ(*world_context->size(), 1);
+}
+
+// Test that initialization is only done once
+TEST_F(MeshDeviceAutoInitDistributedContextTest, MetalContextDoesNotReinitialize) {
+    auto world_context1 = multihost::DistributedContext::get_current_world();
+    auto world_context2 = multihost::DistributedContext::get_current_world();
+    EXPECT_EQ(world_context1, world_context2);
+    EXPECT_EQ(*world_context1->size(), 1);
+}
+
+// Test that creating a new distributed context when one is initialized throws
+TEST_F(MeshDeviceAutoInitDistributedContextTest, CannotCreateNewContextWhenInitialized) {
+    multihost::DistributedContext::get_current_world();
+    // This will just duplicate existing world context
+    EXPECT_NO_THROW(multihost::DistributedContext::create(0, nullptr));
+}
+
+}  // namespace
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/distributed_context.hpp
+++ b/tt_metal/api/tt-metalium/distributed_context.hpp
@@ -150,6 +150,10 @@ public:
     static void create(int argc, char** argv);
     static const ContextPtr& get_current_world();
     static void set_current_world(const ContextPtr& ctx);
+
+    // Returns true if the distributed context has already been initialized
+    static bool is_initialized();
+
     //--- Topology ------------------------------------------------------------
     [[nodiscard]] virtual Rank rank() const = 0;
     [[nodiscard]] virtual Size size() const = 0;

--- a/tt_metal/distributed/multihost/distributed_context.cpp
+++ b/tt_metal/distributed/multihost/distributed_context.cpp
@@ -24,4 +24,7 @@ void DistributedContext::create(int argc, char** argv) { ContextImpl::create(arg
 const ContextPtr& DistributedContext::get_current_world() { return ContextImpl::get_current_world(); }
 
 void DistributedContext::set_current_world(const ContextPtr& ctx) { ContextImpl::set_current_world(ctx); }
+
+bool DistributedContext::is_initialized() { return ContextImpl::is_initialized(); }
+
 }  // namespace tt::tt_metal::distributed::multihost

--- a/tt_metal/distributed/multihost/mpi_distributed_context.cpp
+++ b/tt_metal/distributed/multihost/mpi_distributed_context.cpp
@@ -182,7 +182,10 @@ void MPIContext::create(int argc, char** argv) {
 }
 
 const ContextPtr& MPIContext::get_current_world() {
-    TT_FATAL(current_world_, "MPIContext::get_current_world() called before MPIContext::create()");
+    if (!current_world_) {
+        // Default initialization of MPIContext if not already initialized
+        MPIContext::create(0, nullptr);
+    }
     return current_world_;
 }
 
@@ -191,6 +194,12 @@ void MPIContext::set_current_world(const ContextPtr& ctx) {
         ctx != nullptr && std::dynamic_pointer_cast<MPIContext>(ctx) != nullptr,
         "MPIContext::set_current_world: context is not a MPIContext or a nullptr");
     MPIContext::current_world_ = ctx;
+}
+
+bool MPIContext::is_initialized() {
+    int is_mpi_initialized;
+    MPI_CHECK(MPI_Initialized(&is_mpi_initialized));
+    return is_mpi_initialized != 0;
 }
 
 MPIContext::MPIContext(MPI_Comm comm) : comm_(comm) {

--- a/tt_metal/distributed/multihost/mpi_distributed_context.hpp
+++ b/tt_metal/distributed/multihost/mpi_distributed_context.hpp
@@ -58,6 +58,7 @@ public:
     // factory (initialises MPI environment once per process)
     static void create(int argc, char** argv);
     static const ContextPtr& get_current_world();
+    static bool is_initialized();
 
     // destructor – communicator MPI_COMM_WORLD is freed automatically by MPI_Finalize
     // All other communicators are freed here

--- a/tt_metal/distributed/multihost/single_host_context.cpp
+++ b/tt_metal/distributed/multihost/single_host_context.cpp
@@ -29,6 +29,8 @@ void SingleHostContext::set_current_world(const ContextPtr& ctx) {
     SingleHostContext::current_world_ = ctx;
 }
 
+bool SingleHostContext::is_initialized() { return current_world_ != nullptr; }
+
 // basic info
 Rank SingleHostContext::rank() const { return Rank(rank_); }
 Size SingleHostContext::size() const { return Size(size_); }

--- a/tt_metal/distributed/multihost/single_host_context.hpp
+++ b/tt_metal/distributed/multihost/single_host_context.hpp
@@ -20,6 +20,7 @@ public:
     static void create(int argc, char** argv);
     static const ContextPtr& get_current_world();
     static void set_current_world(const ContextPtr&);
+    static bool is_initialized();
 
     // destructor – no-op
     ~SingleHostContext() override = default;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/control_plane.hpp>
+#include <tt-metalium/distributed_context.hpp>
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include <filesystem>
 #include <tt-metalium/device_pool.hpp>
@@ -191,6 +192,7 @@ void MetalContext::teardown() {
     }
     dispatch_query_manager_.reset();
     dispatch_core_manager_.reset();
+    distributed_context_.reset();
 }
 
 MetalContext& MetalContext::instance() {
@@ -203,6 +205,12 @@ MetalContext::MetalContext() {
         Cluster::is_base_routing_fw_enabled(Cluster::get_cluster_type_from_cluster_desc(rtoptions_));
     hal_ = std::make_unique<Hal>(get_platform_architecture(rtoptions_), is_base_routing_fw_enabled);
     cluster_ = std::make_unique<Cluster>(rtoptions_, *hal_);
+    distributed_context_ = distributed::multihost::DistributedContext::get_current_world();
+}
+
+distributed::multihost::DistributedContext& MetalContext::get_distributed_context() {
+    TT_FATAL(distributed_context_, "Distributed context not initialized.");
+    return *distributed_context_;
 }
 
 MetalContext::~MetalContext() {

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -6,6 +6,7 @@
 
 #include <tt_stl/indestructible.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
+#include <tt-metalium/distributed_context.hpp>
 #include <tt-metalium/core_descriptor.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include "dev_msgs.h"
@@ -81,6 +82,8 @@ public:
     void initialize_fabric_config();
     tt_metal::FabricConfig get_fabric_config() const;
 
+    distributed::multihost::DistributedContext& get_distributed_context();
+
 private:
     friend class tt::stl::Indestructible<MetalContext>;
     MetalContext();
@@ -136,6 +139,7 @@ private:
     std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
     std::unique_ptr<tt::tt_fabric::GlobalControlPlane> global_control_plane_;
     tt_metal::FabricConfig fabric_config_ = tt_metal::FabricConfig::DISABLED;
+    std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
 
     // Strict system health mode requires (expects) all links/devices to be live. When enabled, it
     // is expected that any downed devices/links will result in some sort of error condition being


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/23695)

### Problem description
We're starting to port back some changes back to main. These changes support auto-initializing `DistributedContext` during `MetalContext` initialization. This makes MPI queries accessible and moves toward the goal of virtualization of a larger mesh across multiple hosts without requiring users to be explicitly exposed to distributed environment.

### What's changed
This support initializing MPI environment (via DistributedContext) without requiring explicit initialization in user code. Likewise with MPI backend for torch.distributed (see: https://github.com/pytorch/pytorch/blob/main/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp#L241), we just supply default initialization values for initializing MPI environment and will handle parsing of rank to fabric node in custom launcher in a following PR.

With the merge of https://github.com/tenstorrent/tt-metal/pull/23796, we also have regression testing for `SingleHostContext` now as well.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/15858749902 (latest run)