### PR TITLE
Disable Intermesh Link Queries on BH + Move Addrs to HAL

### DIFF
--- a/tt_metal/api/tt-metalium/hal_types.hpp
+++ b/tt_metal/api/tt-metalium/hal_types.hpp
@@ -43,6 +43,8 @@ enum class HalL1MemAddrType : uint8_t {
     RETRAIN_FORCE,
     FABRIC_ROUTER_CONFIG,
     ETH_FW_MAILBOX,
+    INTERMESH_ETH_LINK_CONFIG,
+    INTERMESH_ETH_LINK_STATUS,
     COUNT  // Keep this last so it always indicates number of enum options
 };
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -43,26 +43,25 @@ namespace tt::tt_fabric {
 
 namespace intermesh_constants {
 
-// Constants for multi-mesh configuration
-constexpr uint32_t MULTI_MESH_CONFIG_ADDR = 0x104C;
-constexpr uint32_t MULTI_MESH_LINK_STATUS_ADDR = 0x1104;
+// Constants used to derive the intermesh ethernet links config
 constexpr uint32_t MULTI_MESH_ENABLED_VALUE = 0x2;
 constexpr uint32_t LINK_CONNECTED_MASK = 0x1;
 constexpr uint32_t MULTI_MESH_MODE_MASK = 0xFF;
 constexpr uint32_t INTERMESH_ETH_LINK_BITS_SHIFT = 8;
 constexpr uint32_t INTERMESH_ETH_LINK_BITS_MASK = 0xFFFF;
-constexpr uint32_t MAX_ETH_LINKS = 16;
 
 }  // namespace intermesh_constants
 
 namespace {
 
 // Helper to extract intermesh ports from config value
-std::vector<chan_id_t> extract_intermesh_eth_links(uint32_t config_value) {
+std::vector<chan_id_t> extract_intermesh_eth_links(uint32_t config_value, chip_id_t chip_id) {
     std::vector<chan_id_t> intermesh_eth_links;
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& soc_desc = cluster.get_soc_desc(chip_id);
     uint32_t intermesh_eth_links_bits = (config_value >> intermesh_constants::INTERMESH_ETH_LINK_BITS_SHIFT) &
                                         intermesh_constants::INTERMESH_ETH_LINK_BITS_MASK;
-    for (chan_id_t link = 0; link < intermesh_constants::MAX_ETH_LINKS; ++link) {
+    for (chan_id_t link = 0; link < soc_desc.get_num_eth_channels(); ++link) {
         if (intermesh_eth_links_bits & (1 << link)) {
             intermesh_eth_links.push_back(link);
         }
@@ -1201,9 +1200,11 @@ void ControlPlane::initialize_intermesh_eth_links() {
             chip_id, cluster.get_virtual_coordinate_from_logical_coordinates(chip_id, first_eth_core, CoreType::ETH));
 
         std::vector<uint32_t> config_data(1, 0);
-        cluster.read_core(config_data, sizeof(uint32_t), virtual_eth_core, intermesh_constants::MULTI_MESH_CONFIG_ADDR);
+        auto multi_mesh_config_addr = tt_metal::MetalContext::instance().hal().get_dev_addr(
+            tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::INTERMESH_ETH_LINK_CONFIG);
+        cluster.read_core(config_data, sizeof(uint32_t), virtual_eth_core, multi_mesh_config_addr);
         std::vector<std::pair<CoreCoord, chan_id_t>> intermesh_eth_links;
-        for (auto link : extract_intermesh_eth_links(config_data[0])) {
+        for (auto link : extract_intermesh_eth_links(config_data[0], chip_id)) {
             // Find the CoreCoord for this channel
             for (const auto& [core_coord, channel] : soc_desc.logical_eth_core_to_chan_map) {
                 if (channel == link) {
@@ -1218,6 +1219,10 @@ void ControlPlane::initialize_intermesh_eth_links() {
 }
 
 bool ControlPlane::is_intermesh_enabled() const {
+    // Check if the architecture and system support intermesh routing
+    if (not tt_metal::MetalContext::instance().hal().intermesh_eth_links_enabled()) {
+        return false;
+    }
     std::vector<uint32_t> config_data(1, 0);
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     auto first_chip_id = *(cluster.all_pci_chip_ids().begin());
@@ -1225,7 +1230,9 @@ bool ControlPlane::is_intermesh_enabled() const {
     tt_cxy_pair virtual_eth_core(
         first_chip_id,
         cluster.get_virtual_coordinate_from_logical_coordinates(first_chip_id, first_eth_core, CoreType::ETH));
-    cluster.read_core(config_data, sizeof(uint32_t), virtual_eth_core, intermesh_constants::MULTI_MESH_CONFIG_ADDR);
+    auto multi_mesh_config_addr = tt_metal::MetalContext::instance().hal().get_dev_addr(
+        tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::INTERMESH_ETH_LINK_CONFIG);
+    cluster.read_core(config_data, sizeof(uint32_t), virtual_eth_core, multi_mesh_config_addr);
     bool intermesh_enabled =
         (config_data[0] & intermesh_constants::MULTI_MESH_MODE_MASK) == intermesh_constants::MULTI_MESH_ENABLED_VALUE;
     return intermesh_enabled;
@@ -1255,8 +1262,9 @@ bool ControlPlane::is_intermesh_eth_link_trained(chip_id_t chip_id, CoreCoord et
     tt_cxy_pair virtual_eth_core(
         chip_id, cluster.get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
     std::vector<uint32_t> status_data(1, 0);
-    cluster.read_core(
-        status_data, sizeof(uint32_t), virtual_eth_core, intermesh_constants::MULTI_MESH_LINK_STATUS_ADDR);
+    auto multi_mesh_link_status_addr = tt_metal::MetalContext::instance().hal().get_dev_addr(
+        tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::INTERMESH_ETH_LINK_STATUS);
+    cluster.read_core(status_data, sizeof(uint32_t), virtual_eth_core, multi_mesh_link_status_addr);
 
     // Check if the link is trained
     return (status_data[0] & intermesh_constants::LINK_CONNECTED_MASK) == intermesh_constants::LINK_CONNECTED_MASK;

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -157,6 +157,10 @@
 // Common Misc
 #define MEM_RETRAIN_COUNT_ADDR 0x7CC10
 #define MEM_RETRAIN_FORCE_ADDR 0x1EFC
+// These values are taken from WH, These may need to be updated when BH needs to support
+// intermesh routing.
+#define MEM_INTERMESH_ETH_LINK_CONFIG_ADDR 0x104C
+#define MEM_INTERMESH_ETH_LINK_STATUS_ADDR 0x1104
 #define MEM_SYSENG_ETH_RESULTS_BASE_ADDR 0x7CC00
 #define MEM_SYSENG_ETH_MAILBOX_BASE_ADDR 0x7D000
 

--- a/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
@@ -116,5 +116,8 @@ struct address_map {
 
     static constexpr std::uint32_t RETRAIN_COUNT_ADDR = 0x1EDC;
     static constexpr std::uint32_t RETRAIN_FORCE_ADDR = 0x1EFC;
+
+    static constexpr std::uint32_t INTERMESH_ETH_LINK_CONFIG_ADDR = 0x104C;
+    static constexpr std::uint32_t INTERMESH_ETH_LINK_STATUS_ADDR = 0x1104;
 };
 }  // namespace eth_l1_mem

--- a/tt_metal/llrt/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal.cpp
@@ -150,6 +150,7 @@ void Hal::initialize_bh() {
     this->virtual_worker_start_x_ = VIRTUAL_TENSIX_START_X;
     this->virtual_worker_start_y_ = VIRTUAL_TENSIX_START_Y;
     this->eth_fw_is_cooperative_ = false;
+    this->intermesh_eth_links_enabled_ = false;  // Intermesh routing is not enabled on Blackhole
     this->virtualized_core_types_ = {
         AddressableCoreType::TENSIX, AddressableCoreType::ETH, AddressableCoreType::PCIE, AddressableCoreType::DRAM};
     this->tensix_harvest_axis_ = static_cast<HalTensixHarvestAxis>(tensix_harvest_axis);

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -52,6 +52,10 @@ HalCoreInfoType create_active_eth_mem_map() {
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::APP_ROUTING_INFO)] = MEM_ERISC_APP_ROUTING_INFO_BASE;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::RETRAIN_COUNT)] = MEM_RETRAIN_COUNT_ADDR;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::RETRAIN_FORCE)] = MEM_RETRAIN_FORCE_ADDR;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::INTERMESH_ETH_LINK_CONFIG)] =
+        MEM_INTERMESH_ETH_LINK_CONFIG_ADDR;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::INTERMESH_ETH_LINK_STATUS)] =
+        MEM_INTERMESH_ETH_LINK_STATUS_ADDR;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::FABRIC_ROUTER_CONFIG)] =
         MEM_ERISC_FABRIC_ROUTER_CONFIG_BASE;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::ETH_FW_MAILBOX)] = MEM_SYSENG_ETH_MAILBOX_ADDR;

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -161,6 +161,7 @@ private:
     uint32_t virtual_worker_start_x_;
     uint32_t virtual_worker_start_y_;
     bool eth_fw_is_cooperative_ = false;  // set when eth riscs have to context switch
+    bool intermesh_eth_links_enabled_ = false;  // set when an architecture enable intermesh routing
     std::unordered_set<AddressableCoreType> virtualized_core_types_;
     HalTensixHarvestAxis tensix_harvest_axis_;
 
@@ -239,6 +240,7 @@ public:
     std::uint32_t get_virtual_worker_start_x() const { return this->virtual_worker_start_x_; }
     std::uint32_t get_virtual_worker_start_y() const { return this->virtual_worker_start_y_; }
     bool get_eth_fw_is_cooperative() const { return this->eth_fw_is_cooperative_; }
+    bool intermesh_eth_links_enabled() const { return this->intermesh_eth_links_enabled_; }
     const std::unordered_set<AddressableCoreType>& get_virtualized_core_types() const {
         return this->virtualized_core_types_;
     }

--- a/tt_metal/llrt/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal.cpp
@@ -154,6 +154,7 @@ void Hal::initialize_wh(bool is_base_routing_fw_enabled) {
     this->virtual_worker_start_x_ = VIRTUAL_TENSIX_START_X;
     this->virtual_worker_start_y_ = VIRTUAL_TENSIX_START_Y;
     this->eth_fw_is_cooperative_ = true;
+    this->intermesh_eth_links_enabled_ = true;  // Intermesh routing is enabled on Wormhole
     this->virtualized_core_types_ = {AddressableCoreType::TENSIX, AddressableCoreType::ETH};
     this->tensix_harvest_axis_ = static_cast<HalTensixHarvestAxis>(tensix_harvest_axis);
 

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -83,7 +83,10 @@ HalCoreInfoType create_active_eth_mem_map(bool is_base_routing_fw_enabled) {
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::RETRAIN_FORCE)] = sizeof(uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::FABRIC_ROUTER_CONFIG)] =
         eth_l1_mem::address_map::FABRIC_ROUTER_CONFIG_SIZE;
-
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::INTERMESH_ETH_LINK_CONFIG)] =
+        eth_l1_mem::address_map::INTERMESH_ETH_LINK_CONFIG_ADDR;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::INTERMESH_ETH_LINK_STATUS)] =
+        eth_l1_mem::address_map::INTERMESH_ETH_LINK_STATUS_ADDR;
     // Base FW api not supported on WH
     std::vector<uint32_t> fw_mailbox_addr(static_cast<std::size_t>(FWMailboxMsg::COUNT), 0);
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23698)

### Problem description
- P100 tests are broken since https://github.com/tenstorrent/tt-metal/pull/23163, since this system does not have ethernet cores
- Intermesh routing has not been brought up on BH, so querying intermesh links should be disabled for this architecture, in general

### What's changed
- Add `HAL::intermesh_eth_links_enabled()` API, which returns true for WH and false for BH
- Modify `ControlPlane::is_intermesh_enabled` to return false if the arch does not have intermesh routing brought up
- Move Intermesh Link Config and status addresses to HAL (share values between WH and BH for now)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes