### PR TITLE
[skip ci] Move tests that are CIv2 compatible over to CIv2

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -25,7 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal", timeout: 120},
+          {name: "N300 WH B0 not yet ported", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal", civ2-compatible: false, timeout: 120},
+          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["tt-beta-ubuntu-2204-n300-large-stable"], machine-type: "CIv2", civ2-compatible: true, timeout: 120},
         ]
     name: "${{ matrix.test-info.name }} device perf"
     runs-on: ${{ matrix.test-info.runs-on }}
@@ -57,39 +58,49 @@ jobs:
 
       - name: ${{ matrix.test-info.name }} tests
         timeout-minutes: ${{ matrix.test-info.timeout }}
+        env:
+          TRACY_NO_INVARIANT_CHECK: 1
         run: |
+          set -x
           if [[ "${{ matrix.test-info.arch }}" == "wormhole_b0" ]]; then
             export MAGIC_ENV=wormhole_b0_80_arch_eth_dispatch.yaml
           fi
-          pytest models/demos/wormhole/stable_diffusion/tests -m models_device_performance_bare_metal --timeout=600
-          pytest models/demos/distilbert/tests -m models_device_performance_bare_metal
-          pytest models/demos/vgg/tests/ -m models_device_performance_bare_metal
-          pytest models/demos/convnet_mnist/tests/ -m models_device_performance_bare_metal
-          pytest models/demos/bert_tiny/tests/ -m models_device_performance_bare_metal
-          pytest models/demos/mnist/tests -m models_device_performance_bare_metal
-          pytest models/demos/squeezebert/tests -m models_device_performance_bare_metal
-          pytest models/demos/roberta/tests/ -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/resnet50/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/sentence_bert/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/functional_unet/tests/test_unet_perf.py -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/mamba/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/metal_BERT_large_11/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/falcon7b_common/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/bert_tiny/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov4/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/distilbert/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov9c/tests/perf -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/mobilenetv2/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8x/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/yolov8s/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/functional_vanilla_unet/test -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/yolov8s_world/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/vgg_unet/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/segformer/tests/perf -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/yolov10/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/ufld_v2/tests -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/vit/demo/test_vit_device_perf.py -m models_device_performance_bare_metal
-          WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py -m models_device_performance_bare_metal
+
+          if [[ "${{ matrix.test-info.civ2-compatible }}" != "true" ]]; then
+            echo "Running tests that are not yet ported to CIv2"
+            pytest models/demos/convnet_mnist/tests/ -m models_device_performance_bare_metal
+            pytest models/demos/mnist/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/falcon7b_common/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/segformer/tests/perf -m models_device_performance_bare_metal
+          else
+            echo "Running CIv2 compatible tests"
+            pytest models/demos/wormhole/stable_diffusion/tests -m models_device_performance_bare_metal --timeout=600
+            pytest models/demos/distilbert/tests -m models_device_performance_bare_metal
+            pytest models/demos/vgg/tests/ -m models_device_performance_bare_metal
+            pytest models/demos/bert_tiny/tests/ -m models_device_performance_bare_metal
+            pytest models/demos/squeezebert/tests -m models_device_performance_bare_metal
+            pytest models/demos/roberta/tests/ -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/resnet50/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/sentence_bert/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/functional_unet/tests/test_unet_perf.py -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/mamba/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/metal_BERT_large_11/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/bert_tiny/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov4/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/distilbert/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov9c/tests/perf -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/mobilenetv2/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8x/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/yolov8s/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/functional_vanilla_unet/test -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/yolov8s_world/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/vgg_unet/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/yolov10/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/ufld_v2/tests -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/vit/demo/test_vit_device_perf.py -m models_device_performance_bare_metal
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py -m models_device_performance_bare_metal
+          fi
+
           python3 models/perf/merge_device_perf_results.py
 
       - name: Check device perf report exists


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Perf tests are severely backlogged in CIv1.  But many of the tests actually run/pass on CIv2.

### What's changed
Move over the CIv2-compatible tests to CIv2.

### Checklist
- [ ] Device perf regressions [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15725470105)