### PR TITLE
#23336: SDXL: ttnn.repeat removed

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_embedding.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_embedding.py
@@ -31,14 +31,14 @@ def test_embedding(device, input_shape, module_path, use_program_cache, reset_se
     torch_output_tensor = torch_embedding(torch_input_tensor)
 
     ttnn_input_tensor = ttnn.from_torch(
-        torch_input_tensor.unsqueeze(0).unsqueeze(0),
+        torch_input_tensor,
         dtype=ttnn.bfloat16,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
     ttnn_output_tensor = tt_embedding.forward(ttnn_input_tensor)
-    output_tensor = ttnn.to_torch(ttnn_output_tensor).view(1, -1)
+    output_tensor = ttnn.to_torch(ttnn_output_tensor)
 
     del unet
     gc.collect()

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -51,7 +51,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 336_562_102
+    expected_device_perf_cycles_per_iteration = 331_180_791
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -51,7 +51,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 331_180_791
+    expected_device_perf_cycles_per_iteration = 327_249_321
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
@@ -52,7 +52,7 @@ def prepare_gn_beta_gamma(device, weights, bias, num_cores):
 
 
 def prepare_linear_params(device, weights, bias, dtype):
-    tt_weights = ttnn.from_torch(torch.permute(weights, (0, 1, 3, 2)), dtype, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_weights = ttnn.from_torch(weights.movedim(-1, -2), dtype, device=device, layout=ttnn.TILE_LAYOUT)
     tt_bias = ttnn.from_torch(bias, dtype, device=device, layout=ttnn.TILE_LAYOUT) if bias is not None else None
     return tt_weights, tt_bias
 

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_embedding.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_embedding.py
@@ -13,10 +13,10 @@ class TtTimestepEmbedding(nn.Module):
         super().__init__()
 
         self.device = device
-        weights_1 = state_dict[f"{module_path}.linear_1.weight"].unsqueeze(0).unsqueeze(0)
+        weights_1 = state_dict[f"{module_path}.linear_1.weight"]
         bias_1 = state_dict[f"{module_path}.linear_1.bias"]
 
-        weights_2 = state_dict[f"{module_path}.linear_2.weight"].unsqueeze(0).unsqueeze(0)
+        weights_2 = state_dict[f"{module_path}.linear_2.weight"]
         bias_2 = state_dict[f"{module_path}.linear_2.bias"]
 
         self.tt_weights_1, self.tt_bias_1 = prepare_linear_params(device, weights_1, bias_1, linear_weights_dtype)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch.nn as nn
-import torch
 import ttnn
 
 from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
@@ -12,6 +11,7 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
     prepare_conv_params,
     prepare_split_conv_params,
     split_conv2d,
+    prepare_linear_params,
 )
 
 
@@ -156,13 +156,8 @@ class TtResnetBlock2D(nn.Module):
         else:
             self.tt_conv3_weights = self.tt_conv3_bias = None
 
-        self.tt_time_emb_weights = ttnn.from_torch(
-            torch.permute(time_emb_weights, (1, 0)), model_config.conv_w_dtype, device=device, layout=ttnn.TILE_LAYOUT
-        )
-        self.tt_time_emb_bias = (
-            ttnn.from_torch(time_emb_bias, model_config.conv_w_dtype, device=device, layout=ttnn.TILE_LAYOUT)
-            if time_emb_bias is not None
-            else None
+        self.tt_time_emb_weights, self.tt_time_emb_bias = prepare_linear_params(
+            device, time_emb_weights, time_emb_bias, model_config.conv_w_dtype
         )
 
         mm_path = f"{module_path}.linear"

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -267,9 +267,6 @@ class TtResnetBlock2D(nn.Module):
             compute_kernel_config=self.default_compute_config,
         )
 
-        temb = ttnn.unsqueeze_to_4D(temb)
-        temb = ttnn.repeat(temb, (1, 1, H * W, 1))
-
         hidden_states = ttnn.sharded_to_interleaved(hidden_states, ttnn.L1_MEMORY_CONFIG)
         hidden_states = ttnn.add(hidden_states, temb)
 


### PR DESCRIPTION
Issue #23336 

### What's changed
Removed unnecessary repeat and unsqueeze ops from resnet block.

There were implications that this op was causing the accuracy hang. Hang still exists but now happens on 270. iteration of the test.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15710378393) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15710383218) CI passes