### PR TITLE
#0: Update trace performant Yolov9c

### DIFF
--- a/models/demos/yolov9c/runner/performant_runner.py
+++ b/models/demos/yolov9c/runner/performant_runner.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import torch.nn.functional as F
-
 import ttnn
 from models.demos.yolov9c.runner.performant_runner_infra import YOLOv9PerformanceRunnerInfra
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -102,9 +100,7 @@ class YOLOv9PerformantRunner:
         assert_with_pcc(torch_output_tensor, result_output_tensor, 0.99)
 
     def run(self, torch_input_tensor, check_pcc=False):
-        n, h, w, c = torch_input_tensor.shape
-        torch_input_tensor = F.pad(torch_input_tensor, (0, 29), mode="constant", value=0)
-        tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+        tt_inputs_host, input_mem_config = self.runner_infra._setup_l1_sharded_input(self.device, torch_input_tensor)
         output = self._execute_yolov9_trace_2cqs_inference(tt_inputs_host)
         if check_pcc:
             torch_input_tensor = torch_input_tensor.reshape(n, h, w, c)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Update YoloV9C Performant to use setup_l1_sharded_input.

### What's changed
- Updated Performant Runner to use setup_l1_sharded_input.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] ~[Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)~
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] ~[Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)~
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes