### PR TITLE
#0: Update matmul sweep test with device data

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -682,6 +682,29 @@ def pytest_addoption(parser):
         default=None,
         help="Check determinism every nth iteration",
     )
+    parser.addoption(
+        "--grid-size",
+        action="store",
+        default=None,
+        help="Size of chip grid for the test to run on. Grid size is defined by nubmer of cores in row x number of cores in column, e.g., 8x8",
+    )
+
+
+@pytest.fixture
+def grid_size(request):
+    """
+    Fixture to set the chip grid size for the test to run on.
+    If --grid-size is provided, it returns a tuple of integers (rows, columns).
+    If not provided, it defaults to None.
+    """
+    grid_size_str = request.config.getoption("--grid-size")
+    if grid_size_str:
+        try:
+            rows, cols = map(int, grid_size_str.split("x"))
+            return (rows, cols)
+        except ValueError:
+            raise ValueError(f"Invalid grid size format: {grid_size_str}. Use format 'rows x cols'.")
+    return None
 
 
 # Indicates the iteration interval at which determinism is verified for the op output

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -526,6 +526,7 @@ def test_matmul_2d_host_perf_out_of_box(
                 "dtype",
                 "math_fidelity",
                 "inference_time_avg (ns)",
+                "TFLOPs (avg)",
                 f"Host based utilization[%] (vs {grid_size[0]}x{grid_size[1]} user selected grid)",
                 f"Host based utilization[%] (vs {compute_grid_size.x}x{compute_grid_size.y} full avaialble grid)",
                 f"Device based utilization[%] (vs {grid_size[0]}x{grid_size[1]} user selected grid)",


### PR DESCRIPTION
### Ticket
[Link to Github Issue ](https://github.com/tenstorrent/tt-llk/issues/370)

### Problem description

- Matmul benchmark results are only based on computation time measured by host that includes overhead introduced by dispatch as well.
- Size of chip grid to run test on is fixed to maximum available value, provide grid_size as optional argument to select different grid sizes.

### What's changed

- Added conftest.py fixture to support setting of chip grid size for test to run on. If not provided use maximum available grid size.
- Added device based utilization calculated using TRISC1 kernel length in number of cycles measured by default when profiler build is used. Kernel length is available in profiler log.
- If frequency throttling is applied during matmul OP utilization based on host timing can be missleading since it will use fixed frequency read by profiler to convert host measured time into number of cycles.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes