### PR TITLE
conv2d deallocate_activation not working for mm conv

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3753,12 +3753,13 @@ def test_conv_yolov10x(
 )
 
 @pytest.mark.parametrize(
-    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, padding, dilation",
+    "batch, input_height, input_width, weights_dtype, output_dtype, groups, kernel, padding, dilation",
     (
-        (1, 64, 64, 64, 64, ttnn.bfloat8_b, ttnn.bfloat16, 1, (1, 1), (0, 0, 0, 0), (1, 1)),
+        (1, 64, 64, ttnn.bfloat8_b, ttnn.bfloat16, 1, (1, 1), (0, 0, 0, 0), (1, 1)),
     ),
 )
-@pytest.mark.parametrize("stride", [(1, 1), (2, 2)])
+@pytest.mark.parametrize( "input_channels, output_channels", [(640, 640),(64,64)])
+@pytest.mark.parametrize("stride", [(1, 1),(2, 2)])
 @pytest.mark.parametrize(
     "input_layout",
     [
@@ -3803,6 +3804,9 @@ def test_conv2d_act_dealloc(
 ):
     if shard_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED and input_layout == ttnn.ROW_MAJOR_LAYOUT and stride == (1,1):
         pytest.skip("Block sharded conv2d does not support input with row major layout")
+
+    if input_channels > 64 and shard_layout is not None:
+        pytest.skip("OOM for this given core_grid (expected)")
     input_shape = (batch, input_channels, input_height, input_width)
     weight_shape = (output_channels, input_channels // groups, kernel[0], kernel[1])
     torch_input_tensor = randomize_torch_tensor(torch_tensor_map, input_shape)

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3753,11 +3753,12 @@ def test_conv_yolov10x(
 )
 
 @pytest.mark.parametrize(
-    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, stride, padding, dilation",
+    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, padding, dilation",
     (
-        (1, 64, 64, 64, 64, ttnn.bfloat8_b, ttnn.bfloat16, 1, (1, 1), (1, 1), (0, 0, 0, 0), (1, 1)),
+        (1, 64, 64, 64, 64, ttnn.bfloat8_b, ttnn.bfloat16, 1, (1, 1), (0, 0, 0, 0), (1, 1)),
     ),
 )
+@pytest.mark.parametrize("stride", [(1, 1), (2, 2)])
 @pytest.mark.parametrize(
     "input_layout",
     [
@@ -3777,6 +3778,7 @@ def test_conv_yolov10x(
     [
         None,
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
     ]
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
@@ -3799,6 +3801,8 @@ def test_conv2d_act_dealloc(
     output_layout,
     shard_layout
 ):
+    if shard_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED and input_layout == ttnn.ROW_MAJOR_LAYOUT and stride == (1,1):
+        pytest.skip("Block sharded conv2d does not support input with row major layout")
     input_shape = (batch, input_channels, input_height, input_width)
     weight_shape = (output_channels, input_channels // groups, kernel[0], kernel[1])
     torch_input_tensor = randomize_torch_tensor(torch_tensor_map, input_shape)
@@ -3812,12 +3816,21 @@ def test_conv2d_act_dealloc(
     )
 
     input_mem_cfg = ttnn.DRAM_MEMORY_CONFIG
-    if shard_layout is not None:
+    if shard_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
         num_cores = 2
         input_mem_cfg = ttnn.create_sharded_memory_config(
                 shape=(input_height*input_width*batch // num_cores, input_channels),
                 core_grid=ttnn.num_cores_to_corerangeset(target_num_cores=num_cores, grid_size=device.compute_with_storage_grid_size(), row_wise=True),
                 strategy=ttnn.ShardStrategy.HEIGHT,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+        )
+    elif shard_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
+        num_cores = 4
+        input_mem_cfg = ttnn.create_sharded_memory_config(
+                shape=(input_height*input_width*batch // 2, input_channels // 2),
+                core_grid=ttnn.CoreGrid(x=2,y=2),
+                strategy=ttnn.ShardStrategy.BLOCK,
                 orientation=ttnn.ShardOrientation.ROW_MAJOR,
                 use_height_and_width_as_shard_shape=True,
         )

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3755,10 +3755,30 @@ def test_conv_yolov10x(
 @pytest.mark.parametrize(
     "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, stride, padding, dilation",
     (
-        (1, 1920, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (1, 1), (1, 1), (0, 0, 0, 0), (1, 1)),
+        (1, 64, 64, 64, 64, ttnn.bfloat8_b, ttnn.bfloat16, 1, (1, 1), (1, 1), (0, 0, 0, 0), (1, 1)),
     ),
 )
-
+@pytest.mark.parametrize(
+    "input_layout",
+    [
+        ttnn.ROW_MAJOR_LAYOUT,
+        ttnn.TILE_LAYOUT,
+    ],
+)
+@pytest.mark.parametrize(
+    "output_layout",
+    [
+        ttnn.ROW_MAJOR_LAYOUT,
+        ttnn.TILE_LAYOUT,
+    ],
+)
+@pytest.mark.parametrize(
+    "shard_layout",
+    [
+        None,
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+    ]
+)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_conv2d_act_dealloc(
     device,
@@ -3775,6 +3795,9 @@ def test_conv2d_act_dealloc(
     stride,
     padding,
     dilation,
+    input_layout,
+    output_layout,
+    shard_layout
 ):
     input_shape = (batch, input_channels, input_height, input_width)
     weight_shape = (output_channels, input_channels // groups, kernel[0], kernel[1])
@@ -3787,19 +3810,30 @@ def test_conv2d_act_dealloc(
         torch_weight_tensor,
         ttnn.bfloat16 if weights_dtype == ttnn.bfloat16 else ttnn.float32,
     )
+
+    input_mem_cfg = ttnn.DRAM_MEMORY_CONFIG
+    if shard_layout is not None:
+        num_cores = 2
+        input_mem_cfg = ttnn.create_sharded_memory_config(
+                shape=(input_height*input_width*batch // num_cores, input_channels),
+                core_grid=ttnn.num_cores_to_corerangeset(target_num_cores=num_cores, grid_size=device.compute_with_storage_grid_size(), row_wise=True),
+                strategy=ttnn.ShardStrategy.HEIGHT,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+        )
     tt_input_tensor = ttnn.from_torch(
         torch_input_tensor,
         output_dtype,
-        layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else ttnn.ROW_MAJOR_LAYOUT,
-        device=device # set the tensor to be on device because is_allocated() returns true for host tensors
+        layout=input_layout,
+        device=device, # set the tensor to be on device because is_allocated() returns true for host tensors
+        memory_config=input_mem_cfg,
     )
 
     conv_config = ttnn.Conv2dConfig(
         dtype=output_dtype,
         weights_dtype=weights_dtype,
-        shard_layout=None,
         deallocate_activation=True,
-        in_place=False,
+        output_layout=output_layout,
     )
     _ = ttnn.conv2d(
         input_tensor=tt_input_tensor,

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3751,3 +3751,71 @@ def test_conv_yolov10x(
     activation = activation,
     math_approx_mode = False,
 )
+
+@pytest.mark.parametrize(
+    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, stride, padding, dilation",
+    (
+        (1, 1920, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (1, 1), (1, 1), (0, 0, 0, 0), (1, 1)),
+    ),
+)
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_conv2d_act_dealloc(
+    device,
+    torch_tensor_map,
+    batch,
+    input_channels,
+    output_channels,
+    input_height,
+    input_width,
+    weights_dtype,
+    output_dtype,
+    groups,
+    kernel,
+    stride,
+    padding,
+    dilation,
+):
+    input_shape = (batch, input_channels, input_height, input_width)
+    weight_shape = (output_channels, input_channels // groups, kernel[0], kernel[1])
+    torch_input_tensor = randomize_torch_tensor(torch_tensor_map, input_shape)
+    torch_input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))
+
+    torch_weight_tensor = randomize_torch_tensor(torch_tensor_map, weight_shape)
+
+    tt_weight_tensor = ttnn.from_torch(
+        torch_weight_tensor,
+        ttnn.bfloat16 if weights_dtype == ttnn.bfloat16 else ttnn.float32,
+    )
+    tt_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        output_dtype,
+        layout=ttnn.TILE_LAYOUT if output_dtype == ttnn.bfloat8_b else ttnn.ROW_MAJOR_LAYOUT,
+        device=device # set the tensor to be on device because is_allocated() returns true for host tensors
+    )
+
+    conv_config = ttnn.Conv2dConfig(
+        dtype=output_dtype,
+        weights_dtype=weights_dtype,
+        shard_layout=None,
+        deallocate_activation=True,
+        in_place=False,
+    )
+    _ = ttnn.conv2d(
+        input_tensor=tt_input_tensor,
+        weight_tensor=tt_weight_tensor,
+        in_channels=input_channels,
+        out_channels=output_channels,
+        device=device,
+        bias_tensor=None,
+        kernel_size=kernel,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        batch_size=batch,
+        input_height=input_height,
+        input_width=input_width,
+        conv_config=conv_config,
+        groups=groups,
+    )
+    assert not tt_input_tensor.is_allocated(), "Input tensor is allocated"

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -438,6 +438,10 @@ Result conv2d_L1(
         auto folding_result = compute_kernel_stride_folding_params(
             input_height, input_width, in_channels, kernel_size, stride, padding_n4, conv_config);
         input_tensor = fold_tensor(input_tensor, device, stride, kernel_size, padding_n4, conv_config.dtype, false);
+        if (conv_config.deallocate_activation) {
+            Tensor input_tensor_pre_folded = input_tensor_;
+            input_tensor_pre_folded.deallocate(true);
+        }
 
         // Update the input tensor parameters to the folding result
         input_height = folding_result.input_height;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -674,6 +674,9 @@ Result conv2d_L1(
             activation,
             compute_config);
 
+        if (conv_config.deallocate_activation) {
+            input_tensor_post_tm.deallocate(/*force*/ true);
+        }
         if (memory_config.has_value() && memory_config.value() != matmul_output.memory_config()) {
             matmul_output = ttnn::to_memory_config(matmul_output, memory_config.value(), std::nullopt);
         }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -639,7 +639,13 @@ Result conv2d_L1(
         return {conv_output, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};
     } else {
         if (input_tensor_post_tm.layout() != Layout::TILE) {
-            input_tensor_post_tm = ttnn::to_layout(input_tensor_post_tm, Layout::TILE);
+            Tensor input_tensor_post_tm_tilized =
+                ttnn::to_layout(input_tensor_post_tm, Layout::TILE);
+            if (conv_config.deallocate_activation) {
+                input_tensor_post_tm.deallocate(/*force*/ true);
+                input_tensor_post_tm_tilized = ttnn::move(input_tensor_post_tm_tilized);
+            }
+            input_tensor_post_tm = input_tensor_post_tm_tilized;
         }
 
         // run conv as matmul

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -702,8 +702,12 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
             if (is_mm_conv && input_tensor.layout() == Layout::ROW_MAJOR &&
                 parallel_config.shard_scheme != TensorMemoryLayout::HEIGHT_SHARDED) {
                 // Workaround #13979 ttnn::tilize doesn't support BLOCK_SHARDED layout
-                input_tensor =
-                    ttnn::to_layout(input_tensor, Layout::TILE);
+                Tensor input_tensor_tilized = ttnn::to_layout(input_tensor, Layout::TILE);
+                if (conv_config.deallocate_activation) {
+                    input_tensor.deallocate(/*force*/ true);
+                    input_tensor_tilized = ttnn::move(input_tensor_tilized);
+                }
+                input_tensor = input_tensor_tilized;
             }
             if (!auto_shard_mm) {
                 ttnn::MemoryConfig input_tensor_sharded_memory_config_to_layout = input_tensor_sharded_memory_config;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -702,13 +702,8 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
             if (is_mm_conv && input_tensor.layout() == Layout::ROW_MAJOR &&
                 parallel_config.shard_scheme != TensorMemoryLayout::HEIGHT_SHARDED) {
                 // Workaround #13979 ttnn::tilize doesn't support BLOCK_SHARDED layout
-                Tensor input_tensor_tilized =
+                input_tensor =
                     ttnn::to_layout(input_tensor, Layout::TILE);
-                if (conv_config.deallocate_activation) {
-                    input_tensor.deallocate(/*force*/ true);
-                    input_tensor_tilized = ttnn::move(input_tensor_tilized);
-                }
-                input_tensor = input_tensor_tilized;
             }
             if (!auto_shard_mm) {
                 ttnn::MemoryConfig input_tensor_sharded_memory_config_to_layout = input_tensor_sharded_memory_config;


### PR DESCRIPTION
### Ticket
#23404

### Problem description
When we hit the code path in conv2d that goes directly to matmul `deallocate_activation` parameter in conv config does not have an effect (when true activation won't be deallocated).

### What's changed
- Added deallocation of activation tensor when `deallocate_activation` is passed

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15851220860)
- [X] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15845479744)
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15708822121)
- [X] (Single-card) [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15711117935) 
- [ ] [(Single-card) Model perf tests](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [in progress](https://github.com/tenstorrent/tt-metal/actions/runs/15732785839)
- [x] New/Existing tests provide coverage for changes