### PR TITLE
Fix grid size calculation in `tt_transformers` to enable different `num_attention_heads`

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1653,6 +1653,15 @@ class ModelArgs:
         per_core_M=None,
         per_core_N=None,
     ):
+        if in0_block_w is None:
+            # Reduce grid size if necessary
+            if k % (self.tile_size * grid_size[1]) != 0:
+                grid_size = (grid_size[0], self.find_largest_divisor(k // self.tile_size, max_divisor=grid_size[1]))
+            assert (
+                k % (self.tile_size * grid_size[1]) == 0
+            ), f"Input width must be divisible by tile size times grid size"
+            in0_block_w = self.find_largest_divisor(k // (self.tile_size * grid_size[1]))
+
         if per_core_M is None:
             per_core_M = math.ceil(m / (self.tile_size * grid_size[1]))
         if per_core_N is None:
@@ -1662,9 +1671,6 @@ class ModelArgs:
         out_subblock_w = (
             get_out_subblock_w(per_core_N, out_subblock_h) if not self.is_galaxy else 1
         )  # TODO: Needed for TG hang workaround
-
-        if in0_block_w is None:
-            in0_block_w = self.find_largest_divisor(k // (self.tile_size * grid_size[1]))
 
         return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=grid_size,

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -788,7 +788,7 @@ class ModelArgs:
                 m=num_rows(seq_len),
                 k=k_dim,
                 n=n_dim,
-                grid_size=self.find_prefill_grid(num_rows(seq_len) // self.tile_size, k_dim // self.tile_size),
+                grid_size=self.find_prefill_grid(prefill_rows, k_dim // self.tile_size),
                 in0_block_w=1 if self.is_galaxy else None,
                 fuse_batch=seq_len <= 1024,
                 per_core_N=math.ceil(n_dim / (self.tile_size * dram_shard_grid_width)) if dram_sharded_wo else None,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23012

### Problem description
Running Qwen2.5-7B on N150x4 mesh device was failing due to incorrect matmul config. 
Grid size was incorrectly aligned with the `n_dim` instead of the `k_dim`, this was uncovered since Qwen has a different `num_attention_heads=28` which is not divisible by 8 like for the other models. Additionally, fixed the first argument of `find_prefill_grid` as well to be in line with the previous steps (noticed that this improved quality of the outputs as well).

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16220466242) CI passes
- [ ] [T3K demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16220201660) CI passes
- [x] [TG demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16220203890) CI passes [Falcon7b fails on main and is unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/16221342885)
