### PR TITLE
Increase global cb size to 732 * 1088

### DIFF
--- a/models/demos/llama3_subdevices/tt/prefetcher_common.py
+++ b/models/demos/llama3_subdevices/tt/prefetcher_common.py
@@ -73,13 +73,11 @@ class TtLlamaPrefetcherSetup(LightweightModule):
             mesh_device.set_sub_device_stall_group([self.worker_sub_device_id])
         else:
             ##### Set up the global circular buffer #####
-            max_tile_size = 1088
             # Global CB must be large enough to atleast double buffer weights
             # This ensures that back to back matmuls (for eg. in MLP) can run
             # without stalling on the weight prefetch
-            # calculated by fitting two largest tensor with extra room, ff2 has 391680B per global CB bank, ff1 has 207360B, plus 16320B gap (one block)
-            # TODO: Above calculation is not accurate, need to find a better lower bound
-            self.global_cb_size = 600 * 1088
+            # To fit entire MLP we'd need ~742 * 1088 but using block-wise prefetching and 732 tiles this is sufficient for now
+            self.global_cb_size = 732 * 1088
             self.sender_receiver_mapping = list(zip(self.all_sender_cores, self.all_receiver_cores))
             # self.global_circular_buffer = ttnn.create_global_circular_buffer(
             #     self.mesh_device, self.sender_receiver_mapping, self.global_cb_size


### PR DESCRIPTION
### Ticket
-

### What's changed
Increasing global cb size to 732 tiles in order to fit enough of FF2 weights to avoid stalling FF2 MM.

### Checklist
- [x] [TG demo](https://github.com/tenstorrent/tt-metal/actions/runs/15819943307)