### PR TITLE
[skip ci] Generate multiple artifacts for perf-tests

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -57,6 +57,7 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
 
       - name: ${{ matrix.test-info.name }} tests
+        id: generate-device-perf-report
         timeout-minutes: ${{ matrix.test-info.timeout }}
         env:
           TRACY_NO_INVARIANT_CHECK: 1
@@ -101,24 +102,23 @@ jobs:
             WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py -m models_device_performance_bare_metal
           fi
 
-          python3 models/perf/merge_device_perf_results.py
+          export DEVICE_PERF_REPORT_FILENAME=Models_Device_Perf_${{ matrix.test-info.test-type }}_$(date +%Y_%m_%d).csv
+          python3 models/perf/merge_device_perf_results.py $DEVICE_PERF_REPORT_FILENAME
+          echo "device_perf_report_filename=$DEVICE_PERF_REPORT_FILENAME" >> "$GITHUB_OUTPUT"
 
       - name: Check device perf report exists
         id: check-device-perf-report
         if: ${{ !cancelled() }}
         run: |
-          ls -hal
-          export DEVICE_PERF_REPORT_FILENAME=Models_Device_Perf_$(date +%Y_%m_%d).csv
-          ls -hal $DEVICE_PERF_REPORT_FILENAME
-          echo "device_perf_report_filename=$DEVICE_PERF_REPORT_FILENAME" >> "$GITHUB_OUTPUT"
+          ls -hal ${{ steps.generate-device-perf-report.outputs.device_perf_report_filename }}
 
       - name: Upload device perf report
         timeout-minutes: 5
         if: ${{ !cancelled() && steps.check-device-perf-report.conclusion == 'success' }}
         uses: actions/upload-artifact@v4
         with:
-          name: device-perf-report-csv-${{ matrix.test-info.arch }}-${{ matrix.test-info.machine-type }}
-          path: /work/${{ steps.check-device-perf-report.outputs.device_perf_report_filename }}
+          name: device-perf-report-csv-${{ matrix.test-info.test-type }}-${{ matrix.test-info.arch }}-${{ matrix.test-info.machine-type }}
+          path: /work/${{ steps.generate-device-perf-report.outputs.device_perf_report_filename }}
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10

--- a/models/perf/merge_device_perf_results.py
+++ b/models/perf/merge_device_perf_results.py
@@ -1,9 +1,14 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
+from pathlib import Path
+
 from models.perf.device_perf_utils import check_device_perf_results
 from models.perf.perf_utils import merge_perf_files, today
+
+DEFAULT_FILENAME = f"Models_Device_Perf_{today}.csv"
 
 expected_cols = [
     "Model",
@@ -33,7 +38,23 @@ expected_cols = [
 
 check_cols = ["AVG DEVICE KERNEL SAMPLES/S"]
 
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Merges device performance CSV reports")
+    parser.add_argument(
+        "output_filename",
+        type=Path,
+        nargs="?",
+        default=DEFAULT_FILENAME,
+        help="The output filename",
+    )
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    fname = f"Models_Device_Perf_{today}.csv"
-    merge_perf_files(fname, "device_perf", expected_cols)
-    check_device_perf_results(fname, expected_cols, check_cols)
+    args = parse_args()
+    assert (
+        args.output_filename
+    ), f"Expected user to provide an output filename for merged report (arguments provided were {args})"
+    merge_perf_files(args.output_filename, "device_perf", expected_cols)
+    check_device_perf_results(args.output_filename, expected_cols, check_cols)


### PR DESCRIPTION
### Ticket
Follow-up to #23701 which jumped the gun

### Problem description
We need to keep the reports distinct

### What's changed
Cherry-picked @esmalTT 's change from #23546

### Checklist
- [ ] Perf regression [runs](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml)