### PR TITLE
#22258: Support negative indexing in chunk partitioning function.

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
@@ -311,6 +311,7 @@ TEST(PartitionTest, ChunkNdimNonUniqueDims) {
     tensor.reshape({2, 3, 4});
 
     EXPECT_ANY_THROW(chunk_ndim(tensor, {2, 2}, {0, 0}));
+    EXPECT_ANY_THROW(chunk_ndim(tensor, {2, 2}, {2, -1}));
     EXPECT_ANY_THROW(chunk_ndim(tensor, {2, 2, 3}, {0, 1, 0}));
 }
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
@@ -82,6 +82,22 @@ TEST(PartitionTest, ChunkFewerChunksThanRequested) {
     EXPECT_EQ(chunks[4].shape()[0], 1u);
 }
 
+TEST(PartitionTest, ChunkNegativeDim) {
+    xt::xarray<float> tensor = xt::arange<float>(20);
+    tensor.reshape({2, 10});
+
+    // Chunk into 3 parts along dimension -1 (i.e., dimension 1)
+    auto chunks_neg = chunk(tensor, 3, -1);
+    auto chunks_pos = chunk(tensor, 3, 1);
+
+    ASSERT_THAT(chunks_neg, SizeIs(3));
+    ASSERT_THAT(chunks_pos, SizeIs(3));
+
+    EXPECT_TRUE(xt::allclose(chunks_neg[0], chunks_pos[0]));
+    EXPECT_TRUE(xt::allclose(chunks_neg[1], chunks_pos[1]));
+    EXPECT_TRUE(xt::allclose(chunks_neg[2], chunks_pos[2]));
+}
+
 TEST(PartitionTest, DefaultAxis) {
     xt::xarray<double> a = {{1.0, 2.0}, {3.0, 4.0}};
     xt::xarray<double> b = {{5.0, 6.0}, {7.0, 8.0}};
@@ -99,6 +115,17 @@ TEST(PartitionTest, AxisOne) {
     std::vector<xt::xarray<int>> input = {x, y};
 
     xt::xarray<int> result = concat(input, 1);
+    xt::xarray<int> expected = {{1, 2, 3, 7, 8}, {4, 5, 6, 9, 10}};
+
+    EXPECT_TRUE(xt::allclose(result, expected));
+}
+
+TEST(PartitionTest, ConcatNegativeDim) {
+    xt::xarray<int> x = {{1, 2, 3}, {4, 5, 6}};
+    xt::xarray<int> y = {{7, 8}, {9, 10}};
+    std::vector<xt::xarray<int>> input = {x, y};
+
+    xt::xarray<int> result = concat(input, -1);
     xt::xarray<int> expected = {{1, 2, 3, 7, 8}, {4, 5, 6, 9, 10}};
 
     EXPECT_TRUE(xt::allclose(result, expected));
@@ -292,7 +319,7 @@ TEST(PartitionTest, ChunkNdimDimsOutOfRange) {
     tensor.reshape({2, 3, 4});
 
     EXPECT_ANY_THROW(chunk_ndim(tensor, {2}, {3}));
-    EXPECT_ANY_THROW(chunk_ndim(tensor, {2}, {-1}));
+    EXPECT_ANY_THROW(chunk_ndim(tensor, {2}, {-5}));
     EXPECT_ANY_THROW(chunk_ndim(tensor, {2, 2}, {0, 5}));
 }
 

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -27,7 +27,6 @@ using StridedViews = std::vector<StridedView<T>>;
 //
 // Splits an xtensor expression into chunks along the specified dimension, and returns a vector of un-owned strided
 // views.
-// The value of `dim` must not be negative.
 template <typename T>
 StridedViews<T> chunk(const xt::xexpression<T>& expr, int num_chunks, int dim = 0);
 
@@ -35,10 +34,9 @@ StridedViews<T> chunk(const xt::xexpression<T>& expr, int num_chunks, int dim = 
 // Chunking is done in row-major order relative to the supplied `dims`, and returned in the vector in the same order.
 // `num_chunks` and `dims` must have the same length. When empty, no chunking is performed, and the entire tensor is
 // returned as a single chunk.
-// The values of `dims` must not be negative.
 template <typename T>
 StridedViews<T> chunk_ndim(
-    const xt::xexpression<T>& expr, tt::stl::SmallVector<int> num_chunks, tt::stl::SmallVector<int> dims);
+    const xt::xexpression<T>& expr, const tt::stl::SmallVector<int>& num_chunks, const tt::stl::SmallVector<int>& dims);
 
 // Concatenates a list of tensors along the specified dimension.
 tt::tt_metal::Tensor concat(const std::vector<tt::tt_metal::Tensor>& tensors, int dim = 0);

--- a/ttnn/core/tensor/xtensor/partition.cpp
+++ b/ttnn/core/tensor/xtensor/partition.cpp
@@ -22,9 +22,19 @@
 namespace ttnn::experimental::xtensor {
 namespace {
 
+tt::stl::SmallVector<int> normalize_dims(const tt::stl::SmallVector<int>& dims, size_t tensor_dims) {
+    tt::stl::SmallVector<int> normalized_dims;
+    std::transform(dims.begin(), dims.end(), std::back_inserter(normalized_dims), [tensor_dims](int dim) {
+        return dim < 0 ? dim + static_cast<int>(tensor_dims) : dim;
+    });
+    return normalized_dims;
+}
+
 template <typename T>
 auto chunk_xexpression(
-    const xt::xexpression<T>& expr_base, tt::stl::SmallVector<int> num_chunks, tt::stl::SmallVector<int> dims) {
+    const xt::xexpression<T>& expr_base,
+    const tt::stl::SmallVector<int>& num_chunks,
+    const tt::stl::SmallVector<int>& dims) {
     const auto& expr = expr_base.derived_cast();
     if (num_chunks.empty()) {
         xt::xstrided_slice_vector indices(expr.dimension(), xt::all());
@@ -35,31 +45,38 @@ auto chunk_xexpression(
     auto sorted_dims = dims;
     std::sort(sorted_dims.begin(), sorted_dims.end());
     TT_FATAL(std::unique(sorted_dims.begin(), sorted_dims.end()) == sorted_dims.end(), "dims must be unique");
+
     TT_FATAL(
-        std::all_of(num_chunks.begin(), num_chunks.end(), [](size_t size) { return size > 0; }),
+        std::all_of(num_chunks.begin(), num_chunks.end(), [](int size) { return size > 0; }),
         "num_chunks must be > 0; got num_chunks: {}",
         num_chunks);
+
+    const auto normalized_dims = normalize_dims(dims, expr.dimension());
     TT_FATAL(
-        std::all_of(dims.begin(), dims.end(), [&expr](size_t dim) { return dim >= 0 && dim < expr.dimension(); }),
+        std::all_of(
+            normalized_dims.begin(),
+            normalized_dims.end(),
+            [&expr](int dim) { return dim >= 0 && dim < expr.dimension(); }),
         "invalid dimension index; got dims: {}, tensor dimension: {}",
         dims,
         expr.dimension());
 
+    const size_t dims_size = normalized_dims.size();
     tt::stl::SmallVector<std::vector<std::pair<int, int>>> dim_ranges;
     tt::stl::SmallVector<size_t> num_chunks_per_dim;
-    for (size_t i = 0; i < dims.size(); ++i) {
-        int dim = dims[i];
-        int num_chunks_along_dim = num_chunks[i];
-        int size_along_dim = static_cast<int>(expr.shape()[dim]);
-        int chunk_size = (size_along_dim + num_chunks_along_dim - 1) / num_chunks_along_dim;
+    for (size_t i = 0; i < dims_size; ++i) {
+        const int dim = normalized_dims[i];
+        const int num_chunks_along_dim = num_chunks[i];
+        const int size_along_dim = static_cast<int>(expr.shape()[dim]);
+        const int chunk_size = (size_along_dim + num_chunks_along_dim - 1) / num_chunks_along_dim;
 
         std::vector<std::pair<int, int>> ranges;
         ranges.reserve(num_chunks_along_dim);
 
         int start = 0;
         for (int chunk_idx = 0; chunk_idx < num_chunks_along_dim && start < size_along_dim; ++chunk_idx) {
-            int current_chunk_size = std::min(chunk_size, size_along_dim - start);
-            int end = start + current_chunk_size;
+            const int current_chunk_size = std::min(chunk_size, size_along_dim - start);
+            const int end = start + current_chunk_size;
             ranges.emplace_back(start, end);
             start = end;
         }
@@ -71,19 +88,18 @@ auto chunk_xexpression(
         std::accumulate(num_chunks_per_dim.begin(), num_chunks_per_dim.end(), 1, std::multiplies<size_t>());
 
     StridedViews<T> chunk_views;
-    tt::stl::SmallVector<size_t> current_indices(dims.size(), 0);
+    tt::stl::SmallVector<size_t> current_indices(dims_size, 0);
     for (size_t chunk_idx = 0; chunk_idx < total_chunks; ++chunk_idx) {
         xt::xstrided_slice_vector indices(expr.dimension(), xt::all());
-        for (size_t i = 0; i < dims.size(); ++i) {
-            int dim = dims[i];
-            auto [start, end] = dim_ranges[i][current_indices[i]];
+        for (size_t i = 0; i < dims_size; ++i) {
+            const int dim = normalized_dims[i];
+            const auto [start, end] = dim_ranges[i][current_indices[i]];
             indices[dim] = xt::range(start, end);
         }
 
-        auto chunk_view = xt::strided_view(expr, indices);
-        chunk_views.push_back(chunk_view);
+        chunk_views.push_back(xt::strided_view(expr, indices));
 
-        for (int i = static_cast<int>(dims.size()) - 1; i >= 0; --i) {
+        for (int i = static_cast<int>(dims_size) - 1; i >= 0; --i) {
             if (++current_indices[i] < num_chunks_per_dim[i]) {
                 break;
             }
@@ -111,7 +127,9 @@ StridedViews<T> chunk(const xt::xexpression<T>& expr, int num_chunks, int dim) {
 
 template <typename T>
 StridedViews<T> chunk_ndim(
-    const xt::xexpression<T>& expr, tt::stl::SmallVector<int> num_chunks, tt::stl::SmallVector<int> dims) {
+    const xt::xexpression<T>& expr,
+    const tt::stl::SmallVector<int>& num_chunks,
+    const tt::stl::SmallVector<int>& dims) {
     return chunk_xexpression(expr, num_chunks, dims);
 }
 
@@ -172,16 +190,18 @@ xt::xarray<T> concat(const std::vector<xt::xarray<T>>& v, int dim) {
 }
 
 // Explicit instantiations for the public API.
-#define EXPLICIT_INSTANTIATIONS_FOR_TYPE(T)                                                                    \
-    template StridedViews<xt::xarray<T>> chunk(const xt::xexpression<xt::xarray<T>>&, int, int);               \
-    template StridedViews<xt::xarray<T>> chunk_ndim(                                                           \
-        const xt::xexpression<xt::xarray<T>>&, tt::stl::SmallVector<int>, tt::stl::SmallVector<int>);          \
-    template StridedViews<AdaptedType<T>> chunk(const xt::xexpression<AdaptedType<T>>&, int, int);             \
-    template StridedViews<AdaptedType<T>> chunk_ndim(                                                          \
-        const xt::xexpression<AdaptedType<T>>&, tt::stl::SmallVector<int>, tt::stl::SmallVector<int>);         \
-    template StridedViews<AdaptedType<const T>> chunk(const xt::xexpression<AdaptedType<const T>>&, int, int); \
-    template StridedViews<AdaptedType<const T>> chunk_ndim(                                                    \
-        const xt::xexpression<AdaptedType<const T>>&, tt::stl::SmallVector<int>, tt::stl::SmallVector<int>);   \
+#define EXPLICIT_INSTANTIATIONS_FOR_TYPE(T)                                                                          \
+    template StridedViews<xt::xarray<T>> chunk(const xt::xexpression<xt::xarray<T>>&, int, int);                     \
+    template StridedViews<xt::xarray<T>> chunk_ndim(                                                                 \
+        const xt::xexpression<xt::xarray<T>>&, const tt::stl::SmallVector<int>&, const tt::stl::SmallVector<int>&);  \
+    template StridedViews<AdaptedType<T>> chunk(const xt::xexpression<AdaptedType<T>>&, int, int);                   \
+    template StridedViews<AdaptedType<T>> chunk_ndim(                                                                \
+        const xt::xexpression<AdaptedType<T>>&, const tt::stl::SmallVector<int>&, const tt::stl::SmallVector<int>&); \
+    template StridedViews<AdaptedType<const T>> chunk(const xt::xexpression<AdaptedType<const T>>&, int, int);       \
+    template StridedViews<AdaptedType<const T>> chunk_ndim(                                                          \
+        const xt::xexpression<AdaptedType<const T>>&,                                                                \
+        const tt::stl::SmallVector<int>&,                                                                            \
+        const tt::stl::SmallVector<int>&);                                                                           \
     template xt::xarray<T> concat(const std::vector<xt::xarray<T>>& v, int dim);
 
 EXPLICIT_INSTANTIATIONS_FOR_TYPE(bfloat16)


### PR DESCRIPTION
### Ticket
#22258

### Problem description
`chunk` implementation doesn't support negative dim indexing, which is needed to migrate off pytorch-based sharidng.

### What's changed
Handle negative dims by normalizing them. Also fix input parameters passed by value instead of const ref.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15737319872)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15737323116)
- [x] New/Existing tests provide coverage for changes