### PR TITLE
Uplift tests to use Dispatch on Fabric

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -18,6 +18,36 @@
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_metal.hpp>
 
+namespace {
+
+constexpr auto k_FabricConfig = tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC;
+constexpr auto k_ReliabilityMode = tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
+
+std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(const std::filesystem::path& graph_desc) {
+    auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(graph_desc.string());
+    tt::tt_metal::MetalContext::instance().set_fabric_config(k_FabricConfig, k_ReliabilityMode);
+    control_plane->initialize_fabric_context(k_FabricConfig, k_ReliabilityMode);
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels(k_ReliabilityMode);
+
+    return control_plane;
+}
+
+std::unique_ptr<tt::tt_fabric::GlobalControlPlane> make_global_control_plane(
+    const std::filesystem::path& graph_desc,
+    const std::map<tt::tt_fabric::FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
+    tt::tt_metal::MetalContext::instance().set_fabric_config(k_FabricConfig, k_ReliabilityMode);
+
+    auto global_control_plane = std::make_unique<tt::tt_fabric::GlobalControlPlane>(
+        graph_desc.string(), logical_mesh_chip_id_to_physical_chip_id_mapping);
+    auto& control_plane = global_control_plane->get_local_node_control_plane();
+    control_plane.initialize_fabric_context(k_FabricConfig, k_ReliabilityMode);
+    control_plane.configure_routing_tables_for_fabric_ethernet_channels(k_ReliabilityMode);
+
+    return global_control_plane;
+}
+
+}  // namespace
+
 namespace tt::tt_fabric::fabric_router_tests {
 
 using ::testing::ElementsAre;
@@ -33,11 +63,7 @@ TEST_F(ControlPlaneFixture, TestTGControlPlaneInit) {
     const std::filesystem::path tg_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
-    auto control_plane = std::make_unique<ControlPlane>(tg_mesh_graph_desc_path.string());
-    control_plane->initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    [[maybe_unused]] auto control_plane = make_control_plane(tg_mesh_graph_desc_path);
 }
 
 TEST_F(ControlPlaneFixture, TestTGMeshAPIs) {
@@ -56,11 +82,7 @@ TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
     const std::filesystem::path tg_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
-    auto control_plane = std::make_unique<ControlPlane>(tg_mesh_graph_desc_path.string());
-    control_plane->initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    auto control_plane = make_control_plane(tg_mesh_graph_desc_path);
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 1);
     EXPECT_GT(valid_chans.size(), 0);
     for (auto chan : valid_chans) {
@@ -80,22 +102,15 @@ TEST_F(ControlPlaneFixture, TestT3kControlPlaneInit) {
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
-    auto control_plane = std::make_unique<ControlPlane>(t3k_mesh_graph_desc_path.string());
-    control_plane->initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    auto control_plane = make_control_plane(t3k_mesh_graph_desc_path);
 }
 
 TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
-    auto control_plane = std::make_unique<ControlPlane>(t3k_mesh_graph_desc_path.string());
-    control_plane->initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    auto control_plane = make_control_plane(t3k_mesh_graph_desc_path);
+
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 0);
     EXPECT_GT(valid_chans.size(), 0);
     for (auto chan : valid_chans) {
@@ -125,14 +140,8 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kControlPlaneInit) {
     auto [mesh_graph_desc_path, mesh_graph_eth_coords] = GetParam();
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
-    auto global_control_plane = std::make_unique<GlobalControlPlane>(
-        t3k_mesh_graph_desc_path.string(),
-        get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
-    auto& control_plane = global_control_plane->get_local_node_control_plane();
-    control_plane.initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane.configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    [[maybe_unused]] auto global_control_plane = make_global_control_plane(
+        t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
 }
 
 TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
@@ -140,14 +149,10 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
     auto [mesh_graph_desc_path, mesh_graph_eth_coords] = GetParam();
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
-    auto global_control_plane = std::make_unique<GlobalControlPlane>(
-        t3k_mesh_graph_desc_path.string(),
-        get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
+    auto global_control_plane = make_global_control_plane(
+        t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
     auto& control_plane = global_control_plane->get_local_node_control_plane();
-    control_plane.initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane.configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+
     for (const auto& src_mesh : control_plane.get_user_physical_mesh_ids()) {
         for (const auto& dst_mesh : control_plane.get_user_physical_mesh_ids()) {
             auto src_mesh_shape = control_plane.get_physical_mesh_shape(src_mesh);
@@ -170,13 +175,10 @@ TEST_F(ControlPlaneFixture, TestT3kDisjointFabricRoutes) {
     auto [mesh_graph_desc_path, mesh_graph_eth_coords] = t3k_disjoint_mesh_descriptor_chip_mappings[0];
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
-    auto global_control_plane = std::make_unique<GlobalControlPlane>(
+    auto global_control_plane = make_global_control_plane(
         t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
     auto& control_plane = global_control_plane->get_local_node_control_plane();
-    control_plane.initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane.configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+
     auto valid_chans = control_plane.get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 0);
     EXPECT_GT(valid_chans.size(), 0);
     for (auto chan : valid_chans) {
@@ -208,11 +210,7 @@ TEST_F(ControlPlaneFixture, TestSingleGalaxyControlPlaneInit) {
     const std::filesystem::path single_galaxy_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.yaml";
-    auto control_plane = std::make_unique<ControlPlane>(single_galaxy_mesh_graph_desc_path.string());
-    control_plane->initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    [[maybe_unused]] auto control_plane = make_control_plane(single_galaxy_mesh_graph_desc_path.string());
 }
 
 TEST_F(ControlPlaneFixture, TestSingleGalaxyMeshAPIs) {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -1358,21 +1358,16 @@ int TestLoopbackEntrypoint(
     const auto& device_0 = view.get_device(MeshCoordinate(0, 0));
     const auto& device_1 = view.get_device(MeshCoordinate(0, 1));
 
-    const auto& active_eth_cores = device_0->get_active_ethernet_cores(true);
-    auto eth_sender_core_iter = active_eth_cores.begin();
-    auto eth_sender_core_iter_end = active_eth_cores.end();
-    chip_id_t device_id = std::numeric_limits<chip_id_t>::max();
-    tt_xy_pair eth_receiver_core;
     bool initialized = false;
-    tt_xy_pair eth_sender_core;
-    do {
-        TT_FATAL(eth_sender_core_iter != eth_sender_core_iter_end, "Error");
-        std::tie(device_id, eth_receiver_core) = device_0->get_connected_ethernet_core(*eth_sender_core_iter);
-        eth_sender_core = *eth_sender_core_iter;
-        eth_sender_core_iter++;
-    } while (device_id != device_1->id());
-    TT_ASSERT(device_id == device_1->id());
-    // const auto& device_1 = test_fixture.mesh_device_->get_device(device_id);
+    const auto eth_receiver_cores = device_1->get_ethernet_sockets(device_0->id());
+    const auto eth_sender_cores = device_0->get_ethernet_sockets(device_1->id());
+
+    TT_ASSERT(
+        !eth_receiver_cores.empty(), "No eth receiver cores found (device {} to {})", device_1->id(), device_0->id());
+    TT_ASSERT(!eth_sender_cores.empty(), "No eth sender cores found (device {} to {})", device_0->id(), device_1->id());
+
+    const auto eth_receiver_core = eth_receiver_cores[0];
+    const auto eth_sender_core = eth_sender_cores[0];
 
     std::vector<Program> programs(1);
     std::optional<std::vector<Program>> fabric_programs;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -36,6 +36,7 @@
 #include <tt-metalium/shape_base.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/sub_device_types.hpp>
+#include "context/metal_context.hpp"
 #include "tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp"
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
@@ -762,7 +763,20 @@ TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast) {
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 
+//
+// The routing plane for fast dispatch uses 1 eth core in each direction
+// Not enough eth cores for tests that need 2 links. Remove when dispatch routing
+// plane can be customized to not create a router in the MMIO to MMIO direction.
+//
+// Function must be macro to because GTEST_SKIP needs to be used inside the context of TEST.
+//
+#define CHECK_TWO_LINKS_AVAILABLE()                                           \
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) { \
+        GTEST_SKIP() << "Not enough eth cores for 2 links";                   \
+    }
+
 TEST(EdmFabric, BasicMcastThroughputTest_SingleMcast) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 1;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -926,6 +940,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast_LineSy
 }
 
 TEST(EdmFabric, BasicMcastThroughputTest_SingleMcast_LineSync) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 1;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1046,6 +1061,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderTwoWrap_ReceiverOneWrap_LineSync)
 }
 
 TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf_2Device) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 70;
     const size_t num_unicasts = 0;
     const size_t num_links = 2;
@@ -1060,6 +1076,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf_2Device) {
 }
 
 TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf0) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 70;
     const size_t num_unicasts = 0;
     const size_t num_links = 2;
@@ -1070,6 +1087,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf0) {
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf1) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 70;
     const size_t num_unicasts = 0;
     const size_t num_links = 2;
@@ -1081,6 +1099,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf1) {
 }
 
 TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_0) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 100;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1093,6 +1112,7 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_0) {
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_1) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 1000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1104,6 +1124,7 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_1) {
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_2) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 50000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1123,6 +1144,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_3_SingleLink) {
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_3) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 200000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1146,6 +1168,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_3_onehop) {
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_4) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 800000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1154,6 +1177,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_4) {
 }
 
 TEST(EdmFabric, BasicMcastThroughputTest_5) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 1;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1162,6 +1186,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_5) {
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_6) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 100;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1170,6 +1195,7 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_6) {
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_7) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 1000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1178,6 +1204,7 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_7) {
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_8) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 50000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1186,6 +1213,7 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_8) {
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_9) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 200000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1194,6 +1222,7 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_9) {
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_10) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 800000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1201,6 +1230,7 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_10) {
     RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_6_Short) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 100;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1208,6 +1238,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_6_Short) {
     RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_7_Short) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 1000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1215,6 +1246,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_7_Short) {
     RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_8_Short) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 50000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1222,6 +1254,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_8_Short) {
     RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_9_Short) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 200000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1229,6 +1262,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_9_Short) {
     RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_10_Short) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 800000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1237,6 +1271,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_10_Short) {
 }
 
 TEST(EdmFabric, BasicMcastThroughputTest_0_WithLineSync) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 100;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1248,6 +1283,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_0_WithLineSync) {
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_1_WithLineSync) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 1000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1259,6 +1295,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_1_WithLineSync) {
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_2_WithLineSync) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 50000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1270,6 +1307,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_2_WithLineSync) {
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_3_WithLineSync) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 200000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -1281,6 +1319,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_3_WithLineSync) {
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_4_WithLineSync) {
+    CHECK_TWO_LINKS_AVAILABLE();
     const size_t num_mcasts = 800000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1430,7 +1430,6 @@ uint16_t ControlPlane::get_routing_mode() const { return this->routing_mode_; }
 
 void ControlPlane::initialize_fabric_context(tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode) {
     TT_FATAL(this->fabric_context_ == nullptr, "Trying to re-initialize fabric context");
-    tt::tt_metal::MetalContext::instance().set_fabric_config(fabric_config, reliability_mode);
     this->fabric_context_ = std::make_unique<FabricContext>(fabric_config);
 }
 
@@ -1568,7 +1567,8 @@ std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(
         for (const auto& eth_channel : logical_active_eth_channels) {
             tt::umd::CoreCoord eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
             const auto& routing_info = eth_routing_info.at(eth_core);
-            if ((routing_info == EthRouterMode::BI_DIR_TUNNELING or routing_info == EthRouterMode::FABRIC_ROUTER) and
+            if ((routing_info == EthRouterMode::BI_DIR_TUNNELING or routing_info == EthRouterMode::FABRIC_ROUTER or
+                 routing_info == EthRouterMode::FABRIC_ROUTER_DISPATCH) and
                 skip_reserved_cores) {
                 continue;
             }

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -318,9 +318,7 @@ void DevicePool::initialize(
                 tt::tt_metal::detail::SetFabricConfig(
                     FabricConfig::FABRIC_1D, tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
                 // Previously disabled. Need to init
-                if (fabric_config == FabricConfig::DISABLED) {
-                    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
-                }
+                tt::tt_metal::MetalContext::instance().initialize_fabric_config();
                 fabric_config = FabricConfig::FABRIC_1D;
                 log_info(tt::LogMetal, "Dispatch on 1D Fabric");
             } else {

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
@@ -74,7 +74,7 @@ void RelayMux::GenerateStaticConfigs() {
         mux_config_core);
     mux_ct_args_ = mux_kernel_config_->get_fabric_mux_compile_time_args();
 
-    log_debug(
+    log_info(
         tt::LogMetal,
         "RelayMux Device:{}, HeaderCh:{}, FullCh:{}, FullB:{}, Logical:{}, Virtual: {}, D2H: {}",
         device_->id(),

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1425,7 +1425,7 @@ void build_tt_fabric_program(
         chip_neighbors.emplace(direction, neighbor_fabric_node_id);
 
         active_fabric_eth_channels.insert({direction, active_eth_chans});
-        log_debug(
+        log_info(
             tt::LogMetal,
             "Building fabric router -> device (phys): {}, (logical): {}, direction: {}, active_eth_chans: {}",
             device->id(),

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -80,9 +80,10 @@ enum class ClusterType : std::uint8_t {
 };
 
 enum class EthRouterMode : uint32_t {
-    IDLE = 0,
-    BI_DIR_TUNNELING = 1,
-    FABRIC_ROUTER = 2,
+    IDLE = 0,                    // Unused
+    BI_DIR_TUNNELING = 1,        // Eth core for legacy dispatch tunneling
+    FABRIC_ROUTER = 2,           // Eth core for Fabric router for general use
+    FABRIC_ROUTER_DISPATCH = 3,  // Eth core for Fabric router dispatch routing
 };
 
 class Cluster {
@@ -321,7 +322,9 @@ public:
     std::set<tt_fabric::chan_id_t> get_fabric_ethernet_channels(chip_id_t chip_id) const;
 
     // Get fabric ethernet cores connecting src to dst
-    std::vector<CoreCoord> get_fabric_ethernet_routers_between_src_and_dest(chip_id_t src_id, chip_id_t dst_id) const;
+    // Will skip routers dedicated for dispatch by default
+    std::vector<CoreCoord> get_fabric_ethernet_routers_between_src_and_dest(
+        chip_id_t src_id, chip_id_t dst_id, bool skip_dispatch_routers = true) const;
 
     bool is_worker_core(const CoreCoord& core, chip_id_t chip_id) const;
     bool is_ethernet_core(const CoreCoord& core, chip_id_t chip_id) const;

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -6,6 +6,7 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/buffer.hpp>
+#include "tt-metalium/data_types.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"
 #include "ttnn/operations/ccl/all_gather/device/all_gather_op.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -9,6 +9,7 @@
 
 #include "ccl_host_datastructures.hpp"
 #include <tt-metalium/erisc_datamover_builder.hpp>
+#include "tt-metalium/data_types.hpp"
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
 
@@ -201,14 +202,22 @@ RingTopology::RingTopology(
         // Get the cores for the sender and receiver worker cores
         if (!is_linear || ring_index != ring_size - 1) {
             uint32_t receiver_device = receiver_device_id.value();
-            auto const& sockets = device->get_ethernet_sockets(receiver_device);
+            const auto& sockets = device->get_ethernet_sockets(receiver_device);
+            log_info(tt::LogMetal, "Sockets size = {}", sockets.size());
+            for (auto c : sockets) {
+                log_info(tt::LogMetal, "Got sender socket {} to {} {}", device->id(), receiver_device, c.str());
+            }
             auto eth_sender_core = sockets.at(sender_socket_idx);
             eth_sender_cores.push_back(eth_sender_core);
             log_trace(tt::LogOp, "\teth_sender_core on link {}: (x={},y={})", l, eth_sender_core.x, eth_sender_core.y);
         }
         if (!is_linear || ring_index != 0) {
             uint32_t sender_device = sender_device_id.value();
-            auto const& sockets = device->get_ethernet_sockets(sender_device);
+            const auto& sockets = device->get_ethernet_sockets(sender_device);
+            log_info(tt::LogMetal, "Sockets size = {}", sockets.size());
+            for (auto c : sockets) {
+                log_info(tt::LogMetal, "Got recv socket {} to {} {}", device->id(), sender_device, c.str());
+            }
             auto eth_receiver_core = sockets.at(receiver_socket_idx);
             eth_receiver_cores.push_back(eth_receiver_core);
             log_trace(

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
@@ -294,7 +294,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
                 }
                 if (enable_core_placement_opt) {
                     if (edm_fwd.my_noc_x < edm_bwd.my_noc_x) {
-                        log_info(
+                        log_trace(
                             tt::LogOp,
                             "Fabric MeshId {} ChipId {} edm_fwd {} {} is connecting to edm_bwd {} {} on link {}",
                             *(edm_fwd.local_fabric_node_id.mesh_id),
@@ -317,7 +317,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
                             edm_bwd.config.sender_channel_ack_noc_ids[i] = 0;
                         }
                     } else if (edm_fwd.my_noc_x > edm_bwd.my_noc_x) {
-                        log_info(
+                        log_trace(
                             tt::LogOp,
                             "Fabric MeshId {} ChipId {} edm_fwd {} {} is connecting to edm_bwd {} {} on link {}",
                             *(edm_fwd.local_fabric_node_id.mesh_id),
@@ -520,15 +520,15 @@ void EdmLineFabricOpInterface::build_kernels() const {
             if (edm_builders.find(device->id()) != edm_builders.end()) {
                 for (auto& edm_builder : edm_builders.at(device->id())) {
                     for (uint32_t risc_id = 0; risc_id < edm_builder.get_configured_risc_count(); risc_id++) {
-                        log_trace(
+                        log_info(
                             tt::LogOp,
-                            "Building EDM kernel on device {}, logical-core (y={},x={}), noc_core (y={},x={}), risc_id "
+                            "Building EDM kernel on device {}, logical-core (x={},y={}), noc_core (x={},y={}), risc_id "
                             "{}",
                             device->id(),
-                            edm_builder.my_eth_core_logical.y,
                             edm_builder.my_eth_core_logical.x,
-                            device->ethernet_core_from_logical_core(edm_builder.my_eth_core_logical).y,
+                            edm_builder.my_eth_core_logical.y,
                             device->ethernet_core_from_logical_core(edm_builder.my_eth_core_logical).x,
+                            device->ethernet_core_from_logical_core(edm_builder.my_eth_core_logical).y,
                             risc_id);
                         auto local_edm_kernel = ttnn::ccl::generate_edm_kernel(
                             *program,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18726

### Problem description
- When fabric was enabled for dispatch only, `Device::get_ethernet_sockets` was returning the cores used for dispatch which caused overlapping cores being created in legacy CCL tests

### What's changed
- Control Plane to keep track routers dedicated for dispatch

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15810076488