### PR TITLE
Modified profiler to use exact RISC count for a given core type

### DIFF
--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -44,8 +44,6 @@ static constexpr uint32_t PROFILER_RISC_COUNT = static_cast<uint32_t>(EthProcess
 #else
 static constexpr uint32_t PROFILER_RISC_COUNT = static_cast<uint32_t>(TensixProcessorTypes::COUNT);
 #endif
-#else
-static constexpr uint32_t PROFILER_RISC_COUNT = 5;
 #endif
 
 // Messages for host to tell brisc to go
@@ -318,7 +316,7 @@ static constexpr uint32_t PROFILER_NOC_ALIGNMENT_PAD_COUNT = 4;
 
 struct profiler_msg_t {
     uint32_t control_vector[kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE];
-    uint32_t buffer[PROFILER_RISC_COUNT][kernel_profiler::PROFILER_L1_VECTOR_SIZE];
+    uint32_t buffer[MAX_RISCV_PER_CORE][kernel_profiler::PROFILER_L1_VECTOR_SIZE];
 };
 
 enum class AddressableCoreType : uint8_t {

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -13,6 +13,9 @@
 #include "hostdevcommon/profiler_common.h"
 #include "hostdevcommon/dprint_common.h"
 
+// TODO: w/ the hal, this can come from core specific defines
+constexpr static std::uint32_t MAX_RISCV_PER_CORE = 5;
+
 // TODO: move these to processor specific files
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 
@@ -44,6 +47,15 @@ static constexpr uint32_t PROFILER_RISC_COUNT = static_cast<uint32_t>(EthProcess
 #else
 static constexpr uint32_t PROFILER_RISC_COUNT = static_cast<uint32_t>(TensixProcessorTypes::COUNT);
 #endif
+struct profiler_msg_t {
+    uint32_t control_vector[kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE];
+    uint32_t buffer[PROFILER_RISC_COUNT][kernel_profiler::PROFILER_L1_VECTOR_SIZE];
+};
+#else
+struct profiler_msg_t {
+    uint32_t control_vector[kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE];
+    uint32_t buffer[MAX_RISCV_PER_CORE][kernel_profiler::PROFILER_L1_VECTOR_SIZE];
+};
 #endif
 
 // Messages for host to tell brisc to go
@@ -290,7 +302,6 @@ enum watcher_enable_msg_t {
 };
 
 // TODO: w/ the hal, this can come from core specific defines
-constexpr static std::uint32_t MAX_RISCV_PER_CORE = 5;
 constexpr static std::uint32_t MAX_NUM_NOCS_PER_CORE = 2;
 
 struct watcher_msg_t {
@@ -313,11 +324,6 @@ struct dprint_buf_msg_t {
 static constexpr uint32_t TT_ARCH_MAX_NOC_WRITE_ALIGNMENT = 16;
 
 static constexpr uint32_t PROFILER_NOC_ALIGNMENT_PAD_COUNT = 4;
-
-struct profiler_msg_t {
-    uint32_t control_vector[kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE];
-    uint32_t buffer[MAX_RISCV_PER_CORE][kernel_profiler::PROFILER_L1_VECTOR_SIZE];
-};
 
 enum class AddressableCoreType : uint8_t {
     TENSIX = 0,

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -16,6 +16,12 @@
 // TODO: w/ the hal, this can come from core specific defines
 constexpr static std::uint32_t MAX_RISCV_PER_CORE = 5;
 
+template <uint32_t RiscCount>
+struct profiler_msg_template_t {
+    uint32_t control_vector[kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE];
+    uint32_t buffer[RiscCount][kernel_profiler::PROFILER_L1_VECTOR_SIZE];
+};  // struct profiler_msg_template_t
+
 // TODO: move these to processor specific files
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 
@@ -47,15 +53,9 @@ static constexpr uint32_t PROFILER_RISC_COUNT = static_cast<uint32_t>(EthProcess
 #else
 static constexpr uint32_t PROFILER_RISC_COUNT = static_cast<uint32_t>(TensixProcessorTypes::COUNT);
 #endif
-struct profiler_msg_t {
-    uint32_t control_vector[kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE];
-    uint32_t buffer[PROFILER_RISC_COUNT][kernel_profiler::PROFILER_L1_VECTOR_SIZE];
-};
+using profiler_msg_t = profiler_msg_template_t<PROFILER_RISC_COUNT>;
 #else
-struct profiler_msg_t {
-    uint32_t control_vector[kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE];
-    uint32_t buffer[MAX_RISCV_PER_CORE][kernel_profiler::PROFILER_L1_VECTOR_SIZE];
-};
+using profiler_msg_t = profiler_msg_template_t<MAX_RISCV_PER_CORE>;
 #endif
 
 // Messages for host to tell brisc to go
@@ -381,7 +381,7 @@ struct mailboxes_t {
     struct core_info_msg_t core_info;
     // Keep profiler last since it's size is dynamic per core type
     uint32_t pads_2[PROFILER_NOC_ALIGNMENT_PAD_COUNT];
-    struct profiler_msg_t profiler;
+    profiler_msg_t profiler;
 };
 
 // Watcher struct needs to be 32b-divisible, since we need to write it from host using write_hex_vec_to_core().

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -175,20 +175,15 @@ void DeviceProfiler::issueSlowDispatchReadFromProfilerBuffer(IDevice* device) {
 std::vector<uint32_t> DeviceProfiler::issueFastDispatchReadFromL1DataBuffer(
     IDevice* device, const CoreCoord& worker_core) {
     ZoneScoped;
+
     TT_ASSERT(tt::DevicePool::instance().is_dispatch_firmware_active());
+
     const chip_id_t device_id = device->id();
+    const Hal& hal = MetalContext::instance().hal();
     const HalProgrammableCoreType core_type = tt::llrt::get_core_type(device_id, worker_core);
-    log_info(
-        tt::LogMetal,
-        "Reading L1 data buffer from core {},{} {}",
-        worker_core.x,
-        worker_core.y,
-        magic_enum::enum_name(core_type));
-    profiler_msg_t* profiler_msg =
-        MetalContext::instance().hal().get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
-    std::vector<uint32_t> data_buffer(
-        kernel_profiler::PROFILER_L1_VECTOR_SIZE * MetalContext::instance().hal().get_num_risc_processors(core_type));
-    log_info(tt::LogMetal, "num risc processors {}", MetalContext::instance().hal().get_num_risc_processors(core_type));
+    profiler_msg_t* profiler_msg = hal.get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
+    const uint32_t num_risc_processors = hal.get_num_risc_processors(core_type);
+    std::vector<uint32_t> data_buffer(kernel_profiler::PROFILER_L1_VECTOR_SIZE * num_risc_processors);
     if (auto mesh_device = device->get_mesh_device()) {
         const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device_id);
         dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue())
@@ -196,8 +191,7 @@ std::vector<uint32_t> DeviceProfiler::issueFastDispatchReadFromL1DataBuffer(
                 distributed::DeviceMemoryAddress{
                     device_coord, worker_core, reinterpret_cast<DeviceAddr>(profiler_msg->buffer)},
                 data_buffer.data(),
-                kernel_profiler::PROFILER_L1_BUFFER_SIZE *
-                    MetalContext::instance().hal().get_num_risc_processors(core_type),
+                kernel_profiler::PROFILER_L1_BUFFER_SIZE * num_risc_processors,
                 true);
     } else {
         dynamic_cast<HWCommandQueue&>(device->command_queue())
@@ -205,8 +199,7 @@ std::vector<uint32_t> DeviceProfiler::issueFastDispatchReadFromL1DataBuffer(
                 worker_core,
                 data_buffer.data(),
                 reinterpret_cast<DeviceAddr>(profiler_msg->buffer),
-                kernel_profiler::PROFILER_L1_BUFFER_SIZE *
-                    MetalContext::instance().hal().get_num_risc_processors(core_type),
+                kernel_profiler::PROFILER_L1_BUFFER_SIZE * num_risc_processors,
                 true);
     }
 
@@ -216,15 +209,16 @@ std::vector<uint32_t> DeviceProfiler::issueFastDispatchReadFromL1DataBuffer(
 std::vector<uint32_t> DeviceProfiler::issueSlowDispatchReadFromL1DataBuffer(
     IDevice* device, const CoreCoord& worker_core) {
     ZoneScoped;
+
     const chip_id_t device_id = device->id();
+    const Hal& hal = MetalContext::instance().hal();
     const HalProgrammableCoreType core_type = tt::llrt::get_core_type(device_id, worker_core);
-    profiler_msg_t* profiler_msg =
-        MetalContext::instance().hal().get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
+    profiler_msg_t* profiler_msg = hal.get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
     return tt::llrt::read_hex_vec_from_core(
         device_id,
         worker_core,
         reinterpret_cast<uint64_t>(profiler_msg->buffer),
-        kernel_profiler::PROFILER_L1_BUFFER_SIZE * MetalContext::instance().hal().get_num_risc_processors(core_type));
+        kernel_profiler::PROFILER_L1_BUFFER_SIZE * hal.get_num_risc_processors(core_type));
 }
 
 void DeviceProfiler::readControlBuffers(IDevice* device, const CoreCoord& worker_core, const ProfilerDumpState state) {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -659,7 +659,7 @@ void InitDeviceProfiler(IDevice* device) {
 
         const uint32_t num_cores_per_dram_bank = soc_desc.profiler_ceiled_core_count_perf_dram_bank;
         const uint32_t bank_size_bytes =
-            PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * PROFILER_RISC_COUNT * num_cores_per_dram_bank;
+            PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * MAX_RISCV_PER_CORE * num_cores_per_dram_bank;
         TT_ASSERT(bank_size_bytes <= MetalContext::instance().hal().get_dev_size(HalDramMemAddrType::PROFILER));
 
         const uint32_t num_dram_banks = soc_desc.get_num_dram_views();

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -142,7 +142,7 @@ JitBuildStateSet create_build_state(JitBuildEnv& build_env, chip_id_t /*device_i
 
     // Prepare the container for build states
     const auto& hal = MetalContext::instance().hal();
-    uint32_t num_build_states = hal.get_num_risc_processors();
+    uint32_t num_build_states = hal.get_total_num_risc_processors();
     std::vector<std::shared_ptr<JitBuildState>> build_states(num_build_states);
 
     // Helper lambda to create a build state based on the core type and processor info.

--- a/tt_metal/llrt/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal.cpp
@@ -60,7 +60,7 @@ void Hal::initialize_bh() {
     static_assert(
         static_cast<int>(HalProgrammableCoreType::IDLE_ETH) == static_cast<int>(ProgrammableCoreType::IDLE_ETH));
 
-    static_assert(MaxProcessorsPerCoreType <= PROFILER_RISC_COUNT);
+    static_assert(MaxProcessorsPerCoreType <= MAX_RISCV_PER_CORE);
 
     HalCoreInfoType tensix_mem_map = blackhole::create_tensix_mem_map();
     this->core_info_.push_back(tensix_mem_map);

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -113,7 +113,6 @@ HalCoreInfoType create_active_eth_mem_map() {
     return {
         HalProgrammableCoreType::ACTIVE_ETH,
         CoreType::ETH,
-        static_cast<uint8_t>(EthProcessorTypes::COUNT),
         processor_classes,
         mem_map_bases,
         mem_map_sizes,

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -108,12 +108,12 @@ HalCoreInfoType create_active_eth_mem_map() {
         };
         processor_classes[processor_class_idx] = processor_types;
     }
-    // TODO: Review if this should  be 2 (the number of eth processors)
-    // Hardcode to 1 to keep size as before
+
     static_assert(llrt_common::k_SingleProcessorMailboxSize<EthProcessorTypes> <= MEM_AERISC_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::ACTIVE_ETH,
         CoreType::ETH,
+        static_cast<uint8_t>(EthProcessorTypes::COUNT),
         processor_classes,
         mem_map_bases,
         mem_map_sizes,

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -100,12 +100,12 @@ HalCoreInfoType create_idle_eth_mem_map() {
         };
         processor_classes[processor_class_idx] = processor_types;
     }
-    // TODO: Review if this should  be 2 (the number of eth processors)
-    // Hardcode to 1 to keep size as before
+
     static_assert(llrt_common::k_SingleProcessorMailboxSize<EthProcessorTypes> <= MEM_IERISC_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::IDLE_ETH,
         CoreType::ETH,
+        static_cast<uint8_t>(EthProcessorTypes::COUNT),
         processor_classes,
         mem_map_bases,
         mem_map_sizes,

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -105,7 +105,6 @@ HalCoreInfoType create_idle_eth_mem_map() {
     return {
         HalProgrammableCoreType::IDLE_ETH,
         CoreType::ETH,
-        static_cast<uint8_t>(EthProcessorTypes::COUNT),
         processor_classes,
         mem_map_bases,
         mem_map_sizes,

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -133,6 +133,7 @@ HalCoreInfoType create_tensix_mem_map() {
     return {
         HalProgrammableCoreType::TENSIX,
         CoreType::WORKER,
+        static_cast<uint8_t>(TensixProcessorTypes::COUNT),
         processor_classes,
         mem_map_bases,
         mem_map_sizes,

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -133,7 +133,6 @@ HalCoreInfoType create_tensix_mem_map() {
     return {
         HalProgrammableCoreType::TENSIX,
         CoreType::WORKER,
-        static_cast<uint8_t>(TensixProcessorTypes::COUNT),
         processor_classes,
         mem_map_bases,
         mem_map_sizes,

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -42,10 +42,7 @@ uint32_t Hal::get_programmable_core_type_index(HalProgrammableCoreType programma
 uint32_t Hal::get_total_num_risc_processors() const {
     uint32_t num_riscs = 0;
     for (uint32_t core_idx = 0; core_idx < core_info_.size(); core_idx++) {
-        uint32_t num_processor_classes = core_info_[core_idx].get_processor_classes_count();
-        for (uint32_t processor_class_idx = 0; processor_class_idx < num_processor_classes; processor_class_idx++) {
-            num_riscs += core_info_[core_idx].get_processor_types_count(processor_class_idx);
-        }
+        num_riscs += this->get_num_risc_processors(this->core_info_[core_idx].programmable_core_type_);
     }
     return num_riscs;
 }
@@ -53,7 +50,6 @@ uint32_t Hal::get_total_num_risc_processors() const {
 HalCoreInfoType::HalCoreInfoType(
     HalProgrammableCoreType programmable_core_type,
     CoreType core_type,
-    uint8_t num_processor_types,
     const std::vector<std::vector<HalJitBuildConfig>>& processor_classes,
     const std::vector<DeviceAddr>& mem_map_bases,
     const std::vector<uint32_t>& mem_map_sizes,
@@ -62,7 +58,6 @@ HalCoreInfoType::HalCoreInfoType(
     bool supports_receiving_multicast_cmds) :
     programmable_core_type_(programmable_core_type),
     core_type_(core_type),
-    num_processor_types_(num_processor_types),
     processor_classes_(processor_classes),
     mem_map_bases_(mem_map_bases),
     mem_map_sizes_(mem_map_sizes),

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -39,7 +39,7 @@ uint32_t Hal::get_programmable_core_type_index(HalProgrammableCoreType programma
     }
 }
 
-uint32_t Hal::get_num_risc_processors() const {
+uint32_t Hal::get_total_num_risc_processors() const {
     uint32_t num_riscs = 0;
     for (uint32_t core_idx = 0; core_idx < core_info_.size(); core_idx++) {
         uint32_t num_processor_classes = core_info_[core_idx].get_processor_classes_count();
@@ -53,6 +53,7 @@ uint32_t Hal::get_num_risc_processors() const {
 HalCoreInfoType::HalCoreInfoType(
     HalProgrammableCoreType programmable_core_type,
     CoreType core_type,
+    uint8_t num_processor_types,
     const std::vector<std::vector<HalJitBuildConfig>>& processor_classes,
     const std::vector<DeviceAddr>& mem_map_bases,
     const std::vector<uint32_t>& mem_map_sizes,
@@ -61,6 +62,7 @@ HalCoreInfoType::HalCoreInfoType(
     bool supports_receiving_multicast_cmds) :
     programmable_core_type_(programmable_core_type),
     core_type_(core_type),
+    num_processor_types_(num_processor_types),
     processor_classes_(processor_classes),
     mem_map_bases_(mem_map_bases),
     mem_map_sizes_(mem_map_sizes),

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -95,7 +95,6 @@ public:
     uint32_t get_dev_size(HalL1MemAddrType addr_type) const;
     uint32_t get_processor_classes_count() const;
     uint32_t get_processor_types_count(uint32_t processor_class_idx) const;
-    uint8_t get_processor_types_count() const;
     const HalJitBuildConfig& get_jit_build_config(uint32_t processor_class_idx, uint32_t processor_type_idx) const;
 };
 
@@ -256,7 +255,6 @@ public:
     uint32_t get_processor_classes_count(std::variant<HalProgrammableCoreType, uint32_t> programmable_core_type) const;
     uint32_t get_processor_types_count(
         std::variant<HalProgrammableCoreType, uint32_t> programmable_core_type, uint32_t processor_class_idx) const;
-    uint8_t get_processor_types_count(HalProgrammableCoreType programmable_core_type) const;
 
     template <typename T = DeviceAddr>
     T get_dev_addr(HalProgrammableCoreType programmable_core_type, HalL1MemAddrType addr_type) const;
@@ -330,12 +328,6 @@ inline uint32_t Hal::get_processor_types_count(
             return this->core_info_[index].get_processor_types_count(processor_class_idx);
         },
         programmable_core_type);
-}
-
-inline uint8_t Hal::get_processor_types_count(HalProgrammableCoreType programmable_core_type) const {
-    uint32_t index = utils::underlying_type<HalProgrammableCoreType>(programmable_core_type);
-    TT_ASSERT(index < this->core_info_.size());
-    return this->core_info_[index].get_processor_types_count();
 }
 
 inline HalProgrammableCoreType Hal::get_programmable_core_type(uint32_t core_type_index) const {

--- a/tt_metal/llrt/llrt_common/mailbox.hpp
+++ b/tt_metal/llrt/llrt_common/mailbox.hpp
@@ -11,6 +11,6 @@ namespace tt::llrt_common {
 template <typename ProcessorType>
 constexpr uint32_t k_SingleProcessorMailboxSize =
     sizeof(mailboxes_t) - sizeof(profiler_msg_t::buffer) +
-    sizeof(profiler_msg_t::buffer) / PROFILER_RISC_COUNT * static_cast<uint32_t>(ProcessorType::COUNT);
+    sizeof(profiler_msg_t::buffer) / MAX_RISCV_PER_CORE * static_cast<uint32_t>(ProcessorType::COUNT);
 
 }  // namespace tt::llrt_common

--- a/tt_metal/llrt/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal.cpp
@@ -60,7 +60,7 @@ void Hal::initialize_wh(bool is_base_routing_fw_enabled) {
     static_assert(
         static_cast<int>(HalProgrammableCoreType::IDLE_ETH) == static_cast<int>(ProgrammableCoreType::IDLE_ETH));
 
-    static_assert(MaxProcessorsPerCoreType <= PROFILER_RISC_COUNT);
+    static_assert(MaxProcessorsPerCoreType <= MAX_RISCV_PER_CORE);
 
     HalCoreInfoType tensix_mem_map = wormhole::create_tensix_mem_map();
     this->core_info_.push_back(tensix_mem_map);

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -11,6 +11,7 @@
 
 #include "core_config.h"
 #include "eth_l1_address_map.h"
+#include "llrt_common/mailbox.hpp"
 #include "hal_types.hpp"
 #include "llrt/hal.hpp"
 #include <umd/device/tt_core_coordinates.h>
@@ -102,13 +103,13 @@ HalCoreInfoType create_active_eth_mem_map(bool is_base_routing_fw_enabled) {
         };
         processor_classes[processor_class_idx] = processor_types;
     }
-    constexpr uint32_t mailbox_size =
-        sizeof(mailboxes_t) - sizeof(profiler_msg_t::buffer) +
-        sizeof(profiler_msg_t::buffer) / PROFILER_RISC_COUNT * static_cast<uint8_t>(EthProcessorTypes::COUNT);
-    static_assert(mailbox_size <= eth_l1_mem::address_map::ERISC_MEM_MAILBOX_SIZE);
+    static_assert(
+        llrt_common::k_SingleProcessorMailboxSize<EthProcessorTypes> <=
+        eth_l1_mem::address_map::ERISC_MEM_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::ACTIVE_ETH,
         CoreType::ETH,
+        static_cast<uint8_t>(EthProcessorTypes::COUNT),
         processor_classes,
         mem_map_bases,
         mem_map_sizes,

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -109,7 +109,6 @@ HalCoreInfoType create_active_eth_mem_map(bool is_base_routing_fw_enabled) {
     return {
         HalProgrammableCoreType::ACTIVE_ETH,
         CoreType::ETH,
-        static_cast<uint8_t>(EthProcessorTypes::COUNT),
         processor_classes,
         mem_map_bases,
         mem_map_sizes,

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -86,7 +86,6 @@ HalCoreInfoType create_idle_eth_mem_map() {
     return {
         HalProgrammableCoreType::IDLE_ETH,
         CoreType::ETH,
-        static_cast<uint8_t>(EthProcessorTypes::COUNT),
         processor_classes,
         mem_map_bases,
         mem_map_sizes,

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -13,6 +13,7 @@
 #include "core_config.h"
 #include "dev_mem_map.h"
 #include "hal_types.hpp"
+#include "llrt_common/mailbox.hpp"
 #include "llrt/hal.hpp"
 #include "noc/noc_parameters.h"
 #include <umd/device/tt_core_coordinates.h>
@@ -81,13 +82,11 @@ HalCoreInfoType create_idle_eth_mem_map() {
         };
         processor_classes[processor_class_idx] = processor_types;
     }
-    constexpr uint32_t mailbox_size =
-        sizeof(mailboxes_t) - sizeof(profiler_msg_t::buffer) +
-        sizeof(profiler_msg_t::buffer) / PROFILER_RISC_COUNT * static_cast<uint8_t>(EthProcessorTypes::COUNT);
-    static_assert(mailbox_size <= MEM_IERISC_MAILBOX_SIZE);
+    static_assert(llrt_common::k_SingleProcessorMailboxSize<EthProcessorTypes> <= MEM_IERISC_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::IDLE_ETH,
         CoreType::ETH,
+        static_cast<uint8_t>(EthProcessorTypes::COUNT),
         processor_classes,
         mem_map_bases,
         mem_map_sizes,

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -131,7 +131,6 @@ HalCoreInfoType create_tensix_mem_map() {
     return {
         HalProgrammableCoreType::TENSIX,
         CoreType::WORKER,
-        static_cast<uint8_t>(TensixProcessorTypes::COUNT),
         processor_classes,
         mem_map_bases,
         mem_map_sizes,

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -12,6 +12,7 @@
 #include "core_config.h"
 #include "dev_mem_map.h"
 #include "hal_types.hpp"
+#include "llrt_common/mailbox.hpp"
 #include "llrt/hal.hpp"
 #include "noc/noc_parameters.h"
 #include <umd/device/tt_core_coordinates.h>
@@ -126,13 +127,11 @@ HalCoreInfoType create_tensix_mem_map() {
         }
         processor_classes[processor_class_idx] = processor_types;
     }
-    constexpr uint32_t mailbox_size =
-        sizeof(mailboxes_t) - sizeof(profiler_msg_t::buffer) +
-        sizeof(profiler_msg_t::buffer) / PROFILER_RISC_COUNT * static_cast<uint8_t>(TensixProcessorTypes::COUNT);
-    static_assert(mailbox_size <= MEM_MAILBOX_SIZE);
+    static_assert(llrt_common::k_SingleProcessorMailboxSize<TensixProcessorTypes> <= MEM_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::TENSIX,
         CoreType::WORKER,
+        static_cast<uint8_t>(TensixProcessorTypes::COUNT),
         processor_classes,
         mem_map_bases,
         mem_map_sizes,


### PR DESCRIPTION
#23646 

This PR adds support for getting the exact number of RISCs for a given core type, so that the profiler can use this when calculating the number of bytes to read from a core's L1 data buffer.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15743807381)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/15743821850)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15743826431)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15743835938)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15743853814)
- [x] [T3K Profiler] (https://github.com/tenstorrent/tt-metal/actions/runs/15743864975)
- [x] [Metal Microbenchmarks] (https://github.com/tenstorrent/tt-metal/actions/runs/15743877808)
- [x] New/Existing tests provide coverage for changes