### PR TITLE
Experimental support for fabric (chip and noc) multicast packet tracing (1D)

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -158,6 +158,13 @@ void RunTestMCastConnAPI(
     RoutingDirection bwd_dir = RoutingDirection::E,
     uint32_t bwd_hops = 1);
 
+void RunTestChipMCast1D(
+    BaseFabricFixture* fixture,
+    RoutingDirection dir,
+    uint32_t start_distance,
+    uint32_t range,
+    bool enable_fabric_tracing = false);
+
 void RunTestLineMcast(
     BaseFabricFixture* fixture, RoutingDirection unicast_dir, const std::vector<McastRoutingInfo>& mcast_routing_info);
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -984,10 +984,257 @@ void RunTestMCastConnAPI(
     }
 }
 
+void RunTestChipMCast1D(
+    BaseFabricFixture* fixture,
+    RoutingDirection dir,
+    uint32_t start_distance,
+    uint32_t range,
+    bool enable_fabric_tracing) {
+    CoreCoord sender_logical_core = {0, 0};
+    CoreCoord receiver_logical_core = {1, 0};
+    std::vector<tt_metal::Program> receiver_programs;
+
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    // use control plane to find a mesh with 3 devices
+    auto user_meshes = control_plane.get_user_physical_mesh_ids();
+    std::optional<MeshId> mesh_id;
+    for (const auto& mesh : user_meshes) {
+        auto mesh_shape = control_plane.get_physical_mesh_shape(mesh);
+        if (mesh_shape.mesh_size() >= 3) {
+            mesh_id = mesh;
+            break;
+        }
+    }
+    if (!mesh_id.has_value()) {
+        GTEST_SKIP() << "No mesh found for 3 chip mcast test";
+    }
+
+    // Check topology and fabric config
+    const auto topology = control_plane.get_fabric_context().get_fabric_topology();
+    const auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+    assert(
+        (topology == Topology::Linear || topology == Topology::Ring) &&
+        (fabric_config == tt_metal::FabricConfig::FABRIC_1D ||
+         fabric_config == tt_metal::FabricConfig::FABRIC_1D_RING));
+
+    // Find a device num_hops away in specified direction.
+    FabricNodeId src_fabric_node_id(MeshId{0}, 0);
+    std::unordered_map<RoutingDirection, uint32_t> fabric_hops;
+    std::unordered_map<RoutingDirection, std::vector<FabricNodeId>> end_fabric_node_ids_by_dir;
+    chip_id_t src_phys_chip_id;
+    std::unordered_map<RoutingDirection, std::vector<chip_id_t>> physical_end_device_ids_by_dir;
+    fabric_hops[dir] = start_distance + range - 1;
+
+    // Get the mcast sender device and mcast receiver devices that satisfy the input number of hops in forward and
+    // backward directions.
+    if (!find_device_with_neighbor_in_multi_direction(
+            fixture,
+            src_fabric_node_id,
+            end_fabric_node_ids_by_dir,
+            src_phys_chip_id,
+            physical_end_device_ids_by_dir,
+            fabric_hops)) {
+        log_info(tt::LogTest, "No Mcast destinations found for {} hops in {}", fabric_hops[dir], dir);
+        GTEST_SKIP() << "Skipping Test";
+    }
+
+    // adjust physical_end_device_ids_by_dir and end_fabric_node_ids_by_dir to start from start_distance
+    auto first_hop_phys_chip_id = physical_end_device_ids_by_dir[dir][0];  // needed to get link_idx
+    physical_end_device_ids_by_dir[dir] = std::vector(
+        physical_end_device_ids_by_dir[dir].begin() + start_distance - 1, physical_end_device_ids_by_dir[dir].end());
+    end_fabric_node_ids_by_dir[dir] = std::vector(
+        end_fabric_node_ids_by_dir[dir].begin() + start_distance - 1, end_fabric_node_ids_by_dir[dir].end());
+
+    tt::tt_metal::distributed::MeshShape mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
+    auto last_recv_phys_chip_id = physical_end_device_ids_by_dir[dir][range - 1];
+    auto first_recv_phys_chip_id = physical_end_device_ids_by_dir[dir][0];
+
+    auto* sender_device = DevicePool::instance().get_active_device(src_phys_chip_id);
+    auto* last_recv_device = DevicePool::instance().get_active_device(last_recv_phys_chip_id);
+
+    auto first_recv_fabric_node_id = end_fabric_node_ids_by_dir[dir][0];
+    auto last_recv_fabric_node_id = end_fabric_node_ids_by_dir[dir][range - 1];
+
+    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
+    CoreCoord receiver_virtual_core =
+        last_recv_device->worker_core_from_logical_core(receiver_logical_core);
+
+    // test parameters
+    auto worker_mem_map = generate_worker_mem_map(sender_device, topology);
+    uint32_t num_packets = 100;
+    uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
+
+    // common compile time args for sender and receiver
+    std::vector<uint32_t> compile_time_args = {
+        worker_mem_map.test_results_address,
+        worker_mem_map.test_results_size_bytes,
+        worker_mem_map.target_address,
+        0 /* is_2d_fabric */,
+        0 /* use_dynamic_routing */,
+        1 /* is_chip_multicast */,
+        0 /* additional_dir */};
+
+    std::map<string, string> defines = {};
+
+    if (enable_fabric_tracing) {
+        defines["TEST_ENABLE_FABRIC_TRACING"] = "1";
+    }
+
+    // Create the sender program
+    auto sender_program = tt_metal::CreateProgram();
+    auto sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp",
+        {sender_logical_core},
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = compile_time_args,
+            .defines = defines});
+
+    log_info(tt::LogTest, "mesh dimensions: {:x}", mesh_shape.dims());
+    log_info(tt::LogTest, "mesh dimension 0: {:x}", mesh_shape[0]);
+    log_info(tt::LogTest, "mesh dimension 1: {:x}", mesh_shape[1]);
+    log_info(
+        tt::LogTest, "Mcast Src: MeshId {} ChipId {}", src_fabric_node_id.mesh_id.get(), src_fabric_node_id.chip_id);
+    log_info(
+        tt::LogTest,
+        "Mcast Dst: from MeshId {} ChipId {} to MeshId {} ChipId {}",
+        first_recv_fabric_node_id.mesh_id.get(),
+        first_recv_fabric_node_id.chip_id,
+        last_recv_fabric_node_id.mesh_id.get(),
+        last_recv_fabric_node_id.chip_id);
+    log_info(
+        tt::LogTest,
+        "Mcast Receiver Core (Logical): {},{}",
+        receiver_logical_core.x,
+        receiver_logical_core.y);
+
+    std::vector<uint32_t> sender_runtime_args = {
+        worker_mem_map.packet_header_address,
+        worker_mem_map.source_l1_buffer_address,
+        worker_mem_map.packet_payload_size_bytes,
+        num_packets,
+        time_seed,
+        receiver_virtual_core.x,
+        receiver_virtual_core.y,
+        mesh_shape[1],
+        src_fabric_node_id.chip_id,
+        start_distance,
+        range,
+        last_recv_fabric_node_id.chip_id,
+        *last_recv_fabric_node_id.mesh_id};
+
+    // append the EDM connection rt args for fwd connection
+    chip_id_t dst_chip_id = first_hop_phys_chip_id;
+    uint32_t link_idx = get_forwarding_link_indices(src_phys_chip_id, dst_chip_id)[0];
+    append_fabric_connection_rt_args(
+        src_phys_chip_id, dst_chip_id, link_idx, sender_program, {sender_logical_core}, sender_runtime_args);
+
+    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
+
+    std::vector<uint32_t> receiver_runtime_args = {worker_mem_map.packet_payload_size_bytes, num_packets, time_seed};
+
+    // Create and launch the receiver program for validation on all mcast receiver devices
+    for (auto& [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
+        for (auto physical_end_device_id : physical_end_device_ids) {
+            auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_id);
+            // Create the receiver program for validation
+            auto receiver_program = tt_metal::CreateProgram();
+            auto receiver_kernel = tt_metal::CreateKernel(
+                receiver_program,
+                "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_rx.cpp",
+                receiver_logical_core,
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = compile_time_args});
+
+            tt_metal::SetRuntimeArgs(
+                receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
+            fixture->RunProgramNonblocking(receiver_device, receiver_program);
+            receiver_programs.push_back(std::move(receiver_program));
+            log_info(tt::LogTest, "{} Rx Launched on physical device {}", routing_direction, physical_end_device_id);
+        }
+    }
+
+    // Launch sender program and wait for sender to finish
+    fixture->RunProgramNonblocking(sender_device, sender_program);
+    log_info(tt::LogTest, "Sender Launched on physical device {}", src_phys_chip_id);
+
+    fixture->WaitForSingleProgramDone(sender_device, sender_program);
+    log_info(tt::LogTest, "Sender Finished");
+
+    // Wait for receivers to finish
+    for (auto [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
+        for (uint32_t i = 0; i < physical_end_device_ids.size(); i++) {
+            auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_ids[i]);
+            fixture->WaitForSingleProgramDone(receiver_device, receiver_programs[i]);
+        }
+    }
+    log_info(tt::LogTest, "All Receivers Finished");
+
+    if (enable_fabric_tracing) {
+        tt_metal::detail::DumpDeviceProfileResults(sender_device);
+    }
+
+    // Validate the status and packets processed by sender and receiver
+    std::vector<uint32_t> sender_status;
+    std::vector<uint32_t> left_recv_status;
+    std::vector<uint32_t> right_recv_status;
+
+    tt_metal::detail::ReadFromDeviceL1(
+        sender_device,
+        sender_logical_core,
+        worker_mem_map.test_results_address,
+        worker_mem_map.test_results_size_bytes,
+        sender_status,
+        CoreType::WORKER);
+
+    EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+
+    uint64_t sender_bytes =
+        ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
+
+    for (auto [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
+        for (uint32_t i = 0; i < physical_end_device_ids.size(); i++) {
+            auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_ids[i]);
+
+            log_info(
+                tt::LogTest,
+                "Checking Status of {} Rx on core ({}, {}) on physical device {}",
+                routing_direction,
+                receiver_logical_core.x,
+                receiver_logical_core.y,
+                physical_end_device_ids[i]);
+
+            std::vector<uint32_t> recv_status;
+
+            tt_metal::detail::ReadFromDeviceL1(
+                receiver_device,
+                receiver_logical_core,
+                worker_mem_map.test_results_address,
+                worker_mem_map.test_results_size_bytes,
+                recv_status,
+                CoreType::WORKER);
+            EXPECT_EQ(recv_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+            uint64_t recv_bytes =
+                ((uint64_t)recv_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | recv_status[TT_FABRIC_WORD_CNT_INDEX];
+
+            EXPECT_EQ(sender_bytes, recv_bytes);
+        }
+    }
+}
+
 TEST_F(Fabric1DFixture, TestUnicastRaw) { RunTestUnicastRaw(this, 1, RoutingDirection::E, false); }
 TEST_F(Fabric1DFixture, TestUnicastConnAPI) { RunTestUnicastConnAPI(this, 1); }
 TEST_F(Fabric1DFixture, TestUnicastTGGateways) { RunTestUnicastTGGateways(this); }
 TEST_F(Fabric1DFixture, TestMCastConnAPI) { RunTestMCastConnAPI(this); }
+
+// only chip multicast (test start and range)
+TEST_F(Fabric1DFixture, TestChipMCast1DWithTracing) { RunTestChipMCast1D(this, RoutingDirection::E, 1, 3, true); }
+TEST_F(Fabric1DFixture, TestChipMCast1DWithTracing2) { RunTestChipMCast1D(this, RoutingDirection::E, 2, 2, true); }
 
 TEST_F(Fabric1DFixture, TestUnicastRawWithTracing) { RunTestUnicastRaw(this, 1, RoutingDirection::E, true); }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp
@@ -23,52 +23,20 @@ constexpr uint32_t test_results_addr_arg = get_compile_time_arg_val(0);
 constexpr uint32_t test_results_size_bytes = get_compile_time_arg_val(1);
 tt_l1_ptr uint32_t* const test_results = reinterpret_cast<tt_l1_ptr uint32_t*>(test_results_addr_arg);
 
-constexpr uint32_t target_address = get_compile_time_arg_val(2);
-constexpr bool mcast_mode = get_compile_time_arg_val(3);
-constexpr bool is_2d_fabric = get_compile_time_arg_val(4);
-constexpr bool use_dynamic_routing = get_compile_time_arg_val(5);
+uint32_t target_address = get_compile_time_arg_val(2);
+constexpr bool is_2d_fabric = get_compile_time_arg_val(3);
+constexpr bool use_dynamic_routing = get_compile_time_arg_val(4);
+constexpr bool is_chip_multicast = get_compile_time_arg_val(5);
+constexpr bool additional_dir = get_compile_time_arg_val(6);
 
-inline void setup_connection_and_headers(
-    tt::tt_fabric::WorkerToFabricEdmSender& connection,
-    volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header,
-    uint32_t hops,
-    uint64_t noc_dest_addr,
-    uint32_t packet_payload_size_bytes) {
-    // connect to edm
-    connection.open();
-    if constexpr (!is_2d_fabric) {
-        if constexpr (mcast_mode) {
-            packet_header->to_chip_multicast(MulticastRoutingCommandHeader{1, static_cast<uint8_t>(hops)});
-        } else {
-            packet_header->to_chip_unicast(static_cast<uint8_t>(hops));
-        }
+inline void setup_header_routing_1d(
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header, uint32_t start_distance, uint32_t range) {
+    if constexpr (is_chip_multicast) {
+        packet_header->to_chip_multicast(
+            MulticastRoutingCommandHeader{static_cast<uint8_t>(start_distance), static_cast<uint8_t>(range)});
+    } else {
+        packet_header->to_chip_unicast(static_cast<uint8_t>(start_distance));
     }
-
-    packet_header->to_noc_unicast_write(NocUnicastCommandHeader{noc_dest_addr}, packet_payload_size_bytes);
-}
-
-inline void send_packet(
-    volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header,
-    uint64_t noc_dest_addr,
-    uint32_t source_l1_buffer_address,
-    uint32_t packet_payload_size_bytes,
-    uint32_t seed,
-    tt::tt_fabric::WorkerToFabricEdmSender& connection) {
-#ifndef BENCHMARK_MODE
-    packet_header->to_noc_unicast_write(NocUnicastCommandHeader{noc_dest_addr}, packet_payload_size_bytes);
-    // fill packet data for sanity testing
-    tt_l1_ptr uint32_t* start_addr = reinterpret_cast<tt_l1_ptr uint32_t*>(source_l1_buffer_address);
-    fill_packet_data(start_addr, packet_payload_size_bytes / 16, seed);
-    tt_l1_ptr uint32_t* last_word_addr =
-        reinterpret_cast<tt_l1_ptr uint32_t*>(source_l1_buffer_address + packet_payload_size_bytes - 4);
-#endif
-    connection.wait_for_empty_write_slot();
-#ifdef TEST_ENABLE_FABRIC_TRACING
-    RECORD_FABRIC_HEADER(packet_header);
-#endif
-    connection.send_payload_without_header_non_blocking_from_address(
-        source_l1_buffer_address, packet_payload_size_bytes);
-    connection.send_payload_blocking_from_address((uint32_t)packet_header, sizeof(PACKET_HEADER_TYPE));
 }
 
 void set_mcast_header(
@@ -88,9 +56,80 @@ void set_mcast_header(
         s_num_hops = num_hops;
     }
 
+    // dst_dev_id is ignored since Low Latency Mesh Fabric does not support arbitrary 2D Mcasts yet
+    // dst_mesh_id is ignored since Low Latency Mesh Fabric is not used for Inter-Mesh Routing
     fabric_set_mcast_route(
         (LowLatencyMeshPacketHeader*)packet_header, 0, 0, e_num_hops, w_num_hops, n_num_hops, s_num_hops);
 }
+
+inline void setup_header_routing_2d(
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header,
+    eth_chan_directions direction,
+    uint32_t range,
+    uint32_t my_dev_id,
+    uint32_t dst_dev_id,
+    uint32_t dst_mesh_id,
+    uint32_t ew_dim) {
+    if constexpr (is_chip_multicast) {
+        static_assert(
+            !(is_2d_fabric && is_chip_multicast &&
+              use_dynamic_routing));  // dynamic routing not supported for 2D multicast in this test
+        set_mcast_header(packet_header, direction, range);
+    } else {
+        if constexpr (use_dynamic_routing) {
+            fabric_set_unicast_route(
+                (MeshPacketHeader*)packet_header,
+                direction,  // Ignored: Dynamic Routing does not need outgoing_direction specified
+                my_dev_id,  // Ignored: Dynamic Routing does not need src chip ID
+                dst_dev_id,
+                dst_mesh_id,
+                ew_dim);  // Ignored: Dynamic Routing does not need mesh dimensions
+        } else {
+            fabric_set_unicast_route(
+                (LowLatencyMeshPacketHeader*)packet_header,
+                direction,
+                my_dev_id,
+                dst_dev_id,
+                dst_mesh_id,  // Ignored since Low Latency Mesh Fabric is not used for Inter-Mesh Routing
+                ew_dim);
+        }
+    }
+}
+
+inline void setup_header_noc_unicast_write(
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header,
+    uint32_t packet_payload_size_bytes,
+    uint32_t dest_addr,
+    uint8_t noc_x_start,
+    uint8_t noc_y_start) {
+    packet_header->to_noc_unicast_write(
+        NocUnicastCommandHeader{get_noc_addr(noc_x_start, noc_y_start, dest_addr)}, packet_payload_size_bytes);
+}
+
+inline void send_packet(
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header,
+    uint32_t source_l1_buffer_address,
+    uint32_t packet_payload_size_bytes,
+    uint32_t seed,
+    tt::tt_fabric::WorkerToFabricEdmSender& connection) {
+#ifndef BENCHMARK_MODE
+    // fill packet data for sanity testing
+    tt_l1_ptr uint32_t* start_addr = reinterpret_cast<tt_l1_ptr uint32_t*>(source_l1_buffer_address);
+    fill_packet_data(start_addr, packet_payload_size_bytes / 16, seed);
+    tt_l1_ptr uint32_t* last_word_addr =
+        reinterpret_cast<tt_l1_ptr uint32_t*>(source_l1_buffer_address + packet_payload_size_bytes - 4);
+#endif
+    connection.wait_for_empty_write_slot();
+#ifdef TEST_ENABLE_FABRIC_TRACING
+    RECORD_FABRIC_HEADER(packet_header);
+#endif
+    connection.send_payload_without_header_non_blocking_from_address(
+        source_l1_buffer_address, packet_payload_size_bytes);
+    connection.send_payload_blocking_from_address((uint32_t)packet_header, sizeof(PACKET_HEADER_TYPE));
+}
+
+// connect to edm
+inline void setup_connection(tt::tt_fabric::WorkerToFabricEdmSender& connection) { connection.open(); }
 
 inline void teardown_connection(tt::tt_fabric::WorkerToFabricEdmSender& connection) { connection.close(); }
 
@@ -102,14 +141,23 @@ void kernel_main() {
     uint32_t source_l1_buffer_address = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t packet_payload_size_bytes = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t num_packets = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t rx_noc_encoding = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t time_seed = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // noc transfer info
+    uint32_t noc_x_start = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t noc_y_start = get_arg_val<uint32_t>(rt_args_idx++);
+
+    // routing info
     uint32_t ew_dim = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t my_dev_id = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t fwd_dev_id = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t fwd_mesh_id = get_arg_val<uint32_t>(rt_args_idx++);
-
-    uint64_t noc_dest_addr = get_noc_addr_helper(rx_noc_encoding, target_address);
+    uint32_t fwd_start_distance = get_arg_val<uint32_t>(rt_args_idx++); // for 1d only
+    uint32_t fwd_range = get_arg_val<uint32_t>(rt_args_idx++);  // for multicast only
+    uint32_t fwd_dev_id = get_arg_val<uint32_t>(rt_args_idx++);   // for 2d unicast only
+    uint32_t fwd_mesh_id = get_arg_val<uint32_t>(rt_args_idx++);  // for 2d unicast only
+    uint32_t bwd_start_distance;
+    uint32_t bwd_range;
+    uint32_t bwd_dev_id;
+    uint32_t bwd_mesh_id;
 
     tt::tt_fabric::WorkerToFabricEdmSender fwd_fabric_connection;
     tt::tt_fabric::WorkerToFabricEdmSender bwd_fabric_connection;
@@ -117,66 +165,62 @@ void kernel_main() {
     volatile tt_l1_ptr PACKET_HEADER_TYPE* fwd_packet_header;
     volatile tt_l1_ptr PACKET_HEADER_TYPE* bwd_packet_header;
 
-    if constexpr (mcast_mode) {
-        uint32_t mcast_fwd_hops = get_arg_val<uint32_t>(rt_args_idx++);
+    /***************** setup forward dir *****************/
+    fwd_fabric_connection =
+        tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);
 
-        fwd_fabric_connection =
-            tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);
+    fwd_packet_header = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(packet_header_buffer_address);
+    zero_l1_buf((uint32_t*)packet_header_buffer_address, sizeof(PACKET_HEADER_TYPE));
 
-        uint32_t bwd_dev_id = get_arg_val<uint32_t>(rt_args_idx++);
-        uint32_t mcast_bwd_hops = get_arg_val<uint32_t>(rt_args_idx++);
+    setup_connection(fwd_fabric_connection);
+
+    if constexpr (!is_2d_fabric) {  // 1D
+        setup_header_routing_1d(fwd_packet_header, fwd_start_distance, fwd_range);
+        DPRINT << "fwd_start_distance" << fwd_start_distance << ", fwd_range" << fwd_range << ENDL();
+    } else {  // 2D
+        setup_header_routing_2d(
+            fwd_packet_header,
+            (eth_chan_directions)fwd_fabric_connection.direction,
+            fwd_range,
+            my_dev_id,
+            fwd_dev_id,
+            fwd_mesh_id,
+            ew_dim);
+    }
+
+    /***************** setup bawkward dir *****************/
+    if constexpr (additional_dir) {
+        // routing info for additional direction
+        bwd_start_distance = get_arg_val<uint32_t>(rt_args_idx++); // for 1d only
+        bwd_range = get_arg_val<uint32_t>(rt_args_idx++);  // for multicast only
+        bwd_dev_id = get_arg_val<uint32_t>(rt_args_idx++);   // for 2d unicast only
+        bwd_mesh_id = get_arg_val<uint32_t>(rt_args_idx++);  // for 2d unicast only
+
         bwd_fabric_connection =
             tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);
 
-        fwd_packet_header = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(packet_header_buffer_address);
         bwd_packet_header = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(
             packet_header_buffer_address + sizeof(PACKET_HEADER_TYPE));
-        zero_l1_buf((uint32_t*)packet_header_buffer_address, sizeof(PACKET_HEADER_TYPE) * 2);
 
-        if constexpr (is_2d_fabric) {
-            set_mcast_header(fwd_packet_header, (eth_chan_directions)fwd_fabric_connection.direction, mcast_fwd_hops);
-            set_mcast_header(bwd_packet_header, (eth_chan_directions)bwd_fabric_connection.direction, mcast_bwd_hops);
+        zero_l1_buf((uint32_t*)packet_header_buffer_address + sizeof(PACKET_HEADER_TYPE), sizeof(PACKET_HEADER_TYPE));
+
+        setup_connection(bwd_fabric_connection);
+
+        if constexpr (!is_2d_fabric) {  // 1D
+            setup_header_routing_1d(bwd_packet_header, bwd_start_distance, bwd_range);
+        } else {  // 2D
+            setup_header_routing_2d(
+                bwd_packet_header,
+                (eth_chan_directions)bwd_fabric_connection.direction,
+                bwd_range,
+                my_dev_id,
+                bwd_dev_id,
+                bwd_mesh_id,
+                ew_dim);
         }
-
-        setup_connection_and_headers(
-            fwd_fabric_connection, fwd_packet_header, mcast_fwd_hops, noc_dest_addr, packet_payload_size_bytes);
-
-        setup_connection_and_headers(
-            bwd_fabric_connection, bwd_packet_header, mcast_bwd_hops, noc_dest_addr, packet_payload_size_bytes);
-
-    } else {
-        uint32_t unicast_hops = get_arg_val<uint32_t>(rt_args_idx++);
-
-        fwd_fabric_connection =
-            tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);
-
-        fwd_packet_header = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(packet_header_buffer_address);
-        zero_l1_buf((uint32_t*)packet_header_buffer_address, sizeof(PACKET_HEADER_TYPE));
-
-        if constexpr (is_2d_fabric) {
-            if constexpr (use_dynamic_routing) {
-                fabric_set_unicast_route(
-                    (MeshPacketHeader*)packet_header_buffer_address,
-                    (eth_chan_directions)fwd_fabric_connection.direction,
-                    my_dev_id,
-                    fwd_dev_id,
-                    fwd_mesh_id,
-                    ew_dim);
-            } else {
-                fabric_set_unicast_route(
-                    (LowLatencyMeshPacketHeader*)packet_header_buffer_address,
-                    (eth_chan_directions)fwd_fabric_connection.direction,
-                    my_dev_id,
-                    fwd_dev_id,
-                    fwd_mesh_id,
-                    ew_dim);
-            }
-        }
-
-        setup_connection_and_headers(
-            fwd_fabric_connection, fwd_packet_header, unicast_hops, noc_dest_addr, packet_payload_size_bytes);
     }
 
+    /***************** send packets *****************/
     zero_l1_buf(test_results, test_results_size_bytes);
     test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_STARTED;
 
@@ -186,46 +230,39 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_packets; i++) {
 #ifndef BENCHMARK_MODE
         time_seed = prng_next(time_seed);
-#endif
-        if constexpr (mcast_mode) {
-            // fwd packet
-            send_packet(
-                fwd_packet_header,
-                noc_dest_addr,
-                source_l1_buffer_address,
-                packet_payload_size_bytes,
-                time_seed,
-                fwd_fabric_connection);
 
+        setup_header_noc_unicast_write(
+            fwd_packet_header, packet_payload_size_bytes, target_address, noc_x_start, noc_y_start);
+
+        if constexpr (additional_dir) {
+            setup_header_noc_unicast_write(
+                bwd_packet_header, packet_payload_size_bytes, target_address, noc_x_start, noc_y_start);
+        }
+#endif
+
+        // fwd packet
+        send_packet(
+            fwd_packet_header, source_l1_buffer_address, packet_payload_size_bytes, time_seed, fwd_fabric_connection);
+
+        if constexpr (additional_dir) {
             // bwd packet
             send_packet(
                 bwd_packet_header,
-                noc_dest_addr,
                 source_l1_buffer_address,
                 packet_payload_size_bytes,
                 time_seed,
                 bwd_fabric_connection);
-        } else {
-            send_packet(
-                fwd_packet_header,
-                noc_dest_addr,
-                source_l1_buffer_address,
-                packet_payload_size_bytes,
-                time_seed,
-                fwd_fabric_connection);
         }
 #ifndef BENCHMARK_MODE
-        noc_dest_addr += packet_payload_size_bytes;
+        target_address += packet_payload_size_bytes;
 #endif
     }
 
     uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
 
-    if constexpr (mcast_mode) {
-        teardown_connection(fwd_fabric_connection);
+    teardown_connection(fwd_fabric_connection);
+    if constexpr (additional_dir) {
         teardown_connection(bwd_fabric_connection);
-    } else {
-        teardown_connection(fwd_fabric_connection);
     }
 
     noc_async_write_barrier();

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -757,20 +757,36 @@ void DeviceProfiler::logNocTracePacketDataToJson(
             noc_trace_json_log.push_back(std::move(data));
         } else if (std::holds_alternative<EMD::FabricNoCEvent>(ev_md_contents)) {
             EMD::FabricNoCEvent fabric_noc_event = std::get<EMD::FabricNoCEvent>(ev_md_contents);
-            auto phys_coord =
-                getPhysicalAddressFromVirtual(device_id, {fabric_noc_event.dst_x, fabric_noc_event.dst_y});
-            noc_trace_json_log.push_back(nlohmann::ordered_json{
+
+            nlohmann::ordered_json data = {
                 {"run_host_id", run_host_id},
                 {"op_name", opname},
                 {"proc", risc_name},
                 {"sx", core_x},
                 {"sy", core_y},
                 {"type", magic_enum::enum_name(ev_md.noc_xfer_type)},
-                {"dx", phys_coord.x},
-                {"dy", phys_coord.y},
                 {"routing_fields_type", magic_enum::enum_name(fabric_noc_event.routing_fields_type)},
                 {"timestamp", timestamp},
-            });
+            };
+
+            // handle dst coordinates correctly for different NocEventType
+            if (KernelProfilerNocEventMetadata::isFabricUnicastEventType(ev_md.noc_xfer_type)) {
+                auto phys_coord =
+                    getPhysicalAddressFromVirtual(device_id, {fabric_noc_event.dst_x, fabric_noc_event.dst_y});
+                data["dx"] = phys_coord.x;
+                data["dy"] = phys_coord.y;
+            } else {
+                auto phys_start_coord =
+                    getPhysicalAddressFromVirtual(device_id, {fabric_noc_event.dst_x, fabric_noc_event.dst_y});
+                data["mcast_start_x"] = phys_start_coord.x;
+                data["mcast_start_y"] = phys_start_coord.y;
+                auto phys_end_coord = getPhysicalAddressFromVirtual(
+                    device_id, {fabric_noc_event.mcast_end_dst_x, fabric_noc_event.mcast_end_dst_y});
+                data["mcast_end_x"] = phys_end_coord.x;
+                data["mcast_end_y"] = phys_end_coord.y;
+            }
+
+            noc_trace_json_log.push_back(std::move(data));
         } else if (std::holds_alternative<EMD::FabricRoutingFields>(ev_md_contents)) {
             uint32_t routing_fields_value = std::get<EMD::FabricRoutingFields>(ev_md_contents).routing_fields_value;
             noc_trace_json_log.push_back(nlohmann::ordered_json{
@@ -897,15 +913,16 @@ void DeviceProfiler::serializeJsonNocTraces(
 
             // determine hop count and other routing metadata from routing fields value
             uint32_t routing_fields_value = fabric_routing_fields_event.at("routing_fields_value").get<uint32_t>();
-            int hops = 0;
-            // TODO: extract multicast start hop and end hop from routing fields value
+            int start_distance = 0;
+            int range = 0;
             switch (routing_fields_type) {
                 case KernelProfilerNocEventMetadata::FabricPacketType::REGULAR: {
-                    hops = get_routing_hops(routing_fields_value);
+                    std::tie(start_distance, range) = get_routing_start_distance_and_range(routing_fields_value);
                     break;
                 }
                 case KernelProfilerNocEventMetadata::FabricPacketType::LOW_LATENCY: {
-                    hops = get_low_latency_routing_hops(routing_fields_value);
+                    std::tie(start_distance, range) =
+                        get_low_latency_routing_start_distance_and_range(routing_fields_value);
                     break;
                 }
                 case KernelProfilerNocEventMetadata::FabricPacketType::LOW_LATENCY_MESH: {
@@ -921,31 +938,49 @@ void DeviceProfiler::serializeJsonNocTraces(
                     tt::LogMetal,
                     "[profiler noc tracing] Fabric edm_location->channel lookup failed for event in op '{}' at ts {}: "
                     "src_dev={}, "
-                    "eth_core=({}, {}), hops={}. Keeping original events.",
+                    "eth_core=({}, {}), start_distance={}. Keeping original events.",
                     fabric_event.value("op_name", "N/A"),
                     fabric_event.value("timestamp", 0.0),
                     device_id,
                     phys_eth_route_coord.x,
                     phys_eth_route_coord.y,
-                    hops);
+                    start_distance);
                 return std::nullopt;
             }
 
             tt::tt_fabric::chan_id_t eth_chan = *eth_chan_opt;
 
-            CoreCoord dst_coord = {fabric_event.at("dx").get<int>(), fabric_event.at("dy").get<int>()};
-
             nlohmann::ordered_json modified_write_event = local_noc_write_event;
             modified_write_event["timestamp"] = fabric_event["timestamp"];
 
             // replace original eth core destination with true destination
-            modified_write_event["dx"] = dst_coord.x;
-            modified_write_event["dy"] = dst_coord.y;
+            auto noc_xfer_type = magic_enum::enum_cast<KernelProfilerNocEventMetadata::NocEventType>(
+                fabric_event["type"].get<std::string>());
+
+            if (!noc_xfer_type.has_value() ||
+                !KernelProfilerNocEventMetadata::isFabricEventType(noc_xfer_type.value())) {
+                log_error(
+                    tt::LogMetal,
+                    "[profiler noc tracing] Failed to parse noc transfer type: {}",
+                    fabric_event["type"].get<std::string>());
+                return std::nullopt;
+            }
+
+            if (KernelProfilerNocEventMetadata::isFabricUnicastEventType(noc_xfer_type.value())) {
+                modified_write_event["dx"] = fabric_event.at("dx").get<int>();
+                modified_write_event["dy"] = fabric_event.at("dy").get<int>();
+            } else {
+                log_error(
+                    tt::LogMetal,
+                    "[profiler noc tracing] Noc multicasts in fabric events are not supported!");
+                return std::nullopt;
+            }
 
             // replace the type with fabric event type
             modified_write_event["type"] = fabric_event["type"];
 
-            modified_write_event["fabric_send"] = {{"eth_chan", eth_chan}, {"hops", hops}};
+            modified_write_event["fabric_send"] = {
+                {"eth_chan", eth_chan}, {"start_distance", start_distance}, {"range", range}};
 
             return modified_write_event;
         } catch (const nlohmann::json::exception& e) {

--- a/tt_metal/tools/profiler/event_metadata.hpp
+++ b/tt_metal/tools/profiler/event_metadata.hpp
@@ -91,9 +91,9 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
         // NOTE: fabric events should be contiguous to allow quick range check!
         FABRIC_UNICAST_WRITE = 28,
         FABRIC_UNICAST_INLINE_WRITE = 29,
-        FABRIC_MULTICAST_WRITE = 30,
-        FABRIC_UNICAST_ATOMIC_INC = 31,
-        FABRIC_FUSED_UNICAST_ATOMIC_INC = 32,
+        FABRIC_UNICAST_ATOMIC_INC = 30,
+        FABRIC_FUSED_UNICAST_ATOMIC_INC = 31,
+        FABRIC_MULTICAST_WRITE = 32,
         FABRIC_MULTICAST_ATOMIC_INC = 33,
         FABRIC_ROUTING_FIELDS = 34,
 
@@ -108,15 +108,20 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
         std::memcpy(this, &raw_data, sizeof(KernelProfilerNocEventMetadata));
     }
 
-    bool isFabricEventType() const {
-        return noc_xfer_type >= NocEventType::FABRIC_UNICAST_WRITE &&
-               noc_xfer_type <= NocEventType::FABRIC_MULTICAST_ATOMIC_INC;
+    static bool isFabricEventType(NocEventType event_type) {
+        return event_type >= NocEventType::FABRIC_UNICAST_WRITE &&
+               event_type <= NocEventType::FABRIC_MULTICAST_ATOMIC_INC;
     }
     bool isFabricRoutingFields() const { return noc_xfer_type == NocEventType::FABRIC_ROUTING_FIELDS; }
 
+    static bool isFabricUnicastEventType(NocEventType event_type) {
+        return event_type >= NocEventType::FABRIC_UNICAST_WRITE &&
+               event_type <= NocEventType::FABRIC_FUSED_UNICAST_ATOMIC_INC;
+    }
+
     // Getter to return the correct variant based on the tag
     std::variant<LocalNocEvent, FabricNoCEvent, FabricRoutingFields> getContents() const {
-        if (isFabricEventType()) {
+        if (isFabricEventType(noc_xfer_type)) {
             return data.fabric_event;
         } else if (isFabricRoutingFields()) {
             return data.fabric_routing_fields;

--- a/tt_metal/tools/profiler/experimental/fabric_event_profiler.hpp
+++ b/tt_metal/tools/profiler/experimental/fabric_event_profiler.hpp
@@ -60,9 +60,28 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
                 fabric_header_ptr->routing_fields.value);
             break;
         }
-        case tt::tt_fabric::NocSendType::NOC_MULTICAST_WRITE:
+        case tt::tt_fabric::NocSendType::NOC_MULTICAST_WRITE: {
+            const volatile auto& mcast_write_cmd = fabric_header_ptr->get_command_fields().mcast_write;
+            noc_event_profiler::recordFabricNocEventMulticast(
+                KernelProfilerNocEventMetadata::NocEventType::FABRIC_MULTICAST_WRITE,
+                routing_fields_type,
+                mcast_write_cmd.noc_x_start,
+                mcast_write_cmd.noc_y_start,
+                mcast_write_cmd.mcast_rect_size_x,
+                mcast_write_cmd.mcast_rect_size_y,
+                fabric_header_ptr->routing_fields.value);
+            break;
+        }
         case tt::tt_fabric::NocSendType::NOC_MULTICAST_ATOMIC_INC: {
-            // UNSUPPORTED for now
+            const volatile auto& mcast_write_cmd = fabric_header_ptr->get_command_fields().mcast_seminc;
+            noc_event_profiler::recordFabricNocEventMulticast(
+                KernelProfilerNocEventMetadata::NocEventType::FABRIC_MULTICAST_ATOMIC_INC,
+                routing_fields_type,
+                mcast_write_cmd.noc_x_start,
+                mcast_write_cmd.noc_y_start,
+                mcast_write_cmd.size_x,
+                mcast_write_cmd.size_y,
+                fabric_header_ptr->routing_fields.value);
             break;
         }
     }

--- a/tt_metal/tools/profiler/noc_event_profiler.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler.hpp
@@ -119,7 +119,7 @@ void recordNocEventWithAddr(
     recordNocEvent(noc_event_type, decoded_x, decoded_y, num_bytes, vc);
 }
 
-template <typename NocAddrU64>
+template <typename NocAddrU64, uint32_t STATIC_ID = 12345>
 FORCE_INLINE void recordFabricNocEvent(
     KernelProfilerNocEventMetadata::NocEventType noc_event_type,
     KernelProfilerNocEventMetadata::FabricPacketType packet_type,
@@ -140,7 +140,7 @@ FORCE_INLINE void recordFabricNocEvent(
     fabric_noc_event.routing_fields_type = packet_type;
 
     kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
-    kernel_profiler::timeStampedData<12345, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
+    kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
 
     // following profiler event just stores the routing fields value
     KernelProfilerNocEventMetadata event_routing_fields;
@@ -148,7 +148,39 @@ FORCE_INLINE void recordFabricNocEvent(
     event_routing_fields.data.fabric_routing_fields.routing_fields_value = routing_fields;
 
     kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
-    kernel_profiler::timeStampedData<12345, kernel_profiler::DoingDispatch::DISPATCH>(event_routing_fields.asU64());
+    kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(event_routing_fields.asU64());
+}
+
+template <uint32_t STATIC_ID = 12345>
+FORCE_INLINE void recordFabricNocEventMulticast(
+    KernelProfilerNocEventMetadata::NocEventType noc_event_type,
+    KernelProfilerNocEventMetadata::FabricPacketType packet_type,
+    uint8_t noc_x_start,
+    uint8_t noc_y_start,
+    uint8_t mcast_rect_size_x,
+    uint8_t mcast_rect_size_y,
+    uint32_t routing_fields) {
+    // first profiler packet stores XY address data as well as packet type tag (used to decode routing fields)
+    KernelProfilerNocEventMetadata ev_md;
+    ev_md.noc_xfer_type = noc_event_type;
+
+    auto& fabric_noc_event = ev_md.data.fabric_event;
+    fabric_noc_event.dst_x = noc_x_start;
+    fabric_noc_event.dst_y = noc_y_start;
+    fabric_noc_event.mcast_end_dst_x = noc_x_start + mcast_rect_size_x - 1;
+    fabric_noc_event.mcast_end_dst_y = noc_y_start + mcast_rect_size_y - 1;
+    fabric_noc_event.routing_fields_type = packet_type;
+
+    kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
+    kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
+
+    // following profiler event just stores the routing fields value
+    KernelProfilerNocEventMetadata event_routing_fields;
+    event_routing_fields.noc_xfer_type = KernelProfilerNocEventMetadata::NocEventType::FABRIC_ROUTING_FIELDS;
+    event_routing_fields.data.fabric_routing_fields.routing_fields_value = routing_fields;
+
+    kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
+    kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(event_routing_fields.asU64());
 }
 }  // namespace noc_event_profiler
 


### PR DESCRIPTION
### Problem description
Expending on https://github.com/tenstorrent/tt-metal/pull/22908 to add support for tracing (chip and noc) multicasts on 1d fabric for use by tt-npe

### What's changed
- No changes to tt_fabric, everything is done within profiler code and unit tests.
- Refactored tt_fabric_1d_tx.cpp kernel for additional 1d fabric multicast tests
- Testing: Added test_fabric_event_profiler_1d_multicast added in tt_metal/tools/profiler/test_device_profiler.py to test chip multicast (noc multicast tracing code is in place but currently noc multicast is not supported: )

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes