### PR TITLE
Uploading scripts to automate multi-run device perf aggregation

### DIFF
--- a/models/demos/llama3_subdevices/tests/automate_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/automate_device_perf.py
@@ -1,10 +1,12 @@
-#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
 
 import subprocess
 import time
 import os
 import json
 import pandas as pd
+import argparse
 
 # Update this to the location of the RESET file
 RESET_SCRIPT_PATH = "/proj_sw/user_dev/yalrawwash/reset/reset-1.json"
@@ -137,8 +139,7 @@ def generate_perf_json(
 
 
 def automate_perf_collection(
-    num_runs: int = 18,
-    sleep_between_resets: int = 10,
+    num_runs: int = 5,
     generate_json: bool = True,
 ):
     """Main automation loop for running perf data collection and generating JSON."""
@@ -149,14 +150,14 @@ def automate_perf_collection(
         print(f"\n===== Run {i}/{num_runs} =====")
 
         reset_device()
-        print(f"Sleeping {sleep_between_resets} seconds to allow hardware reset...")
-        time.sleep(sleep_between_resets)
+        print(f"Sleeping 20 seconds to allow hardware reset...")
+        time.sleep(20)
 
         run_test(decoder_test)
 
         reset_device()
-        print(f"Sleeping {sleep_between_resets} seconds to allow hardware reset...")
-        time.sleep(sleep_between_resets)
+        print(f"Sleeping 20 seconds to allow hardware reset...")
+        time.sleep(20)
 
         run_test(dispatch_test)
 
@@ -165,12 +166,9 @@ def automate_perf_collection(
 
 
 if __name__ == "__main__":
-    import argparse
-
     parser = argparse.ArgumentParser(description="Automate LLaMA performance data collection")
     parser.add_argument("--runs", type=int, default=5, help="Number of times to repeat each test")
-    parser.add_argument("--sleep", type=int, default=10, help="Sleep time between resets")
     parser.add_argument("--no-json", action="store_true", help="Skip generating JSON")
     args = parser.parse_args()
 
-    automate_perf_collection(num_runs=args.runs, sleep_between_resets=args.sleep, generate_json=not args.no_json)
+    automate_perf_collection(num_runs=args.runs, generate_json=not args.no_json)

--- a/models/demos/llama3_subdevices/tests/automate_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/automate_device_perf.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+
+import subprocess
+import time
+import os
+import json
+import pandas as pd
+
+# Update this to the location of the RESET file
+RESET_SCRIPT_PATH = "/proj_sw/user_dev/yalrawwash/reset/reset-1.json"
+
+
+def reset_device():
+    """Reset devices using tt-smi."""
+    print("BE SURE YOU ARE RESETTING THE CORRECT DEVICE")
+    print("Resetting devices...")
+    try:
+        result = subprocess.run(["tt-smi", "-r", RESET_SCRIPT_PATH])
+        if result.returncode != 0:
+            print(f"[ERROR] Device reset failed with code {result.returncode}")
+    except Exception as e:
+        print(f"[EXCEPTION] Exception during device reset: {e}")
+    else:
+        print("Device reset completed.\n")
+
+
+def run_test(test_name: str):
+    """Run a specific pytest test with live output."""
+    print(f"Running test: {test_name}")
+    try:
+        env = os.environ.copy()
+        env["FAKE_DEVICE"] = "TG"
+        env["TT_METAL_ENABLE_ERISC_IRAM"] = "1"
+        env["TT_METAL_KERNELS_EARLY_RETURN"] = "1"
+
+        command = ["pytest", test_name]
+        result = subprocess.run(command, env=env)
+
+        if result.returncode != 0:
+            print(f"[ERROR] Test {test_name} failed with return code {result.returncode}.")
+
+        else:
+            print(f"Completed test: {test_name}\n")
+
+    except Exception as e:
+        print(f"[EXCEPTION] Exception while running {test_name}: {e}")
+
+
+def generate_perf_json(
+    decoder_csv="out.csv", dispatch_csv="out-non-dispatched.csv", output_json="aggregated_perf_targets.json"
+):
+    """Load CSVs and generate aggregated performance target JSON."""
+    print("Generating aggregated performance target JSON...")
+    df_main = pd.read_csv(decoder_csv)
+    df_dispatch = pd.read_csv(dispatch_csv)
+
+    def is_collective(op):
+        return any(keyword in op for keyword in ["AllGather", "ReduceScatter", "AllReduce", "Matmul_RS"])
+
+    decoder_ops = set(df_main[df_main["metric_type"].str.startswith("mid_")]["op_code_with_id"].unique())
+    model_tail_ops = set(df_main[df_main["metric_type"].str.startswith("model_tail")]["op_code_with_id"].unique())
+
+    decoder_df = df_main[df_main["op_code_with_id"].isin(decoder_ops)]
+    model_tail_df = df_main[df_main["op_code_with_id"].isin(model_tail_ops)]
+
+    def aggregate_metrics(df, kernel_metric, dispatch_metric, ftls_metric):
+        df_filtered = df[df["metric_type"].isin([kernel_metric, dispatch_metric, ftls_metric])]
+        pivot = df_filtered.pivot_table(
+            index=["run_number", "op_code_with_id"], columns="metric_type", values="value"
+        ).reset_index()
+        return pivot.groupby("op_code_with_id").mean()
+
+    decoder_kernel_trace = aggregate_metrics(
+        decoder_df, "mid_trace_avg", "mid_dispatch_avg", "mid_first_to_last_start_avg"
+    )
+    decoder_kernel_compile = aggregate_metrics(
+        decoder_df, "mid_compile_avg", "mid_dispatch_avg", "mid_first_to_last_start_avg"
+    )
+    decoder_ftls = aggregate_metrics(decoder_df, "mid_trace_avg", "mid_dispatch_avg", "mid_first_to_last_start_avg")
+
+    decoder_ops_combined = {}
+    for op in sorted(decoder_kernel_trace.index.union(decoder_kernel_compile.index)):
+        kernel_src = decoder_kernel_trace if is_collective(op) else decoder_kernel_compile
+        kernel_duration = kernel_src.at[op, "mid_trace_avg" if is_collective(op) else "mid_compile_avg"]
+        dispatch_duration = decoder_ftls.at[op, "mid_dispatch_avg"]
+        ftls_duration = decoder_ftls.at[op, "mid_first_to_last_start_avg"]
+
+        non_overlap_dispatch = df_dispatch[
+            (df_dispatch["metric_type"] == "mid_dispatch_avg") & (df_dispatch["op_code_with_id"] == op)
+        ]["value"].mean()
+
+        decoder_ops_combined[op] = {
+            "op_name": op,
+            "kernel_duration": kernel_duration,
+            "op_to_op": dispatch_duration,
+            "first_to_last_start": ftls_duration,
+            "non-overlapped-dispatch-time": non_overlap_dispatch,
+            "kernel_duration_relative_margin": 0.05,
+            "op_to_op_duration_relative_margin": 0.2,
+            "first_to_last_start_relative_margin": 0.2,
+            "dispatch_duration_relative_margin": 0.2,
+        }
+
+    model_tail_avg = model_tail_df[
+        model_tail_df["metric_type"].isin(["model_tail_compile_avg", "model_tail_trace_avg", "model_tail_dispatch_avg"])
+    ]
+    pivot_tail = model_tail_avg.pivot_table(
+        index=["run_number", "op_code_with_id"], columns="metric_type", values="value"
+    ).reset_index()
+    tail_grouped = pivot_tail.groupby("op_code_with_id").mean()
+    tail_dispatch = (
+        df_dispatch[df_dispatch["metric_type"] == "model_tail_dispatch_avg"].groupby("op_code_with_id")["value"].mean()
+    )
+
+    model_tail_combined = {}
+    for op in sorted(tail_grouped.index):
+        kernel_duration = tail_grouped.at[op, "model_tail_trace_avg" if is_collective(op) else "model_tail_compile_avg"]
+        dispatch_duration = tail_grouped.at[op, "model_tail_dispatch_avg"]
+        non_overlap_dispatch = tail_dispatch.get(op, 0)
+
+        model_tail_combined[op] = {
+            "op_name": op,
+            "kernel_duration": kernel_duration,
+            "op_to_op": dispatch_duration,
+            "non-overlapped-dispatch-time": non_overlap_dispatch,
+            "kernel_duration_relative_margin": 0.2,
+            "op_to_op_duration_relative_margin": 0.2,
+            "dispatch_duration_relative_margin": 0.5,
+        }
+
+    output_json_data = {"decoder": decoder_ops_combined, "model_tail": model_tail_combined}
+
+    with open(output_json, "w") as f:
+        json.dump(output_json_data, f, indent=4)
+
+    print(f"Saved aggregated metrics to {output_json}")
+
+
+def automate_perf_collection(
+    num_runs: int = 18,
+    sleep_between_resets: int = 10,
+    generate_json: bool = True,
+):
+    """Main automation loop for running perf data collection and generating JSON."""
+    decoder_test = "models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device"
+    dispatch_test = "models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch"
+
+    for i in range(1, num_runs + 1):
+        print(f"\n===== Run {i}/{num_runs} =====")
+
+        reset_device()
+        print(f"Sleeping {sleep_between_resets} seconds to allow hardware reset...")
+        time.sleep(sleep_between_resets)
+
+        run_test(decoder_test)
+
+        reset_device()
+        print(f"Sleeping {sleep_between_resets} seconds to allow hardware reset...")
+        time.sleep(sleep_between_resets)
+
+        run_test(dispatch_test)
+
+    if generate_json:
+        generate_perf_json()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Automate LLaMA performance data collection")
+    parser.add_argument("--runs", type=int, default=5, help="Number of times to repeat each test")
+    parser.add_argument("--sleep", type=int, default=10, help="Sleep time between resets")
+    parser.add_argument("--no-json", action="store_true", help="Skip generating JSON")
+    args = parser.parse_args()
+
+    automate_perf_collection(num_runs=args.runs, sleep_between_resets=args.sleep, generate_json=not args.no_json)

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -886,11 +886,6 @@ def test_llama_TG_perf_device(
     assert all_passing
 
 
-import csv
-import os
-from datetime import datetime
-
-
 def append_non_overlapped_dispatch_data_to_csv(
     avg_dispatch_duration_model_tail,
     min_dispatch_duration_model_tail,
@@ -1042,13 +1037,6 @@ def test_llama_TG_perf_device_non_overlapped_dispatch(
     print_dict(avg_dispatch_duration_mid_layers, "avg_dispatch_duration_mid_layers")
     print_dict(avg_dispatch_duration_model_tail, "avg_dispatch_duration_model_tail")
 
-    assert len(avg_dispatch_duration_mid_layers) == len(
-        perf_targets["decoder"]
-    ), f"Expected {len(perf_targets['decoder'])} operations in decoder, got {len(avg_dispatch_duration_mid_layers)}. If the number or type of operations changed, expected times must be updated."
-    assert len(avg_dispatch_duration_model_tail) == len(
-        perf_targets["model_tail"]
-    ), f"Expected {len(perf_targets['model_tail'])} operations in model tail, got {len(avg_dispatch_duration_model_tail)}. If the number or type of operations changed, expected times must be updated."
-
     append_non_overlapped_dispatch_data_to_csv(
         avg_dispatch_duration_model_tail=avg_dispatch_duration_model_tail,
         min_dispatch_duration_model_tail=min_dispatch_duration_model_tail,
@@ -1058,6 +1046,13 @@ def test_llama_TG_perf_device_non_overlapped_dispatch(
         max_dispatch_duration_mid_layers=max_dispatch_duration_mid_layers,
         csv_filename="out-non-dispatched.csv",
     )
+
+    assert len(avg_dispatch_duration_mid_layers) == len(
+        perf_targets["decoder"]
+    ), f"Expected {len(perf_targets['decoder'])} operations in decoder, got {len(avg_dispatch_duration_mid_layers)}. If the number or type of operations changed, expected times must be updated."
+    assert len(avg_dispatch_duration_model_tail) == len(
+        perf_targets["model_tail"]
+    ), f"Expected {len(perf_targets['model_tail'])} operations in model tail, got {len(avg_dispatch_duration_model_tail)}. If the number or type of operations changed, expected times must be updated."
 
     print("Decoder")
     passing = True

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -373,6 +373,118 @@ def load_perf_targets(galaxy_type):
     return perf_targets
 
 
+import csv
+import os
+from datetime import datetime
+
+
+def append_perf_data_to_csv(
+    avg_kernel_duration_mid_layers_compilation,
+    min_kernel_duration_mid_layers_compilation,
+    max_kernel_duration_mid_layers_compilation,
+    avg_kernel_duration_mid_layers_trace,
+    min_kernel_duration_mid_layers_trace,
+    max_kernel_duration_mid_layers_trace,
+    avg_dispatch_duration_mid_layers_trace,
+    avg_first_to_last_start_mid_layers_trace,
+    avg_kernel_duration_model_tail_compilation,
+    avg_kernel_duration_model_tail_trace,
+    avg_dispatch_duration_model_tail_trace,
+    csv_filename="out.csv",
+):
+    """
+    Appends selected performance data to CSV and prints them in print_dict style.
+    Each row in the CSV corresponds to (op_code_with_id, metric_type, value).
+    """
+    file_exists = os.path.exists(csv_filename)
+    run_number = 1
+
+    if file_exists:
+        try:
+            with open(csv_filename, "r") as f:
+                reader = csv.DictReader(f)
+                run_numbers = [int(row["run_number"]) for row in reader if row["run_number"].isdigit()]
+                if run_numbers:
+                    run_number = max(run_numbers) + 1
+        except:
+            run_number = 1
+
+    fieldnames = ["run_number", "timestamp", "op_code_with_id", "metric_type", "value"]
+
+    timestamp = datetime.now().isoformat()
+
+    def print_dict(d, name):
+        print(f"{name} = {{")
+        for k in sorted(d.keys()):
+            print(f"    '{k}': {d[k]},")
+        print("}\n")
+
+    def write_metrics(writer, metric_dict, metric_type):
+        for op_id, value in metric_dict.items():
+            writer.writerow(
+                {
+                    "run_number": run_number,
+                    "timestamp": timestamp,
+                    "op_code_with_id": op_id,
+                    "metric_type": metric_type,
+                    "value": value,
+                }
+            )
+
+    with open(csv_filename, "a", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        if not file_exists:
+            writer.writeheader()
+
+        metric_groups = [
+            # Mid-layer compilation
+            (
+                "avg_kernel_duration_mid_layers_compilation",
+                avg_kernel_duration_mid_layers_compilation,
+                "mid_compile_avg",
+            ),
+            (
+                "min_kernel_duration_mid_layers_compilation",
+                min_kernel_duration_mid_layers_compilation,
+                "mid_compile_min",
+            ),
+            (
+                "max_kernel_duration_mid_layers_compilation",
+                max_kernel_duration_mid_layers_compilation,
+                "mid_compile_max",
+            ),
+            # Mid-layer trace
+            ("avg_kernel_duration_mid_layers_trace", avg_kernel_duration_mid_layers_trace, "mid_trace_avg"),
+            ("min_kernel_duration_mid_layers_trace", min_kernel_duration_mid_layers_trace, "mid_trace_min"),
+            ("max_kernel_duration_mid_layers_trace", max_kernel_duration_mid_layers_trace, "mid_trace_max"),
+            # Mid-layer dispatch and latency
+            ("avg_dispatch_duration_mid_layers_trace", avg_dispatch_duration_mid_layers_trace, "mid_dispatch_avg"),
+            (
+                "avg_first_to_last_start_mid_layers_trace",
+                avg_first_to_last_start_mid_layers_trace,
+                "mid_first_to_last_start_avg",
+            ),
+            # Model tail
+            (
+                "avg_kernel_duration_model_tail_compilation",
+                avg_kernel_duration_model_tail_compilation,
+                "model_tail_compile_avg",
+            ),
+            ("avg_kernel_duration_model_tail_trace", avg_kernel_duration_model_tail_trace, "model_tail_trace_avg"),
+            (
+                "avg_dispatch_duration_model_tail_trace",
+                avg_dispatch_duration_model_tail_trace,
+                "model_tail_dispatch_avg",
+            ),
+        ]
+
+        for name, d, metric_type in metric_groups:
+            print_dict(d, name)
+            write_metrics(writer, d, metric_type)
+
+    print(f"\nPerformance data appended to {csv_filename} (Run #{run_number})")
+
+
 @pytest.mark.models_device_performance_bare_metal
 # To update:
 # Run FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device
@@ -498,6 +610,21 @@ def test_llama_TG_perf_device(
     print_dict(avg_kernel_duration_model_tail_compilation, "avg_kernel_duration_model_tail_compilation")
     print_dict(avg_kernel_duration_model_tail_trace, "avg_kernel_duration_model_tail_trace")
     print_dict(avg_dispatch_duration_model_tail_trace, "avg_dispatch_duration_model_tail_trace")
+
+    append_perf_data_to_csv(
+        avg_kernel_duration_mid_layers_compilation,
+        min_kernel_duration_mid_layers_compilation,
+        max_kernel_duration_mid_layers_compilation,
+        avg_kernel_duration_mid_layers_trace,
+        min_kernel_duration_mid_layers_trace,
+        max_kernel_duration_mid_layers_trace,
+        avg_dispatch_duration_mid_layers_trace,
+        avg_first_to_last_start_mid_layers_trace,
+        avg_kernel_duration_model_tail_compilation,
+        avg_kernel_duration_model_tail_trace,
+        avg_dispatch_duration_model_tail_trace,
+        "out.csv",
+    )
 
     assert len(avg_kernel_duration_mid_layers_compilation) == len(
         perf_targets["decoder"]
@@ -759,6 +886,83 @@ def test_llama_TG_perf_device(
     assert all_passing
 
 
+import csv
+import os
+from datetime import datetime
+
+
+def append_non_overlapped_dispatch_data_to_csv(
+    avg_dispatch_duration_model_tail,
+    min_dispatch_duration_model_tail,
+    max_dispatch_duration_model_tail,
+    avg_dispatch_duration_mid_layers,
+    min_dispatch_duration_mid_layers,
+    max_dispatch_duration_mid_layers,
+    csv_filename="out-non-dispatched.csv",
+):
+    """
+    Appends dispatch timing (avg/min/max) for model tail and mid decoder layers
+    from the non-overlapped dispatch run to a CSV file. Also prints each dict.
+
+    Args:
+        *_model_tail, *_mid_layers: Dicts of op_code_with_id -> dispatch duration
+        csv_filename: Output CSV file name
+    """
+    file_exists = os.path.exists(csv_filename)
+    run_number = 1
+
+    if file_exists:
+        try:
+            with open(csv_filename, "r") as f:
+                reader = csv.DictReader(f)
+                run_numbers = [int(row["run_number"]) for row in reader if row["run_number"].isdigit()]
+                if run_numbers:
+                    run_number = max(run_numbers) + 1
+        except:
+            run_number = 1
+
+    timestamp = datetime.now().isoformat()
+    fieldnames = ["run_number", "timestamp", "op_code_with_id", "metric_type", "value"]
+
+    def print_dict(d, name):
+        print(f"{name} = {{")
+        for k in sorted(d.keys()):
+            print(f"    '{k}': {d[k]},")
+        print("}\n")
+
+    def write_metrics(writer, metric_dict, metric_type):
+        for op_id, value in metric_dict.items():
+            writer.writerow(
+                {
+                    "run_number": run_number,
+                    "timestamp": timestamp,
+                    "op_code_with_id": op_id,
+                    "metric_type": metric_type,
+                    "value": value,
+                }
+            )
+
+    with open(csv_filename, "a", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        if not file_exists:
+            writer.writeheader()
+
+        metric_groups = [
+            ("avg_dispatch_duration_mid_layers", avg_dispatch_duration_mid_layers, "mid_dispatch_avg"),
+            ("min_dispatch_duration_mid_layers", min_dispatch_duration_mid_layers, "mid_dispatch_min"),
+            ("max_dispatch_duration_mid_layers", max_dispatch_duration_mid_layers, "mid_dispatch_max"),
+            ("avg_dispatch_duration_model_tail", avg_dispatch_duration_model_tail, "model_tail_dispatch_avg"),
+            ("min_dispatch_duration_model_tail", min_dispatch_duration_model_tail, "model_tail_dispatch_min"),
+            ("max_dispatch_duration_model_tail", max_dispatch_duration_model_tail, "model_tail_dispatch_max"),
+        ]
+
+        for name, d, metric_type in metric_groups:
+            print_dict(d, name)
+            write_metrics(writer, d, metric_type)
+
+    print(f"\nDispatch data appended to {csv_filename} (Run #{run_number})")
+
+
 @pytest.mark.models_device_performance_bare_metal
 # To update:
 # Run FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_KERNELS_EARLY_RETURN=1  pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch
@@ -844,6 +1048,16 @@ def test_llama_TG_perf_device_non_overlapped_dispatch(
     assert len(avg_dispatch_duration_model_tail) == len(
         perf_targets["model_tail"]
     ), f"Expected {len(perf_targets['model_tail'])} operations in model tail, got {len(avg_dispatch_duration_model_tail)}. If the number or type of operations changed, expected times must be updated."
+
+    append_non_overlapped_dispatch_data_to_csv(
+        avg_dispatch_duration_model_tail=avg_dispatch_duration_model_tail,
+        min_dispatch_duration_model_tail=min_dispatch_duration_model_tail,
+        max_dispatch_duration_model_tail=max_dispatch_duration_model_tail,
+        avg_dispatch_duration_mid_layers=avg_dispatch_duration_mid_layers,
+        min_dispatch_duration_mid_layers=min_dispatch_duration_mid_layers,
+        max_dispatch_duration_mid_layers=max_dispatch_duration_mid_layers,
+        csv_filename="out-non-dispatched.csv",
+    )
 
     print("Decoder")
     passing = True


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Currently updating perf numbers, essentially requires you run once after every optimization or change. This results in very flaky outputs. 

### What's changed
This code change creates an automated pipeline that calls the necessary resets and all device perf functions, and then aggregates and averages data, and eloquently fills it into a json file, as expected by program.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes