### PR TITLE
#22259: Multi-host serialization format improvements

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
@@ -206,8 +206,6 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard1DFewerShardsThanDevicesRoun
 
     Tensor input_tensor = Tensor::from_vector(
         test_data, get_tensor_spec(ttnn::Shape{1, num_devices - 1, kNumElements, 1}, DataType::FLOAT32));
-    Tensor::from_vector(
-        test_data, get_tensor_spec(ttnn::Shape{1, num_devices - 1, kNumElements, 1}, DataType::FLOAT32));
 
     auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*mesh_device_, 1);
     Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
@@ -112,13 +112,14 @@ using TensorSerializationFlatbufferT3000Test = T3000MeshDeviceFixture;
 TEST_F(TensorSerializationFlatbufferT3000Test, Shard1DTensorRoundtrip) {
     TemporaryFile test_file("shard1d_flatbuffer.bin");
     const int num_devices = mesh_device_->num_devices();
+    constexpr int kNumElements = 1024;
     std::vector<float> test_data;
     for (int i = 0; i < num_devices; i++) {
-        test_data.insert(test_data.end(), {i * 1.0f, i * 2.0f, i * 3.0f});
+        std::generate_n(std::back_inserter(test_data), kNumElements, [i]() { return i * 1.0f; });
     }
 
-    Tensor input_tensor =
-        Tensor::from_vector(test_data, get_tensor_spec(ttnn::Shape{1, num_devices, 3, 1}, DataType::FLOAT32));
+    Tensor input_tensor = Tensor::from_vector(
+        test_data, get_tensor_spec(ttnn::Shape{1, num_devices, kNumElements, 1}, DataType::FLOAT32));
 
     auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*mesh_device_, 1);
     Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);
@@ -150,15 +151,105 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard2DTensorRoundtrip) {
     TemporaryFile test_file("shard2d_flatbuffer.bin");
     constexpr int kNumRows = 2;
     constexpr int kNumCols = 4;
+    constexpr int kNumElements = 1024;
     const int num_devices = kNumRows * kNumCols;
 
     std::vector<float> test_data;
     for (int i = 0; i < num_devices; i++) {
-        test_data.insert(test_data.end(), {i * 1.0f, i * 2.0f, i * 3.0f});
+        std::generate_n(std::back_inserter(test_data), kNumElements, [i]() { return i * 1.0f; });
     }
 
-    Tensor input_tensor =
-        Tensor::from_vector(test_data, get_tensor_spec(ttnn::Shape{1, kNumRows, kNumCols, 3}, DataType::FLOAT32));
+    Tensor input_tensor = Tensor::from_vector(
+        test_data, get_tensor_spec(ttnn::Shape{1, kNumRows, kNumCols, kNumElements}, DataType::FLOAT32));
+
+    auto mapper = ttnn::distributed::create_mesh_mapper(
+        *mesh_device_,
+        ttnn::distributed::MeshMapperConfig{
+            .placements =
+                {ttnn::distributed::MeshMapperConfig::Shard{1}, ttnn::distributed::MeshMapperConfig::Shard{2}},
+        });
+
+    Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);
+
+    ASSERT_TRUE(sharded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+
+    dump_tensor_flatbuffer(test_file.string(), sharded_tensor);
+
+    Tensor loaded_tensor = load_tensor_flatbuffer(test_file.string());
+
+    ASSERT_EQ(loaded_tensor.tensor_spec().logical_shape(), sharded_tensor.tensor_spec().logical_shape());
+    ASSERT_EQ(loaded_tensor.dtype(), sharded_tensor.dtype());
+    ASSERT_EQ(loaded_tensor.layout(), sharded_tensor.layout());
+    ASSERT_TRUE(loaded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+
+    std::vector<Tensor> original_device_tensors = ttnn::distributed::get_device_tensors(sharded_tensor);
+    std::vector<Tensor> loaded_device_tensors = ttnn::distributed::get_device_tensors(loaded_tensor);
+
+    ASSERT_THAT(loaded_device_tensors, SizeIs(original_device_tensors.size()));
+
+    for (size_t i = 0; i < original_device_tensors.size(); i++) {
+        EXPECT_THAT(
+            loaded_device_tensors[i].to_vector<float>(),
+            Pointwise(FloatEq(), original_device_tensors[i].to_vector<float>()));
+        EXPECT_EQ(loaded_device_tensors[i].logical_shape(), original_device_tensors[i].logical_shape());
+    }
+}
+
+TEST_F(TensorSerializationFlatbufferT3000Test, Shard1DFewerShardsThanDevicesRoundtrip) {
+    TemporaryFile test_file("shard1d_fewer_flatbuffer.bin");
+    const int num_devices = mesh_device_->num_devices();
+    constexpr int kNumElements = 1024;
+    std::vector<float> test_data;
+    for (int i = 0; i < num_devices - 1; i++) {
+        std::generate_n(std::back_inserter(test_data), kNumElements, [i]() { return i * 1.0f; });
+    }
+
+    Tensor input_tensor = Tensor::from_vector(
+        test_data, get_tensor_spec(ttnn::Shape{1, num_devices - 1, kNumElements, 1}, DataType::FLOAT32));
+    Tensor::from_vector(
+        test_data, get_tensor_spec(ttnn::Shape{1, num_devices - 1, kNumElements, 1}, DataType::FLOAT32));
+
+    auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*mesh_device_, 1);
+    Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);
+
+    ASSERT_TRUE(sharded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+
+    dump_tensor_flatbuffer(test_file.string(), sharded_tensor);
+
+    Tensor loaded_tensor = load_tensor_flatbuffer(test_file.string());
+
+    ASSERT_EQ(loaded_tensor.tensor_spec().logical_shape(), sharded_tensor.tensor_spec().logical_shape());
+    ASSERT_EQ(loaded_tensor.dtype(), sharded_tensor.dtype());
+    ASSERT_EQ(loaded_tensor.layout(), sharded_tensor.layout());
+    ASSERT_TRUE(loaded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+
+    std::vector<Tensor> original_device_tensors = ttnn::distributed::get_device_tensors(sharded_tensor);
+    std::vector<Tensor> loaded_device_tensors = ttnn::distributed::get_device_tensors(loaded_tensor);
+
+    ASSERT_THAT(loaded_device_tensors, SizeIs(original_device_tensors.size()));
+    ASSERT_THAT(loaded_device_tensors, SizeIs(num_devices - 1));
+
+    for (size_t i = 0; i < original_device_tensors.size(); i++) {
+        EXPECT_THAT(
+            loaded_device_tensors[i].to_vector<float>(),
+            Pointwise(FloatEq(), original_device_tensors[i].to_vector<float>()));
+    }
+}
+
+TEST_F(TensorSerializationFlatbufferT3000Test, Shard2x3SubmeshRoundtrip) {
+    TemporaryFile test_file("shard2x3_flatbuffer.bin");
+    constexpr int kNumRows = 2;
+    constexpr int kNumCols = 3;
+    constexpr int kNumElements = 1024;
+    const int num_devices = kNumRows * kNumCols;
+
+    std::vector<float> test_data;
+    for (int i = 0; i < num_devices; i++) {
+        std::generate_n(std::back_inserter(test_data), kNumElements, [i]() { return i * 1.0f; });
+    }
+
+    Tensor input_tensor = Tensor::from_vector(
+        test_data, get_tensor_spec(ttnn::Shape{1, kNumRows, kNumCols, kNumElements}, DataType::FLOAT32));
 
     auto mapper = ttnn::distributed::create_mesh_mapper(
         *mesh_device_,
@@ -194,64 +285,26 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard2DTensorRoundtrip) {
     }
 }
 
-TEST_F(TensorSerializationFlatbufferT3000Test, Shard1DFewerShardsThanDevicesRoundtrip) {
-    TemporaryFile test_file("shard1d_fewer_flatbuffer.bin");
-    const int num_devices = mesh_device_->num_devices();
-    std::vector<float> test_data;
-    for (int i = 0; i < num_devices - 1; i++) {
-        test_data.insert(test_data.end(), {i * 1.0f, i * 2.0f, i * 3.0f});
-    }
-
-    Tensor input_tensor =
-        Tensor::from_vector(test_data, get_tensor_spec(ttnn::Shape{1, num_devices - 1, 3, 1}, DataType::FLOAT32));
-
-    auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*mesh_device_, 1);
-    Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);
-
-    ASSERT_TRUE(sharded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
-
-    dump_tensor_flatbuffer(test_file.string(), sharded_tensor);
-
-    Tensor loaded_tensor = load_tensor_flatbuffer(test_file.string());
-
-    ASSERT_EQ(loaded_tensor.tensor_spec().logical_shape(), sharded_tensor.tensor_spec().logical_shape());
-    ASSERT_EQ(loaded_tensor.dtype(), sharded_tensor.dtype());
-    ASSERT_EQ(loaded_tensor.layout(), sharded_tensor.layout());
-    ASSERT_TRUE(loaded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
-
-    std::vector<Tensor> original_device_tensors = ttnn::distributed::get_device_tensors(sharded_tensor);
-    std::vector<Tensor> loaded_device_tensors = ttnn::distributed::get_device_tensors(loaded_tensor);
-
-    ASSERT_THAT(loaded_device_tensors, SizeIs(original_device_tensors.size()));
-    ASSERT_THAT(loaded_device_tensors, SizeIs(num_devices - 1));
-
-    for (size_t i = 0; i < original_device_tensors.size(); i++) {
-        EXPECT_THAT(
-            loaded_device_tensors[i].to_vector<float>(),
-            Pointwise(FloatEq(), original_device_tensors[i].to_vector<float>()));
-    }
-}
-
-TEST_F(TensorSerializationFlatbufferT3000Test, Shard2x3SubmeshRoundtrip) {
-    TemporaryFile test_file("shard2x3_flatbuffer.bin");
+TEST_F(TensorSerializationFlatbufferT3000Test, PartiallyReplicatedRoundtrip) {
+    TemporaryFile test_file("partially_replicated_flatbuffer.bin");
     constexpr int kNumRows = 2;
-    constexpr int kNumCols = 3;
+    constexpr int kNumCols = 4;
+    constexpr int kNumElements = 1024;
     const int num_devices = kNumRows * kNumCols;
 
     std::vector<float> test_data;
     for (int i = 0; i < num_devices; i++) {
-        test_data.insert(test_data.end(), {i * 1.0f, i * 2.0f, i * 3.0f});
+        std::generate_n(std::back_inserter(test_data), kNumElements, [i]() { return i * 1.0f; });
     }
 
-    Tensor input_tensor =
-        Tensor::from_vector(test_data, get_tensor_spec(ttnn::Shape{1, kNumRows, kNumCols, 3}, DataType::FLOAT32));
+    Tensor input_tensor = Tensor::from_vector(
+        test_data, get_tensor_spec(ttnn::Shape{1, kNumRows, kNumCols, kNumElements}, DataType::FLOAT32));
 
     auto mapper = ttnn::distributed::create_mesh_mapper(
         *mesh_device_,
         ttnn::distributed::MeshMapperConfig{
             .placements =
-                {ttnn::distributed::MeshMapperConfig::Shard{1}, ttnn::distributed::MeshMapperConfig::Shard{2}},
-            .mesh_shape_override = ttnn::distributed::MeshShape(kNumRows, kNumCols),
+                {ttnn::distributed::MeshMapperConfig::Shard{1}, ttnn::distributed::MeshMapperConfig::Replicate{}},
         });
 
     Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.hpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.hpp
@@ -24,7 +24,8 @@ Tensor from_flatbuffer(
     tt::tt_metal::MemoryPin memory_pin);
 
 // Converts Tensor object to FlatBuffer representation, writing the serialized flatbuffer object to `builder` and
-// recording tensor buffers that need to be serialized in-order to `buffers` vector.
+// recording tensor buffers that need to be serialized in-order to `buffers` vector. Replicated buffers are
+// deduplicated, so that the number of copies that need to be written out from `buffers` is minimized.
 //
 // Only inline file storage (data stored in the same file) is currently supported.
 flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.hpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.hpp
@@ -16,7 +16,10 @@ namespace ttnn {
 
 // Converts FlatBuffer tensor to Tensor object, using inline file storage to offset into `tensor_data`.
 // Only inline file storage (data stored in same file) is currently supported.
-Tensor from_flatbuffer(const ttnn::flatbuffer::Tensor* fb_tensor, tt::stl::Span<std::byte> tensor_data);
+Tensor from_flatbuffer(
+    const ttnn::flatbuffer::Tensor* fb_tensor,
+    tt::stl::Span<std::byte> tensor_data,
+    tt::tt_metal::MemoryPin memory_pin);
 
 // Converts Tensor object to FlatBuffer representation.
 // Only inline file storage (data stored in the same file) is currently supported.

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.hpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.hpp
@@ -15,15 +15,19 @@
 namespace ttnn {
 
 // Converts FlatBuffer tensor to Tensor object, using inline file storage to offset into `tensor_data`.
+// The data is provided in `tensor_data` and `memory_pin` to load the tensor data lazily.
+//
 // Only inline file storage (data stored in same file) is currently supported.
 Tensor from_flatbuffer(
     const ttnn::flatbuffer::Tensor* fb_tensor,
     tt::stl::Span<std::byte> tensor_data,
     tt::tt_metal::MemoryPin memory_pin);
 
-// Converts Tensor object to FlatBuffer representation.
+// Converts Tensor object to FlatBuffer representation, writing the serialized flatbuffer object to `builder` and
+// recording tensor buffers that need to be serialized in-order to `buffers` vector.
+//
 // Only inline file storage (data stored in the same file) is currently supported.
 flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
-    const Tensor& tensor, flatbuffers::FlatBufferBuilder& builder);
+    const Tensor& tensor, flatbuffers::FlatBufferBuilder& builder, std::vector<tt::tt_metal::HostBuffer>& buffers);
 
 }  // namespace ttnn


### PR DESCRIPTION
### Ticket
#22259 

### Problem description
2 key improvements:
1. Don't serialize replicated host buffers. This is redundant.
2. Use mmap to lazily load tensor shards.

### What's changed
See above.

> Don't serialize replicated host buffers

Wrote new test to confirm this `PartiallyReplicatedRoundtrip`. See `test_tensor_partially_replicated_flatbuffer` which as expected blows up in size:
```sh
% ls -al ~/unoptimized_tensor_data
total 284
drwxrwxr-x  2 omilyutin omilyutin   4096 Jun 18 21:06 .
drwx------ 23 omilyutin omilyutin   4096 Jun 18 21:06 ..
-rw-rw-r--  1 omilyutin omilyutin    176 Jun 18 21:06 test_tensor_bfloat16.bin
-rw-rw-r--  1 omilyutin omilyutin    200 Jun 18 21:06 test_tensor_flatbuffer.bin
-rw-rw-r--  1 omilyutin omilyutin 131752 Jun 18 21:06 test_tensor_partially_replicated_flatbuffer.bin
-rw-rw-r--  1 omilyutin omilyutin  29288 Jun 18 21:06 test_tensor_shard1d_fewer_flatbuffer.bin
-rw-rw-r--  1 omilyutin omilyutin  33448 Jun 18 21:06 test_tensor_shard1d_flatbuffer.bin
-rw-rw-r--  1 omilyutin omilyutin  33448 Jun 18 21:06 test_tensor_shard2d_flatbuffer.bin
-rw-rw-r--  1 omilyutin omilyutin  25136 Jun 18 21:06 test_tensor_shard2x3_flatbuffer.bin
-rw-rw-r--  1 omilyutin omilyutin    192 Jun 18 21:06 test_tensor_uint32.bin

% ls -al ~/optimized_tensor_data
total 188
drwxrwxr-x  2 omilyutin omilyutin  4096 Jun 18 21:04 .
drwx------ 23 omilyutin omilyutin  4096 Jun 18 21:06 ..
-rw-rw-r--  1 omilyutin omilyutin   176 Jun 18 21:04 test_tensor_bfloat16.bin
-rw-rw-r--  1 omilyutin omilyutin   200 Jun 18 21:04 test_tensor_flatbuffer.bin
-rw-rw-r--  1 omilyutin omilyutin 33448 Jun 18 21:04 test_tensor_partially_replicated_flatbuffer.bin
-rw-rw-r--  1 omilyutin omilyutin 29288 Jun 18 21:04 test_tensor_shard1d_fewer_flatbuffer.bin
-rw-rw-r--  1 omilyutin omilyutin 33448 Jun 18 21:04 test_tensor_shard1d_flatbuffer.bin
-rw-rw-r--  1 omilyutin omilyutin 33448 Jun 18 21:04 test_tensor_shard2d_flatbuffer.bin
-rw-rw-r--  1 omilyutin omilyutin 25136 Jun 18 21:04 test_tensor_shard2x3_flatbuffer.bin
-rw-rw-r--  1 omilyutin omilyutin   192 Jun 18 21:04 test_tensor_uint32.bin
```

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15743804402)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15743811709)
- [x] New/Existing tests provide coverage for changes