### PR TITLE
Fix reshard stride calculation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -173,6 +173,7 @@ tests/ttnn/unit_tests/operations/eltwise/ @patrickroberts @sjameelTT @ntarafdar 
 tests/ttnn/unit_tests/operations/conv/ @tenstorrent/metalium-developers-convolutions
 tests/ttnn/unit_tests/operations/pool/ @tenstorrent/metalium-developers-convolutions
 tests/ttnn/unit_tests/operations/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT @nsorabaTT @vsureshTT @edwinleeTT
+tests/ttnn/unit_tests/operations/data_movement/ @sjameelTT @ntarafdar @nardoTT @llongTT @amorrisonTT @yugi957 @jvegaTT
 /tests/ttnn/**/unit_tests/operations/fused/ @yugaoTT @bbradelTT @nsorabaTT @vsureshTT @edwinleeTT
 /tests/ttnn/**/unit_tests/operations/reduce/ @bbradelTT @sjameelTT @nsorabaTT @vsureshTT @edwinleeTT @aczajkowskiTT
 tests/ttnn/nightly/unit_tests/operations/conv/ @tenstorrent/metalium-developers-convolutions

--- a/tests/ttnn/unit_tests/operations/data_movement/test_core.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_core.py
@@ -621,7 +621,6 @@ def test_mnist_max_pool_s2i(
     [
         ([1, 1, 224, 384], ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=1, x=3), ttnn.CoreGrid(y=1, x=4)),
         ([1, 1, 64, 384], ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=1, x=3), ttnn.CoreGrid(y=1, x=4)),
-        ([1, 8, 224, 768], ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=8, x=6), ttnn.CoreGrid(y=8, x=8)),
     ],
 )
 def test_reshard_conv(device, shape, orientation, core_grid_1, core_grid_2):

--- a/tests/ttnn/unit_tests/operations/data_movement/test_core.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_core.py
@@ -8,6 +8,7 @@ import torch
 
 import ttnn
 
+from models.utility_functions import get_debug_tensor
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from enum import Enum
 
@@ -613,3 +614,61 @@ def test_mnist_max_pool_s2i(
 
     pcc_thresh = 1.0
     assert_with_pcc(output_pytorch, golden_pytorch, pcc_thresh)
+
+
+@pytest.mark.parametrize(
+    "shape, orientation, core_grid_1, core_grid_2",
+    [
+        # ([1, 1, 224, 384], ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=1, x=3), ttnn.CoreGrid(y=1, x=4)),
+        ([1, 1, 64, 384], ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=1, x=3), ttnn.CoreGrid(y=1, x=4)),
+        # ([1, 8, 224, 768], ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=8, x=6), ttnn.CoreGrid(y=8, x=8)),
+    ],
+)
+def test_reshard_conv(device, shape, orientation, core_grid_1, core_grid_2):
+    torch.manual_seed(0)
+
+    debug = True
+    if not debug:
+        torch_input_tensor = torch.randn(shape, dtype=torch.bfloat16)
+    else:
+        num_tiles_width = shape[3] // 32
+        num_tiles_height = shape[2] // 32
+        torch_input_tensor = get_debug_tensor(num_tiles_width, num_tiles_height, dtype=torch.bfloat16)
+        torch.set_printoptions(profile="full")
+        print("Input Tensor:", torch_input_tensor)
+        torch.set_printoptions(profile="default")
+    ttnn_tensor_1 = ttnn.from_torch(
+        torch_input_tensor,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.create_sharded_memory_config(
+            shape=torch_input_tensor.shape,
+            core_grid=core_grid_1,
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+    out_tensor_1 = ttnn.to_torch(ttnn_tensor_1)
+
+    memory_config_2 = ttnn.create_sharded_memory_config(
+        shape=torch_input_tensor.shape,
+        core_grid=core_grid_2,
+        strategy=ttnn.ShardStrategy.BLOCK,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    # Interleaved to sharded path
+    ttnn_tensor_1_dram = ttnn.to_memory_config(ttnn_tensor_1, ttnn.DRAM_MEMORY_CONFIG)
+    ttnn_tensor_2_interleaved_to_sharded = ttnn.to_memory_config(ttnn_tensor_1_dram, memory_config_2)
+    out_tensor_2_interleaved_to_sharded = ttnn.to_torch(ttnn_tensor_2_interleaved_to_sharded)
+
+    passing, pcc_msg = assert_with_pcc(out_tensor_1, out_tensor_2_interleaved_to_sharded, pcc=1.0)
+
+    ttnn_tensor_2_resharded = ttnn.reshard(ttnn_tensor_1, memory_config_2)
+    out_tensor_2_resharded = ttnn.to_torch(ttnn_tensor_2_resharded)
+    if debug:
+        torch.set_printoptions(profile="full")
+        print("Output Tensor 2 Resharded:", out_tensor_2_resharded)
+        torch.set_printoptions(profile="default")
+
+    passing, pcc_msg = assert_with_pcc(out_tensor_1, out_tensor_2_resharded, pcc=1.0)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_core.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_core.py
@@ -619,15 +619,15 @@ def test_mnist_max_pool_s2i(
 @pytest.mark.parametrize(
     "shape, orientation, core_grid_1, core_grid_2",
     [
-        # ([1, 1, 224, 384], ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=1, x=3), ttnn.CoreGrid(y=1, x=4)),
+        ([1, 1, 224, 384], ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=1, x=3), ttnn.CoreGrid(y=1, x=4)),
         ([1, 1, 64, 384], ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=1, x=3), ttnn.CoreGrid(y=1, x=4)),
-        # ([1, 8, 224, 768], ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=8, x=6), ttnn.CoreGrid(y=8, x=8)),
+        ([1, 8, 224, 768], ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=8, x=6), ttnn.CoreGrid(y=8, x=8)),
     ],
 )
 def test_reshard_conv(device, shape, orientation, core_grid_1, core_grid_2):
     torch.manual_seed(0)
 
-    debug = True
+    debug = False
     if not debug:
         torch_input_tensor = torch.randn(shape, dtype=torch.bfloat16)
     else:

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
@@ -109,13 +109,10 @@ std::unordered_map<CoreCoord, std::vector<PageStride>> get_core_page_ranges(
                             break;
                         }
                         // next page is padding
-                        consecutive_it = consecutive_it + 1;
                         last_it_consec = consecutive_it;
+                        consecutive_it = consecutive_it + 1;
                     }
-                    uint32_t stride_size = std::distance(it, last_it_consec);
-                    if (last_it_consec == it) {
-                        stride_size = 1;
-                    }
+                    uint32_t stride_size = std::distance(it, last_it_consec) + 1;
                     auto stride_it = it + stride_size;
                     auto last_it_stride = it;
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22640)

### Problem description
In conv models discovered that reshard is giving incorrect PCC. This is due to incorrect stride calculation. We use the set of first consecutive pages to calculate the stride size, but we were not calculating it correctly. 


### What's changed
Modified the distance calculation for the stride size, (distance + 1). The plus 1 is because even a distance of 0, means it's a single page. Look at code for more clarity. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15881235546) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/15883983613) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15883923656) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/15883959699) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes