### PR TITLE
#23652: Added tests for Buffer::aligned_size_per_bank for ND sharding

### DIFF
--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -577,7 +577,9 @@ DeviceAddr Buffer::aligned_page_size() const { return align(page_size(), this->a
 DeviceAddr Buffer::aligned_size() const { return this->num_dev_pages() * this->aligned_page_size(); }
 
 DeviceAddr Buffer::aligned_size_per_bank() const {
-    // TODO: Revist for ND sharding (it looks okay since num_cores() handles ND sharding)
+    if (buffer_distribution_spec_.has_value()) {
+        return buffer_distribution_spec_->num_dev_pages_per_core() * aligned_page_size();
+    }
     uint32_t num_banks =
         is_sharded(this->buffer_layout_) ? this->num_cores().value() : allocator_->get_num_banks(this->buffer_type());
     return tt::tt_metal::detail::SizeBytesPerBank(

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -508,7 +508,6 @@ uint32_t Buffer::num_dev_pages() const {
     if (buffer_distribution_spec_.has_value()) {
         return buffer_distribution_spec_.value().num_dev_pages_per_core() * num_cores().value();
     }
-    // TODO: This logic seems wrong since num_cores() doesn't store the actual number of cores used for shards
     return this->shard_spec().num_pages() * this->num_cores().value();
 }
 
@@ -577,9 +576,6 @@ DeviceAddr Buffer::aligned_page_size() const { return align(page_size(), this->a
 DeviceAddr Buffer::aligned_size() const { return this->num_dev_pages() * this->aligned_page_size(); }
 
 DeviceAddr Buffer::aligned_size_per_bank() const {
-    if (buffer_distribution_spec_.has_value()) {
-        return buffer_distribution_spec_->num_dev_pages_per_core() * aligned_page_size();
-    }
     uint32_t num_banks =
         is_sharded(this->buffer_layout_) ? this->num_cores().value() : allocator_->get_num_banks(this->buffer_type());
     return tt::tt_metal::detail::SizeBytesPerBank(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23652

### Problem description
Adding tests for Buffer::aligned_size_per_bank for ND sharding, relating to the issue mentioned above

### What's changed
Added new tests

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/15748675722)
- [x] New/Existing tests provide coverage for changes