### PR TITLE
[skip ci] Shift-right matmul tests which are too slow for Smoke

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -23,7 +23,6 @@ TT_ENABLE_UNITY_BUILD(unit_tests_ttnn_smoke)
 target_sources(
     unit_tests_ttnn_smoke
     PRIVATE
-        test_matmul_benchmark.cpp
         test_multiprod_queue.cpp
         test_multi_cq_multi_dev.cpp
         test_reflect.cpp
@@ -57,6 +56,7 @@ target_sources(
         test_graph_query_op_constraints.cpp
         test_graph_query_op_runtime.cpp
         test_launch_operation.cpp # TODO: Fix data race (TSan) then shift-left
+        test_matmul_benchmark.cpp
 )
 target_include_directories(unit_tests_ttnn_basic PRIVATE ${PROJECT_SOURCE_DIR}/tests)
 target_link_libraries(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
(sometimes?) TTNN smokes are failing because Matmul tests are over the threshold for Smokes.

### What's changed
Kick them out to Basic.