### PR TITLE
SDXL: enable pc on VAE

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -362,9 +362,6 @@ def run_demo_inference(
         if vae_on_device:
             latents = ttnn.div(latents, scaling_factor)
 
-            # Workaround for #22017
-            ttnn_device.disable_and_clear_program_cache()
-
             logger.info("Running TT VAE")
             image = tt_vae.forward(latents, [B, C, H, W])
             ttnn_device.enable_program_cache()

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -6,7 +6,7 @@ import torch
 import inspect
 from typing import List, Optional, Union
 
-SDXL_L1_SMALL_SIZE = 65536
+SDXL_L1_SMALL_SIZE = 57344
 
 
 # Copied from sdxl pipeline

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
@@ -6,6 +6,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_attention import TtAttention
+from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
@@ -17,7 +18,7 @@ from models.utility_functions import torch_random
         ((1, 512, 128, 128), None),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_vae_attention(device, input_shape, encoder_shape, use_program_cache, reset_seeds):
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="vae"

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
@@ -7,6 +7,7 @@ import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
 from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
@@ -22,8 +23,8 @@ from loguru import logger
         ((1, 4, 128, 128), False, 0.89),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 4 * 16384}], indirect=True)
-def test_vae(device, input_shape, host_fallback, pcc, reset_seeds):
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+def test_vae(device, input_shape, host_fallback, pcc, use_program_cache, reset_seeds):
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="vae"
     )

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_decoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_decoder.py
@@ -7,6 +7,7 @@ import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_decoder import TtDecoder
 from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
@@ -22,8 +23,8 @@ from loguru import logger
         ((1, 4, 128, 128), False, 0.84),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 4 * 16384}], indirect=True)
-def test_vae_decoder(device, input_shape, host_fallback, pcc, reset_seeds):
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+def test_vae_decoder(device, input_shape, host_fallback, pcc, use_program_cache, reset_seeds):
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="vae"
     )

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_midblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_midblock2d.py
@@ -7,6 +7,7 @@ import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_midblock2d import TtUNetMidBlock2D
 from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
@@ -18,7 +19,7 @@ from models.utility_functions import torch_random
         (1, 512, 128, 128),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_vae_midblock(device, input_shape, use_program_cache, reset_seeds):
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="vae"

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_resnetblock2d.py
@@ -7,6 +7,7 @@ import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_resnetblock2d import TtResnetBlock2D
 from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
@@ -22,7 +23,7 @@ from models.utility_functions import torch_random
         ((1, 256, 256, 256), 2, 1, False, "up_blocks", 0.999),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 2 * 16384}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_vae_resnetblock2d(
     device, input_shape, block_id, resnet_id, conv_shortcut, block, pcc, use_program_cache, reset_seeds
 ):

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upblock2d.py
@@ -7,6 +7,7 @@ import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_upblock2d import TtUpDecoderBlock2D
 from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
@@ -21,8 +22,8 @@ from models.utility_functions import torch_random
         ((1, 256, 1024, 1024), 3, 0.999),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 4 * 16384}], indirect=True)
-def test_vae_upblock(device, input_shape, block_id, pcc, reset_seeds):
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+def test_vae_upblock(device, input_shape, block_id, pcc, use_program_cache, reset_seeds):
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="vae"
     )

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upsample2d.py
@@ -7,6 +7,7 @@ import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_upsample2d import TtUpsample2D
 from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
@@ -22,7 +23,7 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 @pytest.mark.parametrize("stride", [(1, 1)])
 @pytest.mark.parametrize("padding", [(1, 1)])
 @pytest.mark.parametrize("dilation", [(1, 1)])
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 4 * 16384}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_vae_upsample2d(device, input_shape, up_block_id, stride, padding, dilation, use_program_cache, reset_seeds):
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="vae"


### PR DESCRIPTION
### What's changed
Since #22017 is resolved program cache on VAE is enabled. Overall SDXL L1 small size is reduced.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15757114770) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15757119402) CI passes