### PR TITLE
#22942: Untilize init cleanup

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/untilize.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/untilize.rst
@@ -2,7 +2,6 @@ untilize
 ========
 
 
-.. doxygenfunction:: untilize_init(uint32_t icb, uint32_t ocb)
-.. doxygenfunction:: untilize_init_short(uint32_t icb)
-.. doxygenfunction:: untilize_block(uint32_t icb, uint32_t block, uint32_t ocb)
-.. doxygenfunction:: untilize_uninit(uint32_t icb)
+.. doxygenfunction:: untilize_init
+.. doxygenfunction:: untilize_block
+.. doxygenfunction:: untilize_uninit

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -322,13 +322,12 @@ void run_single_core_tilize_program(tt_metal::IDevice* device, const TestConfig&
     }
     log_info(
         tt::LogTest,
-        "Done running test with: num_tiles_r = {}, num_tiles_c = {}, FP32_DestAcc = {}, DstSyncFull = {}, ShortInit = "
-        "{}, FastTilize = {}, pass = {}",
+        "Done running test with: num_tiles_r = {}, num_tiles_c = {}, FP32_DestAcc = {}, DstSyncFull = {}, "
+        "FastTilize = {}, pass = {}",
         test_config.num_tiles_r,
         test_config.num_tiles_c,
         test_config.fp32_dest_acc_en,
         test_config.dst_full_sync_en,
-        test_config.short_init,
         test_config.fast_tilize,
         pass);
     ASSERT_TRUE(pass);

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -73,8 +73,6 @@ using GoldenFunc = std::variant<
         const ::unit_tests::compute::GoldenConfig& config)>>;
 
 struct TestConfig {
-    // Whether or not to use *_init_short LLK API calls:
-    bool short_init = false;
     // Whether or not to sync full/half DST between MATH and PACK:
     bool dst_full_sync_en = false;
     // Whether or not we want the result to be stored in DST in FP32 is
@@ -204,9 +202,6 @@ void run_single_core_tilize_program(tt_metal::IDevice* device, const TestConfig&
 
     std::map<std::string, std::string> defines = {};
 
-    if (test_config.short_init) {
-        defines["SHORT_INIT"] = "1";
-    }
     if (test_config.fp32_dest_acc_en) {
         defines["DST_ACCUM_MODE"] = "1";
     }
@@ -412,57 +407,6 @@ TEST_F(DeviceFixture, TensixComputeUnpackTilizeA_B) {
     }
 }
 
-TEST_F(DeviceFixture, TensixComputeUnpackTilizeShortInit) {
-    vector<vector<uint32_t>> num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}};
-    for (auto num_tile : num_tiles) {
-        for (bool fp32_dest_acc_en : {true, false}) {
-            // FP32 dest acc not possible for GS
-            if ((fp32_dest_acc_en) && (this->arch_ == tt::ARCH::GRAYSKULL)) {
-                continue;
-            }
-            for (bool dst_full_sync_en : {true, false}) {
-                unit_tests::compute::tilize::TestConfig test_config = {
-                    .short_init = true,
-                    .dst_full_sync_en = dst_full_sync_en,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .input_single_tile_size = 2 * 1024,
-                    .output_single_tile_size = 1024 * (fp32_dest_acc_en ? 4 : 2),
-                    .num_tiles_r = num_tile[0],
-                    .num_tiles_c = num_tile[1],
-                    .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A,
-                    .golden_function = ::unit_tests::compute::gold_standard_tilize};
-                unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
-            }
-        }
-    }
-}
-
-TEST_F(DeviceFixture, TensixComputeFastTilizeShortInit) {
-    vector<vector<uint32_t>> num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}};
-    for (auto num_tile : num_tiles) {
-        for (bool fp32_dest_acc_en : {false}) {
-            // FP32 dest acc not possible for GS
-            if ((fp32_dest_acc_en) && (this->arch_ == tt::ARCH::GRAYSKULL)) {
-                continue;
-            }
-            for (bool dst_full_sync_en : {false}) {
-                unit_tests::compute::tilize::TestConfig test_config = {
-                    .short_init = true,
-                    .dst_full_sync_en = dst_full_sync_en,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .fast_tilize = true,
-                    .input_single_tile_size = 2 * 1024,
-                    .output_single_tile_size = 1024 * (fp32_dest_acc_en ? 4 : 2),
-                    .num_tiles_r = num_tile[0],
-                    .num_tiles_c = num_tile[1],
-                    .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A,
-                    .golden_function = ::unit_tests::compute::gold_standard_tilize};
-                unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
-            }
-        }
-    }
-}
-
 /**************************************
 Following tests are for Unpack Untilize
 ***************************************/
@@ -477,31 +421,6 @@ TEST_F(DeviceFixture, TensixComputeUnpackUntilize) {
             }
             for (bool dst_full_sync_en : {true, false}) {
                 unit_tests::compute::tilize::TestConfig test_config = {
-                    .dst_full_sync_en = dst_full_sync_en,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .input_single_tile_size = 2 * 1024,
-                    .output_single_tile_size = 1024 * (fp32_dest_acc_en ? 4 : 2),
-                    .num_tiles_r = num_tile[0],
-                    .num_tiles_c = num_tile[1],
-                    .untilize_type = unit_tests::compute::tilize::UntilizeType::UNPACK,
-                    .golden_function = ::unit_tests::compute::gold_standard_untilize};
-                unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
-            }
-        }
-    }
-}
-
-TEST_F(DeviceFixture, TensixComputeUnpackUntilizeShortInit) {
-    vector<vector<uint32_t>> num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}};
-    for (auto num_tile : num_tiles) {
-        for (bool fp32_dest_acc_en : {true, false}) {
-            // FP32 dest acc not possible for GS
-            if ((fp32_dest_acc_en) && (this->arch_ == tt::ARCH::GRAYSKULL)) {
-                continue;
-            }
-            for (bool dst_full_sync_en : {true, false}) {
-                unit_tests::compute::tilize::TestConfig test_config = {
-                    .short_init = true,
                     .dst_full_sync_en = dst_full_sync_en,
                     .fp32_dest_acc_en = fp32_dest_acc_en,
                     .input_single_tile_size = 2 * 1024,
@@ -571,7 +490,6 @@ TEST_F(DeviceFixture, TensixComputePackUntilizeDstTinyTile) {
             uint32_t num_faces_per_tile = test_config_value[2];
             uint32_t face_r_dim = test_config_value[3];
             unit_tests::compute::tilize::TestConfig test_config = {
-                .short_init = true,
                 .dst_full_sync_en = dst_full_sync_en,
                 .input_single_tile_size = 2 * 1024,
                 .output_single_tile_size = 2 * num_faces_per_tile * face_r_dim * face_c_dim,

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_tilize_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_tilize_untilize.cpp
@@ -74,7 +74,7 @@ inline void reblock_and_untilize(
         cb_push_back(reblock_cb_id, out_block_w);
 
         // Untilize
-        untilize_init_short(reblock_cb_id);
+        untilize_init(reblock_cb_id);
         cb_wait_front(reblock_cb_id, out_block_w);
         cb_reserve_back(out_cb_id, out_block_w);
         untilize_block(reblock_cb_id, out_block_w, out_cb_id);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block.cpp
@@ -60,7 +60,7 @@ inline void reblock_and_untilize(
         cb_push_back(reblock_cb_id, out_block_w);
 
         // Untilize
-        untilize_init_short(reblock_cb_id);
+        untilize_init(reblock_cb_id);
         cb_wait_front(reblock_cb_id, out_block_w);
         cb_reserve_back(out_cb_id, out_block_w);
         untilize_block(reblock_cb_id, out_block_w, out_cb_id);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_generalized.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_generalized.cpp
@@ -57,7 +57,7 @@ inline void reblock_and_untilize(
         cb_push_back(reblock_cb_id, out_block_w);
 
         // Untilize
-        untilize_init_short(reblock_cb_id);
+        untilize_init(reblock_cb_id);
         cb_wait_front(reblock_cb_id, out_block_w);
         cb_reserve_back(out_cb_id, out_block_w);
         untilize_block(reblock_cb_id, out_block_w, out_cb_id);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rotary_embedding.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rotary_embedding.cpp
@@ -41,7 +41,7 @@ ALWI void MUL_TILES(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t 
 }
 
 ALWI void UNTILIZE_TILES(uint32_t in0_cb, uint32_t out_cb, uint32_t num_tiles) {
-    untilize_init_short(in0_cb);
+    untilize_init(in0_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_reserve_back(out_cb, num_tiles);
     untilize_block(in0_cb, num_tiles, out_cb);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/transformer_attn_matmul.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/transformer_attn_matmul.cpp
@@ -55,7 +55,7 @@ void MAIN {
 
                     // untilize tile and write to CBIndex::c_25
                     cb_wait_front(cb_intermed0, onetile);
-                    untilize_init_short(cb_intermed0);
+                    untilize_init(cb_intermed0);
                     cb_reserve_back(cb_intermed1, 1);
                     untilize_block(cb_intermed0, 1, cb_intermed1);
                     cb_push_back(cb_intermed1, 1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unpack_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unpack_untilize.cpp
@@ -11,12 +11,9 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
-#ifndef SHORT_INIT
-    untilize_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
-#else
-    unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
-    untilize_init_short(tt::CBIndex::c_0);
-#endif
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    untilize_init(tt::CBIndex::c_0);
 
     for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
         cb_wait_front(tt::CBIndex::c_0, per_core_block_tile_cnt);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/update_cache.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/update_cache.cpp
@@ -21,10 +21,10 @@ void MAIN {
     constexpr uint32_t B = get_compile_time_arg_val(6);
     constexpr uint32_t Wt = get_compile_time_arg_val(7);
 
-    untilize_init(in_cb, untilized_in_cb);
+    compute_kernel_hw_startup(in_cb, untilized_in_cb);
 
     for (uint32_t b = 0; b < B / 32; b++) {
-        untilize_init_short(in_cb);
+        untilize_init(in_cb);
 
         cb_wait_front(in_cb, Wt);
         cb_reserve_back(untilized_in_cb, Wt);
@@ -34,7 +34,7 @@ void MAIN {
         untilize_uninit(in_cb);
 
         for (uint32_t u = 0; u < 32; u++) {
-            untilize_init_short(cache_cb);
+            untilize_init(cache_cb);
             cb_wait_front(cache_cb, Wt);
             cb_reserve_back(untilized_cache_cb, Wt);
             untilize_block(cache_cb, Wt, untilized_cache_cb);

--- a/tests/tt_metal/tt_metal/test_kernels/misc/print_tile_trisc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/print_tile_trisc.cpp
@@ -26,7 +26,8 @@ inline void cb_wait_front_pack(int operand, std::int32_t num_tiles) {
 #include "compute_kernel_api/common.h"
 #include "compute_kernel_api/untilize.h"
 ALWI void UNTILIZE_TILES(uint32_t in0_cb, uint32_t out_cb, uint32_t num_tiles) {
-    untilize_init(in0_cb, out_cb);
+    compute_kernel_hw_startup(in0_cb, out_cb);
+    untilize_init(in0_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_reserve_back(out_cb, num_tiles);
     untilize_block(in0_cb, num_tiles, out_cb);

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -45,7 +45,7 @@ namespace ckernel {
  * | Param Type | Name         | Description                              | Type      | Valid Range     | Required |
  * |------------|--------------|------------------------------------------|-----------|-----------------|----------|
  * | Template   | block_ct_dim | Width of a single block in tiles         | uint32_t  | 1 to max (see note) | False (default = 8) |
- * | Template   | full_ct_dim  | Width of a full input in tiles           | uint32_t  | >= block_ct_dim | False    |
+ * | Template   | full_ct_dim  | Width of a full input in tiles           | uint32_t  | Divisible by block_ct_dim | False    |
  * | Template   | narrow_row   |  Whether the provided input is narrow    | bool      | true/false      | False    |
  * | Template   | row_num_datums | Number of datums per row               | uint32_t  | >= 1            | False    |
  * | Function   | ocb          | Output circular buffer identifier        | uint32_t  | 0 to 31         | True     |
@@ -98,7 +98,7 @@ ALWI void pack_untilize_dest_init(uint32_t ocb, uint32_t face_r_dim = 16, uint32
  * | Param Type | Name         | Description                                | Type      | Valid Range     | Required |
  * |------------|--------------|--------------------------------------------|-----------|-----------------|----------|
  * | Template   | block_ct_dim | Width of a single block in tiles           | uint32_t  | 1 to max (see note) | False (default = 8) |
- * | Template   | full_ct_dim  | Width of a full input in tiles             | uint32_t  | >= block_ct_dim | False    |
+ * | Template   | full_ct_dim  | Width of a full input in tiles             | uint32_t  | Divisible by block_ct_dim | False    |
  * | Function   | icb          | Input circular buffer identifier           | uint32_t  | 0 to 31         | True     |
  * | Function   | ocb          | Output circular buffer identifier          | uint32_t  | 0 to 31         | True     |
  */
@@ -130,7 +130,7 @@ ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb) {
  * | Param Type | Name         | Description                                 | Type      | Valid Range     | Required |
  * |------------|--------------|---------------------------------------------|-----------|-----------------|----------|
  * | Template   | block_ct_dim | Width of a single block in tiles            | uint32_t  | 1 to max (see note) | False (default = 8) |
- * | Template   | full_ct_dim  | Width of a full input in tiles              | uint32_t  | >= block_ct_dim | False    |
+ * | Template   | full_ct_dim  | Width of a full input in tiles              | uint32_t  | Divisible by block_ct_dim | False    |
  * | Function   | icb          | Input circular buffer identifier            | uint32_t  | 0 to 31         | True     |
  * | Function   | block_rt_dim | Height of a single block in tiles           | uint32_t  | >= 1            | True     |
  * | Function   | ocb          | Output circular buffer identifier           | uint32_t  | 0 to 31         | True     |
@@ -174,7 +174,7 @@ ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb,
  * | Param Type | Name           | Description                                                   | Type      | Valid Range     | Required |
  * |------------|----------------|---------------------------------------------------------------|-----------|-----------------|----------|
  * | Template   | block_ct_dim   | Width of a single block in tiles                              | uint32_t  | 1 to max (see note) | False (default = 8) |
- * | Template   | full_ct_dim    | Width of a full input in tiles                                | uint32_t  | >= block_ct_dim | False    |
+ * | Template   | full_ct_dim    | Width of a full input in tiles                                | uint32_t  | Divisible by block_ct_dim | False    |
  * | Template   | diagonal       | Whether to use diagonal packing                               | bool      | true/false      | False    |
  * | Template   | narrow_row     | Whether the provided input is narrow                          | bool      | true/false      | False    |
  * | Template   | row_num_datums | Number of datums per row                                      | uint32_t  | >= 1            | False    |

--- a/tt_metal/include/compute_kernel_api/untilize.h
+++ b/tt_metal/include/compute_kernel_api/untilize.h
@@ -53,11 +53,11 @@ ALWI void untilize_init(uint32_t icb) {
  * |------------|--------------|------------------------------------------------------|----------|---------------------------|----------|
  * | Template   | block_ct_dim | The number of tiles stored in DEST at one moment     | uint32_t | 1 to max (see comment)    | False    |
  * | Function   | icb          | The identifier of the circular buffer (CB) for input | uint32_t | 0 to 31                   | True     |
- * | Function   | full_ct_dim  | The width of the block in tiles                      | uint32_t | Divisible by block_ct_dim | True     |
+ * | Function   | full_ct_dim  | Width of a full input in tiles                       | uint32_t | Divisible by block_ct_dim | True     |
  * | Function   | ocb          | The identifier of the circular buffer (CB) for output| uint32_t | 0 to 31                   | True     |
  */
 // clang-format on
-template <int block_ct_dim = 1>
+template <uint32_t block_ct_dim = 1>
 ALWI void untilize_block(uint32_t icb, uint32_t full_ct_dim, uint32_t ocb) {
     UNPACK((llk_unpack_untilize(icb, full_ct_dim)));
 
@@ -65,7 +65,7 @@ ALWI void untilize_block(uint32_t icb, uint32_t full_ct_dim, uint32_t ocb) {
         MATH((llk_math_wait_for_dest_available()));
 
         // Datacopy
-        for (int reg_id = 0; reg_id < block_ct_dim; reg_id++) {
+        for (uint32_t reg_id = 0; reg_id < block_ct_dim; reg_id++) {
             MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(reg_id)));
         }
 
@@ -74,7 +74,7 @@ ALWI void untilize_block(uint32_t icb, uint32_t full_ct_dim, uint32_t ocb) {
         PACK((llk_packer_wait_for_math_done()));
 
         // Datacopy
-        for (int reg_id = 0; reg_id < block_ct_dim; reg_id++) {
+        for (uint32_t reg_id = 0; reg_id < block_ct_dim; reg_id++) {
             PACK((llk_pack<DST_ACCUM_MODE, false, false>(reg_id, ocb)));
         }
 

--- a/tt_metal/include/compute_kernel_api/untilize.h
+++ b/tt_metal/include/compute_kernel_api/untilize.h
@@ -14,44 +14,58 @@
 
 namespace ckernel {
 
+// clang-format off
 /**
- * Init function for untilize operations, to be used at the beginning of the kernel.
+ * Initializes the hardware and internal state for the untilize operation. This function should be called before
+ * performing any untilize operations in the compute kernel. The circular buffer (CB) ID provided must correspond
+ * to the buffer containing the input data to be untilized. If the data format or properties of the input operand
+ * differ from those previously configured, ensure that the appropriate reconfiguration functions are called before
+ * this initialization.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name | Description                                               | Type     | Valid Range | Required |
+ * |------------|------|-----------------------------------------------------------|----------|-------------|----------|
+ * | Function   | icb  | The identifier of the circular buffer (CB) for input data | uint32_t | 0 to 31     | True     |
  */
-ALWI void untilize_init(uint32_t icb, uint32_t ocb) {
-    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
-        false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
-    MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb)));
-
-    PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
-    PACK((llk_pack_init(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
-
-    UNPACK((llk_unpack_untilize_hw_configure_disaggregated<DST_ACCUM_MODE>(icb)));
-    UNPACK((llk_unpack_untilize_init(icb)));  // init must be after configure
-}
-
-/**
- * Short init function to initialize untilize op, after a full init is already performed.
- */
-ALWI void untilize_init_short(uint32_t icb) {
+// clang-format on
+ALWI void untilize_init(uint32_t icb) {
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
     UNPACK((llk_unpack_untilize_init(icb)));
 }
 
+// clang-format off
 /**
- * Perform the untilize operation on a block of tiles. This simply loops over the provided block size.
+ * Copies a block of tiles from the DEST register buffer to the specified circular buffer (CB) for the untilize
+ * operation. This function is used to transfer multiple tiles at once, with the number of tiles determined by the
+ * template parameter `block_ct_dim`. The DEST register buffer must be in the acquired state before calling this function. The CB
+ * ID provided must correspond to the buffer where the untilized data will be stored. Note that the maximum size
+ * of the block is limited by the size of the DEST and synchronization mode used. These are maximum sizes:
+ * - half-sync mode (16-bit mode): 8 tiles
+ * - half-sync mode (32-bit mode): 4 tiles
+ * - full-sync mode (16-bit mode): 16 tiles
+ * - full-sync mode (32-bit mode): 8 tiles
+ *
+ * Return value: None
+ *
+ * | Param Type | Name         | Description                                          | Type     | Valid Range               | Required |
+ * |------------|--------------|------------------------------------------------------|----------|---------------------------|----------|
+ * | Template   | block_ct_dim | The number of tiles stored in DEST at one moment     | uint32_t | 1 to max (see comment)    | False    |
+ * | Function   | icb          | The identifier of the circular buffer (CB) for input | uint32_t | 0 to 31                   | True     |
+ * | Function   | full_ct_dim  | The width of the block in tiles                      | uint32_t | Divisible by block_ct_dim | True     |
+ * | Function   | ocb          | The identifier of the circular buffer (CB) for output| uint32_t | 0 to 31                   | True     |
  */
-template <int N = 1>
-ALWI void untilize_block(uint32_t icb, uint32_t block, uint32_t ocb) {
-    UNPACK((llk_unpack_untilize(icb, block)));
+// clang-format on
+template <int block_ct_dim = 1>
+ALWI void untilize_block(uint32_t icb, uint32_t full_ct_dim, uint32_t ocb) {
+    UNPACK((llk_unpack_untilize(icb, full_ct_dim)));
 
-    for (uint32_t t = 0; t < block / N; t++) {
+    for (uint32_t t = 0; t < full_ct_dim / block_ct_dim; t++) {
         MATH((llk_math_wait_for_dest_available()));
 
         // Datacopy
-        for (int reg_id = 0; reg_id < N; reg_id++) {
+        for (int reg_id = 0; reg_id < block_ct_dim; reg_id++) {
             MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(reg_id)));
         }
 
@@ -60,7 +74,7 @@ ALWI void untilize_block(uint32_t icb, uint32_t block, uint32_t ocb) {
         PACK((llk_packer_wait_for_math_done()));
 
         // Datacopy
-        for (int reg_id = 0; reg_id < N; reg_id++) {
+        for (int reg_id = 0; reg_id < block_ct_dim; reg_id++) {
             PACK((llk_pack<DST_ACCUM_MODE, false, false>(reg_id, ocb)));
         }
 
@@ -69,9 +83,22 @@ ALWI void untilize_block(uint32_t icb, uint32_t block, uint32_t ocb) {
     }
 }
 
+// clang-format off
 /**
- * Uninitialize untilize operation, to allow initializing another operation.
+ * Restores hardware and internal state after the untilize operation is complete. This function should be called after
+ * untilize_block operation is finished. The circular buffer (CB) ID provided must correspond to the buffer that was
+ * used for the untilize operation and it's initialization.
+ *
+ * NOTE: This function is not in line with our programming model, and will be removed by the end of 2025
+ * as a part of tt-metal#22904.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name | Description                                               | Type     | Valid Range | Required |
+ * |------------|------|-----------------------------------------------------------|----------|-------------|----------|
+ * | Function   | icb  | The identifier of the circular buffer (CB) for input data | uint32_t | 0 to 31     | True     |
  */
+// clang-format on
 ALWI void untilize_uninit(uint32_t icb) { UNPACK((llk_unpack_untilize_uninit(icb))); }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/bmm_tilize_untilize.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/bmm_tilize_untilize.cpp
@@ -82,7 +82,7 @@ inline void reblock_and_untilize(
         cb_push_back(reblock_cb_id, out_block_w);
 
         // Untilize
-        untilize_init_short(reblock_cb_id);
+        untilize_init(reblock_cb_id);
         cb_wait_front(reblock_cb_id, out_block_w);
         cb_reserve_back(out_cb_id, out_block_w);
         untilize_block(reblock_cb_id, out_block_w, out_cb_id);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -444,7 +444,7 @@ void MAIN {
                 }
                 pack_untilize_uninit(matmul_partials_cb);
 #else
-                untilize_init_short(matmul_partials_cb);
+                untilize_init(matmul_partials_cb);
                 for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
                     for (uint32_t out_block_h_i = 0; out_block_h_i < out_subblock_h; ++out_block_h_i) {
                         cb_wait_front(matmul_partials_cb, out_block_w);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -30,7 +30,7 @@ ALWI void transpose_with_untilize(uint32_t cb_tilize, uint32_t cb_untilize, uint
         cb_push_back(cb_untilize, Ht);
 
         // tilize
-        untilize_init_short(cb_untilize);
+        untilize_init(cb_untilize);
         cb_wait_front(cb_untilize, Ht);
         cb_reserve_back(cb_out, Ht);
         untilize_block(cb_untilize, Ht, cb_out);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp
@@ -13,7 +13,8 @@ void MAIN {
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(2);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(3);
 
-    untilize_init(src_cb_id, out_cb_id);
+    compute_kernel_hw_startup(src_cb_id, out_cb_id);
+    untilize_init(src_cb_id);
 
     for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
         cb_wait_front(src_cb_id, per_core_block_tile_cnt);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp
@@ -14,7 +14,8 @@ void MAIN {
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(1);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(2);
 
-    untilize_init(src_cb_id, out_cb_id);
+    compute_kernel_hw_startup(src_cb_id, out_cb_id);
+    untilize_init(src_cb_id);
 
     for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
         cb_wait_front(src_cb_id, per_core_block_tile_cnt);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_w.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_w.cpp
@@ -10,7 +10,9 @@ void MAIN {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
     uint32_t third_dim = get_compile_time_arg_val(2);
-    untilize_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    untilize_init(tt::CBIndex::c_0);
 
     uint32_t onetile = 1;
     for (uint32_t b = 0; b < per_core_block_cnt * per_core_block_tile_cnt * third_dim; ++b) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp
@@ -11,7 +11,8 @@ void MAIN {
     const uint32_t block_size_row = get_compile_time_arg_val(1);
     const uint32_t third_dim = get_compile_time_arg_val(2);
 
-    untilize_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    untilize_init(tt::CBIndex::c_0);
 
     for (uint32_t b = 0; b < block_size_col * third_dim; ++b) {
         cb_wait_front(tt::CBIndex::c_0, block_size_row);

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/compute.cpp
@@ -265,7 +265,7 @@ void MAIN {
 
                             // After reduction (if any), untilize result
                             cb_wait_front(cb_matmul_interm_tiled, output_tiles);
-                            untilize_init_short(cb_matmul_interm_tiled);
+                            untilize_init(cb_matmul_interm_tiled);
                             for (uint32_t patch_t = 0; patch_t < matmul_M_t; patch_t++) {
                                 cb_reserve_back(cb_matmul_result_rm, matmul_N_t);
                                 untilize_block(cb_matmul_interm_tiled, matmul_N_t, cb_matmul_result_rm);

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp
@@ -60,7 +60,7 @@ void MAIN {
                     // untilize tile and write to CBIndex::c_25
                     reconfig_data_format_srca(cb_in1, cb_intermed0);
                     cb_wait_front(cb_intermed0, onetile);
-                    untilize_init_short(cb_intermed0);
+                    untilize_init(cb_intermed0);
                     cb_reserve_back(cb_intermed1, onetile);
                     untilize_block(cb_intermed0, onetile, cb_intermed1);
                     cb_push_back(cb_intermed1, onetile);

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
@@ -32,7 +32,7 @@ FORCE_INLINE void pack_block_rows_into_tiles(uint32_t cb_in, uint32_t cb_out, ui
     reconfig_data_format_srca(cb_in);
     pack_reconfig_data_format(cb_out);
 
-    untilize_init_short(cb_in);
+    untilize_init(cb_in);
 
     cb_wait_front(cb_in, num_tiles);
     cb_reserve_back(cb_out, NUM_TILES_IN_TILIZED_CHUNK);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/rotary_embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/rotary_embedding.cpp
@@ -41,7 +41,7 @@ ALWI void MUL_TILES(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t 
 }
 
 ALWI void UNTILIZE_TILES(uint32_t in0_cb, uint32_t out_cb, uint32_t num_tiles) {
-    untilize_init_short(in0_cb);
+    untilize_init(in0_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_reserve_back(out_cb, num_tiles);
     untilize_block(in0_cb, num_tiles, out_cb);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -772,7 +772,7 @@ void MAIN {
 
 #ifdef UNTILIZE_OUT
                 // untilize
-                untilize_init_short(cb_untilize_in);
+                untilize_init(cb_untilize_in);
                 cb_wait_front(cb_untilize_in, per_core_MN);
                 for (uint32_t m = 0; m < per_core_M; ++m) {
                     cb_reserve_back(cb_untilize_out, per_core_N);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -540,7 +540,7 @@ void MAIN {
 
 #ifdef UNTILIZE_OUT
     // untilize
-    untilize_init_short(cb_untilize_in);
+    untilize_init(cb_untilize_in);
     cb_wait_front(cb_untilize_in, per_core_MN);
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_reserve_back(cb_untilize_out, per_core_N);

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp
@@ -22,12 +22,11 @@ void MAIN {
 
     constexpr bool use_pack_untilize = tiles_per_row <= MAX_PACK_UNTILIZE_WIDTH;
 
+    compute_kernel_hw_startup(src_cb_id, out_cb_id0);
     if constexpr (use_pack_untilize) {
-        // Will be moved above the if-else statement in untilize cleanup PR: tt-metal#23774.
-        compute_kernel_hw_startup(src_cb_id, out_cb_id0);
         pack_untilize_init<tiles_per_row>(src_cb_id, out_cb_id0);
     } else {
-        untilize_init(src_cb_id, out_cb_id0);
+        untilize_init(src_cb_id);
     }
 
     constexpr uint32_t tiles_per_block = block_size * tiles_per_row;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -291,7 +291,7 @@ void MAIN {
                 if constexpr (use_pack_untilize) {
                     pack_untilize_init<out_chunk_tiles>(cb_out_accumulate_im, cb_out_final);
                 } else {
-                    untilize_init_short(cb_out_accumulate_im);
+                    untilize_init(cb_out_accumulate_im);
                 }
                 cb_wait_front(cb_out_accumulate_im, out_chunk_tiles);
                 cb_reserve_back(cb_out_final, out_chunk_tiles);


### PR DESCRIPTION
### Ticket
#22942  

### Problem description
Compute API currently has a lot of unused or redundant function arguments, and even unused functions. Furthermore, the programming model is violated at several places and the boundary between full and short inits is not clear. Lastly, some ops require calling an `_uninit`/`_revert` function, but not all, which introduces more confusion. We will do a series of PRs to fix these issues for all ops so that in the end Compute kernels look like this:
```
compute_kernel_hw_startup # called once at the start of the kernel
<op1>_init # called before op1
<op1>_tile / <op1>_block # We will add block ops where applicable
<op2>_init
<op2>_tile / <op2>_block
...
```

### What's changed
This PR addresses the mentioned drawbacks of Compute API for **untilize** op. It is the initial PR that doesn't fix all the problems, but does the following:

* Uses `compute_kernel_hw_startup` function at kernel beginnings.
* `untilize_init_short` renamed to `untilize_init` and old full init removed. 
* Adapt API calls in all kernels to reflect the changes.
* Add documentation skeleton for functions that will remain in `untilize.h` at the end of the effort.

### Review Process Suggestion:
* Code owners should check their files and see whether all `untilize_` init calls are modified. All `untilize_init_short` calls should be swapped with `untilize_init` calls.
* LLK team will review `untilize.h` for functional, structural and code documentation changes. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/16314669285
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/16314674898
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/16316111688
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes