### PR TITLE
[tt_transformers] Support nested configs and weights with prefixes

### DIFF
--- a/models/tt_transformers/tt/load_checkpoints.py
+++ b/models/tt_transformers/tt/load_checkpoints.py
@@ -12,6 +12,15 @@ from safetensors.torch import load_file as safetensors_load_file
 from tqdm import tqdm
 
 
+def _get_known_prefixes():
+    return [
+        "text_model.",  # Llama Vision
+        "vision_model.",
+        "language_model.",  # Gemma3
+        "vision_tower.",
+    ]
+
+
 # TODO Update function for large models: For 1 layer tests we only want to load 1 checkpoint file, instead of all.
 def load_hf_state_dict(ckpt_dir):
     # First check if index file exists
@@ -42,9 +51,17 @@ def load_hf_state_dict(ckpt_dir):
 
 
 def standardize_hf_keys(state_dict):
-    if not "lm_head.weight" in state_dict:
+    key_meta = "lm_head.weight"
+    key_hf = "model.embed_tokens.weight"
+
+    # Check if the key_meta exists with any known prefix
+    if not any(f"{prefix}{key_meta}" in state_dict for prefix in _get_known_prefixes()):
         # Assume tied to the embeddings if not present
-        state_dict["lm_head.weight"] = state_dict["model.embed_tokens.weight"]
+        for prefix in _get_known_prefixes():
+            if f"{prefix}{key_hf}" in state_dict:
+                state_dict[f"{prefix}{key_meta}"] = state_dict[f"{prefix}{key_hf}"]
+                break
+
     return state_dict
 
 
@@ -111,16 +128,20 @@ def map_hf_to_meta_keys(loaded_weights):
 
     meta_state_dict = {}
     for key, tensor in loaded_weights.items():
+        # Remove known prefix if present
+        prefix = next((p for p in _get_known_prefixes() if key.startswith(p)), "")
+        key = key[len(prefix) :]
+
         if key in hf_to_meta:
             # Direct match for top-level keys
-            meta_state_dict[hf_to_meta[key]] = tensor
+            meta_state_dict[prefix + hf_to_meta[key]] = tensor
         elif "model.layers." in key:
             # Extract layer number and form a template key
             parts = key.split(".")
             layer_num = parts[2]  # e.g. "0" in "model.layers.0.input_layernorm.weight"
             template_key = "model.layers.{layer}." + ".".join(parts[3:])
             if template_key in hf_to_meta:
-                meta_state_dict[hf_to_meta[template_key].format(layer=layer_num)] = tensor
+                meta_state_dict[prefix + hf_to_meta[template_key].format(layer=layer_num)] = tensor
 
     return meta_state_dict
 

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -5,6 +5,7 @@
 import json
 import math
 import os
+import re
 from enum import Enum, auto
 from pathlib import Path
 from typing import Tuple
@@ -540,6 +541,7 @@ class ModelArgs:
         if max_prefill_chunk_size_div1024 is None:
             # TODO Improve this to be more general to more devices and models
             MAX_PREFILL_CHUNK_SIZES_DIV1024 = {
+                "gemma-3-4b": {"N150": 8, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
                 "Llama-3.2-1B": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
                 "Llama-3.2-3B": {"N150": 8, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
                 "Llama-3.1-8B": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128, "P150x4": 128},
@@ -1354,37 +1356,40 @@ class ModelArgs:
         )
         return xs_1BSH
 
-    def _set_params_from_dict(self, params, is_hf=False):
+    def _set_params_from_dict(self, config, is_hf=False):
+        # Try to get text_config, if it doesn't exist everything is text config
+        text_config = config.get("text_config", config)
+
         # Common params with different names between Meta and HF
-        self.dim = params.get("dim", params.get("hidden_size"))
-        self.n_heads = params.get("n_heads", params.get("num_attention_heads"))
-        self.n_kv_heads = params.get("n_kv_heads", params.get("num_key_value_heads"))
-        self.n_layers = params.get("n_layers", params.get("num_hidden_layers"))
+        self.dim = text_config.get("dim", text_config.get("hidden_size"))
+        self.n_heads = text_config.get("n_heads", text_config.get("num_attention_heads"))
+        self.n_kv_heads = text_config.get("n_kv_heads", text_config.get("num_key_value_heads"))
+        self.n_layers = text_config.get("n_layers", text_config.get("num_hidden_layers"))
         self.full_model_n_layers = self.n_layers
-        self.norm_eps = params.get("norm_eps", params.get("rms_norm_eps"))
-        self.vocab_size = params["vocab_size"]
+        self.norm_eps = text_config.get("norm_eps", text_config.get("rms_norm_eps"))
+        self.vocab_size = text_config["vocab_size"]
         self.padded_vocab_size = 128 * 1024 if self.is_galaxy else None
-        self.head_dim = params.get("head_dim", self.dim // self.n_heads)
+        self.head_dim = text_config.get("head_dim", self.dim // self.n_heads)
         if is_hf:
-            self.max_context_len = params.get("max_position_embeddings")
+            self.max_context_len = text_config.get("max_position_embeddings")
         else:
             self.max_context_len = (
                 128 * 1024
             )  # For Llama3 Meta weights TODO: Remove this when we move to HF weights only
 
         # Handle different MLP dimension specifications
-        if "intermediate_size" in params:
-            self.hidden_dim = params["intermediate_size"]
+        if "intermediate_size" in text_config:
+            self.hidden_dim = text_config["intermediate_size"]
             self.ffn_dim_multiplier = None
             self.multiple_of = None
         else:
-            self.ffn_dim_multiplier = params["ffn_dim_multiplier"]
-            self.multiple_of = params["multiple_of"]
+            self.ffn_dim_multiplier = text_config["ffn_dim_multiplier"]
+            self.multiple_of = text_config["multiple_of"]
             self.hidden_dim = calculate_hidden_dim(self.dim, self.ffn_dim_multiplier, self.multiple_of)
 
-        if "_name_or_path" in params:
+        if "_name_or_path" in config:
             if is_hf:
-                normalized_path = os.path.normpath(params["_name_or_path"])
+                normalized_path = os.path.normpath(config["_name_or_path"])
                 # For HF paths, they might end with `<model_name>/snapshots/<snapshot_id>/`
                 if "snapshots" in normalized_path:
                     full_model_name = normalized_path.split(os.path.sep)[-3]
@@ -1392,8 +1397,8 @@ class ModelArgs:
                 else:
                     self.model_name = os.path.basename(normalized_path)
             else:
-                self.model_name = os.path.basename(params["_name_or_path"])
-            logger.info(f"Model name from params: {self.model_name}")
+                self.model_name = os.path.basename(config["_name_or_path"])
+            logger.info(f"Model name from config: {self.model_name}")
 
         if self.base_model_name == "Qwen2.5-7B" and self.num_devices not in [0, 2, 4]:
             raise AssertionError(
@@ -1425,22 +1430,22 @@ class ModelArgs:
                     self.hidden_dim = padded_hidden_dim
 
         # RoPE params
-        self.rope_theta = params.get("rope_theta")
+        self.rope_theta = text_config.get("rope_theta")
         # If use_scaled_rope is not present, assume setting rope_scaling means use scaled rope
         # If it is present and is set to false, do not use scaled rope
         # Setting self.rope_scaling_factor to None is our way of saying do not use scaled rope
-        rope_scaling_params = params.get("rope_scaling", None)
+        rope_scaling_params = text_config.get("rope_scaling", None)
         if rope_scaling_params:
             self.rope_scaling_factor = rope_scaling_params.get("factor", None)
-            self.orig_context_len = rope_scaling_params.get("original_max_position_embeddings", None)
+            self.orig_context_len = rope_scaling_params.get("original_max_position_embeddings", self.max_context_len)
         else:
             self.rope_scaling_factor = None
             self.orig_context_len = None
 
         # Vision params (Meta-specific)
-        self.vision_chunk_size = params.get("vision_chunk_size", -1)
-        self.vision_max_num_chunks = params.get("vision_max_num_chunks", 4)
-        self.vision_num_cross_attention_layers = params.get("vision_num_cross_attention_layers", -1)
+        self.vision_chunk_size = config.get("vision_chunk_size", -1)
+        self.vision_max_num_chunks = config.get("vision_max_num_chunks", 4)
+        self.vision_num_cross_attention_layers = config.get("vision_num_cross_attention_layers", -1)
 
         # Vision constants
         self.vision_dim = 1280


### PR DESCRIPTION
### Ticket
#22799

### Problem description
Gemma3, being multimodal, has nested config and weights.

### What's changed
Interpret text part for the nested config.
Load weights with predefined prefix.

### Checklist
- [ ✅ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15758059973)
- [ ❌ ] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/15758074284) Same as main
- [ ❌ ] [(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/15758090556) t3k_llama3_vision_tests is above the perf target, the same as main.