### PR TITLE
Merge logic for calculating l1 memory usage with factory code

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -840,6 +840,9 @@ def test_conv_ws(
     if device.core_grid.y != 8 and is_wormhole_b0():
         pytest.skip("Needs 8x8 grid for wormhole_b0")
 
+    if input_channels == 2560 and auto_shard:
+        pytest.skip("Skipping 2560 input channels with auto_shard due to #23712")
+
     stride_h = stride
     stride_w = stride
     fp32_accum = True

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -53,7 +53,7 @@ std::vector<CBInfo> get_cb_info(
 
     const uint32_t weights_tile_size = tt::tile_size(weights_df);
     const uint32_t bias_tile_size = weights_tile_size;
-    const uint32_t output_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_config.dtype));
+    const uint32_t output_tile_size = tt::tile_size(output_df);
 
     // Block dims
     const uint32_t act_block_num_tiles = block_config.act_block_h_ntiles * block_config.act_block_w_ntiles;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -3,11 +3,282 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "conv2d_op_program_factory_common.hpp"
-
+#include <cstdint>
+#include <optional>
+#include <vector>
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/constants.hpp"
+#include "tt-metalium/hal.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+#include "ttnn/operations/cb_utils.hpp"
 namespace ttnn::operations::conv {
 namespace conv2d {
 
-uint32_t CBIndices::get_next_cb_index() { return next_cb_index++; }
+constexpr uint32_t l1_scratchpad_CB_size = 64;
+
+std::vector<CBInfo> get_cb_info(
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    const OptimizedConvBlockConfig& block_config,
+    const OptimizedConvParallelizationConfig& pconfig,
+    const ttnn::Shape& weights_shape,
+    std::array<uint32_t, 2> kernel_size,
+    const Conv2dConfig& conv_config,
+    DataType input_datatype,
+    std::array<uint32_t, 2> conv_input_shard_shape,
+    bool enable_bias,
+    bool is_1d_depthwise_conv) {
+    const uint32_t num_cbs = static_cast<uint32_t>(Conv2dCb::COUNT);
+    std::vector<CBInfo> cb_info;
+    cb_info.reserve(num_cbs);
+
+    const bool untilize_out = conv_config.output_layout == Layout::ROW_MAJOR;
+
+    // Tile dimensions and data formats
+
+    // Output of halo op is always ROW_MAJOR, so input for convs is either DataType::FLOAT32 or DataType::BFLOAT16
+    const tt::tt_metal::DataType conv_input_dtype = (input_datatype == tt::tt_metal::DataType::FLOAT32)
+                                                        ? tt::tt_metal::DataType::FLOAT32
+                                                        : tt::tt_metal::DataType::BFLOAT16;
+    const uint32_t input_datum_size = conv_input_dtype == tt::tt_metal::DataType::FLOAT32 ? 4 : 2;
+    const tt::DataFormat conv_input_df = datatype_to_dataformat_converter(conv_input_dtype);
+    const uint32_t input_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_input_dtype));
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(tt::tt_metal::hal::get_arch(), compute_kernel_config);
+
+    TT_FATAL(conv_config.weights_dtype.has_value(), "get_cb_info expects conv_config.weights_dtype to be already set");
+    const tt::DataFormat weights_df = datatype_to_dataformat_converter(conv_config.weights_dtype.value());
+    const tt::DataFormat bias_df = weights_df;
+    const tt::DataFormat output_df = datatype_to_dataformat_converter(conv_config.dtype);
+
+    const uint32_t weights_tile_size = tt::tile_size(weights_df);
+    const uint32_t bias_tile_size = weights_tile_size;
+    const uint32_t output_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_config.dtype));
+
+    // Block dims
+    const uint32_t act_block_num_tiles = block_config.act_block_h_ntiles * block_config.act_block_w_ntiles;
+    const uint32_t weight_matrix_height_ntiles = weights_shape[2] / tt::constants::TILE_HEIGHT;
+    const uint32_t weight_matrix_width_ntiles = weights_shape[3] / tt::constants::TILE_WIDTH;
+
+    const uint32_t per_core_out_matrix_width_ntiles = pconfig.per_core_out_matrix_width_ntile;
+    const uint32_t per_core_out_matrix_height_ntiles = pconfig.per_core_out_matrix_height_ntile;
+    const uint32_t per_core_out_ntiles =
+        pconfig.per_core_out_matrix_height_ntile * pconfig.per_core_out_matrix_width_ntile;
+
+    const uint32_t num_blocks_act_h = per_core_out_matrix_height_ntiles / block_config.act_block_h_ntiles;
+
+    const uint32_t num_blocks_act_w = weight_matrix_height_ntiles / block_config.act_block_w_ntiles;
+
+    const TensorMemoryLayout sharding_scheme = conv_config.shard_layout.value();
+    const uint32_t conv_act_c_blocks = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
+    const uint32_t in0_num_blocks_w =
+        sharding_scheme == TensorMemoryLayout::BLOCK_SHARDED ? num_blocks_act_w * conv_act_c_blocks : num_blocks_act_w;
+    packer_l1_acc = determine_packer_l1_acc(packer_l1_acc, enable_bias, in0_num_blocks_w);
+    const tt::tt_metal::DataType partial_dtype =
+        packer_l1_acc ? (fp32_dest_acc_en ? DataType::FLOAT32 : DataType::BFLOAT16) : conv_config.dtype;
+    const tt::DataFormat partial_df = datatype_to_dataformat_converter(partial_dtype);
+    const uint32_t partial_tile_size = tt::tile_size(partial_df);
+
+    {
+        // Weights CB
+        uint32_t weight_block_num_tiles =
+            per_core_out_matrix_width_ntiles *
+            (is_1d_depthwise_conv ? block_config.act_block_h_ntiles : block_config.act_block_w_ntiles);
+        if (sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
+            if (num_blocks_act_h > 1) {
+                // Fully buffered weights
+                weight_block_num_tiles *= kernel_size[0];
+            } else if (conv_config.enable_weights_double_buffer) {
+                weight_block_num_tiles *= 2;
+            }
+        } else if (conv_config.enable_weights_double_buffer) {
+            weight_block_num_tiles *= 2;
+        }
+
+        cb_info.emplace_back(CBInfo{
+            .name = Conv2dCb::WEIGHTS,
+            .num_pages = weight_block_num_tiles,
+            .page_size = weights_tile_size,
+            .data_format = weights_df});
+    }
+
+    // Matmul partials CB
+    cb_info.emplace_back(CBInfo{
+        .name = Conv2dCb::MATMUL_PARTIALS,
+        .num_pages = is_1d_depthwise_conv ? 1 : per_core_out_ntiles,
+        .page_size = partial_tile_size,
+        .is_globally_allocated = (!untilize_out && partial_dtype == conv_config.dtype && !is_1d_depthwise_conv),
+        .data_format = partial_df});
+
+    {
+        // ACT and ACT_SECOND_READER CB
+        uint32_t act_cb_num_tiles = act_block_num_tiles;
+        uint32_t act_block_split_num_tiles = 0;
+        if (sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED && conv_config.enable_split_reader) {
+            uint32_t act_block_h_nsubblocks = block_config.act_block_h_ntiles / block_config.out_subblock_h_ntiles;
+            uint32_t act_block_h_nsubblocks_split_last = act_block_h_nsubblocks / 2;
+            uint32_t act_block_h_nsubblocks_split = act_block_h_nsubblocks - act_block_h_nsubblocks_split_last;
+
+            act_cb_num_tiles =
+                act_block_h_nsubblocks_split * block_config.out_subblock_h_ntiles * block_config.act_block_w_ntiles;
+            act_block_split_num_tiles = act_block_h_nsubblocks_split_last * block_config.out_subblock_h_ntiles *
+                                        block_config.act_block_w_ntiles;
+        }
+        if (conv_config.enable_act_double_buffer) {
+            act_cb_num_tiles *= 2;
+            act_block_split_num_tiles *= 2;
+        }
+
+        const uint32_t act_cb_tile_size =
+            sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED ? input_tile_size : output_tile_size;
+        const tt::DataFormat act_cb_data_format =
+            sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED ? conv_input_df : output_df;
+        cb_info.emplace_back(CBInfo{
+            .name = Conv2dCb::ACT,
+            .num_pages = act_cb_num_tiles,
+            .page_size = act_cb_tile_size,
+            .data_format = act_cb_data_format});
+        cb_info.emplace_back(CBInfo{
+            .name = Conv2dCb::ACT_SECOND_READER,
+            .num_pages = act_block_split_num_tiles,
+            .page_size = act_cb_tile_size,
+            .data_format = act_cb_data_format});
+    }
+
+    // Temp sum CB (1d depthwise conv only)
+    cb_info.emplace_back(CBInfo{
+        .name = Conv2dCb::TEMP_SUM,
+        .num_pages = is_1d_depthwise_conv ? 1 : 0,
+        .page_size = output_tile_size,
+        .data_format = output_df});
+
+    // Tilized act CB
+    const uint32_t tlized_act_cb_num_tiles = act_block_num_tiles;
+    cb_info.emplace_back(CBInfo{
+        .name = Conv2dCb::ACT_TILIZED,
+        .num_pages = act_block_num_tiles,
+        .page_size = output_tile_size,
+        .data_format = output_df});
+
+    // Bias CB
+    cb_info.emplace_back(CBInfo{
+        .name = Conv2dCb::BIAS,
+        .num_pages = enable_bias ? per_core_out_matrix_width_ntiles : 0,
+        .page_size = bias_tile_size,
+        .data_format = bias_df});
+
+    {
+        // Act row major CB
+        uint32_t row_major_act_cb_num_tiles = 0;
+        if (sharding_scheme == TensorMemoryLayout::WIDTH_SHARDED) {
+            row_major_act_cb_num_tiles = block_config.act_block_w_ntiles * 2;
+        } else if (sharding_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
+            row_major_act_cb_num_tiles = act_block_num_tiles;
+        }
+
+        const bool overlap_act_cb = sharding_scheme == TensorMemoryLayout::BLOCK_SHARDED && conv_input_df == output_df;
+        cb_info.emplace_back(CBInfo{
+            .name = Conv2dCb::ACT_ROW_MAJOR_BFLOAT16,
+            .num_pages = overlap_act_cb ? 0 : row_major_act_cb_num_tiles,
+            .page_size = input_tile_size,
+            .data_format = conv_input_df,
+            .overlapped_by_cb = overlap_act_cb ? std::optional<Conv2dCb>(Conv2dCb::ACT) : std::nullopt});
+    }
+
+    // Output CB
+    cb_info.emplace_back(CBInfo{
+        .name = Conv2dCb::OUT,
+        .num_pages = per_core_out_ntiles,
+        .page_size = output_tile_size,
+        .is_globally_allocated = true,
+        .data_format = output_df});
+
+    // Reader indices CB
+    cb_info.emplace_back(CBInfo{
+        .name = Conv2dCb::READER_INDICES,
+        .num_pages = 1,
+        .page_size = pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT * 2,  // 2B per indexß
+        .is_globally_allocated = true,
+        .data_format = tt::DataFormat::UInt16});
+
+    // L1 scratchpad CB
+    cb_info.emplace_back(CBInfo{
+        .name = Conv2dCb::L1_ARRAY,
+        .num_pages = 1,
+        .page_size = l1_scratchpad_CB_size,
+        .data_format = tt::DataFormat::Float16_b});
+
+    // Act sharded CB
+    cb_info.emplace_back(CBInfo{
+        .name = Conv2dCb::ACT_SHARDED,
+        .num_pages = conv_input_shard_shape[0],
+        .page_size = conv_input_shard_shape[1] * input_datum_size,
+        .is_globally_allocated = true,
+        .data_format = conv_input_df});
+
+    TT_FATAL(cb_info.size() == num_cbs, "Expected info for {} cbs  by got {}!", num_cbs, cb_info.size());
+    return cb_info;
+}
+
+void allocate_cbs(
+    std::vector<CBInfo>& cb_info,
+    tt::tt_metal::Program& program,
+    const CoreRange& all_cores,
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    const Tensor& l1_indices_tensor) {
+    uint32_t cb_index = 0;
+    for (auto& cb : cb_info) {
+        if (cb.num_pages == 0) {
+            // Skip circular buffers with zero pages
+            continue;
+        }
+
+        // cbs for sharded tensors.
+        Buffer* buffer = nullptr;
+        if (cb.is_globally_allocated) {
+            if (cb.name == Conv2dCb::ACT_SHARDED) {
+                buffer = input_tensor.buffer();
+            } else if (cb.name == Conv2dCb::OUT || cb.name == Conv2dCb::MATMUL_PARTIALS) {
+                buffer = output_tensor.buffer();
+            } else if (cb.name == Conv2dCb::READER_INDICES) {
+                buffer = l1_indices_tensor.buffer();
+            } else {
+                TT_THROW(
+                    "Unexpected circular buffer name {}. Expected one of: SHARDED_ACT_CB, OUT0_CB, READER_INDICES_CB",
+                    magic_enum::enum_name(cb.name));
+            }
+        }
+
+        std::tie(cb.index, cb.handle) =
+            tt::tt_metal::create_cb(cb_index++, program, all_cores, cb.page_size, cb.num_pages, cb.data_format, buffer);
+        log_debug(
+            tt::LogOp,
+            "Allocated circular buffer {} with index {}, num pages {}, page size {}, globally allocated: {}",
+            magic_enum::enum_name(cb.name),
+            cb.index,
+            cb.num_pages,
+            cb.page_size,
+            cb.is_globally_allocated);
+    }
+
+    for (auto& cb : cb_info) {
+        if (cb.overlapped_by_cb.has_value()) {
+            // If this CB is overlapped by another CB, set the handle to the overlapped CB's handle
+            const CBInfo& overlapped_cb = get_cb_info_by_name(cb_info, cb.overlapped_by_cb.value());
+            cb.handle = overlapped_cb.handle;
+            cb.index = overlapped_cb.index;
+        }
+    }
+}
+
+const CBInfo& get_cb_info_by_name(const std::vector<CBInfo>& cb_info, Conv2dCb cb_name) {
+    auto it = std::find_if(cb_info.begin(), cb_info.end(), [cb_name](const CBInfo& cb) { return cb.name == cb_name; });
+    return *it;
+}
+CBInfo& access_cb_info_by_name(const std::vector<CBInfo>& cb_info, Conv2dCb cb_name) {
+    return const_cast<CBInfo&>(get_cb_info_by_name(cb_info, cb_name));
+}
 
 }  // namespace conv2d
 }  // namespace ttnn::operations::conv

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -5,37 +5,86 @@
 #pragma once
 
 #include <cstdint>
-#include "hostdevcommon/kernel_structs.h"
+#include <optional>
+
+#include "conv2d/device/conv2d_op.hpp"
+
+#include "tt-metalium/circular_buffer_config.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
 
 namespace ttnn::operations::conv {
 namespace conv2d {
 
-using namespace tt;
+// Invalid value for cb id is 32, number greater than the maximum number of index circular buffer can have.
+constexpr static uint32_t kInvalidCBIndex = 32;
 
-// In order to make circular buffer indicies sequential, we use variable to keep track of the next available index.
-// Circular buffer indices should be assigned right before their creation.
-struct CBIndices {
-    // Invalid value for cb id is 32, number greater than the maximum number of index circular buffer can have.
-    // Not assigning get_next_cb_index() value before creating cb will throw exception in circular_buffer_config.cpp
-    // which can be used as a reminder.
-    uint32_t weight_cb = 32;
-    uint32_t tilize_mode_tilized_act_cb = 32;
-    uint32_t act_cb = 32;
-    uint32_t bias_cb = 32;
-    uint32_t sharded_act_cb = 32;
-    uint32_t cb_for_reader_indices = 32;
-    uint32_t cb_for_l1_array = 32;
-    uint32_t act_cb_row_major_bfloat16 = 32;
-    uint32_t act_cb_second_reader = 32;
-    uint32_t matmul_partials_cb = 32;
-    uint32_t untilize_mode_reblock_cb = 32;
-    uint32_t out0_cb = 32;
-    uint32_t temp_sum_cb = 32;
-
-    uint32_t get_next_cb_index();
-
-private:
-    uint32_t next_cb_index = tt::CBIndex::c_0;
+// List of all circular buffers used in Conv2d operations.
+enum class Conv2dCb {
+    ACT_SHARDED,
+    ACT,
+    ACT_ROW_MAJOR_BFLOAT16,
+    ACT_SECOND_READER,
+    ACT_TILIZED,
+    WEIGHTS,
+    BIAS,
+    READER_INDICES,
+    L1_ARRAY,
+    MATMUL_PARTIALS,
+    OUT,
+    TEMP_SUM,
+    COUNT
 };
+struct CBInfo {
+    // Index of CB that will be passed in to the kernel.
+    uint32_t index = kInvalidCBIndex;
+    // CB handle
+    tt::tt_metal::CBHandle handle;
+    // Type of the CB
+    Conv2dCb name;
+    // Number of pages in the circular buffer.
+    uint32_t num_pages;
+    // Size of each page in the circular buffer.
+    uint32_t page_size;
+    // Whether this CB is globally allocated (true for sharded tensors).
+    bool is_globally_allocated = false;
+    // Data format of the circular buffer.
+    tt::DataFormat data_format = tt::DataFormat::Invalid;
+    // Optional: If this CB is overlapped by another CB, this will hold the name of that CB.
+    std::optional<Conv2dCb> overlapped_by_cb = std::nullopt;
+
+    uint32_t cb_size_per_core() const { return num_pages * page_size; }
+};
+
+// Returns a vector of CBInfo objects for the Conv2d operation.
+// The vector will contain information about all circular buffers used in the Conv2d operation.
+// CBInfo::index and CBInfo::handle won't be valid until allocate_cbs() is called.
+std::vector<CBInfo> get_cb_info(
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    const OptimizedConvBlockConfig& block_config,
+    const OptimizedConvParallelizationConfig& pconfig,
+    const ttnn::Shape& weights_shape,
+    std::array<uint32_t, 2> kernel_size,
+    const Conv2dConfig& conv_config,
+    DataType input_datatype,
+    std::array<uint32_t, 2> conv_input_shard_shape,
+    bool enable_bias,
+    bool is_1d_depthwise_conv);
+
+// Allocates circular buffers for the Conv2d operation.
+// This function will populate index and handle fields of each CBInfo in the cb_info vector,
+// and add these circular buffers to the provided program.
+void allocate_cbs(
+    std::vector<CBInfo>& cb_info,
+    tt::tt_metal::Program& program,
+    const CoreRange& all_cores,
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    const Tensor& l1_indices_tensor);
+
+const CBInfo& get_cb_info_by_name(const std::vector<CBInfo>& cb_info, Conv2dCb cb_name);
+CBInfo& access_cb_info_by_name(const std::vector<CBInfo>& cb_info, Conv2dCb cb_name);
+
 }  // namespace conv2d
 }  // namespace ttnn::operations::conv

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <sys/types.h>
-#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <tuple>
@@ -15,7 +14,6 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "tt-metalium/math.hpp"
-#include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
 #include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -10,9 +10,11 @@
 
 #include "conv2d_utils.hpp"
 #include <tt-metalium/buffer_types.hpp>
+#include "conv2d/conv2d_op_program_factory_common.hpp"
 #include "tt-metalium/constants.hpp"
 #include <tt-metalium/hal.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include "tt-metalium/math.hpp"
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
 #include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
@@ -902,7 +904,6 @@ Conv2dConfig determine_conv_config_for_auto_shard(
             kernel_size,
             conv_config,
             input_datatype,
-            conv_out_memory_config,
             enable_bias,
             conv_is_1d_deptwise);
 
@@ -1007,308 +1008,36 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
     std::array<uint32_t, 2> kernel_size,
     const Conv2dConfig& conv_config,
     const DataType input_datatype,
-    const MemoryConfig& output_memory_config,
     const bool enable_bias,
     bool is_1d_depthwise_conv) {
-    bool untilize_out = conv_config.output_layout == Layout::ROW_MAJOR;
-
-    // Output of halo op is always ROW_MAJOR, so input for convs is either DataType::FLOAT32 or DataType::BFLOAT16
-    auto conv_input_dtype = (input_datatype == tt::tt_metal::DataType::FLOAT32) ? tt_metal::DataType::FLOAT32
-                                                                                : tt_metal::DataType::BFLOAT16;
-    uint32_t input_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_input_dtype));
-
-    TT_FATAL(
-        conv_config.weights_dtype.has_value(),
-        "calculate_L1_usage expects conv_config.weights_dtype to be already set");
-    uint32_t weights_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_config.weights_dtype.value()));
-    uint32_t bias_tile_size = 0;
-    if (enable_bias) {
-        bias_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_config.weights_dtype.value()));
+    // Input shard doesn't affect L1 usage calculation.
+    std::array<uint32_t, 2> dummy_input_shard_shape = {0, 0};
+    std::vector<CBInfo> cb_info = get_cb_info(
+        compute_kernel_config,
+        block_config,
+        pconfig,
+        weights_shape,
+        kernel_size,
+        conv_config,
+        input_datatype,
+        dummy_input_shard_shape,
+        enable_bias,
+        is_1d_depthwise_conv);
+    uint32_t total_CB_size = 0;
+    uint32_t output_size = 0;
+    for (const CBInfo& cb : cb_info) {
+        if (!cb.is_globally_allocated) {
+            total_CB_size += cb.cb_size_per_core();
+            log_debug(tt::LogOp, "CB: {}, size: {}", magic_enum::enum_name(cb.name), cb.cb_size_per_core());
+        }
+        if (cb.name == Conv2dCb::OUT) {
+            output_size = cb.cb_size_per_core();
+        }
     }
-    uint32_t output_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_config.dtype));
+    log_debug(tt::LogOp, "Total CB size: {}", total_CB_size);
+    log_debug(tt::LogOp, "Output size: {}", output_size);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(tt::tt_metal::hal::get_arch(), compute_kernel_config);
-
-    uint32_t act_block_w_ntiles = block_config.act_block_w_ntiles;
-    uint32_t act_block_h_ntiles = block_config.act_block_h_ntiles;
-    uint32_t act_block_num_tiles = block_config.act_block_h_ntiles * act_block_w_ntiles;
-
-    uint32_t weight_matrix_height = weights_shape[2];
-    uint32_t weight_matrix_width = weights_shape[3];
-    uint32_t weight_matrix_height_ntiles = weight_matrix_height / tt::constants::TILE_HEIGHT;
-    uint32_t weight_matrix_width_ntiles = weight_matrix_width / tt::constants::TILE_WIDTH;
-
-    uint32_t per_core_out_matrix_width_ntiles = pconfig.per_core_out_matrix_width_ntile;
-    uint32_t per_core_out_matrix_height_ntiles = pconfig.per_core_out_matrix_height_ntile;
-
-    uint32_t num_blocks_act_h_per_core =
-        (per_core_out_matrix_height_ntiles + act_block_h_ntiles - 1) / act_block_h_ntiles;
-    uint32_t out_block_h_ntiles_padded = num_blocks_act_h_per_core * act_block_h_ntiles;
-
-    TensorMemoryLayout sharding_scheme = conv_config.shard_layout.value();
-    if (sharding_scheme == TensorMemoryLayout::WIDTH_SHARDED) {
-        uint32_t conv_output_c_per_core = per_core_out_matrix_width_ntiles * tt::constants::TILE_WIDTH;
-
-        uint32_t output_size_per_core_in_bytes = per_core_out_matrix_width_ntiles * per_core_out_matrix_height_ntiles *
-                                                 tt::tile_size(datatype_to_dataformat_converter(conv_config.dtype));
-
-        uint32_t tilized_act_block_num_bytes = act_block_num_tiles * output_tile_size;
-
-        uint32_t weight_block_w_ntiles = per_core_out_matrix_width_ntiles;
-        uint32_t weight_block_num_tiles =
-            weight_block_w_ntiles * act_block_w_ntiles;  // act_block_w_ntiles == weight_block_h_ntiles
-        if (conv_config.enable_weights_double_buffer) {
-            weight_block_num_tiles *= 2;
-        }
-        uint32_t weight_block_num_bytes = weight_block_num_tiles * weights_tile_size;
-
-        uint32_t bias_block_num_bytes = per_core_out_matrix_width_ntiles * bias_tile_size;
-
-        uint32_t out_block_num_tiles = per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles;
-
-        uint32_t num_blocks_act_w = weight_matrix_height_ntiles / act_block_w_ntiles;
-
-        packer_l1_acc = packer_l1_acc && ((enable_bias && num_blocks_act_w > 1) || (num_blocks_act_w > 2));
-
-        auto interm_dtype =
-            packer_l1_acc ? (fp32_dest_acc_en ? DataType::FLOAT32 : DataType::BFLOAT16) : conv_config.dtype;
-
-        uint32_t partial_tile_size = tt::tile_size(datatype_to_dataformat_converter(interm_dtype));
-
-        uint32_t partials_block_num_bytes = out_block_num_tiles * partial_tile_size;
-
-        // ACT CB
-        uint32_t act_cb_size = tilized_act_block_num_bytes;
-        if (conv_config.enable_act_double_buffer) {
-            act_cb_size *= 2;
-        }
-        log_debug(tt::LogOp, "Act CB Size: {}", act_cb_size);
-
-        // WEIGHTS CB
-        uint32_t weights_cb_size = weight_block_num_bytes;
-        log_debug(tt::LogOp, "Weights CB Size: {}", weights_cb_size);
-
-        // BIAS CB
-        uint32_t bias_cb_size = bias_block_num_bytes;
-        log_debug(tt::LogOp, "Bias CB Size: {}", bias_cb_size);
-
-        // L1 CB
-        uint32_t l1_scratchpad_cb_size = conv2d::l1_scratchpad_CB_size;
-        log_debug(tt::LogOp, "L1 CB Size: {}", l1_scratchpad_cb_size);
-
-        // ACT ROW MAJOR CB
-        uint32_t row_major_act_cb_size = act_block_w_ntiles * input_tile_size * 2;
-        log_debug(tt::LogOp, "Act row major CB Size: {}", row_major_act_cb_size);
-
-        // MATMUL PARTIALs CB
-        uint32_t matmul_partials_cb_size = partials_block_num_bytes;
-        if (!untilize_out && interm_dtype == conv_config.dtype) {
-            matmul_partials_cb_size = 0;
-        } else {
-            log_debug(tt::LogOp, "Matmul partial CB Size: {}", matmul_partials_cb_size);
-        }
-
-        // TILIZED ACT CB
-        uint32_t tilized_act_cb_size = tilized_act_block_num_bytes;
-        log_debug(tt::LogOp, "Tilized act CB Size: {}", tilized_act_cb_size);
-
-        uint32_t total_CB_size = act_cb_size + weights_cb_size + bias_cb_size + l1_scratchpad_cb_size +
-                                 row_major_act_cb_size + matmul_partials_cb_size + tilized_act_cb_size;
-
-        log_debug(tt::LogOp, "Total CB Size: {}", total_CB_size);
-
-        return conv2d::conv_op_l1_usage{
-            .tensor_allocation_size = output_size_per_core_in_bytes, .CB_allocation_size = total_CB_size};
-    } else if (sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
-        uint32_t output_size = per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles * output_tile_size;
-
-        uint32_t bias_block_num_bytes = per_core_out_matrix_width_ntiles * bias_tile_size;
-
-        uint32_t conv_act_c_blocks = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
-
-        uint32_t weight_block_w_ntiles = per_core_out_matrix_width_ntiles;
-        uint32_t weight_block_h_ntiles = (is_1d_depthwise_conv) ? act_block_h_ntiles : act_block_w_ntiles;
-
-        uint32_t act_block_cb_ntiles = act_block_h_ntiles * act_block_w_ntiles;
-
-        uint32_t act_block_cb_size = act_block_cb_ntiles * input_tile_size;
-        uint32_t tilzed_act_cb_size = act_block_cb_ntiles * output_tile_size;
-
-        uint32_t output_block_ntiles = out_block_h_ntiles_padded * per_core_out_matrix_width_ntiles;
-
-        uint32_t num_blocks_act_w = weight_matrix_height_ntiles / act_block_w_ntiles;
-        uint32_t num_blocks_act_h = per_core_out_matrix_height_ntiles / act_block_h_ntiles;
-        uint32_t in0_num_blocks_w =
-            num_blocks_act_w * conv_act_c_blocks;  // Fold outer c_block loop together with weight_block_num_tiles = 9
-
-        packer_l1_acc = packer_l1_acc && ((enable_bias && in0_num_blocks_w > 1) || (in0_num_blocks_w > 2));
-
-        auto interm_dtype =
-            packer_l1_acc ? (fp32_dest_acc_en ? DataType::FLOAT32 : DataType::BFLOAT16) : conv_config.dtype;
-
-        uint32_t partial_tile_size = tt::tile_size(datatype_to_dataformat_converter(interm_dtype));
-
-        uint32_t act_block_split_last_ntiles = 0;
-        uint32_t act_block_split_ntiles = act_block_cb_ntiles;
-        if (conv_config.enable_split_reader) {
-            uint32_t act_block_h_nsubblocks = block_config.act_block_h_ntiles / block_config.out_subblock_h_ntiles;
-            uint32_t act_block_split_last_ntiles = act_block_cb_ntiles / 2;
-            uint32_t act_block_split_ntiles = act_block_cb_ntiles - act_block_split_last_ntiles;
-        }
-
-        if (conv_config.enable_act_double_buffer) {
-            act_block_split_last_ntiles *= 2;
-            act_block_split_ntiles *= 2;
-        }
-        // ACT CB
-        uint32_t act_cb_size = act_block_split_ntiles * input_tile_size;
-        log_debug(tt::LogOp, "Act CB Size: {}", act_cb_size);
-
-        // WEIGHTS CB
-        uint32_t weights_cb_size = weight_block_h_ntiles * weight_block_w_ntiles * weights_tile_size;
-        if (num_blocks_act_h > 1) {
-            weights_cb_size *= kernel_size[0];
-        }
-        if (num_blocks_act_h <= 1 && conv_config.enable_weights_double_buffer) {
-            weights_cb_size *= 2;
-        }
-        log_debug(tt::LogOp, "Weights CB Size: {}", weights_cb_size);
-
-        // BIAS CB
-        uint32_t bias_cb_size = bias_block_num_bytes;
-        log_debug(tt::LogOp, "Bias CB Size: {}", bias_cb_size);
-
-        // L1 CB
-        uint32_t l1_scratchpad_cb_size = conv2d::l1_scratchpad_CB_size;
-        log_debug(tt::LogOp, "L1 CB Size: {}", l1_scratchpad_cb_size);
-
-        // SPLIT READER CB
-        uint32_t split_second_act_reader_cb_size = act_block_split_last_ntiles * input_tile_size;
-        log_debug(tt::LogOp, "Split reader CB Size: {}", split_second_act_reader_cb_size);
-
-        // MATMUL PARTIALS CB
-        uint32_t matmul_partials_cb_size = output_block_ntiles * partial_tile_size;
-        if (!untilize_out && interm_dtype == conv_config.dtype) {
-            matmul_partials_cb_size = 0;
-        }
-        if (is_1d_depthwise_conv) {
-            matmul_partials_cb_size = output_tile_size;
-        }
-        if (matmul_partials_cb_size != 0) {
-            log_debug(tt::LogOp, "Matmul partials CB Size: {}", matmul_partials_cb_size);
-        }
-        // TILIZED ACT CB
-        uint32_t tilized_act_cb_size = tilzed_act_cb_size;
-        log_debug(tt::LogOp, "Tilized act CB Size: {}", tilized_act_cb_size);
-
-        // TEMP SUM CB
-        uint32_t temp_sum_cb_size = 0;
-        if (is_1d_depthwise_conv) {
-            temp_sum_cb_size = output_tile_size;
-            log_debug(tt::LogOp, "Temp sum CB Size: {}", temp_sum_cb_size);
-        }
-        uint32_t total_CB_size = act_cb_size + weights_cb_size + bias_cb_size + l1_scratchpad_cb_size +
-                                 split_second_act_reader_cb_size + matmul_partials_cb_size + tilized_act_cb_size +
-                                 temp_sum_cb_size;
-        return conv2d::conv_op_l1_usage{.tensor_allocation_size = output_size, .CB_allocation_size = total_CB_size};
-    } else if (sharding_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
-        auto output_shard_shape = output_memory_config.shard_spec().value().shape;
-
-        uint32_t output_size = 0;
-        if (untilize_out) {
-            uint32_t per_core_out_width_aligned = pconfig.per_core_out_matrix_width_ntile * tt::constants::TILE_WIDTH;
-            if (conv_config.dtype == DataType::BFLOAT16) {
-                per_core_out_width_aligned *= 2;
-            } else if (conv_config.dtype == DataType::FLOAT32) {
-                per_core_out_width_aligned *= 4;
-            }
-            output_size = tt::round_up(per_core_out_width_aligned, tt::tt_metal::hal::get_l1_alignment()) *
-                          pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT;
-        } else {
-            output_size = per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles * output_tile_size;
-        }
-
-        uint32_t bias_block_num_bytes = per_core_out_matrix_width_ntiles * bias_tile_size;
-
-        uint32_t conv_act_c_blocks = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
-
-        uint32_t weight_block_w_ntiles = per_core_out_matrix_width_ntiles;
-        uint32_t weight_block_h_ntiles = act_block_w_ntiles;
-
-        uint32_t tilized_act_block_cb_size = act_block_h_ntiles * act_block_w_ntiles * output_tile_size;
-        const uint32_t row_major_act_cb_size =
-            conv_input_dtype != conv_config.dtype ? act_block_h_ntiles * act_block_w_ntiles * input_tile_size : 0;
-
-        uint32_t output_block_ntiles = per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles;
-
-        uint32_t num_blocks_act_w = 1;
-        uint32_t num_blocks_act_h = per_core_out_matrix_height_ntiles / act_block_h_ntiles;
-        uint32_t in0_num_blocks_w =
-            num_blocks_act_w * conv_act_c_blocks;  // Fold outer c_block loop together with weight_block_num_tiles = 9
-
-        packer_l1_acc = packer_l1_acc && ((enable_bias && in0_num_blocks_w > 1) || (in0_num_blocks_w > 2));
-
-        auto interm_dtype =
-            packer_l1_acc ? (fp32_dest_acc_en ? DataType::FLOAT32 : DataType::BFLOAT16) : conv_config.dtype;
-
-        uint32_t partial_tile_size = tt::tile_size(datatype_to_dataformat_converter(interm_dtype));
-
-        // ACT CB
-        uint32_t act_cb_size = tilized_act_block_cb_size;
-        if (conv_config.enable_act_double_buffer) {
-            act_cb_size *= 2;
-        }
-        log_debug(tt::LogOp, "Act CB Size: {}", act_cb_size);
-
-        // WEIGHTS CB
-        uint32_t weights_cb_size = weight_block_h_ntiles * weight_block_w_ntiles * weights_tile_size;
-        if (conv_config.enable_weights_double_buffer) {
-            weights_cb_size *= 2;
-        }
-        log_debug(tt::LogOp, "Weights CB Size: {}", weights_cb_size);
-
-        // BIAS CB
-        uint32_t bias_cb_size = bias_block_num_bytes;
-        log_debug(tt::LogOp, "Bias CB Size: {}", bias_cb_size);
-
-        // L1 CB
-        uint32_t l1_scratchpad_cb_size = conv2d::l1_scratchpad_CB_size;
-        log_debug(tt::LogOp, "L1 CB Size: {}", l1_scratchpad_cb_size);
-
-        // ACT ROW MAJOR CB
-        log_debug(tt::LogOp, "Act row major CB Size: {}", row_major_act_cb_size);
-
-        // MATMUL PARTIALS CB
-        uint32_t matmul_partials_cb_size = output_block_ntiles * partial_tile_size;
-        if (!untilize_out && interm_dtype == conv_config.dtype) {
-            matmul_partials_cb_size = 0;
-        } else {
-            log_debug(tt::LogOp, "Matmul partials CB Size: {}", matmul_partials_cb_size);
-        }
-
-        // TILIZED ACT CB
-        uint32_t tilized_act_cb_size = tilized_act_block_cb_size;
-        log_debug(tt::LogOp, "Tilized act CB Size: {}", tilized_act_cb_size);
-
-        bool need_unpad_after_untilize =
-            output_shard_shape[1] * output_shard_shape[0] <
-            per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles * tt::constants::TILE_HW;
-
-        log_debug(tt::LogOp, "Need Unpad after untilize: {}", need_unpad_after_untilize);
-
-        // UNTILIZED UNPADDED OUT CB
-        uint32_t untilized_unpadded_out_cb_size = 0;
-        if (need_unpad_after_untilize && untilize_out) {
-            untilized_unpadded_out_cb_size = output_block_ntiles * output_tile_size;
-            log_debug(tt::LogOp, "Untilized unapadded out CB Size: {}", untilized_unpadded_out_cb_size);
-        }
-        uint32_t total_CB_size = act_cb_size + weights_cb_size + bias_cb_size + l1_scratchpad_cb_size +
-                                 row_major_act_cb_size + matmul_partials_cb_size + tilized_act_cb_size +
-                                 untilized_unpadded_out_cb_size;
-        return conv2d::conv_op_l1_usage{.tensor_allocation_size = output_size, .CB_allocation_size = total_CB_size};
-    }
-    TT_THROW("Invalid shard layout {}", sharding_scheme);
+    return conv2d::conv_op_l1_usage{.tensor_allocation_size = output_size, .CB_allocation_size = total_CB_size};
 }
 
 bool conv2d::determine_packer_l1_acc(bool packer_l1_acc, bool enable_bias, uint32_t in0_num_blocks_w) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -282,10 +282,8 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(
             .output_layout = (untilize_out ? Layout::ROW_MAJOR : Layout::TILE),
             .enable_act_double_buffer = enable_act_double_buffer,
             .enable_weights_double_buffer = enable_weights_double_buffer,
-            .enable_split_reader = enable_split_reader,
-            .enable_subblock_padding = enable_subblock_padding},
+            .enable_split_reader = enable_split_reader},
         input_tensor_a.dtype(),
-        this->memory_config,
         has_bias,
         is_1d_deptwise_conv(
             groups,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -16,7 +16,6 @@ namespace ttnn {
 namespace operations::conv {
 namespace conv2d {
 
-constexpr uint32_t l1_scratchpad_CB_size = 64;
 struct Conv2dConfig {
     tt::tt_metal::DataType dtype = tt::tt_metal::DataType::BFLOAT16;
 
@@ -344,7 +343,6 @@ conv_op_l1_usage calculate_L1_usage(
     std::array<uint32_t, 2> kernel_size,
     const Conv2dConfig& conv_config,
     tt::tt_metal::DataType input_datatype,
-    const tt::tt_metal::MemoryConfig& output_memory_config,
     bool enable_bias,
     bool is_1d_depthwise_conv);
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -82,7 +82,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    // it is bad for compute, pad act_block_h_ntiles
     uint32_t out_subblock_h_ntiles_padded = out_subblock_h_ntiles;
     if (enable_subblock_padding) {
         uint32_t max_num_subblock = fp32_dest_acc_en ? 4 : 8;
@@ -688,7 +687,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     if (filter_h >= 1 and filter_w >= 1) {
         if (!is_conv_1d_depthwise_conv and weight_width_sliced) {
             // Block sharded conv
-            TT_FATAL(weight_width_sliced == true, "read_window_in_inner_loop should be true for this conv");
+            TT_FATAL(weight_width_sliced == true, "weight_width_sliced should be true for this conv");
             reader_kernel =
                 "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
                 "reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp";

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1,15 +1,14 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt-metalium/circular_buffer.hpp"
 #include "tt-metalium/circular_buffer_config.hpp"
-#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include "ttnn/tensor/types.hpp"
+#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tt_metal.hpp>
@@ -17,15 +16,11 @@
 #include <tt-metalium/host_api.hpp>
 #include "ttnn/operations/compute_throttle_utils.hpp"
 
-using namespace tt::constants;
-
 namespace ttnn::operations::conv {
 namespace conv2d {
 
-using namespace tt;
-
 tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
-    tt_metal::Program& program,
+    tt::tt_metal::Program& program,
     const Tensor& a,
     const Tensor& b,
     const ttnn::Shape& ashape,
@@ -41,345 +36,14 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     const std::optional<unary::UnaryWithParam>& fused_activation,
     const OptimizedConvParallelizationConfig& parallelization_config,
     const OptimizedConvBlockConfig& block_config,
-    bool transpose_mcast,
     Tensor& output,
     DeviceComputeKernelConfig compute_kernel_config,
     bool enable_act_double_buffer,
     bool enable_weights_double_buffer,
-    bool enable_split_reader,
     bool enable_subblock_padding);
 
-// TODO: Add namespace for utilities?
-std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharded_input_v2(
-    tt_metal::Program& program,
-    const Tensor& input,
-    CoreRange core,
-    uint32_t num_cb0_tiles,
-    uint32_t num_cb0_second_reader_tiles,
-    uint32_t num_cb1_tiles,
-    uint32_t num_cb0_tilized_tiles,
-    uint32_t num_output_tiles,
-    uint32_t num_reblock_cb_tiles,
-    uint32_t num_writer_output_tiles,
-    bool untilize_out,
-    tt::DataFormat act_df,
-    tt::DataFormat weight_df,
-    tt::DataFormat tilized_act_df,
-    tt::DataFormat out_df,
-    tt::DataFormat bias_df,
-    bool weight_width_sliced,
-    const Tensor& output,
-    uint32_t bias_ntiles,
-    bool with_bias,
-    bool split_reader,
-    bool fp32_dest_acc_en,
-    bool packer_l1_acc_en,
-    CBIndices& cb_indices) {
-    using tt::tt_metal::CBHandle;
-    using tt::tt_metal::CircularBuffer;
-    using tt::tt_metal::CircularBufferConfig;
-
-    tt::DataFormat interm0_df =
-        packer_l1_acc_en ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b) : out_df;
-
-    uint32_t act_tile_size = tt_metal::detail::TileSize(act_df);
-    uint32_t weight_tile_size = tt_metal::detail::TileSize(weight_df);
-    uint32_t tilized_act_tile_size = tt_metal::detail::TileSize(tilized_act_df);
-    uint32_t out_tile_size = tt_metal::detail::TileSize(out_df);
-    uint32_t interm0_single_tile_size = tt_metal::detail::TileSize(interm0_df);
-
-    CBHandle cb_sharded_act = 0;
-    CBHandle cb_output = 0;
-    CBHandle cb_matmul_partials = 0;
-    if (input.memory_config().is_sharded()) {
-        uint32_t num_bytes_for_df = datum_size(act_df);
-        auto shard_shape = input.shard_spec().value().shape;
-        // 2D-sys-conv already has uint16_t indicies, TODO: do the same for 1D-sys-conv
-        TT_FATAL(
-            shard_shape[0] <= (1 << 16), "Shard height must be less than 2^16, read pattern indicies are uint16_t");
-        // incoming data is the input cb instead of raw l1/dram addr
-        std::tie(cb_indices.sharded_act_cb, cb_sharded_act) = tt::tt_metal::create_cb(
-            cb_indices.get_next_cb_index(),
-            program,
-            core,
-            shard_shape[1] * num_bytes_for_df,
-            shard_shape[0],
-            act_df,
-            input.buffer());
-
-        if (weight_width_sliced) {
-            // For 2D convs, each core creates and tilizes full input matrix then mcasts round robin style
-            // Each core receives input into act_cb, so won't need a separate cb to receive
-            // However, we need a separate cb to push ROW_MAJOR BFLOAT16 data for tilizing and configure act cb to be
-            // output df
-
-            // num_cb0_tiles is double buffered
-            cb_indices.act_cb = cb_indices.get_next_cb_index();
-            tt::tt_metal::create_cb(
-                cb_indices.act_cb, program, core, tilized_act_tile_size, num_cb0_tiles, tilized_act_df);
-            log_debug(
-                LogOp, "Act CB: {}, npages: {}, pagesize: {}", cb_indices.act_cb, num_cb0_tiles, tilized_act_tile_size);
-
-            if (act_df != tilized_act_df) {
-                // num_cb0_tilized_tiles is single buffered
-                cb_indices.act_cb_row_major_bfloat16 = cb_indices.get_next_cb_index();
-                tt::tt_metal::create_cb(
-                    cb_indices.act_cb_row_major_bfloat16, program, core, act_tile_size, num_cb0_tilized_tiles, act_df);
-                log_debug(
-                    LogOp,
-                    "Act CB Row Major BFLOAT16: {}, npages: {}, pagesize: {}",
-                    cb_indices.act_cb_row_major_bfloat16,
-                    num_cb0_tilized_tiles,
-                    act_tile_size);
-            } else {
-                // In case formats match reuse act_cb for row major act cb
-                cb_indices.act_cb_row_major_bfloat16 = cb_indices.act_cb;
-            }
-        } else {
-            // For 1D convs, locally create act matrix in act_cb, which is always ROW_MAJOR BFLOAT16
-            // Then, tilize input in compute
-
-            // Extra cb for second reader if we split act reads across two RISCs
-            // In this case, the regular reader only does first half of reads along output block h
-            if (split_reader) {
-                cb_indices.act_cb_second_reader = cb_indices.get_next_cb_index();
-                tt::tt_metal::create_cb(
-                    cb_indices.act_cb_second_reader, program, core, act_tile_size, num_cb0_second_reader_tiles, act_df);
-                log_debug(
-                    LogOp,
-                    "Act CB Second Reader: {}, npages: {}, pagesize: {}",
-                    cb_indices.act_cb_second_reader,
-                    num_cb0_second_reader_tiles,
-                    act_tile_size);
-            }
-            cb_indices.act_cb = cb_indices.get_next_cb_index();
-            tt::tt_metal::create_cb(cb_indices.act_cb, program, core, act_tile_size, num_cb0_tiles, act_df);
-            log_debug(LogOp, "Act CB: {}, npages: {}, pagesize: {}", cb_indices.act_cb, num_cb0_tiles, act_tile_size);
-        }
-    } else {
-        TT_THROW("Input must be sharded!");
-    }
-
-    tt::tt_metal::create_cb(cb_indices.weight_cb, program, core, weight_tile_size, num_cb1_tiles, weight_df);
-    log_debug(LogOp, "Weight CB: {}, npages: {}, pagesize: {}", cb_indices.weight_cb, num_cb1_tiles, weight_tile_size);
-
-    // Used for placing tilized activations
-    tt::tt_metal::create_cb(
-        cb_indices.tilize_mode_tilized_act_cb,
-        program,
-        core,
-        tilized_act_tile_size,
-        num_cb0_tilized_tiles,
-        tilized_act_df);
-    log_debug(
-        LogOp,
-        "Tilized Act CB: {}, npages: {}, pagesize: {}",
-        cb_indices.tilize_mode_tilized_act_cb,
-        num_cb0_tilized_tiles,
-        tilized_act_tile_size);
-
-    if (untilize_out) {
-        auto output_shard_shape = output.shard_spec().value().shape;
-        std::tie(cb_indices.matmul_partials_cb, cb_matmul_partials) = tt::tt_metal::create_cb(
-            cb_indices.get_next_cb_index(), program, core, interm0_single_tile_size, num_output_tiles, interm0_df);
-        log_debug(
-            LogOp,
-            "Matmul Partials CB: {}, npages: {}, pagesize: {}",
-            cb_indices.matmul_partials_cb,
-            num_output_tiles,
-            interm0_single_tile_size);
-
-        bool need_unpad_after_untilize =
-            output_shard_shape[1] * output_shard_shape[0] < num_writer_output_tiles * TILE_HW;
-
-        auto shard_shape = output.shard_spec().value().shape;
-        uint32_t aligned_output_stick_nbytes = out_tile_size;
-        uint32_t aligned_output_num_pages = num_writer_output_tiles;
-        std::tie(cb_indices.out0_cb, cb_output) = tt::tt_metal::create_cb(
-            cb_indices.get_next_cb_index(),
-            program,
-            core,
-            aligned_output_stick_nbytes,
-            aligned_output_num_pages,
-            out_df,
-            output.buffer());
-    } else {
-        // Share buffer if same data format
-        if (interm0_df == out_df) {
-            cb_indices.matmul_partials_cb = cb_indices.get_next_cb_index();
-            cb_indices.out0_cb = cb_indices.get_next_cb_index();
-            auto cb_tuple = tt::tt_metal::create_cb(
-                {cb_indices.matmul_partials_cb, cb_indices.out0_cb},
-                program,
-                core,
-                out_tile_size,
-                num_output_tiles,
-                out_df,
-                output.is_sharded() ? output.buffer() : nullptr);
-
-            cb_output = cb_matmul_partials = std::get<1>(cb_tuple);
-
-            if (!output.is_sharded()) {
-                log_debug(
-                    LogOp,
-                    "Matmul Partials CB: {}, npages: {}, pagesize: {}",
-                    cb_indices.matmul_partials_cb,
-                    num_output_tiles,
-                    out_tile_size);
-            }
-        } else {
-            // Separate buffer if not same data format
-            std::tie(cb_indices.matmul_partials_cb, cb_matmul_partials) = tt::tt_metal::create_cb(
-                cb_indices.get_next_cb_index(), program, core, interm0_single_tile_size, num_output_tiles, interm0_df);
-            log_debug(
-                LogOp,
-                "Matmul Partials CB: {}, npages: {}, pagesize: {}",
-                cb_indices.matmul_partials_cb,
-                num_output_tiles,
-                interm0_single_tile_size);
-
-            std::tie(cb_indices.out0_cb, cb_output) = tt::tt_metal::create_cb(
-                cb_indices.get_next_cb_index(),
-                program,
-                core,
-                out_tile_size,
-                num_output_tiles,
-                out_df,
-                output.is_sharded() ? output.buffer() : nullptr);
-        }
-    }
-
-    if (with_bias) {
-        uint32_t bias_tile_size = tt_metal::detail::TileSize(bias_df);
-        // bias input
-        uint32_t bias_pagesize = bias_tile_size;
-        cb_indices.bias_cb = cb_indices.get_next_cb_index();
-        tt::tt_metal::create_cb(cb_indices.bias_cb, program, core, bias_pagesize, bias_ntiles, bias_df);
-        log_debug(LogOp, "Bias CB: {}, npages: {}, pagesize: {}", cb_indices.bias_cb, bias_ntiles, bias_pagesize);
-    }
-
-    return {cb_sharded_act, cb_output, cb_matmul_partials};
-}
-
-// TODO: Add namespace for utilities?
-std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandle>
-create_CBs_for_depthwise_sharded_input(
-    tt_metal::Program& program,
-    const Tensor& input,
-    CoreRange core,
-    uint32_t num_cb0_tiles,
-    uint32_t num_cb1_tiles,
-    uint32_t num_cb0_tilized_tiles,
-    uint32_t num_output_tiles,
-    uint32_t num_reblock_cb_tiles,
-    uint32_t num_writer_output_tiles,
-    bool untilize_out,
-    tt::DataFormat act_df,
-    tt::DataFormat weight_df,
-    tt::DataFormat tilized_act_df,
-    tt::DataFormat out_df,
-    tt::DataFormat bias_df,
-    bool weight_width_sliced,
-    const Tensor& output,
-    uint32_t bias_ntiles,
-    bool with_bias,
-    bool split_reader,
-    bool fp32_dest_acc_en,
-    bool packer_l1_acc_en,
-    CBIndices& cb_indices) {
-    using tt::tt_metal::CBHandle;
-    using tt::tt_metal::CircularBuffer;
-    using tt::tt_metal::CircularBufferConfig;
-
-    tt::DataFormat interm0_df =
-        packer_l1_acc_en ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b) : out_df;
-
-    uint32_t act_tile_size = tt_metal::detail::TileSize(act_df);
-    uint32_t weight_tile_size = tt_metal::detail::TileSize(weight_df);
-    uint32_t tilized_act_tile_size = tt_metal::detail::TileSize(tilized_act_df);
-    uint32_t out_tile_size = tt_metal::detail::TileSize(out_df);
-    uint32_t interm0_single_tile_size = tt_metal::detail::TileSize(interm0_df);
-
-    CBHandle cb_sharded_act = 0;
-    if (input.memory_config().is_sharded()) {
-        uint32_t num_bytes_for_df = datum_size(act_df);
-        auto shard_shape = input.shard_spec().value().shape;
-        // 2D-sys-conv already has uint16_t indicies, TODO: do the same for 1D-sys-conv
-        TT_FATAL(
-            shard_shape[0] <= (1 << 16), "Shard height must be less than 2^16, read pattern indicies are uint16_t");
-        // incoming data is the input cb instead of raw l1/dram addr
-        std::tie(cb_indices.sharded_act_cb, cb_sharded_act) = tt::tt_metal::create_cb(
-            cb_indices.get_next_cb_index(),
-            program,
-            core,
-            shard_shape[1] * num_bytes_for_df,
-            shard_shape[0],
-            act_df,
-            input.buffer());
-
-        // For 1D convs, locally create act matrix in act_cb, which is always ROW_MAJOR BFLOAT16
-        // Then, tilize input in compute
-        cb_indices.act_cb = cb_indices.get_next_cb_index();
-        tt::tt_metal::create_cb(cb_indices.act_cb, program, core, act_tile_size, num_cb0_tiles, act_df);
-        log_debug(LogOp, "Act CB: {}, npages: {}, pagesize: {}", cb_indices.act_cb, num_cb0_tiles, act_tile_size);
-
-    } else {
-        TT_THROW("Input must be sharded!");
-    }
-
-    tt::tt_metal::create_cb(cb_indices.weight_cb, program, core, weight_tile_size, num_cb1_tiles, weight_df);
-    log_debug(LogOp, "Weight CB: {}, npages: {}, pagesize: {}", cb_indices.weight_cb, num_cb1_tiles, weight_tile_size);
-
-    // Used for placing tilized activations
-    tt::tt_metal::create_cb(
-        cb_indices.tilize_mode_tilized_act_cb,
-        program,
-        core,
-        tilized_act_tile_size,
-        num_cb0_tilized_tiles,
-        tilized_act_df);
-    log_debug(
-        LogOp,
-        "Act Tilized CB: {}, npages: {}, pagesize: {}",
-        cb_indices.tilize_mode_tilized_act_cb,
-        num_cb0_tilized_tiles,
-        tilized_act_tile_size);
-
-    CBHandle cb_output = 0;
-    // Share buffer if same data format
-    CoreRangeSet cores(std::set<CoreRange>({core}));
-
-    // breakdown above as separate CBs
-    CBHandle cb_matmul_partials = 0;
-
-    std::tie(cb_indices.matmul_partials_cb, cb_matmul_partials) =
-        tt::tt_metal::create_cb(cb_indices.get_next_cb_index(), program, core, out_tile_size, 1, out_df);
-    log_debug(
-        LogOp, "Matmul Partials CB: {}, npages: {}, pagesize: {}", cb_indices.matmul_partials_cb, 1, out_tile_size);
-
-    cb_indices.temp_sum_cb = cb_indices.get_next_cb_index();
-    tt::tt_metal::create_cb(cb_indices.temp_sum_cb, program, core, out_tile_size, 1, out_df);
-    log_debug(LogOp, "Temp Sum CB: {}, npages: {}, pagesize: {}", cb_indices.temp_sum_cb, 1, out_tile_size);
-
-    std::tie(cb_indices.out0_cb, cb_output) = tt::tt_metal::create_cb(
-        cb_indices.get_next_cb_index(),
-        program,
-        cores,
-        out_tile_size,
-        num_output_tiles,
-        out_df,
-        output.is_sharded() ? output.buffer() : nullptr);
-
-    if (!output.is_sharded()) {
-        log_debug(
-            LogOp, "Output CB: {}, npages: {}, pagesize: {}", cb_indices.out0_cb, num_output_tiles, out_tile_size);
-    }
-
-    return {cb_sharded_act, cb_output, cb_matmul_partials};
-}
-
 tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
-    tt_metal::Program& program,
+    tt::tt_metal::Program& program,
     const Tensor& a,
     const Tensor& b,
     const ttnn::Shape& ashape,
@@ -402,16 +66,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     bool enable_weights_double_buffer,
     bool enable_split_reader,
     bool enable_subblock_padding) {
-    using tt::tt_metal::CBHandle;
-    using tt::tt_metal::CircularBuffer;
-    using tt::tt_metal::CircularBufferConfig;
-    CBIndices cb_indices = CBIndices();
-    // Non-optional circular buffer indicies
-    cb_indices.weight_cb = cb_indices.get_next_cb_index();
-    cb_indices.tilize_mode_tilized_act_cb = cb_indices.get_next_cb_index();
-
-    bool pass = true;
-    tt_metal::IDevice* device = a.device();
+    tt::tt_metal::IDevice* device = a.device();
     TT_FATAL(a.layout() == Layout::ROW_MAJOR, "Conv activation should be in row major layout");
     TT_FATAL(a.memory_config().is_sharded(), "Conv activation must be sharded.");
     TT_FATAL(output_channels <= b.padded_shape()[3], "Invalid weight shape. Incorrect weight tensor.");
@@ -422,36 +77,17 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     uint32_t out_subblock_h_ntiles = block_config.out_subblock_h_ntiles;
     uint32_t out_subblock_w_ntiles = block_config.out_subblock_w_ntiles;
 
-    const tt::DataFormat act_df = tt_metal::datatype_to_dataformat_converter(a.dtype());
-    const tt::DataFormat weight_df = tt_metal::datatype_to_dataformat_converter(b.dtype());
-    const tt::DataFormat out_df = tt_metal::datatype_to_dataformat_converter(output.dtype());
-    const tt::DataFormat bias_df =
-        has_bias ? tt_metal::datatype_to_dataformat_converter(bias.value().dtype()) : tt::DataFormat::Float16_b;
-    const tt::DataFormat tilized_act_df = out_df;
+    const tt::DataFormat tilized_act_df = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    if (fp32_dest_acc_en and (out_subblock_h_ntiles * out_subblock_w_ntiles > 4)) {
-        if (out_subblock_w_ntiles >= 4) {
-            out_subblock_h_ntiles = 1;
-            out_subblock_w_ntiles = tt::tt_metal::find_max_block_size(out_subblock_w_ntiles, 4);
-        } else {
-            while (out_subblock_h_ntiles * out_subblock_w_ntiles > 4) {
-                uint32_t div = tt::tt_metal::find_max_divisor(out_subblock_h_ntiles, out_subblock_h_ntiles - 1);
-                out_subblock_h_ntiles = tt::tt_metal::find_max_block_size(out_subblock_h_ntiles, div);
-            }
-        }
-    }
     // it is bad for compute, pad act_block_h_ntiles
-    uint32_t max_num_subblock = fp32_dest_acc_en ? 4 : 8;
-    uint32_t max_subblock_h = fp32_dest_acc_en ? 4 : 8;
-    uint32_t act_block_h_ntiles_padded = act_block_h_ntiles;
     uint32_t out_subblock_h_ntiles_padded = out_subblock_h_ntiles;
-    // bool enable_subblock_padding = false;
-    // bool enable_split_reader = false;
-    // enable_act_double_buffer = false;
     if (enable_subblock_padding) {
+        uint32_t max_num_subblock = fp32_dest_acc_en ? 4 : 8;
+        uint32_t max_subblock_h = fp32_dest_acc_en ? 4 : 8;
+
         TT_FATAL(
             act_block_h_ntiles == out_block_h_ntiles, "to pad subblock, the number of blocks on height dim must be 1");
 
@@ -473,11 +109,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                 }
             }
             out_subblock_h_ntiles_padded = preferred_out_subblock_h;
-            act_block_h_ntiles_padded = out_subblock_h_ntiles_padded * num_subblock_h;
         }
     }
 
-    // TT_FATAL(out_block_h_ntiles == act_block_h_ntiles); // TODO: fix output block sizing
     TT_FATAL(
         out_block_h_ntiles >= act_block_h_ntiles,
         "Output block height (in # of tiles) ({}) should be greater than or equal to activation block height (in # of "
@@ -491,16 +125,10 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     TT_FATAL(b.padded_shape()[1] == 1, "Conv weight matrix shape is invalid");
     uint32_t weight_matrix_height = b.padded_shape()[2];
     uint32_t weight_matrix_width = b.padded_shape()[3];
-    uint32_t weight_matrix_height_ntiles = weight_matrix_height / TILE_HEIGHT;
-    uint32_t weight_matrix_width_ntiles = weight_matrix_width / TILE_WIDTH;
+    uint32_t weight_matrix_width_ntiles = weight_matrix_width / tt::constants::TILE_WIDTH;
 
-    // Partitions conv inner dim into blocks to support sharding along this dim
-    // TODO: Only 2D convs with sharded input use this, but we can uplift to support generically
-    // TODO: Only updated variables which is affected, but there may be more that needs to account for this
-    // TODO: Loop naming in reader, writer, and compute kernels could also be cleaned up
-    // TODO: Can conv_act_c_blocks be same as num_blocks_act_w?
     auto a_shard_spec = a.shard_spec().value();
-    auto shard_shape = a.shard_spec().value().shape;
+    const auto shard_shape = a.shard_spec().value().shape;
 
     // parallelization config
     const auto& p_config = parallelization_config;
@@ -532,31 +160,24 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     } else {
         input_channels_padded = shard_shape[1];
     }
-    ttnn::Shape ashape_with_channels_padded({ashape[0], ashape[1], ashape[2], input_channels_padded});
-    uint32_t conv_act_size_h = ashape_with_channels_padded[1];
+    const ttnn::Shape ashape_with_channels_padded({ashape[0], ashape[1], ashape[2], input_channels_padded});
     uint32_t conv_act_size_w = ashape_with_channels_padded[2];
-    uint32_t conv_act_size_c = ashape_with_channels_padded[3];
-    uint32_t filter_h = (uint32_t)sliding_window_config.window_hw.first;   // filter_h
-    uint32_t filter_w = (uint32_t)sliding_window_config.window_hw.second;  // filter_W
-    uint32_t stride_h = (uint32_t)sliding_window_config.stride_hw.first;
-    uint32_t stride_w = (uint32_t)sliding_window_config.stride_hw.second;
-    uint32_t pad_h = (uint32_t)sliding_window_config.get_pad_h();
+    const uint32_t conv_act_size_c = ashape_with_channels_padded[3];
+    const uint32_t filter_h = (uint32_t)sliding_window_config.window_hw.first;   // filter_h
+    const uint32_t filter_w = (uint32_t)sliding_window_config.window_hw.second;  // filter_W
     uint32_t pad_w = (uint32_t)sliding_window_config.get_pad_w();
-    uint32_t dilation_h = (uint32_t)sliding_window_config.dilation_hw.first;
-    uint32_t dilation_w = (uint32_t)sliding_window_config.dilation_hw.second;
+    const uint32_t dilation_h = (uint32_t)sliding_window_config.dilation_hw.first;
+    const uint32_t dilation_w = (uint32_t)sliding_window_config.dilation_hw.second;
+    const uint32_t stride_w = (uint32_t)sliding_window_config.stride_hw.second;
 
     if (sliding_window_config.is_transpose) {
         auto input_shape = sliding_window_config.get_transposed_full_input_shape();
-        conv_act_size_h = input_shape[1];
         conv_act_size_w = input_shape[2];
-        pad_h = 0;
         pad_w = 0;
     }
 
-    uint32_t input_width = ashape[2];
-    uint32_t input_channels = ashape[3];
     const bool is_conv_1d_depthwise_conv =
-        is_1d_deptwise_conv(groups, input_channels, output_channels, filter_w, input_width, has_bias);
+        is_1d_deptwise_conv(groups, ashape[3], output_channels, filter_w, ashape[2], has_bias);
     if ((block_sharded || is_conv_1d_depthwise_conv) && enable_split_reader) {
         enable_split_reader = false;
         log_warning(tt::LogOp, "Split reader is not supported for block sharded or 1d depthwise conv");
@@ -591,10 +212,11 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     uint32_t act_matrix_width = (uint32_t)act_matrix_shape[2];
     if (block_sharded) {
         act_matrix_width =
-            round_up((input_channels_padded / conv_act_c_blocks) * filter_w * filter_h, TILE_WIDTH) * conv_act_c_blocks;
+            tt::round_up((input_channels_padded / conv_act_c_blocks) * filter_w * filter_h, tt::constants::TILE_WIDTH) *
+            conv_act_c_blocks;
     }
-    uint32_t act_matrix_height_unpadded = (uint32_t)act_matrix_shape_unpadded[1];
-    uint32_t act_matrix_width_unpadded = (uint32_t)act_matrix_shape_unpadded[2];
+
+    const uint32_t act_matrix_height_unpadded = (uint32_t)act_matrix_shape_unpadded[1];
 
     if (has_bias) {
         if (is_conv_1d_depthwise_conv) {
@@ -616,10 +238,14 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             weight_matrix_height);
     }
     // Tile size divisibility checks
-    TT_FATAL(act_matrix_height % TILE_HEIGHT == 0, "Height of activation matrix needs to be divisible by 32");
-    TT_FATAL(act_matrix_width % TILE_WIDTH == 0, "Width of activation matrix needs to be divisible by 32");
-    TT_FATAL(weight_matrix_height % TILE_HEIGHT == 0, "Height of weight matrix needs to be divisible by 32");
-    TT_FATAL(weight_matrix_width % TILE_WIDTH == 0, "Width of weight matrix needs to be divisible by 32");
+    TT_FATAL(
+        act_matrix_height % tt::constants::TILE_HEIGHT == 0, "Height of activation matrix needs to be divisible by 32");
+    TT_FATAL(
+        act_matrix_width % tt::constants::TILE_WIDTH == 0, "Width of activation matrix needs to be divisible by 32");
+    TT_FATAL(
+        weight_matrix_height % tt::constants::TILE_HEIGHT == 0, "Height of weight matrix needs to be divisible by 32");
+    TT_FATAL(
+        weight_matrix_width % tt::constants::TILE_WIDTH == 0, "Width of weight matrix needs to be divisible by 32");
 
     // Device compatibility checks
     TT_FATAL(
@@ -634,8 +260,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     }
 
     // Convert tensor dims to tile dims
-    uint32_t act_matrix_height_ntiles = act_matrix_height / TILE_HEIGHT;
-    uint32_t act_matrix_width_ntiles = act_matrix_width / TILE_WIDTH;
+    uint32_t act_matrix_height_ntiles = act_matrix_height / tt::constants::TILE_HEIGHT;
+    uint32_t act_matrix_width_ntiles = act_matrix_width / tt::constants::TILE_WIDTH;
 
     TT_FATAL(
         act_matrix_height_ntiles % act_block_h_ntiles == 0,
@@ -674,19 +300,14 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         act_block_h_nsubblocks_split_last = act_block_h_nsubblocks / 2;
         act_block_h_nsubblocks_split = act_block_h_nsubblocks - act_block_h_nsubblocks_split_last;
     }
-    uint32_t act_block_h_datums_split = act_block_h_nsubblocks_split * out_subblock_h_ntiles * TILE_HEIGHT;
-    uint32_t act_block_h_datums_split_last = act_block_h_nsubblocks_split_last * out_subblock_h_ntiles * TILE_HEIGHT;
+    uint32_t act_block_h_datums_split =
+        act_block_h_nsubblocks_split * out_subblock_h_ntiles * tt::constants::TILE_HEIGHT;
+    uint32_t act_block_h_datums_split_last =
+        act_block_h_nsubblocks_split_last * out_subblock_h_ntiles * tt::constants::TILE_HEIGHT;
 
     uint32_t act_block_num_tiles_split = act_block_h_nsubblocks_split * out_subblock_h_ntiles * act_block_w_ntiles;
     uint32_t act_block_num_tiles_split_last =
         act_block_h_nsubblocks_split_last * out_subblock_h_ntiles * act_block_w_ntiles;
-
-    log_debug(LogOp, "act_block_h_nsubblocks_split: {}", act_block_h_nsubblocks_split);
-    log_debug(LogOp, "act_block_h_nsubblocks_split_last: {}", act_block_h_nsubblocks_split_last);
-    log_debug(LogOp, "act_block_h_datums_split: {}", act_block_h_datums_split);
-    log_debug(LogOp, "act_block_h_datums_split_last: {}", act_block_h_datums_split_last);
-    log_debug(LogOp, "act_block_num_tiles_split: {}", act_block_num_tiles_split);
-    log_debug(LogOp, "act_block_num_tiles_split_last: {}", act_block_num_tiles_split_last);
 
     // weight block info
     uint32_t weight_block_w_datums = weight_matrix_width / num_blocks_weight_w;
@@ -702,7 +323,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     uint32_t num_groups = num_blocks_act_h * num_blocks_act_w * num_blocks_weight_w;
     // writer of conv op partially removes padding on the width
     // it removes the padding done for block width but it doesn't remove padding done for tiled width
-    uint32_t output_channels_padded_to_tile_width = round_up(output_channels, TILE_WIDTH);
+    uint32_t output_channels_padded_to_tile_width = tt::round_up(output_channels, tt::constants::TILE_WIDTH);
     TT_FATAL(
         output_channels_padded_to_tile_width <= weight_matrix_width,
         "output_channels_padded_to_tile_width {} should be less than or equal to weight_matrix_width {}",
@@ -714,11 +335,11 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                                            ? weight_block_w_datums
                                            : (output_channels_padded_to_tile_width % weight_block_w_datums);
     TT_FATAL(
-        last_block_width_datums % TILE_WIDTH == 0,
+        last_block_width_datums % tt::constants::TILE_WIDTH == 0,
         "last_block_width_datums {} should be divisible by TILE_WIDTH",
         last_block_width_datums);
 
-    uint32_t out_block_h_datums = out_block_h_ntiles * TILE_HEIGHT;
+    uint32_t out_block_h_datums = out_block_h_ntiles * tt::constants::TILE_HEIGHT;
 
     TT_FATAL(output.is_sharded(), "Output buffer must be sharded!");
 
@@ -731,7 +352,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         "act_block_h_ntiles {} should be divisible by out_subblock_h_ntiles {}",
         act_block_h_ntiles,
         out_subblock_h_ntiles);
-    // TT_FATAL(out_block_h_ntiles % out_subblock_h_ntiles == 0);
+
     uint32_t act_num_subblocks = act_block_h_ntiles / out_subblock_h_ntiles;
     uint32_t act_block_num_tiles = act_block_h_ntiles * act_block_w_ntiles;
     uint32_t act_subblock_h_ntiles = out_subblock_h_ntiles;
@@ -741,13 +362,14 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     const uint32_t weight_dram_addr = b.buffer()->address();
 
     // bias
-    tt_metal::Buffer* bias_buffer = nullptr;
+    tt::tt_metal::Buffer* bias_buffer = nullptr;
     uint32_t bias_dram_addr = 0;
     uint32_t bias_ntiles = 0;
     if (has_bias) {
         bias_buffer = bias.value().buffer();
         bias_dram_addr = bias_buffer->address();
-        bias_ntiles = bias.value().padded_shape()[3] / constants::TILE_WIDTH;  // TODO: support non tile multiple sizes
+        bias_ntiles =
+            bias.value().padded_shape()[3] / tt::constants::TILE_WIDTH;  // TODO: support non tile multiple sizes
     }
 
     std::map<string, string> reader_defines;
@@ -756,93 +378,13 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         reader_defines["ACT_BLOCK_HEIGHT_PADDING"] = "1";
     }
 
-    if (conv_act_c_blocks > 1) {
-        reader_defines["ACT_W_OUTER_BLOCKS"] = "1";
-    }
-
-    uint32_t output_height_padded_to_tile_height = round_up(act_matrix_height_unpadded, TILE_HEIGHT);
-    uint32_t output_height_num_tiles = output_height_padded_to_tile_height / TILE_HEIGHT;
+    uint32_t output_height_padded_to_tile_height = tt::round_up(act_matrix_height_unpadded, tt::constants::TILE_HEIGHT);
+    uint32_t output_height_num_tiles = output_height_padded_to_tile_height / tt::constants::TILE_HEIGHT;
     TT_FATAL(
         output_height_num_tiles <= act_matrix_height_ntiles,
         "output_height_num_tiles {} should be less than or equal to act_matrix_height_ntiles {}",
         output_height_num_tiles,
         act_matrix_height_ntiles);
-
-    uint32_t dst_l1_act_buffer_size_bytes =
-        out_block_h_ntiles * act_block_w_ntiles * tt::tt_metal::detail::TileSize(act_df);
-    uint32_t dst_l1_weight_buffer_size_bytes =
-        weight_block_h_ntiles * weight_block_w_ntiles * tt::tt_metal::detail::TileSize(weight_df);
-
-    // log info for debugging opts
-    {
-        log_debug(LogOp, "grid_size: {}", p_config.grid_size);
-        log_debug(LogOp, "packer_l1: {}", packer_l1_acc);
-        log_debug(LogOp, "enable_split_reader: {}", enable_split_reader);
-        log_debug(LogOp, "enable_act_double_buffer: {}", enable_act_double_buffer);
-        log_debug(LogOp, "enable block padding: {}", (per_core_out_matrix_height_ntiles % act_block_h_ntiles != 0));
-        log_debug(LogOp, "enable subblock padding: {}", enable_subblock_padding);
-        log_debug(LogOp, "per_core_out_matrix_height_ntiles: {}", per_core_out_matrix_height_ntiles);
-        log_debug(LogOp, "act_block_h_ntiles_padded: {}", act_block_h_ntiles_padded);
-        log_debug(LogOp, "act_block_w_ntiles: {}", act_block_w_ntiles);
-        log_debug(LogOp, "weight_block_w_ntiles: {}", weight_block_w_ntiles);
-        log_debug(LogOp, "out_subblock_h_ntiles_padded: {}", out_subblock_h_ntiles_padded);
-        log_debug(LogOp, "out_subblock_w_ntiles: {}", out_subblock_w_ntiles);
-        log_debug(LogOp, "filter_h: {}", filter_h);
-        log_debug(LogOp, "filter_w: {}", filter_w);
-        log_debug(LogOp, "dilation_h: {}", dilation_h);
-        log_debug(LogOp, "dilation_w: {}", dilation_w);
-        log_debug(LogOp, "stride_h: {}", stride_h);
-        log_debug(LogOp, "stride_w: {}", stride_w);
-        log_debug(LogOp, "pad_h: {}", pad_h);
-        log_debug(LogOp, "pad_w: {}", pad_w);
-    }
-
-    // For debug
-    {
-        log_debug(LogOp, "multi_core_optimized_conv_sharded_v2_");
-        log_debug(LogOp, "conv_act_size_h: {}", conv_act_size_h);
-        log_debug(LogOp, "conv_act_size_w: {}", conv_act_size_w);
-        log_debug(LogOp, "conv_act_c_blocks: {}", conv_act_c_blocks);
-        log_debug(LogOp, "act_matrix_height: {}", act_matrix_height);
-        log_debug(LogOp, "act_matrix_width: {}", act_matrix_width);
-        log_debug(LogOp, "act_matrix_height_unpadded: {}", act_matrix_height_unpadded);
-        log_debug(LogOp, "act_matrix_width_unpadded: {}", act_matrix_width_unpadded);
-        log_debug(LogOp, "act_matrix_height_ntiles: {}", act_matrix_height_ntiles);
-        log_debug(LogOp, "act_matrix_width_ntiles: {}", act_matrix_width_ntiles);
-        log_debug(LogOp, "weight_matrix_width_ntiles: {}", weight_matrix_width_ntiles);
-        log_debug(LogOp, "per_core_out_matrix_height_ntiles: {}", per_core_out_matrix_height_ntiles);
-        log_debug(LogOp, "per_core_out_matrix_width_ntiles: {}", per_core_out_matrix_width_ntiles);
-        log_debug(LogOp, "num_blocks_act_h: {}", num_blocks_act_h);
-        log_debug(LogOp, "num_blocks_act_w: {}", num_blocks_act_w);
-        log_debug(LogOp, "num_blocks_weight_w: {}", num_blocks_weight_w);
-        log_debug(LogOp, "num_blocks_out_h: {}", num_blocks_out_h);
-        log_debug(LogOp, "act_block_h_ntiles: {}", act_block_h_ntiles);
-        log_debug(LogOp, "act_block_h_datums: {}", act_block_h_datums);
-        log_debug(LogOp, "act_block_w_ntiles: {}", act_block_w_ntiles);
-        log_debug(LogOp, "act_block_w_datums: {}", act_block_w_datums);
-        log_debug(LogOp, "out_block_h_ntiles: {}", out_block_h_ntiles);
-        log_debug(LogOp, "act_num_subblocks: {}", act_num_subblocks);
-        log_debug(LogOp, "act_block_num_tiles: {}", act_block_num_tiles);
-        log_debug(LogOp, "act_subblock_h_ntiles: {}", act_subblock_h_ntiles);
-        log_debug(LogOp, "act_subblock_num_tiles: {}", act_subblock_num_tiles);
-        log_debug(LogOp, "out_subblock_num_tiles: {}", out_subblock_num_tiles);
-        log_debug(LogOp, "weight_dram_addr: {}", weight_dram_addr);
-        log_debug(LogOp, "weight_num_subblocks: {}", weight_num_subblocks);
-        log_debug(LogOp, "weight_block_num_tiles: {}", weight_block_num_tiles);
-        log_debug(LogOp, "weight_block_w_ntiles: {}", weight_block_w_ntiles);
-        log_debug(LogOp, "weight_block_h_ntiles: {}", weight_block_h_ntiles);
-        log_debug(LogOp, "has_bias: {}", has_bias);
-        log_debug(LogOp, "bias_dram_addr: {}", bias_dram_addr);
-        log_debug(LogOp, "bias_ntiles: {}", bias_ntiles);
-        log_debug(LogOp, "out_subblock_h_ntiles: {}", out_subblock_h_ntiles);
-        log_debug(LogOp, "out_subblock_w_ntiles: {}", out_subblock_w_ntiles);
-        log_debug(LogOp, "out_subblock_num_tiles: {}", out_subblock_num_tiles);
-        log_debug(LogOp, "num_groups: {}", num_groups);
-        log_debug(LogOp, "math_fidelity: {}", math_fidelity);
-        log_debug(LogOp, "math_approx_mode: {}", math_approx_mode);
-        log_debug(LogOp, "fp32_dest_acc_en: {}", fp32_dest_acc_en);
-        log_debug(LogOp, "packer_l1_acc: {}", packer_l1_acc);
-    }
 
     uint32_t window_outer;
     uint32_t window_inner;
@@ -856,7 +398,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     }
 
     reader_defines["WINDOW_INNER"] = std::to_string(window_inner);
-    log_debug(LogOp, "window_outer: {}, window_inner: {}", window_outer, window_inner);
+    log_debug(tt::LogOp, "window_outer: {}, window_inner: {}", window_outer, window_inner);
 
     TT_FATAL(
         weight_matrix_width_ntiles % per_core_out_matrix_width_ntiles == 0,
@@ -897,7 +439,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             uint32_t num_cores_x_per_weight_slice_width = num_cores_x / num_weight_slices_width;
             uint32_t num_act_slices_height = act_matrix_height_ntiles / per_core_out_matrix_height_ntiles;
             total_num_cores_per_act_slice = num_cores_x * num_cores_y / num_act_slices_height;
-            log_debug(LogOp, "total_num_cores_per_act_slice: {}", total_num_cores_per_act_slice);
+            log_debug(tt::LogOp, "total_num_cores_per_act_slice: {}", total_num_cores_per_act_slice);
             total_num_cores_per_weight_slice = num_cores_x_per_weight_slice_width * num_cores_y;
         }
         TT_FATAL(
@@ -948,7 +490,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         TT_FATAL(num_cores_x == 1, "num_cores_x {} should be equal to 1", num_cores_x);
     }
     uint32_t act_block_h_datums_last_block =
-        (per_core_out_matrix_height_ntiles - (num_blocks_act_h_per_core - 1) * act_block_h_ntiles) * TILE_HEIGHT;
+        (per_core_out_matrix_height_ntiles - (num_blocks_act_h_per_core - 1) * act_block_h_ntiles) *
+        tt::constants::TILE_HEIGHT;
 
     std::vector<std::vector<uint16_t>> conv_sharded_input_top_left_indices =
         ttnn::operations::sliding_window::generate_sliding_window_op_config(
@@ -964,19 +507,12 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     // For 2d convs, each core in a column or row share the same specs
     CoreCoord grid_size = parallel_config.grid.bounding_box().grid_size();
 
-    bool is_block_sharded = a.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
-
     Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
         conv_sharded_input_top_left_indices, parallel_config);
     conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
-        conv_reader_indices_tensor, parallel_config, is_block_sharded, a.device());
+        conv_reader_indices_tensor, parallel_config, block_sharded, a.device());
 
-    const optimized_conv_op_utils::DeviceStorage& conv_reader_indices_storage =
-        conv_reader_indices_tensor.device_storage();
-
-    log_debug(LogOp, "total_num_cores_per_weight_slice: {}", total_num_cores_per_weight_slice);
-    log_debug(LogOp, "num_blocks_act_h_per_core: {}", num_blocks_act_h_per_core);
-    log_debug(LogOp, "num_blocks_out_h_per_core: {}", num_blocks_out_h_per_core);
+    const tt::tt_metal::DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
 
     TT_FATAL(act_matrix_height_ntiles % per_core_out_matrix_height_ntiles == 0, "Error");
     uint32_t total_active_num_cores_per_weight_slice = act_matrix_height_ntiles / per_core_out_matrix_height_ntiles;
@@ -1050,8 +586,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             mcast_sender_cores = CoreRange(top_left_core, CoreCoord(num_cores_x - 1, 0));
             mcast_receiver_cores = CoreRange(CoreCoord(0, 1), bottom_right_core);
         }
-        weights_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-        weights_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+        weights_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+        weights_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
     } else {
         // 1D mcast
         if (total_num_cores > 1) {
@@ -1071,63 +607,10 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                 }
             }
             mcast_receiver_cores = mcast_receiver_set;
-            weights_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-            weights_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            weights_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            weights_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
         }
     }
-
-    bool read_window_in_inner_loop = false;
-    uint32_t num_weight_cb_tiles = weight_block_h_ntiles * weight_block_w_ntiles / conv_act_c_blocks;
-    bool fully_buffer_weights = false;
-    uint32_t num_act_cb_tiles = act_block_h_ntiles * act_block_w_ntiles / conv_act_c_blocks;
-
-    if (block_sharded) {
-        num_act_cb_tiles = act_block_h_ntiles * act_block_w_ntiles;
-        num_weight_cb_tiles = weight_block_h_ntiles * weight_block_w_ntiles;
-    }
-    uint32_t num_act_cb_second_reader_tiles = 0;
-    // TODO: This flag should be set in kernel logic but need this for create_CB
-    if (weight_width_sliced) {
-        // If conv_act_c_blocks > 1 and we have 2D conv with sharded input, we always read entire filter_h x filter_w
-        // window before pushing in reader/writer
-        // TODO: Generalize this to not make this assumption
-        read_window_in_inner_loop = true;
-        if (!block_sharded) {
-            num_weight_cb_tiles *= filter_h * filter_w;
-            num_act_cb_tiles *= filter_h * filter_w;
-        }
-    } else if (num_blocks_act_h_per_core > 1) {
-        fully_buffer_weights = true;
-    }
-    uint32_t num_cb0_tilized_tiles = num_act_cb_tiles;
-
-    if (fully_buffer_weights) {
-        num_weight_cb_tiles *= window_outer;
-    } else if (enable_weights_double_buffer) {
-        num_weight_cb_tiles = num_weight_cb_tiles * 2;
-    }
-
-    if (enable_split_reader) {
-        if (enable_act_double_buffer) {
-            num_act_cb_tiles = act_block_num_tiles_split;
-            num_act_cb_second_reader_tiles = act_block_num_tiles_split_last;
-            num_act_cb_tiles = num_act_cb_tiles * 2;                              // double buffered
-            num_act_cb_second_reader_tiles = num_act_cb_second_reader_tiles * 2;  // double buffered
-        } else {
-            num_act_cb_tiles = act_block_num_tiles_split;
-            num_act_cb_second_reader_tiles = act_block_num_tiles_split_last;
-        }
-    } else {
-        if (enable_act_double_buffer) {
-            num_act_cb_tiles = num_act_cb_tiles * 2;
-        }
-    }
-    uint32_t out_block_h_ntiles_padded = num_blocks_act_h_per_core * act_block_h_ntiles;
-    uint32_t writer_output_block_num_tiles = out_block_h_ntiles_padded * weight_block_w_ntiles;
-    uint32_t output_block_num_tiles =
-        enable_subblock_padding ? (act_block_h_ntiles_padded * weight_block_w_ntiles) : writer_output_block_num_tiles;
-
-    uint32_t aligned_output_num_pages = writer_output_block_num_tiles;
 
     std::vector<uint32_t> reader_rt_args;
     std::vector<uint32_t> reader_compile_time_args;
@@ -1135,10 +618,11 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
 
     uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / conv_act_c_blocks;
     uint32_t act_block_w_extra_align_bytes =
-        block_sharded ? (round_up(a_shard_spec.shape[1] * filter_h * filter_w, TILE_WIDTH) -
+        block_sharded ? (tt::round_up(a_shard_spec.shape[1] * filter_h * filter_w, tt::constants::TILE_WIDTH) -
                          (a_shard_spec.shape[1] * filter_h * filter_w)) *
                             a.element_size()
-                      : (round_up(a_shard_spec.shape[1] * filter_w, TILE_WIDTH) - (a_shard_spec.shape[1] * filter_w)) *
+                      : (tt::round_up(a_shard_spec.shape[1] * filter_w, tt::constants::TILE_WIDTH) -
+                         (a_shard_spec.shape[1] * filter_w)) *
                             a.element_size();
     const uint32_t act_block_w_extra_align_scalars = act_block_w_extra_align_bytes / a.element_size();
     // When using block float format, we must handle cases where the data doesn't align to 16-scalar boundaries.
@@ -1146,7 +630,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     // we need to zero out the temporary circular buffers used during the tiling process.
     // Failing to do this could allow residual junk data in L1 memory to corrupt valid input data.
     const bool needs_act_block_zero_out =
-        act_block_w_extra_align_scalars % 16 != 0 && tt_metal::is_block_float(output.dtype());
+        act_block_w_extra_align_scalars % 16 != 0 && tt::tt_metal::is_block_float(output.dtype());
 
     uint32_t in0_block_w = act_block_w_ntiles / conv_act_c_blocks;
     uint32_t in0_block_num_tiles = act_block_num_tiles / conv_act_c_blocks;
@@ -1154,94 +638,57 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     uint32_t in0_num_blocks_w =
         num_blocks_act_w * conv_act_c_blocks;  // Fold outer c_block loop together with weight_block_num_tiles = 9
 
-    uint32_t tilized_act_tile_size = tt_metal::detail::TileSize(tilized_act_df);
+    const uint32_t tilized_act_tile_size = tt::tt_metal::detail::TileSize(tilized_act_df);
 
     // Only enable packer l1 accumulation when there are in0_num_blocks_w > 2, otherwise
     // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
     // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
     // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
-    bool packer_l1_acc_en = determine_packer_l1_acc(packer_l1_acc, has_bias, in0_num_blocks_w);
+    const bool packer_l1_acc_en = determine_packer_l1_acc(packer_l1_acc, has_bias, in0_num_blocks_w);
 
-    std::tuple<CBHandle, CBHandle, CBHandle> input_output_cbs = {0, 0, 0};
-    if (is_conv_1d_depthwise_conv) {
-        input_output_cbs = create_CBs_for_depthwise_sharded_input(
-            program,
-            a,
-            all_cores,
-            num_act_cb_tiles,               // row major act cb
-            num_weight_cb_tiles,            // tiled weight cb
-            num_cb0_tilized_tiles,          // tiled act cb
-            writer_output_block_num_tiles,  // math output cb
-            weight_block_w_ntiles,          // reblock cb
-            writer_output_block_num_tiles,  // writer output cb, double bufferred
-            untilize_out,
-            act_df,
-            weight_df,
-            tilized_act_df,
-            out_df,
-            bias_df,
-            weight_width_sliced,
-            output,
-            bias_ntiles_per_core,
-            has_bias,
-            enable_split_reader,
-            fp32_dest_acc_en,
-            packer_l1_acc_en,
-            cb_indices);
-    } else {
-        // TODO: Moving this function call to after kernel logic causes pcc fails
-        // There are additional CBs and semaphores created in 2D conv in kernel logic,
-        // so does order of create_cb calls matter?
-        input_output_cbs = create_CBs_for_sharded_input_v2(
-            program,
-            a,
-            all_cores,
-            num_act_cb_tiles,                // row major act cb
-            num_act_cb_second_reader_tiles,  // row major act cb second reader
-            num_weight_cb_tiles,             // tiled weight cb
-            num_cb0_tilized_tiles,           // tiled act cb
-            output_block_num_tiles,          // math output cb
-            weight_block_w_ntiles,           // reblock cb
-            writer_output_block_num_tiles,   // writer output cb, double bufferred
-            untilize_out,
-            act_df,
-            weight_df,
-            tilized_act_df,
-            out_df,
-            bias_df,
-            weight_width_sliced,
-            output,
-            bias_ntiles_per_core,
-            has_bias,
-            enable_split_reader,
-            fp32_dest_acc_en,
-            packer_l1_acc_en,
-            cb_indices);
-    }
-    CBHandle cb_sharded_act = std::get<0>(input_output_cbs);
-    CBHandle cb_output = std::get<1>(input_output_cbs);
-    CBHandle cb_matmul_partials = std::get<2>(input_output_cbs);
-    CircularBufferConfig cb_config_output = GetCircularBufferConfig(program, cb_output);
-    CircularBufferConfig cb_config_matmul_partials = GetCircularBufferConfig(program, cb_matmul_partials);
-    bool partials_cb_uses_output = false;
-    if (cb_config_matmul_partials.globally_allocated_address().has_value() &&
-        cb_config_output.globally_allocated_address().has_value()) {
-        partials_cb_uses_output = cb_config_matmul_partials.globally_allocated_address().value() ==
-                                  cb_config_output.globally_allocated_address().value();
-    }
+    Conv2dConfig conv_config = Conv2dConfig{
+        .dtype = output.dtype(),
+        .weights_dtype = b.dtype(),
+        .shard_layout = a.memory_config().memory_layout(),
+        .output_layout = (untilize_out ? Layout::ROW_MAJOR : Layout::TILE),
+        .enable_act_double_buffer = enable_act_double_buffer,
+        .enable_weights_double_buffer = enable_weights_double_buffer,
+        .enable_split_reader = enable_split_reader};
+    std::vector<CBInfo> cb_info = get_cb_info(
+        compute_kernel_config,
+        block_config,
+        p_config,
+        b.padded_shape(),
+        {filter_h, filter_w},
+        conv_config,
+        a.dtype(),
+        a.memory_config().shard_spec().value().shape,
+        has_bias,
+        is_conv_1d_depthwise_conv);
+
+    access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size = conv_sharded_input_top_left_indices[0].size();
+
+    // call function to allocate circular buffers
+    allocate_cbs(cb_info, program, all_cores, a, output, conv_reader_indices_tensor);
+
+    const tt::tt_metal::CBHandle cb_sharded_act = get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).handle;
+    const tt::tt_metal::CBHandle cb_output = get_cb_info_by_name(cb_info, Conv2dCb::OUT).handle;
+    const bool partials_cb_uses_output = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
+    log_debug(tt::LogOp, "partials_cb_uses_output: {}", partials_cb_uses_output);
+    const tt::tt_metal::CBHandle cb_partials = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).handle;
 
     string reader_kernel;
-    string compute_kernel;
+    string compute_kernel =
+        "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp";
     string writer_mcast_sender_kernel;
     string writer_mcast_receiver_kernel;
     bool tilize_in0 = true;
 
-    compute_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp";
     // Input should always be sharded in this conv; always use reader kernel for input shard with halo and padding
     if (filter_h >= 1 and filter_w >= 1) {
         if (!is_conv_1d_depthwise_conv and weight_width_sliced) {
             // Block sharded conv
-            TT_FATAL(read_window_in_inner_loop == true, "read_window_in_inner_loop should be true for this conv");
+            TT_FATAL(weight_width_sliced == true, "read_window_in_inner_loop should be true for this conv");
             reader_kernel =
                 "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
                 "reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp";
@@ -1251,8 +698,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             writer_mcast_receiver_kernel =
                 "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
                 "writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp";
-            act_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-            act_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            act_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            act_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
 
             if (transpose_mcast) {
                 act_mcast_noc_y.reserve(num_cores_y);
@@ -1271,7 +718,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             tilize_in0 = false;
         } else if (is_conv_1d_depthwise_conv) {
             // 1D Depthwise Conv (height sharded)
-            TT_FATAL(act_block_w_datums == round_up(conv_act_size_c * filter_w, TILE_WIDTH), "Error");
+            TT_FATAL(
+                act_block_w_datums == tt::round_up(conv_act_size_c * filter_w, tt::constants::TILE_WIDTH), "Error");
 
             compute_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp";
             reader_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp";
@@ -1284,7 +732,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
 
         } else {
             // Height sharded conv
-            TT_FATAL(act_block_w_datums == round_up(conv_act_size_c * filter_w, TILE_WIDTH), "Error");
+            TT_FATAL(
+                act_block_w_datums == tt::round_up(conv_act_size_c * filter_w, tt::constants::TILE_WIDTH), "Error");
 
             reader_kernel =
                 "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
@@ -1297,27 +746,11 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                 "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
                 "reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp";
         }
-        // Local L1 to store array for reader indices
-        // All convs use packed uint16 indices, so each entry can be 2B (not 4)
-        CBHandle cb_for_reader_indices_id = 0;
-        std::tie(cb_indices.cb_for_reader_indices, cb_for_reader_indices_id) = tt::tt_metal::create_cb(
-            cb_indices.get_next_cb_index(),
-            program,
-            all_cores,
-            conv_sharded_input_top_left_indices[0].size(),
-            1,
-            tt::DataFormat::Float16_b,
-            conv_reader_indices_storage.get_buffer());
-
-        // Local L1 to store temp vars
-        cb_indices.cb_for_l1_array = cb_indices.get_next_cb_index();
-        tt::tt_metal::create_cb(
-            cb_indices.cb_for_l1_array, program, all_cores, l1_scratchpad_CB_size, 1, tt::DataFormat::Float16_b);
     } else {
         TT_THROW("Sharded input not supported for this conv yet!");
     }
 
-    if (read_window_in_inner_loop) {
+    if (weight_width_sliced) {
         const uint32_t window_size = filter_h * filter_w;
         in0_block_w *= window_size;
         in0_block_num_tiles *= window_size;
@@ -1355,12 +788,13 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         (uint32_t)in0_block_num_tiles * tilized_act_tile_size,  // act_mcast_sender_size_bytes
         (uint32_t)(transpose_mcast ? 1 : 0),
         (uint32_t)needs_act_block_zero_out,  // zero_out_act_cb
-        (uint32_t)cb_indices.act_cb,
-        (uint32_t)cb_indices.sharded_act_cb,
-        (uint32_t)cb_indices.cb_for_reader_indices,
-        (uint32_t)cb_indices.tilize_mode_tilized_act_cb,
-        (uint32_t)cb_indices.act_cb_row_major_bfloat16,
-        (uint32_t)cb_indices.cb_for_l1_array};
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::L1_ARRAY).index,
+    };
 
     // define for bias
     std::map<string, string> writer_defines;
@@ -1401,16 +835,16 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     ttnn::operations::compute_throttle_utils::throttle_mm_perf(device->arch(), total_num_cores, compute_defines);
 
     for (auto elem : compute_defines) {
-        log_debug(LogOp, "compute_defines: {} = {}", elem.first, elem.second);
+        log_debug(tt::LogOp, "compute_defines: {} = {}", elem.first, elem.second);
     }
 
     writer_compile_time_args = {
-        cb_indices.weight_cb,
-        cb_indices.bias_cb,
+        get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
         (uint32_t)(bias_buffer == nullptr ? 0 : (bias_buffer->buffer_type() == BufferType::DRAM ? 1 : 0)),
-        cb_indices.act_cb_second_reader,
-        cb_indices.sharded_act_cb,
-        cb_indices.cb_for_reader_indices,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).index,
         num_blocks_act_w,
         in1_block_num_tiles,
         conv_act_c_blocks,
@@ -1470,20 +904,19 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
 
         bias_ntiles_per_core,
 
-        cb_indices.bias_cb,
-        cb_indices.act_cb,
-        cb_indices.weight_cb,
-        cb_indices.act_cb_row_major_bfloat16,
-        cb_indices.act_cb_second_reader,
-        cb_indices.matmul_partials_cb,
-        cb_indices.tilize_mode_tilized_act_cb,
+        get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
 
-        cb_indices.out0_cb,
-        cb_indices.temp_sum_cb,
+        get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::TEMP_SUM).index,
         partials_cb_uses_output};
 
     const tt::tt_metal::NOC writer_mcast_noc = tt::tt_metal::detail::GetPreferredNOCForDRAMRead(device->arch());
-    ;
     const tt::tt_metal::NOC reader_noc =
         writer_mcast_noc == tt::tt_metal::NOC::NOC_0 ? tt::tt_metal::NOC::NOC_1 : tt::tt_metal::NOC::NOC_0;
     auto writer_mcast_sender_id = CreateKernel(
@@ -1555,9 +988,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         }
 
         if (weight_width_sliced) {
-            auto shard_shape = a.shard_spec().value().shape;
-            uint32_t tilized_act_tile_size = tt_metal::detail::TileSize(tilized_act_df);
-
             bool reader_is_noc_0 = reader_noc == tt::tt_metal::NOC::NOC_0;
 
             if (transpose_mcast) {
@@ -1735,6 +1165,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
          writer_mcast_sender_id = writer_mcast_sender_id,
          cb_sharded_act = cb_sharded_act,
          cb_output = cb_output,
+         cb_partials = cb_partials,
+         partials_cb_uses_output = partials_cb_uses_output,
          has_bias = has_bias,
          conv_reader_indices_storage = conv_reader_indices_storage](
             const void* operation,
@@ -1748,7 +1180,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             auto src_buffer_a = input_tensors.at(0).buffer();
             auto src_buffer_b = input_tensors.at(1).buffer();
 
-            std::optional<tt_metal::Buffer*> src_buffer_c = std::nullopt;
+            std::optional<tt::tt_metal::Buffer*> src_buffer_c = std::nullopt;
             if (has_bias) {
                 src_buffer_c = optional_input_tensors.at(0).value().buffer();
                 TT_FATAL(src_buffer_c.value() != nullptr, "Error");
@@ -1765,6 +1197,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
 
             UpdateDynamicCircularBufferAddress(program, cb_sharded_act, *src_buffer_a);
             UpdateDynamicCircularBufferAddress(program, cb_output, *output_tensors.at(0).buffer());
+            if (partials_cb_uses_output) {
+                UpdateDynamicCircularBufferAddress(program, cb_partials, *output_tensors.at(0).buffer());
+            }
         };
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
@@ -1788,7 +1223,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     bool enable_weights_double_buffer,
     bool enable_split_reader,
     bool enable_subblock_padding) {
-    tt_metal::Program program = tt_metal::CreateProgram();
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     ttnn::operations::sliding_window::ParallelConfig parallel_config{
         .grid = a.shard_spec().value().grid,
@@ -1818,12 +1253,10 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             fused_activation,
             parallelization_config,
             block_config,
-            a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR,
             output,
             compute_kernel_config.value(),
             enable_act_double_buffer,
             enable_weights_double_buffer,
-            enable_split_reader,
             enable_subblock_padding);
     }
     return multi_core_optimized_conv_sharded_v2_impl(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include "tt-metalium/circular_buffer.hpp"
-#include "tt-metalium/circular_buffer_config.hpp"
-#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
@@ -17,16 +14,11 @@
 #include <tt-metalium/host_api.hpp>
 #include "ttnn/operations/compute_throttle_utils.hpp"
 
-using namespace tt::constants;
-
 namespace ttnn::operations::conv {
-
 namespace conv2d {
 
-using namespace tt;
-
 tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
-    tt_metal::Program& program,
+    tt::tt_metal::Program& program,
     const Tensor& a,
     const Tensor& b,
     const ttnn::Shape& ashape,
@@ -42,21 +34,12 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     const std::optional<unary::UnaryWithParam>& fused_activation,
     const OptimizedConvParallelizationConfig& parallelization_config,
     const OptimizedConvBlockConfig& block_config,
-    bool transpose_mcast,
     Tensor& output,
     DeviceComputeKernelConfig compute_kernel_config,
     bool enable_act_double_buffer,
     bool enable_weights_double_buffer,
-    bool enable_split_reader,
     bool enable_subblock_padding) {
-    using tt::tt_metal::CBHandle;
-    using tt::tt_metal::CircularBuffer;
-    using tt::tt_metal::CircularBufferConfig;
-
-    CBIndices cb_indices = CBIndices();
-    bool pass = true;
-    enable_split_reader = false;
-    tt_metal::IDevice* device = a.device();
+    tt::tt_metal::IDevice* device = a.device();
     TT_FATAL(a.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Conv activation should be in row major layout");
     TT_FATAL(a.memory_config().is_sharded(), "Conv activation must be sharded.");
     TT_FATAL(output_channels <= b.padded_shape()[3], "Invalid weight shape. Incorrect weight tensor.");
@@ -67,41 +50,16 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     uint32_t out_subblock_h_ntiles = block_config.out_subblock_h_ntiles;
     uint32_t out_subblock_w_ntiles = block_config.out_subblock_w_ntiles;
 
-    // out_subblock_h_ntiles = 8;
-
-    tt::DataFormat act_df = tt_metal::datatype_to_dataformat_converter(a.dtype());
-    tt::DataFormat weight_df = tt_metal::datatype_to_dataformat_converter(b.dtype());
-    tt::DataFormat out_df = tt_metal::datatype_to_dataformat_converter(output.dtype());
-    tt::DataFormat bias_df =
-        has_bias ? tt_metal::datatype_to_dataformat_converter(bias.value().dtype()) : tt::DataFormat::Float16_b;
-    tt::DataFormat tilized_act_df = out_df;
-
-    log_debug(LogOp, "act_df: {}", act_df);
-    log_debug(LogOp, "weight_df: {}", weight_df);
-    log_debug(LogOp, "out_df: {}", out_df);
-    log_debug(LogOp, "bias_df: {}", bias_df);
-    log_debug(LogOp, "tilized_act_df: {}", tilized_act_df);
+    const tt::DataFormat tilized_act_df = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
-    if (fp32_dest_acc_en and (out_subblock_h_ntiles * out_subblock_w_ntiles > 4)) {
-        if (out_subblock_w_ntiles >= 4) {
-            out_subblock_h_ntiles = 1;
-            out_subblock_w_ntiles = tt::tt_metal::find_max_block_size(out_subblock_w_ntiles, 4);
-        } else {
-            while (out_subblock_h_ntiles * out_subblock_w_ntiles > 4) {
-                uint32_t div = tt::tt_metal::find_max_divisor(out_subblock_h_ntiles, out_subblock_h_ntiles - 1);
-                out_subblock_h_ntiles = tt::tt_metal::find_max_block_size(out_subblock_h_ntiles, div);
-            }
-        }
-    }
     // it is bad for compute, pad act_block_h_ntiles
-    uint32_t max_num_subblock = fp32_dest_acc_en ? 4 : 8;
-    uint32_t max_subblock_h = fp32_dest_acc_en ? 4 : 8;
-    uint32_t act_block_h_ntiles_padded = act_block_h_ntiles;
     uint32_t out_subblock_h_ntiles_padded = out_subblock_h_ntiles;
     if (enable_subblock_padding) {
+        uint32_t max_num_subblock = fp32_dest_acc_en ? 4 : 8;
+        uint32_t max_subblock_h = fp32_dest_acc_en ? 4 : 8;
         TT_FATAL(
             act_block_h_ntiles == out_block_h_ntiles, "to pad subblock, the number of blocks on height dim must be 1");
 
@@ -123,11 +81,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
                 }
             }
             out_subblock_h_ntiles_padded = preferred_out_subblock_h;
-            act_block_h_ntiles_padded = out_subblock_h_ntiles_padded * num_subblock_h;
         }
     }
 
-    // TT_FATAL(out_block_h_ntiles == act_block_h_ntiles, "Error"); // TODO: fix output block sizing
     TT_FATAL(
         out_block_h_ntiles >= act_block_h_ntiles,
         "Output block height (in # of tiles) ({}) should be greater than or equal to activation block height (in # of "
@@ -141,15 +97,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     TT_FATAL(b.padded_shape()[1] == 1, "Conv weight matrix shape is invalid");
     uint32_t weight_matrix_height = b.padded_shape()[2];
     uint32_t weight_matrix_width = b.padded_shape()[3];
-    uint32_t weight_matrix_height_ntiles = weight_matrix_height / TILE_HEIGHT;
-    uint32_t weight_matrix_width_ntiles = weight_matrix_width / TILE_WIDTH;
+    uint32_t weight_matrix_width_ntiles = weight_matrix_width / tt::constants::TILE_WIDTH;
 
-    // Partitions conv inner dim into blocks to support sharding along this dim
-    // TODO: Only 2D convs with sharded input use this, but we can uplift to support generically
-    // TODO: Only updated variables which is affected, but there may be more that needs to account for this
-    // TODO: Loop naming in reader, writer, and compute kernels could also be cleaned up
-    // TODO: Can conv_act_c_blocks be same as num_blocks_act_w?
-    auto shard_shape = a.shard_spec().value().shape;
+    const auto shard_shape = a.shard_spec().value().shape;
 
     CoreRangeSet input_cores = a.memory_config().shard_spec().value().grid;
     CoreRangeSet output_cores = output.memory_config().shard_spec().value().grid;
@@ -165,35 +115,18 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     const auto& p_config = parallelization_config;
     uint32_t num_cores_x = p_config.grid_size.x;
     uint32_t num_cores_y = p_config.grid_size.y;
-    uint32_t per_core_out_matrix_height_ntiles = p_config.per_core_out_matrix_height_ntile;
     // weight_width_sliced determines is 1d-sysarr-conv or 2d-sysarr-conv
     bool weight_width_sliced = p_config.per_core_out_matrix_width_ntile < weight_matrix_width_ntiles;
-    // uint32_t conv_act_c_blocks = weight_matrix_width_ntiles / p_config.per_core_out_matrix_width_ntile;
     uint32_t input_channels_padded = shard_shape[1] * input_num_cores;
-    // TT_FATAL(conv_act_c_blocks == p_config.num_cores_c, "Error");
     TT_FATAL(input_channels_padded >= ashape[3], "Incorrect padding of input channels!");
     // check is for 16-byte alignment
     TT_FATAL(
         input_channels_padded % 16 == 0,
         "Expected input channels to be padded for 16 byte alignment in L1");  // TODO: For bfp16, check if its divisible
                                                                               // by 8 not 16.
-    // TODO: Expose option to split readers for 1D convs to python?
-    if (enable_split_reader) {
-        TT_FATAL(not weight_width_sliced, "split reader does not work with 2d conv");
-        TT_FATAL(
-            (act_block_h_ntiles / block_config.out_subblock_h_ntiles) >= 2,
-            "split reader needs to have at leaset two subblocks");
-    }
-    bool split_reader = enable_split_reader;
-    if (split_reader) {
-        TT_FATAL(
-            block_config.act_block_h_ntiles % block_config.out_subblock_h_ntiles == 0,
-            "Out_block_h must be divisible by out_subblock_h!");
-    }
 
     ttnn::Shape ashape_with_channels_padded({ashape[0], ashape[1], ashape[2], input_channels_padded});
 
-    uint32_t conv_act_size_h = ashape_with_channels_padded[1];
     uint32_t conv_act_size_w = ashape_with_channels_padded[2];
     uint32_t conv_act_size_c = ashape_with_channels_padded[3];
 
@@ -204,7 +137,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     uint32_t dilation_h = (uint32_t)sliding_window_config.dilation_hw.first;
     uint32_t dilation_w = (uint32_t)sliding_window_config.dilation_hw.second;
 
-    uint32_t pad_h = (uint32_t)sliding_window_config.get_pad_h();
     uint32_t pad_w = (uint32_t)sliding_window_config.get_pad_w();
 
     uint32_t input_size_w = conv_act_size_w + pad_w;
@@ -225,7 +157,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     uint32_t act_matrix_height = (uint32_t)act_matrix_shape[1];
     uint32_t act_matrix_width = (uint32_t)act_matrix_shape[2];
     uint32_t act_matrix_height_unpadded = (uint32_t)act_matrix_shape_unpadded[1];
-    uint32_t act_matrix_width_unpadded = (uint32_t)act_matrix_shape_unpadded[2];
 
     // TODO: Move all these TT_FATALs/checks to validate?
 
@@ -241,10 +172,14 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     TT_FATAL(act_matrix_width == weight_matrix_height, "The width of tensor a needs to match the height of tensor b");
 
     // Tile size divisibility checks
-    TT_FATAL(act_matrix_height % TILE_HEIGHT == 0, "Height of activation matrix needs to be divisible by 32");
-    TT_FATAL(act_matrix_width % TILE_WIDTH == 0, "Width of activation matrix needs to be divisible by 32");
-    TT_FATAL(weight_matrix_height % TILE_HEIGHT == 0, "Height of weight matrix needs to be divisible by 32");
-    TT_FATAL(weight_matrix_width % TILE_WIDTH == 0, "Width of weight matrix needs to be divisible by 32");
+    TT_FATAL(
+        act_matrix_height % tt::constants::TILE_HEIGHT == 0, "Height of activation matrix needs to be divisible by 32");
+    TT_FATAL(
+        act_matrix_width % tt::constants::TILE_WIDTH == 0, "Width of activation matrix needs to be divisible by 32");
+    TT_FATAL(
+        weight_matrix_height % tt::constants::TILE_HEIGHT == 0, "Height of weight matrix needs to be divisible by 32");
+    TT_FATAL(
+        weight_matrix_width % tt::constants::TILE_WIDTH == 0, "Width of weight matrix needs to be divisible by 32");
 
     // Device compatibility checks
     TT_FATAL(
@@ -259,8 +194,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     }
 
     // Convert tensor dims to tile dims
-    uint32_t act_matrix_height_ntiles = act_matrix_height / TILE_HEIGHT;
-    uint32_t act_matrix_width_ntiles = act_matrix_width / TILE_WIDTH;
+    uint32_t act_matrix_height_ntiles = act_matrix_height / tt::constants::TILE_HEIGHT;
+    uint32_t act_matrix_width_ntiles = act_matrix_width / tt::constants::TILE_WIDTH;
 
     TT_FATAL(
         act_matrix_height_ntiles % act_block_h_ntiles == 0,
@@ -284,7 +219,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         out_block_h_ntiles);
 
     uint32_t num_blocks_act_h = act_matrix_height_ntiles / act_block_h_ntiles;
-    uint32_t num_blocks_out_h = act_matrix_height_ntiles / out_block_h_ntiles;
     uint32_t num_blocks_act_w = act_matrix_width_ntiles / act_block_w_ntiles;
     uint32_t num_blocks_weight_w = weight_matrix_width_ntiles / weight_block_w_ntiles;
 
@@ -293,10 +227,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         "Number of Act Blocks along the Width {} should be divisible by the number of cores {}",
         num_blocks_act_w,
         input_num_cores);
-    bool packer_l1_acc_en = determine_packer_l1_acc(packer_l1_acc, has_bias, num_blocks_act_w);
-    tt::DataFormat interm0_df =
-        packer_l1_acc_en ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b) : out_df;
-    log_debug(LogOp, "interm0_df: {}", interm0_df);
 
     TT_FATAL(
         num_blocks_act_w % input_num_cores == 0,
@@ -306,41 +236,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     uint32_t per_core_num_blocks_act_w = num_blocks_act_w / input_num_cores;
 
     // act block info
-    uint32_t act_block_w_datums = act_matrix_width / num_blocks_act_w;
     uint32_t act_block_h_datums = act_matrix_height / num_blocks_act_h;
 
-    uint32_t act_block_h_nsubblocks = block_config.act_block_h_ntiles / block_config.out_subblock_h_ntiles;
-    uint32_t act_block_h_nsubblocks_split = act_block_h_nsubblocks;
-    uint32_t act_block_h_nsubblocks_split_last = 0;
-    if (split_reader) {
-        act_block_h_nsubblocks_split_last = act_block_h_nsubblocks / 2;
-        act_block_h_nsubblocks_split = act_block_h_nsubblocks - act_block_h_nsubblocks_split_last;
-    }
-    uint32_t act_block_h_datums_split = act_block_h_nsubblocks_split * out_subblock_h_ntiles * TILE_HEIGHT;
-    uint32_t act_block_h_datums_split_last = act_block_h_nsubblocks_split_last * out_subblock_h_ntiles * TILE_HEIGHT;
-
-    uint32_t act_block_num_tiles_split = act_block_h_nsubblocks_split * out_subblock_h_ntiles * act_block_w_ntiles;
-    uint32_t act_block_num_tiles_split_last =
-        act_block_h_nsubblocks_split_last * out_subblock_h_ntiles * act_block_w_ntiles;
-
-    log_debug(LogOp, "act_block_h_nsubblocks_split: {}", act_block_h_nsubblocks_split);
-    log_debug(LogOp, "act_block_h_nsubblocks_split_last: {}", act_block_h_nsubblocks_split_last);
-    log_debug(LogOp, "act_block_h_datums_split: {}", act_block_h_datums_split);
-    log_debug(LogOp, "act_block_h_datums_split_last: {}", act_block_h_datums_split_last);
-    log_debug(LogOp, "act_block_num_tiles_split: {}", act_block_num_tiles_split);
-    log_debug(LogOp, "act_block_num_tiles_split_last: {}", act_block_num_tiles_split_last);
-    log_debug(LogOp, "act_block_w_datums: {}", act_block_w_datums);
-    log_debug(LogOp, "conv_act_size_c: {}", conv_act_size_c);
-    log_debug(LogOp, "filter_h: {}", filter_h);
-    log_debug(LogOp, "filter_w: {}", filter_w);
-    log_debug(LogOp, "dilation_h: {}", dilation_h);
-    log_debug(LogOp, "dilation_w: {}", dilation_w);
-
-    // TT_FATAL(
-    //     (act_block_w_datums == round_up(conv_act_size_c * filter_w, TILE_WIDTH)) ||
-    //     ((act_block_w_datums <= conv_act_size_c)
-    //      && (conv_act_size_c % act_block_w_datums == 0)
-    //      ));
+    const uint32_t act_block_num_tiles = act_block_h_ntiles * act_block_w_ntiles;
 
     // weight block info
     uint32_t weight_block_w_datums = weight_matrix_width / num_blocks_weight_w;
@@ -350,25 +248,24 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         weight_block_w_ntiles,
         out_subblock_w_ntiles);
     uint32_t weight_num_subblocks = weight_block_w_ntiles / out_subblock_w_ntiles;
-    uint32_t weight_block_h_ntiles = act_block_w_ntiles;
-    uint32_t weight_block_num_tiles = weight_block_w_ntiles * weight_block_h_ntiles;
+    uint32_t weight_block_num_tiles = weight_block_w_ntiles * act_block_w_ntiles;
     uint32_t weight_block_in_channels_ntiles =
         input_channels_padded / (32 * input_num_cores * per_core_num_blocks_act_w);
     TT_FATAL(
-        input_channels_padded >= (TILE_HEIGHT * input_num_cores),
+        input_channels_padded >= (tt::constants::TILE_HEIGHT * input_num_cores),
         "input_channels_padded {} should be greater than or equal to TILE_HEIGHT * input_num_cores {}",
         input_channels_padded,
-        TILE_HEIGHT * input_num_cores);
+        tt::constants::TILE_HEIGHT * input_num_cores);
     TT_FATAL(
-        input_channels_padded % (TILE_HEIGHT * input_num_cores) == 0,
+        input_channels_padded % (tt::constants::TILE_HEIGHT * input_num_cores) == 0,
         "input_channels_padded {} should be divisible by TILE_HEIGHT * input_num_cores {}",
         input_channels_padded,
-        TILE_HEIGHT * input_num_cores);
+        tt::constants::TILE_HEIGHT * input_num_cores);
 
-    uint32_t num_groups = num_blocks_act_h * num_blocks_act_w * num_blocks_weight_w;
     // writer of conv op partially removes padding on the width
     // it removes the padding done for block width but it doesn't remove padding done for tiled width
-    uint32_t output_channels_padded_to_tile_width = round_up(output_channels, output_num_cores * TILE_WIDTH);
+    uint32_t output_channels_padded_to_tile_width =
+        tt::round_up(output_channels, output_num_cores * tt::constants::TILE_WIDTH);
     TT_FATAL(
         output_channels_padded_to_tile_width <= weight_matrix_width,
         "output_channels_padded_to_tile_width {} should be less than or equal to weight_matrix_width {}",
@@ -380,10 +277,10 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
                                            ? weight_block_w_datums
                                            : (output_channels_padded_to_tile_width % weight_block_w_datums);
     TT_FATAL(
-        last_block_width_datums % TILE_WIDTH == 0,
+        last_block_width_datums % tt::constants::TILE_WIDTH == 0,
         "last_block_width_datums {} should be divisible by TILE_WIDTH {}",
         last_block_width_datums,
-        TILE_WIDTH);
+        tt::constants::TILE_WIDTH);
 
     // sanity check
     TT_FATAL(
@@ -392,57 +289,33 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         num_blocks_output_w,
         num_blocks_weight_w);
 
-    uint32_t out_block_h_datums = out_block_h_ntiles * TILE_HEIGHT;
+    TT_FATAL(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
-    tt_metal::Buffer* src0_dram_buffer = a.buffer();
-    tt_metal::Buffer* src1_dram_buffer = b.buffer();
-
-    tt_metal::Buffer* dst_dram_buffer = output.buffer();
-    TT_FATAL(dst_dram_buffer != nullptr, "Output buffer should be allocated on device!");
-
-    // out
-    uint32_t out_dram_addr = dst_dram_buffer->address();
     uint32_t out_subblock_num_tiles = out_subblock_h_ntiles * out_subblock_w_ntiles;
     TT_FATAL(out_subblock_num_tiles <= 8, "Need to ensure that matmul partials fit in dst");
-
-    // act
-    uint32_t act_dram_addr = src0_dram_buffer->address();
 
     TT_FATAL(
         act_block_h_ntiles % out_subblock_h_ntiles == 0,
         "act_block_h_ntiles {} should be divisible by out_subblock_h_ntiles {}",
         act_block_h_ntiles,
         out_subblock_h_ntiles);
-    // TT_FATAL(out_block_h_ntiles % out_subblock_h_ntiles == 0, "Error");
     uint32_t act_num_subblocks = act_block_h_ntiles / out_subblock_h_ntiles;
-    uint32_t act_block_num_tiles = act_block_h_ntiles * act_block_w_ntiles;
     uint32_t act_subblock_h_ntiles = out_subblock_h_ntiles;
     uint32_t act_subblock_num_tiles = act_subblock_h_ntiles * act_block_w_ntiles;
 
-    // weight
-    uint32_t weight_dram_addr = src1_dram_buffer->address();
-
     // bias
-    tt_metal::Buffer* bias_buffer = nullptr;
-    uint32_t bias_dram_addr = 0;
+    tt::tt_metal::Buffer* bias_buffer = nullptr;
     uint32_t bias_ntiles = 0;
     bool bias_in_dram = true;
     if (has_bias) {
         bias_buffer = bias.value().buffer();
-        bias_dram_addr = bias_buffer->address();
         bias_ntiles = weight_block_w_ntiles;
         bias_in_dram = bias_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     }
 
-    uint32_t num_weight_slices_width = weight_matrix_width_ntiles / p_config.per_core_out_matrix_width_ntile;
     uint32_t num_blocks_act_h_per_core =
         (p_config.per_core_out_matrix_height_ntile + act_block_h_ntiles - 1) / act_block_h_ntiles;
     uint32_t num_blocks_weight_w_per_core = p_config.per_core_out_matrix_width_ntile / weight_block_w_ntiles;
-    uint32_t bias_ntiles_per_core = bias_ntiles / num_weight_slices_width;
-
-    auto output_shape = sliding_window_config.get_output_shape();
-    uint32_t conv_output_size_h = output_shape[1];
-    uint32_t conv_output_size_w = output_shape[2];
 
     std::map<string, string> reader_defines;
 
@@ -450,100 +323,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         reader_defines["ACT_BLOCK_HEIGHT_PADDING"] = "1";
     }
 
-    // if (conv_act_c_blocks > 1) {
-    //     reader_defines["ACT_W_OUTER_BLOCKS"] = "1";
-    // }
-
-    uint32_t output_height_padded_to_tile_height = round_up(act_matrix_height_unpadded, TILE_HEIGHT);
-    uint32_t output_height_num_tiles = output_height_padded_to_tile_height / TILE_HEIGHT;
-    TT_FATAL(
-        output_height_num_tiles <= act_matrix_height_ntiles,
-        "output_height_num_tiles {} should be less than or equal to act_matrix_height_ntiles {}",
-        output_height_num_tiles,
-        act_matrix_height_ntiles);
-
-    uint32_t src_dram_act_buffer_size_bytes = src0_dram_buffer->size();
-    uint32_t src_dram_weight_buffer_size_bytes = src1_dram_buffer->size();
-    uint32_t dst_l1_act_buffer_size_bytes =
-        out_block_h_ntiles * act_block_w_ntiles * tt::tt_metal::detail::TileSize(act_df);
-    uint32_t dst_l1_weight_buffer_size_bytes =
-        weight_block_h_ntiles * weight_block_w_ntiles * tt::tt_metal::detail::TileSize(weight_df);
-    // Number of bytes to be read from the channel dimension in one block.
     uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / (input_num_cores * per_core_num_blocks_act_w);
-
-    // log info for debugging opts
-    {
-        log_debug(LogOp, "input_channels_padded: {}", input_channels_padded);
-        log_debug(LogOp, "grid_size: {}", p_config.grid_size);
-        log_debug(LogOp, "packer_l1: {}", packer_l1_acc);
-        log_debug(LogOp, "split_reader: {}", split_reader);
-        log_debug(LogOp, "enable_act_double_buffer: {}", enable_act_double_buffer);
-        log_debug(LogOp, "enable block padding: {}", (per_core_out_matrix_height_ntiles % act_block_h_ntiles != 0));
-        log_debug(LogOp, "enable subblock padding: {}", enable_subblock_padding);
-        log_debug(LogOp, "per_core_out_matrix_height_ntiles: {}", per_core_out_matrix_height_ntiles);
-        log_debug(LogOp, "act_block_h_ntiles_padded: {}", act_block_h_ntiles_padded);
-        log_debug(LogOp, "act_block_w_ntiles: {}", act_block_w_ntiles);
-        log_debug(LogOp, "weight_block_w_ntiles: {}", weight_block_w_ntiles);
-        log_debug(LogOp, "out_subblock_h_ntiles_padded: {}", out_subblock_h_ntiles_padded);
-        log_debug(LogOp, "out_subblock_w_ntiles: {}", out_subblock_w_ntiles);
-        log_debug(LogOp, "num_blocks_weight_w_per_core: {}", num_blocks_weight_w_per_core);
-    }
-
-    // For debug
-    {
-        log_debug(LogOp, "OP Name : multi_core_optimized_conv_width_sharded_v2_");
-        log_debug(LogOp, "split readers: {}", split_reader);
-        log_debug(LogOp, "conv_act_size_h: {}", conv_act_size_h);
-        log_debug(LogOp, "conv_act_size_w: {}", conv_act_size_w);
-        log_debug(LogOp, "act_matrix_height: {}", act_matrix_height);
-        log_debug(LogOp, "act_matrix_width: {}", act_matrix_width);
-        log_debug(LogOp, "act_matrix_height_unpadded: {}", act_matrix_height_unpadded);
-        log_debug(LogOp, "act_matrix_width_unpadded: {}", act_matrix_width_unpadded);
-        log_debug(LogOp, "act_matrix_height_ntiles: {}", act_matrix_height_ntiles);
-        log_debug(LogOp, "act_matrix_width_ntiles: {}", act_matrix_width_ntiles);
-        log_debug(LogOp, "weight_matrix_width_ntiles: {}", weight_matrix_width_ntiles);
-        log_debug(LogOp, "per_core_out_matrix_height_ntiles: {}", p_config.per_core_out_matrix_height_ntile);
-        log_debug(LogOp, "per_core_out_matrix_width_ntiles: {}", p_config.per_core_out_matrix_width_ntile);
-        log_debug(LogOp, "per_core_num_blocks_act_w: {}", per_core_num_blocks_act_w);
-
-        log_debug(LogOp, "num_blocks_act_h: {}", num_blocks_act_h);
-        log_debug(LogOp, "num_blocks_act_w: {}", num_blocks_act_w);
-        log_debug(LogOp, "num_blocks_weight_w: {}", num_blocks_weight_w);
-        log_debug(LogOp, "num_blocks_out_h: {}", num_blocks_out_h);
-        log_debug(LogOp, "act_dram_addr: {}", act_dram_addr);
-
-        log_debug(LogOp, "conv_act_c_read_bytes: {}", conv_act_c_read_bytes);
-        log_debug(LogOp, "act_block_h_ntiles: {}", act_block_h_ntiles);
-        log_debug(LogOp, "act_block_h_datums: {}", act_block_h_datums);
-        log_debug(LogOp, "act_block_w_ntiles: {}", act_block_w_ntiles);
-        log_debug(LogOp, "act_block_w_datums: {}", act_block_w_datums);
-        log_debug(LogOp, "out_block_h_ntiles: {}", out_block_h_ntiles);
-        log_debug(LogOp, "act_num_subblocks: {}", act_num_subblocks);
-        log_debug(LogOp, "act_block_num_tiles: {}", act_block_num_tiles);
-        log_debug(LogOp, "act_subblock_h_ntiles: {}", act_subblock_h_ntiles);
-        log_debug(LogOp, "act_subblock_num_tiles: {}", act_subblock_num_tiles);
-        log_debug(LogOp, "out_subblock_num_tiles: {}", out_subblock_num_tiles);
-        log_debug(LogOp, "weight_dram_addr: {}", weight_dram_addr);
-        log_debug(LogOp, "weight_num_subblocks: {}", weight_num_subblocks);
-        log_debug(LogOp, "weight_block_num_tiles: {}", weight_block_num_tiles);
-        log_debug(LogOp, "weight_block_w_ntiles: {}", weight_block_w_ntiles);
-        log_debug(LogOp, "weight_block_h_ntiles: {}", weight_block_h_ntiles);
-        log_debug(LogOp, "weight_block_in_channels_ntiles: {}", weight_block_in_channels_ntiles);
-        log_debug(LogOp, "has_bias: {}", has_bias);
-        log_debug(LogOp, "bias_dram_addr: {}", bias_dram_addr);
-        log_debug(LogOp, "bias_ntiles: {}", bias_ntiles);
-        log_debug(LogOp, "out_dram_addr: {}", out_dram_addr);
-        log_debug(LogOp, "out_subblock_h_ntiles: {}", out_subblock_h_ntiles);
-        log_debug(LogOp, "out_subblock_w_ntiles: {}", out_subblock_w_ntiles);
-        log_debug(LogOp, "out_subblock_num_tiles: {}", out_subblock_num_tiles);
-        log_debug(LogOp, "num_groups: {}", num_groups);
-        log_debug(LogOp, "math_fidelity: {}", math_fidelity);
-        log_debug(LogOp, "math_approx_mode: {}", math_approx_mode);
-        log_debug(LogOp, "fp32_dest_acc_en: {}", fp32_dest_acc_en);
-        log_debug(LogOp, "packer_l1_acc: {}", packer_l1_acc);
-        log_debug(LogOp, "all_cores: {}", all_cores.str());
-        log_debug(LogOp, "all_reader_cores: {}", all_reader_cores.str());
-    }
 
     std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp";
@@ -557,8 +337,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     std::vector<uint32_t> compute_kernel_args;
     bool tilize_in0 = false;
 
-    uint32_t act_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, 0);    // 0==INVALID
-    uint32_t act_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, 0);  // 0==INVALID.
+    uint32_t act_mcast_sender_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, 0);    // 0==INVALID
+    uint32_t act_mcast_receiver_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, 0);  // 0==INVALID.
 
     CoreCoord act_mcast_start_core_logical(0, 0);
     CoreCoord act_mcast_end_core_logical(all_cores.bounding_box().end_coord.x, all_cores.bounding_box().end_coord.y);
@@ -590,11 +370,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         }
     }
 
-    if (split_reader) {
-        reader_defines["SPLIT_READER"] = "1";
-        compute_defines["SPLIT_READER"] = "1";
-    }
-
     if (packer_l1_acc) {
         compute_defines["PACKER_L1_ACC"] = "1";
     }
@@ -604,174 +379,49 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     ttnn::operations::compute_throttle_utils::throttle_mm_perf(device->arch(), all_cores.num_cores(), compute_defines);
 
     for (auto elem : compute_defines) {
-        log_debug(LogOp, "compute_defines: {} = {}", elem.first, elem.second);
+        log_debug(tt::LogOp, "compute_defines: {} = {}", elem.first, elem.second);
     }
 
-    uint32_t num_output_tiles = per_core_out_matrix_height_ntiles * p_config.per_core_out_matrix_width_ntile;
-    uint32_t act_tile_size = tt_metal::detail::TileSize(act_df);
-    uint32_t tilized_act_tile_size = tt_metal::detail::TileSize(tilized_act_df);
-    uint32_t weight_tile_size = tt_metal::detail::TileSize(weight_df);
-
-    // Local L1 to store temp vars
-    // Used for act_mcast_sender_semaphore_valid_addr_ptr
-    cb_indices.cb_for_l1_array = cb_indices.get_next_cb_index();
-    tt::tt_metal::create_cb(
-        cb_indices.cb_for_l1_array, program, all_cores, l1_scratchpad_CB_size, 1, tt::DataFormat::Float16_b);
-    log_debug(LogOp, "CB for L1 Array CB: {}, npages: {}, pagesize: {}", cb_indices.cb_for_l1_array, 1, 32 * 2);
-
-    cb_indices.sharded_act_cb = cb_indices.get_next_cb_index();
-    auto [_, cb_input] = tt::tt_metal::create_cb(
-        cb_indices.sharded_act_cb,
-        program,
-        all_cores,
-        shard_shape[1] * datum_size(act_df),
-        shard_shape[0],
-        act_df,
-        a.buffer());
-
-    cb_indices.act_cb = cb_indices.get_next_cb_index();
-    const uint32_t act_cb_num_tiles =
-        enable_act_double_buffer ? act_block_num_tiles_split * 2 : act_block_num_tiles_split;
-    tt::tt_metal::create_cb(
-        cb_indices.act_cb, program, all_cores, tilized_act_tile_size, act_cb_num_tiles, tilized_act_df);
-    log_debug(
-        LogOp, "Act CB: {}, npages: {}, pagesize: {}", cb_indices.act_cb, act_cb_num_tiles, tilized_act_tile_size);
-
-    // Used for placing tilized activations
-    cb_indices.tilize_mode_tilized_act_cb = cb_indices.get_next_cb_index();
-    tt::tt_metal::create_cb(
-        cb_indices.tilize_mode_tilized_act_cb,
-        program,
-        all_cores,
-        tilized_act_tile_size,
-        act_block_num_tiles_split,
-        tilized_act_df);
-
-    log_debug(
-        LogOp,
-        "Tilized Act CB: {}, npages: {}, pagesize: {}",
-        cb_indices.tilize_mode_tilized_act_cb,
-        act_block_num_tiles,
-        tilized_act_tile_size);
-
-    cb_indices.weight_cb = cb_indices.get_next_cb_index();
-    const uint32_t weights_cb_num_tiles =
-        enable_weights_double_buffer ? weight_block_num_tiles * 2 : weight_block_num_tiles;
-    tt::tt_metal::create_cb(
-        cb_indices.weight_cb, program, all_cores, weight_tile_size, weights_cb_num_tiles, weight_df);
-    log_debug(
-        LogOp,
-        "Weight CB: {}, npages: {}, pagesize: {}, ",
-        cb_indices.weight_cb,
-        weights_cb_num_tiles,
-        weight_tile_size);
-
-    cb_indices.act_cb_row_major_bfloat16 = cb_indices.get_next_cb_index();
-    tt::tt_metal::create_cb(
-        cb_indices.act_cb_row_major_bfloat16, program, all_cores, act_tile_size, 2 * act_block_w_ntiles, act_df);
-    log_debug(
-        LogOp,
-        "Act Row Major CB: {}, npages: {}, pagesize: {}",
-        cb_indices.act_cb_row_major_bfloat16,
-        2 * act_block_w_ntiles,
-        act_tile_size);
+    Conv2dConfig conv_config = Conv2dConfig{
+        .dtype = output.dtype(),
+        .weights_dtype = b.dtype(),
+        .shard_layout = a.memory_config().memory_layout(),
+        .output_layout = (untilize_out ? Layout::ROW_MAJOR : Layout::TILE),
+        .enable_act_double_buffer = enable_act_double_buffer,
+        .enable_weights_double_buffer = enable_weights_double_buffer};
+    std::vector<CBInfo> cb_info = get_cb_info(
+        compute_kernel_config,
+        block_config,
+        p_config,
+        b.padded_shape(),
+        {filter_h, filter_w},
+        conv_config,
+        a.dtype(),
+        a.memory_config().shard_spec().value().shape,
+        has_bias,
+        false);
 
     std::vector<std::vector<uint16_t>> conv_sharded_input_top_left_indices =
         ttnn::operations::sliding_window::generate_sliding_window_op_config(
             op_trace_metadata, shard_boundaries, stride_w, true, act_block_h_datums, 0);
 
     // create sharded ttnn config tensors
-    optimized_conv_op_utils::DataType indices_tt_dtype = optimized_conv_op_utils::DataType::UINT16;
-    // For 2d convs, each core in a column or row share the same specs
-    CoreCoord grid_size = parallel_config.grid.bounding_box().grid_size();
-
-    bool is_block_sharded =
-        a.memory_config().memory_layout() == optimized_conv_op_utils::TensorMemoryLayout::BLOCK_SHARDED;
+    tt::tt_metal::DataType indices_tt_dtype = tt::tt_metal::DataType::UINT16;
     Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
         conv_sharded_input_top_left_indices, parallel_config);
     conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
-        conv_reader_indices_tensor, parallel_config, is_block_sharded, a.device());
+        conv_reader_indices_tensor, parallel_config, false, a.device());
 
-    const optimized_conv_op_utils::DeviceStorage& conv_reader_indices_storage =
-        conv_reader_indices_tensor.device_storage();
+    const tt::tt_metal::DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
 
-    cb_indices.cb_for_reader_indices = cb_indices.get_next_cb_index();
-    tt::tt_metal::create_cb(
-        cb_indices.cb_for_reader_indices,
-        program,
-        all_cores,
-        conv_sharded_input_top_left_indices[0].size(),
-        1,
-        tt::DataFormat::Float16_b,
-        conv_reader_indices_storage.get_buffer());
+    access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size = conv_sharded_input_top_left_indices[0].size();
 
-    if (has_bias) {
-        uint32_t bias_tile_size = tt_metal::detail::TileSize(bias_df);
-        // bias input
-        uint32_t bias_pagesize = bias_tile_size;
-        cb_indices.bias_cb = cb_indices.get_next_cb_index();
-        tt::tt_metal::create_cb(cb_indices.bias_cb, program, all_cores, bias_pagesize, bias_ntiles, bias_df);
-        log_debug(LogOp, "Bias CB: {}, npages: {}, pagesize: {}", cb_indices.bias_cb, bias_ntiles, bias_pagesize);
-    }
-
-    uint32_t out_tile_size = tt_metal::detail::TileSize(out_df);
-    uint32_t interm0_single_tile_size = tt_metal::detail::TileSize(interm0_df);
-
-    cb_indices.matmul_partials_cb = cb_indices.get_next_cb_index();
-    // Share buffer if same data format
-    CBHandle cb_output = 0;
-    CBHandle cb_matmul_partials = 0;
-    if (!untilize_out && interm0_df == out_df) {
-        cb_indices.out0_cb = cb_indices.get_next_cb_index();
-        auto cb_tuple = tt::tt_metal::create_cb(
-            {cb_indices.matmul_partials_cb, cb_indices.out0_cb},
-            program,
-            all_cores,
-            out_tile_size,
-            num_output_tiles,
-            out_df,
-            output.is_sharded() ? output.buffer() : nullptr);
-
-        cb_output = cb_matmul_partials = std::get<1>(cb_tuple);
-
-        if (!output.is_sharded()) {
-            log_debug(
-                LogOp,
-                "Matmul Partials CB: {}, npages: {}, pagesize: {}",
-                cb_indices.matmul_partials_cb,
-                num_output_tiles,
-                out_tile_size);
-        }
-    } else {
-        // Separate buffer if not same data format
-        std::tie(cb_indices.matmul_partials_cb, cb_matmul_partials) = tt::tt_metal::create_cb(
-            cb_indices.matmul_partials_cb, program, all_cores, interm0_single_tile_size, num_output_tiles, interm0_df);
-        log_debug(
-            LogOp,
-            "Matmul Partials CB: {}, npages: {}, pagesize: {}",
-            cb_indices.matmul_partials_cb,
-            num_output_tiles,
-            interm0_single_tile_size);
-
-        std::tie(cb_indices.out0_cb, cb_output) = tt::tt_metal::create_cb(
-            cb_indices.get_next_cb_index(),
-            program,
-            all_cores,
-            out_tile_size,
-            num_output_tiles,
-            out_df,
-            output.is_sharded() ? output.buffer() : nullptr);
-    }
-
-    CircularBufferConfig cb_config_output = GetCircularBufferConfig(program, cb_output);
-    CircularBufferConfig cb_config_matmul_partials = GetCircularBufferConfig(program, cb_matmul_partials);
-
-    bool partials_cb_uses_output = false;
-    if (cb_config_matmul_partials.globally_allocated_address().has_value() &&
-        cb_config_output.globally_allocated_address().has_value()) {
-        partials_cb_uses_output = cb_config_matmul_partials.globally_allocated_address().value() ==
-                                  cb_config_output.globally_allocated_address().value();
-    }
+    // call function to allocate circular buffers
+    allocate_cbs(cb_info, program, all_reader_cores, a, output, conv_reader_indices_tensor);
+    const tt::tt_metal::CBHandle cb_sharded_act = get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).handle;
+    const tt::tt_metal::CBHandle cb_output = get_cb_info_by_name(cb_info, Conv2dCb::OUT).handle;
+    const bool partials_cb_uses_output = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
+    const tt::tt_metal::CBHandle cb_partials = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).handle;
 
     compute_kernel_args = {
         act_block_w_ntiles,      // in0_block_w
@@ -796,15 +446,15 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         untilize_out,  // untilize_out
 
         bias_ntiles,
-        cb_indices.bias_cb,
+        get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
 
-        cb_indices.act_cb,
-        cb_indices.weight_cb,
-        cb_indices.act_cb_row_major_bfloat16,
-        cb_indices.act_cb_second_reader,
-        cb_indices.matmul_partials_cb,
-        cb_indices.tilize_mode_tilized_act_cb,
-        cb_indices.out0_cb,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,
         0,
         partials_cb_uses_output,
         input_num_cores,  // in0_nblocks_w_tilize. Repeat tilize after all cores have done one round of MCAST.
@@ -830,18 +480,18 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         (uint32_t)act_mcast_start.y,
         (uint32_t)act_mcast_end.x,
         (uint32_t)act_mcast_end.y,
-        (uint32_t)act_block_num_tiles * tt_metal::detail::TileSize(tilized_act_df),
+        (uint32_t)act_block_num_tiles * tt::tt_metal::detail::TileSize(tilized_act_df),
         (uint32_t)output_num_cores,
         (uint32_t)all_reader_cores.size(),
-        (uint32_t)cb_indices.act_cb,
-        (uint32_t)cb_indices.sharded_act_cb,
-        (uint32_t)cb_indices.cb_for_reader_indices,
-        (uint32_t)cb_indices.cb_for_l1_array,
-        (uint32_t)cb_indices.act_cb_row_major_bfloat16,
-        (uint32_t)cb_indices.tilize_mode_tilized_act_cb};
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::L1_ARRAY).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index};
 
     weights_kernel_compile_args = {
-        cb_indices.weight_cb,                                           // cb_id_weight
+        get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,          // cb_id_weight
         act_block_w_ntiles / (filter_h * filter_w),                     // core_in_channels_ntiles
         filter_h * filter_w,                                            // window_size_hw
         weight_block_w_ntiles,                                          // weight_block_width_ntiles
@@ -854,7 +504,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         input_num_cores,            // other_core_weight_height_blocks
         per_core_num_blocks_act_w,  // this_core_weight_height_blocks
         num_blocks_act_h_per_core,
-        cb_indices.bias_cb,
+        get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
         bias_in_dram};
 
     auto act_kernel_id = CreateKernel(
@@ -935,8 +585,10 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     }
 
     auto override_runtime_arguments_callback =
-        [cb_input,
+        [cb_sharded_act,
          cb_output,
+         cb_partials,
+         partials_cb_uses_output,
          has_bias,
          full_core_grid,
          weights_kernel_id,
@@ -947,12 +599,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<Tensor>& output_tensors) {
-            bool src_a_is_sharded = input_tensors[0].is_sharded();
-            bool out_sharded = output_tensors[0].is_sharded();
-
             auto src_buffer_a = input_tensors.at(0).buffer();
             auto src_buffer_b = input_tensors.at(1).buffer();
-            auto dst_buffer = output_tensors.at(0).buffer();
 
             auto& weights_kernel_runtime_args = GetRuntimeArgs(program, weights_kernel_id);
             for (uint32_t core_index = 0; core_index < total_num_active_cores; core_index++) {
@@ -966,12 +614,10 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
                 }
             }
 
-            if (src_a_is_sharded) {
-                UpdateDynamicCircularBufferAddress(program, cb_input, *src_buffer_a);
-            }
-
-            if (out_sharded) {
-                UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+            UpdateDynamicCircularBufferAddress(program, cb_sharded_act, *src_buffer_a);
+            UpdateDynamicCircularBufferAddress(program, cb_output, *output_tensors.at(0).buffer());
+            if (partials_cb_uses_output) {
+                UpdateDynamicCircularBufferAddress(program, cb_partials, *output_tensors.at(0).buffer());
             }
         };
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};


### PR DESCRIPTION
Instead of having two separate paths for calculating size of each CB,
one in conv2d_utils and other in conv2d factories, make one common code that
figures out size of each CB and one generic function for allocating those CBs in a program.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15744005272)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15744030078)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15744015325)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/15744034950)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15744020127)
- [x] [(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/15744009428)