### PR TITLE
Remove Exact L1 and CB Usage Counts from get_op_constraint Tests

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -212,8 +212,9 @@ TEST_P(EltwiseUnaryOpIfTest, UnaryRelu) {
             ttnn::relu, device, input_spec, output_spec.tensor_layout().get_memory_config());
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
-        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 0);
-        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 0);
+        // Ensure some real usage is reported
+        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 1024);
+        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 1024);
         ASSERT_TRUE(query.output_tensor_spec.has_value());
         EXPECT_EQ(query.output_tensor_spec.value(), input_spec);
     }
@@ -265,9 +266,10 @@ TEST_P(SoftmaxOpIfTest, Softmax) {
             ttnn::softmax, device, input_spec, dim_arg, output_spec.tensor_layout().get_memory_config());
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
-        EXPECT_GT(query.resource_usage.cb_peak_size_per_core, 0);
-        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 0);
-        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 0);
+        // Ensure some real usage is reported
+        EXPECT_GT(query.resource_usage.cb_peak_size_per_core, 1024);
+        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 1024);
+        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 1024);
         EXPECT_EQ(query.output_tensor_spec.value(), input_spec);
     }
 }
@@ -330,8 +332,9 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryAdd) {
             false);
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
-        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 0);
-        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 0);
+        // Ensure some real usage is reported
+        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 1024);
+        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 1024);
     }
 }
 
@@ -437,9 +440,10 @@ TEST_P(MatmulOpIfTest, Matmul) {
             tt::LogTest, "query status = {}, error_message = {}", query.status, query.error_message.value_or("none"));
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
-        EXPECT_GT(query.resource_usage.cb_peak_size_per_core, 0);
-        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 0);
-        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 0);
+        // Ensure some real usage is reported
+        EXPECT_GT(query.resource_usage.cb_peak_size_per_core, 1024);
+        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 1024);
+        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 1024);
         ASSERT_TRUE(query.output_tensor_spec.has_value());
         EXPECT_EQ(query.output_tensor_spec.value(), output_spec);
     }
@@ -544,8 +548,9 @@ TEST_F(Conv2dOpIfTest, Conv2d) {
             output_spec.tensor_layout().get_memory_config());
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
-        EXPECT_GT(query.resource_usage.cb_peak_size_per_core, 0);
-        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 0);
+        // Ensure some real usage is reported
+        EXPECT_GT(query.resource_usage.cb_peak_size_per_core, 10000);
+        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 10000);
         ASSERT_TRUE(query.output_tensor_spec.has_value());
         EXPECT_EQ(query.output_tensor_spec.value(), output_spec);
     }

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -330,7 +330,6 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryAdd) {
             false);
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
-        EXPECT_GT(query.resource_usage.cb_peak_size_per_core, 0);
         EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 0);
         EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 0);
     }

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -212,7 +212,6 @@ TEST_P(EltwiseUnaryOpIfTest, UnaryRelu) {
             ttnn::relu, device, input_spec, output_spec.tensor_layout().get_memory_config());
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
-        EXPECT_GT(query.resource_usage.cb_peak_size_per_core, 0);
         EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 0);
         EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 0);
         ASSERT_TRUE(query.output_tensor_spec.has_value());


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`get_op_constraints()` tests hardcode the exact expected L1/CB usage. This is a problem for ops under active development as they have to constantly update these tests when they change the op, reducing development velocity

### What's changed
Instead of hardcoding the L1 and CB usage, just check the query status and verify the returned numbers are nonzero (have been set by the query). This is still acceptable validation and unblocks the ops teams from having to update the tests

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes