### PR TITLE
Add Shallow UNet support for BH P150a target 

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -69,5 +69,5 @@ def test_unet_model(batch, groups, device, reset_seeds):
         device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 110
         and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 130
     ):
-        pytest.skip(f"Shallow UNet only support 110 cores on BH (was {device.compute_with_storage_grid_size()})")
+        pytest.skip(f"Shallow UNet only support 110 or 130 cores on BH (was {device.compute_with_storage_grid_size()})")
     run_unet_model(batch, groups, device)

--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -65,9 +65,9 @@ def run_unet_model(batch, groups, device, iterations=1):
 @pytest.mark.parametrize("groups", [4])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": UNET_L1_SMALL_REGION_SIZE}], indirect=True)
 def test_unet_model(batch, groups, device, reset_seeds):
-    if (
-        not is_wormhole_b0(device)
-        and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 110
+    if not is_wormhole_b0(device) and (
+        device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 110
+        and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 130
     ):
         pytest.skip(f"Shallow UNet only support 110 cores on BH (was {device.compute_with_storage_grid_size()})")
     run_unet_model(batch, groups, device)

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -28,6 +28,7 @@ def test_unet_model(batch, groups, device, iterations, reset_seeds):
     if (
         not is_wormhole_b0(device)
         and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 110
+        and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 130
     ):
         pytest.skip(f"Shallow UNet only support 110 cores on BH (was {device.compute_with_storage_grid_size()})")
     device.disable_and_clear_program_cache()  # Needed to give consistent device perf between iterations
@@ -92,8 +93,9 @@ def test_unet_trace_perf(
     if (
         not is_wormhole_b0(device)
         and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 110
+        and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 130
     ):
-        pytest.skip(f"shallow unet only support 110 cores on bh (was {device.compute_with_storage_grid_size()})")
+        pytest.skip(f"Shallow UNet only support 110 cores on BH (was {device.compute_with_storage_grid_size()})")
 
     from models.experimental.functional_unet.tests.test_unet_trace import (
         test_unet_trace_2cq,

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -30,7 +30,7 @@ def test_unet_model(batch, groups, device, iterations, reset_seeds):
         and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 110
         and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 130
     ):
-        pytest.skip(f"Shallow UNet only support 110 cores on BH (was {device.compute_with_storage_grid_size()})")
+        pytest.skip(f"Shallow UNet only support 110 or 130 cores on BH (was {device.compute_with_storage_grid_size()})")
     device.disable_and_clear_program_cache()  # Needed to give consistent device perf between iterations
     run_unet_model(batch, groups, device, iterations)
 
@@ -95,7 +95,7 @@ def test_unet_trace_perf(
         and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 110
         and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 130
     ):
-        pytest.skip(f"Shallow UNet only support 110 cores on BH (was {device.compute_with_storage_grid_size()})")
+        pytest.skip(f"Shallow UNet only support 110 or 130 cores on BH (was {device.compute_with_storage_grid_size()})")
 
     from models.experimental.functional_unet.tests.test_unet_trace import (
         test_unet_trace_2cq,

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -49,11 +49,14 @@ def get_core_grid_from_num_cores(num_cores: int, grid_rows: int, grid_cols: int)
 
 
 def is_valid_device_for_unet(device):
-    """Check that each device is an 8x8 grid."""
+    """Check that each device is an 8x8/11x10/13x10 grid."""
     return (
         device.core_grid.x == 8 and device.core_grid.y == 8
         if is_wormhole_b0(device)
-        else device.core_grid.x >= 11 and device.core_grid.y >= 10
+        else (
+            (device.core_grid.x == 13 and device.core_grid.y == 10)
+            or (device.core_grid.x == 11 and device.core_grid.y == 10)
+        )
     )
 
 
@@ -185,7 +188,7 @@ class UNetConv2D:
         if override_core_grid is not None:
             self.conv_config.core_grid = get_core_grid_from_num_cores(
                 override_core_grid,
-                grid_rows=8 if is_wormhole_b0(self.device) else 11,
+                grid_rows=8 if is_wormhole_b0(self.device) else 13,
                 grid_cols=8 if is_wormhole_b0(self.device) else 10,
             )
             self.conv_config.override_sharding_config = True
@@ -339,11 +342,11 @@ class UNetUpblock:
         x = ttnn.reshape(x, (self.batch_size, self.input_height // 2, self.input_width // 2, x.shape[-1]))
         nhw = x.shape[0] * x.shape[1] * x.shape[2]
         num_cores = determine_num_cores_for_upsample(
-            nhw, x.shape[2], max_cores=64 if is_wormhole_b0(self.device) else 110
+            nhw, x.shape[2], max_cores=64 if is_wormhole_b0(self.device) else 130
         )
         core_grid = get_core_grid_from_num_cores(
             num_cores,
-            grid_rows=8 if is_wormhole_b0(self.device) else 11,
+            grid_rows=8 if is_wormhole_b0(self.device) else 13,
             grid_cols=8 if is_wormhole_b0(self.device) else 10,
         )
         shardspec = ttnn.create_sharded_memory_config_(
@@ -372,7 +375,7 @@ class UNetUpblock:
         if not residual_rm.is_sharded():
             core_grid = get_core_grid_from_num_cores(
                 x_upsampled.memory_config().shard_spec.num_cores(),
-                grid_rows=8 if is_wormhole_b0(self.device) else 11,
+                grid_rows=8 if is_wormhole_b0(self.device) else 13,
                 grid_cols=8 if is_wormhole_b0(self.device) else 10,
             )
             mem_cfg = ttnn.create_sharded_memory_config_(

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -143,7 +143,7 @@ class UNetConv2D:
         override_core_grid=None,
         mesh_mapper=None,
     ):
-        assert is_valid_device_for_unet(device), "UNet Shallow requires an 8x8 grid on all devices"
+        assert is_valid_device_for_unet(device), "UNet Shallow requires an 8x8 grid on WH or 10x13/10x11 on BH"
 
         self.device = device
         self.batch_size = conv.batch_size

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
@@ -19,6 +19,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_chw(
     const auto input_cores = corerange_to_cores(
         input_core_grid, std::nullopt, a.shard_spec()->orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
 
+    const auto output_shard_shape = output.shard_spec()->shape;
+
     const auto HW = input_shape[2];
     const auto C = input_shape[3];
 
@@ -67,8 +69,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_chw(
     const tt::DataFormat output_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     const uint32_t cb_out_id = tt::CBIndex::c_1;
     const uint32_t element_size = tt::datum_size(output_format);
-    const uint32_t cb_out_total_size = tt::div_up(C * HW * element_size, input_cores.size());
-    const uint32_t cb_out_page_size = tt::div_up(HW * element_size, input_cores.size());
+    const uint32_t cb_out_total_size = output_shard_shape[0] * output_shard_shape[1] * element_size;
+    const uint32_t cb_out_page_size = output_shard_shape[1] * element_size;
     const auto cb_out =
         create_circular_buffer(cb_out_id, cb_out_total_size, cb_out_page_size, output_format, output.buffer());
 


### PR DESCRIPTION
### Summary
Add Shallow UNet support for P150a card. To make this work, this change fixes a small issue when creating CBs in `ttnn.convert_to_chw`.

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/15910464676, https://github.com/tenstorrent/tt-metal/actions/runs/15910512698
- [x] Blackhole demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/15910503716