### PR TITLE
Assert that pcc is not 1

### DIFF
--- a/tests/sweep_framework/sweep_utils/conv2d_common.py
+++ b/tests/sweep_framework/sweep_utils/conv2d_common.py
@@ -9,7 +9,12 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import (
+    check_with_pcc,
+    check_with_pcc_without_tensor_printout,
+    start_measuring_time,
+    stop_measuring_time,
+)
 from models.utility_functions import torch_random
 
 # Override the default timeout in seconds for hang detection.
@@ -319,7 +324,7 @@ def run_conv2d_short_sweep(
 
     torch_output_tensor = torch.permute(torch_output_tensor, (0, 3, 1, 2))
 
-    return [check_with_pcc(torch_output_tensor, torch_out_golden_tensor, pcc=0.985), e2e_perf]
+    return [check_with_pcc_without_tensor_printout(torch_output_tensor, torch_out_golden_tensor, pcc=0.985), e2e_perf]
 
 
 def run_conv1d_short_sweep(
@@ -393,4 +398,4 @@ def run_conv1d_short_sweep(
 
     torch_output_tensor = torch.permute(torch_output_tensor, (0, 2, 1))
 
-    return [check_with_pcc(torch_output_tensor, torch_out_golden_tensor, pcc=0.998), e2e_perf]
+    return [check_with_pcc_without_tensor_printout(torch_output_tensor, torch_out_golden_tensor, pcc=0.998), e2e_perf]

--- a/tests/sweep_framework/sweeps/conv2d/short/conv2d_short_sweep.py
+++ b/tests/sweep_framework/sweeps/conv2d/short/conv2d_short_sweep.py
@@ -1608,11 +1608,13 @@ import pytest
 @pytest.mark.parametrize("input_spec", parameters["short_sweep_suite_conv2d"]["input_specs"])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_conv2d_localrun(device, input_spec):
-    pcc, messsage = run_conv2d_short_sweep(
+    passed, pcc = run_conv2d_short_sweep(
         input_spec,
         device,
     )[0]
-    assert pcc, messsage
+    print(pcc)
+    assert pcc != 1
+    assert passed, pcc
 
 
 failing_parameters = [
@@ -1626,21 +1628,25 @@ failing_parameters = [
 @pytest.mark.parametrize("input_spec", failing_parameters)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_conv2d_localrun_fail_only(device, input_spec):
-    pcc, messsage = run_conv2d_short_sweep(
+    passed, pcc = run_conv2d_short_sweep(
         input_spec,
         device,
     )[0]
-    assert pcc, messsage
+    print(pcc)
+    assert pcc != 1
+    assert passed, pcc
 
 
 @pytest.mark.parametrize("input_spec", parameters["short_sweep_suite_conv1d"]["input_specs"])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_conv2d_localrun_conv1d(device, input_spec):
-    pcc, messsage = run_conv1d_short_sweep(
+    passed, pcc = run_conv1d_short_sweep(
         input_spec,
         device,
     )[0]
-    assert pcc, messsage
+    print(pcc)
+    assert pcc != 1
+    assert passed, pcc
 
 
 failing_parameters_conv1d = [

--- a/tests/sweep_framework/sweeps/conv2d/short/conv2d_short_sweep.py
+++ b/tests/sweep_framework/sweeps/conv2d/short/conv2d_short_sweep.py
@@ -1613,8 +1613,8 @@ def test_conv2d_localrun(device, input_spec):
         device,
     )[0]
     print(pcc)
-    assert pcc != 1
     assert passed, pcc
+    assert pcc != 1, "Conv2d with ranndomized input and wegihts can't ligitimately return PCC of 1"
 
 
 failing_parameters = [
@@ -1633,8 +1633,8 @@ def test_conv2d_localrun_fail_only(device, input_spec):
         device,
     )[0]
     print(pcc)
-    assert pcc != 1
     assert passed, pcc
+    assert pcc != 1, "Conv2d with ranndomized input and wegihts can't ligitimately return PCC of 1"
 
 
 @pytest.mark.parametrize("input_spec", parameters["short_sweep_suite_conv1d"]["input_specs"])
@@ -1645,8 +1645,8 @@ def test_conv2d_localrun_conv1d(device, input_spec):
         device,
     )[0]
     print(pcc)
-    assert pcc != 1
     assert passed, pcc
+    assert pcc != 1, "Conv2d with ranndomized input and wegihts can't ligitimately return PCC of 1"
 
 
 failing_parameters_conv1d = [

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -327,7 +327,8 @@ def run_conv(
     else:
         passing, pcc_msg = check_with_pcc_without_tensor_printout(out, ref, pcc=pcc)
         logger.info(f"PCC = {pcc_msg}. Threshold = {pcc}")
-        assert passing and pcc_msg != 1, pcc_msg
+        assert passing, pcc_msg
+        assert pcc_msg != 1, "Conv2d with ranndomized input and wegihts can't ligitimately return PCC of 1"
 
     if memory_config:
         output_memory_config = ttnn.get_memory_config(tt_output_tensor_on_device)
@@ -952,11 +953,10 @@ def test_conv_ws(
     pcc = 0.99
     passing, pcc_msg = check_with_pcc_without_tensor_printout(torch_output_tensor, torch_out_golden_tensor, pcc=pcc)
     logger.info(f"{pcc_msg} Threshold : {pcc}")
-    print(torch_output_tensor)
     if not passing:
         logger.error("Fails with PCC ", pcc_msg)
     assert passing
-    assert pcc_msg != 1.0
+    assert pcc_msg != 1.0, "Conv2d with ranndomized input and wegihts can't ligitimately return PCC of 1"
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -49,12 +49,17 @@ def torch_tensor_map(request):
     return torch_tensor_map
 
 
-def randomize_torch_tensor(torch_tensor_map, tensor_shape):
-    if tensor_shape in torch_tensor_map.keys():
-        torch_tensor = torch_tensor_map[tensor_shape]
-    else:
+def randomize_torch_tensor(torch_tensor_map, tensor_shape, generate_positive_numbers=False):
+    if generate_positive_numbers:
         torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16).float()
-        torch_tensor_map[tensor_shape] = torch_tensor
+        torch_tensor = torch.abs(torch_tensor)
+        return torch_tensor
+    else:
+        if tensor_shape in torch_tensor_map.keys():
+            torch_tensor = torch_tensor_map[tensor_shape]
+        else:
+            torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16).float()
+            torch_tensor_map[tensor_shape] = torch_tensor
 
     return torch_tensor
 
@@ -149,11 +154,23 @@ def run_conv(
     conv_input_shape = (total_batch_size, input_channels, input_height, input_width)
     conv_weight_shape = (output_channels, input_channels // groups, filter_height, filter_width)
     conv_bias_shape = (1, 1, 1, output_channels)
-    torch_input_tensor_nchw = randomize_torch_tensor(torch_tensor_map, conv_input_shape)
+
+    # for Sqrt activation functions we need positive numbers as output of conv2d
+    # in order to get valid sqrt values
+    sqrt_act_function = activation == "sqrt"
+    torch_input_tensor_nchw = randomize_torch_tensor(
+        torch_tensor_map, conv_input_shape, generate_positive_numbers=sqrt_act_function
+    )
     torch_input_tensor = torch.permute(torch_input_tensor_nchw, (0, 2, 3, 1))
 
-    torch_weight_tensor = randomize_torch_tensor(torch_tensor_map, conv_weight_shape)
-    torch_bias_tensor = randomize_torch_tensor(torch_tensor_map, conv_bias_shape) * 10 if has_bias else None
+    torch_weight_tensor = randomize_torch_tensor(
+        torch_tensor_map, conv_weight_shape, generate_positive_numbers=sqrt_act_function
+    )
+    torch_bias_tensor = (
+        randomize_torch_tensor(torch_tensor_map, conv_bias_shape, generate_positive_numbers=sqrt_act_function) * 10
+        if has_bias
+        else None
+    )
 
     torch_padded_input = torch.nn.functional.pad(
         torch_input_tensor_nchw,
@@ -224,12 +241,6 @@ def run_conv(
 
     if config_override and "act_block_w_div" in config_override and not auto_shard:
         conv_config.act_block_w_div = config_override["act_block_w_div"]
-
-    if config_override and "num_cores_nhw" in config_override:
-        if config_override["num_cores_nhw"] == 98:
-            conv_config.core_grid = ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (11, 7)), ttnn.CoreRange((0, 8), (1, 8))})
-            conv_config.override_sharding_config = True
-            print("Setting num_cores_nhw to 98")
 
     if config_override and "enable_act_double_buffer" in config_override:
         conv_config.enable_act_double_buffer = config_override["enable_act_double_buffer"]
@@ -316,7 +327,7 @@ def run_conv(
     else:
         passing, pcc_msg = check_with_pcc_without_tensor_printout(out, ref, pcc=pcc)
         logger.info(f"PCC = {pcc_msg}. Threshold = {pcc}")
-        assert passing, pcc_msg
+        assert passing and pcc_msg != 1, pcc_msg
 
     if memory_config:
         output_memory_config = ttnn.get_memory_config(tt_output_tensor_on_device)
@@ -941,9 +952,11 @@ def test_conv_ws(
     pcc = 0.99
     passing, pcc_msg = check_with_pcc_without_tensor_printout(torch_output_tensor, torch_out_golden_tensor, pcc=pcc)
     logger.info(f"{pcc_msg} Threshold : {pcc}")
+    print(torch_output_tensor)
     if not passing:
         logger.error("Fails with PCC ", pcc_msg)
     assert passing
+    assert pcc_msg != 1.0
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d_sweeps.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d_sweeps.py
@@ -37,8 +37,8 @@ def test_ttnn_pytorch_sweep(device, input_spec):
         device,
     )[0]
     print(pcc)
-    assert pcc != 1
     assert passed, pcc
+    assert pcc != 1, "Conv2d with ranndomized input and wegihts can't ligitimately return PCC of 1"
 
 
 @skip_for_grayskull()
@@ -57,5 +57,5 @@ def test_tt_forge_sweep(device, input_spec):
         device,
     )[0]
     print(pcc)
-    assert pcc != 1
     assert passed, pcc
+    assert pcc != 1, "Conv2d with ranndomized input and wegihts can't ligitimately return PCC of 1"

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d_sweeps.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d_sweeps.py
@@ -32,11 +32,13 @@ def test_ttnn_pytorch_sweep(device, input_spec):
     if input_spec in failing_parameters_ttnn_pytorch:
         pytest.skip(f"Skipping test for failing input_spec: {input_spec}")
 
-    pcc, messsage = run_conv2d_short_sweep(
+    passed, pcc = run_conv2d_short_sweep(
         input_spec,
         device,
     )[0]
-    assert pcc, messsage
+    print(pcc)
+    assert pcc != 1
+    assert passed, pcc
 
 
 @skip_for_grayskull()
@@ -50,8 +52,10 @@ def test_tt_forge_sweep(device, input_spec):
     if input_spec in failing_parameters_ttnn_forge:
         pytest.skip(f"Skipping test for failing input_spec: {input_spec}")
 
-    pcc, messsage = run_conv2d_short_sweep(
+    passed, pcc = run_conv2d_short_sweep(
         input_spec,
         device,
     )[0]
-    assert pcc, messsage
+    print(pcc)
+    assert pcc != 1
+    assert passed, pcc


### PR DESCRIPTION
PCC == 1.0 is hiding issues in Conv2d unit tests.
Given that test tensors are randomly initialised,PCC == 1.0 is just a red flag that something really bad is going.
In practice this happens if output is all "inf" or if reference impl is providing small value and op output has really large values.

Setting assert for PCC != 1 uncovered two problems:
1. https://github.com/tenstorrent/tt-metal/issues/23712
2. For sqrt act function we need positive values as output from conv2d in order to get valid output from activation function.

Second one is addressed in this PR.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15730544761)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15733532444)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/15730519881)
- [x] [(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/15730535983)