### PR TITLE
Use vc 2/3 for fabric to avoid clash with default VCs

### DIFF
--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -88,7 +88,7 @@ struct FabricEriscDatamoverConfig {
     static constexpr uint32_t WR_REG_CMD_BUF = 2;  // for small writes (e.g., registers, semaphores)
     static constexpr uint32_t AT_CMD_BUF = 3;      // for atomics
     static constexpr uint32_t DEFAULT_NOC_VC = 2;
-    static constexpr uint32_t MAX_EDM_NOC_VC = 3;
+    static constexpr uint32_t NUM_EDM_NOC_VCS = 2;
 
     static constexpr uint32_t DEFAULT_RECEIVER_FORWARDING_NOC = 1;
     static constexpr uint32_t DEFAULT_RECEIVER_LOCAL_WRITE_NOC = 1;

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1486,7 +1486,7 @@ void build_tt_fabric_program(
                 edm_builder2.connect_to_downstream_edm(edm_builder1);
 
                 // select VC based on the current link
-                auto edm_noc_vc = link & edm_builder1.config.MAX_EDM_NOC_VC;
+                auto edm_noc_vc = edm_builder1.config.DEFAULT_NOC_VC + (link % edm_builder1.config.NUM_EDM_NOC_VCS);
                 edm_builder1.config.edm_noc_vc = edm_noc_vc;
                 edm_builder2.config.edm_noc_vc = edm_noc_vc;
 

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
@@ -276,7 +276,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
 
                     for (size_t l = 0; l < num_links; l++) {
                         auto& edm = direction_edm[l];
-                        auto edm_noc_vc = l & edm.config.MAX_EDM_NOC_VC;
+                        auto edm_noc_vc = edm.config.DEFAULT_NOC_VC + (l % edm.config.NUM_EDM_NOC_VCS);
                         edm.config.edm_noc_vc = edm_noc_vc;
                     }
                 }


### PR DESCRIPTION
### Problem description
Use vc 0/1 clashes with local prefetcher kernel and CCL op itself, since prefetcher and CCL ops also use the default vc 0/1.

### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/15760925686
- [ ] TG  https://github.com/tenstorrent/tt-metal/actions/runs/15760980479