### PR TITLE
#0: refactor fabric buffer config

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -2567,32 +2567,60 @@ Fabric1DWorkerConfig get_fabric_1d_worker_config(
 }
 
 tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_wormhole(
-    tt::ClusterType cluster_type, FabricTestMode fabric_mode) {
+    tt::ClusterType cluster_type, FabricTestMode fabric_mode, size_t line_size) {
     tt::tt_fabric::FabricRouterBufferConfig buffer_config{};
     switch (cluster_type) {
         case tt::ClusterType::TG:
         case tt::ClusterType::GALAXY:
-            if (fabric_mode == FabricTestMode::HalfRing) {
-                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
-            } else if (fabric_mode == FabricTestMode::FullRing) {
-                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{false, true, true, false, true};
-            } else if (fabric_mode == FabricTestMode::SaturateChipToChipRing) {
-                // SaturateChipToChipRing cannot use the buffering optimization since it writes back to itself.
-                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, false, false};
-            } else if (fabric_mode == FabricTestMode::RingAsLinear) {
-                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
+            // long axis, more buffering.
+            if (line_size >= tt::tt_fabric::FabricEriscDatamoverConfig::MESH_LONG_AXIS_OPTIMIZATION_THRESHOLD) {
+                if (fabric_mode == FabricTestMode::HalfRing) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, true};
+                } else if (fabric_mode == FabricTestMode::FullRing) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{false, true, true, false, true};
+                } else if (fabric_mode == FabricTestMode::SaturateChipToChipRing) {
+                    // SaturateChipToChipRing cannot use the buffering optimization since it writes back to itself.
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, false, false};
+                } else if (fabric_mode == FabricTestMode::RingAsLinear) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
+                }
+            } else {
+                if (fabric_mode == FabricTestMode::HalfRing) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
+                } else if (fabric_mode == FabricTestMode::FullRing) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, false, true};
+                } else if (fabric_mode == FabricTestMode::SaturateChipToChipRing) {
+                    // SaturateChipToChipRing cannot use the buffering optimization since it writes back to itself.
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, false, false};
+                } else if (fabric_mode == FabricTestMode::RingAsLinear) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
+                }
             }
             break;
         case tt::ClusterType::T3K:
-            if (fabric_mode == FabricTestMode::HalfRing) {
-                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, true, true};
-            } else if (fabric_mode == FabricTestMode::FullRing) {
-                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{false, true, true, false, true};
-            } else if (fabric_mode == FabricTestMode::SaturateChipToChipRing) {
-                // SaturateChipToChipRing cannot use the buffering optimization since it writes back to itself.
-                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, false, false};
-            } else if (fabric_mode == FabricTestMode::RingAsLinear) {
-                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
+            // Need more tunning on T3K, for now keep the long/short axis the same.
+            if (line_size >= tt::tt_fabric::FabricEriscDatamoverConfig::MESH_LONG_AXIS_OPTIMIZATION_THRESHOLD) {
+                if (fabric_mode == FabricTestMode::HalfRing) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, true, true};
+                } else if (fabric_mode == FabricTestMode::FullRing) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{false, true, true, false, true};
+                } else if (fabric_mode == FabricTestMode::SaturateChipToChipRing) {
+                    // SaturateChipToChipRing cannot use the buffering optimization since it writes back to itself.
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, false, false};
+                } else if (fabric_mode == FabricTestMode::RingAsLinear) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
+                }
+            } else {
+                if (fabric_mode == FabricTestMode::HalfRing) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, true, true};
+                } else if (fabric_mode == FabricTestMode::FullRing) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{false, true, true, false, true};
+                } else if (fabric_mode == FabricTestMode::SaturateChipToChipRing) {
+                    // SaturateChipToChipRing cannot use the buffering optimization since it writes back to itself.
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, false, false};
+                } else if (fabric_mode == FabricTestMode::RingAsLinear) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
+                }
             }
             break;
         default: break;
@@ -2601,20 +2629,33 @@ tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_wormhole(
 }
 
 tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_blackhole(
-    tt::ClusterType cluster_type, FabricTestMode fabric_mode) {
+    tt::ClusterType cluster_type, FabricTestMode fabric_mode, size_t line_size) {
     tt::tt_fabric::FabricRouterBufferConfig buffer_config{};
     switch (cluster_type) {
         // For now just copy the galaxy config to BH since we don't have any data points.
         case tt::ClusterType::P150_X4:
-            if (fabric_mode == FabricTestMode::HalfRing) {
-                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
-            } else if (fabric_mode == FabricTestMode::FullRing) {
-                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{false, true, true, false, true};
-            } else if (fabric_mode == FabricTestMode::SaturateChipToChipRing) {
-                // SaturateChipToChipRing cannot use the buffering optimization since it writes back to itself.
-                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, false, false};
-            } else if (fabric_mode == FabricTestMode::RingAsLinear) {
-                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
+            if (line_size >= tt::tt_fabric::FabricEriscDatamoverConfig::MESH_LONG_AXIS_OPTIMIZATION_THRESHOLD) {
+                if (fabric_mode == FabricTestMode::HalfRing) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
+                } else if (fabric_mode == FabricTestMode::FullRing) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{false, true, true, false, true};
+                } else if (fabric_mode == FabricTestMode::SaturateChipToChipRing) {
+                    // SaturateChipToChipRing cannot use the buffering optimization since it writes back to itself.
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, false, false};
+                } else if (fabric_mode == FabricTestMode::RingAsLinear) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
+                }
+            } else {
+                if (fabric_mode == FabricTestMode::HalfRing) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
+                } else if (fabric_mode == FabricTestMode::FullRing) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{false, true, true, false, true};
+                } else if (fabric_mode == FabricTestMode::SaturateChipToChipRing) {
+                    // SaturateChipToChipRing cannot use the buffering optimization since it writes back to itself.
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, false, false};
+                } else if (fabric_mode == FabricTestMode::RingAsLinear) {
+                    buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
+                }
             }
             break;
         // the other BH cluster type P150_X2 only has 2 devices, not suitable for ring.
@@ -2623,12 +2664,12 @@ tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_blackhole(
     return buffer_config;
 }
 
-tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_helper(FabricTestMode fabric_mode) {
+tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_helper(FabricTestMode fabric_mode, size_t line_size) {
     const auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
     const auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
     switch (arch) {
-        case tt::ARCH::WORMHOLE_B0: return get_edm_buffer_config_wormhole(cluster_type, fabric_mode);
-        case tt::ARCH::BLACKHOLE: return get_edm_buffer_config_blackhole(cluster_type, fabric_mode);
+        case tt::ARCH::WORMHOLE_B0: return get_edm_buffer_config_wormhole(cluster_type, fabric_mode, line_size);
+        case tt::ARCH::BLACKHOLE: return get_edm_buffer_config_blackhole(cluster_type, fabric_mode, line_size);
         default: return tt::tt_fabric::FabricRouterBufferConfig{};
     }
 }
@@ -2687,7 +2728,7 @@ void Run1DFabricPacketSendTest(
         case FabricTestMode::RingAsLinear: topology = ttnn::ccl::Topology::Ring; break;
     }
 
-    const auto edm_buffer_config = get_edm_buffer_config_helper(fabric_mode);
+    const auto edm_buffer_config = get_edm_buffer_config_helper(fabric_mode, line_size);
 
     auto worker_core_logical = [](size_t link) { return CoreCoord(link, 0); };
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -1235,8 +1235,7 @@ void setup_test_with_persistent_fabric(
     size_t switch_interval = 0,
     bool loopback_on_last_device = false,
     bool is_galaxy = false,
-    const tt::tt_fabric::FabricEriscDatamoverBufferConfig& edm_buffer_config =
-        tt::tt_fabric::FabricEriscDatamoverBufferConfig{}) {
+    const tt::tt_fabric::FabricRouterBufferConfig& edm_buffer_config = tt::tt_fabric::FabricRouterBufferConfig{}) {
     log_info(tt::LogTest, "Enabling persistent fabric");
     fabric_programs = std::vector<Program>(devices.size());
     subdevice_managers = create_subdevices(devices);
@@ -2567,33 +2566,33 @@ Fabric1DWorkerConfig get_fabric_1d_worker_config(
     return config;
 }
 
-tt::tt_fabric::FabricEriscDatamoverBufferConfig get_edm_buffer_config_wormhole(
+tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_wormhole(
     tt::ClusterType cluster_type, FabricTestMode fabric_mode) {
-    tt::tt_fabric::FabricEriscDatamoverBufferConfig buffer_config{};
+    tt::tt_fabric::FabricRouterBufferConfig buffer_config{};
     switch (cluster_type) {
         case tt::ClusterType::TG:
         case tt::ClusterType::GALAXY:
             if (fabric_mode == FabricTestMode::HalfRing) {
-                buffer_config = tt::tt_fabric::FabricEriscDatamoverBufferConfig{true, true, true, true, false};
+                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
             } else if (fabric_mode == FabricTestMode::FullRing) {
-                buffer_config = tt::tt_fabric::FabricEriscDatamoverBufferConfig{false, true, true, false, true};
+                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{false, true, true, false, true};
             } else if (fabric_mode == FabricTestMode::SaturateChipToChipRing) {
                 // SaturateChipToChipRing cannot use the buffering optimization since it writes back to itself.
-                buffer_config = tt::tt_fabric::FabricEriscDatamoverBufferConfig{true, true, false, false, false};
+                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, false, false};
             } else if (fabric_mode == FabricTestMode::RingAsLinear) {
-                buffer_config = tt::tt_fabric::FabricEriscDatamoverBufferConfig{true, true, true, true, false};
+                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
             }
             break;
         case tt::ClusterType::T3K:
             if (fabric_mode == FabricTestMode::HalfRing) {
-                buffer_config = tt::tt_fabric::FabricEriscDatamoverBufferConfig{true, true, false, true, true};
+                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, true, true};
             } else if (fabric_mode == FabricTestMode::FullRing) {
-                buffer_config = tt::tt_fabric::FabricEriscDatamoverBufferConfig{false, true, true, false, true};
+                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{false, true, true, false, true};
             } else if (fabric_mode == FabricTestMode::SaturateChipToChipRing) {
                 // SaturateChipToChipRing cannot use the buffering optimization since it writes back to itself.
-                buffer_config = tt::tt_fabric::FabricEriscDatamoverBufferConfig{true, true, false, false, false};
+                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, false, false};
             } else if (fabric_mode == FabricTestMode::RingAsLinear) {
-                buffer_config = tt::tt_fabric::FabricEriscDatamoverBufferConfig{true, true, true, true, false};
+                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
             }
             break;
         default: break;
@@ -2601,21 +2600,21 @@ tt::tt_fabric::FabricEriscDatamoverBufferConfig get_edm_buffer_config_wormhole(
     return buffer_config;
 }
 
-tt::tt_fabric::FabricEriscDatamoverBufferConfig get_edm_buffer_config_blackhole(
+tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_blackhole(
     tt::ClusterType cluster_type, FabricTestMode fabric_mode) {
-    tt::tt_fabric::FabricEriscDatamoverBufferConfig buffer_config{};
+    tt::tt_fabric::FabricRouterBufferConfig buffer_config{};
     switch (cluster_type) {
         // For now just copy the galaxy config to BH since we don't have any data points.
         case tt::ClusterType::P150_X4:
             if (fabric_mode == FabricTestMode::HalfRing) {
-                buffer_config = tt::tt_fabric::FabricEriscDatamoverBufferConfig{true, true, true, true, false};
+                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
             } else if (fabric_mode == FabricTestMode::FullRing) {
-                buffer_config = tt::tt_fabric::FabricEriscDatamoverBufferConfig{false, true, true, false, true};
+                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{false, true, true, false, true};
             } else if (fabric_mode == FabricTestMode::SaturateChipToChipRing) {
                 // SaturateChipToChipRing cannot use the buffering optimization since it writes back to itself.
-                buffer_config = tt::tt_fabric::FabricEriscDatamoverBufferConfig{true, true, false, false, false};
+                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, false, false, false};
             } else if (fabric_mode == FabricTestMode::RingAsLinear) {
-                buffer_config = tt::tt_fabric::FabricEriscDatamoverBufferConfig{true, true, true, true, false};
+                buffer_config = tt::tt_fabric::FabricRouterBufferConfig{true, true, true, true, false};
             }
             break;
         // the other BH cluster type P150_X2 only has 2 devices, not suitable for ring.
@@ -2624,13 +2623,13 @@ tt::tt_fabric::FabricEriscDatamoverBufferConfig get_edm_buffer_config_blackhole(
     return buffer_config;
 }
 
-tt::tt_fabric::FabricEriscDatamoverBufferConfig get_edm_buffer_config_helper(FabricTestMode fabric_mode) {
+tt::tt_fabric::FabricRouterBufferConfig get_edm_buffer_config_helper(FabricTestMode fabric_mode) {
     const auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
     const auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: return get_edm_buffer_config_wormhole(cluster_type, fabric_mode);
         case tt::ARCH::BLACKHOLE: return get_edm_buffer_config_blackhole(cluster_type, fabric_mode);
-        default: return tt::tt_fabric::FabricEriscDatamoverBufferConfig{};
+        default: return tt::tt_fabric::FabricRouterBufferConfig{};
     }
 }
 

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -71,15 +71,19 @@ enum class FabricEriscDatamoverAxis : std::size_t {
     Invalid = 2,
 };
 
-// enable extra buffer slots configuration based on sender/receiver channel and EDM type.
-struct FabricEriscDatamoverOptions {
-    FabricEriscDatamoverType edm_type = FabricEriscDatamoverType::Default;
-    FabricEriscDatamoverAxis edm_axis = FabricEriscDatamoverAxis::Short;
+struct FabricEriscDatamoverBufferConfig {
     bool enable_dateline_sender_extra_buffer_slots = false;
     bool enable_dateline_receiver_extra_buffer_slots = false;
     bool enable_dateline_upstream_sender_extra_buffer_slots = false;
     bool enable_dateline_upstream_receiver_extra_buffer_slots = false;
     bool enable_dateline_upstream_adjacent_sender_extra_buffer_slots = false;
+};
+
+// enable extra buffer slots configuration based on sender/receiver channel and EDM type.
+struct FabricEriscDatamoverOptions {
+    FabricEriscDatamoverType edm_type = FabricEriscDatamoverType::Default;
+    FabricEriscDatamoverAxis edm_axis = FabricEriscDatamoverAxis::Short;
+    FabricEriscDatamoverBufferConfig edm_buffer_config = FabricEriscDatamoverBufferConfig{};
 };
 
 struct FabricEriscDatamoverConfig {

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -71,7 +71,7 @@ enum class FabricEriscDatamoverAxis : std::size_t {
     Invalid = 2,
 };
 
-struct FabricEriscDatamoverBufferConfig {
+struct FabricRouterBufferConfig {
     bool enable_dateline_sender_extra_buffer_slots = false;
     bool enable_dateline_receiver_extra_buffer_slots = false;
     bool enable_dateline_upstream_sender_extra_buffer_slots = false;
@@ -83,7 +83,7 @@ struct FabricEriscDatamoverBufferConfig {
 struct FabricEriscDatamoverOptions {
     FabricEriscDatamoverType edm_type = FabricEriscDatamoverType::Default;
     FabricEriscDatamoverAxis edm_axis = FabricEriscDatamoverAxis::Short;
-    FabricEriscDatamoverBufferConfig edm_buffer_config = FabricEriscDatamoverBufferConfig{};
+    FabricRouterBufferConfig edm_buffer_config = FabricRouterBufferConfig{};
 };
 
 struct FabricEriscDatamoverConfig {

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -77,22 +77,18 @@ size_t FabricContext::get_max_payload_size_bytes() const {
 
 std::unique_ptr<tt::tt_fabric::FabricEriscDatamoverConfig> FabricContext::get_edm_config_options(
     tt::tt_fabric::FabricEriscDatamoverType edm_type, tt::tt_fabric::FabricEriscDatamoverAxis edm_axis) {
-    constexpr bool enable_dateline_sender_extra_buffer_slots = true;
-    constexpr bool enable_dateline_receiver_extra_buffer_slots = true;
-    constexpr bool enable_dateline_upstream_sender_extra_buffer_slots = true;
-    constexpr bool enable_dateline_upstream_receiver_extra_buffer_slots = true;
-    bool enable_dateline_upstream_adjacent_sender_extra_buffer_slots =
-        edm_axis != tt::tt_fabric::FabricEriscDatamoverAxis::Short;
-
+    auto edm_buffer_config = tt::tt_fabric::FabricEriscDatamoverBufferConfig{
+        .enable_dateline_sender_extra_buffer_slots = true,
+        .enable_dateline_receiver_extra_buffer_slots = true,
+        .enable_dateline_upstream_sender_extra_buffer_slots = true,
+        .enable_dateline_upstream_receiver_extra_buffer_slots = true,
+        .enable_dateline_upstream_adjacent_sender_extra_buffer_slots =
+            edm_axis != tt::tt_fabric::FabricEriscDatamoverAxis::Short,
+    };
     auto edm_options = tt::tt_fabric::FabricEriscDatamoverOptions{
         .edm_type = edm_type,
         .edm_axis = edm_axis,
-        .enable_dateline_sender_extra_buffer_slots = enable_dateline_sender_extra_buffer_slots,
-        .enable_dateline_receiver_extra_buffer_slots = enable_dateline_receiver_extra_buffer_slots,
-        .enable_dateline_upstream_sender_extra_buffer_slots = enable_dateline_upstream_sender_extra_buffer_slots,
-        .enable_dateline_upstream_receiver_extra_buffer_slots = enable_dateline_upstream_receiver_extra_buffer_slots,
-        .enable_dateline_upstream_adjacent_sender_extra_buffer_slots =
-            enable_dateline_upstream_adjacent_sender_extra_buffer_slots,
+        .edm_buffer_config = edm_buffer_config,
     };
 
     return std::make_unique<tt::tt_fabric::FabricEriscDatamoverConfig>(

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -77,7 +77,7 @@ size_t FabricContext::get_max_payload_size_bytes() const {
 
 std::unique_ptr<tt::tt_fabric::FabricEriscDatamoverConfig> FabricContext::get_edm_config_options(
     tt::tt_fabric::FabricEriscDatamoverType edm_type, tt::tt_fabric::FabricEriscDatamoverAxis edm_axis) {
-    auto edm_buffer_config = tt::tt_fabric::FabricEriscDatamoverBufferConfig{
+    auto edm_buffer_config = tt::tt_fabric::FabricRouterBufferConfig{
         .enable_dateline_sender_extra_buffer_slots = true,
         .enable_dateline_receiver_extra_buffer_slots = true,
         .enable_dateline_upstream_sender_extra_buffer_slots = true,

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
@@ -50,7 +50,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
     bool build_in_worker_connection_mode,
     Topology topology,
     bool is_galaxy,
-    const tt::tt_fabric::FabricEriscDatamoverBufferConfig& edm_buffer_config) :
+    const tt::tt_fabric::FabricRouterBufferConfig& edm_buffer_config) :
     device_sequence(device_sequence), programs(program_sequence) {
     if (topology == Topology::Ring) {
         TT_FATAL(device_sequence.size() > 2, "Ring topology only supports more than 2 devices");

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
@@ -50,11 +50,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
     bool build_in_worker_connection_mode,
     Topology topology,
     bool is_galaxy,
-    bool en_dateline_sender_extra_buffer,
-    bool en_dateline_receiver_extra_buffer,
-    bool en_dateline_upstream_sender_extra_buffer,
-    bool en_dateline_upstream_receiver_extra_buffer,
-    bool en_dateline_upstream_adjcent_sender_extra_buffer) :
+    const tt::tt_fabric::FabricEriscDatamoverBufferConfig& edm_buffer_config) :
     device_sequence(device_sequence), programs(program_sequence) {
     if (topology == Topology::Ring) {
         TT_FATAL(device_sequence.size() > 2, "Ring topology only supports more than 2 devices");
@@ -166,22 +162,12 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
             auto src_edm_options = tt::tt_fabric::FabricEriscDatamoverOptions{
                 .edm_type = src_device_edm_type,
                 .edm_axis = edm_axis,
-                .enable_dateline_sender_extra_buffer_slots = en_dateline_sender_extra_buffer,
-                .enable_dateline_receiver_extra_buffer_slots = en_dateline_receiver_extra_buffer,
-                .enable_dateline_upstream_sender_extra_buffer_slots = en_dateline_upstream_sender_extra_buffer,
-                .enable_dateline_upstream_receiver_extra_buffer_slots = en_dateline_upstream_receiver_extra_buffer,
-                .enable_dateline_upstream_adjacent_sender_extra_buffer_slots =
-                    en_dateline_upstream_adjcent_sender_extra_buffer,
+                .edm_buffer_config = edm_buffer_config,
             };
             auto dest_edm_options = tt::tt_fabric::FabricEriscDatamoverOptions{
                 .edm_type = dest_device_edm_type,
                 .edm_axis = edm_axis,
-                .enable_dateline_sender_extra_buffer_slots = en_dateline_sender_extra_buffer,
-                .enable_dateline_receiver_extra_buffer_slots = en_dateline_receiver_extra_buffer,
-                .enable_dateline_upstream_sender_extra_buffer_slots = en_dateline_upstream_sender_extra_buffer,
-                .enable_dateline_upstream_receiver_extra_buffer_slots = en_dateline_upstream_receiver_extra_buffer,
-                .enable_dateline_upstream_adjacent_sender_extra_buffer_slots =
-                    en_dateline_upstream_adjcent_sender_extra_buffer,
+                .edm_buffer_config = edm_buffer_config,
             };
             const auto src_curr_edm_config =
                 tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, topology, src_edm_options);

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.hpp
@@ -30,8 +30,7 @@ public:
         bool build_in_worker_connection_mode = false,
         Topology topology = Topology::Linear,
         bool is_galaxy = false,
-        const tt::tt_fabric::FabricEriscDatamoverBufferConfig& edm_buffer_config =
-            tt::tt_fabric::FabricEriscDatamoverBufferConfig{});
+        const tt::tt_fabric::FabricRouterBufferConfig& edm_buffer_config = tt::tt_fabric::FabricRouterBufferConfig{});
 
     // Invocable per chip if we want to collectively build the fabric by building this separately per chip
     // (and implicitly building the fabric that way)

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.hpp
@@ -30,11 +30,8 @@ public:
         bool build_in_worker_connection_mode = false,
         Topology topology = Topology::Linear,
         bool is_galaxy = false,
-        bool en_dateline_sender_extra_buffer = false,
-        bool en_dateline_receiver_extra_buffer = false,
-        bool en_dateline_upstream_sender_extra_buffer = false,
-        bool en_dateline_upstream_receiver_extra_buffer = false,
-        bool en_dateline_upstream_adjcent_sender_extra_buffer = false);
+        const tt::tt_fabric::FabricEriscDatamoverBufferConfig& edm_buffer_config =
+            tt::tt_fabric::FabricEriscDatamoverBufferConfig{});
 
     // Invocable per chip if we want to collectively build the fabric by building this separately per chip
     // (and implicitly building the fabric that way)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23731)

### Problem description
currently tests need to pass in separate args for enable different buffer configs, wrap them into one struct to avoid passing too many args.

### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/15764137071
- [ ] ubenchmark https://github.com/tenstorrent/tt-metal/actions/runs/15764143325