### PR TITLE
Revert "Fix block_ct_dim != full_ct_dim issue on BH"

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -465,7 +465,7 @@ TEST_F(DeviceFixture, TensixComputeUnpackUntilizeShortInit) {
 Following tests are for pack untilize
 ***************************************/
 TEST_F(DeviceFixture, TensixComputePackUntilize) {
-    vector<vector<uint32_t>> num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}, {10, 10}, {2, 40}};
+    vector<vector<uint32_t>> num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}};
     for (auto num_tile : num_tiles) {
         for (bool fp32_dest_acc_en : {true, false}) {
             // FP32 dest acc not possible for GS

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp
@@ -9,53 +9,25 @@
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 
 namespace NAMESPACE {
-
-// Helper constexpr function to compute num_blocks_per_col
-constexpr uint32_t compute_num_blocks_per_col(uint32_t per_core_block_tile_cnt) {
-    if (DST_ACCUM_MODE) {
-        for (uint32_t bct = 4; bct >= 1; --bct) {
-            if (per_core_block_tile_cnt % bct == 0) {
-                return per_core_block_tile_cnt / bct;
-            }
-        }
-    } else {
-        for (uint32_t bct = 8; bct >= 1; --bct) {
-            if (per_core_block_tile_cnt % bct == 0) {
-                return per_core_block_tile_cnt / bct;
-            }
-        }
-    }
-
-    return 1;  // fallback, though unreachable if per_core_block_tile_cnt ≥ 1
-}
-
 void MAIN {
     constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
 
-    // Compute optimal num_blocks_per_col and block_ct_dim
-    constexpr uint32_t num_blocks_per_col = compute_num_blocks_per_col(per_core_block_tile_cnt);
-    constexpr uint32_t block_ct_dim = per_core_block_tile_cnt / num_blocks_per_col;
-    constexpr uint32_t full_ct_dim = per_core_block_tile_cnt;
-
-    pack_untilize_init<block_ct_dim, full_ct_dim>(tt::CBIndex::c_0, tt::CBIndex::c_16);
-
 #ifdef SHORT_INIT
     unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
-    pack_untilize_init_short<block_ct_dim, full_ct_dim>(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    pack_untilize_init_short<per_core_block_tile_cnt>(tt::CBIndex::c_0, tt::CBIndex::c_16);
 #else
-    pack_untilize_init<block_ct_dim, full_ct_dim>(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    pack_untilize_init<per_core_block_tile_cnt>(tt::CBIndex::c_0, tt::CBIndex::c_16);
 #endif
 
-    for (uint32_t r = 0; r < per_core_block_cnt; ++r) {
-        cb_reserve_back(tt::CBIndex::c_16, full_ct_dim);
+    for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
+        cb_wait_front(tt::CBIndex::c_0, per_core_block_tile_cnt);
+        cb_reserve_back(tt::CBIndex::c_16, per_core_block_tile_cnt);
 
-        for (uint32_t b = 0; b < num_blocks_per_col; ++b) {
-            cb_wait_front(tt::CBIndex::c_0, block_ct_dim);
-            pack_untilize_block<block_ct_dim, full_ct_dim>(tt::CBIndex::c_0, 1, tt::CBIndex::c_16, b);
-            cb_pop_front(tt::CBIndex::c_0, block_ct_dim);
-        }
-        cb_push_back(tt::CBIndex::c_16, full_ct_dim);
+        pack_untilize_block<per_core_block_tile_cnt>(tt::CBIndex::c_0, 1, tt::CBIndex::c_16);
+
+        cb_push_back(tt::CBIndex::c_16, per_core_block_tile_cnt);
+        cb_pop_front(tt::CBIndex::c_0, per_core_block_tile_cnt);
     }
 
     pack_untilize_uninit(tt::CBIndex::c_16);

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -33,23 +33,11 @@ ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb) {
         false, false, icb)));  // init must be after configure
 }
 
-// clang-format off
 /**
  * Perform the untilize operation on a block of tiles. This simply loops over the provided block size.
- * Performs the untilize operation on a block of tiles. Loops over the provided block size.
- *
- * | Param Type | Name          | Description                                 | Type      | Valid Range     | Required |
- * |------------|---------------|---------------------------------------------|-----------|-----------------|----------|
- * | Template   | block_ct_dim  | Width of a single block in tiles            | uint32_t  | 1 to 8          | False    |
- * | Template   | full_ct_dim   | Width of a full input in tiles              | uint32_t  | >= block_ct_dim | False    |
- * | Function   | icb           | Input circular buffer identifier            | uint32_t  | 0 to 31         | True     |
- * | Function   | block_rt_dim  | Height of a single block in tiles           | uint32_t  | >= 1            | True     |
- * | Function   | ocb           | Output circular buffer identifier           | uint32_t  | 0 to 31         | True     |
- * | Function   | block_c_index | Index of the currently processed block      | uint32_t  | >= 0            | False    |
  */
-// clang-format on
 template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
-ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb, uint32_t block_c_index = 0) {
+ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb) {
     for (uint32_t r = 0; r < block_rt_dim; ++r) {
         MATH((llk_math_wait_for_dest_available()));
         for (uint32_t c = 0; c < block_ct_dim; ++c) {
@@ -57,11 +45,10 @@ ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb,
                 (llk_unpack_A<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(icb, c)));
             MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(c)));
         }
-
         MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));
 
         PACK((llk_packer_wait_for_math_done()));
-        PACK((llk_pack_untilize<block_ct_dim, full_ct_dim>(1 /*num_blocks*/, ocb, FACE_R_DIM, 4, block_c_index)));
+        PACK((llk_pack_untilize<block_ct_dim, full_ct_dim>(1 /*num_blocks*/, ocb)));
         PACK((llk_pack_dest_section_done<DST_ACCUM_MODE>()));
     }
 }


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#22876

Breaking ttnn group 12 (seen on both p100 and p150)
https://github.com/tenstorrent/tt-metal/actions/runs/15761995231/job/44431111227#step:6:16170

```
FAILED tests/ttnn/unit_tests/operations/pool/test_upsample.py::test_bilinear_multi_core[math_approx_mode=True-math_fidelity=MathFidelity.LoFi-shard_strategy=ShardStrategy.HEIGHT-batch_size=1-num_channels=288-height=8-width=8-scale_h=2-scale_w=2-device_params={'l1_small_size': 24576}] - RuntimeError: TT_THROW @ /project/tt_metal/impl/program/program.cpp:134: tt::exception
[...]
/work/.ttnn_runtime_artifacts/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h:140:32: error: static assertion failed: block_ct_dim must be less than or equal to 8
  140 |     static_assert(block_ct_dim <= 8, "block_ct_dim must be less than or equal to 8");
      |                   ~~~~~~~~~~~~~^~~~
/work/.ttnn_runtime_artifacts/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_pack_untilize.h:140:32: note: the comparison reduces to '(9 <= 8)'
```
