### PR TITLE
#22690: add nd sharding to multi core height reduce op

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_nd_shard.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_nd_shard.py
@@ -2,15 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-
 import torch
-from functools import partial
-
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import torch_random
-
-from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_nd_shard.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_nd_shard.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+import torch
+from functools import partial
+
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import torch_random
+
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        ([1, 1, 512, 4096], [1, 1, 512, 256]),
+    ],
+)
+@pytest.mark.parametrize("keepdim", [True, False])
+def test_nd_shard(device, shapes, keepdim):
+    dim = -2
+    input_shape, shard_shape = shapes
+    torch_input_tensor = torch.rand(input_shape)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim, keepdim)
+
+    memory_config = ttnn.MemoryConfig(
+        buffer_type=ttnn.BufferType.L1,
+        nd_shard_spec=ttnn.NdShardSpec(
+            shard_shape,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 4))}),
+        ),
+    )
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=ttnn.float32, device=device, layout=ttnn.TILE_LAYOUT, memory_config=memory_config
+    )
+    op_output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_torch(op_output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_nd_shard.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_nd_shard.py
@@ -16,13 +16,16 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 @pytest.mark.parametrize(
     "shapes",
     [
-        ([1, 1, 512, 4096], [1, 1, 512, 256]),
+        ([1, 1, 512, 4096], [1, 1, 512, 256], 2, 4),
+        ([1, 1, 512, 4096], [1, 1, 512, 256], 4, 2),
+        ([1, 1, 32, 64], [1, 1, 32, 32], 0, 0),
+        ([1, 1, 64, 128], [1, 1, 64, 32], 0, 0),
     ],
 )
 @pytest.mark.parametrize("keepdim", [True, False])
 def test_nd_shard(device, shapes, keepdim):
     dim = -2
-    input_shape, shard_shape = shapes
+    input_shape, shard_shape, end_x, end_y = shapes
     torch_input_tensor = torch.rand(input_shape)
     torch_output_tensor = torch.sum(torch_input_tensor, dim, keepdim)
 
@@ -30,7 +33,7 @@ def test_nd_shard(device, shapes, keepdim):
         buffer_type=ttnn.BufferType.L1,
         nd_shard_spec=ttnn.NdShardSpec(
             shard_shape,
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 4))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(end_x, end_y))}),
         ),
     )
     input_tensor = ttnn.from_torch(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_unary_nd_shard_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_unary_nd_shard_start_id.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 TenstorrentAI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "accessor/sharded_accessor.h"
+
+void kernel_main() {
+    uint32_t bank_base_address = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr tt::CBIndex cb_id_out = static_cast<tt::CBIndex>(get_compile_time_arg_val(0));
+    constexpr uint32_t tile_elements = get_compile_time_arg_val(1);
+    constexpr uint32_t page_size = get_compile_time_arg_val(2);
+    constexpr uint32_t rank = get_compile_time_arg_val(3);
+    constexpr uint32_t num_banks = get_compile_time_arg_val(4);
+    constexpr uint32_t arg_index = 5;
+    using output_dspec = distribution_spec_t<arg_index, rank, num_banks>;
+    auto sharded_accessor = ShardedAccessor<output_dspec, page_size>{.bank_base_address = bank_base_address};
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_wait_front(cb_id_out, onetile);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        uint64_t curr_noc_addr = sharded_accessor.get_noc_addr(i);
+        noc_async_write(curr_noc_addr, l1_read_addr, tile_bytes);
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_unary_nd_shard_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_unary_nd_shard_start_id.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 TenstorrentAI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_unary_nd_shard_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_unary_nd_shard_start_id.cpp
@@ -28,7 +28,7 @@ void kernel_main() {
         cb_wait_front(cb_id_out, onetile);
         uint32_t l1_read_addr = get_read_ptr(cb_id_out);
         uint64_t curr_noc_addr = sharded_accessor.get_noc_addr(i);
-        noc_async_write(curr_noc_addr, l1_read_addr, tile_bytes);
+        noc_async_write(l1_read_addr, curr_noc_addr, tile_bytes);
         noc_async_write_barrier();
         cb_pop_front(cb_id_out, onetile);
     }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
@@ -121,7 +121,7 @@ operation::ProgramWithCallbacks reduce_multi_core_h(
     bfloat16 bfloat_scaler_value = bfloat16(scaler);
     uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
 
-    uint32_t chunk_size = (out_sharded) ? 1 : ttnn::get_dest_reg_count(compute_kernel_config);
+    uint32_t chunk_size = (out_sharded && !use_nd_sharding) ? 1 : ttnn::get_dest_reg_count(compute_kernel_config);
 
     if (in_sharded && !use_nd_sharding) {
         std::vector<uint32_t> reader_compile_time_args = {src0_cb_index, src1_cb_index, scaler_cb_index};

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 TenstorrentAI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -121,7 +121,7 @@ operation::ProgramWithCallbacks reduce_multi_core_h(
     bfloat16 bfloat_scaler_value = bfloat16(scaler);
     uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
 
-    uint32_t chunk_size = (out_sharded && !use_nd_sharding) ? 1 : ttnn::get_dest_reg_count(compute_kernel_config);
+    uint32_t chunk_size = (out_sharded) ? 1 : ttnn::get_dest_reg_count(compute_kernel_config);
 
     if (in_sharded && !use_nd_sharding) {
         std::vector<uint32_t> reader_compile_time_args = {src0_cb_index, src1_cb_index, scaler_cb_index};

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -44,10 +44,12 @@ void Reduce::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL((input_tensor.layout() == Layout::TILE), "Inputs to reduce must be tilized");
     if (this->dim == ReduceOpDim::H) {
         if (input_tensor.memory_config().is_sharded()) {
-            TT_FATAL(
-                input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
-                "Illegal input memory config {} for sharded reduction along H!",
-                input_tensor.memory_config().memory_layout());
+            if (input_tensor.shard_spec().has_value()) {
+                TT_FATAL(
+                    input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+                    "Illegal input memory config {} for sharded reduction along H!",
+                    input_tensor.memory_config().memory_layout());
+            }
         } else {
             TT_FATAL(
                 input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
@@ -100,9 +102,26 @@ std::vector<ttnn::TensorSpec> Reduce::compute_output_specs(const std::vector<Ten
 
     auto output_mem_config = this->output_mem_config;
     if (output_mem_config.is_sharded()) {
-        auto shard_spec = input_tensor.shard_spec().value();  // TODO: This will segfault if input is not sharded...
-        shard_spec.shape[0] = output_padded_shape.volume() / output_padded_shape[-1];
-        output_mem_config = output_mem_config.with_shard_spec(shard_spec);
+        if (input_tensor.shard_spec().has_value()) {
+            auto shard_spec = input_tensor.shard_spec().value();
+            shard_spec.shape[0] = output_padded_shape.volume() / output_padded_shape[-1];
+            output_mem_config = output_mem_config.with_shard_spec(shard_spec);
+        } else {
+            TT_FATAL(
+                input_tensor.nd_shard_spec().has_value(),
+                "Sharded input needs nd shard spec when there is no shard spec");
+            auto nd_shard_spec = input_tensor.nd_shard_spec().value();
+            auto tile = input_tensor.tensor_spec().tile().get_tile_shape();
+            if (this->dim == ReduceOpDim::H) {
+                nd_shard_spec.shard_shape[-2] = tile[0];
+            } else if (this->dim == ReduceOpDim::W) {
+                nd_shard_spec.shard_shape[-1] = tile[1];
+            } else {
+                nd_shard_spec.shard_shape[-1] = tile[0];
+                nd_shard_spec.shard_shape[-2] = tile[1];
+            }
+            output_mem_config = MemoryConfig(output_mem_config.buffer_type(), nd_shard_spec);
+        }
     }
 
     return {ttnn::TensorSpec(


### PR DESCRIPTION
### Ticket
Link to Github Issue #22690

### Problem description
nd sharding is being introduced. It needs to be implemented for an op.

### What's changed
- Plumb through nd shard info for the reduce op across the height dimension (dim=-2) when the input is sharded and does not have regular (2d) shard info.
- Modify the height reduction reader kernel for interleaved input to optionally use nd shard information.
- Copy a generic writer kernel into the reduction kernel directories and adjust the copied kernel to use nd shard information.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes