### PR TITLE
#23728: Reimplement identity op

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -110,7 +110,7 @@ def run_identity_test(device, h, w, data_type):
         assert_equal(torch_output_tensor, output_tensor)
     elif data_type == ttnn.uint16:
         # init value
-        torch_input_tensor = torch.randint(0, 60000, (1, 1, h, w), dtype=torch.int32)
+        torch_input_tensor = torch.randint(0, 60000, (1, 1, h, w), dtype=torch.uint16)
         bias = 2000
 
         # run torch
@@ -201,6 +201,8 @@ def run_identity_test(device, h, w, data_type):
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint8, ttnn.uint32, ttnn.int32, ttnn.float32])
 def test_fp32_uint32(device, h, w, dtype):
+    if dtype == ttnn.uint8:
+        pytest.skip(" Need uint8 LLK support without workarounds - see #24571")
     run_identity_test(device, h, w, dtype)
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -72,7 +72,6 @@ enum class UnaryOpType {
     SUB_UNARY_SFPU,
     MUL_UNARY_SFPU,
     DIV_UNARY_SFPU,
-    IDENTITY_UINT32,
     UNARY_NE,
     UNARY_EQ,
     UNARY_GT,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -32,8 +32,6 @@ std::string get_macro_definition(UnaryOpType op_type) {
         case UnaryOpType::SUB_UNARY_SFPU:
         case UnaryOpType::MUL_UNARY_SFPU:
         case UnaryOpType::DIV_UNARY_SFPU: return "SFPU_OP_BINOP_WITH_SCALAR_INCLUDE";
-        case UnaryOpType::IDENTITY:
-        case UnaryOpType::IDENTITY_UINT32: return "SFPU_OP_IDENTITY_INCLUDE";
         case UnaryOpType::FLOOR:
         case UnaryOpType::CEIL:
         case UnaryOpType::TRUNC:
@@ -454,12 +452,6 @@ std::pair<string, string> get_op_init_and_func_default(
         case UnaryOpType::ATAN: op_init_and_name = {"atan_tile_init();", fmt::format("atan_tile({});", idst)}; break;
         case UnaryOpType::TAN: op_init_and_name = {"tan_tile_init();", fmt::format("tan_tile({});", idst)}; break;
         case UnaryOpType::SILU: op_init_and_name = {"silu_tile_init();", fmt::format("silu_tile({});", idst)}; break;
-        case UnaryOpType::IDENTITY:
-            op_init_and_name = {"identity_tile_init();", fmt::format("identity_tile({});", idst)};
-            break;
-        case UnaryOpType::IDENTITY_UINT32:
-            op_init_and_name = {"identity_tile_init();", fmt::format("identity_tile_uint32({});", idst)};
-            break;
         case UnaryOpType::FLOOR:
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
@@ -497,6 +489,7 @@ std::pair<string, string> get_op_init_and_func_default(
             op_init_and_name = {"alt_complex_rotate90_tile_init();", fmt::format("alt_complex_rotate90_tile({});", idst)};
             break;
         case UnaryOpType::MISH: op_init_and_name = {}; break;
+        case UnaryOpType::IDENTITY: op_init_and_name = {}; break;
         case UnaryOpType::TANHSHRINK: op_init_and_name = {}; break;
         default: TT_THROW("Undefined non-parametrized op type {}", op_type);
     }
@@ -620,6 +613,7 @@ std::string get_compute_kernel_path(UnaryOpType op_type, const std::string& comp
     switch (op_type) {
         case UnaryOpType::MISH: return fmt::format("{}/{}", compute_root, "mish_kernel.cpp");
         case UnaryOpType::TANHSHRINK: return fmt::format("{}/{}", compute_root, "tanhshrink_kernel.cpp");
+        case UnaryOpType::IDENTITY: return fmt::format("{}/{}", compute_root, "eltwise_identity_kernel.cpp");
         default: return fmt::format("{}/{}", compute_root, "eltwise_sfpu.cpp");
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_identity_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_identity_kernel.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
+    uint32_t per_core_block_dim = get_compile_time_arg_val(1);
+
+    init_sfpu(tt::CBIndex::c_0, tt::CBIndex::c_2);
+    copy_tile_init(tt::CBIndex::c_0);
+
+    for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
+        cb_reserve_back(tt::CBIndex::c_2, per_core_block_dim);
+        for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
+            tile_regs_acquire();
+
+            // Pop tile after tile, copy to DST and pack
+            cb_wait_front(tt::CBIndex::c_0, 1);
+
+            copy_tile(tt::CBIndex::c_0, 0, 0);
+
+            tile_regs_commit();
+
+            tile_regs_wait();
+
+            pack_tile(0, tt::CBIndex::c_2);
+
+            cb_pop_front(tt::CBIndex::c_0, 1);
+
+            tile_regs_release();
+        }
+        cb_push_back(tt::CBIndex::c_2, per_core_block_dim);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -24,15 +24,20 @@ inline Tensor unary_impl(
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const std::optional<Tensor>& optional_output_tensor = std::nullopt) {
     TT_FATAL(op_chain.size() > 0, "Op chain cannot be empty");
-    DataType output_dtype = (op_chain[0].op_type == UnaryOpType::TYPECAST)
-                                ? static_cast<DataType>(op_chain[0].params[1])
-                                : input_tensor.dtype();
-    bool preserve_fp32_precision = input_tensor.dtype() == DataType::FLOAT32;
+    DataType input_dtype = input_tensor.dtype();
+    DataType output_dtype =
+        (op_chain[0].op_type == UnaryOpType::TYPECAST) ? static_cast<DataType>(op_chain[0].params[1]) : input_dtype;
+    bool preserve_fp32_precision = input_dtype == DataType::FLOAT32;
     bool fp32_dest_acc_en = preserve_fp32_precision or output_dtype == DataType::UINT32 or
                             output_dtype == DataType::INT32 or output_dtype == DataType::FLOAT32 or
-                            input_tensor.dtype() == DataType::UINT32 or input_tensor.dtype() == DataType::INT32;
+                            input_dtype == DataType::UINT32 or input_dtype == DataType::INT32;
     bool bfp8_pack_precise = (op_chain[0].op_type == UnaryOpType::TYPECAST && output_dtype == DataType::BFLOAT8_B);
-
+    if (op_chain.size() == 3 && op_chain[0].op_type == UnaryOpType::TYPECAST &&
+        op_chain[1].op_type == UnaryOpType::IDENTITY && op_chain[2].op_type == UnaryOpType::TYPECAST &&
+        input_dtype == DataType::UINT8) {
+        output_dtype = DataType::UINT8;
+        preserve_fp32_precision = true;
+    }
     auto output_memory_config = optional_output_tensor.has_value()
                                     ? optional_output_tensor.value().memory_config()
                                     : memory_config.value_or(input_tensor.memory_config());
@@ -312,11 +317,23 @@ Tensor Identity::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     UnaryOpType op_type = UnaryOpType::IDENTITY;
-    if (input_tensor.dtype() == DataType::UINT32) {
-        op_type = UnaryOpType::IDENTITY_UINT32;
-    }
+    DataType input_dtype = input_tensor.get_dtype();
 
-    return detail::unary_impl(queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+    if (input_dtype != DataType::UINT8) {
+        return detail::unary_impl(
+            queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+    } else {
+        DataType output_dtype = DataType::UINT32;
+        return detail::unary_impl(
+            queue_id,
+            input_tensor,
+            {UnaryWithParam{UnaryOpType::TYPECAST, {static_cast<float>(input_dtype), static_cast<float>(output_dtype)}},
+             UnaryWithParam{op_type},
+             UnaryWithParam{
+                 UnaryOpType::TYPECAST, {static_cast<float>(output_dtype), static_cast<float>(input_dtype)}}},
+            memory_config,
+            optional_output_tensor);
+    }
 }
 
 Tensor Abs::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -32,12 +32,7 @@ inline Tensor unary_impl(
                             output_dtype == DataType::INT32 or output_dtype == DataType::FLOAT32 or
                             input_dtype == DataType::UINT32 or input_dtype == DataType::INT32;
     bool bfp8_pack_precise = (op_chain[0].op_type == UnaryOpType::TYPECAST && output_dtype == DataType::BFLOAT8_B);
-    if (op_chain.size() == 3 && op_chain[0].op_type == UnaryOpType::TYPECAST &&
-        op_chain[1].op_type == UnaryOpType::IDENTITY && op_chain[2].op_type == UnaryOpType::TYPECAST &&
-        input_dtype == DataType::UINT8) {
-        output_dtype = DataType::UINT8;
-        preserve_fp32_precision = true;
-    }
+
     auto output_memory_config = optional_output_tensor.has_value()
                                     ? optional_output_tensor.value().memory_config()
                                     : memory_config.value_or(input_tensor.memory_config());
@@ -323,16 +318,7 @@ Tensor Identity::invoke(
         return detail::unary_impl(
             queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
     } else {
-        DataType output_dtype = DataType::UINT32;
-        return detail::unary_impl(
-            queue_id,
-            input_tensor,
-            {UnaryWithParam{UnaryOpType::TYPECAST, {static_cast<float>(input_dtype), static_cast<float>(output_dtype)}},
-             UnaryWithParam{op_type},
-             UnaryWithParam{
-                 UnaryOpType::TYPECAST, {static_cast<float>(output_dtype), static_cast<float>(input_dtype)}}},
-            memory_config,
-            optional_output_tensor);
+        TT_THROW("ttnn.identity doesn't support uint8 datatype");
     }
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #23728

### Problem description
Identity op doesn't have dtype support for INT32, UINT8

### What's changed
- Provided support for all the INT32 datatype
- Enabled skipped tests which now pass - with workaround for uint8
<img width="915" alt="image" src="https://github.com/user-attachments/assets/71824391-b2aa-416a-bdd9-6706e7549de2" />

- Without workaround for uint8 
<img width="945" alt="image" src="https://github.com/user-attachments/assets/d3d418c8-fd4f-4f0e-a8ab-b7db03e94431" />
- I have removed the workaround for uint8 and will wait for #24571 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16070160610
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16070165104
- [x] Blackhole nightly - https://github.com/tenstorrent/tt-metal/actions/runs/16070168701
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes