### PR TITLE
Update EDM <-> EDM handshake in fabric_erisc_datamover

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_mux_ubench_drainer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_mux_ubench_drainer.cpp
@@ -40,11 +40,7 @@ void kernel_main() {
     init_ptr_val(slots_free_stream_id, NUM_BUFFERS);
 
     tt::tt_fabric::DrainerChannelBuffer drainer_channel(
-        channel_base_address,
-        BUFFER_SIZE_BYTES,
-        sizeof(PACKET_HEADER_TYPE),
-        0, /* unused, eth_transaction_ack_word_addr */
-        0 /* channel_id */);
+        channel_base_address, BUFFER_SIZE_BYTES, sizeof(PACKET_HEADER_TYPE), 0 /* channel_id */);
 
     auto connection_worker_info_ptr =
         reinterpret_cast<volatile tt::tt_fabric::DrainerChannelClientLocationInfo*>(connection_info_address);

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -808,7 +808,10 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
 
     // TODO: allow specification per eth txq
     const size_t default_num_eth_txq_data_packet_accept_ahead = 32;
-
+    // By default have the ERISC cores context switch to base routing FW every 4K cycles during the peer handshake.
+    // This allows host to write Fabric kernels to remote chips over ethernet, when ERISC cores already running fabric
+    // are waiting for the handshake to complete.
+    const size_t default_handshake_context_switch_timeout = 4096;
     size_t num_sender_channels = config.num_used_sender_channels;
     size_t num_receiver_channels = config.num_used_receiver_channels;
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
@@ -915,6 +918,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         eth_txq_spin_wait_receiver_send_completion_ack,
         default_num_eth_txq_data_packet_accept_ahead,
 
+        default_handshake_context_switch_timeout,
         // Special marker to help with identifying misalignment bugs
         0x00c0ffee};
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
@@ -382,7 +382,7 @@ constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_comple
             to_sender_3_pkts_completed_id, to_sender_4_pkts_completed_id});
 
 // Miscellaneous configuration
-constexpr size_t DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT = 0;
+constexpr size_t DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT = 4096;
 
 // TODO: move this to compile time args if we need to enable it
 constexpr bool enable_trid_flush_check_on_noc_txn = false;

--- a/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
@@ -295,7 +295,10 @@ constexpr bool ETH_TXQ_SPIN_WAIT_RECEIVER_SEND_COMPLETION_ACK = get_compile_time
 
 constexpr size_t DEFAULT_NUM_ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 11);
 
-constexpr size_t SPECIAL_MARKER_0_IDX = MAIN_CT_ARGS_IDX_5 + 12;
+// Context switch timeouts
+constexpr size_t DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 12);
+
+constexpr size_t SPECIAL_MARKER_0_IDX = MAIN_CT_ARGS_IDX_5 + 13;
 constexpr size_t SPECIAL_MARKER_0 = 0x00c0ffee;
 static_assert(
     !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(SPECIAL_MARKER_0_IDX) == SPECIAL_MARKER_0,
@@ -382,7 +385,6 @@ constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_comple
             to_sender_3_pkts_completed_id, to_sender_4_pkts_completed_id});
 
 // Miscellaneous configuration
-constexpr size_t DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT = 4096;
 
 // TODO: move this to compile time args if we need to enable it
 constexpr bool enable_trid_flush_check_on_noc_txn = false;

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
@@ -50,7 +50,7 @@ struct handshake_info_t {
     uint32_t scratch[4];   // TODO: This can be removed if we use a stream register for handshaking.
 };
 
-FORCE_INLINE volatile tt_l1_ptr handshake_info_t* init_handshake_info(std::uint32_t handshake_register_address) {
+FORCE_INLINE volatile tt_l1_ptr handshake_info_t* init_handshake_info(uint32_t handshake_register_address) {
     volatile tt_l1_ptr handshake_info_t* handshake_info =
         reinterpret_cast<volatile tt_l1_ptr handshake_info_t*>(handshake_register_address);
     handshake_info->local_value = 0;
@@ -59,7 +59,7 @@ FORCE_INLINE volatile tt_l1_ptr handshake_info_t* init_handshake_info(std::uint3
 }
 
 FORCE_INLINE void sender_side_handshake(
-    std::uint32_t handshake_register_address, size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
+    uint32_t handshake_register_address, size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
     volatile tt_l1_ptr handshake_info_t* handshake_info = init_handshake_info(handshake_register_address);
     uint32_t local_val_addr = ((uint32_t)(&handshake_info->local_value)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
     uint32_t scratch_addr = ((uint32_t)(&handshake_info->scratch)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
@@ -77,7 +77,7 @@ FORCE_INLINE void sender_side_handshake(
 }
 
 FORCE_INLINE void receiver_side_handshake(
-    std::uint32_t handshake_register_address, size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
+    uint32_t handshake_register_address, size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
     volatile tt_l1_ptr handshake_info_t* handshake_info = init_handshake_info(handshake_register_address);
     uint32_t local_val_addr = ((uint32_t)(&handshake_info->local_value)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
     uint32_t scratch_addr = ((uint32_t)(&handshake_info->scratch)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
@@ -118,7 +118,7 @@ namespace deprecated {
  *
  * See ChannelBuffer::eth_receiver_channel_ack for more information
  */
-FORCE_INLINE void initialize_edm_common_datastructures(std::uint32_t handshake_register_address) {
+FORCE_INLINE void initialize_edm_common_datastructures(uint32_t handshake_register_address) {
     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(handshake_register_address)[4] = 1;
     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(handshake_register_address)[5] = 1;
     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(handshake_register_address)[6] = 0x1c0ffee1;
@@ -137,7 +137,7 @@ FORCE_INLINE void initialize_edm_common_datastructures(std::uint32_t handshake_r
  * memory region.
  */
 FORCE_INLINE void sender_side_start(
-    std::uint32_t handshake_register_address, size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
+    uint32_t handshake_register_address, size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
     initialize_edm_common_datastructures(handshake_register_address);
     eth_wait_receiver_done(HS_CONTEXT_SWITCH_TIMEOUT);
     while (eth_txq_is_busy()) {
@@ -150,11 +150,11 @@ FORCE_INLINE void sender_side_start(
  * As the designated master EDM core, wait for the acknowledgement from the subordinate EDM core
  */
 FORCE_INLINE void sender_side_finish(
-    std::uint32_t handshake_register_address, size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
+    uint32_t handshake_register_address, size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
     eth_wait_for_receiver_done(HS_CONTEXT_SWITCH_TIMEOUT);
 }
 
-FORCE_INLINE void receiver_side_start(std::uint32_t handshake_register_address) {
+FORCE_INLINE void receiver_side_start(uint32_t handshake_register_address) {
     initialize_edm_common_datastructures(handshake_register_address);
 }
 
@@ -170,7 +170,7 @@ FORCE_INLINE bool receiver_side_can_finish() { return eth_bytes_are_available_on
  * from the master EDM core.
  */
 FORCE_INLINE void receiver_side_finish(
-    std::uint32_t handshake_register_address, size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
+    uint32_t handshake_register_address, size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
     eth_wait_for_bytes(16, HS_CONTEXT_SWITCH_TIMEOUT);
     while (eth_txq_is_busy()) {
         asm volatile("nop");

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -53,12 +53,7 @@ public:
      * Expected that *buffer_index_ptr is initialized outside of this object
      */
     EthChannelBuffer(
-        size_t channel_base_address,
-        size_t buffer_size_bytes,
-        size_t header_size_bytes,
-        size_t eth_transaction_ack_word_addr,  // Assume for receiver channel, this address points to a chunk of memory
-                                               // that can fit 2 eth_channel_syncs cfor ack
-        uint8_t channel_id) :
+        size_t channel_base_address, size_t buffer_size_bytes, size_t header_size_bytes, uint8_t channel_id) :
         buffer_size_in_bytes(buffer_size_bytes),
         max_eth_payload_size_in_bytes(buffer_size_in_bytes),
         channel_id(channel_id) {
@@ -134,7 +129,6 @@ struct EthChannelBufferTuple {
         const size_t channel_base_address[],
         const size_t buffer_size_bytes,
         const size_t header_size_bytes,
-        const size_t eth_transaction_ack_word_addr,
         const size_t channel_base_id) {
         size_t idx = 0;
 
@@ -144,7 +138,6 @@ struct EthChannelBufferTuple {
                       channel_base_address[idx],
                       buffer_size_bytes,
                       header_size_bytes,
-                      eth_transaction_ack_word_addr,
                       static_cast<uint8_t>(channel_base_id + idx)),
                   ++idx),
                  ...);

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -1905,9 +1905,11 @@ void kernel_main() {
 
     if constexpr (enable_ethernet_handshake) {
         if constexpr (is_handshake_sender) {
-            erisc::datamover::handshake::sender_side_handshake(DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT);
+            erisc::datamover::handshake::sender_side_handshake(
+                handshake_addr, DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT);
         } else {
-            erisc::datamover::handshake::receiver_side_handshake(DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT);
+            erisc::datamover::handshake::receiver_side_handshake(
+                handshake_addr, DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT);
         }
 
         *edm_status_ptr = tt::tt_fabric::EDMStatus::REMOTE_HANDSHAKE_COMPLETE;

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -1425,8 +1425,6 @@ void kernel_main() {
     //
     // COMMON CT ARGS (not specific to sender or receiver)
     //
-    *reinterpret_cast<volatile uint32_t*>(handshake_addr) = 0;
-    auto eth_transaction_ack_word_addr = handshake_addr + sizeof(eth_channel_sync_t);
 
     // Initialize stream register state for credit management across the Ethernet link.
     // We make sure to do this before we handshake to guarantee that the registers are
@@ -1464,14 +1462,6 @@ void kernel_main() {
         init_ptr_val<to_sender_packets_acked_streams[4]>(0);
         init_ptr_val<to_sender_packets_completed_streams[3]>(0);
         init_ptr_val<to_sender_packets_completed_streams[4]>(0);
-    }
-
-    if constexpr (enable_ethernet_handshake) {
-        if constexpr (is_handshake_sender) {
-            erisc::datamover::handshake::sender_side_start(handshake_addr, DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT);
-        } else {
-            erisc::datamover::handshake::receiver_side_start(handshake_addr);
-        }
     }
 
     // TODO: CONVERT TO SEMAPHORE
@@ -1875,7 +1865,6 @@ void kernel_main() {
         local_receiver_buffer_addresses.data(),
         channel_buffer_size,
         sizeof(PACKET_HEADER_TYPE),
-        eth_transaction_ack_word_addr,
         receiver_channel_base_id);
 
     // initialize the remote receiver channel buffers
@@ -1883,16 +1872,11 @@ void kernel_main() {
         remote_receiver_buffer_addresses.data(),
         channel_buffer_size,
         sizeof(PACKET_HEADER_TYPE),
-        eth_transaction_ack_word_addr,
         receiver_channel_base_id);
 
     // initialize the local sender channel worker interfaces
     local_sender_channels.init(
-        local_sender_buffer_addresses.data(),
-        channel_buffer_size,
-        sizeof(PACKET_HEADER_TYPE),
-        0,  // For sender channels there is no eth_transaction_ack_word_addr because they don't send acks
-        sender_channel_base_id);
+        local_sender_buffer_addresses.data(), channel_buffer_size, sizeof(PACKET_HEADER_TYPE), sender_channel_base_id);
 
     // initialize the local sender channel worker interfaces
     init_local_sender_channel_worker_interfaces(
@@ -1921,9 +1905,9 @@ void kernel_main() {
 
     if constexpr (enable_ethernet_handshake) {
         if constexpr (is_handshake_sender) {
-            erisc::datamover::handshake::sender_side_finish(handshake_addr, DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT);
+            erisc::datamover::handshake::sender_side_handshake(DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT);
         } else {
-            erisc::datamover::handshake::receiver_side_finish(handshake_addr, DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT);
+            erisc::datamover::handshake::receiver_side_handshake(DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT);
         }
 
         *edm_status_ptr = tt::tt_fabric::EDMStatus::REMOTE_HANDSHAKE_COMPLETE;

--- a/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
@@ -55,11 +55,7 @@ void setup_channel(
     size_t& sender_flow_control_address,
     StreamId my_channel_free_slots_stream_id) {
     new (channel_ptr) tt::tt_fabric::FabricMuxChannelBuffer<NUM_BUFFERS>(
-        channel_base_address,
-        buffer_size_bytes,
-        sizeof(PACKET_HEADER_TYPE),
-        0, /* unused, eth_transaction_ack_word_addr */
-        channel_id);
+        channel_base_address, buffer_size_bytes, sizeof(PACKET_HEADER_TYPE), channel_id);
     channel_base_address += NUM_BUFFERS * buffer_size_bytes;
     init_ptr_val(my_channel_free_slots_stream_id, NUM_BUFFERS);
 

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/device/kernels/barrier_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/device/kernels/barrier_receiver.cpp
@@ -55,8 +55,8 @@ void kernel_main() {
     channels_syncs_addrs->bytes_sent = 0;
     channels_syncs_addrs->receiver_ack = 0;
     // Semaphore is mapped to sender core
-    erisc::datamover::handshake::receiver_side_start(handshake_addr);
-    erisc::datamover::handshake::receiver_side_finish(handshake_addr);
+    erisc::datamover::handshake::deprecated::receiver_side_start(handshake_addr);
+    erisc::datamover::handshake::deprecated::receiver_side_finish(handshake_addr);
 
     *start_semaphore = 0;
 

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/device/kernels/barrier_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/device/kernels/barrier_sender.cpp
@@ -46,7 +46,7 @@ void kernel_main() {
     uint32_t arg_idx = 0;
     const bool is_ring_start = get_arg_val<uint32_t>(arg_idx++) == 1;
     const uint32_t handshake_addr = get_arg_val<uint32_t>(arg_idx++);
-    erisc::datamover::handshake::sender_side_start(handshake_addr);
+    erisc::datamover::handshake::deprecated::sender_side_start(handshake_addr);
     uint32_t channels_addrs = get_arg_val<uint32_t>(arg_idx++);
     volatile uint32_t* sem_addr = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
     const uint32_t host_noc_x = get_arg_val<uint32_t>(arg_idx++);
@@ -60,7 +60,7 @@ void kernel_main() {
     channels_syncs_addrs->bytes_sent = 0;
     channels_syncs_addrs->receiver_ack = 0;
     *sem_addr = 0;
-    erisc::datamover::handshake::sender_side_finish(handshake_addr);
+    erisc::datamover::handshake::deprecated::sender_side_finish(handshake_addr);
     noc_semaphore_inc(host_semaphore_addr, 1);
 
     // Ensure every core has completed their previous tasks

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
@@ -145,9 +145,9 @@ void kernel_main() {
 
     bool is_done_as_rx_handshaker = is_handshake_sender;
     if constexpr (is_handshake_sender) {
-        erisc::datamover::handshake::sender_side_start(handshake_addr);
+        erisc::datamover::handshake::deprecated::sender_side_start(handshake_addr);
     } else {
-        erisc::datamover::handshake::receiver_side_start(handshake_addr);
+        erisc::datamover::handshake::deprecated::receiver_side_start(handshake_addr);
     }
 
     // Receiver args
@@ -184,7 +184,7 @@ void kernel_main() {
     }
 
     if (!is_handshake_sender) {
-        if (!is_done_as_rx_handshaker && erisc::datamover::handshake::receiver_side_can_finish()) {
+        if (!is_done_as_rx_handshaker && erisc::datamover::handshake::deprecated::receiver_side_can_finish()) {
             is_done_as_rx_handshaker = true;
             erisc::datamover::handshake::receiver_side_finish(handshake_addr);
         }
@@ -224,10 +224,10 @@ void kernel_main() {
     }
 
     if constexpr (is_handshake_sender) {
-        erisc::datamover::handshake::sender_side_finish(handshake_addr);
+        erisc::datamover::handshake::deprecated::sender_side_finish(handshake_addr);
     } else {
         if (!is_done_as_rx_handshaker) {
-            erisc::datamover::handshake::receiver_side_finish(handshake_addr);
+            erisc::datamover::handshake::deprecated::receiver_side_finish(handshake_addr);
             is_done_as_rx_handshaker = true;
         }
     }

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
@@ -186,7 +186,7 @@ void kernel_main() {
     if (!is_handshake_sender) {
         if (!is_done_as_rx_handshaker && erisc::datamover::handshake::deprecated::receiver_side_can_finish()) {
             is_done_as_rx_handshaker = true;
-            erisc::datamover::handshake::receiver_side_finish(handshake_addr);
+            erisc::datamover::handshake::deprecated::receiver_side_finish(handshake_addr);
         }
     }
 


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- The current EDM <-> EDM handshake approach for `fabric_erisc_datamover` kernels relies on all devices in the Mesh being initialized before fabric is loaded
- This assumption is true for single host scenarios, but breaks down in the multi-host case, since each host will initialize it's local mesh asynchronous of all other hosts
- With delays added to device startup on some hosts, the handshake step hangs. This is because the delayed host clears the handshake message written to it

### What's changed
- Add new _single step_ handshake APIs to `edm_handshake.hpp`: `sender_side_handshake` and `receiver_side_handshake` (protocol described in header)
- Use them in `fabric_erisc_datamover.cpp` to ensure that the multi-host scenario described above is supported
- Mark handshake APIs used by legacy CCLs as deprecated. These will be removed once legacy CCLs are purged.
- General cleanup - remove unused args from `EthChannelBuffer` ctor

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes