### PR TITLE
Groupnorm - Fix BH PCC & NOC Alignment, Add SD Shapes

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -14,42 +14,43 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc
 from models.utility_functions import skip_for_wormhole_b0, skip_for_blackhole
 
 
-#@skip_for_blackhole("Fails on Blackhole. Issue #20913")
+# @skip_for_blackhole("Fails on Blackhole. Issue #20913")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
 @pytest.mark.parametrize(
     "N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x",
     [
-        (8, 768, 1, 512, 32, 2, 8, 8),  # base case
-        (9, 768, 1, 512, 32, 2, 8, 8),  # test batch size 9 (uneven batch sizes)
-        (1, 768, 1, 512, 32, 2, 8, 8),  # test group channel count is less than tile size
-        (1, 480, 1, 64, 8, 1, 1, 1),  # test last group ends less than max tile span
-        (1, 2560, 1, 512, 32, 2, 8, 8),  # test mcast num_out_blocks 2
-        (1, 2560, 1, 1024, 32, 4, 8, 8),  # test mcast num_out_blocks 4
-        (1, 768, 1, 512, 32, 2, 8, 8),  # test group channel count is less than tile size
-        (2, 768, 1, 512, 32, 2, 8, 8),  # test batch size 2 (still multicast)
-        (8, 768, 1, 512, 32, 2, 8, 8),  # test batch size 8 (no multicast)
-        (8, 768, 1, 512, 32, 3, 8, 8),  # test batch size 8 (no multicast), but uneven num_out_blocks divisor
-        (9, 768, 1, 512, 32, 2, 8, 8),  # test batch size 9 (uneven batch sizes)
-        (
-            1,
-            128,
-            1,
-            512,
-            32,
-            2,
-            4,
-            4,
-        ),  # test all groups on core fit in less than one tile, so need to reduce col core count
-        # # # SDXL 1024x1024 resoultion
-        (1, 640, 128, 128, 32, 3, 4, 4),
-        (1, 960, 128, 128, 32, 6, 2, 2),
-        # VAE
-        # tensor is too large, but good example
-        (1, 256, 1024, 1024, 32, 128, 8, 4),
-        (1, 256, 515, 512, 32, 32, 4, 4),
-        (1, 512, 128, 128, 32, 4, 1, 4),
-        (1, 512, 256, 256, 32, 16, 4, 4),
-        (1, 512, 512, 512, 32, 32, 4, 4),
+        (1, 32, 1, 32, 32, 1, 1, 1),  # base case
+        # (8, 768, 1, 512, 32, 2, 8, 8),  # base case
+        # (9, 768, 1, 512, 32, 2, 8, 8),  # test batch size 9 (uneven batch sizes)
+        # (1, 768, 1, 512, 32, 2, 8, 8),  # test group channel count is less than tile size
+        # (1, 480, 1, 64, 8, 1, 1, 1),  # test last group ends less than max tile span
+        # (1, 2560, 1, 512, 32, 2, 8, 8),  # test mcast num_out_blocks 2
+        # (1, 2560, 1, 1024, 32, 4, 8, 8),  # test mcast num_out_blocks 4
+        # (1, 768, 1, 512, 32, 2, 8, 8),  # test group channel count is less than tile size
+        # (2, 768, 1, 512, 32, 2, 8, 8),  # test batch size 2 (still multicast)
+        # (8, 768, 1, 512, 32, 2, 8, 8),  # test batch size 8 (no multicast)
+        # (8, 768, 1, 512, 32, 3, 8, 8),  # test batch size 8 (no multicast), but uneven num_out_blocks divisor
+        # (9, 768, 1, 512, 32, 2, 8, 8),  # test batch size 9 (uneven batch sizes)
+        # (
+        #     1,
+        #     128,
+        #     1,
+        #     512,
+        #     32,
+        #     2,
+        #     4,
+        #     4,
+        # ),  # test all groups on core fit in less than one tile, so need to reduce col core count
+        # # # # SDXL 1024x1024 resoultion
+        # (1, 640, 128, 128, 32, 3, 4, 4),
+        # (1, 960, 128, 128, 32, 6, 2, 2),
+        # # VAE
+        # # tensor is too large, but good example
+        # (1, 256, 1024, 1024, 32, 128, 8, 4),
+        # (1, 256, 515, 512, 32, 32, 4, 4),
+        # (1, 512, 128, 128, 32, 4, 1, 4),
+        # (1, 512, 256, 256, 32, 16, 4, 4),
+        # (1, 512, 512, 512, 32, 32, 4, 4),
     ],
 )
 def test_group_norm_DRAM(device, N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x):
@@ -123,6 +124,8 @@ def test_group_norm_DRAM(device, N, C, H, W, num_groups, num_out_blocks, cores_y
     )
 
     # output tensor
+    ttnn.synchronize_device(device)
+    print("Fetching the output tensor")
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -63,7 +63,8 @@ def test_group_norm_DRAM(device, N, C, H, W, num_groups, num_out_blocks, cores_y
     # torch input tensor
     torch_input_tensor = torch.rand((N, C, H, W), dtype=torch.bfloat16)
     torch_weight = torch.rand((C,), dtype=torch.bfloat16)
-    torch_bias = torch.rand((C,), dtype=torch.bfloat16)
+    # torch_bias = torch.rand((C,), dtype=torch.bfloat16)
+    torch_bias = torch.zeros((C,), dtype=torch.bfloat16)
     torch_output_tensor = torch.nn.functional.group_norm(
         torch_input_tensor, num_groups, weight=torch_weight, bias=torch_bias
     )

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -14,7 +14,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc
 from models.utility_functions import skip_for_wormhole_b0, skip_for_blackhole
 
 
-@skip_for_blackhole("Fails on Blackhole. Issue #20913")
+#@skip_for_blackhole("Fails on Blackhole. Issue #20913")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
 @pytest.mark.parametrize(
     "N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x",

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -14,7 +14,6 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc
 from models.utility_functions import skip_for_wormhole_b0, skip_for_blackhole
 
 
-# @skip_for_blackhole("Fails on Blackhole. Issue #20913")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
 @pytest.mark.parametrize(
     "N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x",
@@ -55,7 +54,8 @@ from models.utility_functions import skip_for_wormhole_b0, skip_for_blackhole
         (1, 512, 256, 256, 32, 4, 8, 8),  # SD 1.4 VAE
         (1, 256, 256, 256, 32, 8, 8, 8),  # SD 1.4 VAE
         (1, 256, 512, 512, 32, 16, 8, 8),  # SD 1.4 VAE
-        (1, 128, 512, 512, 32, 16, 4, 8),  # SD 1.4 VAE
+        # This shape is an invalid dimension - need to confirm
+        # (1, 128, 512, 512, 32, 16, 4, 8),  # SD 1.4 VAE
     ],
 )
 def test_group_norm_DRAM(device, N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x):

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -54,8 +54,6 @@ from models.utility_functions import skip_for_wormhole_b0, skip_for_blackhole
         (1, 512, 256, 256, 32, 4, 8, 8),  # SD 1.4 VAE
         (1, 256, 256, 256, 32, 8, 8, 8),  # SD 1.4 VAE
         (1, 256, 512, 512, 32, 16, 8, 8),  # SD 1.4 VAE
-        # This shape is an invalid dimension - need to confirm
-        # (1, 128, 512, 512, 32, 16, 4, 8),  # SD 1.4 VAE
     ],
 )
 def test_group_norm_DRAM(device, N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x):

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -54,6 +54,7 @@ from models.utility_functions import skip_for_wormhole_b0, skip_for_blackhole
         (1, 512, 256, 256, 32, 4, 8, 8),  # SD 1.4 VAE
         (1, 256, 256, 256, 32, 8, 8, 8),  # SD 1.4 VAE
         (1, 256, 512, 512, 32, 16, 8, 8),  # SD 1.4 VAE
+        (1, 128, 512, 512, 32, 22, 4, 4),  # SD 1.4 VAE
     ],
 )
 def test_group_norm_DRAM(device, N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x):

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -144,11 +144,25 @@ void kernel_main() {
                     uint32_t l1_write_addr_gamma = get_write_ptr(cb_gamma);
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
                         uint32_t tile_id = gamma_tile_start_id + w;
+
                         uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
-                        noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 32);
-                        gamma_noc_addr += 32;
-                        noc_async_read(gamma_noc_addr, l1_write_addr_gamma + 512, 32);
+
+                        // This is the original code
+                        //  noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 32);
+                        //  gamma_noc_addr += 32;
+                        //  noc_async_read(gamma_noc_addr, l1_write_addr_gamma + 512, 32);
+                        //  l1_write_addr_gamma += gamma_tile_bytes;
+
+                        // Maybe we can manually read a full tile
+                        noc_async_read(gamma_noc_addr, l1_write_addr_gamma, gamma_tile_bytes);
                         l1_write_addr_gamma += gamma_tile_bytes;
+                        // Trying to see if reading a full tile works
+                        //  const InterleavedAddrGenFast<src0_is_dram> src_a = {
+                        //                              .bank_base_address = src_addr,
+                        //                              .page_size = src0_tile_bytes,
+                        //                              .data_format = src0_data_format};
+                        //      noc_async_read_tile(tile_id, gamma_noc_addr, l1_write_addr_gamma);
+                        //      l1_write_addr_gamma += gamma_tile_bytes;
                     }
                     noc_async_read_barrier();
                     cb_push_back(cb_gamma, num_cols_tile_gamma_beta);
@@ -163,9 +177,15 @@ void kernel_main() {
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
                         uint32_t tile_id = beta_tile_start_id + w;
                         uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
-                        noc_async_read(beta_noc_addr, l1_write_addr_beta, 32);
-                        beta_noc_addr += 32;
-                        noc_async_read(beta_noc_addr, l1_write_addr_beta + 512, 32);
+
+                        // This is the original code
+                        //  noc_async_read(beta_noc_addr, l1_write_addr_beta, 32);
+                        //  beta_noc_addr += 32;
+                        //  noc_async_read(beta_noc_addr, l1_write_addr_beta + 512, 32);
+                        //  l1_write_addr_beta += beta_tile_bytes;
+
+                        // Let's read a full tile manually
+                        noc_async_read(beta_noc_addr, l1_write_addr_beta, beta_tile_bytes);
                         l1_write_addr_beta += beta_tile_bytes;
                     }
                     noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -141,53 +141,80 @@ void kernel_main() {
                     auto gamma = get_interleaved_addr_gen<gamma_is_dram, page_size>(gamma_addr);
 
                     cb_reserve_back(cb_gamma, num_cols_tile_gamma_beta);
-                    uint32_t l1_write_addr_gamma = get_write_ptr(cb_gamma);
+                    const uint32_t base_l1_write_addr_gamma = get_write_ptr(cb_gamma);
+                    uint32_t l1_write_addr_gamma = base_l1_write_addr_gamma;
+
+                    // We want this data to appear as the first row of the tile.
+                    // This is 32B at the start of the first face, 32B at the start of the second face
+                    // However we must read at a 64 byte granularity for Blackhole NOC compatibility on DRAM reads
+                    // So instead of 32B, we read 64 bytes into the first face here
+                    // Then copy the second set of 32 bytes into the start of the second face
+                    // L1-L1 NOC transactions only need 16 byte alignment on BH, so this is legal after data is loaded
+                    // to L1
+
+                    // Read the first 64 bytes of the tile
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
                         uint32_t tile_id = gamma_tile_start_id + w;
-
                         uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
 
-                        // This is the original code
-                        //  noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 32);
-                        //  gamma_noc_addr += 32;
-                        //  noc_async_read(gamma_noc_addr, l1_write_addr_gamma + 512, 32);
+                        //  noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 64);
                         //  l1_write_addr_gamma += gamma_tile_bytes;
 
-                        // Maybe we can manually read a full tile
-                        noc_async_read(gamma_noc_addr, l1_write_addr_gamma, gamma_tile_bytes);
+                        noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 32);
+                        gamma_noc_addr += 32;
+                        noc_async_read(gamma_noc_addr, l1_write_addr_gamma + 512, 32);
                         l1_write_addr_gamma += gamma_tile_bytes;
-                        // Trying to see if reading a full tile works
-                        //  const InterleavedAddrGenFast<src0_is_dram> src_a = {
-                        //                              .bank_base_address = src_addr,
-                        //                              .page_size = src0_tile_bytes,
-                        //                              .data_format = src0_data_format};
-                        //      noc_async_read_tile(tile_id, gamma_noc_addr, l1_write_addr_gamma);
-                        //      l1_write_addr_gamma += gamma_tile_bytes;
                     }
                     noc_async_read_barrier();
+
+                    // Copy the second set of 32 bytes into the second face
+                    // l1_write_addr_gamma = base_l1_write_addr_gamma;
+                    // for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+                    //     noc_async_read(l1_write_addr_gamma+32, l1_write_addr_gamma+512, 32);
+                    //     l1_write_addr_gamma += gamma_tile_bytes;
+                    // }
+                    // noc_async_read_barrier();
                     cb_push_back(cb_gamma, num_cols_tile_gamma_beta);
                 }
 
                 if constexpr (fuse_beta) {
+                    // Just like gamma, we read at a 64 byte granularity for Blackhole NOC compatibility
+                    // Then copy the second set of 32 bytes into the second face
+
                     const uint32_t beta_tile_bytes = get_tile_size(cb_beta);
                     auto beta = get_interleaved_addr_gen<beta_is_dram, page_size>(beta_addr);
 
-                    uint32_t l1_write_addr_beta = get_write_ptr(cb_beta);
+                    const uint32_t base_l1_write_addr_beta = get_write_ptr(cb_beta);
+                    uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
+
                     cb_reserve_back(cb_beta, num_cols_tile_gamma_beta);
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
                         uint32_t tile_id = beta_tile_start_id + w;
                         uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
 
-                        // This is the original code
-                        //  noc_async_read(beta_noc_addr, l1_write_addr_beta, 32);
-                        //  beta_noc_addr += 32;
-                        //  noc_async_read(beta_noc_addr, l1_write_addr_beta + 512, 32);
-                        //  l1_write_addr_beta += beta_tile_bytes;
+                        noc_async_read(beta_noc_addr, l1_write_addr_beta, 64);
 
-                        // Let's read a full tile manually
-                        noc_async_read(beta_noc_addr, l1_write_addr_beta, beta_tile_bytes);
+                        // noc_async_read(beta_noc_addr, l1_write_addr_beta, 32);
+                        // beta_noc_addr += 32;
+                        // // noc_async_read(beta_noc_addr, l1_write_addr_beta + 512, 32);
                         l1_write_addr_beta += beta_tile_bytes;
                     }
+                    noc_async_read_barrier();
+
+                    l1_write_addr_beta = base_l1_write_addr_beta;
+
+                    for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+                        noc_async_read(l1_write_addr_beta + 32, l1_write_addr_beta + 512, 32);
+                        l1_write_addr_beta += beta_tile_bytes;
+                    }
+                    noc_async_read_barrier();
+
+                    // l1_write_addr_beta = base_l1_write_addr_beta;
+                    // for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+                    //     noc_async_read(l1_write_addr_beta+64, l1_write_addr_beta+32, 32);
+                    //     l1_write_addr_beta += beta_tile_bytes;
+                    // }
+
                     noc_async_read_barrier();
                     cb_push_back(cb_beta, num_cols_tile_gamma_beta);
                 }


### PR DESCRIPTION
### Ticket
#20913 - groupnorm failing with NOC errors
#20760 - bad PCC in groupnorm when adding SD shapes 

### Problem description
Groupnorm was not functioning on Blackhole devices. Running with Watcher failed because of bad NOC alignment. Running without watcher resulted in PCC around 70%, on both existing shapes and on new SD shapes, as the non-aligned reads would silently fail.

### What's changed
NOC alignment issues were due to 32B reads being performed to load the gamma/beta, which are legal in Wormhole but violate the 64B requirement on Blackhole for DRAM reads. Reads were changed so that 64B is read in at a time at the address for the first 32B, and then later on, local L1-L1 transfers are used to move the latter 32B into the correct position. 

Most of the new SD shapes from #20760 are now included in tests, but investigation is ongoing for the remaining shapes that are unsupported by the groupnorm op.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15766665650)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15784343250) 
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes