### PR TITLE
Revert "Trace Support for Yolov4 Demo"

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -36,13 +36,12 @@ jobs:
           { name: "stable_diffusion", runner-label: "N150", performance: false, cmd: run_stable_diffusion_func, owner_id: U045U3DEKM4}, # Mohamed Bahnas
           { name: "segformer", runner-label: "N150", performance: false, cmd: run_segformer_func, owner_id: U045U3DEKM4}, # Mohamed Bahnas (vguduruTT)
           { name: "yolov9c", runner-label: "N150", performance: false, cmd: run_yolov9c_perf, owner_id: U056BK5U81E}, # Dalar Vartanians
-          { name: "mobilenetv2", runner-label: "N150", performance: false, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E}, # Dalar Vartanians
+          { name: "mobilenetv2", runner-label: "N150", performance: true, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E}, # Dalar Vartanians
           { name: "yolov8s_world", runner-label: "N150", performance: false, cmd: run_yolov8s_world_perf, owner_id: U056BK5U81E}, # Dalar Vartanians
           { name: "ufld_v2", runner-label: "N150", performance: false, cmd: run_ufld_v2_func, owner_id: U056BK5U81E}, # Dalar Vartanians
           { name: "vanilla_unet", runner-label: "N150", performance: false, cmd: run_vanilla_unet_demo, owner_id: U045U3DEKM4}, # Mohamed Bahnas (keerthana-r-mcw)
           { name: "yolov8x", runner-label: "N150", performance: false, cmd: run_yolov8x_perf, owner_id: U056BK5U81E}, # Dalar Vartanians
           { name: "vgg_unet", runner-label: "N150", performance: false, cmd: run_vgg_unet_demo, owner_id: U045U3DEKM4}, # Mohamed Bahnas (keerthana-r-mcw)
-          { name: "yolov4", runner-label: "N150", performance: false, cmd: run_yolov4_perf, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Sudhanshu Singhal)
           { name: "resnet", runner-label: "N150", performance: true, cmd: run_resnet_stability, owner_id: U0837MYG788}, # Marko Radosavljevic
           { name: "sdxl", runner-label: "N150", performance: false, cmd: run_sdxl_func, owner_id: U0837MYG788}, # Marko Radosavljevic
           { name: "falcon7b", runner-label: "N300", performance: false, cmd: run_falcon7b_func, owner_id: U05RWH3QUPM}, # Salar Hosseini
@@ -70,7 +69,6 @@ jobs:
           { name: "yolov8s_world", runner-label: "N300", performance: false, cmd: run_yolov8s_world_perf, owner_id: U056BK5U81E}, # Dalar Vartanians
           { name: "vanilla_unet", runner-label: "N300", performance: false, cmd: run_vanilla_unet_demo, owner_id: U045U3DEKM4}, # Mohamed Bahnas (keerthana-r-mcw)
           { name: "vgg_unet", runner-label: "N300", performance: false, cmd: run_vgg_unet_demo, owner_id: U045U3DEKM4}, # Mohamed Bahnas (keerthana-r-mcw)
-          { name: "yolov4", runner-label: "N300", performance: false, cmd: run_yolov4_perf, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Sudhanshu Singhal)
           # Moved to t3k tests until OOM on single card runners resolved
           # { name: "qwen7b", runner-label: "N300", performance: false, cmd: run_qwen7b_func, owner_id: U03PUAKE719}, # Mark O'Connor
         ]

--- a/models/demos/yolov4/README.md
+++ b/models/demos/yolov4/README.md
@@ -1,4 +1,4 @@
-# Yolov4
+# Yolov4 Demo
 
 ## Platforms:
     WH N150/N300
@@ -8,58 +8,42 @@ Or, make sure to set the following environment variable in the terminal:
 ```
 export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
 ```
-To obtain the perf reports through profiler, please build with following command:
-```
-./build_metal.sh -p
-```
 
-### Details
-
-- The entry point to the yolov4 is located at:`models/demos/yolov4/tt/yolov4.py`
-- Batch Size :1
-- Supported Input Resolution - (640,640), (320,320) (Height,Width)
-
-
-## How to run
-Use the following command to run the model :
-
-#### For 320x320:
-```
-pytest models/demos/yolov4/tests/pcc/test_ttnn_yolov4.py::test_yolov4[0-pretrained_weight_true-0]
-```
-#### For 640x640:
-```
-pytest models/demos/yolov4/tests/pcc/test_ttnn_yolov4.py::test_yolov4[1-pretrained_weight_true-0]
-```
+## How to run yolov4
 
 ### Model performant running with Trace+2CQ
 
 #### For 320x320:
-- end-2-end perf is 114 FPS
-  ```
+- end-2-end perf is 80 FPS
+  ```bash
   pytest models/demos/yolov4/tests/perf/test_e2e_performant.py::test_e2e_performant[resolution0-1-act_dtype0-weight_dtype0-device_params0]
   ```
 #### For 640x640:
-- end-2-end perf is 56 FPS
-  ```
+- end-2-end perf is 30 FPS
+  ```bash
   pytest models/demos/yolov4/tests/perf/test_e2e_performant.py::test_e2e_performant[resolution1-1-act_dtype0-weight_dtype0-device_params0]
   ```
+
 
 ### Single Image Demo
 
 - Use the following command to run the yolov4 with a giraffe image:
 
 For 320x320:
-  ```
+  ```bash
   pytest models/demos/yolov4/demo.py::test_yolov4[device_params0-resolution0]
   ```
 For 640x640:
-  ```
+  ```bash
   pytest models/demos/yolov4/demo.py::test_yolov4[device_params0-resolution1]
   ```
-- Output images will be saved in the yolov4_predictions/ folder.
+- The output file `ttnn_yolov4_prediction_demo.jpg` will be generated.
 
-- To run the test with a different input image, add your image path to the `imgfile` parameter in the `@pytest.mark.parametrize` section of `demo.py`:
+- Use the following command to run the yolov4 with different input image:
+  ```bash
+  pytest  --disable-warnings --input-path=<PATH_TO_INPUT_IMAGE> models/demos/yolov4/demo.py
+  ```
+
 
 ### mAP Accuracy Test
 - To be added soon

--- a/models/demos/yolov4/demo.py
+++ b/models/demos/yolov4/demo.py
@@ -1,27 +1,20 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-
 import cv2
 import pytest
+import torch
 
 import ttnn
-from models.demos.yolov4.common import image_to_tensor, load_image
+from models.demos.yolov4.common import image_to_tensor, load_image, load_torch_model
 from models.demos.yolov4.post_processing import load_class_names, plot_boxes_cv2, post_processing
-from models.demos.yolov4.runner.performant_runner import YOLOv4PerformantRunner
-from models.utility_functions import disable_persistent_kernel_cache, run_for_wormhole_b0
+from models.demos.yolov4.runner.runner import YOLOv4Runner
+from models.demos.yolov4.tt.model_preprocessing import create_yolov4_model_parameters
+from models.utility_functions import skip_for_grayskull
 
 
-@run_for_wormhole_b0()
-@pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 40960, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
-)
-@pytest.mark.parametrize(
-    "batch_size, act_dtype, weight_dtype",
-    ((1, ttnn.bfloat16, ttnn.bfloat16),),
-)
+@skip_for_grayskull()
 @pytest.mark.parametrize(
     "resolution",
     [
@@ -29,55 +22,29 @@ from models.utility_functions import disable_persistent_kernel_cache, run_for_wo
         (640, 640),
     ],
 )
-@pytest.mark.parametrize(
-    "imgfile",
-    [
-        "models/demos/yolov4/resources/giraffe_320.jpg",
-    ],
-)
-def test_yolov4(
-    device,
-    use_program_cache,
-    batch_size,
-    act_dtype,
-    weight_dtype,
-    model_location_generator,
-    resolution,
-    imgfile,
-):
-    disable_persistent_kernel_cache()
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_yolov4(device, reset_seeds, model_location_generator, resolution):
+    torch.manual_seed(0)
 
-    yolov4_trace_2cq = YOLOv4PerformantRunner(
-        device,
-        batch_size,
-        act_dtype,
-        weight_dtype,
-        resolution=resolution,
-        model_location_generator=None,
-    )
-
+    imgfile = "models/demos/yolov4/resources/giraffe_320.jpg"
     img = load_image(imgfile, resolution)
-    torch_input_tensor = image_to_tensor(img)
-    # torch_input_tensor = torch_input_tensor.permute(0, 2, 3, 1)
+    torch_input = image_to_tensor(img)
 
-    preds = yolov4_trace_2cq.run(torch_input_tensor)
+    input_tensor = torch_input.permute(0, 2, 3, 1)
+    ttnn_input = ttnn.from_torch(input_tensor, ttnn.bfloat16)
 
+    torch_model = load_torch_model(model_location_generator)
+    parameters = create_yolov4_model_parameters(torch_model, torch_input, resolution, device)
+
+    ttnn_model_runner = YOLOv4Runner(device, parameters, resolution)
+
+    ## Giraffe image detection
     conf_thresh = 0.3
     nms_thresh = 0.4
-    boxes = post_processing(img, conf_thresh, nms_thresh, preds)
+    output = ttnn_model_runner.run(ttnn_input)
 
+    boxes = post_processing(img, conf_thresh, nms_thresh, output)
     namesfile = "models/demos/yolov4/resources/coco.names"
     class_names = load_class_names(namesfile)
-
-    img_cv = cv2.imread(imgfile)
-
-    # Create a unique output file using image name and resolution
-    output_dir = "yolov4_predictions"
-    os.makedirs(output_dir, exist_ok=True)
-    img_base = os.path.splitext(os.path.basename(imgfile))[0]
-    output_filename = f"ttnn_yolov4_{img_base}_{resolution[0]}x{resolution[1]}.jpg"
-    output_path = os.path.join(output_dir, output_filename)
-
-    plot_boxes_cv2(img_cv, boxes[0], output_path, class_names)
-
-    yolov4_trace_2cq.release()
+    img = cv2.imread(imgfile)
+    plot_boxes_cv2(img, boxes[0], "ttnn_yolov4_prediction_demo.jpg", class_names)

--- a/models/demos/yolov4/runner/performant_runner.py
+++ b/models/demos/yolov4/runner/performant_runner.py
@@ -108,11 +108,15 @@ class YOLOv4PerformantRunner:
         assert_with_pcc(ref_confs, result_confs, YOLOV4_CONFS_PCC)
 
     def run(self, torch_input_tensor, check_pcc=False):
-        n, c, h, w = torch_input_tensor.shape
-        tt_inputs_host, input_mem_config = self.runner_infra._setup_l1_sharded_input(self.device, torch_input_tensor)
+        n, h, w, c = torch_input_tensor.shape
+        torch_input_tensor = torch_input_tensor.reshape(1, 1, h * w * n, c)
+        tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+        tt_inputs_host = ttnn.pad(tt_inputs_host, [1, 1, n * h * w, 16], [0, 0, 0, 0], 0)
         output = self._execute_yolov4_trace_2cqs_inference(tt_inputs_host)
 
         if check_pcc:
+            torch_input_tensor = torch_input_tensor.reshape(n, h, w, c)
+            torch_input_tensor = torch_input_tensor.permute(0, 3, 1, 2)
             self._validate(torch_input_tensor, output)
 
         return output

--- a/models/demos/yolov4/runner/performant_runner_infra.py
+++ b/models/demos/yolov4/runner/performant_runner_infra.py
@@ -62,16 +62,20 @@ class YOLOv4PerformanceRunnerInfra:
         torch_input_tensor = self.torch_input_tensor if torch_input_tensor is None else torch_input_tensor
 
         n, c, h, w = torch_input_tensor.shape
-
-        if c == 3:
-            c = 16
-        input_mem_config = ttnn.create_sharded_memory_config(
-            [n, c, h, w],
-            ttnn.CoreGrid(x=8, y=8),
-            ttnn.ShardStrategy.HEIGHT,
+        # sharded mem config for fold input
+        num_cores = core_grid.x * core_grid.y
+        shard_h = (n * w * h + num_cores - 1) // num_cores
+        grid_size = core_grid
+        grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
+        shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
+        shard_spec = ttnn.ShardSpec(shard_grid, (shard_h, 16), ttnn.ShardOrientation.ROW_MAJOR)
+        input_mem_config = ttnn.MemoryConfig(
+            ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
         )
+        torch_input_tensor = torch_input_tensor.permute(0, 2, 3, 1)
+        torch_input_tensor = torch_input_tensor.reshape(1, 1, h * w * n, c)
         tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
-
+        tt_inputs_host = ttnn.pad(tt_inputs_host, [1, 1, n * h * w, 16], [0, 0, 0, 0], 0)
         return tt_inputs_host, input_mem_config
 
     def setup_dram_sharded_input(self, device, torch_input_tensor=None, mesh_mapper=None, mesh_composer=None):
@@ -83,7 +87,7 @@ class YOLOv4PerformanceRunnerInfra:
             ),
             [
                 divup(tt_inputs_host.volume() // tt_inputs_host.shape[-1], (dram_grid_size.x * dram_grid_size.y)),
-                tt_inputs_host.shape[-1],
+                16,
             ],
             ttnn.ShardOrientation.ROW_MAJOR,
         )

--- a/models/demos/yolov4/tests/pcc/test_ttnn_yolov4.py
+++ b/models/demos/yolov4/tests/pcc/test_ttnn_yolov4.py
@@ -42,16 +42,8 @@ def run_yolov4(device, reset_seeds, model_location_generator, use_pretrained_wei
     img = load_image(imgfile, resolution)
     torch_input = image_to_tensor(img)
 
-    n, c, h, w = torch_input.shape
-    if c == 3:
-        c = 8
-    input_mem_config = ttnn.create_sharded_memory_config(
-        [n, c, h, w],
-        ttnn.CoreGrid(x=8, y=8),
-        ttnn.ShardStrategy.HEIGHT,
-    )
-    ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
-    ttnn_input = ttnn_input.to(device, input_mem_config)
+    input_tensor = torch.permute(torch_input, (0, 2, 3, 1))
+    ttnn_input = ttnn.from_torch(input_tensor, ttnn.bfloat16)
 
     torch_output_tensor = torch_model(torch_input)
 

--- a/models/demos/yolov4/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov4/tests/perf/test_e2e_performant.py
@@ -14,7 +14,6 @@ from models.utility_functions import run_for_wormhole_b0
 
 
 @run_for_wormhole_b0()
-@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "device_params", [{"l1_small_size": 40960, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
 )
@@ -49,7 +48,7 @@ def test_e2e_performant(
 
     inference_times = []
     for _ in range(10):
-        input_shape = (1, 3, *resolution)
+        input_shape = (1, *resolution, 3)
         torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
 
         t0 = time.time()

--- a/models/demos/yolov4/tests/perf/test_perf.py
+++ b/models/demos/yolov4/tests/perf/test_perf.py
@@ -21,7 +21,7 @@ from models.utility_functions import disable_persistent_kernel_cache, profiler
     "input_shape, expected_compile_time, expected_inference_time",
     [
         ((1, 320, 320, 3), 70, 0.5),
-        ((1, 640, 640, 3), 55, 0.6),
+        ((1, 640, 640, 3), 70, 0.6),
     ],
 )
 def test_yolov4(
@@ -41,7 +41,8 @@ def test_yolov4(
     torch_input = torch_input_tensor.permute(0, 3, 1, 2).float()
     parameters = create_yolov4_model_parameters(torch_model, torch_input, resolution, device)
 
-    ttnn_input = ttnn.from_torch(torch_input, ttnn.bfloat16, device=device)
+    ttnn_input = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16)
+
     ttnn_model = TtYOLOv4(parameters, device)
 
     logger.info(f"Compiling model with warmup run")
@@ -64,7 +65,6 @@ def test_yolov4(
     for idx in range(iterations):
         profiler.start("inference_time")
         profiler.start(f"inference_time_{idx}")
-        ttnn_input = ttnn.from_torch(torch_input, ttnn.bfloat16, device=device)
         ttnn_output_tensor = ttnn_model(ttnn_input)
         ttnn.deallocate(ttnn_output_tensor[0])
         ttnn.deallocate(ttnn_output_tensor[1])

--- a/models/demos/yolov4/tests/test_stability.py
+++ b/models/demos/yolov4/tests/test_stability.py
@@ -69,7 +69,7 @@ def test_yolov4_stability(
                 check_pcc = True
                 pcc_iter += 1
 
-            torch_input_tensor = torch.randn((1, 3, *resolution), dtype=torch.float32)
+            torch_input_tensor = torch.randn((1, *resolution, 3), dtype=torch.float32)
             _ = performant_runner.run(torch_input_tensor, check_pcc=check_pcc)
             check_pcc = False
 

--- a/models/demos/yolov4/tt/yolov4.py
+++ b/models/demos/yolov4/tt/yolov4.py
@@ -41,20 +41,8 @@ class TtYOLOv4:
         self.downs = []  # [self.down1]
         self.device = device
 
-    def __call__(self, x):
-        N, C, H, W = x.shape
-        min_channels = 8
-        if C < min_channels:
-            channel_padding_needed = min_channels - C
-            nchw = ttnn.pad(x, ((0, 0), (0, channel_padding_needed), (0, 0), (0, 0)), value=0.0)
-        else:
-            nchw = x
-        nhwc = ttnn.permute(nchw, (0, 2, 3, 1))  # NCHW -> NHWC
-        ttnn.deallocate(nchw)
-        ttnn.deallocate(x)
-        nhwc = ttnn.reallocate(nhwc)
-        x = ttnn.reshape(nhwc, [1, 1, nhwc.shape[0] * nhwc.shape[1] * nhwc.shape[2], nhwc.shape[-1]])
-        d1 = self.down1(x)
+    def __call__(self, input_tensor):
+        d1 = self.down1(input_tensor)
         d2 = self.down2(d1)
         ttnn.deallocate(d1)
         d3 = self.down3(d2)

--- a/models/demos/yolov4/web_demo/server/fast_api_yolov4.py
+++ b/models/demos/yolov4/web_demo/server/fast_api_yolov4.py
@@ -186,7 +186,7 @@ async def objdetection_v2(file: UploadFile = File(...)):
     else:
         print("unknow image type")
         exit(-1)
-    image = image.permute(0, 3, 1, 2)
+
     t1 = time.time()
     response = model.run(image)
     t2 = time.time()

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -22,7 +22,7 @@ run_perf_models_other() {
 
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/bert_tiny/tests/test_performance.py -m $test_marker
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/yolov4/tests/perf -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/yolov4/tests/perf/test_perf.py -m $test_marker
 
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/distilbert/tests/test_perf_distilbert.py -m $test_marker
 

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -239,19 +239,13 @@ run_yolov8x_perf() {
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/yolov8x/demo/demo.py --timeout 600
 
 }
-run_yolov4_perf() {
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/yolov4/demo.py --timeout 600
-
-}
 
 run_vgg_unet_demo() {
 
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/vgg_unet/demo/demo.py --timeout 600
 
 }
-
-
 
 main() {
   # For CI pipeline - source func commands but don't execute tests if not invoked directly


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#23416

Breaking all post commit model unit tests with PCC errors
https://github.com/tenstorrent/tt-metal/actions/runs/15766987401/job/44447573289

```
      assert pcc_passed, construct_pcc_assert_message(pcc_message, expected_pytorch_result, actual_pytorch_result)
E       AssertionError: 0.8404217125269587
```