### PR TITLE
#23273: SDXL Resnet mm optimizations

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
@@ -73,7 +73,7 @@ def test_crossattndown(
         dtype=ttnn.bfloat16,
         device=device,
         layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.L1_MEMORY_CONFIG,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     B, C, H, W = list(ttnn_input_tensor.shape)
 

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
@@ -26,7 +26,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
         ((1, 640, 128, 128), (1, 1280), 2, 1, True, 2, "up_blocks", 0.998),
         ((1, 2560, 32, 32), (1, 1280), 0, 0, True, 1, "up_blocks", 0.996),
         ((1, 1920, 32, 32), (1, 1280), 0, 2, True, 1, "up_blocks", 0.995),
-        ((1, 1920, 64, 64), (1, 1280), 1, 0, True, 1, "up_blocks", 0.998),
+        ((1, 1920, 64, 64), (1, 1280), 1, 0, True, 1, "up_blocks", 0.999),
         ((1, 1280, 64, 64), (1, 1280), 1, 1, True, 1, "up_blocks", 0.998),
         ((1, 960, 64, 64), (1, 1280), 1, 2, True, 1, "up_blocks", 0.998),
     ],
@@ -74,11 +74,12 @@ def test_resnetblock2d(
     torch_temb_tensor = torch_random(temb_shape, -0.1, 0.1, dtype=torch.float32)
     torch_output_tensor = torch_resnet(torch_input_tensor, torch_temb_tensor)
 
-    input_mem_cfg = (
-        ttnn.L1_MEMORY_CONFIG if down_block_id != 0 and not block == "up_blocks" else ttnn.DRAM_MEMORY_CONFIG
-    )
     ttnn_input_tensor = ttnn.from_torch(
-        torch_input_tensor, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=input_mem_cfg
+        torch_input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     B, C, H, W = list(ttnn_input_tensor.shape)
 

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -51,7 +51,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 275_797_309
+    expected_device_perf_cycles_per_iteration = 274_713_570
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
@@ -551,9 +551,32 @@ class ModelOptimisations:
             fused_activation=None,
         )
 
+        self.matmul_configs["2D_RESNET_CONV_320_640"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            in0_block_w=2,
+            per_core_M=16,
+            per_core_N=3,
+            out_subblock_h=2,
+            out_subblock_w=3,
+            transpose_mcast=False,
+            fused_activation=None,
+            fuse_batch=False,
+        )
+
         self.matmul_configs["2D_ATTN_OUT_LINEAR_1280"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(8, 8),
             in0_block_w=5,
+            per_core_M=4,
+            per_core_N=5,
+            out_subblock_h=1,
+            out_subblock_w=5,
+            transpose_mcast=False,
+            fused_activation=None,
+        )
+
+        self.matmul_configs["2D_RESNET_CONV_640_1280"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            in0_block_w=4,
             per_core_M=4,
             per_core_N=5,
             out_subblock_h=1,
@@ -573,6 +596,17 @@ class ModelOptimisations:
             fused_activation=None,
         )
 
+        self.matmul_configs["2D_RESNET_CONV_2560_1280"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            in0_block_w=2,
+            per_core_M=4,
+            per_core_N=5,
+            out_subblock_h=1,
+            out_subblock_w=5,
+            transpose_mcast=False,
+            fused_activation=None,
+        )
+
         self.matmul_configs["2D_ATTN_QKV_LINEAR_1280"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(8, 8),
             in0_block_w=4,
@@ -581,6 +615,78 @@ class ModelOptimisations:
             out_subblock_h=1,
             out_subblock_w=5,
             transpose_mcast=False,
+            fused_activation=None,
+            fuse_batch=False,
+        )
+
+        self.matmul_configs["2D_RESNET_CONV_1920_1280"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            in0_block_w=5,
+            per_core_M=4,
+            per_core_N=5,
+            out_subblock_h=1,
+            out_subblock_w=5,
+            transpose_mcast=False,
+            fused_activation=None,
+            fuse_batch=False,
+        )
+
+        self.matmul_configs["2D_RESNET_CONV_1920_640"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            in0_block_w=3,
+            per_core_M=16,
+            per_core_N=3,
+            out_subblock_h=2,
+            out_subblock_w=3,
+            transpose_mcast=False,
+            fused_activation=None,
+        )
+
+        self.matmul_configs["2D_RESNET_CONV_1280_640"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            in0_block_w=1,
+            per_core_M=16,
+            per_core_N=3,
+            out_subblock_h=2,
+            out_subblock_w=3,
+            transpose_mcast=False,
+            fused_activation=None,
+        )
+
+        self.matmul_configs["2D_RESNET_CONV_960_640"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            in0_block_w=2,
+            per_core_M=16,
+            per_core_N=3,
+            out_subblock_h=1,
+            out_subblock_w=3,
+            transpose_mcast=False,
+            fused_activation=None,
+        )
+
+        self.matmul_configs["1D_RESNET_CONV_960_320"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            in0_block_w=2,
+            out_subblock_h=1,
+            out_subblock_w=5,
+            per_core_M=8,
+            per_core_N=10,
+            mcast_in0=False,
+            gather_in0=False,
+            fuse_batch=False,
+            fused_activation=None,
+        )
+
+        self.matmul_configs["1D_RESNET_CONV_640_320"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            in0_block_w=1,
+            out_subblock_h=2,
+            out_subblock_w=2,
+            per_core_M=8,
+            per_core_N=10,
+            mcast_in0=False,
+            gather_in0=False,
+            fuse_batch=False,
             fused_activation=None,
         )
 
@@ -608,6 +714,29 @@ class ModelOptimisations:
             return None
 
         if not ("decoder" in matmul_path):
+            # # # RESNET CONV MM # # #
+            if "conv_shortcut" in matmul_path:
+                if "down_blocks.1" in matmul_path:
+                    return self.matmul_configs["2D_RESNET_CONV_320_640"]
+                if "down_blocks.2" in matmul_path:
+                    return self.matmul_configs["2D_RESNET_CONV_640_1280"]
+                if "up_blocks.0.resnets.0" in matmul_path or "up_blocks.0.resnets.1" in matmul_path:
+                    return self.matmul_configs["2D_RESNET_CONV_2560_1280"]
+                if "up_blocks.0.resnets.2" in matmul_path:
+                    return self.matmul_configs["2D_RESNET_CONV_1920_1280"]
+                if "up_blocks.1.resnets.0" in matmul_path:
+                    return self.matmul_configs["2D_RESNET_CONV_1920_640"]
+                if "up_blocks.1.resnets.1" in matmul_path:
+                    return self.matmul_configs["2D_RESNET_CONV_1280_640"]
+                if "up_blocks.1.resnets.2" in matmul_path:
+                    return self.matmul_configs["2D_RESNET_CONV_960_640"]
+                if "up_blocks.2.resnets.0" in matmul_path:
+                    return self.matmul_configs["1D_RESNET_CONV_960_320"]
+                if "up_blocks.2.resnets.1" in matmul_path or "up_blocks.2.resnets.2" in matmul_path:
+                    return self.matmul_configs["1D_RESNET_CONV_640_320"]
+                else:
+                    return None
+
             # # # GEGLU # # #
             if "net.0.proj" in matmul_path:
                 if "down_blocks.1" in matmul_path or "up_blocks.1" in matmul_path:

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -60,8 +60,8 @@ class TtResnetBlock2D(nn.Module):
         conv_bias_2 = state_dict[f"{module_path}.conv2.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
 
         if conv_shortcut:
-            conv_weights_3 = state_dict[f"{module_path}.conv_shortcut.weight"]
-            conv_bias_3 = state_dict[f"{module_path}.conv_shortcut.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
+            conv_weights_3 = state_dict[f"{module_path}.conv_shortcut.weight"].squeeze()
+            conv_bias_3 = state_dict[f"{module_path}.conv_shortcut.bias"]
 
         if split_in > 1:
             self.norm_1_blocks = 6 if "up_blocks.2.resnets.0" in module_path else 3
@@ -138,20 +138,8 @@ class TtResnetBlock2D(nn.Module):
         )
 
         if conv_shortcut:
-            self.conv3_config = model_config.get_conv_config(conv_path=f"{module_path}.conv_shortcut")
-            (
-                self.compute_config_conv_linear,
-                self.tt_conv3_weights,
-                self.tt_conv3_bias,
-                self.conv3_params,
-            ) = prepare_conv_params(
-                device,
-                conv_weights_3,
-                conv_bias_3,
-                model_config.conv_w_dtype,
-                fp32_dest_acc_en=False,
-                math_fidelity=ttnn.MathFidelity.HiFi2,
-                packer_l1_acc=True,
+            self.tt_conv3_weights, self.tt_conv3_bias = prepare_linear_params(
+                device, conv_weights_3, conv_bias_3, model_config.conv_w_dtype
             )
         else:
             self.tt_conv3_weights = self.tt_conv3_bias = None
@@ -314,29 +302,13 @@ class TtResnetBlock2D(nn.Module):
 
         if self.tt_conv3_weights is not None:
             input_tensor_pre_conv = input_tensor
-            [input_tensor, [H, W], [self.tt_conv3_weights, self.tt_conv3_bias]] = ttnn.conv2d(
-                input_tensor=input_tensor,
-                weight_tensor=self.tt_conv3_weights,
-                in_channels=self.conv3_params["input_channels"],
-                out_channels=self.conv3_params["output_channels"],
-                device=self.device,
-                bias_tensor=self.tt_conv3_bias,
-                kernel_size=self.conv3_params["kernel_size"],
-                stride=self.stride,
-                padding=(0, 0),
-                dilation=self.dilation,
-                batch_size=input_shape[0],
-                input_height=input_shape[2],
-                input_width=input_shape[3],
-                conv_config=self.conv3_config,
-                compute_config=self.compute_config_conv_linear,
-                groups=self.groups,
-                memory_config=None,
-                return_output_dim=True,
-                return_weights_and_bias=True,
+            input_tensor = ttnn.linear(
+                input_tensor,
+                self.tt_conv3_weights,
+                bias=self.tt_conv3_bias,
             )
             ttnn.deallocate(input_tensor_pre_conv)
-            C = self.conv3_params["output_channels"]
+
             if input_tensor.is_sharded():
                 input_tensor = ttnn.sharded_to_interleaved(input_tensor, ttnn.L1_MEMORY_CONFIG)
 

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -303,7 +303,6 @@ class TtResnetBlock2D(nn.Module):
 
         if self.tt_conv3_weights is not None:
             input_tensor_pre_conv = input_tensor
-            print(input_tensor.shape)
             input_tensor = ttnn.linear(
                 input_tensor,
                 self.tt_conv3_weights,


### PR DESCRIPTION
#23273 

### What's changed
Converted 1x1 convs to optimized matmuls. Removed i2s and s2i at the end of resnet block where possible.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15773060336) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15773062696) CI passes