### PR TITLE
Fix init call for pack_untilize_dst in bilinear.cpp

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
@@ -57,18 +57,17 @@ void MAIN {
 
     constexpr uint32_t num_output_tiles = out_ntiles_c;  //* nblocks;
     tilizeA_B_reduce_init<false, true>(in_cb_id1, in_scalar_cb_id1, max_tiles_per_iter, out_cb_id, 2, 4);
+    pack_untilize_dst_init_short<max_tiles_per_iter>(out_cb_id, 1, 2); /* pack 1 row (1x32) */
     for (uint32_t i = 0; i < nsticks_per_core_by_nblocks; i++) {
         const uint32_t cb_id = (i % 2 == 0) ? in_cb_id1 : in_cb_id2;
         const uint32_t scalar_cb_id = (i % 2 == 0) ? in_scalar_cb_id1 : in_scalar_cb_id2;
 
-        pack_untilize_dst_init_short<max_tiles_per_iter>(out_cb_id, 1, 2); /* pack 1 row (1x32) */
         for (uint32_t j = 0; j < blocks - 1; j++) {
             // Wait for the core to push data in cb
             cb_wait_front(scalar_cb_id, 1);
             reduce_h_fused<max_tiles_per_iter, window_size_hw>(cb_id, scalar_cb_id, out_cb_id);
             cb_pop_front(scalar_cb_id, 1);
         }
-        pack_untilize_dst_init_short<partial_iter_output_tiles>(out_cb_id, 1, 2);
         cb_wait_front(scalar_cb_id, 1);
         reduce_h_fused<partial_iter_output_tiles, window_size_hw>(cb_id, scalar_cb_id, out_cb_id);
         cb_pop_front(scalar_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
@@ -57,17 +57,18 @@ void MAIN {
 
     constexpr uint32_t num_output_tiles = out_ntiles_c;  //* nblocks;
     tilizeA_B_reduce_init<false, true>(in_cb_id1, in_scalar_cb_id1, max_tiles_per_iter, out_cb_id, 2, 4);
-    pack_untilize_dst_init_short<num_output_tiles>(out_cb_id, 1, 2); /* pack 1 row (1x32) */
     for (uint32_t i = 0; i < nsticks_per_core_by_nblocks; i++) {
         const uint32_t cb_id = (i % 2 == 0) ? in_cb_id1 : in_cb_id2;
         const uint32_t scalar_cb_id = (i % 2 == 0) ? in_scalar_cb_id1 : in_scalar_cb_id2;
 
+        pack_untilize_dst_init_short<max_tiles_per_iter>(out_cb_id, 1, 2); /* pack 1 row (1x32) */
         for (uint32_t j = 0; j < blocks - 1; j++) {
             // Wait for the core to push data in cb
             cb_wait_front(scalar_cb_id, 1);
             reduce_h_fused<max_tiles_per_iter, window_size_hw>(cb_id, scalar_cb_id, out_cb_id);
             cb_pop_front(scalar_cb_id, 1);
         }
+        pack_untilize_dst_init_short<partial_iter_output_tiles>(out_cb_id, 1, 2);
         cb_wait_front(scalar_cb_id, 1);
         reduce_h_fused<partial_iter_output_tiles, window_size_hw>(cb_id, scalar_cb_id, out_cb_id);
         cb_pop_front(scalar_cb_id, 1);


### PR DESCRIPTION
### Ticket
#23800 

### Problem description
In `tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp`,  parameters for `pack_untilize_dst_init_short` were not passed correctly. 
In cases where inputs are wider than 8 tiles, they are split into blocks of size 8, and the potential remaining tiles are processed separately. However, in `bilinear.cpp`,  common pack_untilize_dst_init_short was used for all blocks, and block_ct_dim parameter was not limited to 8.

### What's changed
Divide the initialization of pack_unitilize_dst to reflect the correct block sizes. 

Note: Ran BH nightly tests, they are [passing](https://github.com/tenstorrent/tt-metal/actions/runs/15819601512).
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [Link to workflow](https://github.com/tenstorrent/tt-metal/actions/runs/15819164225/job/44589527055)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [Link to workflow](https://github.com/tenstorrent/tt-metal/actions/runs/15819167465)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [Broken on main, passes partially](https://github.com/tenstorrent/tt-metal/actions/runs/15819239782) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) [Link to workflow](https://github.com/tenstorrent/tt-metal/actions/runs/15819244399/job/44585087216)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes