### PR TITLE
Skip uploading data for mobilenetv2

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -124,7 +124,7 @@ jobs:
             source ${{ github.workspace }}/tests/scripts/single_card/run_single_card_demo_tests.sh
             ${{ matrix.test-group.cmd }}
       - name: Save environment data
-        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !cancelled() && matrix.test-group.name != 'whisper' }}
+        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !cancelled() && matrix.test-group.name != 'whisper' && matrix.test-group.name != 'mobilenetv2' }}
         uses: ./.github/actions/docker-run
         env:
           LOGURU_LEVEL: INFO
@@ -139,7 +139,7 @@ jobs:
           install_wheel: true
           run_args: python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
       - name: Upload benchmark data
-        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !cancelled() && matrix.test-group.name != 'whisper' }}
+        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !cancelled() && matrix.test-group.name != 'whisper' && matrix.test-group.name != 'mobilenetv2' }}
         uses: ./.github/actions/upload-data-via-sftp
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23820

### Problem description
Currently, the model perf test for mobilenetv2 does not generate benchmark result report to upload and  so it is unable to save the environment data in single-card demo tests.

### What's changed
Skip uploading data for mobilenetv2

### Checklist
- [Y] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/15765802747) CI passes (mobilenetv2 passes)
- [Y] New/Existing tests provide coverage for changes