### PR TITLE
Changing toplogy mesh definition to explicity specify the chip topology

### DIFF
--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x1_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x1_mesh_graph_descriptor.yaml
@@ -19,42 +19,50 @@ Mesh: [
 {
   id: 0,
   board:  1x1,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 1,
   board: 1x1,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 2,
   board: 1x1,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 3,
   board: 1x1,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 4,
   board:  1x1,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 5,
   board: 1x1,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 6,
   board: 1x1,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 7,
   board: 1x1,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]}
 ]
 

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x2_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x2_mesh_graph_descriptor.yaml
@@ -19,22 +19,22 @@ Mesh: [
 {
   id: 0,
   board:  1x2,
-  topology: [1, 1],
+  topology: [1, 2],
   host_ranks: [[0]]},
 {
   id: 1,
   board: 1x2,
-  topology: [1, 1],
+  topology: [1, 2],
   host_ranks: [[0]]},
 {
   id: 2,
   board: 1x2,
-  topology: [1, 1],
+  topology: [1, 2],
   host_ranks: [[0]]},
 {
   id: 3,
   board: 1x2,
-  topology: [1, 1],
+  topology: [1, 2],
   host_ranks: [[0]]}
 ]
 

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x2_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x2_mesh_graph_descriptor.yaml
@@ -19,22 +19,26 @@ Mesh: [
 {
   id: 0,
   board:  1x2,
-  topology: [1, 2],
+  device_topology: [1, 2],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 1,
   board: 1x2,
-  topology: [1, 2],
+  device_topology: [1, 2],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 2,
   board: 1x2,
-  topology: [1, 2],
+  device_topology: [1, 2],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 3,
   board: 1x2,
-  topology: [1, 2],
+  device_topology: [1, 2],
+  host_topology: [1, 1],
   host_ranks: [[0]]}
 ]
 

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_1x2_1x1_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_1x2_1x1_mesh_graph_descriptor.yaml
@@ -25,22 +25,26 @@ Mesh: [
 {
   id: 0,
   board:  2x2,
-  topology: [2, 2],
+  device_topology: [2, 2],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 1,
   board: 1x2,
-  topology: [1, 2],
+  device_topology: [1, 2],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 2,
   board: 1x1,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 3,
   board: 1x1,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]}
 ]
 

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_1x2_1x1_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_1x2_1x1_mesh_graph_descriptor.yaml
@@ -25,12 +25,12 @@ Mesh: [
 {
   id: 0,
   board:  2x2,
-  topology: [1, 1],
+  topology: [2, 2],
   host_ranks: [[0]]},
 {
   id: 1,
   board: 1x2,
-  topology: [1, 1],
+  topology: [1, 2],
   host_ranks: [[0]]},
 {
   id: 2,

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_disjoint_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_disjoint_mesh_graph_descriptor.yaml
@@ -19,12 +19,14 @@ Mesh: [
 {
   id: 0,
   board: 2x2,
-  topology: [2, 2],
+  device_topology: [2, 2],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 1,
   board: 2x2,
-  topology: [2, 2],
+  device_topology: [2, 2],
+  host_topology: [1, 1],
   host_ranks: [[0]]}
 ]
 

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml
@@ -19,12 +19,12 @@ Mesh: [
 {
   id: 0,
   board: 2x2,
-  topology: [1, 1],
+  topology: [2, 2],
   host_ranks: [[0]]},
 {
   id: 1,
   board: 2x2,
-  topology: [1, 1],
+  topology: [2, 2],
   host_ranks: [[0]]}
 ]
 

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml
@@ -19,12 +19,14 @@ Mesh: [
 {
   id: 0,
   board: 2x2,
-  topology: [2, 2],
+  device_topology: [2, 2],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 1,
   board: 2x2,
-  topology: [2, 2],
+  device_topology: [2, 2],
+  host_topology: [1, 1],
   host_ranks: [[0]]}
 ]
 

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.yaml
@@ -19,7 +19,7 @@ Mesh: [
 {
   id: 0,
   board: T3K,
-  topology: [1, 2],
+  topology: [2, 4],
   host_ranks: [[0, 1]]}
 ]
 

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.yaml
@@ -19,7 +19,8 @@ Mesh: [
 {
   id: 0,
   board: T3K,
-  topology: [2, 4],
+  device_topology: [2, 4],
+  host_topology: [1, 2],
   host_ranks: [[0, 1]]}
 ]
 

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_invalid_shape_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_invalid_shape_mesh_graph_descriptor.yaml
@@ -10,7 +10,7 @@ ChipSpec: {
 
 
 Board: [
-  { name: 2x2,
+  { name: T3K,
     type: Mesh,
     topology: [2, 2]}
 ]
@@ -18,14 +18,9 @@ Board: [
 Mesh: [
 {
   id: 0,
-  board: 2x2,
-  topology: [2, 2],
-  host_ranks: [[0]]},
-{
-  id: 1,
-  board: 2x2,
-  topology: [2, 2],
-  host_ranks: [[0]]}
+  board: T3K,
+  shape: [3, 5],  # Invalid: 3 is not divisible by 2, 5 is not divisible by 2
+  host_ranks: [[0, 1]]}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_invalid_shape_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_invalid_shape_mesh_graph_descriptor.yaml
@@ -19,7 +19,8 @@ Mesh: [
 {
   id: 0,
   board: T3K,
-  shape: [3, 5],  # Invalid: 3 is not divisible by 2, 5 is not divisible by 2
+  device_topology: [3, 5],  # Invalid: 3 is not divisible by 2, 5 is not divisible by 2
+  host_topology: [1, 1],
   host_ranks: [[0, 1]]}
 ]
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -370,4 +370,14 @@ TEST(MeshGraphValidation, TestGetHostRankForChip) {
     EXPECT_EQ(mesh_graph_2x2->get_host_rank_for_chip(MeshId{1}, 4), std::nullopt);
 }
 
+TEST(MeshGraphValidation, TestExplicitShapeValidationNegative) {
+    // Test that invalid shapes are properly rejected
+    const std::filesystem::path invalid_shape_mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_invalid_shape_mesh_graph_descriptor.yaml";
+
+    // This should throw an exception due to incompatible shape
+    EXPECT_THROW(std::make_unique<tt_fabric::MeshGraph>(invalid_shape_mesh_graph_desc_path.string()), std::exception);
+}
+
 }  // namespace tt::tt_fabric::fabric_router_tests

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -232,10 +232,22 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
             "MeshGraph: Board not found: {}",
             mesh["board"].as<std::string>());
 
-        std::uint32_t mesh_board_ew_size = mesh["topology"][1].as<std::uint32_t>();
-        std::uint32_t mesh_board_ns_size = mesh["topology"][0].as<std::uint32_t>();
-        std::uint32_t mesh_ew_size = mesh_board_ew_size * board_name_to_topology[mesh_board][1];
-        std::uint32_t mesh_ns_size = mesh_board_ns_size * board_name_to_topology[mesh_board][0];
+        std::uint32_t mesh_ew_size = mesh["topology"][1].as<std::uint32_t>();
+        std::uint32_t mesh_ns_size = mesh["topology"][0].as<std::uint32_t>();
+
+        std::uint32_t board_ew_size = board_name_to_topology[mesh_board][1];
+        std::uint32_t board_ns_size = board_name_to_topology[mesh_board][0];
+
+        TT_FATAL(
+            mesh_ew_size % board_ew_size == 0 and mesh_ns_size % board_ns_size == 0,
+            "MeshGraph: Mesh topology of {}x{} is not divisible by board topology of {}x{}",
+            mesh_ew_size,
+            mesh_ns_size,
+            board_ew_size,
+            board_ns_size);
+
+        std::uint32_t mesh_board_ew_size = mesh_ew_size / board_ew_size;
+        std::uint32_t mesh_board_ns_size = mesh_ns_size / board_ns_size;
 
         std::uint32_t mesh_size = mesh_ew_size * mesh_ns_size;
         std::vector<chip_id_t> chip_ids(mesh_size);

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -232,24 +232,40 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
             "MeshGraph: Board not found: {}",
             mesh["board"].as<std::string>());
 
-        std::uint32_t mesh_ew_size = mesh["topology"][1].as<std::uint32_t>();
-        std::uint32_t mesh_ns_size = mesh["topology"][0].as<std::uint32_t>();
+        // Parse device topology (actual number of chips used)
+        TT_FATAL(mesh["device_topology"].IsDefined(), "MeshGraph: Expecting yaml mesh to define device_topology");
+        std::uint32_t mesh_ns_size = mesh["device_topology"][0].as<std::uint32_t>();
+        std::uint32_t mesh_ew_size = mesh["device_topology"][1].as<std::uint32_t>();
 
-        std::uint32_t board_ew_size = board_name_to_topology[mesh_board][1];
+        // Parse host topology (number of boards)
+        TT_FATAL(mesh["host_topology"].IsDefined(), "MeshGraph: Expecting yaml mesh to define host_topology");
+        std::uint32_t mesh_board_ns_size = mesh["host_topology"][0].as<std::uint32_t>();
+        std::uint32_t mesh_board_ew_size = mesh["host_topology"][1].as<std::uint32_t>();
+
         std::uint32_t board_ns_size = board_name_to_topology[mesh_board][0];
+        std::uint32_t board_ew_size = board_name_to_topology[mesh_board][1];
 
+        // Assert that device topology is divisible by board topology
         TT_FATAL(
-            mesh_ew_size % board_ew_size == 0 and mesh_ns_size % board_ns_size == 0,
-            "MeshGraph: Mesh topology of {}x{} is not divisible by board topology of {}x{}",
-            mesh_ew_size,
+            mesh_ns_size % board_ns_size == 0 and mesh_ew_size % board_ew_size == 0,
+            "MeshGraph: Device topology size {}x{} must be divisible by board topology size {}x{}",
             mesh_ns_size,
-            board_ew_size,
-            board_ns_size);
+            mesh_ew_size,
+            board_ns_size,
+            board_ew_size);
 
-        std::uint32_t mesh_board_ew_size = mesh_ew_size / board_ew_size;
-        std::uint32_t mesh_board_ns_size = mesh_ns_size / board_ns_size;
+        // Assert that device topology aligns with host topology and board topology
+        TT_FATAL(
+            mesh_ns_size == mesh_board_ns_size * board_ns_size and mesh_ew_size == mesh_board_ew_size * board_ew_size,
+            "MeshGraph: Device topology size {}x{} must equal host topology size {}x{} * board topology size {}x{}",
+            mesh_ns_size,
+            mesh_ew_size,
+            mesh_board_ns_size,
+            mesh_board_ew_size,
+            board_ns_size,
+            board_ew_size);
 
-        std::uint32_t mesh_size = mesh_ew_size * mesh_ns_size;
+        std::uint32_t mesh_size = mesh_ns_size * mesh_ew_size;
         std::vector<chip_id_t> chip_ids(mesh_size);
         std::iota(chip_ids.begin(), chip_ids.end(), 0);
         this->mesh_to_chip_ids_.emplace(
@@ -258,7 +274,8 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
         // Fill in host ranks for Mesh
         TT_FATAL(
             mesh["host_ranks"].IsSequence() and mesh["host_ranks"].size() == mesh_board_ns_size,
-            "MeshGraph: Expecting host_ranks to define a 2D array that matches topology");
+            "MeshGraph: Expecting host_ranks to define a 2D array that matches host topology NS size {}",
+            mesh_board_ns_size);
 
         std::vector<HostRankId> mesh_host_ranks_values;
         mesh_host_ranks_values.reserve(mesh_board_ns_size * mesh_board_ew_size);
@@ -268,7 +285,8 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
         for (std::uint32_t i = 0; i < mesh_board_ns_size; i++) {
             TT_FATAL(
                 mesh["host_ranks"][i].IsSequence() and mesh["host_ranks"][i].size() == mesh_board_ew_size,
-                "MeshGraph: Expecting host_ranks to define a 2D array that matches topology");
+                "MeshGraph: Expecting host_ranks to define a 2D array that matches host topology EW size {}",
+                mesh_board_ew_size);
             for (std::uint32_t j = 0; j < mesh_board_ew_size; j++) {
                 HostRankId host_rank{mesh["host_ranks"][i][j].as<std::uint32_t>()};
                 if (host_rank_submesh_start_end_coords.find(host_rank) == host_rank_submesh_start_end_coords.end()) {
@@ -285,12 +303,9 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
             this->mesh_host_rank_coord_ranges_.emplace(
                 std::make_pair(*mesh_id, host_rank),
                 MeshCoordinateRange(
+                    MeshCoordinate(coords.first[0] * board_ns_size, coords.first[1] * board_ew_size),
                     MeshCoordinate(
-                        coords.first[0] * board_name_to_topology[mesh_board][0],
-                        coords.first[1] * board_name_to_topology[mesh_board][1]),
-                    MeshCoordinate(
-                        (coords.second[0] + 1) * board_name_to_topology[mesh_board][0] - 1,
-                        (coords.second[1] + 1) * board_name_to_topology[mesh_board][1] - 1)));
+                        (coords.second[0] + 1) * board_ns_size - 1, (coords.second[1] + 1) * board_ew_size - 1)));
         }
         this->mesh_host_ranks_[*mesh_id] =
             MeshContainer<HostRankId>(MeshShape(mesh_board_ns_size, mesh_board_ew_size), mesh_host_ranks_values);

--- a/tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.yaml
@@ -19,7 +19,7 @@ Mesh: [
 {
   id: 0,
   board: Galaxy,
-  topology: [1, 2],
+  topology: [8, 8],
   host_ranks: [[0, 1]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.yaml
@@ -19,7 +19,8 @@ Mesh: [
 {
   id: 0,
   board: Galaxy,
-  topology: [8, 8],
+  device_topology: [8, 8],
+  host_topology: [1, 2],
   host_ranks: [[0, 1]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.yaml
@@ -18,7 +18,8 @@ Mesh: [
 {
   id: 0,
   board: N150,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.yaml
@@ -18,7 +18,7 @@ Mesh: [
 {
   id: 0,
   board: N300,
-  topology: [1, 1],
+  topology: [1, 2],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.yaml
@@ -18,7 +18,8 @@ Mesh: [
 {
   id: 0,
   board: N300,
-  topology: [1, 2],
+  device_topology: [1, 2],
+  host_topology: [1, 1],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/p100_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p100_mesh_graph_descriptor.yaml
@@ -18,7 +18,8 @@ Mesh: [
 {
   id: 0,
   board: P100,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.yaml
@@ -18,7 +18,8 @@ Mesh: [
 {
   id: 0,
   board: P150,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.yaml
@@ -18,7 +18,8 @@ Mesh: [
 {
   id: 0,
   board: P150,
-  topology: [1, 2],
+  device_topology: [1, 2],
+  host_topology: [1, 1],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.yaml
@@ -18,7 +18,7 @@ Mesh: [
 {
   id: 0,
   board: P150,
-  topology: [1, 1],
+  topology: [1, 2],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
@@ -18,7 +18,7 @@ Mesh: [
 {
   id: 0,
   board: P150,
-  topology: [1, 1],
+  topology: [2, 2],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
@@ -18,7 +18,8 @@ Mesh: [
 {
   id: 0,
   board: P150,
-  topology: [2, 2],
+  device_topology: [2, 2],
+  host_topology: [1, 1],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.yaml
@@ -19,7 +19,8 @@ Mesh: [
 {
   id: 0,
   board: Galaxy,
-  topology: [8, 4],
+  device_topology: [8, 4],
+  host_topology: [1, 1],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.yaml
@@ -19,7 +19,7 @@ Mesh: [
 {
   id: 0,
   board: Galaxy,
-  topology: [1, 1],
+  topology: [8, 4],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_2d_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_2d_graph_descriptor.yaml
@@ -19,7 +19,8 @@ Mesh: [
 {
   id: 0,
   board: Galaxy,
-  topology: [8, 4],
+  device_topology: [8, 4],
+  host_topology: [1, 1],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_2d_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_2d_graph_descriptor.yaml
@@ -19,7 +19,7 @@ Mesh: [
 {
   id: 0,
   board: Galaxy,
-  topology: [1, 1],
+  topology: [8, 4],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml
@@ -19,7 +19,8 @@ Mesh: [
 {
   id: 0,
   board: T3K,
-  topology: [2, 4],
+  device_topology: [2, 4],
+  host_topology: [1, 1],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml
@@ -19,7 +19,7 @@ Mesh: [
 {
   id: 0,
   board: T3K,
-  topology: [1, 1],
+  topology: [2, 4],
   host_ranks: [[0]]}
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml
@@ -22,27 +22,32 @@ Mesh: [
 {
   id: 0,
   board: N150Gateway,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 1,
   board: N150Gateway,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 2,
   board: N150Gateway,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 3,
   board: N150Gateway,
-  topology: [1, 1],
+  device_topology: [1, 1],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 {
   id: 4,
   board: Galaxy,
-  topology: [4, 8],
+  device_topology: [4, 8],
+  host_topology: [1, 1],
   host_ranks: [[0]]},
 ]
 

--- a/tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml
@@ -42,7 +42,7 @@ Mesh: [
 {
   id: 4,
   board: Galaxy,
-  topology: [1, 1],
+  topology: [4, 8],
   host_ranks: [[0]]},
 ]
 


### PR DESCRIPTION
instead of implied through board type

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23739)

### Problem description
Currently, the Mesh topology is implied through the board type, however, would like to change this to explicitly specify the mesh topology without needing to know the board size.

ex: 
```
Board: [
  { name: T3K,
    type: Mesh,
    topology: [2, 2]} 
]

Mesh: [
{
  id: 0,
  board: T3K,
  topology: [1, 2], << What it was before (now it's [2,4])
  host_ranks: [[0]]}
]
```

### What's changed
- [x] Changed `mesh_graph.cpp` to use the mesh topology explicitly
  - [x] Asserts error if mesh topology is not possible with the board shape
- [x] Added unit tests to test invalid mesh graphs
- [x] Changed unit tests and descriptors to match new syntax

### Checklist
- [x] All Post-commit https://github.com/tenstorrent/tt-metal/actions/runs/15833757981
- [x] Galaxy Quick Test https://github.com/tenstorrent/tt-metal/actions/runs/15829048250
- [x] T3K Tests https://github.com/tenstorrent/tt-metal/actions/runs/15829061659