### PR TITLE
[Fabric] Fix parallelized fabric init. TG's hang

### DIFF
--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -177,6 +177,8 @@ public:
     virtual void init_command_queue_host() = 0;
     virtual void init_command_queue_device() = 0;
 
+    virtual bool compile_fabric() = 0;
+    virtual void configure_fabric() = 0;
     virtual void init_fabric() = 0;
     // Puts device into reset
     virtual bool close() = 0;

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -177,6 +177,7 @@ public:
     virtual void init_command_queue_host() = 0;
     virtual void init_command_queue_device() = 0;
 
+    // return false if compile fails (mainly come from Nebula on TG)
     virtual bool compile_fabric() = 0;
     virtual void configure_fabric() = 0;
     virtual void init_fabric() = 0;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -222,6 +222,8 @@ public:
     void initialize_and_launch_firmware() override;
     void init_command_queue_host() override;
     void init_command_queue_device() override;
+    bool compile_fabric() override;
+    void configure_fabric() override;
     void init_fabric() override;
     bool close() override;
     void enable_program_cache() override;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -845,6 +845,14 @@ void MeshDevice::init_command_queue_device() {
     TT_THROW("init_command_queue_device() is not supported on MeshDevice - use individual devices instead");
     reference_device()->init_command_queue_device();
 }
+bool MeshDevice::compile_fabric() {
+    TT_THROW("compile_fabric() is not supported on MeshDevice - use individual devices instead");
+    return reference_device()->compile_fabric();
+}
+void MeshDevice::configure_fabric() {
+    TT_THROW("configure_fabric() is not supported on MeshDevice - use individual devices instead");
+    reference_device()->configure_fabric();
+}
 void MeshDevice::init_fabric() {
     TT_THROW("init_fabric_program() is not supported on MeshDevice - use individual devices instead");
     reference_device()->init_fabric();

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1003,8 +1003,12 @@ void Device::init_command_queue_device() {
     }
 }
 
-void Device::init_fabric() {
+bool Device::compile_fabric() {
     fabric_program_ = create_and_compile_fabric_program(this);
+    return fabric_program_ != nullptr;
+}
+
+void Device::configure_fabric() {
     if (fabric_program_ == nullptr) {
         return;
     }
@@ -1037,6 +1041,12 @@ void Device::init_fabric() {
         }
     }
     log_info(tt::LogMetal, "Fabric initialized on Device {}", this->id_);
+}
+
+// backward compatibility
+void Device::init_fabric() {
+    this->compile_fabric();
+    this->configure_fabric();
 }
 
 bool Device::initialize(

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -148,6 +148,8 @@ public:
     void init_command_queue_host() override;
     void init_command_queue_device() override;
 
+    bool compile_fabric() override;
+    void configure_fabric() override;
     void init_fabric() override;
     // Puts device into reset
     bool close() override;

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -327,6 +327,7 @@ void DevicePool::init_fabric(const std::vector<tt_metal::IDevice*>& active_devic
             if (dev->compile_fabric()) {
                 return dev;
             } else {
+                // compile failure mostly come from Nebula (TG)
                 return (tt_metal::IDevice*)nullptr;
             }
         }));

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -333,7 +333,7 @@ void DevicePool::init_fabric(const std::vector<tt_metal::IDevice*>& active_devic
     }
 
     // Sequentially execute fabric configuration on all devices
-    // Empirically TG hanged when this is alsow parallelized
+    // Empirically TG hung when this is also parallelized
     for (const auto& event : events) {
         auto dev = event.get();
         if (dev) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22634

### Problem description
Hang reported
- when running fabric_unit_tests on TG especially after fabric initialization.
- My previous parallelization seems to be the cause.

### What's changed
Parallelize only compile phase. configure phase is executed sequentially

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes