### PR TITLE
[skip ci] run smoke on main

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -168,7 +168,8 @@ jobs:
       publish-artifact: false
 
   basic-tests:
-    if: ${{ true ||
+    if: ${{
+        github.ref_name == 'main' ||
         needs.find-changes.outputs.cmake-changed == 'true' ||
         needs.find-changes.outputs.tt-metalium-changed == 'true' ||
         needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -80,6 +80,7 @@ jobs:
   metalium-smoke-tests:
     needs: [ asan-build, find-changed-files ]
     if: ${{
+        github.ref_name == 'main' ||
         needs.find-changed-files.outputs.cmake-changed == 'true' ||
         needs.find-changed-files.outputs.tt-metalium-changed == 'true' ||
         needs.find-changed-files.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
@@ -101,6 +102,7 @@ jobs:
   ttnn-smoke-tests:
     needs: [ asan-build, find-changed-files ]
     if: ${{
+        github.ref_name == 'main' ||
         needs.find-changed-files.outputs.cmake-changed == 'true' ||
         needs.find-changed-files.outputs.tt-nn-changed == 'true' ||
         needs.find-changed-files.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
@@ -139,6 +141,7 @@ jobs:
   metalium-examples:
     needs: [ build, find-changed-files ]
     if: ${{
+        github.ref_name == 'main' ||
         needs.find-changed-files.outputs.cmake-changed == 'true' ||
         needs.find-changed-files.outputs.tt-metalium-changed == 'true'
       }}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Sometimes a test is variable enough to trip over the slowness threshold.  We're not easily aware of them to adjust accordingly.

### What's changed
Ensure the tests run when the workflow runs on `main` so that we can suss out variable runtimes that trip up.