### PR TITLE
[skip ci] Relax the Basic tests up to 10s to give a bit more wiggle room

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -15,7 +15,7 @@ on:
       per-test-timeout:
         required: false
         type: string
-        default: 5.5
+        default: 10
 
 jobs:
   metalium-basic:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
A CQ test sometimes runs slow-ish in CIv2.  eg: https://github.com/tenstorrent/tt-metal/actions/runs/15782744358/job/44493232085
10s still feels acceptable for the Basic tests (for now at least).  Rather than shifting that test right, let's permit slightly longer tests in Basic.

### What's changed
Increased the threshold for Basic tests.