### PR TITLE
Change timeout for perf tests to 10min

### DIFF
--- a/models/demos/llama3_subdevices/tests/decoder_perf_targets_4u.json
+++ b/models/demos/llama3_subdevices/tests/decoder_perf_targets_4u.json
@@ -13,7 +13,7 @@
         },
         "AllGatherConcat_0": {
             "op_name": "AllGatherConcat",
-            "kernel_duration": 12541.880208333332,
+            "kernel_duration": 11884.732638888889 ,
             "op_to_op": 909.3484848484849,
             "first_to_last_start": 2055.777777777778,
             "non-overlapped-dispatch-time": 12462.644444444442,
@@ -236,7 +236,7 @@
         },
         "BinaryDeviceOperation_2": {
             "op_name": "BinaryDeviceOperation_Indices_Correction",
-            "kernel_duration": 3447.309659090909,
+            "kernel_duration": 5649.625,
             "op_to_op": 735.5454545454545,
             "non-overlapped-dispatch-time": 7268.7,
             "kernel_duration_relative_margin": 0.2,
@@ -254,7 +254,7 @@
         },
         "InterleavedToShardedDeviceOperation_1": {
             "op_name": "InterleavedToSharded_1",
-            "kernel_duration": 1650.4005681818182,
+            "kernel_duration": 1224.71875,
             "op_to_op": 757.2272727272727,
             "non-overlapped-dispatch-time": 2611.15,
             "kernel_duration_relative_margin": 0.2,
@@ -263,7 +263,7 @@
         },
         "InterleavedToShardedDeviceOperation_2": {
             "op_name": "InterleavedToSharded_2",
-            "kernel_duration": 1452.78125,
+            "kernel_duration": 1960.875,
             "op_to_op": 761.3636363636364,
             "non-overlapped-dispatch-time": 2869.15,
             "kernel_duration_relative_margin": 0.2,
@@ -326,7 +326,7 @@
         },
         "Sampling_0": {
             "op_name": "Sampling_0",
-            "kernel_duration": 74001.71306818182,
+            "kernel_duration": 144524.375,
             "op_to_op": 61393.90909090909,
             "non-overlapped-dispatch-time": 90340.2,
             "kernel_duration_relative_margin": 0.2,
@@ -344,8 +344,8 @@
         },
         "ShardedToInterleavedDeviceOperation_1": {
             "op_name": "ShardedToInterleavedDeviceOperation_1",
-            "kernel_duration": 1177.0113636363637,
-            "op_to_op": 742.1363636363636,
+            "kernel_duration": 1724.0625,
+            "op_to_op": 901.0,
             "non-overlapped-dispatch-time": 2297.1,
             "kernel_duration_relative_margin": 0.2,
             "op_to_op_duration_relative_margin": 0.2,
@@ -354,7 +354,7 @@
         "TopK_0": {
             "op_name": "TopK_0",
             "kernel_duration": 615934.5340909091,
-            "op_to_op": 1508.0,
+            "op_to_op": 733.0,
             "non-overlapped-dispatch-time": 5187.35,
             "kernel_duration_relative_margin": 0.2,
             "op_to_op_duration_relative_margin": 0.3,

--- a/models/demos/llama3_subdevices/tests/decoder_perf_targets_4u.json
+++ b/models/demos/llama3_subdevices/tests/decoder_perf_targets_4u.json
@@ -201,7 +201,7 @@
         "AllGatherAsync_1": {
             "op_name": "AllGatherAsync_1",
             "kernel_duration": 11966.91903409091,
-            "op_to_op": 742.9545454545455,
+            "op_to_op": 2422.0,
             "non-overlapped-dispatch-time": 3521.8,
             "kernel_duration_relative_margin": 0.2,
             "op_to_op_duration_relative_margin": 0.2,
@@ -236,7 +236,7 @@
         },
         "BinaryDeviceOperation_2": {
             "op_name": "BinaryDeviceOperation_Indices_Correction",
-            "kernel_duration": 5649.625,
+            "kernel_duration": 3421.53125,
             "op_to_op": 735.5454545454545,
             "non-overlapped-dispatch-time": 7268.7,
             "kernel_duration_relative_margin": 0.2,
@@ -254,7 +254,7 @@
         },
         "InterleavedToShardedDeviceOperation_1": {
             "op_name": "InterleavedToSharded_1",
-            "kernel_duration": 1224.71875,
+            "kernel_duration": 974.84375,
             "op_to_op": 757.2272727272727,
             "non-overlapped-dispatch-time": 2611.15,
             "kernel_duration_relative_margin": 0.2,
@@ -263,7 +263,7 @@
         },
         "InterleavedToShardedDeviceOperation_2": {
             "op_name": "InterleavedToSharded_2",
-            "kernel_duration": 1960.875,
+            "kernel_duration":  1453.34375,
             "op_to_op": 761.3636363636364,
             "non-overlapped-dispatch-time": 2869.15,
             "kernel_duration_relative_margin": 0.2,
@@ -317,7 +317,7 @@
         },
         "ReshardDeviceOperation_1": {
             "op_name": "Reshard_1",
-            "kernel_duration": 3272.434659090909,
+            "kernel_duration": 4412.8125,
             "op_to_op": 692.3181818181819,
             "non-overlapped-dispatch-time": 5203.55,
             "kernel_duration_relative_margin": 0.2,
@@ -326,7 +326,7 @@
         },
         "Sampling_0": {
             "op_name": "Sampling_0",
-            "kernel_duration": 144524.375,
+            "kernel_duration": 76003.5625,
             "op_to_op": 61393.90909090909,
             "non-overlapped-dispatch-time": 90340.2,
             "kernel_duration_relative_margin": 0.2,
@@ -344,7 +344,7 @@
         },
         "ShardedToInterleavedDeviceOperation_1": {
             "op_name": "ShardedToInterleavedDeviceOperation_1",
-            "kernel_duration": 1724.0625,
+            "kernel_duration": 1159.96875,
             "op_to_op": 901.0,
             "non-overlapped-dispatch-time": 2297.1,
             "kernel_duration_relative_margin": 0.2,

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -249,21 +249,26 @@ def build_duration_per_instance_dict(input_dict, num_layers):
 def average_per_instance_dict(input_dict):
     averaged_dict = {}
     for op_code_with_id in input_dict:
-        averaged_dict[op_code_with_id] = sum(input_dict[op_code_with_id]) / len(input_dict[op_code_with_id])
+        input_dict_values = [v if v is not None else 0 for v in input_dict[op_code_with_id]]
+        averaged_dict[op_code_with_id] = (
+            sum(input_dict_values) / len(input_dict_values) if len(input_dict_values) > 0 else 0
+        )
     return averaged_dict
 
 
 def min_per_instance_dict(input_dict):
     min_dict = {}
     for op_code_with_id in input_dict:
-        min_dict[op_code_with_id] = min(input_dict[op_code_with_id])
+        input_dict_values = [v if v is not None else 0 for v in input_dict[op_code_with_id]]
+        min_dict[op_code_with_id] = min(input_dict[op_code_with_id]) if len(input_dict_values) > 0 else 0
     return min_dict
 
 
 def max_per_instance_dict(input_dict):
     max_dict = {}
     for op_code_with_id in input_dict:
-        max_dict[op_code_with_id] = max(input_dict[op_code_with_id])
+        input_dict_values = [v if v is not None else 0 for v in input_dict[op_code_with_id]]
+        max_dict[op_code_with_id] = max(input_dict[op_code_with_id]) if len(input_dict_values) > 0 else 0
     return max_dict
 
 

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -534,7 +534,19 @@ def test_llama_TG_perf_device(
                 max_kernel_duration = max_kernel_duration_mid_layers_compilation[op_code_with_id]
 
             avg_dispatch_duration = avg_dispatch_duration_mid_layers_trace[op_code_with_id]
+
+            # Avg first to last
             avg_first_to_last_start = avg_first_to_last_start_mid_layers_trace[op_code_with_id]
+            avg_first_to_last_start = avg_first_to_last_start if avg_first_to_last_start is not None else 0
+
+            # Min first to last
+            min_first_to_last_start = min_first_to_last_start_mid_layers_trace[op_code_with_id]
+            min_first_to_last_start = min_first_to_last_start if min_first_to_last_start is not None else 0
+
+            # Max first to last
+            max_first_to_last_start = max_dispatch_duration_mid_layers_trace[op_code_with_id]
+            max_first_to_last_start = max_first_to_last_start if max_first_to_last_start is not None else 0
+
             # average
             add_benchmark_measurement(
                 profiler,
@@ -590,7 +602,7 @@ def test_llama_TG_perf_device(
                 0,
                 step_name,
                 op_name + "-model-first_to_last-min",
-                min_first_to_last_start_mid_layers_trace[op_code_with_id],
+                min_first_to_last_start,
             )
 
             # max
@@ -619,7 +631,7 @@ def test_llama_TG_perf_device(
                 0,
                 step_name,
                 op_name + "-model-first_to_last-max",
-                max_first_to_last_start_mid_layers_trace[op_code_with_id],
+                max_first_to_last_start,
             )
 
             # Verify kernel duration is within tolerance

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -37,6 +37,7 @@ MIN_TYPE = "min"
 MAX_TYPE = "max"
 
 
+@pytest.mark.timeout(600)
 @pytest.mark.parametrize(
     "weights, layers, input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stress_test, start_pos",
     [

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -503,6 +503,7 @@ def test_llama_TG_perf_device(
     print_dict(avg_kernel_duration_mid_layers_compilation, "avg_kernel_duration_mid_layers_compilation")
     print_dict(avg_kernel_duration_mid_layers_trace, "avg_kernel_duration_mid_layers_trace")
     print_dict(avg_dispatch_duration_mid_layers_trace, "avg_dispatch_duration_mid_layers_trace")
+    print_dict(avg_first_to_last_start_mid_layers_trace, "avg_first_to_last_start_mid_layers_trace")
 
     ## model tail ops
     print_dict(avg_kernel_duration_model_tail_compilation, "avg_kernel_duration_model_tail_compilation")
@@ -537,15 +538,15 @@ def test_llama_TG_perf_device(
 
             # Avg first to last
             avg_first_to_last_start = avg_first_to_last_start_mid_layers_trace[op_code_with_id]
-            avg_first_to_last_start = avg_first_to_last_start if avg_first_to_last_start is not None else 0
+            avg_first_to_last_start = avg_first_to_last_start if not math.isnan(avg_first_to_last_start) else 0
 
             # Min first to last
             min_first_to_last_start = min_first_to_last_start_mid_layers_trace[op_code_with_id]
-            min_first_to_last_start = min_first_to_last_start if min_first_to_last_start is not None else 0
+            min_first_to_last_start = min_first_to_last_start if not math.isnan(min_first_to_last_start) else 0
 
             # Max first to last
-            max_first_to_last_start = max_dispatch_duration_mid_layers_trace[op_code_with_id]
-            max_first_to_last_start = max_first_to_last_start if max_first_to_last_start is not None else 0
+            max_first_to_last_start = max_first_to_last_start_mid_layers_trace[op_code_with_id]
+            max_first_to_last_start = max_first_to_last_start if not math.isnan(max_first_to_last_start) else 0
 
             # average
             add_benchmark_measurement(

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -22,10 +22,10 @@ run_tg_llama_70b_model_perf_tests() {
   echo "LOG_METAL: Running run_tg_llama_70b_model_perf_tests"
 
   # Run kernel and op to op latency test
-  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device --timeout=600 ; fail+=$?
+  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device ; fail+=$?
 
   # Run non-overlapped dispatch perf test
-  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch --timeout=600 ; fail+=$?
+  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch ; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     echo "LOG_METAL: run_tg_llama_70b_model_perf_tests failed"

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -22,10 +22,10 @@ run_tg_llama_70b_model_perf_tests() {
   echo "LOG_METAL: Running run_tg_llama_70b_model_perf_tests"
 
   # Run kernel and op to op latency test
-  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device ; fail+=$?
+  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device --timeout=600 ; fail+=$?
 
   # Run non-overlapped dispatch perf test
-  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch ; fail+=$?
+  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch --timeout=600 ; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     echo "LOG_METAL: run_tg_llama_70b_model_perf_tests failed"

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -21,11 +21,11 @@ run_tg_llama_70b_model_perf_tests() {
 
   echo "LOG_METAL: Running run_tg_llama_70b_model_perf_tests"
 
-  # Run kernel and op to op latency test
-  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device --timeout=600 ; fail+=$?
-
   # Run non-overlapped dispatch perf test
   TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch --timeout=600 ; fail+=$?
+
+  # Run kernel and op to op latency test
+  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device --timeout=600 ; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     echo "LOG_METAL: run_tg_llama_70b_model_perf_tests failed"


### PR DESCRIPTION
### Problem description
TG Llama Model Perf tests were prematurely timing out after 5 minutes for `test_decoder_device_perf.py ` 

### What's changed
Changed timeout to 10minutes

### Checklist
- Model perf tests [passing](https://github.com/tenstorrent/tt-metal/actions/runs/15935729964) (only perf targets failing, will be addressed by @djordje-tt ) 
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes