### PR TITLE
Pin cats-image dataset to older revision

### DIFF
--- a/tests/ttnn/integration_tests/vit/test_ttnn_optimized_sharded_vit_wh.py
+++ b/tests/ttnn/integration_tests/vit/test_ttnn_optimized_sharded_vit_wh.py
@@ -89,7 +89,7 @@ def test_vit_embeddings(device, model_name, batch_size, image_size, image_channe
     config = ttnn_optimized_sharded_vit.update_model_config(config, batch_size)
     model = transformers.ViTForImageClassification.from_pretrained("google/vit-base-patch16-224")
 
-    dataset = load_dataset("huggingface/cats-image")
+    dataset = load_dataset("huggingface/cats-image", revision="ccdec0af347ae11c5315146402c3e16c8bbf4149")
     image = dataset["test"]["image"][0]
     image_processor = AutoImageProcessor.from_pretrained("google/vit-base-patch16-224")
     torch_pixel_values = image_processor(image, return_tensors="pt").pixel_values
@@ -381,7 +381,7 @@ def test_vit(device, model_name, batch_size, image_size, image_channels, sequenc
     config = transformers.ViTConfig.from_pretrained(model_name)
     model = transformers.ViTForImageClassification.from_pretrained("google/vit-base-patch16-224", config=config)
     config = ttnn_optimized_sharded_vit.update_model_config(config, batch_size)
-    dataset = load_dataset("huggingface/cats-image")
+    dataset = load_dataset("huggingface/cats-image", revision="ccdec0af347ae11c5315146402c3e16c8bbf4149")
     image = dataset["test"]["image"][0]
     image_processor = AutoImageProcessor.from_pretrained("google/vit-base-patch16-224")
     torch_pixel_values = image_processor(image, return_tensors="pt").pixel_values


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23873

### Problem description
Latest version of `cats-image` dataset breaking APC ViT model tests:
```
tests/ttnn/integration_tests/vit/test_ttnn_optimized_sharded_vit_wh.py:385: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = DatasetDict({
    train: Dataset({
        features: ['image'],
        num_rows: 1
    })
})
k = 'test'

    def __getitem__(self, k) -> Dataset:
        if isinstance(k, (str, NamedSplit)) or len(self) == 0:
>           return super().__getitem__(k)
E           KeyError: 'test'

/opt/venv/lib/python3.10/site-packages/datasets/dataset_dict.py:58: KeyError

[...]
FAILED tests/ttnn/integration_tests/vit/test_ttnn_optimized_sharded_vit_wh.py::test_vit[sequence_size=224-image_channels=3-image_size=224-batch_size=8-model_name=google/vit-base-patch16-224] - KeyError: 'test'
```

### What's changed
Pin to older revision of dataset

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15798557415