### PR TITLE
Cache AICLK as the umd query is heavy

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -189,6 +189,15 @@ Cluster::Cluster(const llrt::RunTimeOptions& rtoptions, const tt_metal::Hal& hal
     this->set_tunnels_from_mmio_device();
 
     this->assert_risc_reset();
+
+    this->cache_hardware_info();
+}
+
+void Cluster::cache_hardware_info() {
+    this->aiclks_.reserve(this->all_chip_ids().size());
+    for (const auto& chip_id : this->all_chip_ids()) {
+        this->aiclks_.push_back(this->driver_->get_chip(chip_id)->get_clock());
+    }
 }
 
 void Cluster::detect_arch_and_target() {
@@ -606,7 +615,7 @@ std::unordered_map<int, int> Cluster::get_worker_logical_to_virtual_y(chip_id_t 
     return worker_logical_to_virtual_y;
 }
 
-int Cluster::get_device_aiclk(const chip_id_t& chip_id) const { return this->driver_->get_chip(chip_id)->get_clock(); }
+int Cluster::get_device_aiclk(const chip_id_t& chip_id) const { return this->aiclks_.at(chip_id); }
 
 void Cluster::deassert_risc_reset_at_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets) const {
     const metal_SocDescriptor &soc_desc = this->get_soc_desc(core.chip);

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -359,6 +359,7 @@ private:
     void get_metal_desc_from_tt_desc();
     void generate_virtual_to_umd_coord_mapping();
     void generate_virtual_to_profiler_flat_id_mapping();
+    void cache_hardware_info();
 
     // Reserves ethernet cores in cluster for tunneling
     void reserve_ethernet_cores_for_tunneling();
@@ -426,6 +427,8 @@ private:
     std::unordered_map<chip_id_t, std::unordered_map<CoreCoord, EthRouterMode>> device_eth_routing_info_;
 
     std::unordered_map<chip_id_t, std::unordered_map<chip_id_t, std::vector<CoreCoord>>> ethernet_sockets_;
+
+    std::vector<int> aiclks_;
 
     uint32_t routing_info_addr_ = 0;
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23088

### Problem description
One of fabric test overhead comes from UMD query to AICLK by profiler. (This is common overhead come prom profiler)

### What's changed
Cache AICLK info in tt_cluster. This should improve any workloads which uses profiler

Result:
Only device init fabric on T3K improves performance. 6U doesn't change and cannot investigate detail due to system availability
Device init fabric tests (pytest's `-k "_t3K_"`) 40sec -> 20sec (forget detail numbers)



### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes