### PR TITLE
Disable conversions from 2D logical sharding to ND sharding

### DIFF
--- a/ttnn/core/tensor/tensor_spec.cpp
+++ b/ttnn/core/tensor/tensor_spec.cpp
@@ -167,11 +167,9 @@ std::optional<MemoryConfig> TensorSpec::populate_nd_shard_spec_from_legacy() con
 
     const auto& shard_spec = mem_config.shard_spec().value();
 
-    // Can't convert logical sharding if physical shard shape is different from logical shard shape
+    // Can't convert logical sharding
     if (shard_spec.mode == ShardMode::LOGICAL) {
-        if (shard_spec.physical_shard_shape.has_value() && *shard_spec.physical_shard_shape != shard_spec.shape) {
-            return std::nullopt;
-        }
+        return std::nullopt;
     }
 
     NdShardSpec nd_shard_spec{


### PR DESCRIPTION
### Ticket

### Problem description
Currently we allow some conversion from 2D logical sharding to ND sharding, however it sometimes results in incorrect conversions, for example because of different logic for calculating physical size.

### What's changed
Disabled conversions from 2D logical sharding to ND sharding

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/15792510518)
- [x] New/Existing tests provide coverage for changes