### PR TITLE
Add Intermesh APIs needed for Multi-Host

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_intermesh_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_intermesh_apis.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <tt-metalium/control_plane.hpp>
 #include "impl/context/metal_context.hpp"
+#include "tt_metal/fabric/serialization/intermesh_link_table.hpp"
 #include <iomanip>
 #include <sstream>
 #include <set>
@@ -101,6 +102,47 @@ TEST(IntermeshAPIs, IntermeshLinksAreDistinctFromEthernetLinks) {
 
         log_info(tt::LogTest, "Chip {}: {} intermesh links are distinct from {} active ethernet cores",
                  chip_id, intermesh_links.size(), active_eth_cores.size());
+    }
+}
+
+TEST(IntermeshAPIs, LocalIntermeshLinkTable) {
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    if (!control_plane.system_has_intermesh_links()) {
+        GTEST_SKIP() << "Cluster does not support intermesh links";
+    }
+
+    log_info(tt::LogTest, "=== Verifying Local Intermesh Link Table Serialization ===");
+
+    // Get the local intermesh link table
+    const auto& intermesh_link_table = control_plane.get_local_intermesh_link_table();
+    auto serialized_table = serialize_to_bytes(intermesh_link_table);
+    IntermeshLinkTable deserialized_table = deserialize_from_bytes(serialized_table);
+    EXPECT_EQ(intermesh_link_table.local_mesh_id, deserialized_table.local_mesh_id)
+        << "Deserialized local mesh ID does not match original";
+
+    for (const auto& [local_chan, remote_chan] : intermesh_link_table.intermesh_links) {
+        EXPECT_TRUE(deserialized_table.intermesh_links.contains(local_chan))
+            << "Deserialized table does not contain local channel Board " << local_chan.board_id << " Chan "
+            << local_chan.chan_id;
+        EXPECT_EQ(deserialized_table.intermesh_links.at(local_chan), remote_chan)
+            << "Remote channel for Board " << local_chan.board_id << " Chan "
+            << local_chan.chan_id << " does not match after deserialization";
+
+        auto board_id = local_chan.board_id;
+        bool chip_found = false;
+        for (auto chip_id : cluster.user_exposed_chip_ids()) {
+            if (control_plane.has_intermesh_links(chip_id) == false) {
+                continue;
+            }
+            if (control_plane.get_asic_id(chip_id) == board_id) {
+                EXPECT_TRUE(control_plane.is_intermesh_eth_link(chip_id, CoreCoord{0, local_chan.chan_id}))
+                    << "Expected valid intermesh links in the local intermesh link table";
+                    chip_found = true;
+            }
+        }
+        EXPECT_TRUE(chip_found) << "No chip found with ASIC ID " << board_id;
     }
 }
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_intermesh_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_intermesh_apis.cpp
@@ -139,7 +139,8 @@ TEST(IntermeshAPIs, LocalIntermeshLinkTable) {
             if (control_plane.get_asic_id(chip_id) == board_id) {
                 EXPECT_TRUE(control_plane.is_intermesh_eth_link(chip_id, CoreCoord{0, local_chan.chan_id}))
                     << "Expected valid intermesh links in the local intermesh link table";
-                    chip_found = true;
+                chip_found = true;
+                break;
             }
         }
         EXPECT_TRUE(chip_found) << "No chip found with ASIC ID " << board_id;

--- a/tt_metal/api/tt-metalium/hal_types.hpp
+++ b/tt_metal/api/tt-metalium/hal_types.hpp
@@ -43,6 +43,7 @@ enum class HalL1MemAddrType : uint8_t {
     RETRAIN_FORCE,
     FABRIC_ROUTER_CONFIG,
     ETH_FW_MAILBOX,
+    ETH_LINK_REMOTE_INFO,
     INTERMESH_ETH_LINK_CONFIG,
     INTERMESH_ETH_LINK_STATUS,
     COUNT  // Keep this last so it always indicates number of enum options

--- a/tt_metal/api/tt-metalium/multi_mesh_types.hpp
+++ b/tt_metal/api/tt-metalium/multi_mesh_types.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <map>
+#include <tt-metalium/fabric_types.hpp>
+
+namespace tt::tt_fabric {
+
+// Fully specifies the location of an ethernet channel using a unique board ID and channel ID
+// The board ID is programmed by SPI-ROM Firmware and is queried by reading L1.
+struct EthChanDescriptor {
+    uint64_t board_id = 0;  // Unique board identifier
+    uint32_t chan_id = 0;   // Eth Channel ID
+
+    bool operator==(const EthChanDescriptor& other) const {
+        return board_id == other.board_id && chan_id == other.chan_id;
+    }
+
+    bool operator<(const EthChanDescriptor& other) const {
+        if (board_id != other.board_id) {
+            return board_id < other.board_id;
+        }
+        return chan_id < other.chan_id;
+    }
+};
+
+// The Control Plane running on each host populates this table to track all intermesh links
+// on the Mesh it manages. All hosts exchange their local table with all other hosts to map
+// their intermesh links to remote meshes.
+struct IntermeshLinkTable {
+    // Local mesh ID
+    MeshId local_mesh_id = MeshId{0};
+    // Maps local eth channel to remote eth channel
+    std::map<EthChanDescriptor, EthChanDescriptor> intermesh_links;
+};
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(
         fabric.cpp
         fabric_host_utils.cpp
         fabric_context.cpp
+        serialization/intermesh_link_table.cpp
 )
 
 # These headers are for the device, not host; will require cross compiling to verify.
@@ -43,7 +44,26 @@ target_sources(
             hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
 )
 
-target_include_directories(fabric PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+# Include helper functions and generate headers from flatbuffer schemas
+include(flatbuffers)
+set(FLATBUFFER_SCHEMAS ${CMAKE_CURRENT_SOURCE_DIR}/serialization/intermesh_link_table.fbs)
+
+# Collect all generated headers
+set(GENERATED_FBS_HEADERS)
+foreach(FBS_FILE ${FLATBUFFER_SCHEMAS})
+    GENERATE_FBS_HEADER(${FBS_FILE})
+    list(APPEND GENERATED_FBS_HEADERS ${FBS_GENERATED_HEADER_FILE})
+endforeach()
+
+# Add the generated headers to your target
+target_sources(fabric PRIVATE ${GENERATED_FBS_HEADERS})
+
+target_include_directories(
+    fabric
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers
+)
 
 target_link_libraries(
     fabric
@@ -56,6 +76,7 @@ target_link_libraries(
         yaml-cpp::yaml-cpp
         Metalium::Metal::Impl
         TT::Metalium::HostDevCommon
+        FlatBuffers::FlatBuffers
 )
 
 target_precompile_headers(fabric REUSE_FROM TT::CommonPCH)

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -27,6 +27,7 @@
 #include "core_coord.hpp"
 #include "fabric_host_interface.h"
 #include "hal_types.hpp"
+#include "intermesh_constants.hpp"
 #include "impl/context/metal_context.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include "mesh_coord.hpp"
@@ -40,17 +41,6 @@
 #include "tt_metal/fabric/fabric_context.hpp"
 
 namespace tt::tt_fabric {
-
-namespace intermesh_constants {
-
-// Constants used to derive the intermesh ethernet links config
-constexpr uint32_t MULTI_MESH_ENABLED_VALUE = 0x2;
-constexpr uint32_t LINK_CONNECTED_MASK = 0x1;
-constexpr uint32_t MULTI_MESH_MODE_MASK = 0xFF;
-constexpr uint32_t INTERMESH_ETH_LINK_BITS_SHIFT = 8;
-constexpr uint32_t INTERMESH_ETH_LINK_BITS_MASK = 0xFFFF;
-
-}  // namespace intermesh_constants
 
 namespace {
 
@@ -277,6 +267,7 @@ ControlPlane::ControlPlane(const std::string& mesh_graph_desc_file) {
     this->load_physical_chip_mapping(logical_mesh_chip_id_to_physical_chip_id_mapping);
     // Query and generate intermesh ethernet links per physical chip
     this->initialize_intermesh_eth_links();
+    this->generate_local_intermesh_link_table();
 }
 
 ControlPlane::ControlPlane(
@@ -292,6 +283,7 @@ ControlPlane::ControlPlane(
     this->load_physical_chip_mapping(logical_mesh_chip_id_to_physical_chip_id_mapping);
     // Query and generate intermesh ethernet links per physical chip
     this->initialize_intermesh_eth_links();
+    this->generate_local_intermesh_link_table();
 }
 
 void ControlPlane::load_physical_chip_mapping(
@@ -1623,6 +1615,63 @@ std::unordered_set<CoreCoord> ControlPlane::get_inactive_ethernet_cores(chip_id_
         }
     }
     return inactive_ethernet_cores;
+}
+
+void ControlPlane::generate_local_intermesh_link_table() {
+    // Populate the local to remote mapping for all intermesh links
+    // This cannot be done by UMD, since it has no knowledge of links marked
+    // for intermesh routing (these links are hidden from UMD).
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    // TODO: (AS) Populate this with the correct local mesh id once we have rank bindings
+    intermesh_link_table_.local_mesh_id = MeshId{0};
+    const uint32_t remote_config_base_addr = tt_metal::MetalContext::instance().hal().get_dev_addr(
+        tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::ETH_LINK_REMOTE_INFO);
+    for (const auto& chip_id : cluster.user_exposed_chip_ids()) {
+        if (this->has_intermesh_links(chip_id)) {
+            for (const auto& [eth_core, chan_id] : this->get_intermesh_eth_links(chip_id)) {
+                if (not this->is_intermesh_eth_link_trained(chip_id, eth_core)) {
+                    // Link is untrained/unusuable
+                    continue;
+                }
+                tt_cxy_pair virtual_eth_core(
+                    chip_id, cluster.get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
+                uint64_t local_board_id = 0;
+                uint64_t remote_board_id = 0;
+                uint32_t remote_chan_id = 0;
+                cluster.read_core(
+                    &local_board_id,
+                    sizeof(uint64_t),
+                    virtual_eth_core,
+                    remote_config_base_addr + intermesh_constants::LOCAL_BOARD_ID_OFFSET);
+                cluster.read_core(
+                    &remote_board_id,
+                    sizeof(uint64_t),
+                    virtual_eth_core,
+                    remote_config_base_addr + intermesh_constants::REMOTE_BOARD_ID_OFFSET);
+                cluster.read_core(
+                    &remote_chan_id,
+                    sizeof(uint32_t),
+                    virtual_eth_core,
+                    remote_config_base_addr + intermesh_constants::REMOTE_ETH_CHAN_ID_OFFSET);
+                auto local_eth_chan_desc = EthChanDescriptor{
+                    .board_id = local_board_id,
+                    .chan_id = chan_id,
+                };
+                auto remote_eth_chan_desc = EthChanDescriptor{
+                    .board_id = remote_board_id,
+                    .chan_id = remote_chan_id,
+                };
+                intermesh_link_table_.intermesh_links[local_eth_chan_desc] = remote_eth_chan_desc;
+                chip_id_to_asic_id_[chip_id] = local_board_id;
+            }
+        }
+    }
+}
+
+const IntermeshLinkTable& ControlPlane::get_local_intermesh_link_table() const { return intermesh_link_table_; }
+
+uint64_t ControlPlane::get_asic_id(chip_id_t chip_id) const {
+    return chip_id_to_asic_id_.at(chip_id);
 }
 
 ControlPlane::~ControlPlane() = default;

--- a/tt_metal/fabric/intermesh_constants.hpp
+++ b/tt_metal/fabric/intermesh_constants.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace tt::tt_fabric {
+namespace intermesh_constants {
+
+// Constants used to derive the intermesh ethernet links config
+static constexpr uint32_t MULTI_MESH_ENABLED_VALUE = 0x2;
+static constexpr uint32_t LINK_CONNECTED_MASK = 0x1;
+static constexpr uint32_t MULTI_MESH_MODE_MASK = 0xFF;
+static constexpr uint32_t INTERMESH_ETH_LINK_BITS_SHIFT = 8;
+static constexpr uint32_t INTERMESH_ETH_LINK_BITS_MASK = 0xFFFF;
+static constexpr uint32_t LOCAL_BOARD_ID_OFFSET = 256;
+static constexpr uint32_t REMOTE_BOARD_ID_OFFSET = 288;
+static constexpr uint32_t REMOTE_ETH_CHAN_ID_OFFSET = 304;
+
+}  // namespace intermesh_constants
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/serialization/intermesh_link_table.cpp
+++ b/tt_metal/fabric/serialization/intermesh_link_table.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <vector>
 #include "tt_metal/fabric/serialization/intermesh_link_table.hpp"
 #include "intermesh_link_table_generated.h"
 

--- a/tt_metal/fabric/serialization/intermesh_link_table.cpp
+++ b/tt_metal/fabric/serialization/intermesh_link_table.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/fabric/serialization/intermesh_link_table.hpp"
+#include "intermesh_link_table_generated.h"
+
+namespace tt::tt_fabric {
+
+std::vector<uint8_t> serialize_to_bytes(const IntermeshLinkTable& intermesh_link_table) {
+    flatbuffers::FlatBufferBuilder builder;
+
+    auto mesh_id = tt::tt_fabric::flatbuffer::CreateMeshId(builder, *(intermesh_link_table.local_mesh_id));
+
+    // Create vector of EthernetLink objects (flatbuffers dont support std::unordered_map directly)
+    std::vector<flatbuffers::Offset<tt::tt_fabric::flatbuffer::EthernetLink>> ethernet_links;
+
+    for (const auto& [local_chan, remote_chan] : intermesh_link_table.intermesh_links) {
+        auto local_eth_chan =
+            tt::tt_fabric::flatbuffer::CreateEthChanDescriptor(builder, local_chan.board_id, local_chan.chan_id);
+
+        auto remote_eth_chan =
+            tt::tt_fabric::flatbuffer::CreateEthChanDescriptor(builder, remote_chan.board_id, remote_chan.chan_id);
+
+        auto ethernet_link = tt::tt_fabric::flatbuffer::CreateEthernetLink(builder, local_eth_chan, remote_eth_chan);
+
+        ethernet_links.push_back(ethernet_link);
+    }
+
+    // Create vector of ethernet links
+    auto ethernet_links_vector = builder.CreateVector(ethernet_links);
+
+    // Create the root IntermeshLinkTable
+    auto serialized_intermesh_link_table =
+        tt::tt_fabric::flatbuffer::CreateIntermeshLinkTable(builder, mesh_id, ethernet_links_vector);
+
+    // Finish the buffer
+    builder.Finish(serialized_intermesh_link_table);
+
+    // Return the serialized data
+    return std::vector<uint8_t>(builder.GetBufferPointer(), builder.GetBufferPointer() + builder.GetSize());
+}
+
+IntermeshLinkTable deserialize_from_bytes(const std::vector<uint8_t>& data) {
+    IntermeshLinkTable result;
+
+    auto verifier = flatbuffers::Verifier(data.data(), data.size());
+    if (!tt::tt_fabric::flatbuffer::VerifyIntermeshLinkTableBuffer(verifier)) {
+        throw std::runtime_error("Invalid FlatBuffer data");
+    }
+
+    auto intermesh_link_table = tt::tt_fabric::flatbuffer::GetIntermeshLinkTable(data.data());
+
+    if (intermesh_link_table->local_mesh_id()) {
+        result.local_mesh_id = MeshId{intermesh_link_table->local_mesh_id()->value()};
+    }
+
+    // Extract intermesh links into unordered_map
+    if (intermesh_link_table->intermesh_links()) {
+        for (const auto* ethernet_link : *intermesh_link_table->intermesh_links()) {
+            EthChanDescriptor local_chan;
+            EthChanDescriptor remote_chan;
+
+            if (ethernet_link->local_chan()) {
+                local_chan.board_id = ethernet_link->local_chan()->board_id();
+                local_chan.chan_id = ethernet_link->local_chan()->chan_id();
+            }
+
+            if (ethernet_link->remote_chan()) {
+                remote_chan.board_id = ethernet_link->remote_chan()->board_id();
+                remote_chan.chan_id = ethernet_link->remote_chan()->chan_id();
+            }
+
+            result.intermesh_links[local_chan] = remote_chan;
+        }
+    }
+
+    return result;
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/serialization/intermesh_link_table.cpp
+++ b/tt_metal/fabric/serialization/intermesh_link_table.cpp
@@ -14,6 +14,7 @@ std::vector<uint8_t> serialize_to_bytes(const IntermeshLinkTable& intermesh_link
 
     // Create vector of EthernetLink objects (flatbuffers dont support std::unordered_map directly)
     std::vector<flatbuffers::Offset<tt::tt_fabric::flatbuffer::EthernetLink>> ethernet_links;
+    ethernet_links.reserve(intermesh_link_table.intermesh_links.size());
 
     for (const auto& [local_chan, remote_chan] : intermesh_link_table.intermesh_links) {
         auto local_eth_chan =

--- a/tt_metal/fabric/serialization/intermesh_link_table.fbs
+++ b/tt_metal/fabric/serialization/intermesh_link_table.fbs
@@ -1,0 +1,22 @@
+namespace tt.tt_fabric.flatbuffer;
+
+table MeshId {
+  value: uint32;
+}
+
+table EthChanDescriptor {
+    board_id: uint64;
+    chan_id: uint32;
+}
+
+table EthernetLink {
+    local_chan: EthChanDescriptor;
+    remote_chan: EthChanDescriptor;
+}
+
+table IntermeshLinkTable {
+  local_mesh_id: MeshId;
+  intermesh_links: [EthernetLink];
+}
+
+root_type IntermeshLinkTable;

--- a/tt_metal/fabric/serialization/intermesh_link_table.hpp
+++ b/tt_metal/fabric/serialization/intermesh_link_table.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/multi_mesh_types.hpp>
+
+namespace tt::tt_fabric {
+
+std::vector<uint8_t> serialize_to_bytes(const IntermeshLinkTable& intermesh_link_table);
+IntermeshLinkTable deserialize_from_bytes(const std::vector<uint8_t>& data);
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -159,8 +159,10 @@
 #define MEM_RETRAIN_FORCE_ADDR 0x1EFC
 // These values are taken from WH, These may need to be updated when BH needs to support
 // intermesh routing.
+#define MEM_ETH_LINK_REMOTE_INFO_ADDR 0x1EC0
 #define MEM_INTERMESH_ETH_LINK_CONFIG_ADDR 0x104C
 #define MEM_INTERMESH_ETH_LINK_STATUS_ADDR 0x1104
+
 #define MEM_SYSENG_ETH_RESULTS_BASE_ADDR 0x7CC00
 #define MEM_SYSENG_ETH_MAILBOX_BASE_ADDR 0x7D000
 

--- a/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
@@ -109,7 +109,7 @@ struct address_map {
     };
 
     static constexpr std::int32_t RISC_LOCAL_MEM_BASE =
-        0xffb00000;  // Actaul local memory address as seen from risc firmware
+        0xffb00000;  // Actual local memory address as seen from risc firmware
                      // As part of the init risc firmware will copy local memory data from
                      // l1 locations listed above into internal local memory that starts
                      // at RISC_LOCAL_MEM_BASE address
@@ -117,6 +117,7 @@ struct address_map {
     static constexpr std::uint32_t RETRAIN_COUNT_ADDR = 0x1EDC;
     static constexpr std::uint32_t RETRAIN_FORCE_ADDR = 0x1EFC;
 
+    static constexpr uint32_t ETH_LINK_REMOTE_INFO_ADDR = 0x1EC0;
     static constexpr std::uint32_t INTERMESH_ETH_LINK_CONFIG_ADDR = 0x104C;
     static constexpr std::uint32_t INTERMESH_ETH_LINK_STATUS_ADDR = 0x1104;
 };

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -52,6 +52,7 @@ HalCoreInfoType create_active_eth_mem_map() {
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::APP_ROUTING_INFO)] = MEM_ERISC_APP_ROUTING_INFO_BASE;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::RETRAIN_COUNT)] = MEM_RETRAIN_COUNT_ADDR;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::RETRAIN_FORCE)] = MEM_RETRAIN_FORCE_ADDR;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::ETH_LINK_REMOTE_INFO)] = MEM_ETH_LINK_REMOTE_INFO_ADDR;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::INTERMESH_ETH_LINK_CONFIG)] =
         MEM_INTERMESH_ETH_LINK_CONFIG_ADDR;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::INTERMESH_ETH_LINK_STATUS)] =

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -84,6 +84,8 @@ HalCoreInfoType create_active_eth_mem_map(bool is_base_routing_fw_enabled) {
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::RETRAIN_FORCE)] = sizeof(uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::FABRIC_ROUTER_CONFIG)] =
         eth_l1_mem::address_map::FABRIC_ROUTER_CONFIG_SIZE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::ETH_LINK_REMOTE_INFO)] =
+        eth_l1_mem::address_map::ETH_LINK_REMOTE_INFO_ADDR;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::INTERMESH_ETH_LINK_CONFIG)] =
         eth_l1_mem::address_map::INTERMESH_ETH_LINK_CONFIG_ADDR;
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::INTERMESH_ETH_LINK_STATUS)] =


### PR DESCRIPTION
 ### Ticket
No Ticket.

### Problem description
- Fabric init on multi-host systems requires each host to assign directions to its intermesh links
- Direction Assignment Algorithm:
  - Each host iterates over its intermesh links and queries the remote board and channel ID its connected to (by reading L1)
  - Each host broadcasts this information to all other hosts using the `DistributedContext` (this information is stored in a table in the `ControlPlane`)
  - Each host locally iterates over the meshes its connected to. For each intermesh link it owns, it checks which neighbour mesh owns its link's peer (this is the target mesh). The direction specified between the local and target mesh is assigned to the intermesh link.
- To facilitate this, we need 2 changes:
  - Locally querying each intermesh link's peer board and channel ID
  - Resolving directions through an MPI handshake
- This PR covers the first change, the second change will be done through a separate PR, once `DistributedContext` is default initialized by `MetalContext` 

### What's changed
- Add APIs in Control Plane to generate a mapping to the remote board and channel for all intermesh links, by reading dedicated L1 regions (shared between UBB and N300 systems)
 - Expose the unique Board ID (used for UBB) to other systems requiring multi-host routing
 - Store local to remote mapping of intermesh links in the `IntermeshLinkTable` data structure exposed to `ControlPlane`
 - Add flatbuffer (de)serialization functionality for `IntermeshLinkTable`, since each host will need to exchange its tables with all other hosts during host side fabric initialization
 - Misc Cleanup: Move Intermesh related functionality and constants to dedicated headers

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes