### PR TITLE
[tt-train] Update reflect to v1.2.6

### DIFF
--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -52,7 +52,7 @@ CPMAddPackage(
 # boost-ext reflect : https://github.com/boost-ext/reflect
 ############################################################################################################################
 
-CPMAddPackage(NAME reflect GITHUB_REPOSITORY boost-ext/reflect GIT_TAG v1.1.1)
+CPMAddPackage(NAME reflect GITHUB_REPOSITORY boost-ext/reflect GIT_TAG v1.2.6)
 
 ############################################################################################################################
 # fmt : https://github.com/fmtlib/fmt


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23879)

### Problem description
Inconsistent version of reflect in `tt-metal` and `tt-train`

### What's changed
Change dependency from v1.1.1 to v1.2.6

### Checklist
- [x] New/Existing tests provide coverage for changes