### PR TITLE
Test Silicon path when Cluster is created with simulator SoC yaml

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -44,6 +44,7 @@ jobs:
           {name: dispatch, cmd: "./build/test/tt_metal/unit_tests_dispatch"},
           {name: eth, cmd: "./build/test/tt_metal/unit_tests_eth"},
           {name: llk, cmd: "./build/test/tt_metal/unit_tests_llk"},
+          {name: silicon_with_simulator_soc, cmd: "TT_METAL_SILICON_WITH_SIMULATOR_SOC=1 ./build/test/tt_metal/unit_tests_llk --gtest_filter=DeviceFixture.TensixBinaryComputeSingleCoreSingleTileAdd"},
           {name: sfpi, cmd: "./build/test/tt_metal/unit_tests_sfpi"},
           {name: distributed, cmd: "./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter=MeshDeviceSuite.*"},
           {name: FD2, cmd: ./tests/scripts/run_cpp_fd2_tests.sh},

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -304,6 +304,11 @@ bool single_core_binary(tt_metal::IDevice* device, const SingleCoreBinaryConfig&
 }  // namespace unit_tests::compute::binary
 
 TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreSingleTileAdd) {
+    // Temporary solution to skip the test on wormhole B0 and silicon simulator SOC
+    auto arch = this->arch_;
+    if (arch != tt::ARCH::WORMHOLE_B0 && getenv("TT_METAL_SILICON_WITH_SIMULATOR_SOC") != nullptr) {
+        GTEST_SKIP();
+    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -68,7 +68,7 @@ inline std::string get_soc_description_file(
         path.push_back('/');
     }
     path += "tt_metal/soc_descriptors/";
-    bool is_sim = target_device == tt::TargetDevice::Simulator;
+    bool is_sim = target_device == tt::TargetDevice::Simulator || getenv("TT_METAL_SILICON_WITH_SIMULATOR_SOC") != nullptr;
     const char* file = nullptr;
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: file = is_sim ? "wormhole_b0_versim.yaml" : "wormhole_b0_80_arch.yaml"; break;


### PR DESCRIPTION
### Ticket
#23832

### Problem description
To prevent future regressions where changes in tt-metal break Simulator functionality, we are adding an llk_unit test that runs the Silicon target using the Simulator SoC descriptor.

This will help ensure compatibility and catch issues early when running standard tests with the Simulator configuration.

### What's changed
Added a new environment variable: `TT_METAL_SILICON_WITH_SIMULATOR_SOC`.
When this variable is set, the Simulator SoC descriptor will be loaded even on Silicon targets.
Introduced a new test named `silicon_with_simulator_soc`, which reuses the existing `llk_unit` test to verify this configuration.
For now, the test is skipped on all architectures except `Wormhole`.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes