### PR TITLE
#23295: [skip ci] Rename llmbox fabric unit tests to unit tests, create llmbox wrapper

### DIFF
--- a/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
@@ -39,6 +39,7 @@ jobs:
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on:
       - in-service
+      - arch-blackhole
       - ${{ inputs.runner-label }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved' }}

--- a/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
@@ -1,4 +1,4 @@
-name: "[internal] Blackhole LLMBox Fabric unit tests impl"
+name: "[internal] Blackhole LLMBox unit tests impl"
 
 on:
   workflow_call:
@@ -37,12 +37,9 @@ jobs:
           # {name: t3000 fast fabric tests, cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests" },
         ]
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
-    runs-on: >-
-      ${{
-        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
-        || github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
-        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
-      }}
+    runs-on:
+      - in-service
+      - ${{ inputs.runner-label }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved' }}
       env:
@@ -75,7 +72,7 @@ jobs:
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          owner: U06CXU895AP # Michael Chiou
+          owner: U0883RN6CRE # William Ly
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/blackhole-llmbox-unit-tests.yaml
+++ b/.github/workflows/blackhole-llmbox-unit-tests.yaml
@@ -1,0 +1,25 @@
+name: "(Blackhole) LLMBox unit tests"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      build-wheel: true
+      version: 22.04
+  blackhole-llmbox-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
+    with:
+      arch: blackhole
+      runner-label: BH-LLMBox
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -91,10 +91,10 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  blackhole-llmbox-fabric-unit-tests:
+  blackhole-llmbox-unit-tests:
     needs: build-artifact
     secrets: inherit
-    uses: ./.github/workflows/blackhole-llmbox-fabric-build-and-unit-tests.yaml
+    uses: ./.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
     with:
       arch: blackhole
       runner-label: BH-LLMBox


### PR DESCRIPTION
### Ticket
#23295

### Problem description
Slightly annoying to have to run BH nightly just to run llmbox tests

### What's changed
Add a llmbox test wrapper workflow (won't exist until I merge this PR)
Remove `fabric` from llmbox test impl workflow name (we plan on adding+running more than just fabric tests)

### Checklist
- [x] BH nightly: https://github.com/tenstorrent/tt-metal/actions/runs/15830157213