### PR TITLE
#0: Don't expose dispatch thread pool through `MeshDevice` interface

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -303,9 +303,6 @@ public:
     // These are prefixed with "mesh_" to avoid conflicts with the IDevice* methods
     MeshCommandQueue& mesh_command_queue(std::size_t cq_id = 0) const;
 
-    // Currently expose users to the dispatch thread pool through the MeshDevice
-    void enqueue_to_thread_pool(std::function<void()>&& f);
-    void wait_for_thread_pool();
     static std::shared_ptr<MeshDevice> create(
         const MeshDeviceConfig& config,
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -228,10 +228,6 @@ std::shared_ptr<MeshDevice> MeshDevice::create(
     return mesh_device;
 }
 
-void MeshDevice::enqueue_to_thread_pool(std::function<void()>&& f) { dispatch_thread_pool_->enqueue(std::move(f)); }
-
-void MeshDevice::wait_for_thread_pool() { dispatch_thread_pool_->wait(); }
-
 std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_unit_meshes(
     const std::vector<int>& device_ids,
     size_t l1_small_size,

--- a/tt_metal/distributed/mesh_workload_impl.hpp
+++ b/tt_metal/distributed/mesh_workload_impl.hpp
@@ -44,7 +44,6 @@ private:
     void set_program_binary_status(std::size_t mesh_id, ProgramBinaryStatus status);
     ProgramConfig& get_program_config(uint32_t index);
     ProgramCommandSequence& get_dispatch_cmds_for_program(Program& program, uint64_t command_hash);
-    void compile_program(const MeshCoordinateRange& device_range, MeshDevice* mesh_device);
     void finalize_offsets(MeshDevice* mesh_device);
 
     std::unordered_map<std::size_t, ProgramBinaryStatus> program_binary_status_;


### PR DESCRIPTION
### Ticket
N/A

### Problem description
TTNN's use of thread pool internal to `MeshDevice` was migrated to taskflow, hidden from within `DistributedHostBuffer`. Moving mesh workload compilation to taskflow similarly allows to remove the public API entirely.

### What's changed
Use taskflow for each for compiling mesh workloads.

Remove `MeshDevice::enqueue_to_thread_pool` / `MeshDevice::wait_for_thread_pool`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15831039529) - pending
- [ ] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15831050532) - pending
- [x] New/Existing tests provide coverage for changes
