### PR TITLE
Slee/allpostcommit g14compile

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -249,7 +249,7 @@ jobs:
             publish-artifact: false
             skip-tt-train: false
           - version: "24.04"
-            toolchain: "cmake/x86_64-linux-gcc-14-libstdcpp-toolchain.cmake"
+            toolchain: "cmake/x86_64-linux-gcc-14-toolchain.cmake"
             build-type: "Release"
             publish-artifact: false
             skip-tt-train: false

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -248,6 +248,11 @@ jobs:
             build-type: "Release"
             publish-artifact: false
             skip-tt-train: false
+          - version: "24.04"
+            toolchain: "cmake/x86_64-linux-gcc-14-libstdcpp-toolchain.cmake"
+            build-type: "Release"
+            publish-artifact: false
+            skip-tt-train: false
     with:
       version: ${{ matrix.config.version }}
       toolchain: ${{ matrix.config.toolchain }}

--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -43,6 +43,9 @@ jobs:
           - version: "24.04"
             toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
             build-type: "Release"
+          - version: "24.04"
+            toolchain: "cmake/x86_64-linux-gcc-14-toolchain.cmake"
+            build-type: "RelWithDebInfo"
     with:
       version: ${{ matrix.config.version }}
       toolchain: ${{ matrix.config.toolchain }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,9 @@ add_compile_options(
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-stringop-overread>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-unused-local-typedefs>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-volatile>"
+    "$<$<CXX_COMPILER_ID:GNU>:-Wno-pessimizing-move>"
+    "$<$<CXX_COMPILER_ID:GNU>:-Wno-dangling-reference>"
+    "$<$<CXX_COMPILER_ID:GNU>:-Wno-overloaded-virtual>"
 )
 
 # Planned to be temporary, remove later.

--- a/cmake/x86_64-linux-gcc-14-toolchain.cmake
+++ b/cmake/x86_64-linux-gcc-14-toolchain.cmake
@@ -1,0 +1,8 @@
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+
+set(CMAKE_C_COMPILER gcc-14 CACHE INTERNAL "C compiler")
+
+set(CMAKE_CXX_COMPILER g++-14 CACHE INTERNAL "C++ compiler")
+
+# Use for configure time
+set(ENABLE_LIBCXX FALSE CACHE INTERNAL "Using clang's libc++")

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(
         umd::Firmware
         umd::device
         simde::simde
+        Taskflow::Taskflow
     PRIVATE
         Metalium::Metal::Hardware
         Tracy::TracyClient


### PR DESCRIPTION
### Ticket

Closes #23441 

Fixed issue #23805 by adding some compiler flags (i.e. -Wno-pessimizing-move, -Wno-dangling-reference, -Wno-overloaded-virtual)

### Problem description
Wanted to upgrade the GNU Compiler Collection (GCC) to version 14 on an Ubuntu 24.04 system. The goal is to leverage the latest compiler features, optimizations, and language support (e.g., C++23 enhancements, improved diagnostics, and new warnings)

### What's changed
The toolmake cmake/x86_64-linux-gcc-14-toolchain.cmake was developed and the implementation code was added to the all-post-commits.yaml file
```
          - version: "24.04"
            toolchain: "cmake/x86_64-linux-gcc-14-toolchain.cmake"
            build-type: "Release"
            publish-artifact: false
            skip-tt-train: false
```
In CMake list, three more complier flags were added to enable to allow the code to run with no errors
```
    "$<$<CXX_COMPILER_ID:GNU>:-Wno-pessimizing-move>"
    "$<$<CXX_COMPILER_ID:GNU>:-Wno-dangling-reference>"
    "$<$<CXX_COMPILER_ID:GNU>:-Wno-overloaded-virtual>"
```

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] No broken builds of other jobs (https://github.com/tenstorrent/tt-metal/actions/runs/15766282893)