### PR TITLE
#0: `ttsl::Cleanup`

### DIFF
--- a/tt_stl/CMakeLists.txt
+++ b/tt_stl/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(
         FILES
             tt_stl/aligned_allocator.hpp
             tt_stl/any_range.hpp
+            tt_stl/cleanup.hpp
             tt_stl/concepts.hpp
             tt_stl/indestructible.hpp
             tt_stl/overloaded.hpp

--- a/tt_stl/tests/CMakeLists.txt
+++ b/tt_stl/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(
     unit_tests_stl_smoke
     PRIVATE
         test_any_range.cpp
+        test_cleanup.cpp
         test_indestructible.cpp
         test_slotmap.cpp
         test_span.cpp

--- a/tt_stl/tests/test_cleanup.cpp
+++ b/tt_stl/tests/test_cleanup.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+
+#include <tt_stl/cleanup.hpp>
+#include <memory>
+#include <vector>
+
+namespace ttsl {
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::HasSubstr;
+
+TEST(CleanupTest, Basic) {
+    int counter = 0;
+    {
+        auto cleanup = make_cleanup([&counter]() { counter++; });
+        EXPECT_EQ(counter, 0);
+    }
+    EXPECT_EQ(counter, 1);
+}
+
+TEST(CleanupTest, MultipleCleanupsInOrder) {
+    std::vector<int> log;
+    {
+        auto cleanup1 = make_cleanup([&log]() { log.push_back(1); });
+        auto cleanup2 = make_cleanup([&log]() { log.push_back(2); });
+        auto cleanup3 = make_cleanup([&log]() { log.push_back(3); });
+    }
+    EXPECT_THAT(log, ElementsAre(3, 2, 1));
+}
+
+TEST(CleanupTest, CancelCleanup) {
+    int counter = 0;
+    {
+        auto cleanup = make_cleanup([&counter]() { counter++; });
+        EXPECT_EQ(counter, 0);
+        std::move(cleanup).cancel();
+    }
+    EXPECT_EQ(counter, 0);
+}
+
+TEST(CleanupTest, MoveConstruction) {
+    int counter = 0;
+    {
+        auto cleanup1 = make_cleanup([&counter]() { counter++; });
+        auto cleanup2 = std::move(cleanup1);
+        EXPECT_EQ(counter, 0);
+    }
+    EXPECT_EQ(counter, 1);
+}
+
+TEST(CleanupTest, ExceptionSafety) {
+    bool cleanup_called = false;
+    try {
+        auto cleanup = make_cleanup([&cleanup_called]() { cleanup_called = true; });
+        throw std::runtime_error("test exception");
+    } catch (const std::runtime_error& e) {
+        // Exception caught, cleanup should still execute
+        EXPECT_THAT(e.what(), HasSubstr("test exception"));
+    }
+    EXPECT_TRUE(cleanup_called);
+}
+
+TEST(CleanupTest, PerfectForwarding) {
+    std::vector<int> captured = {1, 2, 3};
+    {
+        auto cleanup = make_cleanup([captured = std::move(captured)]() {
+            // captured should be moved into the lambda
+        });
+        EXPECT_TRUE(captured.empty());  // Should be moved from
+    }
+}
+
+}  // namespace
+}  // namespace ttsl

--- a/tt_stl/tt_stl/cleanup.hpp
+++ b/tt_stl/tt_stl/cleanup.hpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <functional>
+#include <optional>
+
+namespace ttsl {
+
+// `Cleanup` is a RAII wrapper that calls a callable automatically upon leaving the scope of the object.
+//
+// Example usage:
+//
+// FILE* input_file = fopen(file_name.c_str(), "rb");
+// TT_FATAL(input_file != nullptr, "Cannot open \"{}\"", file_name);
+// auto cleanup = ttsl::make_cleanup([input_file]() { fclose(input_file); });
+// ...
+//
+template <typename Callable>
+class Cleanup {
+public:
+    explicit Cleanup(Callable callable) : callable_(std::move(callable)) {}
+    ~Cleanup() {
+        if (callable_.has_value()) {
+            (*callable_)();
+        }
+    }
+
+    // Support move-only construction only, no re-assignment.
+    Cleanup(const Cleanup&) = delete;
+    Cleanup& operator=(const Cleanup&) = delete;
+    Cleanup(Cleanup&& other) noexcept : callable_(std::move(other.callable_)) { other.callable_.reset(); }
+    Cleanup& operator=(Cleanup&& other) noexcept = delete;
+
+    // Cancels the cleanup.
+    // Must be called on an rvalue-qualified object, to explicitly signal the cleanup instance should no longer be used.
+    void cancel() && { callable_.reset(); }
+
+private:
+    std::optional<Callable> callable_;
+};
+
+template <typename Callable>
+auto make_cleanup(Callable&& callable) {
+    return Cleanup(std::forward<Callable>(callable));
+}
+
+}  // namespace ttsl

--- a/tt_stl/tt_stl/cleanup.hpp
+++ b/tt_stl/tt_stl/cleanup.hpp
@@ -19,9 +19,9 @@ namespace ttsl {
 // ...
 //
 template <typename Callable>
-class Cleanup {
+class Cleanup final {
 public:
-    explicit Cleanup(Callable callable) : callable_(std::move(callable)) {}
+    constexpr explicit Cleanup(Callable callable) : callable_(std::move(callable)) {}
     ~Cleanup() {
         if (callable_.has_value()) {
             (*callable_)();
@@ -35,7 +35,8 @@ public:
     Cleanup& operator=(Cleanup&& other) noexcept = delete;
 
     // Cancels the cleanup.
-    // Must be called on an rvalue-qualified object, to explicitly signal the cleanup instance should no longer be used.
+    // Must be called on an rvalue-qualified object, to explicitly signal the cleanup instance should no longer be used;
+    // use-after-move clang check can be used to enforce this.
     void cancel() && { callable_.reset(); }
 
 private:

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -18,6 +18,7 @@
 #include <flatbuffers/flatbuffers.h>
 
 #include <tt_stl/overloaded.hpp>
+#include <tt_stl/cleanup.hpp>
 
 #include "distributed/distributed_tensor_config.hpp"
 #include "tensor/tensor_spec.hpp"
@@ -50,23 +51,15 @@ void validate_version(uint8_t version_id) {
         VERSION_ID);
 }
 
-struct FileCloser {
-    void operator()(FILE* file) const {
+auto make_file_closer(FILE* file) {
+    return ttsl::make_cleanup([file]() {
         if (file) {
             if (fclose(file) != 0) {
                 log_warning(tt::LogAlways, "Failed to close file");
             }
         }
-    }
-};
-
-struct FileDescriptorCloser {
-    void operator()(int* fd) const {
-        if (*fd != -1) {
-            close(*fd);
-        }
-    }
-};
+    });
+}
 
 constexpr uint64_t SENTINEL_VALUE = std::numeric_limits<uint64_t>::max();
 
@@ -273,7 +266,7 @@ Tensor load_tensor(const std::string& file_name, MeshDevice* device) {
     if (not input_file) {
         TT_THROW("Cannot open \"{}\"", file_name);
     }
-    std::unique_ptr<FILE, FileCloser> file_guard(input_file);
+    auto cleanup = make_file_closer(input_file);
 
     std::size_t read_sentinel;
     safe_fread(&read_sentinel, sizeof(read_sentinel), 1, input_file);
@@ -303,7 +296,7 @@ void dump_tensor(
     if (not output_file) {
         TT_THROW("Cannot open \"{}\"", file_name);
     }
-    std::unique_ptr<FILE, FileCloser> file_guard(output_file);
+    auto cleanup = make_file_closer(output_file);
 
     safe_fwrite(&SENTINEL_VALUE, sizeof(SENTINEL_VALUE), 1, output_file);
     safe_fwrite(&VERSION_ID, sizeof(VERSION_ID), 1, output_file);
@@ -350,7 +343,7 @@ void dump_memory_config(const std::string& file_name, const MemoryConfig& memory
     if (not output_file) {
         TT_THROW("Cannot open \"{}\"", file_name);
     }
-    std::unique_ptr<FILE, FileCloser> file_guard(output_file);
+    auto cleanup = make_file_closer(output_file);
     dump_memory_config(output_file, memory_config);
 }
 
@@ -376,14 +369,14 @@ MemoryConfig load_memory_config(const std::string& file_name) {
     if (not input_file) {
         TT_THROW("Cannot open \"{}\"", file_name);
     }
-    std::unique_ptr<FILE, FileCloser> file_guard(input_file);
+    auto cleanup = make_file_closer(input_file);
     return load_memory_config(input_file);
 }
 
 void dump_tensor_flatbuffer(const std::string& file_name, const Tensor& tensor) {
     FILE* output_file = fopen(file_name.c_str(), "wb");
     TT_FATAL(output_file != nullptr, "Cannot open \"{}\"", file_name);
-    std::unique_ptr<FILE, FileCloser> file_guard(output_file);
+    auto cleanup = make_file_closer(output_file);
 
     Tensor cpu_tensor = tensor.cpu();
 
@@ -405,7 +398,7 @@ void dump_tensor_flatbuffer(const std::string& file_name, const Tensor& tensor) 
 Tensor load_tensor_flatbuffer(const std::string& file_name, MeshDevice* device) {
     int fd = open(file_name.c_str(), O_RDONLY | O_CLOEXEC);
     TT_FATAL(fd != -1, "Cannot open \"{}\"", file_name);
-    std::unique_ptr<int, FileDescriptorCloser> fd_guard(&fd);
+    auto cleanup = ttsl::make_cleanup([fd]() { close(fd); });
 
     struct stat file_stat;
     TT_FATAL(fstat(fd, &file_stat) == 0, "Failed to get file stats for \"{}\"", file_name);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Helper RAII wrapper to cleanup resources; e.g. using C style APIs.

### What's changed
Add `ttsl::Cleanup`, along with tests and sample usage in TTNN serialization.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15832556120) (failures unrelated)
- [x] New/Existing tests provide coverage for changes