### PR TITLE
Slightly increase Falcon7B-4U/6U CI perf targets

### DIFF
--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -73,11 +73,11 @@ def test_demo_multichip(
         expected_perf_dict = {
             "4U": {
                 128: {"prefill_t/s": 22160, "decode_t/s/u": 8.10},
-                1024: {"prefill_t/s": 19460, "decode_t/s/u": 6.96},
+                1024: {"prefill_t/s": 19460, "decode_t/s/u": 7.30},
                 2048: {"prefill_t/s": 14010, "decode_t/s/u": 7.40},
             },
             "6U": {
-                128: {"prefill_t/s": 31500, "decode_t/s/u": 13.70},
+                128: {"prefill_t/s": 31500, "decode_t/s/u": 13.00},
                 1024: {"prefill_t/s": 29090, "decode_t/s/u": 11.19},
                 2048: {"prefill_t/s": 23100, "decode_t/s/u": 10.90},
             },

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -72,14 +72,14 @@ def test_demo_multichip(
         assert max_seq_len in [128, 1024, 2048], f"Unexpected max_seq_len: {max_seq_len} for perf mode"
         expected_perf_dict = {
             "4U": {
-                128: {"prefill_t/s": 21200, "decode_t/s/u": 7.30},
-                1024: {"prefill_t/s": 19180, "decode_t/s/u": 6.96},
-                2048: {"prefill_t/s": 13050, "decode_t/s/u": 7.05},
+                128: {"prefill_t/s": 22160, "decode_t/s/u": 8.10},
+                1024: {"prefill_t/s": 19460, "decode_t/s/u": 6.96},
+                2048: {"prefill_t/s": 14010, "decode_t/s/u": 7.40},
             },
             "6U": {
-                128: {"prefill_t/s": 31500, "decode_t/s/u": 11.80},
-                1024: {"prefill_t/s": 29090, "decode_t/s/u": 10.90},
-                2048: {"prefill_t/s": 21300, "decode_t/s/u": 10.37},
+                128: {"prefill_t/s": 31500, "decode_t/s/u": 13.70},
+                1024: {"prefill_t/s": 29090, "decode_t/s/u": 11.19},
+                2048: {"prefill_t/s": 23100, "decode_t/s/u": 10.90},
             },
         }
         expected_perf_metrics = expected_perf_dict[galaxy_type][max_seq_len]

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -77,7 +77,7 @@ def test_demo_multichip(
                 2048: {"prefill_t/s": 14010, "decode_t/s/u": 7.40},
             },
             "6U": {
-                128: {"prefill_t/s": 31500, "decode_t/s/u": 13.00},
+                128: {"prefill_t/s": 31500, "decode_t/s/u": 12.55},
                 1024: {"prefill_t/s": 29090, "decode_t/s/u": 11.19},
                 2048: {"prefill_t/s": 23100, "decode_t/s/u": 10.90},
             },


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Falcon7B perf on galaxy slightly increased so CI perf targets needed to be updated

### What's changed
- Increased CI perf targets for Falcon7B 4U/6U.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes