### PR TITLE
Improving Llama Vision Models Cross-Attention Mask Implementation for Lower Prefill Latency

### DIFF
--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -245,7 +245,13 @@ def test_multimodal_demo_text(
             prefill_start = time.perf_counter()
             if batch_idx == 0:  # Get compile time for first batch
                 with profiler("compile_prefill", iteration=batch_idx):
-                    batch_logits, prefill_batch_xattn_masks, prefill_batch_text_masks, decode_batch_xattn_masks, decode_batch_text_masks = generator.prefill_forward(
+                    (
+                        batch_logits,
+                        prefill_batch_xattn_masks,
+                        prefill_batch_text_masks,
+                        decode_batch_xattn_masks,
+                        decode_batch_text_masks,
+                    ) = generator.prefill_forward(
                         vision_images,
                         vision_mask,
                         tokens,
@@ -256,7 +262,13 @@ def test_multimodal_demo_text(
 
             # Get cached prefill time
             with profiler("inference_prefill", iteration=batch_idx):
-                batch_logits, prefill_batch_xattn_masks, prefill_batch_text_masks, decode_batch_xattn_masks, decode_batch_text_masks = generator.prefill_forward(
+                (
+                    batch_logits,
+                    prefill_batch_xattn_masks,
+                    prefill_batch_text_masks,
+                    decode_batch_xattn_masks,
+                    decode_batch_text_masks,
+                ) = generator.prefill_forward(
                     vision_images,
                     vision_mask,
                     tokens,
@@ -373,13 +385,13 @@ def test_multimodal_demo_text(
         tt_device_name = model_args[0].device_name
         base_model_name = model_args[0].base_model_name
         target_prefill_tok_s = {
-            "N300_Llama-3.2-11B": 10.8,
+            "N300_Llama-3.2-11B": 13.2,
             "T3K_Llama-3.2-11B": 6.5,
             "T3K_Llama-3.2-90B": 3,
         }[f"{tt_device_name}_{base_model_name}"]
 
         target_decode_tok_s_u = {
-            "N300_Llama-3.2-11B": 20,
+            "N300_Llama-3.2-11B": 22.3,
             "T3K_Llama-3.2-11B": 33,
             "T3K_Llama-3.2-90B": 6,
         }[f"{tt_device_name}_{base_model_name}"]

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -391,7 +391,7 @@ def test_multimodal_demo_text(
         }[f"{tt_device_name}_{base_model_name}"]
 
         target_decode_tok_s_u = {
-            "N300_Llama-3.2-11B": 22.3,
+            "N300_Llama-3.2-11B": 21.5,
             "T3K_Llama-3.2-11B": 33,
             "T3K_Llama-3.2-90B": 6,
         }[f"{tt_device_name}_{base_model_name}"]

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -245,7 +245,7 @@ def test_multimodal_demo_text(
             prefill_start = time.perf_counter()
             if batch_idx == 0:  # Get compile time for first batch
                 with profiler("compile_prefill", iteration=batch_idx):
-                    batch_logits, batch_xattn_masks, batch_text_masks = generator.prefill_forward(
+                    batch_logits, prefill_batch_xattn_masks, prefill_batch_text_masks, decode_batch_xattn_masks, decode_batch_text_masks = generator.prefill_forward(
                         vision_images,
                         vision_mask,
                         tokens,
@@ -256,7 +256,7 @@ def test_multimodal_demo_text(
 
             # Get cached prefill time
             with profiler("inference_prefill", iteration=batch_idx):
-                batch_logits, batch_xattn_masks, batch_text_masks = generator.prefill_forward(
+                batch_logits, prefill_batch_xattn_masks, prefill_batch_text_masks, decode_batch_xattn_masks, decode_batch_text_masks = generator.prefill_forward(
                     vision_images,
                     vision_mask,
                     tokens,
@@ -285,8 +285,10 @@ def test_multimodal_demo_text(
                     logits = generator.decode_forward(
                         position_id,
                         next_token_tensor,
-                        batch_xattn_masks,
-                        batch_text_masks,
+                        prefill_batch_xattn_masks,
+                        prefill_batch_text_masks,
+                        decode_batch_xattn_masks,
+                        decode_batch_text_masks,
                         xattn_caches,
                         enable_trace=enable_trace,
                     )

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -386,7 +386,7 @@ def test_multimodal_demo_text(
         base_model_name = model_args[0].base_model_name
         target_prefill_tok_s = {
             "N300_Llama-3.2-11B": 13.2,
-            "T3K_Llama-3.2-11B": 6.5,
+            "T3K_Llama-3.2-11B": 13.2,
             "T3K_Llama-3.2-90B": 3,
         }[f"{tt_device_name}_{base_model_name}"]
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -415,19 +415,22 @@ class Generator:
         if not text_only_inference:
             (
                 vision_tokens,
-                cross_attention_masks,
-                full_text_row_masked_out_mask,
+                prefill_cross_attention_masks,
+                prefill_full_text_row_masked_out_mask,
+                decode_cross_attention_masks,
+                decode_full_text_row_masked_out_mask,
             ) = self.model[model_id].compute_vision_tokens_masks(
                 batch_images=[vision_images],
                 batch_masks=[vision_mask],
                 total_len=total_len,
+                prefill_len=prefill_len,
             )
 
             if cross_page_table is not None:
                 num_vision_tokens = vision_tokens.shape[2]
                 cross_page_table = self._get_prefill_user_page_table(cross_page_table, kv_cache, num_vision_tokens)
         else:
-            vision_tokens, cross_attention_masks, full_text_row_masked_out_mask = None, None, None
+            vision_tokens, prefill_cross_attention_masks, prefill_full_text_row_masked_out_mask, decode_cross_attention_masks, decode_full_text_row_masked_out_mask = None, None, None, None, None
 
         if page_table is not None:
             page_table = self._get_prefill_user_page_table(page_table, kv_cache, prefill_len)
@@ -442,8 +445,8 @@ class Generator:
             tt_cross_page_table,
         ) = self.model[model_id].prepare_inputs_prefill(
             tokens,
-            cross_attention_masks,
-            full_text_row_masked_out_mask,
+            prefill_cross_attention_masks,
+            prefill_full_text_row_masked_out_mask,
             prefill_len=prefill_len,
             page_table=page_table,
             cross_page_table=cross_page_table,
@@ -469,7 +472,7 @@ class Generator:
         del tt_page_table
         del tt_cross_page_table
 
-        return xattn_caches, cross_attention_masks, full_text_row_masked_out_mask, tt_logits
+        return xattn_caches, prefill_cross_attention_masks, prefill_full_text_row_masked_out_mask, decode_cross_attention_masks, decode_full_text_row_masked_out_mask, tt_logits
 
     # Note: This function is called by vLLM
     def prefill_forward(
@@ -493,8 +496,10 @@ class Generator:
         output_logits = torch.zeros(batch_size, 1, self.model_args[0].vocab_size)
 
         out_list = [[] for _ in range(self.data_parallel)]
-        output_xattn_masks = [None for _ in range(batch_size)]
-        output_full_text_row_masked_out_masks = [None for _ in range(batch_size)]
+        prefill_output_xattn_masks = [None for _ in range(batch_size)]
+        prefill_output_full_text_row_masked_out_masks = [None for _ in range(batch_size)]
+        decode_output_xattn_masks = [None for _ in range(batch_size)]
+        decode_output_full_text_row_masked_out_masks = [None for _ in range(batch_size)]
 
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
@@ -519,8 +524,10 @@ class Generator:
                 xattn_cache = xattn_caches[model_id] if xattn_caches is not None else None
                 (
                     xattn_cache,
-                    cross_attention_masks,
-                    full_text_row_masked_out_mask,
+                    prefill_cross_attention_masks,
+                    prefill_full_text_row_masked_out_mask,
+                    decode_cross_attention_masks,
+                    decode_full_text_row_masked_out_mask,
                     logits,
                 ) = self._prefill_forward_single_user(
                     vision_images=vision_images[user_id],
@@ -538,8 +545,10 @@ class Generator:
                 if xattn_caches is not None:
                     xattn_caches[model_id] = xattn_cache
                 out_list[model_id].append(logits)
-                output_xattn_masks[user_id] = cross_attention_masks
-                output_full_text_row_masked_out_masks[user_id] = full_text_row_masked_out_mask
+                prefill_output_xattn_masks[user_id] = prefill_cross_attention_masks
+                prefill_output_full_text_row_masked_out_masks[user_id] = prefill_full_text_row_masked_out_mask
+                decode_output_xattn_masks[user_id] = decode_cross_attention_masks
+                decode_output_full_text_row_masked_out_masks[user_id] = decode_full_text_row_masked_out_mask
 
         # We gather prefill output at the end of prefill to reduce unnecessary device sync
         for group_user_id in range(max_batch_size_per_model):
@@ -556,15 +565,17 @@ class Generator:
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
 
-        return output_logits, output_xattn_masks, output_full_text_row_masked_out_masks
+        return output_logits, prefill_output_xattn_masks, prefill_output_full_text_row_masked_out_masks, decode_output_xattn_masks, decode_output_full_text_row_masked_out_masks
 
     # Note: This function is called by vLLM
     def decode_forward(
         self,
         start_pos,
         tokens,
-        cross_attention_masks,
-        full_text_row_masked_out_mask,
+        prefill_cross_attention_masks,
+        prefill_full_text_row_masked_out_mask,
+        decode_cross_attention_masks,
+        decode_full_text_row_masked_out_mask,
         xattn_caches=None,
         page_table=None,
         kv_cache=None,
@@ -577,11 +588,19 @@ class Generator:
         batch_per_device = B // data_parallel
         tokens = torch.chunk(tokens, self.data_parallel, 0)
         start_pos = torch.chunk(start_pos, self.data_parallel, 0)
-        cross_attention_masks = [
-            cross_attention_masks[i * batch_per_device : (i + 1) * batch_per_device] for i in range(data_parallel)
+        prefill_cross_attention_masks = [
+            prefill_cross_attention_masks[i * batch_per_device : (i + 1) * batch_per_device] for i in range(data_parallel)
         ]
-        full_text_row_masked_out_mask = [
-            full_text_row_masked_out_mask[i * batch_per_device : (i + 1) * batch_per_device]
+        prefill_full_text_row_masked_out_mask = [
+            prefill_full_text_row_masked_out_mask[i * batch_per_device : (i + 1) * batch_per_device]
+            for i in range(data_parallel)
+        ]
+        decode_cross_attention_masks = [
+            decode_cross_attention_masks[i * batch_per_device : (i + 1) * batch_per_device]
+            for i in range(data_parallel)
+        ]
+        decode_full_text_row_masked_out_mask = [
+            decode_full_text_row_masked_out_mask[i * batch_per_device : (i + 1) * batch_per_device]
             for i in range(data_parallel)
         ]
         page_table = torch.chunk(page_table, self.data_parallel, 0) if page_table is not None else None
@@ -592,8 +611,10 @@ class Generator:
         decode_kwargs = {
             "position_id": start_pos,
             "tokens": tokens,
-            "cross_attention_masks": cross_attention_masks,
-            "full_text_row_masked_out_mask": full_text_row_masked_out_mask,
+            "prefill_cross_attention_masks": prefill_cross_attention_masks,
+            "prefill_full_text_row_masked_out_mask": prefill_full_text_row_masked_out_mask,
+            "decode_cross_attention_masks": decode_cross_attention_masks,
+            "decode_full_text_row_masked_out_mask": decode_full_text_row_masked_out_mask,
             "xattn_caches": xattn_caches,
             "page_table": page_table,
             "kv_cache": kv_cache,
@@ -635,8 +656,10 @@ class Generator:
         self,
         position_id,
         tokens,
-        cross_attention_masks,
-        full_text_row_masked_out_mask,
+        prefill_cross_attention_masks,
+        prefill_full_text_row_masked_out_mask,
+        decode_cross_attention_masks,
+        decode_full_text_row_masked_out_mask,
         xattn_caches=None,
         page_table=None,
         kv_cache=None,
@@ -675,8 +698,10 @@ class Generator:
                 tt_cross_page_table_i,
             ) = self.model[i].prepare_inputs_decode(
                 tokens[i],
-                cross_attention_masks[i],
-                full_text_row_masked_out_mask[i],
+                prefill_cross_attention_masks[i],
+                prefill_full_text_row_masked_out_mask[i],
+                decode_cross_attention_masks[i],
+                decode_full_text_row_masked_out_mask[i],
                 position_id=position_id[i],
                 page_table=user_page_table,
                 cross_page_table=user_cross_page_table,
@@ -715,8 +740,10 @@ class Generator:
         self,
         position_id,
         tokens,
-        cross_attention_masks,
-        full_text_row_masked_out_mask,
+        prefill_cross_attention_masks,
+        prefill_full_text_row_masked_out_mask,
+        decode_cross_attention_masks,
+        decode_full_text_row_masked_out_mask,
         xattn_caches,
         page_table=None,
         kv_cache=None,
@@ -747,8 +774,10 @@ class Generator:
                 tt_cross_page_table_i,
             ) = self.model[i].prepare_inputs_decode(
                 tokens[i],
-                cross_attention_masks[i],
-                full_text_row_masked_out_mask[i],
+                prefill_cross_attention_masks[i],
+                prefill_full_text_row_masked_out_mask[i],
+                decode_cross_attention_masks[i],
+                decode_full_text_row_masked_out_mask[i],
                 position_id=position_id[i],
                 page_table=user_page_table,
                 cross_page_table=user_cross_page_table,
@@ -805,8 +834,10 @@ class Generator:
                 tt_cross_page_table_i,
             ) = self.model[i].prepare_decode_inputs_host(
                 tokens[i],
-                cross_attention_masks[i],
-                full_text_row_masked_out_mask[i],
+                prefill_cross_attention_masks[i],
+                prefill_full_text_row_masked_out_mask[i],
+                decode_cross_attention_masks[i],
+                decode_full_text_row_masked_out_mask[i],
                 position_id[i],
                 page_table=user_page_table,
                 cross_page_table=user_cross_page_table,
@@ -903,8 +934,10 @@ class Generator:
         self,
         position_id,
         tokens,
-        cross_attention_masks,
-        full_text_row_masked_out_mask,
+        prefill_cross_attention_masks,
+        prefill_full_text_row_masked_out_mask,
+        decode_cross_attention_masks,
+        decode_full_text_row_masked_out_mask,
         page_table,
         cross_page_table,
         trace_ids,
@@ -935,8 +968,10 @@ class Generator:
                 tt_cross_page_table,
             ) = self.model[i].prepare_decode_inputs_host(
                 tokens[i],
-                cross_attention_masks[i],
-                full_text_row_masked_out_mask[i],
+                prefill_cross_attention_masks[i],
+                prefill_full_text_row_masked_out_mask[i],
+                decode_cross_attention_masks[i],
+                decode_full_text_row_masked_out_mask[i],
                 position_id=position_id[i],
                 page_table=user_page_table,
                 cross_page_table=user_cross_page_table,
@@ -973,8 +1008,10 @@ class Generator:
         self,
         position_id,
         tokens,
-        cross_attention_masks,
-        full_text_row_masked_out_mask,
+        prefill_cross_attention_masks,
+        prefill_full_text_row_masked_out_mask,
+        decode_cross_attention_masks,
+        decode_full_text_row_masked_out_mask,
         xattn_caches=None,
         page_table=None,
         kv_cache=None,
@@ -998,8 +1035,10 @@ class Generator:
             ) = self._capture_trace(
                 position_id,
                 tokens,
-                cross_attention_masks,
-                full_text_row_masked_out_mask,
+                prefill_cross_attention_masks,
+                prefill_full_text_row_masked_out_mask,
+                decode_cross_attention_masks,
+                decode_full_text_row_masked_out_mask,
                 xattn_caches,
                 page_table=page_table,
                 kv_cache=kv_cache,
@@ -1023,8 +1062,10 @@ class Generator:
         trace_logits_rm = self._decode_forward_trace(
             position_id,
             tokens,
-            cross_attention_masks,
-            full_text_row_masked_out_mask,
+            prefill_cross_attention_masks,
+            prefill_full_text_row_masked_out_mask,
+            decode_cross_attention_masks,
+            decode_full_text_row_masked_out_mask,
             page_table,
             cross_page_table,
             self.trace_ids,
@@ -1061,8 +1102,10 @@ class Generator:
         xattn_caches = self.model[model_id].setup_cache(self.model_args[model_id].max_batch_size)
         (
             xattn_caches,
-            cross_attention_masks,
-            full_text_row_masked_out_mask,
+            prefill_cross_attention_masks,
+            prefill_full_text_row_masked_out_mask,
+            decode_cross_attention_masks,
+            decode_full_text_row_masked_out_mask,
             logits,
         ) = self._prefill_forward_single_user(
             vision_images,
@@ -1079,10 +1122,15 @@ class Generator:
         logits = self.model[model_id].process_output_prefill(logits, 1, last_token_idx=(last_token_idx % 32))
         logits = logits.view(1, 1, self.model_args[model_id].vocab_size)
 
-        output_xattn_masks = [[] for _ in range(self.data_parallel)]
-        output_full_text_row_masked_out_masks = [[] for _ in range(self.data_parallel)]
-        output_xattn_masks[model_id].append(cross_attention_masks)
-        output_full_text_row_masked_out_masks[model_id].append(full_text_row_masked_out_mask)
+        prefill_output_xattn_masks = [[] for _ in range(self.data_parallel)]
+        prefill_output_full_text_row_masked_out_masks = [[] for _ in range(self.data_parallel)]
+        decode_output_xattn_masks = [[] for _ in range(self.data_parallel)]
+        decode_output_full_text_row_masked_out_masks = [[] for _ in range(self.data_parallel)]
+
+        prefill_output_xattn_masks[model_id].append(prefill_cross_attention_masks)
+        prefill_output_full_text_row_masked_out_masks[model_id].append(prefill_full_text_row_masked_out_mask)
+        decode_output_xattn_masks[model_id].append(decode_cross_attention_masks)
+        decode_output_full_text_row_masked_out_masks[model_id].append(decode_full_text_row_masked_out_mask)
 
         def sample(logits):
             if temperature > 0:
@@ -1107,8 +1155,10 @@ class Generator:
             logits = self.decode_forward(
                 position_id,
                 next_token_tensor,
-                output_xattn_masks,
-                output_full_text_row_masked_out_masks,
+                prefill_output_xattn_masks,
+                prefill_output_full_text_row_masked_out_masks,
+                decode_output_xattn_masks,
+                decode_output_full_text_row_masked_out_masks,
                 [xattn_caches],
                 enable_trace=False,
             )

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -430,7 +430,13 @@ class Generator:
                 num_vision_tokens = vision_tokens.shape[2]
                 cross_page_table = self._get_prefill_user_page_table(cross_page_table, kv_cache, num_vision_tokens)
         else:
-            vision_tokens, prefill_cross_attention_masks, prefill_full_text_row_masked_out_mask, decode_cross_attention_masks, decode_full_text_row_masked_out_mask = None, None, None, None, None
+            (
+                vision_tokens,
+                prefill_cross_attention_masks,
+                prefill_full_text_row_masked_out_mask,
+                decode_cross_attention_masks,
+                decode_full_text_row_masked_out_mask,
+            ) = (None, None, None, None, None)
 
         if page_table is not None:
             page_table = self._get_prefill_user_page_table(page_table, kv_cache, prefill_len)
@@ -472,7 +478,14 @@ class Generator:
         del tt_page_table
         del tt_cross_page_table
 
-        return xattn_caches, prefill_cross_attention_masks, prefill_full_text_row_masked_out_mask, decode_cross_attention_masks, decode_full_text_row_masked_out_mask, tt_logits
+        return (
+            xattn_caches,
+            prefill_cross_attention_masks,
+            prefill_full_text_row_masked_out_mask,
+            decode_cross_attention_masks,
+            decode_full_text_row_masked_out_mask,
+            tt_logits,
+        )
 
     # Note: This function is called by vLLM
     def prefill_forward(
@@ -565,7 +578,13 @@ class Generator:
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
 
-        return output_logits, prefill_output_xattn_masks, prefill_output_full_text_row_masked_out_masks, decode_output_xattn_masks, decode_output_full_text_row_masked_out_masks
+        return (
+            output_logits,
+            prefill_output_xattn_masks,
+            prefill_output_full_text_row_masked_out_masks,
+            decode_output_xattn_masks,
+            decode_output_full_text_row_masked_out_masks,
+        )
 
     # Note: This function is called by vLLM
     def decode_forward(
@@ -589,7 +608,8 @@ class Generator:
         tokens = torch.chunk(tokens, self.data_parallel, 0)
         start_pos = torch.chunk(start_pos, self.data_parallel, 0)
         prefill_cross_attention_masks = [
-            prefill_cross_attention_masks[i * batch_per_device : (i + 1) * batch_per_device] for i in range(data_parallel)
+            prefill_cross_attention_masks[i * batch_per_device : (i + 1) * batch_per_device]
+            for i in range(data_parallel)
         ]
         prefill_full_text_row_masked_out_mask = [
             prefill_full_text_row_masked_out_mask[i * batch_per_device : (i + 1) * batch_per_device]

--- a/models/tt_transformers/tt/multimodal/llama_vision_model.py
+++ b/models/tt_transformers/tt/multimodal/llama_vision_model.py
@@ -74,7 +74,6 @@ def _get_full_row_masked_out_mask(
 
 
 def _get_xattn_mask(
-    num_tokens,
     text_device,
     text_dtype,
     vision_tokens,
@@ -88,9 +87,7 @@ def _get_xattn_mask(
     assert (
         vision_tokens.shape[2] == cross_attention_masks.shape[3]
     ), f"Vision tokens shape {vision_tokens.shape} mismatch with xattn shape {cross_attention_masks.shape}"
-    assert (
-        num_tokens == cross_attention_masks.shape[1]
-    ), f"Mismatch in text sequence length and cross attention mask sequence length {num_tokens} {cross_attention_masks.shape}"
+
     _, _, _, num_image_tokens, image_token_dim = tuple(vision_tokens.shape)
     bsz, ntext, nimg, nchunks = cross_attention_masks.shape
     cross_attention_masks = (
@@ -166,6 +163,7 @@ class CrossAttentionTransformer(torch.nn.Module):
         batch_images: List[List[PIL_Image.Image]],
         batch_masks: List[List[List[int]]],
         total_len: int,
+        prefill_len: int,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         skip_vision_encoder = False
 
@@ -206,56 +204,46 @@ class CrossAttentionTransformer(torch.nn.Module):
         else:
             # TT vision_model
             vision_tokens = self.vision_model(stacked_images, aspect_ratios)
-            # Back to torch
-            vision_tokens = ttnn.to_torch(ttnn.get_device_tensors(vision_tokens)[0])
             chunk_seq_len = self.configuration.vision_chunk_ntok
             # NOTE: slicing up to chunk_seq_len is necessary because padding information is lost by this point
             vision_tokens = (
-                vision_tokens[0, :, :chunk_seq_len]
-                .reshape(bsz, max_num_images, self.max_num_chunks, -1, self.model_dim)
-                .float()
+                ttnn.reshape(vision_tokens[0, :, :chunk_seq_len], (bsz, max_num_images, self.max_num_chunks, -1, self.model_dim))
             )
 
         bsz, nimg, nchunk, ntok, image_token_dim = tuple(vision_tokens.shape)
         padded_seq_len = self.num_vision_tokens
 
         # Prepare vision tokens for TT text_model
-        vision_tokens_squeeze = vision_tokens.view(1, bsz, -1, image_token_dim)
-        vision_tokens_squeeze = torch.nn.functional.pad(
-            vision_tokens_squeeze, (0, 0, 0, padded_seq_len - vision_tokens_squeeze.shape[2]), "constant", 0
-        )
-        vision_tokens_tt = ttnn.from_torch(
-            vision_tokens_squeeze,
-            layout=ttnn.TILE_LAYOUT,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            dtype=ttnn.bfloat16,
-            device=self.mesh_device,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        vision_tokens_squeeze = ttnn.reshape(vision_tokens, (1, bsz, -1, image_token_dim))
+        vision_tokens_squeeze = ttnn.pad(
+            vision_tokens_squeeze, 
+            [(0, 0), (0, 0), (0, padded_seq_len - vision_tokens_squeeze.shape[2]), (0, 0)],
+            0
         )
 
-        padded_masks = _pad_masks(  # torch.Size([1, 512, 1, 4])
+        prefill_padded_masks, decode_padded_masks = _pad_masks(  # torch.Size([1, 512, 1, 4])
             batch_masks,
             num_chunks,
             total_len,
             self.max_num_chunks,
+            prefill_len,
         )
 
         # torch.Size([1, 1, 512, 4100]), torch.Size([1, 1, 512, 1])
-        cross_attention_masks, full_text_row_masked_out_mask = _get_xattn_mask(
-            num_tokens=total_len,
+        prefill_cross_attention_masks, prefill_full_text_row_masked_out_mask = _get_xattn_mask(
             text_device="cpu",
             text_dtype=torch.float32,  # next(self.text_model.parameters()).dtype,
             vision_tokens=vision_tokens,
-            cross_attention_masks=padded_masks,
+            cross_attention_masks=prefill_padded_masks,
         )
-
-        cross_attention_masks = torch.nn.functional.pad(
-            cross_attention_masks,
-            (0, padded_seq_len - cross_attention_masks.shape[3]),
-            "constant",
-            get_negative_inf_value(torch.float32),
+        decode_cross_attention_masks, decode_full_text_row_masked_out_mask = _get_xattn_mask(
+            text_device="cpu",
+            text_dtype=torch.float32,  # next(self.text_model.parameters()).dtype,
+            vision_tokens=vision_tokens,
+            cross_attention_masks=decode_padded_masks,
         )
-        return (vision_tokens_tt, cross_attention_masks, full_text_row_masked_out_mask)
+        
+        return (vision_tokens_squeeze, prefill_cross_attention_masks, prefill_full_text_row_masked_out_mask, decode_cross_attention_masks, decode_full_text_row_masked_out_mask)
 
     def validate_inputs(self, tokens, position_ids):
         batch, seq_len = tokens.shape[:2]
@@ -291,7 +279,7 @@ class CrossAttentionTransformer(torch.nn.Module):
             xattn_mask = cross_attention_masks[:, :, position_ids]
             xattn_mask = torch.nn.functional.pad(
                 xattn_mask,
-                (0, 0, 0, padded_seq_len - xattn_mask.shape[2]),
+                (0, self.num_vision_tokens - xattn_mask.shape[3], 0, padded_seq_len - xattn_mask.shape[2]),
                 "constant",
                 get_negative_inf_value(torch.float32),
             )
@@ -388,8 +376,10 @@ class CrossAttentionTransformer(torch.nn.Module):
     def prepare_inputs_decode(
         self,
         tokens,
-        cross_attention_masks,
-        full_text_row_masked_out_mask,
+        prefill_cross_attention_masks,
+        prefill_full_text_row_masked_out_mask,
+        decode_cross_attention_masks,
+        decode_full_text_row_masked_out_mask,
         position_id,
         page_table=None,
         cross_page_table=None,
@@ -405,8 +395,10 @@ class CrossAttentionTransformer(torch.nn.Module):
             tt_cross_page_table,
         ) = self.prepare_decode_inputs_host(
             tokens,
-            cross_attention_masks,
-            full_text_row_masked_out_mask,
+            prefill_cross_attention_masks,
+            prefill_full_text_row_masked_out_mask,
+            decode_cross_attention_masks,
+            decode_full_text_row_masked_out_mask,
             position_id,
             page_table=page_table,
             cross_page_table=cross_page_table,
@@ -464,8 +456,10 @@ class CrossAttentionTransformer(torch.nn.Module):
     def prepare_decode_inputs_host(
         self,
         tokens,
-        cross_attention_masks,
-        full_text_row_masked_out_mask,
+        prefill_cross_attention_masks,
+        prefill_full_text_row_masked_out_mask,
+        decode_cross_attention_masks,
+        decode_full_text_row_masked_out_mask,
         position_id,
         page_table=None,
         cross_page_table=None,
@@ -474,10 +468,13 @@ class CrossAttentionTransformer(torch.nn.Module):
         assert (
             B == self.configuration.max_batch_size
         ), f"Batch size must match max batch size. Got {B}, expected {self.configuration.max_batch_size}"
-        unpadded_batch_size = len(cross_attention_masks)
+        unpadded_batch_size = len(prefill_cross_attention_masks)
         assert unpadded_batch_size == len(
-            full_text_row_masked_out_mask
-        ), f"cross_attention_masks batch dim ({unpadded_batch_size}) does not match full_text_row_masked_out_mask batch dim ({len(full_text_row_masked_out_mask)})"
+            prefill_full_text_row_masked_out_mask
+        ), f"prefill_cross_attention_masks batch dim ({unpadded_batch_size}) does not match prefill_full_text_row_masked_out_mask batch dim ({len(prefill_full_text_row_masked_out_mask)})"
+        assert unpadded_batch_size == len(
+            decode_cross_attention_masks
+        ), f"decode_cross_attention_masks batch dim ({unpadded_batch_size}) does not match decode_full_text_row_masked_out_mask batch dim ({len(decode_full_text_row_masked_out_mask)})"
         h = self.prepare_inputs_common(position_id, tokens)
         tt_h = self.configuration.prepare_residual_tensor_decode(
             h,
@@ -501,10 +498,27 @@ class CrossAttentionTransformer(torch.nn.Module):
         xattn_mask = []
         full_text_mask = []
         for i in range(unpadded_batch_size):
-            text_only_user = cross_attention_masks[i] is None and full_text_row_masked_out_mask[i] is None
+            text_only_user = prefill_cross_attention_masks[i] is None and prefill_full_text_row_masked_out_mask[i] is None
             if not text_only_user:
-                xattn_mask.append(cross_attention_masks[i][:, :, position_id[i]])
-                full_text_mask.append(full_text_row_masked_out_mask[i][:, :, position_id[i]])
+                if prefill_cross_attention_masks[i].shape[2] > position_id[i].item():
+
+                    xattn_mask_i = torch.nn.functional.pad(
+                        prefill_cross_attention_masks[i][:, :, position_id[i]],
+                        (0, self.num_vision_tokens - prefill_cross_attention_masks[i].shape[3]),
+                        "constant",
+                        get_negative_inf_value(torch.float32),
+                    )
+                    xattn_mask.append(xattn_mask_i)
+                    full_text_mask.append(prefill_full_text_row_masked_out_mask[i][:, :, position_id[i]])
+                else:
+                    xattn_mask_i = torch.nn.functional.pad(
+                        decode_cross_attention_masks[i][:, :, 0],
+                        (0, self.num_vision_tokens - decode_cross_attention_masks[i].shape[3]),
+                        "constant",
+                        get_negative_inf_value(torch.float32),
+                    )
+                    xattn_mask.append(xattn_mask_i)
+                    full_text_mask.append(decode_full_text_row_masked_out_mask[i][:, :, 0])
             else:
                 xattn_mask.append(torch.zeros(1, 1, self.num_vision_tokens))
                 full_text_mask.append(torch.zeros(1, 1, 1))
@@ -751,6 +765,7 @@ def _pad_masks(
     all_num_chunks: List[List[int]],
     total_len: int,
     max_num_chunks: int,
+    prefill_len: int,
 ) -> torch.Tensor:
     # dtype = torch.bfloat16
     dtype = torch.float32
@@ -758,9 +773,17 @@ def _pad_masks(
 
     bsz = len(all_masks)
     max_num_media = max([len(m) for m in all_masks])
+    max_mask_len = max([max(m[1]) if len(m) == 2 and m[1] != -1 else prefill_len for m in all_masks])
+    max_mask_len = min(max_mask_len, total_len)
 
-    out_masks = torch.full(
-        (bsz, total_len, max_num_media, max_num_chunks),
+    prefill_out_masks = torch.full(
+        (bsz, max_mask_len, max_num_media, max_num_chunks),
+        inf_value,
+        dtype=dtype,
+    )
+
+    decode_out_masks = torch.full(
+        (bsz, 1, max_num_media, max_num_chunks),
         inf_value,
         dtype=dtype,
     )
@@ -768,9 +791,10 @@ def _pad_masks(
     for idx, (mask, num_chunks) in enumerate(zip(all_masks, all_num_chunks)):
         for mask_idx, (mask_elem, mask_num_chunks) in enumerate(zip(mask, num_chunks)):
             if len(mask_elem) == 2:
-                mask_elem[1] = min(mask_elem[1], total_len)
+                mask_elem[1] = min(mask_elem[1], max_mask_len)
                 if mask_elem[1] == -1:
-                    mask_elem[1] = total_len
-                out_masks[idx, mask_elem[0] : mask_elem[1], mask_idx, :mask_num_chunks].fill_(0.0)
+                    decode_out_masks[idx, 0, mask_idx, :mask_num_chunks].fill_(0.0)
+                    mask_elem[1] = max_mask_len
+                prefill_out_masks[idx, mask_elem[0] : mask_elem[1], mask_idx, :mask_num_chunks].fill_(0.0)
 
-    return out_masks
+    return prefill_out_masks, decode_out_masks


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23383

### Problem description
Currently the way cross-attention masks work in llama-vision models is that we allocate a single Tensor of shape (1, 1, max_generation_length, num_vision_tokens) for each request in a batch during prefill which is stored in cpu memory. This introduces significant memory overhead (around 3GB per user for Llama-3.2-11B-Vision-Instruct) which causes hangs for batch-size 16 and also increases the time to first token (TTFT). 

### What's changed

## Dynamic Cross Attention Mask Allocation

Instead of allocating for a single cross-attention mask across max generation length we create two tensors: a `prefill-cross-attention_mask` and a `decode_cross_attention_mask`. The `prefill_cross_attention_mask` is allocated for all prefill tokens and ids specified by the vision masks. The `decode_cross_attention_mask` is used for future tokens generated by the decoder as specified by the vision_masks. This significantly lowers prefill time and resolves the prefill hangs at higher batch sizes. For an image of size 512x512 with isl=128 and osl=128, the TTFT drops from 3000ms to 2000ms.

## Removed unnecessary copying of vision_tokens from tt-device to cpu and back

This was being done to pad vision_tokens with 0 values. however this can be done using ttnn, so we do not need to perform this roundtrip. This reduces TTFT by around 400 ms using tt-inference-server benchmarks.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes