### PR TITLE
#0: Add lsan.supp to side-step errors from mem-leaks in openmpi lib

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -54,6 +54,7 @@ jobs:
           TT_METAL_HOME: /usr/libexec/tt-metalium # TODO: Need to get away from env vars!
           TT_METAL_WATCHER: 5
           TT_METAL_WATCHER_TEST_MODE: 1
+          LSAN_OPTIONS: suppressions=lsan.supp
         run: |
           /usr/bin/tt-metalium-validation-basic
 

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -60,6 +60,7 @@ jobs:
           GTEST_COLOR: yes
           GTEST_OUTPUT: xml:/work/test-reports/
           TT_METAL_HOME: /usr/libexec/tt-metalium # TODO: Need to get away from env vars!
+          LSAN_OPTIONS: suppressions=lsan.supp
           TT_METAL_WATCHER: 5
           TT_METAL_WATCHER_TEST_MODE: 1
         run: |

--- a/lsan.supp
+++ b/lsan.supp
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Manifests in OpenMPI v4.1.2 and remains an issue on v5.0.3
+# Bug: https://github.com/open-mpi/ompi/issues/12584
+# ASan Build with LeakSantizer complains about leaks in openmpi lib.
+leak:openmpi

--- a/lsan.supp
+++ b/lsan.supp
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
### Ticket
None
### Problem description
There seems to be an unresolved openmpi library bug that result in LeakSanitizer complaining about memory leaks on ASan builds. 

### What's changed
Add suppression file and use it on workflow runs with ASan builds.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/15836682731 