### PR TITLE
#21880: Add support for multiple visible devices

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,7 @@ conftest.py @tenstorrent/metalium-developers-infra
 tests/CMakeLists.txt @tenstorrent/metalium-developers-infra
 tests/scripts/ @tenstorrent/metalium-developers-infra
 tests/scripts/run_profiler_regressions.sh @mo-tenstorrent @tenstorrent/metalium-developers-infra
+tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh @cfjchu @tenstorrent/metalium-developers-infra
 
 # TT-STL
 tt_stl/ @patrickroberts @ayerofieiev-tt @dmakoviichuk-tt @sminakov-tt @omilyutin-tt

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -14,6 +14,10 @@ run_t3000_ttmetal_tests() {
 
   echo "LOG_METAL: Running run_t3000_ttmetal_tests"
   ./build/test/tt_metal/distributed/distributed_unit_tests
+
+  echo "LOG_METAL: Testing TT_METAL_VISIBLE_DEVICES functionality"
+  ./tests/tt_metal/distributed/run_visible_devices_mp_tests.sh ; fail+=$?
+
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_eth --gtest_filter="DeviceFixture.ActiveEthKernelsDirectSendAllConnectedChips" ; fail+=$?
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_eth --gtest_filter="DeviceFixture.ActiveEthKernelsSendInterleavedBufferAllConnectedChips" ; fail+=$?
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_eth --gtest_filter="DeviceFixture.ActiveEthKernelsDirectRingGatherAllChips" ; fail+=$?

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -16,7 +16,7 @@ run_t3000_ttmetal_tests() {
   ./build/test/tt_metal/distributed/distributed_unit_tests
 
   echo "LOG_METAL: Testing TT_METAL_VISIBLE_DEVICES functionality"
-  ./tests/tt_metal/distributed/run_visible_devices_mp_tests.sh ; fail+=$?
+  ./tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh ; fail+=$?
 
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_eth --gtest_filter="DeviceFixture.ActiveEthKernelsDirectSendAllConnectedChips" ; fail+=$?
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_eth --gtest_filter="DeviceFixture.ActiveEthKernelsSendInterleavedBufferAllConnectedChips" ; fail+=$?

--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -71,3 +71,5 @@ set_target_properties(
         RUNTIME_OUTPUT_DIRECTORY
             ${PROJECT_BINARY_DIR}/test/tt_metal/distributed
 )
+
+add_subdirectory(multiprocess)

--- a/tests/tt_metal/distributed/multiprocess/CMakeLists.txt
+++ b/tests/tt_metal/distributed/multiprocess/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Target for all STL tests regardless of duration
+add_executable(distributed_multiprocess_tests)
+target_sources(
+    distributed_multiprocess_tests
+    PRIVATE
+        main.cpp
+        test_visible_devices_mp.cpp
+)
+set_target_properties(
+    distributed_multiprocess_tests
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tt_metal/distributed/multiprocess
+)
+target_link_libraries(distributed_multiprocess_tests PRIVATE test_metal_common_libs)
+target_include_directories(
+    distributed_multiprocess_tests
+    PRIVATE
+        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+        ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/distributed/multiprocess
+)

--- a/tests/tt_metal/distributed/multiprocess/CMakeLists.txt
+++ b/tests/tt_metal/distributed/multiprocess/CMakeLists.txt
@@ -1,4 +1,3 @@
-# Target for all STL tests regardless of duration
 add_executable(distributed_multiprocess_tests)
 target_sources(
     distributed_multiprocess_tests

--- a/tests/tt_metal/distributed/multiprocess/README.md
+++ b/tests/tt_metal/distributed/multiprocess/README.md
@@ -1,0 +1,54 @@
+# Visible Devices Multi-Process Tests
+
+This directory contains tests for validating the `TT_METAL_VISIBLE_DEVICES` environment variable functionality in a distributed multi-process context.
+
+## Overview
+
+This basic test suite validates when `TT_METAL_VISIBLE_DEVICES` is set, the process only sees the PCIe devices exposed to it.
+This means on a T3000, you can effectively:
+1) Emulate a single N300 process running tt-metal, for every N300 board independently
+2) Expose multiple PCIe devices through `TT_METAL_VISIBLE_DEVICES` and test 2x2 mesh configuration
+3) Emulate multi-host configuration by simultaneously launching multiple processes working on independent parts of the available system mesh.
+
+## Test Script: `run_visible_devices_mp_tests.sh`
+
+### Purpose
+Runs the `distributed_multiprocess_tests` executable with various device configurations to validate visible devices functionality.
+
+### Device Configurations Tested
+- Single devices: `"0"`, `"1"`, `"2"`, `"3"`
+- Device pairs: `"0,1"`, `"0,3"`, `"1,2"`, `"2,3"`
+
+### Usage
+```bash
+./run_visible_devices_mp_tests.sh
+```
+
+### Prerequisites
+- Build the tests first: `./build_metal.sh --debug --build-tests`
+- Requires `mpirun` to be installed and available in PATH
+- Requires tt-metal devices to be available on the system
+
+### Output
+The script will:
+- Display progress for each device configuration
+- Show ✓ for passed tests and ✗ for failed tests
+- Exit with code 0 if all tests pass, 1 if any test fails
+
+### Example Output
+```
+Testing TT_METAL_VISIBLE_DEVICES functionality with distributed_mp_unit_tests
+============================================================================
+
+Testing with TT_METAL_VISIBLE_DEVICES="0"
+------------------------------------------------
+✓ Test passed for configuration: 0
+
+Testing with TT_METAL_VISIBLE_DEVICES="0,1"
+------------------------------------------------
+✓ Test passed for configuration: 0,1
+
+...
+
+All tests passed!
+```

--- a/tests/tt_metal/distributed/multiprocess/main.cpp
+++ b/tests/tt_metal/distributed/multiprocess/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/distributed_context.hpp>
+#include <gtest/gtest.h>
+#include "tests/tt_metal/multihost/common/multihost_test_tools.hpp"
+#include <fmt/format.h>
+int main(int argc, char** argv) { return multihost::common::multihost_main(argc, argv); }

--- a/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
+++ b/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
@@ -17,7 +17,7 @@ for config in "${DEVICE_CONFIGS[@]}"; do
     echo "------------------------------------------------"
 
     # Run with mpirun, setting the environment variable
-    TT_METAL_VISIBLE_DEVICES="$config" mpirun -np 1 ./build/test/tt_metal/distributed/multiprocess/distributed_multiprocess_tests
+    TT_METAL_VISIBLE_DEVICES="$config" mpirun --allow-run-as-root -np 1 ./build/test/tt_metal/distributed/multiprocess/distributed_multiprocess_tests
 
     if [ $? -eq 0 ]; then
         echo "✓ [distributed tests] Test passed for configuration: $config"

--- a/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
+++ b/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
@@ -32,6 +32,6 @@ if [ "$ALL_PASSED" = true ]; then
     echo "[distributed tests] All tests passed!"
     exit 0
 else
-    echo "Some tests failed!"
+    echo "[distributed tests] Some tests failed!"
     exit 1
 fi

--- a/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
+++ b/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
@@ -22,7 +22,7 @@ for config in "${DEVICE_CONFIGS[@]}"; do
     if [ $? -eq 0 ]; then
         echo "✓ [distributed tests] Test passed for configuration: $config"
     else
-        echo "✗ Test failed for configuration: $config"
+        echo "✗ [distributed tests] Test failed for configuration: $config"
         ALL_PASSED=false
     fi
 done

--- a/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
+++ b/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
@@ -13,7 +13,7 @@ ALL_PASSED=true
 
 for config in "${DEVICE_CONFIGS[@]}"; do
     echo
-    echo "Testing with TT_METAL_VISIBLE_DEVICES=\"$config\""
+    echo "[distributed tests] Testing with TT_METAL_VISIBLE_DEVICES=\"$config\""
     echo "------------------------------------------------"
 
     # Run with mpirun, setting the environment variable

--- a/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
+++ b/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
@@ -8,16 +8,6 @@ DEVICE_CONFIGS=("0" "1" "2" "3" "0,1" "0,3" "1,2" "2,3")
 echo "Testing TT_METAL_VISIBLE_DEVICES functionality with distributed_mp_unit_tests"
 echo "============================================================================"
 
-# Build if needed
-if [ ! -f "build/test/tt_metal/distributed/distributed_mp_unit_tests" ]; then
-    echo "Building tests..."
-    ./build_metal.sh --debug --build-tests
-    if [ $? -ne 0 ]; then
-        echo "Build failed!"
-        exit 1
-    fi
-fi
-
 # Track overall success
 ALL_PASSED=true
 
@@ -27,7 +17,7 @@ for config in "${DEVICE_CONFIGS[@]}"; do
     echo "------------------------------------------------"
 
     # Run with mpirun, setting the environment variable
-    TT_METAL_VISIBLE_DEVICES="$config" mpirun -np 1 ./build/test/tt_metal/distributed/distributed_mp_unit_tests --gtest_filter="VisibleDevicesMPTest.*"
+    TT_METAL_VISIBLE_DEVICES="$config" mpirun -np 1 ./build/test/tt_metal/distributed/multiprocess/distributed_multiprocess_tests
 
     if [ $? -eq 0 ]; then
         echo "✓ Test passed for configuration: $config"

--- a/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
+++ b/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
@@ -29,7 +29,7 @@ done
 
 echo
 if [ "$ALL_PASSED" = true ]; then
-    echo "All tests passed!"
+    echo "[distributed tests] All tests passed!"
     exit 0
 else
     echo "Some tests failed!"

--- a/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
+++ b/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
@@ -20,7 +20,7 @@ for config in "${DEVICE_CONFIGS[@]}"; do
     TT_METAL_VISIBLE_DEVICES="$config" mpirun -np 1 ./build/test/tt_metal/distributed/multiprocess/distributed_multiprocess_tests
 
     if [ $? -eq 0 ]; then
-        echo "✓ Test passed for configuration: $config"
+        echo "✓ [distributed tests] Test passed for configuration: $config"
     else
         echo "✗ Test failed for configuration: $config"
         ALL_PASSED=false

--- a/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
+++ b/tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh
@@ -5,7 +5,7 @@
 # Array of device configurations to test
 DEVICE_CONFIGS=("0" "1" "2" "3" "0,1" "0,3" "1,2" "2,3")
 
-echo "Testing TT_METAL_VISIBLE_DEVICES functionality with distributed_mp_unit_tests"
+echo "[distributed tests] Testing TT_METAL_VISIBLE_DEVICES functionality with distributed_mp_unit_tests"
 echo "============================================================================"
 
 # Track overall success

--- a/tests/tt_metal/distributed/multiprocess/test_visible_devices_mp.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_visible_devices_mp.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/device.hpp>
+#include <gtest/gtest.h>
+#include <cstdlib>
+#include <string>
+#include <iostream>
+
+namespace tt::tt_metal::distributed {
+
+namespace {
+
+TEST(VisibleDevicesMPTest, ValidateDeviceRatio) {
+    // Validate the 2:1 ratio of total devices to PCIe devices
+    size_t num_available = tt::tt_metal::GetNumAvailableDevices();
+    size_t num_pcie = tt::tt_metal::GetNumPCIeDevices();
+
+    // Each PCIe device should correspond to 2 chips (one with PCIe, one without)
+    if (num_pcie > 0) {
+        EXPECT_EQ(num_available, num_pcie * 2)
+            << "Total available devices should be exactly 2x the number of PCIe devices";
+    }
+
+    // Log the device configuration for debugging
+    const char* visible_devices_env = std::getenv("TT_METAL_VISIBLE_DEVICES");
+    std::string visible_devices = visible_devices_env ? visible_devices_env : "<not set>";
+
+    std::cout << "Device configuration summary:" << std::endl;
+    std::cout << "  TT_METAL_VISIBLE_DEVICES: " << visible_devices << std::endl;
+    std::cout << "  PCIe devices: " << num_pcie << std::endl;
+    std::cout << "  Total available devices: " << num_available << std::endl;
+    std::cout << "  Ratio: " << (num_pcie > 0 ? static_cast<double>(num_available) / num_pcie : 0) << std::endl;
+}
+
+}  // namespace
+
+}  // namespace tt::tt_metal::distributed

--- a/tests/tt_metal/distributed/run_visible_devices_mp_tests.sh
+++ b/tests/tt_metal/distributed/run_visible_devices_mp_tests.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Script to run distributed multi-process visible devices tests
+
+# Array of device configurations to test
+DEVICE_CONFIGS=("0" "1" "2" "3" "0,1" "0,3" "1,2" "2,3")
+
+echo "Testing TT_METAL_VISIBLE_DEVICES functionality with distributed_mp_unit_tests"
+echo "============================================================================"
+
+# Build if needed
+if [ ! -f "build/test/tt_metal/distributed/distributed_mp_unit_tests" ]; then
+    echo "Building tests..."
+    ./build_metal.sh --debug --build-tests
+    if [ $? -ne 0 ]; then
+        echo "Build failed!"
+        exit 1
+    fi
+fi
+
+# Track overall success
+ALL_PASSED=true
+
+for config in "${DEVICE_CONFIGS[@]}"; do
+    echo
+    echo "Testing with TT_METAL_VISIBLE_DEVICES=\"$config\""
+    echo "------------------------------------------------"
+
+    # Run with mpirun, setting the environment variable
+    TT_METAL_VISIBLE_DEVICES="$config" mpirun -np 1 ./build/test/tt_metal/distributed/distributed_mp_unit_tests --gtest_filter="VisibleDevicesMPTest.*"
+
+    if [ $? -eq 0 ]; then
+        echo "✓ Test passed for configuration: $config"
+    else
+        echo "✗ Test failed for configuration: $config"
+        ALL_PASSED=false
+    fi
+done
+
+echo
+if [ "$ALL_PASSED" = true ]; then
+    echo "All tests passed!"
+    exit 0
+else
+    echo "Some tests failed!"
+    exit 1
+fi

--- a/tt_metal/common/thread_pool.cpp
+++ b/tt_metal/common/thread_pool.cpp
@@ -38,8 +38,7 @@ bool balanced_physical_device_numa() {
     if (numa_available() != -1) {
         int num_nodes = numa_max_node() + 1;
         std::unordered_set<int> numa_nodes_for_cluster = {};
-        for (uint32_t device_id = 0; device_id < MetalContext::instance().get_cluster().number_of_devices();
-             device_id++) {
+        for (auto device_id : MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
             auto numa_node_for_device = MetalContext::instance().get_cluster().get_numa_node_for_device(device_id);
             numa_nodes_for_cluster.insert(numa_node_for_device);
         }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -37,7 +37,7 @@ static const char* TT_METAL_KERNEL_PATH_ENV_VAR = "TT_METAL_KERNEL_PATH";
 static const char* TT_METAL_CACHE_ENV_VAR = "TT_METAL_CACHE";
 // Used for demonstration purposes and will be removed in the future.
 static const char* TT_METAL_FD_FABRIC_DEMO = "TT_METAL_FD_FABRIC";
-static const char* TT_METAL_VISIBLE_DEVICE_ENV_VAR = "TT_METAL_VISIBLE_DEVICE";
+static const char* TT_METAL_VISIBLE_DEVICES_ENV_VAR = "TT_METAL_VISIBLE_DEVICES";
 
 RunTimeOptions::RunTimeOptions() {
     const char* root_dir_str = std::getenv(TT_METAL_HOME_ENV_VAR);
@@ -60,10 +60,19 @@ RunTimeOptions::RunTimeOptions() {
     }
     this->system_kernel_dir = "/usr/share/tenstorrent/kernels/";
 
-    const char* visible_device_str = std::getenv(TT_METAL_VISIBLE_DEVICE_ENV_VAR);
-    if (visible_device_str != nullptr) {
-        this->is_visible_device_env_var_set = true;
-        this->visible_device = std::stoi(std::string(visible_device_str));
+    const char* visible_devices_str = std::getenv(TT_METAL_VISIBLE_DEVICES_ENV_VAR);
+    if (visible_devices_str != nullptr) {
+        this->is_visible_devices_env_var_set = true;
+        std::string devices_string(visible_devices_str);
+        size_t pos = 0;
+        while ((pos = devices_string.find(',')) != std::string::npos) {
+            std::string device_str = devices_string.substr(0, pos);
+            this->visible_devices.push_back(std::stoi(device_str));
+            devices_string.erase(0, pos + 1);
+        }
+        if (!devices_string.empty()) {
+            this->visible_devices.push_back(std::stoi(devices_string));
+        }
     }
 
     build_map_enabled = (getenv("TT_METAL_KERNEL_MAP") != nullptr);

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -106,8 +106,8 @@ class RunTimeOptions {
     std::string kernel_dir;
     std::string system_kernel_dir;
 
-    bool is_visible_device_env_var_set = false;
-    uint32_t visible_device;
+    bool is_visible_devices_env_var_set = false;
+    std::vector<uint32_t> visible_devices;
 
     bool build_map_enabled = false;
 
@@ -197,8 +197,8 @@ public:
     // Location where kernels are installed via package manager.
     const std::string& get_system_kernel_dir() const;
 
-    inline bool is_visible_device_specified() const { return this->is_visible_device_env_var_set; }
-    inline uint32_t get_visible_device() const { return this->visible_device; }
+    inline bool is_visible_devices_specified() const { return this->is_visible_devices_env_var_set; }
+    inline const std::vector<uint32_t>& get_visible_devices() const { return this->visible_devices; }
 
     inline bool get_build_map_enabled() const { return build_map_enabled; }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/21880)

### Problem description
We currently only support mapping a single PCIe device to a process. 

### What's changed
This extends the work done in #21406 to support exposing multiple PCIE devices to a process. `TT_METAL_VISIBLE_DEVICE` is now changed to `TT_METAL_VISIBLE_DEVICES`, which also follows same convention as `CUDA_VISIBLE_DEVICES`. This feature support enables emulated multi-host support through multiple processes.

### Why?
1) Emulate a single N300 process running tt-metal, for every PCIe connected N300 board independently
2) Expose multiple PCIe devices through `TT_METAL_VISIBLE_DEVICES` and test 2x2 mesh configuration
3) Emulate multi-host configuration by simultaneously launching multiple processes working on independent parts of the available system mesh.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/15918289638
- [x] T3K Unit Tests: https://github.com/tenstorrent/tt-metal/actions/runs/15930363350