### PR TITLE
Wrap expected number of workers complete

### DIFF
--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -228,6 +228,22 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     uint32_t expected_num_workers_completed = sysmem_manager.get_bypass_mode()
                                                   ? trace_ctx_->descriptors[sub_device_id].num_completion_worker_cores
                                                   : expected_num_workers_completed_[*sub_device_id];
+    const auto updated_worker_counts =
+        program_dispatch::get_expected_num_workers_completed_updates(expected_num_workers_completed, num_workers);
+
+    // Need to stall and reset counters if host wraps
+    if (updated_worker_counts.wrapped) [[unlikely]] {
+        get_config_buffer_mgr(*sub_device_id).mark_completely_full(0);
+        if (sysmem_manager.get_bypass_mode()) {
+            capture_expected_worker_count_reset_cmd(expected_num_workers_completed, sub_device_id);
+        } else {
+            for (auto device : mesh_device_->get_devices()) {
+                program_dispatch::reset_expected_num_workers_completed_on_device(
+                    device, sub_device_id, expected_num_workers_completed, id());
+            }
+        }
+    }
+
     if (sysmem_manager.get_bypass_mode()) {
         if (mcast_go_signals) {
             // The workload contains programs that required a go signal mcast. Capture this here
@@ -239,20 +255,11 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
             trace_ctx_->descriptors[sub_device_id].num_traced_programs_needing_go_signal_unicast++;
         }
         // Update the expected number of workers dispatch must wait on
-        trace_ctx_->descriptors[sub_device_id].num_completion_worker_cores += num_workers;
+        trace_ctx_->descriptors[sub_device_id].num_completion_worker_cores = updated_worker_counts.current;
     } else {
-        const auto updated_worker_counts =
-            program_dispatch::get_expected_num_workers_completed_updates(expected_num_workers_completed, num_workers);
-        if (updated_worker_counts.wrapped) [[unlikely]] {
-            get_config_buffer_mgr(*sub_device_id).mark_completely_full(0);
-            for (auto device : mesh_device_->get_devices()) {
-                program_dispatch::reset_expected_num_workers_completed_on_device(
-                    device, sub_device_id, expected_num_workers_completed, id());
-            }
-        }
         expected_num_workers_completed_[*sub_device_id] = updated_worker_counts.current;
-        expected_num_workers_completed = updated_worker_counts.previous;
     }
+    expected_num_workers_completed = updated_worker_counts.previous;
 
     // Reserve space in the L1 Kernel Config Ring Buffer for this workload.
     program_dispatch::reserve_space_in_kernel_config_buffer(
@@ -995,6 +1002,32 @@ void FDMeshCommandQueue::reset_prefetcher_cache_manager() { prefetcher_cache_man
 
 int FDMeshCommandQueue::get_prefetcher_cache_sizeB() const {
     return this->prefetcher_cache_manager_->get_cache_sizeB();
+}
+
+void FDMeshCommandQueue::capture_expected_worker_count_reset_cmd(
+    uint32_t previous_expected_workers, SubDeviceId sub_device) {
+    for (auto device : mesh_device_->get_devices()) {
+        auto& sysmem_manager = device->sysmem_manager();
+        uint32_t sysmem_manager_offset = sysmem_manager.get_issue_queue_write_ptr(id_);
+        program_dispatch::reset_expected_num_workers_completed_on_device(
+            device, sub_device, previous_expected_workers, id());
+
+        // Find the coordinate for this device by iterating over all coordinates
+        MeshCoordinate device_coord{0xffffffff};
+        for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
+            if (mesh_device_->get_device(coord) == device) {
+                device_coord = coord;
+                break;
+            }
+        }
+        TT_ASSERT(device_coord != MeshCoordinate{0xffffffff});
+        auto mesh_trace_md = MeshTraceStagingMetadata{
+            MeshCoordinateRange{device_coord},
+            device_coord,
+            sysmem_manager_offset,
+            sysmem_manager.get_issue_queue_write_ptr(id_) - sysmem_manager_offset};
+        ordered_mesh_trace_md_.push_back(mesh_trace_md);
+    }
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -53,6 +53,9 @@ private:
         bool stall_first,
         bool stall_before_program,
         uint32_t program_runtime_id);
+    // Captures a dispatch command to reset the expected number of workers. Used when the worker
+    // counter on the host overflows.
+    void capture_expected_worker_count_reset_cmd(uint32_t previous_expected_workers, SubDeviceId sub_device);
     // For a given MeshWorkload, a subgrid is unused if no programs are run on it. Go signals
     // must be sent to this subgrid, to ensure consistent global state across the Virtual Mesh.
     // When running trace, the dispatch commands responsible for forwarding go signals must be

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -793,7 +793,7 @@ void HWCommandQueue::allocate_trace_programs() {
         }
 
         program_dispatch::ProgramDispatchMetadata dispatch_metadata;
-        // Reserve space for this program in the kernel config ring buffer, potentially after a wrap and reset aboe
+        // Reserve space for this program in the kernel config ring buffer, potentially after a wrap and reset above
         program_dispatch::reserve_space_in_kernel_config_buffer(
             get_config_buffer_mgr(sub_device_index),
             program.get_program_config_sizes(),

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -875,8 +875,10 @@ void HWCommandQueue::record_end() {
             // Wait for the previous node to complete and then clear count
             program_dispatch::reset_expected_num_workers_completed_on_device(
                 device_, node.sub_device_id, expected_workers_completed, id());
-            // Clean state as workers are done and counter is reset to 0
-            this->trace_ctx_->descriptors[sub_device_id].num_completion_worker_cores = expected_workers_completed;
+            // Number of completion worker cores is just num workers now
+            this->trace_ctx_->descriptors[sub_device_id].num_completion_worker_cores = num_workers;
+            // Expected workers completed to pass into update_traced_program_dispatch_commands
+            // for the mcast go signal is zero now because we already waited and cleared
             expected_workers_completed = 0;
         }
         // Update the generated dispatch commands based on the state of the CQ and the ring buffer

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -43,6 +43,7 @@
 #include "hal_types.hpp"
 #include "kernel.hpp"
 #include "math.hpp"
+#include "mesh_device.hpp"
 #include "program_device_map.hpp"
 #include "tt-metalium/program.hpp"
 #include "runtime_args_data.hpp"
@@ -2419,9 +2420,6 @@ void reset_worker_dispatch_state_on_device(
     const DispatchArray<uint32_t>& expected_num_workers_completed,
     bool reset_launch_msg_state) {
     auto num_sub_devices = device->num_sub_devices();
-    if (reset_launch_msg_state) {
-        uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
-    }
 
     tt::tt_metal::DeviceCommandCalculator calculator;
     if (reset_launch_msg_state) {
@@ -2535,6 +2533,96 @@ void set_go_signal_noc_data_on_dispatch(
     manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
     manager.fetch_queue_reserve_back(cq_id);
     manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);
+}
+
+// Wait for number of workers to complete and then reset the counter on the device
+void reset_expected_num_workers_completed_on_device(
+    tt::tt_metal::IDevice* device,
+    tt::tt_metal::SubDeviceId sub_device_id,
+    uint32_t num_expected_workers,
+    uint8_t cq_id) {
+    tt::tt_metal::DeviceCommandCalculator calculator;
+    bool distributed_dispatcher =
+        tt::tt_metal::MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher();
+    if (distributed_dispatcher) {
+        calculator.add_dispatch_wait();
+    }
+    calculator.add_dispatch_wait();
+
+    auto& manager = device->sysmem_manager();
+    const auto cmd_sequence_sizeB = calculator.write_offset_bytes();
+    void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
+    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    const auto populate_dispatch_wait_cmd = [&](uint32_t dispatcher_type) {
+        command_sequence.add_dispatch_wait(
+            CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM,
+            0,
+            tt::tt_metal::MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(*sub_device_id),
+            num_expected_workers,
+            dispatcher_type);
+    };
+
+    if (distributed_dispatcher) {
+        populate_dispatch_wait_cmd(1);
+    }
+    populate_dispatch_wait_cmd(0);
+
+    manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
+    manager.fetch_queue_reserve_back(cq_id);
+    manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);
+}
+
+uint32_t update_expected_num_workers_completed(
+    tt::tt_metal::distributed::MeshDevice* mesh_device,
+    tt::tt_metal::SubDeviceId sub_device_id,
+    WorkerConfigBufferMgr& config_buffer_mgr,
+    uint32_t& expected_num_workers_completed_to_update,
+    uint32_t num_additional_workers,
+    uint8_t cq_id) {
+    auto sub_device_index = *sub_device_id;
+    uint32_t previous_expected_num_workers_completed = expected_num_workers_completed_to_update;
+
+    if (previous_expected_num_workers_completed >
+        std::numeric_limits<decltype(previous_expected_num_workers_completed)>::max() - num_additional_workers) {
+        for (auto device : mesh_device->get_devices()) {
+            reset_expected_num_workers_completed_on_device(
+                device, sub_device_id, previous_expected_num_workers_completed, cq_id);
+        }
+
+        expected_num_workers_completed_to_update = 0;
+        previous_expected_num_workers_completed = 0;
+        config_buffer_mgr.mark_completely_full(0);
+    }
+
+    expected_num_workers_completed_to_update += num_additional_workers;
+
+    return previous_expected_num_workers_completed;
+}
+
+uint32_t update_expected_num_workers_completed(
+    tt::tt_metal::IDevice* device,
+    tt::tt_metal::SubDeviceId sub_device_id,
+    WorkerConfigBufferMgr& config_buffer_mgr,
+    uint32_t& expected_num_workers_completed_to_update,
+    uint32_t num_additional_workers,
+    uint8_t cq_id) {
+    auto sub_device_index = *sub_device_id;
+    uint32_t previous_expected_num_workers_completed = expected_num_workers_completed_to_update;
+
+    if (previous_expected_num_workers_completed >
+        std::numeric_limits<decltype(previous_expected_num_workers_completed)>::max() - num_additional_workers)
+        [[unlikely]] {
+        reset_expected_num_workers_completed_on_device(
+            device, sub_device_id, previous_expected_num_workers_completed, cq_id);
+
+        expected_num_workers_completed_to_update = 0;
+        previous_expected_num_workers_completed = 0;
+        config_buffer_mgr.mark_completely_full(0);
+    }
+
+    expected_num_workers_completed_to_update += num_additional_workers;
+
+    return previous_expected_num_workers_completed;
 }
 
 template uint32_t program_base_addr_on_core<ProgramImpl, IDevice*>(ProgramImpl&, IDevice*, HalProgrammableCoreType);

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -2553,7 +2553,7 @@ void reset_expected_num_workers_completed_on_device(
     const auto cmd_sequence_sizeB = calculator.write_offset_bytes();
     void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
-    const auto populate_dispatch_wait_cmd = [&](uint32_t dispatcher_type) {
+    const auto populate_dispatch_wait_cmd = [&](DispatcherSelect dispatcher_type) {
         command_sequence.add_dispatch_wait(
             CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM,
             0,
@@ -2563,9 +2563,9 @@ void reset_expected_num_workers_completed_on_device(
     };
 
     if (distributed_dispatcher) {
-        populate_dispatch_wait_cmd(1);
+        populate_dispatch_wait_cmd(DispatcherSelect::DISPATCH_SUBORDINATE);
     }
-    populate_dispatch_wait_cmd(0);
+    populate_dispatch_wait_cmd(DispatcherSelect::DISPATCH_MASTER);
 
     manager.cq_write(cmd_region, cmd_sequence_sizeB, manager.get_issue_queue_write_ptr(cq_id));
     manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -2567,62 +2567,28 @@ void reset_expected_num_workers_completed_on_device(
     }
     populate_dispatch_wait_cmd(0);
 
+    manager.cq_write(cmd_region, cmd_sequence_sizeB, manager.get_issue_queue_write_ptr(cq_id));
     manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
     manager.fetch_queue_reserve_back(cq_id);
     manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);
 }
 
-uint32_t update_expected_num_workers_completed(
-    tt::tt_metal::distributed::MeshDevice* mesh_device,
-    tt::tt_metal::SubDeviceId sub_device_id,
-    WorkerConfigBufferMgr& config_buffer_mgr,
-    uint32_t& expected_num_workers_completed_to_update,
-    uint32_t num_additional_workers,
-    uint8_t cq_id) {
-    auto sub_device_index = *sub_device_id;
-    uint32_t previous_expected_num_workers_completed = expected_num_workers_completed_to_update;
+ExpectedNumWorkerUpdates get_expected_num_workers_completed_updates(
+    uint32_t num_workers, uint32_t num_additional_workers) {
+    uint32_t previous_expected_num_workers_completed = num_workers;
+    bool wrapped = false;
 
-    if (previous_expected_num_workers_completed >
-        std::numeric_limits<decltype(previous_expected_num_workers_completed)>::max() - num_additional_workers) {
-        for (auto device : mesh_device->get_devices()) {
-            reset_expected_num_workers_completed_on_device(
-                device, sub_device_id, previous_expected_num_workers_completed, cq_id);
-        }
-
-        expected_num_workers_completed_to_update = 0;
-        previous_expected_num_workers_completed = 0;
-        config_buffer_mgr.mark_completely_full(0);
-    }
-
-    expected_num_workers_completed_to_update += num_additional_workers;
-
-    return previous_expected_num_workers_completed;
-}
-
-uint32_t update_expected_num_workers_completed(
-    tt::tt_metal::IDevice* device,
-    tt::tt_metal::SubDeviceId sub_device_id,
-    WorkerConfigBufferMgr& config_buffer_mgr,
-    uint32_t& expected_num_workers_completed_to_update,
-    uint32_t num_additional_workers,
-    uint8_t cq_id) {
-    auto sub_device_index = *sub_device_id;
-    uint32_t previous_expected_num_workers_completed = expected_num_workers_completed_to_update;
-
-    if (previous_expected_num_workers_completed >
-        std::numeric_limits<decltype(previous_expected_num_workers_completed)>::max() - num_additional_workers)
+    if (previous_expected_num_workers_completed > std::numeric_limits<uint32_t>::max() - num_additional_workers)
         [[unlikely]] {
-        reset_expected_num_workers_completed_on_device(
-            device, sub_device_id, previous_expected_num_workers_completed, cq_id);
-
-        expected_num_workers_completed_to_update = 0;
+        num_workers = 0;
         previous_expected_num_workers_completed = 0;
-        config_buffer_mgr.mark_completely_full(0);
+        wrapped = true;
     }
 
-    expected_num_workers_completed_to_update += num_additional_workers;
+    num_workers += num_additional_workers;
 
-    return previous_expected_num_workers_completed;
+    return ExpectedNumWorkerUpdates{
+        .previous = previous_expected_num_workers_completed, .current = num_workers, .wrapped = wrapped};
 }
 
 template uint32_t program_base_addr_on_core<ProgramImpl, IDevice*>(ProgramImpl&, IDevice*, HalProgrammableCoreType);

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -172,6 +172,30 @@ void set_num_worker_sems_on_dispatch(
 void set_go_signal_noc_data_on_dispatch(
     IDevice* device, const vector_aligned<uint32_t>& go_signal_noc_data, SystemMemoryManager& manager, uint8_t cq_id);
 
+//
+// Update the expected number of workers completed value for the given Program to run on the sub device.
+// Expected number of workers is used for the wait command to stall until all workers are completed.
+//
+// Will trigger a reset of the config buffer if the expected number of workers is about to overflow.
+//
+// Returns a snapshot of the expected number of workers **before** the update.
+//
+uint32_t update_expected_num_workers_completed(
+    tt::tt_metal::distributed::MeshDevice* mesh_device,
+    tt::tt_metal::SubDeviceId sub_device_id,
+    WorkerConfigBufferMgr& config_buffer_mgr,
+    uint32_t& expected_num_workers_completed_to_update,
+    uint32_t num_additional_workers,
+    uint8_t cq_id);
+
+uint32_t update_expected_num_workers_completed(
+    tt::tt_metal::IDevice* device,
+    tt::tt_metal::SubDeviceId sub_device_id,
+    WorkerConfigBufferMgr& config_buffer_mgr,
+    uint32_t& expected_num_workers_completed_to_update,
+    uint32_t num_additional_workers,
+    uint8_t cq_id);
+
 }  // namespace program_dispatch
 
 }  // namespace tt_metal

--- a/tt_metal/impl/trace/trace_node.hpp
+++ b/tt_metal/impl/trace/trace_node.hpp
@@ -19,6 +19,7 @@ struct TraceDispatchMetadata {
     uint32_t sync_count = 0;
     uint32_t stall_first = false;
     uint32_t stall_before_program = false;
+    bool reset_worker_counts_before_program = false;
 
     struct {
         uint32_t mesh_max_program_kernels_sizeB;  // TBD: max program size across all programs in a mesh


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23518

### Problem description
- Hang reported during long running workloads with EnqueueProgram
- Expected number of workers (`uint32_t`) monotonically increases and when it overflows it will become out of sync with the device side counter
  - E.g., Host expected 504 but device counter is 224
- Each call to EnqueueProgram will increase the counter 56 on Worker dispatch or 64 on Ethernet dispatch
- FDMeshCommandQueue and HardwareCommandQueue components are affected

### What's changed
- Check for potential overflows before incrementing the counter. If incrementing it will cause an overflow, then enqueue a Wait command to wait for previous workers to finish and reset the stream register counter. Then reset the counters to zero on the host
- Overflow handling will cause a small blip in performance when it happens but no overall impact

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15908286955
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/15908294292
TG
https://github.com/tenstorrent/tt-metal/actions/runs/15908291414
BH
https://github.com/tenstorrent/tt-metal/actions/runs/15908289281