### PR TITLE
Remove deprecated inc paths to prevent regressions

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -85,7 +85,6 @@ target_include_directories(
         api/ttnn
         core
         cpp # FIXME: Depend on the Ops needed (make the circular obvious)
-        . # FIXME: Depend on the Ops needed (make the circular obvious)
 )
 target_include_directories(ttnn_core SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers)
 target_link_libraries(
@@ -421,8 +420,7 @@ target_include_directories(
     ttnncpp
     PUBLIC
         api
-        # FIXME: decide what to do about these dirs. Device includes complicate matters.
-        .
+        # FIXME: decide what to do about this dir. Device includes complicate matters.
         cpp
 )
 


### PR DESCRIPTION
### Ticket
Follow up to #23567

### Problem description
Earlier we normalized the include prefixes in TTNN.  Now some incdirs are obsolete and risks permitting regressions (using include prefixes that cause grief for non-source consumption).

### What's changed
rm -rf obsolete paths

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15837946197)