### PR TITLE
[skip ci] README and license updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 </h1>
 
-<img src="./docs/source/common/_static/tt_nn_w_logo.png" alt="ttnn logo" height="180"/>
+<img src="https://raw.githubusercontent.com/tenstorrent/tt-metal/main/docs/source/common/_static/tt_nn_w_logo.png" alt="ttnn logo" height="180"/>
 
 **TT-NN** is a Python & C++ Neural Network OP library.
 
@@ -25,7 +25,8 @@
 
 | Release | Release Date |
 |---------|--------------|
-| 0.59.0 | ETA Jun 18, 2025 |
+| 0.60.0  | Jul 18, 2025 |
+| [0.59.0](https://github.com/tenstorrent/tt-metal/releases/tag/v0.59.0) | Jun 18, 2025 |
 | [0.58.0](https://github.com/tenstorrent/tt-metal/releases/tag/v0.58.0) | May 13, 2025 |
 | [0.57.0](https://github.com/tenstorrent/tt-metal/releases/tag/v0.57.0) | Apr 15, 2025 |
 | [0.56.0](https://github.com/tenstorrent/tt-metal/releases/tag/v0.56.0) | Mar 7, 2025 |
@@ -126,7 +127,7 @@ For information on initial model procedures, please see [Model Bring-Up and Test
 
 <div align="center">
 
-<img src="./docs/source/common/images/tt_refresh_metalium_w_icon.png" alt="TT-Metalium logo" height="180"/>
+<img src="https://raw.githubusercontent.com/tenstorrent/tt-metal/main/docs/source/common/images/tt_refresh_metalium_w_icon.png" alt="TT-Metalium logo" height="180"/>
 
 **TT-Metalium** is our low-level programming model, enabling kernel development for Tenstorrent hardware.
 
@@ -203,3 +204,15 @@ pip install ttnn-visualizer
 
 ### Tenstorrent Bounty Program Terms and Conditions
 This repo is a part of Tenstorrent’s bounty program. If you are interested in helping to improve tt-metal, please make sure to read the [Tenstorrent Bounty Program Terms and Conditions](https://docs.tenstorrent.com/bounty_terms.html) before heading to the issues tab. Look for the issues that are tagged with both “bounty” and difficulty level!
+
+## License
+TT-Metalium and TTNN are licensed under the Apache 2.0 License, as detailed in [LICENSE](LICENSE) and [LICENSE_understanding.txt](LICENSE_understanding.txt).
+
+Some distributable forms of this project—such as manylinux-compliant wheels—may need to bundle additional libraries beyond the standard Linux system libraries. For example:
+
+- libnuma
+- libhwloc
+- openmpi (when built with multihost support)
+- libevent (when built with multihost support)
+
+These libraries are bound by their own license terms.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   # "seaborn>=0.13.2",
 ]
 requires-python = ">=3.10"
-keywords = ["metalium", "ttnn", "tt-metal", "machine learning", "tenstorrent", "libnnuma", "libhwloc"]
+keywords = ["metalium", "ttnn", "tt-metal", "machine learning", "tenstorrent", "libnuma", "libhwloc"]
 license = { text = "Apache-2.0" }
 description = "General compute framework for Tenstorrent devices"
 dynamic = ["version", "readme"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   # "seaborn>=0.13.2",
 ]
 requires-python = ">=3.10"
-keywords = ["metalium", "ttnn", "tt-metal", "machine learning", "tenstorrent"]
+keywords = ["metalium", "ttnn", "tt-metal", "machine learning", "tenstorrent", "libnnuma", "libhwloc"]
 license = { text = "Apache-2.0" }
 description = "General compute framework for Tenstorrent devices"
 dynamic = ["version", "readme"]


### PR DESCRIPTION
### Ticket
#22986 

### Problem description
Images were not displaying correctly when our readme is used as source for pypi landing page.
Need to make it more clear that the distributable version of the project bundles third party libraries with additional license terms.

### What's changed
Use URLs for images.
Add text to README.md