### PR TITLE
[skip ci] Revert "#0: Add lsan.supp to side-step errors from mem-leaks in openmpi lib (#24025)"

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -54,7 +54,6 @@ jobs:
           TT_METAL_HOME: /usr/libexec/tt-metalium # TODO: Need to get away from env vars!
           TT_METAL_WATCHER: 5
           TT_METAL_WATCHER_TEST_MODE: 1
-          LSAN_OPTIONS: suppressions=lsan.supp
         run: |
           /usr/bin/tt-metalium-validation-basic
 

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -60,7 +60,6 @@ jobs:
           GTEST_COLOR: yes
           GTEST_OUTPUT: xml:/work/test-reports/
           TT_METAL_HOME: /usr/libexec/tt-metalium # TODO: Need to get away from env vars!
-          LSAN_OPTIONS: suppressions=lsan.supp
           TT_METAL_WATCHER: 5
           TT_METAL_WATCHER_TEST_MODE: 1
         run: |

--- a/lsan.supp
+++ b/lsan.supp
@@ -1,9 +1,0 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-
-# Manifests in OpenMPI v4.1.2 and remains an issue on v5.0.3
-# Bug: https://github.com/open-mpi/ompi/issues/12584
-# ASan Build with LeakSantizer complains about leaks in openmpi lib.
-leak:openmpi


### PR DESCRIPTION
This reverts commit 37cf037f93ca18e9f5509bf6ac888ece213c7413.

This was missed b/c the logic to decide whether it's worthwhile running tests figured no code change occurred.

The problem is that the suppressions file needs to be packaged up else it doesn't exist in the environment that needs it.  That was my oversight.  Will fix tomorrow.  Tonight just un-break main.
