### PR TITLE
#21195: Add int32 support for Tensor-scalar version of min

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
@@ -163,3 +163,103 @@ def test_unary_min_fp32(input_shapes, low, high, scalar, device):
     tt_result = ttnn.minimum(tt_in, scalar)
     comp_pass = compare_equal([tt_result], [golden])
     assert comp_pass
+
+
+@pytest.mark.parametrize("scalar", [-1, -2, -3, -4, -5, 3, 0, 1, 100, 10, 5, 2147483, -2147483, -16777216, 16777216])
+def test_unary_min_int32_test(scalar, device):
+    num_elements = torch.prod(torch.tensor(torch.Size([1, 1, 32, 32]))).item()
+    torch_input = torch.linspace(-10, 10, num_elements, dtype=torch.int32)
+    torch_input = torch_input[:num_elements].reshape(torch.Size([1, 1, 32, 32]))
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input, torch.full(torch.Size([1, 1, 32, 32]), scalar), device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_result = ttnn.minimum(tt_in, scalar)
+    comp_pass = compare_equal([tt_result], [golden])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 2, 64, 120])),
+        (torch.Size([1, 3, 320, 320])),
+        (torch.Size([1, 3, 1024, 1024])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low, high",
+    [
+        (-5, 5),
+        (-100, 100),
+        (-21474, 21474),
+        (-2147483600, 2147483600),
+        (-21474836, 21474836),
+        (-214748364, 214748364),
+        (-2147483647, 2147483647),
+        (-(2**31) + 1, (2**31) - 1),
+    ],
+)
+@pytest.mark.parametrize("scalar", [-1, -2, -3, -4, -5, 3, 0, 1, 100, 10, 5, -16777216, 16777216, -16777215, 16777215])
+def test_unary_min_int32(input_shapes, low, high, scalar, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input = torch.linspace(high, low, num_elements, dtype=torch.int32)
+    torch_input = torch_input[:num_elements].reshape(input_shapes)
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input, torch.full(input_shapes, scalar), device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.minimum(tt_in, scalar)
+    comp_pass = compare_equal([tt_result], [golden])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@pytest.mark.parametrize(
+    "input_val, scalar",
+    [
+        (-1, 1),
+        (1, 0),
+        (0, 0),
+        (1, 1),
+        (11, 53),
+    ],
+)
+def test_unary_min_fill_val_int32(input_shapes, input_val, scalar, device):
+    torch_input = torch.ones(input_shapes, dtype=torch.int32) * input_val
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input, torch.full(input_shapes, scalar), device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.minimum(tt_in, scalar)
+    result = ttnn.to_torch(tt_result)
+
+    comp_pass = compare_equal([tt_result], [golden])
+    assert comp_pass

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -7,8 +7,6 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 
-using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -39,8 +39,8 @@ inline void calculate_unary_max_min(uint value) {
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_max_int32(uint value) {
+template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_unary_max_min_int32(uint value) {
     // Load value param to lreg2 and cast 2's complement to sign + magnitude format
     _sfpu_load_imm32_(p_sfpu::LREG2, value);
     TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG3, 2);
@@ -56,12 +56,18 @@ inline void calculate_unary_max_int32(uint value) {
        // Copy value param to lreg1
        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
 
-       // Swap and store maximum in lreg1
+       // Swap and store maximum in lreg1, minimum in lreg0
        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
 
-       TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG3, 3);
-       TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG1, 0);
-       TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
+       if constexpr (IS_MAX_OP) {
+           TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG3, 3);
+           TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG1, 0);
+           TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
+       } else {
+           TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG3, 3);
+           TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);
+           TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
+       }
 
        dst_reg++;
    }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
@@ -28,7 +28,7 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max_int32<APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min_int32<true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
 // Unary minimum
@@ -41,6 +41,13 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_max_min_int32<false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -7,8 +7,6 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 
-using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -40,8 +40,8 @@ inline void calculate_unary_max_min(uint value) {
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_max_int32(uint value) {
+template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_unary_max_min_int32(uint value) {
     int scalar = value;
     if (scalar < 0) {  // To convert from 2's complement to sign+magnitude
         scalar = -scalar;
@@ -60,11 +60,15 @@ inline void calculate_unary_max_int32(uint value) {
         // Copy value param to lreg2 to lreg1
         TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
 
-        // Swap and store maximum in lreg1 (sign + magnitude format)
+        // Swap and store maximum in lreg1, minimum in lreg0 (sign + magnitude format)
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
 
         // Store the result
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
+        if constexpr (IS_MAX_OP) {
+            TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
+        } else {
+            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_3, 0);
+        }
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
@@ -28,7 +28,7 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max_int32<APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min_int32<true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
 // Unary minimum
@@ -41,6 +41,13 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_max_min_int32<false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -1155,6 +1155,26 @@ ALWI void alt_complex_rotate90_tile_init() { MATH((llk_math_eltwise_unary_sfpu_a
  * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
  */
 // clang-format on
+ALWI void unary_min_int32_tile(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_min_int32<APPROX>(idst, param0)));
+}
+
+// unary_min : if x < value --> x, else value
+// clang-format off
+/**
+ * Performs element-wise computation of:  result = x if x < value , where x is each element of a tile
+ * in DST register at index tile_index. The value is provided as const param0 The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
+ */
+// clang-format on
 ALWI void unary_min_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_min<APPROX>(idst, param0)));
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -143,10 +143,13 @@ Tensor ExecuteMinimum::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
-    TT_FATAL(std::holds_alternative<float>(value), "int32 minimum not yet supported");
-    return ttnn::operations::unary::
-        ExecuteUnaryWithVariantFloatIntParameter<ttnn::operations::unary::UnaryOpType::MINIMUM>::invoke(
-            queue_id, input_a, std::get<float>(value), memory_config, optional_output_tensor);
+    return std::visit(
+        [&](auto input_b) {
+            return ttnn::operations::unary::
+                ExecuteUnaryWithVariantFloatIntParameter<ttnn::operations::unary::UnaryOpType::MINIMUM>::invoke(
+                    queue_id, input_a, input_b, memory_config, optional_output_tensor);
+        },
+        value);
 }
 
 Tensor ExecuteMaximum::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -307,9 +307,16 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
             }
             break;
         case UnaryOpType::MINIMUM:
-            op_init_and_name = {
-                "unary_min_tile_init();",
-                fmt::format("unary_min_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+            TT_FATAL(
+                input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
+            if (input_dtype == DataType::INT32) {
+                op_init_and_name = {
+                    "unary_min_tile_init();", fmt::format("unary_min_int32_tile({}, {}u);", idst, (uint)param0)};
+            } else {
+                op_init_and_name = {
+                    "unary_min_tile_init();",
+                    fmt::format("unary_min_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+            }
             break;
         default: TT_THROW("unexpected parameterized op type {}", op_type);
     };

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -207,6 +207,9 @@ template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_EQ>;
 template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MINIMUM>::invoke<float>(
     QueueId, const Tensor&, const float, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
 
+template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MINIMUM>::invoke<int32_t>(
+    QueueId, const Tensor&, const int32_t, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
+
 template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MAXIMUM>::invoke<float>(
     QueueId, const Tensor&, const float, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
 


### PR DESCRIPTION
### Ticket
[#21195](https://github.com/tenstorrent/tt-metal/issues/21195)

### Problem description
Int32 support required for unary version of min

### What's changed
Provided int32 support for Tensor - scalar version of minimum
Range constraint : https://github.com/tenstorrent/tt-metal/issues/21194#issuecomment-2942827295

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15895666067) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15895668476) CI passed
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/15895669844) CI passes
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15895671118) CI passes
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes