### PR TITLE
Llama TG: reset inputs fix for vllm overhead

### DIFF
--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -554,6 +554,7 @@ def test_demo_text(
                     page_table=page_table,
                     kv_cache=tt_kv_cache,
                     sampling_params=device_sampling_params,
+                    reset_inputs=True,
                 )
             except Exception as e:
                 logger.error(f"Error during decoding: {str(e)}")


### PR DESCRIPTION
Only reset input when page table changes or if prefill switched to decode 

### Checklist
TG demo: https://github.com/tenstorrent/tt-metal/actions/runs/15845866487