### PR TITLE
Mobilenetv2 batch 10

### DIFF
--- a/models/demos/mobilenetv2/tests/mobilenetv2_common.py
+++ b/models/demos/mobilenetv2/tests/mobilenetv2_common.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+MOBILENETV2_L1_SMALL_SIZE = 8 * 1024  # 8 KiB
+MOBILENETV2_BATCH_SIZE = 10

--- a/models/demos/mobilenetv2/tests/test_e2e_performant.py
+++ b/models/demos/mobilenetv2/tests/test_e2e_performant.py
@@ -9,6 +9,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.demos.mobilenetv2.tests.mobilenetv2_common import MOBILENETV2_BATCH_SIZE, MOBILENETV2_L1_SMALL_SIZE
 from models.demos.mobilenetv2.tests.mobilenetv2_e2e_performant import MobileNetV2Trace2CQ
 from models.utility_functions import run_for_wormhole_b0
 
@@ -17,11 +18,13 @@ from models.utility_functions import run_for_wormhole_b0
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 24576, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
+    "device_params",
+    [{"l1_small_size": MOBILENETV2_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
+    indirect=True,
 )
 @pytest.mark.parametrize(
     "batch_size",
-    ((1),),
+    ((MOBILENETV2_BATCH_SIZE),),
 )
 def test_run_mobilenetv2_trace_2cqs_inference(
     device,

--- a/models/demos/mobilenetv2/tests/test_mobilenetv2_performant.py
+++ b/models/demos/mobilenetv2/tests/test_mobilenetv2_performant.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+from models.demos.mobilenetv2.tests.mobilenetv2_common import MOBILENETV2_L1_SMALL_SIZE
 from models.demos.mobilenetv2.tests.mobilenetv2_performant import (
     run_mobilenetv2_inference,
     run_mobilenetv2_trace_2cqs_inference,
@@ -11,7 +12,7 @@ from models.demos.mobilenetv2.tests.mobilenetv2_performant import (
 )
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": MOBILENETV2_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("device_batch_size", [(1)])
 def test_run_mobilenetv2_inference(
     device,
@@ -24,7 +25,9 @@ def test_run_mobilenetv2_inference(
     )
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 3686400}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": MOBILENETV2_L1_SMALL_SIZE, "trace_region_size": 3686400}], indirect=True
+)
 @pytest.mark.parametrize("device_batch_size", [(1)])
 def test_run_mobilenetv2_trace_inference(
     device,
@@ -38,7 +41,9 @@ def test_run_mobilenetv2_trace_inference(
 
 
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 24576, "trace_region_size": 3686400, "num_command_queues": 2}], indirect=True
+    "device_params",
+    [{"l1_small_size": MOBILENETV2_L1_SMALL_SIZE, "trace_region_size": 3686400, "num_command_queues": 2}],
+    indirect=True,
 )
 @pytest.mark.parametrize("device_batch_size", [(1)])
 def test_run_mobilenetv2_trace_2cq_inference(

--- a/models/demos/mobilenetv2/tests/test_perf_mobilenetv2.py
+++ b/models/demos/mobilenetv2/tests/test_perf_mobilenetv2.py
@@ -16,6 +16,7 @@ from models.demos.mobilenetv2.tt.model_preprocessing import create_mobilenetv2_m
 from models.perf.device_perf_utils import check_device_perf, prep_device_perf_report, run_device_perf
 from models.perf.perf_utils import prep_perf_report
 from models.utility_functions import disable_persistent_kernel_cache, profiler
+from tests.ttnn.integration_tests.mobilenetv2.test_mobilenetv2 import MOBILENETV2_BATCH_SIZE, MOBILENETV2_L1_SMALL_SIZE
 
 
 def get_expected_times(name):
@@ -25,7 +26,7 @@ def get_expected_times(name):
 
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": MOBILENETV2_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("input_tensor", [torch.rand((1, 224, 224, 3))], ids=["input_tensor"])
 @pytest.mark.parametrize(
     "use_pretrained_weight",
@@ -35,7 +36,7 @@ def get_expected_times(name):
         "pretrained_weight_false",
     ],
 )
-def test_mobilenetv2(device, input_tensor, use_pretrained_weight, reset_seeds):
+def test_mobilenetv2(device, input_tensor, use_pretrained_weight, reset_seeds, use_program_cache):
     # Check if weights file exists, if not, download them
     disable_persistent_kernel_cache()
     profiler.clear()
@@ -118,11 +119,11 @@ def test_mobilenetv2(device, input_tensor, use_pretrained_weight, reset_seeds):
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 728],
+        [MOBILENETV2_BATCH_SIZE, 3178],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal
-def test_perf_device_bare_metal_mobilenetv2(batch_size, expected_perf):
+def test_perf_device_bare_metal_mobilenetv2(batch_size, expected_perf, use_program_cache):
     subdir = "ttnn_mobilenetv2"
     num_iterations = 1
     margin = 0.03

--- a/models/demos/mobilenetv2/tt/common.py
+++ b/models/demos/mobilenetv2/tt/common.py
@@ -27,6 +27,7 @@ class TtMobileNetV2Conv2D:
         reshard_if_not_optimal=True,
         activation_dtype=ttnn.bfloat8_b,
         shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        activation_function=None,
     ):
         self.device = device
         self.parameters = parameters
@@ -45,6 +46,7 @@ class TtMobileNetV2Conv2D:
         self.reshard_if_not_optimal = reshard_if_not_optimal
         self.batch_size = batch_size
         self.shard_layout = shard_layout
+        self.activation_function = activation_function
         if self.block_shard:
             self.shard_layout = ttnn.TensorMemoryLayout.BLOCK_SHARDED
         if self.width_shard:
@@ -58,16 +60,19 @@ class TtMobileNetV2Conv2D:
         conv_config = ttnn.Conv2dConfig(
             dtype=self.activation_dtype,
             weights_dtype=ttnn.bfloat8_b,
-            activation="",
+            activation=self.activation_function if self.activation_function is not None else "",
             shard_layout=self.shard_layout,
             act_block_w_div=1,
             deallocate_activation=self.deallocate_activation,
             enable_act_double_buffer=self.enable_act_double_buffer,
-            enable_split_reader=self.enable_split_reader,
+            enable_split_reader=True
+            if self.shard_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+            else self.enable_split_reader,
             enable_subblock_padding=False,
             output_layout=self.output_layout,
             reallocate_halo_output=False,
             reshard_if_not_optimal=self.reshard_if_not_optimal,
+            enable_weights_double_buffer=True,
         )
 
         if self.act_block_h:
@@ -140,6 +145,9 @@ class TtInvertedResidual:
                 device,
                 batchsize,
                 block_shard=False if id == 6 and (11 < id <= 16) else self.block_shard,
+                deallocate_activation=True if not self.use_res_connect else False,
+                enable_act_double_buffer=True,
+                activation_function="relu6",
             )
 
         self.conv2 = TtMobileNetV2Conv2D(
@@ -149,6 +157,8 @@ class TtInvertedResidual:
             batchsize,
             groups=hidden_dim,
             block_shard=self.block_shard,
+            deallocate_activation=True,
+            activation_function="relu6",
         )
         self.conv3 = TtMobileNetV2Conv2D(
             [1, 1, 0, out_channels],
@@ -156,17 +166,19 @@ class TtInvertedResidual:
             device,
             batchsize,
             block_shard=False if (10 <= id <= 16) else self.block_shard,
+            deallocate_activation=True,
+            enable_act_double_buffer=True,
         )
 
     def __call__(self, x):
         identity = x
         if self.conv1 is not None:
-            out, h, w = self.conv1(x)
-            out = ttnn.relu6(out)
-            x = out
+            x, h, w = self.conv1(x)
         out, h, w = self.conv2(x)
-        out = ttnn.relu6(out)
         out, h, w = self.conv3(out)
         if self.use_res_connect:
-            return ttnn.add(identity, out)
+            tmp = ttnn.add(identity, out)
+            ttnn.deallocate(identity)
+            ttnn.deallocate(out)
+            out = tmp
         return out

--- a/tests/ttnn/integration_tests/mobilenetv2/test_mobilenetv2.py
+++ b/tests/ttnn/integration_tests/mobilenetv2/test_mobilenetv2.py
@@ -8,6 +8,7 @@ import torch
 import pytest
 import ttnn
 from models.demos.mobilenetv2.reference.mobilenetv2 import Mobilenetv2
+from models.demos.mobilenetv2.tests.mobilenetv2_common import MOBILENETV2_BATCH_SIZE, MOBILENETV2_L1_SMALL_SIZE
 from models.demos.mobilenetv2.tt.model_preprocessing import (
     create_mobilenetv2_input_tensors,
     create_mobilenetv2_model_parameters,
@@ -16,7 +17,7 @@ from models.demos.mobilenetv2.tt import ttnn_mobilenetv2
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": MOBILENETV2_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     "use_pretrained_weight",
     [
@@ -29,7 +30,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "batch_size",
     [
-        1,
+        MOBILENETV2_BATCH_SIZE,
     ],
 )
 def test_mobilenetv2(device, use_pretrained_weight, batch_size, reset_seeds):
@@ -66,4 +67,4 @@ def test_mobilenetv2(device, use_pretrained_weight, batch_size, reset_seeds):
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.93 if use_pretrained_weight else 0.999)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.944 if use_pretrained_weight else 0.999)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -517,6 +517,8 @@ bool get_op_approx_mode(UnaryOpType op_type) {
 UnaryWithParam string_to_unary_with_param(const std::string& name) {
     if (name == "relu") {
         return UnaryWithParam(UnaryOpType::RELU);
+    } else if (name == "relu6") {
+        return UnaryWithParam(UnaryOpType::RELU6);
     } else if (name == "gelu") {
         return UnaryWithParam(UnaryOpType::GELU, static_cast<float>(true));
     } else if (name == "silu") {


### PR DESCRIPTION
Mobilenetv2 batch 10
Device perf 728->3178

Reworked model to properly deallocate tensors when they can be discarded.

Enabled fusing of relu6 with conv2d.
Now using only fused relu6 in the model.

Enabled weights double buffering on all convs.
Enabled activation double buffering where possible.

Enabled split reader for height sharded convs.

Reduced L1_SMALL allocation 32kb -> 8Kb.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15848030456)
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15852891286)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15848048506l)