### PR TITLE
conv2d nightly remove unnecessary skip

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -549,9 +549,6 @@ def test_conv_features_multi_device(
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat8_b:
         pytest.skip("Row major layout not compatible with bfloat8_b")
 
-    if output_dtype == ttnn.bfloat8_b and shard_layout == WS:
-        pytest.skip("Skipping until Issue: #21209 is fixed")
-
     run_conv(
         mesh_device,
         torch_tensor_map,


### PR DESCRIPTION
### Ticket
#21209

### Problem description
Some tests in nightly were skipped due to failing pcc
PCC no longer fails so the test cases shouldn't be skipped

### What's changed
Removed pyskip for the given testcases

### Checklist
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15848466153)