### PR TITLE
Fix incorrect key value in Segformer Image Classification test

### DIFF
--- a/tests/ttnn/integration_tests/segformer/test_segformer_for_image_classification.py
+++ b/tests/ttnn/integration_tests/segformer/test_segformer_for_image_classification.py
@@ -52,7 +52,7 @@ def create_custom_preprocessor(device):
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 def test_segformer_image_classificaton(device, reset_seeds):
     dataset = load_dataset("huggingface/cats-image")
-    image = dataset["test"]["image"][0]
+    image = dataset["train"]["image"][0]
     torch_model = SegformerForImageClassification.from_pretrained("nvidia/mit-b0")
     config = torch_model.config
     reference_model = SegformerForImageClassificationReference(config=config)


### PR DESCRIPTION
### Ticket
None

### Problem description
Dataset used for test seems to have changed, causing it to fail in CI.

### What's changed
Changed key value to new value. Test script now executes.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes