### PR TITLE
Fix block_ct_dim != full_ct_dim issue on BH

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -465,7 +465,7 @@ TEST_F(DeviceFixture, TensixComputeUnpackUntilizeShortInit) {
 Following tests are for pack untilize
 ***************************************/
 TEST_F(DeviceFixture, TensixComputePackUntilize) {
-    vector<vector<uint32_t>> num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}};
+    vector<vector<uint32_t>> num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}, {10, 10}, {2, 40}};
     for (auto num_tile : num_tiles) {
         for (bool fp32_dest_acc_en : {true, false}) {
             // FP32 dest acc not possible for GS

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp
@@ -9,25 +9,53 @@
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 
 namespace NAMESPACE {
+
+// Helper constexpr function to compute num_blocks_per_col
+constexpr uint32_t compute_num_blocks_per_col(uint32_t per_core_block_tile_cnt) {
+    if (DST_ACCUM_MODE) {
+        for (uint32_t bct = 4; bct >= 1; --bct) {
+            if (per_core_block_tile_cnt % bct == 0) {
+                return per_core_block_tile_cnt / bct;
+            }
+        }
+    } else {
+        for (uint32_t bct = 8; bct >= 1; --bct) {
+            if (per_core_block_tile_cnt % bct == 0) {
+                return per_core_block_tile_cnt / bct;
+            }
+        }
+    }
+
+    return 1;  // fallback, though unreachable if per_core_block_tile_cnt ≥ 1
+}
+
 void MAIN {
     constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
 
+    // Compute optimal num_blocks_per_col and block_ct_dim
+    constexpr uint32_t num_blocks_per_col = compute_num_blocks_per_col(per_core_block_tile_cnt);
+    constexpr uint32_t block_ct_dim = per_core_block_tile_cnt / num_blocks_per_col;
+    constexpr uint32_t full_ct_dim = per_core_block_tile_cnt;
+
+    pack_untilize_init<block_ct_dim, full_ct_dim>(tt::CBIndex::c_0, tt::CBIndex::c_16);
+
 #ifdef SHORT_INIT
     unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
-    pack_untilize_init_short<per_core_block_tile_cnt>(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    pack_untilize_init_short<block_ct_dim, full_ct_dim>(tt::CBIndex::c_0, tt::CBIndex::c_16);
 #else
-    pack_untilize_init<per_core_block_tile_cnt>(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    pack_untilize_init<block_ct_dim, full_ct_dim>(tt::CBIndex::c_0, tt::CBIndex::c_16);
 #endif
 
-    for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
-        cb_wait_front(tt::CBIndex::c_0, per_core_block_tile_cnt);
-        cb_reserve_back(tt::CBIndex::c_16, per_core_block_tile_cnt);
+    for (uint32_t r = 0; r < per_core_block_cnt; ++r) {
+        cb_reserve_back(tt::CBIndex::c_16, full_ct_dim);
 
-        pack_untilize_block<per_core_block_tile_cnt>(tt::CBIndex::c_0, 1, tt::CBIndex::c_16);
-
-        cb_push_back(tt::CBIndex::c_16, per_core_block_tile_cnt);
-        cb_pop_front(tt::CBIndex::c_0, per_core_block_tile_cnt);
+        for (uint32_t b = 0; b < num_blocks_per_col; ++b) {
+            cb_wait_front(tt::CBIndex::c_0, block_ct_dim);
+            pack_untilize_block<block_ct_dim, full_ct_dim>(tt::CBIndex::c_0, 1, tt::CBIndex::c_16, b);
+            cb_pop_front(tt::CBIndex::c_0, block_ct_dim);
+        }
+        cb_push_back(tt::CBIndex::c_16, full_ct_dim);
     }
 
     pack_untilize_uninit(tt::CBIndex::c_16);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp
@@ -12,21 +12,15 @@ namespace NAMESPACE {
 
 // Helper constexpr function to compute num_blocks_per_col
 constexpr uint32_t compute_num_blocks_per_col(uint32_t per_core_block_tile_cnt) {
-    if (DST_ACCUM_MODE) {
-        for (uint32_t bct = 4; bct >= 1; --bct) {
-            if (per_core_block_tile_cnt % bct == 0) {
-                return per_core_block_tile_cnt / bct;
-            }
-        }
-    } else {
-        for (uint32_t bct = 8; bct >= 1; --bct) {
-            if (per_core_block_tile_cnt % bct == 0) {
-                return per_core_block_tile_cnt / bct;
-            }
+    const uint32_t max_bct = DST_ACCUM_MODE ? 4 : 8;
+
+    for (uint32_t bct = max_bct; bct >= 1; --bct) {
+        if (per_core_block_tile_cnt % bct == 0) {
+            return per_core_block_tile_cnt / bct;
         }
     }
 
-    return 1;  // fallback, though unreachable if per_core_block_tile_cnt ≥ 1
+    return 1;
 }
 
 void MAIN {

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -33,11 +33,23 @@ ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb) {
         false, false, icb)));  // init must be after configure
 }
 
+// clang-format off
 /**
  * Perform the untilize operation on a block of tiles. This simply loops over the provided block size.
+ * Performs the untilize operation on a block of tiles. Loops over the provided block size.
+ *
+ * | Param Type | Name          | Description                                 | Type      | Valid Range     | Required |
+ * |------------|---------------|---------------------------------------------|-----------|-----------------|----------|
+ * | Template   | block_ct_dim  | Width of a single block in tiles            | uint32_t  | 1 to 8          | False    |
+ * | Template   | full_ct_dim   | Width of a full input in tiles              | uint32_t  | >= block_ct_dim | False    |
+ * | Function   | icb           | Input circular buffer identifier            | uint32_t  | 0 to 31         | True     |
+ * | Function   | block_rt_dim  | Height of a single block in tiles           | uint32_t  | >= 1            | True     |
+ * | Function   | ocb           | Output circular buffer identifier           | uint32_t  | 0 to 31         | True     |
+ * | Function   | block_c_index | Index of the currently processed block      | uint32_t  | >= 0            | False    |
  */
+// clang-format on
 template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
-ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb) {
+ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb, uint32_t block_c_index = 0) {
     for (uint32_t r = 0; r < block_rt_dim; ++r) {
         MATH((llk_math_wait_for_dest_available()));
         for (uint32_t c = 0; c < block_ct_dim; ++c) {
@@ -45,10 +57,11 @@ ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb)
                 (llk_unpack_A<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(icb, c)));
             MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(c)));
         }
+
         MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));
 
         PACK((llk_packer_wait_for_math_done()));
-        PACK((llk_pack_untilize<block_ct_dim, full_ct_dim>(1 /*num_blocks*/, ocb)));
+        PACK((llk_pack_untilize<block_ct_dim, full_ct_dim>(1 /*num_blocks*/, ocb, FACE_R_DIM, 4, block_c_index)));
         PACK((llk_pack_dest_section_done<DST_ACCUM_MODE>()));
     }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11573
### Problem description
Note: This PR was originally reverted due to BH nightly tests failing. This lead to the discovery of a small issue on the op level which [got fixed](https://github.com/tenstorrent/tt-metal/pull/23834).

Untilize operation can be performed either using the slow algorithm (unpack_untilize) or by using the fast algorithm (pack_untilize). However, pack_untilize had the limitation of input tensor fitting only in one Destination register bank (8 tiles width). The goal of this fix is to enable the pack_untilize operation to work for any input size, by fixing the block_ct_dim != full_ct_dim code path, where block_ct_dim is the number of tiles in the single Destination register bank, and full_ct_dim is the width of the whole input tensor expressed in tiles.

This PR aims to solve the untilize portion of the issue https://github.com/tenstorrent/tt-metal/issues/16860 as well.

### What's changed

- Adapted testing kernel to set block_ct_dim based on the size of the input
- Modified pack_untilize test to use larger dimensions
- Introduced [LLK changes](https://github.com/tenstorrent/tt-llk/pull/280)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) [Passing](https://github.com/tenstorrent/tt-metal/actions/runs/15967668011)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [Passing](https://github.com/tenstorrent/tt-metal/actions/runs/15967672128)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [Same as main](https://github.com/tenstorrent/tt-metal/actions/runs/15967676803)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) [Passing](https://github.com/tenstorrent/tt-metal/actions/runs/15967704218)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes