### PR TITLE
SDXL: device perf CI test fix

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
@@ -160,7 +160,8 @@ def run_unet_model(
             [B, C, H, W],
             timestep=ttnn_timestep_tensor,
             encoder_hidden_states=ttnn_encoder_tensor,
-            added_cond_kwargs=ttnn_added_cond_kwargs,
+            time_ids=ttnn_added_cond_kwargs["time_ids"],
+            text_embeds=ttnn_added_cond_kwargs["text_embeds"],
         )
         ttnn.deallocate(ttnn_input_tensor)
         ttnn.deallocate(ttnn_output_tensor)


### PR DESCRIPTION
### Problem description
UNet unit test failing when `iterations > 1`. Invalid arguments are being passed after 1st iteration.

### What's changed
Changed arguments passed to iterations after 1st.