### PR TITLE
#0: Fix transpose_wh_rm.cpp narrow row check

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -120,8 +120,8 @@ void MAIN {
     constexpr uint32_t pack_num_pages_last_row = get_compile_time_arg_val(7);
     constexpr uint32_t pack_num_pages_last_row_col = get_compile_time_arg_val(8);
 
-    constexpr bool use_narrow_row = last_output_row_num_datums < TILE_WIDTH ? true : false;
-    constexpr uint32_t row_size = last_output_row_num_datums < TILE_WIDTH ? last_output_row_num_datums : TILE_WIDTH;
+    constexpr bool use_narrow_row = last_output_row_num_datums < FACE_WIDTH ? true : false;
+    constexpr uint32_t row_size = last_output_row_num_datums < FACE_WIDTH ? last_output_row_num_datums : TILE_WIDTH;
 #else
     uint32_t num_hw_blocks_per_core = get_arg_val<uint32_t>(0);
 #endif


### PR DESCRIPTION
### Ticket
N/A
### Problem description
narrow_row should be true if there are less than 16 pieces of data in a row, not <32. When running `models/demos/yolov4/tests/pcc/test_ttnn_yolov4_bh.py::test_yolov4[device_params0]` which calls `ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp` kernel, the condition for `use_narrow_row` checks agains `TILE_WIDTH` which is 32, instead of `FACE_WIDTH` which is 16.

### What's changed
Fix the check for `use_narrow_row` in `transpose_wh_rm.cpp`. 

FYI: @yugaoTT @pavlejosipovic @pmilenkovicTT 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes - [waiting](https://github.com/tenstorrent/tt-metal/actions/runs/15852844139) 
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) - [waiting](https://github.com/tenstorrent/tt-metal/actions/runs/15852848255) 
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes