### PR TITLE
Fix template ordering in 3T tests

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
@@ -10,7 +10,7 @@
 namespace NAMESPACE {
 
 inline void tilize_activation(uint32_t in0_subblock_h, uint32_t in0_block_w, uint32_t in0_num_subblocks) {
-    llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE, false>();
+    llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>();
     for (uint32_t in0_subblock = 0U; in0_subblock < in0_num_subblocks; in0_subblock++) {
         for (uint32_t i = 0U; i < in0_subblock_h; i++) {
             for (uint32_t j = 0U; j < in0_block_w; j++) {
@@ -23,7 +23,7 @@ inline void tilize_activation(uint32_t in0_subblock_h, uint32_t in0_block_w, uin
 }
 
 inline void reblock_and_untilize_output(uint32_t out_subblock_h, uint32_t out_block_w) {
-    llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE, false>();
+    llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>();
 
     for (uint32_t i = 0; i < out_subblock_h; i++) {
         for (int j = 0; j < 2; j++) {
@@ -88,7 +88,7 @@ void math_main() {
             for (uint32_t in1_subblock = 0U; in1_subblock < in1_num_subblocks; in1_subblock++) {
                 llk_math_wait_for_dest_available();
                 if (enable_reload) {
-                    llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE, false>();
+                    llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>();
                     for (uint32_t i = 0U; i < out_subblock_num_tiles; i++) {
                         llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(i);
                     }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
@@ -10,7 +10,7 @@
 namespace NAMESPACE {
 
 inline void tilize_activation(uint32_t in0_subblock_h, uint32_t in0_block_w, uint32_t in0_num_subblocks) {
-    llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, false, BroadcastType::NONE>();
+    llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE, false>();
     for (uint32_t in0_subblock = 0U; in0_subblock < in0_num_subblocks; in0_subblock++) {
         for (uint32_t i = 0U; i < in0_subblock_h; i++) {
             for (uint32_t j = 0U; j < in0_block_w; j++) {
@@ -23,7 +23,7 @@ inline void tilize_activation(uint32_t in0_subblock_h, uint32_t in0_block_w, uin
 }
 
 inline void reblock_and_untilize_output(uint32_t out_subblock_h, uint32_t out_block_w) {
-    llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, false, BroadcastType::NONE>();
+    llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE, false>();
 
     for (uint32_t i = 0; i < out_subblock_h; i++) {
         for (int j = 0; j < 2; j++) {
@@ -88,7 +88,7 @@ void math_main() {
             for (uint32_t in1_subblock = 0U; in1_subblock < in1_num_subblocks; in1_subblock++) {
                 llk_math_wait_for_dest_available();
                 if (enable_reload) {
-                    llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, false, BroadcastType::NONE>();
+                    llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE, false>();
                     for (uint32_t i = 0U; i < out_subblock_num_tiles; i++) {
                         llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(i);
                     }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_math.cpp
@@ -19,7 +19,7 @@ void math_main() {
     for (uint32_t block = 0; block < per_core_num_blocks; block++) {
         for (uint32_t r = 0; r < per_core_block_r_tiles; r++) {
             // Untilize
-            llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, false, BroadcastType::NONE>();
+            llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE, false>();
             for (uint32_t c = 0; c < per_core_block_c_tiles; c++) {
                 llk_math_wait_for_dest_available();
                 llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_math.cpp
@@ -19,7 +19,7 @@ void math_main() {
     for (uint32_t block = 0; block < per_core_num_blocks; block++) {
         for (uint32_t r = 0; r < per_core_block_r_tiles; r++) {
             // Untilize
-            llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE, false>();
+            llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>();
             for (uint32_t c = 0; c < per_core_block_c_tiles; c++) {
                 llk_math_wait_for_dest_available();
                 llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0);


### PR DESCRIPTION
### Ticket
[#19844](https://github.com/tenstorrent/tt-metal/issues/19844)

### Problem description
After changing `is_fp32_dest_acc_en` template parameter from default to non-default some bugs were introduced in `tests/tt_metal/tt_metal/test_kernels/compute/3T/` tests.

### What's changed
This PR fixes ordering of template parameters in `llk_math_eltwise_unary_datacopy_init` function calls.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes