### PR TITLE
Convert inline latex math to raw string to avoid python warning

### DIFF
--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -85,7 +85,7 @@ def assert_allclose(
     rtol=1e-05,
     atol=1e-08,
 ):
-    """
+    r"""
      Assert that two tensors are similar.
 
      Two tensors are considered close if


### PR DESCRIPTION
### Ticket
Sometimes we get the following python warnings in CI:
```[Run unit regression tests: work/tests/ttnn/utils_for_testing.py#L88](https://github.com/tenstorrent/tt-metal/commit/34deed68e517065dfb85f4eabab7bccc1022b52d#annotation_35971106640)
invalid escape sequence '\l'
```
https://github.com/tenstorrent/tt-metal/actions/runs/15829232898/job/44617900242

### What's changed
Convert to raw string so python stops throwing warnings

### Checklist
Tested here on branch:
https://github.com/tenstorrent/tt-metal/actions/runs/15837173815/job/44643267090