### PR TITLE
Replace write barrier with read barrier for zero_out_tiles

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp
@@ -19,10 +19,10 @@ FORCE_INLINE void zero_out_tiles() {
 
     noc_async_read_one_packet_set_state(zeros_noc_addr, MEM_ZEROS_SIZE);
     for (uint32_t i = 0; i < num_zeros_reads; ++i) {
-        noc_async_read_one_packet_with_state(zeros_noc_addr, write_addr);
+        noc_async_read_one_packet_with_state<true>(zeros_noc_addr, write_addr);
         write_addr += MEM_ZEROS_SIZE;
     }
-    noc_async_write_barrier();
+    noc_async_read_barrier();
 }
 
 template <


### PR DESCRIPTION
### Problem description
`noc_async_read_one_packet_with_state` should be followed by read barrier instead of write barrier.

### What's changed
Change read barrier with write barrier and add template argument for `noc_async_read_one_packet_with_state` for better clarity.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15856625190)
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes [WH](https://github.com/tenstorrent/tt-metal/actions/runs/15848466153), [BH](https://github.com/tenstorrent/tt-metal/actions/runs/15853320014) same as [main](https://github.com/tenstorrent/tt-metal/actions/runs/15854928759)