### PR TITLE
Fix SetFabricRouterConfig

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -26,7 +26,7 @@ constexpr auto k_ReliabilityMode = tt::tt_metal::FabricReliabilityMode::STRICT_S
 std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(const std::filesystem::path& graph_desc) {
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(graph_desc.string());
     tt::tt_metal::MetalContext::instance().set_fabric_config(k_FabricConfig, k_ReliabilityMode);
-    control_plane->initialize_fabric_context(k_FabricConfig, k_ReliabilityMode);
+    control_plane->initialize_fabric_context(k_FabricConfig);
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(k_ReliabilityMode);
 
     return control_plane;
@@ -40,7 +40,7 @@ std::unique_ptr<tt::tt_fabric::GlobalControlPlane> make_global_control_plane(
     auto global_control_plane = std::make_unique<tt::tt_fabric::GlobalControlPlane>(
         graph_desc.string(), logical_mesh_chip_id_to_physical_chip_id_mapping);
     auto& control_plane = global_control_plane->get_local_node_control_plane();
-    control_plane.initialize_fabric_context(k_FabricConfig, k_ReliabilityMode);
+    control_plane.initialize_fabric_context(k_FabricConfig);
     control_plane.configure_routing_tables_for_fabric_ethernet_channels(k_ReliabilityMode);
 
     return global_control_plane;

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -26,7 +26,7 @@ constexpr auto k_ReliabilityMode = tt::tt_metal::FabricReliabilityMode::STRICT_S
 std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(const std::filesystem::path& graph_desc) {
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(graph_desc.string());
     control_plane->initialize_fabric_context(k_FabricConfig);
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels(k_ReliabilityMode);
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels(k_FabricConfig, k_ReliabilityMode);
 
     return control_plane;
 }
@@ -39,7 +39,7 @@ std::unique_ptr<tt::tt_fabric::GlobalControlPlane> make_global_control_plane(
         graph_desc.string(), logical_mesh_chip_id_to_physical_chip_id_mapping);
     auto& control_plane = global_control_plane->get_local_node_control_plane();
     control_plane.initialize_fabric_context(k_FabricConfig);
-    control_plane.configure_routing_tables_for_fabric_ethernet_channels(k_ReliabilityMode);
+    control_plane.configure_routing_tables_for_fabric_ethernet_channels(k_FabricConfig, k_ReliabilityMode);
 
     return global_control_plane;
 }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -52,13 +52,6 @@ namespace tt::tt_fabric::fabric_router_tests {
 
 using ::testing::ElementsAre;
 
-TEST_F(ControlPlaneFixture, TestSetFabricConfigRoutingPlaneCount) {
-    tt::tt_metal::MetalContext::instance().set_fabric_config(k_FabricConfig, k_ReliabilityMode, 1);
-
-    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    const auto& fabric_context = control_plane.get_fabric_context();
-}
-
 TEST_F(ControlPlaneFixture, TestTGMeshGraphInit) {
     const std::filesystem::path tg_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -18,9 +18,46 @@
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_metal.hpp>
 
+namespace {
+
+constexpr auto k_FabricConfig = tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC;
+constexpr auto k_ReliabilityMode = tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
+
+std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(const std::filesystem::path& graph_desc) {
+    auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(graph_desc.string());
+    tt::tt_metal::MetalContext::instance().set_fabric_config(k_FabricConfig, k_ReliabilityMode);
+    control_plane->initialize_fabric_context(k_FabricConfig, k_ReliabilityMode);
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels(k_ReliabilityMode);
+
+    return control_plane;
+}
+
+std::unique_ptr<tt::tt_fabric::GlobalControlPlane> make_global_control_plane(
+    const std::filesystem::path& graph_desc,
+    const std::map<tt::tt_fabric::FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
+    tt::tt_metal::MetalContext::instance().set_fabric_config(k_FabricConfig, k_ReliabilityMode);
+
+    auto global_control_plane = std::make_unique<tt::tt_fabric::GlobalControlPlane>(
+        graph_desc.string(), logical_mesh_chip_id_to_physical_chip_id_mapping);
+    auto& control_plane = global_control_plane->get_local_node_control_plane();
+    control_plane.initialize_fabric_context(k_FabricConfig, k_ReliabilityMode);
+    control_plane.configure_routing_tables_for_fabric_ethernet_channels(k_ReliabilityMode);
+
+    return global_control_plane;
+}
+
+}  // namespace
+
 namespace tt::tt_fabric::fabric_router_tests {
 
 using ::testing::ElementsAre;
+
+TEST_F(ControlPlaneFixture, TestSetFabricConfigRoutingPlaneCount) {
+    tt::tt_metal::MetalContext::instance().set_fabric_config(k_FabricConfig, k_ReliabilityMode, 1);
+
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& fabric_context = control_plane.get_fabric_context();
+}
 
 TEST_F(ControlPlaneFixture, TestTGMeshGraphInit) {
     const std::filesystem::path tg_mesh_graph_desc_path =
@@ -33,11 +70,7 @@ TEST_F(ControlPlaneFixture, TestTGControlPlaneInit) {
     const std::filesystem::path tg_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
-    auto control_plane = std::make_unique<ControlPlane>(tg_mesh_graph_desc_path.string());
-    control_plane->initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    [[maybe_unused]] auto control_plane = make_control_plane(tg_mesh_graph_desc_path);
 }
 
 TEST_F(ControlPlaneFixture, TestTGMeshAPIs) {
@@ -56,11 +89,7 @@ TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
     const std::filesystem::path tg_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
-    auto control_plane = std::make_unique<ControlPlane>(tg_mesh_graph_desc_path.string());
-    control_plane->initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    auto control_plane = make_control_plane(tg_mesh_graph_desc_path);
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 1);
     EXPECT_GT(valid_chans.size(), 0);
     for (auto chan : valid_chans) {
@@ -80,22 +109,15 @@ TEST_F(ControlPlaneFixture, TestT3kControlPlaneInit) {
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
-    auto control_plane = std::make_unique<ControlPlane>(t3k_mesh_graph_desc_path.string());
-    control_plane->initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    auto control_plane = make_control_plane(t3k_mesh_graph_desc_path);
 }
 
 TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
-    auto control_plane = std::make_unique<ControlPlane>(t3k_mesh_graph_desc_path.string());
-    control_plane->initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    auto control_plane = make_control_plane(t3k_mesh_graph_desc_path);
+
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 0);
     EXPECT_GT(valid_chans.size(), 0);
     for (auto chan : valid_chans) {
@@ -125,14 +147,8 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kControlPlaneInit) {
     auto [mesh_graph_desc_path, mesh_graph_eth_coords] = GetParam();
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
-    auto global_control_plane = std::make_unique<GlobalControlPlane>(
-        t3k_mesh_graph_desc_path.string(),
-        get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
-    auto& control_plane = global_control_plane->get_local_node_control_plane();
-    control_plane.initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane.configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    [[maybe_unused]] auto global_control_plane = make_global_control_plane(
+        t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
 }
 
 TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
@@ -140,14 +156,10 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
     auto [mesh_graph_desc_path, mesh_graph_eth_coords] = GetParam();
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
-    auto global_control_plane = std::make_unique<GlobalControlPlane>(
-        t3k_mesh_graph_desc_path.string(),
-        get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
+    auto global_control_plane = make_global_control_plane(
+        t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
     auto& control_plane = global_control_plane->get_local_node_control_plane();
-    control_plane.initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane.configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+
     for (const auto& src_mesh : control_plane.get_user_physical_mesh_ids()) {
         for (const auto& dst_mesh : control_plane.get_user_physical_mesh_ids()) {
             auto src_mesh_shape = control_plane.get_physical_mesh_shape(src_mesh);
@@ -170,13 +182,10 @@ TEST_F(ControlPlaneFixture, TestT3kDisjointFabricRoutes) {
     auto [mesh_graph_desc_path, mesh_graph_eth_coords] = t3k_disjoint_mesh_descriptor_chip_mappings[0];
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
-    auto global_control_plane = std::make_unique<GlobalControlPlane>(
+    auto global_control_plane = make_global_control_plane(
         t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
     auto& control_plane = global_control_plane->get_local_node_control_plane();
-    control_plane.initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane.configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+
     auto valid_chans = control_plane.get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 0);
     EXPECT_GT(valid_chans.size(), 0);
     for (auto chan : valid_chans) {
@@ -208,11 +217,7 @@ TEST_F(ControlPlaneFixture, TestSingleGalaxyControlPlaneInit) {
     const std::filesystem::path single_galaxy_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.yaml";
-    auto control_plane = std::make_unique<ControlPlane>(single_galaxy_mesh_graph_desc_path.string());
-    control_plane->initialize_fabric_context(
-        tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
-        tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels(tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    [[maybe_unused]] auto control_plane = make_control_plane(single_galaxy_mesh_graph_desc_path.string());
 }
 
 TEST_F(ControlPlaneFixture, TestSingleGalaxyMeshAPIs) {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -25,7 +25,6 @@ constexpr auto k_ReliabilityMode = tt::tt_metal::FabricReliabilityMode::STRICT_S
 
 std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(const std::filesystem::path& graph_desc) {
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(graph_desc.string());
-    tt::tt_metal::MetalContext::instance().set_fabric_config(k_FabricConfig, k_ReliabilityMode);
     control_plane->initialize_fabric_context(k_FabricConfig);
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(k_ReliabilityMode);
 
@@ -35,7 +34,6 @@ std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(const std::files
 std::unique_ptr<tt::tt_fabric::GlobalControlPlane> make_global_control_plane(
     const std::filesystem::path& graph_desc,
     const std::map<tt::tt_fabric::FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
-    tt::tt_metal::MetalContext::instance().set_fabric_config(k_FabricConfig, k_ReliabilityMode);
 
     auto global_control_plane = std::make_unique<tt::tt_fabric::GlobalControlPlane>(
         graph_desc.string(), logical_mesh_chip_id_to_physical_chip_id_mapping);

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -38,7 +38,8 @@ public:
     void print_all_ethernet_connections() const;
 
     // Converts chip level routing tables to per ethernet channel
-    void configure_routing_tables_for_fabric_ethernet_channels(tt_metal::FabricReliabilityMode reliability_mode);
+    void configure_routing_tables_for_fabric_ethernet_channels(
+        tt::tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode);
     void write_routing_tables_to_all_chips() const;
 
     // Return mesh_id, chip_id from physical chip id

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -98,7 +98,7 @@ public:
     void set_routing_mode(uint16_t mode);
     uint16_t get_routing_mode() const;
 
-    void initialize_fabric_context(tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode);
+    void initialize_fabric_context(tt_metal::FabricConfig fabric_config);
 
     FabricContext& get_fabric_context() const;
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -855,8 +855,8 @@ size_t ControlPlane::get_num_live_routing_planes(
 
 // Only builds the routing table representation, does not actually populate the routing tables in memory of the
 // fabric routers on device
-void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(tt_metal::FabricReliabilityMode reliability_mode) {
-    TT_FATAL(this->fabric_context_ != nullptr, "Must call initialize_fabric_context first");
+void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
+    tt::tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode) {
     this->intra_mesh_routing_tables_.clear();
     this->inter_mesh_routing_tables_.clear();
     this->router_port_directions_to_physical_eth_chan_map_.clear();
@@ -964,8 +964,7 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(tt_meta
         }
     }
 
-    this->initialize_dynamic_routing_plane_counts(
-        intra_mesh_connectivity, this->fabric_context_->get_fabric_config(), reliability_mode);
+    this->initialize_dynamic_routing_plane_counts(intra_mesh_connectivity, fabric_config, reliability_mode);
 
     // Order the ethernet channels so that when we use them for deciding connections, indexing into ports per direction
     // is consistent for each each neighbouring chip.

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1422,7 +1422,6 @@ uint16_t ControlPlane::get_routing_mode() const { return this->routing_mode_; }
 
 void ControlPlane::initialize_fabric_context(tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode) {
     TT_FATAL(this->fabric_context_ == nullptr, "Trying to re-initialize fabric context");
-    tt::tt_metal::MetalContext::instance().set_fabric_config(fabric_config, reliability_mode);
     this->fabric_context_ = std::make_unique<FabricContext>(fabric_config);
 }
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -856,6 +856,7 @@ size_t ControlPlane::get_num_live_routing_planes(
 // Only builds the routing table representation, does not actually populate the routing tables in memory of the
 // fabric routers on device
 void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(tt_metal::FabricReliabilityMode reliability_mode) {
+    TT_FATAL(this->fabric_context_ != nullptr, "Must call initialize_fabric_context first");
     this->intra_mesh_routing_tables_.clear();
     this->inter_mesh_routing_tables_.clear();
     this->router_port_directions_to_physical_eth_chan_map_.clear();

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -26,6 +26,7 @@
 #include "control_plane.hpp"
 #include "core_coord.hpp"
 #include "fabric_host_interface.h"
+#include "fabric_types.hpp"
 #include "hal_types.hpp"
 #include "intermesh_constants.hpp"
 #include "impl/context/metal_context.hpp"
@@ -132,7 +133,7 @@ static void build_golden_link_counts(
 
 void ControlPlane::initialize_dynamic_routing_plane_counts(
     const IntraMeshConnectivity& intra_mesh_connectivity, tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode) {
-    if (fabric_config == tt_metal::FabricConfig::CUSTOM) {
+    if (fabric_config == tt_metal::FabricConfig::CUSTOM || fabric_config == tt_metal::FabricConfig::DISABLED) {
         return;
     }
     auto topology = FabricContext::get_topology_from_config(fabric_config);
@@ -963,7 +964,7 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(tt_meta
     }
 
     this->initialize_dynamic_routing_plane_counts(
-        intra_mesh_connectivity, tt::tt_metal::MetalContext::instance().get_fabric_config(), reliability_mode);
+        intra_mesh_connectivity, this->fabric_context_->get_fabric_config(), reliability_mode);
 
     // Order the ethernet channels so that when we use them for deciding connections, indexing into ports per direction
     // is consistent for each each neighbouring chip.

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1420,7 +1420,7 @@ void ControlPlane::set_routing_mode(uint16_t mode) {
 
 uint16_t ControlPlane::get_routing_mode() const { return this->routing_mode_; }
 
-void ControlPlane::initialize_fabric_context(tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode) {
+void ControlPlane::initialize_fabric_context(tt_metal::FabricConfig fabric_config) {
     TT_FATAL(this->fabric_context_ == nullptr, "Trying to re-initialize fabric context");
     this->fabric_context_ = std::make_unique<FabricContext>(fabric_config);
 }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -427,7 +427,7 @@ void MetalContext::initialize_fabric_config() {
         this->fabric_config_, this->num_fabric_active_routing_planes_);
     auto& control_plane = this->get_control_plane();
     if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
-        control_plane.initialize_fabric_context(this->fabric_config_, this->fabric_reliability_mode_);
+        control_plane.initialize_fabric_context(this->fabric_config_);
     }
     control_plane.configure_routing_tables_for_fabric_ethernet_channels(this->fabric_reliability_mode_);
 }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -429,7 +429,8 @@ void MetalContext::initialize_fabric_config() {
     if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
         control_plane.initialize_fabric_context(this->fabric_config_);
     }
-    control_plane.configure_routing_tables_for_fabric_ethernet_channels(this->fabric_reliability_mode_);
+    control_plane.configure_routing_tables_for_fabric_ethernet_channels(
+        this->fabric_config_, this->fabric_reliability_mode_);
 }
 
 tt_metal::FabricConfig MetalContext::get_fabric_config() const {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18726

### Problem description
- Some legacy CCL tests are failing when using Dispatch on Fabric when run in the test suite
- Dispatch only needs Fabric to initialize 1 routing plane. But initialize_fabric_context will call set fabric config again without specifying the routing planes, so there will always be 2 routing planes initialized and legacy CCLs will see no ethernet cores are available to them

### What's changed
- Revert the extra set fabric config call introduced by https://github.com/tenstorrent/tt-metal/commit/d4eeaedc1846e9f828eb17fe3d857a19fd9c2947

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15914800443

TG
https://github.com/tenstorrent/tt-metal/actions/runs/15857132296

T3K Fast
https://github.com/tenstorrent/tt-metal/actions/runs/15914805043

T3K
https://github.com/tenstorrent/tt-metal/actions/runs/15914803762