### PR TITLE
#0: Create `MemoryPin` from shared_ptr of py::object.

### DIFF
--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -96,16 +96,28 @@ public:
 
     // Creates a `Tensor` with storage "borrowed" from the buffer of elements of type `T`.
     //
-    // The primary use case for this API is to interop with Python, where `on_creation_callback` and
-    // `on_destruction_callback` are specified to be called when the tensor storage is created and destroyed (when
-    // making copies of Tensor object):
+    // The primary use case for this API is to interop with Python, where `MemoryPin` can be set to retain the lifetime
+    // of the Python object that owns the underlying data. For example, in pybind11:
     //
     // py::object py_tensor = ...;
-    // auto on_creation_callback = [t = py_tensor] { t.inc_ref(); };
-    // auto on_destruction_callback = [t = py_tensor] { t.dec_ref(); };
+    // MemoryPin py_data_pin(std::make_shared<py::object>(py_tensor));
+    // Tensor tensor = Tensor::from_borrowed_data(buffer, shape, py_data_pin);
     //
-    // When working in C++, prefer creating owned tensors, and retaining a reference to the internal buffer, if
-    // necessary.
+    // This API can also be used to create file-backed Tensors by means of `mmap`:
+    //
+    // void* mmap_addr = mmap(...);
+    // MemoryPin memory_pin(std::shared_ptr<void>(mmap_addr, [](void* addr) { munmap(addr, ...); }));
+    // Tensor tensor = Tensor::from_borrowed_data(
+    //     tt::stl::Span<T>(reinterpret_cast<T*>(mmap_addr), buffer_size), shape, memory_pin);
+    //
+    template <typename T>
+    [[nodiscard]] static Tensor from_borrowed_data(
+        tt::stl::Span<T> buffer,
+        const ttnn::Shape& shape,
+        tt::tt_metal::MemoryPin buffer_pin,
+        const std::optional<Tile>& tile = std::nullopt);
+
+    // Overload that takes `on_creation_callback` and `on_destruction_callback` as separate arguments.
     template <typename T>
     [[nodiscard]] static Tensor from_borrowed_data(
         tt::stl::Span<T> buffer,
@@ -115,14 +127,6 @@ public:
         const std::optional<Tile>& tile = std::nullopt) {
         return from_borrowed_data(buffer, shape, MemoryPin(on_creation_callback, on_destruction_callback), tile);
     }
-
-    // Overload that takes a memory pin.
-    template <typename T>
-    [[nodiscard]] static Tensor from_borrowed_data(
-        tt::stl::Span<T> buffer,
-        const ttnn::Shape& shape,
-        tt::tt_metal::MemoryPin buffer_pin,
-        const std::optional<Tile>& tile = std::nullopt);
 
     // Same as `from_span`, but operates on a vector instead.
     template <typename T>


### PR DESCRIPTION
### Ticket
N/A

### Problem description
[With C++ based sharding](https://github.com/tenstorrent/tt-metal/pull/23684), we optimize away copying of pydata in case of fully replicated mesh mappers.

To make it work with pybind's requirement of incrementing / decrementing reference while holding GIL, this forced me to introduce a level of indirection. Instead of allowing C++ code running from multiple threads to change the pyobject refcount, we only increment / decrement refcount on the `MemoryPin`. The last instance that decrements the pin refcount will decrement `pyobject` refcount only once - in our multi-threaded code it is guaranteed to happen in `DistributedHostBuffer` destruction, from the main thread.

### What's changed
Clarify comments in `tensor.hpp` and `pytensor.cpp`.

Change `pydata_pin` creation to the following simplified form:
```cpp
tt::tt_metal::MemoryPin pydata_pin(std::make_shared<py::object>(preprocessed_py_tensor.contiguous_py_tensor));
```

`py::object` copying and destruction performs what we did manually with `inc_ref` / `dec_ref`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15857398861)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15857405422)
- [x] New/Existing tests provide coverage for changes