### PR TITLE
Remove retries on all tg and t3k tests

### DIFF
--- a/.github/workflows/_auto-retry-nightly-workflows.yaml
+++ b/.github/workflows/_auto-retry-nightly-workflows.yaml
@@ -13,18 +13,6 @@ on:
         type: number
   workflow_run:
     workflows:
-      - "(T3K) T3000 demo tests"
-      - "(T3K) T3000 frequent tests"
-      - "(T3K) T3000 model perf tests"
-      - "(T3K) T3000 nightly tests"
-      - "(T3K) T3000 perplexity tests"
-      - "(T3K) T3000 profiler tests"
-      - "(T3K) T3000 unit tests"
-      - "(TG) TG demo tests"
-      - "(TG) TG frequent tests"
-      - "(TG) TG model perf tests"
-      - "(TG) TG nightly tests"
-      - "(TG) TG unit tests"
       - "(Single-card) Frequent model and ttnn tests"
       - "Package and release"
     types:


### PR DESCRIPTION
### Ticket
T3k and TG tests are stable enough such that we don't need retries to get a good pass rate. We want to disable retries whenever possible to avoid masking any non deterministic problems.


### What's changed
Remove all T3k and TG (4U) pipelines from auto-retry