### PR TITLE
Fix MetalContext to re-init when fabric config changes

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -50,6 +50,10 @@ void MetalContext::initialize(
     const BankMapping& l1_bank_remap,
     size_t worker_l1_size,
     bool minimal) {
+    // Workaround for galaxy and BH, need to always re-init
+    if (cluster_->is_galaxy_cluster() or cluster_->arch() == ARCH::BLACKHOLE) {
+        force_reinit_ = true;
+    }
     // Settings that affect FW build can also trigger a re-initialization
     auto fw_compile_hash = std::hash<std::string>{}(rtoptions_.get_compile_hash_string());
     validate_worker_l1_size(worker_l1_size, *hal_);

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -62,8 +62,7 @@ public:
         uint8_t num_hw_cqs,
         const BankMapping& l1_bank_remap,
         size_t worker_l1_size,
-        bool minimal = false,
-        bool force_reinit = false);
+        bool minimal = false);
     void reinitialize();
     void teardown();
 
@@ -110,6 +109,7 @@ private:
 
     bool initialized_ = false;
     bool teardown_registered_ = false;
+    bool force_reinit_ = false;
 
     uint8_t num_hw_cqs_ = 0;
     BankMapping l1_bank_remap_;


### PR DESCRIPTION
Also add workaround for BH/TG to always re-init so the tests can pass.

https://github.com/tenstorrent/tt-metal/actions/runs/15863235896

https://github.com/tenstorrent/tt-metal/actions/runs/15858970890

https://github.com/tenstorrent/tt-metal/actions/runs/15863181404