### PR TITLE
Fixing unused function compiler warning in TT-NN

### DIFF
--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -325,7 +325,7 @@ Attributes get_attributes(const T& object) {
     }
 }
 
-static std::ostream& operator<<(std::ostream& os, const Attribute& attribute) {
+inline std::ostream& operator<<(std::ostream& os, const Attribute& attribute) {
     os << attribute.to_string();
     return os;
 }

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -163,7 +163,7 @@ private:
 
 inline ProgramHashToOpName program_hash_to_opname_{};
 
-static void start_tracy_zone(const string& source, const string& functName, uint32_t lineNum, uint32_t color = 0) {
+inline void start_tracy_zone(const string& source, const string& functName, uint32_t lineNum, uint32_t color = 0) {
 #if defined(TRACY_ENABLE)
     auto tracySrcLoc =
         ___tracy_alloc_srcloc(lineNum, source.c_str(), source.length(), functName.c_str(), functName.length());
@@ -176,7 +176,7 @@ static void start_tracy_zone(const string& source, const string& functName, uint
 #endif
 }
 
-static bool stop_tracy_zone(const string& name = "", uint32_t color = 0) {
+inline bool stop_tracy_zone(const string& name = "", uint32_t color = 0) {
     bool callStackWasEmpty = true;
 #if defined(TRACY_ENABLE)
     if (!call_stack.empty()) {
@@ -195,11 +195,11 @@ static bool stop_tracy_zone(const string& name = "", uint32_t color = 0) {
     return callStackWasEmpty;
 }
 
-static void tracy_message(const std::string& source, uint32_t color = 0xf0f8ff) {
+inline void tracy_message(const std::string& source, uint32_t color = 0xf0f8ff) {
     TracyMessageC(source.c_str(), source.size(), color);
 }
 
-static void tracy_frame() { FrameMark; }
+inline void tracy_frame() { FrameMark; }
 
 #if defined(TRACY_ENABLE)
 static inline json get_kernels_json(chip_id_t device_id, const Program& program) {

--- a/ttnn/api/ttnn/decorators.hpp
+++ b/ttnn/api/ttnn/decorators.hpp
@@ -31,12 +31,12 @@ static std::string base_name(const std::string& cpp_fully_qualified_name) {
 }
 
 // Convert "ttnn::add" to "add_t"
-static std::string class_name(const std::string& cpp_fully_qualified_name) {
+inline std::string class_name(const std::string& cpp_fully_qualified_name) {
     return base_name(cpp_fully_qualified_name) + "_t";
 }
 
 // Convert "ttnn::add" to "ttnn.add"
-static std::string python_fully_qualified_name(const std::string& cpp_fully_qualified_name) {
+inline std::string python_fully_qualified_name(const std::string& cpp_fully_qualified_name) {
     auto replace = [](const std::string& input, const std::string& from, const std::string& to) {
         if (from.empty()) {
             return input;

--- a/ttnn/api/ttnn/operation.hpp
+++ b/ttnn/api/ttnn/operation.hpp
@@ -249,7 +249,7 @@ struct ProfilerInfo {
 
 inline MemoryConfig DEFAULT_OUTPUT_MEMORY_CONFIG;
 
-static void set_default_operation_output_memory_config(const MemoryConfig& memory_config) {
+inline void set_default_operation_output_memory_config(const MemoryConfig& memory_config) {
     DEFAULT_OUTPUT_MEMORY_CONFIG = memory_config;
 }
 

--- a/ttnn/api/ttnn/types.hpp
+++ b/ttnn/api/ttnn/types.hpp
@@ -56,7 +56,7 @@ struct CoreGrid {
 
 using Buffer = tt::tt_metal::Buffer;
 
-static std::ostream& operator<<(std::ostream& os, const CoreGrid& core_grid) {
+inline std::ostream& operator<<(std::ostream& os, const CoreGrid& core_grid) {
     os << "ttnn.CoreGrid(x=" << core_grid.x << ", y=" << core_grid.y << ")";
     return os;
 }

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -211,7 +211,7 @@ static void emit_sharded_tensor_kernel_rt_args(IDevice* d, Tensor const& tensor,
     std::copy(std::begin(new_args), std::end(new_args), std::back_inserter(args));
 }
 
-static bool shard_grid_is_transposed(Tensor const& t) {
+inline bool shard_grid_is_transposed(const Tensor& t) {
     TT_FATAL(
         t.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
             t.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED ||

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
@@ -410,9 +410,7 @@ std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_sender_kernel_rt_a
 }
 
 
-static void convert_slices_to_ccl_commands() {
 
-}
 
 // Moved to (and updated in) ccl_worker_builder.cpp
 /*

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp
@@ -50,7 +50,6 @@ inline bool is_dram(const Tensor& input_tensor) {
 inline bool is_dram(const std::optional<const Tensor>& input_tensor) {
     return input_tensor.has_value() ? is_dram(input_tensor.value()) : true;
 }
-inline bool is_dram(const Buffer* b) { return b->buffer_type() == BufferType::DRAM; }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.cpp
@@ -179,42 +179,6 @@ Tensor pre_scatter_transform_tensor(
 
 Tensor post_scatter_transform_tensor(
     Tensor& output_tensor,
-    const int32_t dim,
-    const bool is_dim_last_idx,
-    const Shape& original_logical_shape,
-    const Layout& original_layout) {
-    const auto orig_rank = original_logical_shape.rank();
-
-    if (orig_rank == 1) {
-        output_tensor = ttnn::reshape(output_tensor, original_logical_shape);
-    } else if (orig_rank < 4) {
-        output_tensor = ttnn::squeeze_from_4D(output_tensor, orig_rank);
-    } else if (orig_rank > 4) {
-        ttnn::SmallVector<uint32_t> result_shape(original_logical_shape.cbegin(), original_logical_shape.cend());
-        output_tensor = ttnn::reshape(output_tensor, original_logical_shape);
-    }
-
-    // transposing a row-major tensor here
-    if (!is_dim_last_idx) {
-        output_tensor = ttnn::transpose(output_tensor, dim, -1, output_tensor.memory_config());
-    }
-
-    TT_FATAL(
-        output_tensor.get_logical_shape() == original_logical_shape,
-        "Output tensor transformation did not create correct output shape! Got: {}, expected: {}",
-        output_tensor.get_logical_shape(),
-        original_logical_shape);
-
-    // if the output tensor's original layout is not row-major, convert the output tensor back
-    if (original_layout != Layout::ROW_MAJOR) {
-        output_tensor = ttnn::to_layout(output_tensor, original_layout);
-    }
-
-    return output_tensor;
-}
-
-Tensor post_scatter_transform_tensor(
-    Tensor& output_tensor,
     const Shape& after_transpose_shape,
     const int32_t dim,
     const bool is_dim_last_idx,

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -438,7 +438,7 @@ namespace random {
 
 inline auto RANDOM_GENERATOR = std::mt19937(0);
 
-static void seed(std::size_t seed) { RANDOM_GENERATOR = std::mt19937(seed); }
+inline void seed(std::size_t seed) { RANDOM_GENERATOR = std::mt19937(seed); }
 
 template <typename T>
 static Tensor uniform(T low, T high, const ttnn::Shape& shape, const Layout layout = Layout::ROW_MAJOR) {
@@ -468,7 +468,7 @@ static Tensor uniform(T low, T high, const ttnn::Shape& shape, const Layout layo
     return Tensor(tt::tt_metal::HostBuffer(std::move(output_buffer)), spec).to_layout(layout);
 }
 
-static Tensor random(
+inline Tensor random(
     const ttnn::Shape& shape, const DataType data_type = DataType::BFLOAT16, const Layout layout = Layout::ROW_MAJOR) {
     switch (data_type) {
         case DataType::UINT8: return uniform(uint8_t(0), uint8_t(1), shape, layout);
@@ -483,7 +483,7 @@ static Tensor random(
 }  // namespace random
 
 namespace detail {
-static bool nearly_equal(float a, float b, float epsilon = 1e-5f, float abs_threshold = 1e-5f) {
+inline bool nearly_equal(float a, float b, float epsilon = 1e-5f, float abs_threshold = 1e-5f) {
     auto diff = std::abs(a - b);
     auto norm = std::min((std::abs(a) + std::abs(b)), std::numeric_limits<float>::max());
     auto result = diff < std::max(abs_threshold, epsilon * norm);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -27,47 +27,6 @@ inline bool is_dram(const Tensor& input_tensor) {
 inline bool is_dram(const std::optional<const Tensor>& input_tensor) {
     return input_tensor.has_value() ? is_dram(input_tensor.value()) : true;
 }
-inline bool is_dram(const Buffer* b) { return b->buffer_type() == BufferType::DRAM; }
-
-inline bool cbs_fit_in_DRAM(
-    uint32_t in0_CB_size,
-    uint32_t in_CB_size,
-    uint32_t in2_CB_size,
-    uint32_t in3_CB_size,
-    uint32_t in5_CB_size,
-    uint32_t in6_CB_size,
-    uint32_t in_mask_CB_size,
-    uint32_t repack_CB_size,
-    uint32_t x_CB_size,
-    uint32_t xmm_CB_size,
-    uint32_t ex_partial_CB_size,
-    uint32_t ex_global_CB_size,
-    uint32_t ex2_global_CB_size,
-    uint32_t xmm2_CB_size,
-    uint32_t xmm3_CB_size,
-    uint32_t ex2pe_CB_size,
-    uint32_t out_CB_size,
-    uint32_t l1_size) {
-    uint32_t sum = 0;
-    sum += in0_CB_size;
-    sum += in_CB_size;
-    sum += in2_CB_size;
-    sum += in3_CB_size;
-    sum += in5_CB_size;
-    sum += in6_CB_size;
-    sum += in_mask_CB_size;
-    sum += repack_CB_size;
-    sum += x_CB_size;
-    sum += xmm_CB_size;
-    sum += ex_partial_CB_size;
-    sum += ex_global_CB_size;
-    sum += ex2_global_CB_size;
-    sum += xmm2_CB_size;
-    sum += xmm3_CB_size;
-    sum += ex2pe_CB_size;
-    sum += out_CB_size;
-    return sum < l1_size;
-}
 
 int get_max_subblock(uint32_t n, uint32_t max_subblock_w) {
     if (n <= max_subblock_w) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -27,7 +27,6 @@ inline bool is_dram(const Tensor& input_tensor) {
 inline bool is_dram(const std::optional<const Tensor>& input_tensor) {
     return input_tensor.has_value() ? is_dram(input_tensor.value()) : true;
 }
-inline bool is_dram(const Buffer* b) { return b->buffer_type() == BufferType::DRAM; }
 
 inline uint16_t bfloat16(float float_num) {
     uint32_t uint32_data;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
@@ -29,7 +29,6 @@ inline bool is_dram(const Tensor& input_tensor) {
 inline bool is_dram(const std::optional<const Tensor>& input_tensor) {
     return input_tensor.has_value() ? is_dram(input_tensor.value()) : true;
 }
-inline bool is_dram(const Buffer* b) { return b->buffer_type() == BufferType::DRAM; }
 
 inline uint16_t bfloat16(float float_num) {
     uint32_t uint32_data;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
@@ -23,10 +23,6 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 inline bool is_dram(const Tensor& input_tensor) {
     return input_tensor.memory_config().buffer_type() == BufferType::DRAM;
 }
-inline bool is_dram(const std::optional<const Tensor>& input_tensor) {
-    return input_tensor.has_value() ? is_dram(input_tensor.value()) : true;
-}
-inline bool is_dram(const Buffer* b) { return b->buffer_type() == BufferType::DRAM; }
 
 inline uint16_t bfloat16(float float_num) {
     uint32_t uint32_data;

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
@@ -26,13 +26,8 @@ namespace ttnn::operations::normalization {
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
-inline bool is_dram(const Tensor& input_tensor) {
-    return input_tensor.memory_config().buffer_type() == tt::tt_metal::BufferType::DRAM;
-}
-inline bool is_dram(const std::optional<const Tensor>& input_tensor) {
-    return input_tensor.has_value() ? is_dram(input_tensor.value()) : true;
-}
-inline bool is_dram(const tt::tt_metal::Buffer* b) { return b->buffer_type() == tt::tt_metal::BufferType::DRAM; }
+
+
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 // implementation of softmax with optional scale/mask (see the header for input_tensor more detailed description)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23444)

### Problem description
removing unused functions, as well as making static functions inline functions so that the unused function compiler warnings no longer occur and have to be suppressed. This is the first PR of many to remove all the compiler warnings

### What's changed
many functions have been deleted or been changed from static to inline so that they don't go unused.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15860334329
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes