### PR TITLE
[skip ci] skip llama galaxy perf unit tests

### DIFF
--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -42,15 +42,16 @@ jobs:
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_llama_model_perf_tg_device --dispatch-mode ""',
             owner_id: U053W15B6JF # Djordje Ivanovic
           },
-          {
-            name: "Llama Galaxy Perf Unit Tests",
-            arch: wormhole_b0,
-            cmd: 'pytest models/demos/llama3_subdevices/tests/tg_perf_unit_tests',
-            timeout: 100,
-            tracy: true,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
-            owner_id: U071CKL4AFK # Ammar Vora
-          },
+          # skip test until issue resolved https://github.com/tenstorrent/tt-metal/issues/24002
+          # {
+          #   name: "Llama Galaxy Perf Unit Tests",
+          #   arch: wormhole_b0,
+          #   cmd: 'pytest models/demos/llama3_subdevices/tests/tg_perf_unit_tests',
+          #   timeout: 100,
+          #   tracy: true,
+          #   runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+          #   owner_id: U071CKL4AFK # Ammar Vora
+          # },
           {
             name: "Galaxy Llama 70B prefill perf tests [128]",
             arch: wormhole_b0,


### PR DESCRIPTION
### Ticket
Llama galaxy perf unit tests fail due to https://github.com/tenstorrent/tt-metal/issues/24002

### What's changed
Skip the test until issue resolved