### PR TITLE
[skip ci] Publish `ttnn` wheel to real pypi

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -245,14 +245,14 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     secrets: inherit
-  publish-to-test-pypi:
+  publish-to-pypi:
     name: >-
-      Publish Python 🐍 distribution 📦 to Test PyPI
+      Publish Python 🐍 distribution 📦 to PyPI
     needs: [build-artifact, test-wheels]
     runs-on: ubuntu-latest
     environment:
-      name: testpypi
-      url: https://test.pypi.org/p/ttnn
+      name: pypi
+      url: https://pypi.org/project/ttnn/
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
@@ -261,7 +261,5 @@ jobs:
       with:
         name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
         path: dist/
-    - name: Publish distribution 📦 to Test PyPI
+    - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
### Ticket
Closes #22986 

### Problem description
Currently we publish our `ttnn` wheel to test pypi, need to publish to the real deal now.

### What's changed
Now that our wheel has been manually uploaded to pypi, and it is owned by tenstorrent, and we have configured trusted publishing, we can now use CI to publish to real pypi.

https://pypi.org/project/ttnn/

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes