### PR TITLE
changed fabric APIs to accept FabricNodeId instead of physical chip id

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -557,9 +557,9 @@ void test_single_connection_multi_device_socket(
     // Used to setup fabric connections
     const uint32_t sender_physical_device_id = md0->get_device(MeshCoordinate(0, 0))->id();
     const uint32_t recv_physical_device_id = md1->get_device(MeshCoordinate(0, 0))->id();
-    const auto& sender_fabric_node_id =
+    const auto sender_fabric_node_id =
         control_plane.get_fabric_node_id_from_physical_chip_id(sender_physical_device_id);
-    const auto& recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
+    const auto recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
 
     // Create Socket between Sender and Receiver
     SocketConnection socket_connection = {
@@ -758,9 +758,9 @@ void test_single_connection_multi_device_socket_with_workers(
     // Used to setup fabric connections
     const uint32_t sender_physical_device_id = md0->get_device(MeshCoordinate(0, 0))->id();
     const uint32_t recv_physical_device_id = md1->get_device(MeshCoordinate(0, 0))->id();
-    const auto& sender_fabric_node_id =
+    const auto sender_fabric_node_id =
         control_plane.get_fabric_node_id_from_physical_chip_id(sender_physical_device_id);
-    const auto& recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
+    const auto recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
     // Create Socket between Sender and Receiver
     SocketConnection socket_connection = {
         .sender_core = {MeshCoordinate(0, 0), sender_logical_coord},
@@ -945,9 +945,9 @@ std::shared_ptr<Program> create_sender_program(
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Used to setup fabric connections
-    const auto& sender_fabric_node_id =
+    const auto sender_fabric_node_id =
         control_plane.get_fabric_node_id_from_physical_chip_id(sender_physical_device_id);
-    const auto& recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
+    const auto recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
 
     auto fabric_max_packet_size = tt_fabric::get_tt_fabric_max_payload_size_bytes();
     auto packet_header_size_bytes = tt_fabric::get_tt_fabric_packet_header_size_bytes();
@@ -1011,10 +1011,10 @@ std::shared_ptr<Program> create_split_reduce_program(
 
     // Used to setup fabric connections
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    const auto& recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
-    const auto& sender0_fabric_node_id =
+    const auto recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
+    const auto sender0_fabric_node_id =
         control_plane.get_fabric_node_id_from_physical_chip_id(sender0_physical_device_id);
-    const auto& sender1_fabric_node_id =
+    const auto sender1_fabric_node_id =
         control_plane.get_fabric_node_id_from_physical_chip_id(sender1_physical_device_id);
 
     auto recv_virtual_coord_0 = recv_data_buffer->device()->worker_core_from_logical_core(recv_logical_coord_0);

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -552,6 +552,8 @@ void test_single_connection_multi_device_socket(
     auto fabric_max_packet_size = tt_fabric::get_tt_fabric_max_payload_size_bytes();
     auto packet_header_size_bytes = tt_fabric::get_tt_fabric_packet_header_size_bytes();
 
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
     // Used to setup fabric connections
     const uint32_t sender_physical_device_id = md0->get_device(MeshCoordinate(0, 0))->id();
     const uint32_t recv_physical_device_id = md1->get_device(MeshCoordinate(0, 0))->id();
@@ -941,15 +943,14 @@ std::shared_ptr<Program> create_sender_program(
     chip_id_t recv_physical_device_id,
     uint32_t sender_link_idx) {
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    const auto& fabric_context = control_plane.get_fabric_context();
 
     // Used to setup fabric connections
     const auto& sender_fabric_node_id =
         control_plane.get_fabric_node_id_from_physical_chip_id(sender_physical_device_id);
     const auto& recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
 
-    auto fabric_max_packet_size = fabric_context.get_fabric_max_payload_size_bytes();
-    auto packet_header_size_bytes = fabric_context.get_fabric_packet_header_size_bytes();
+    auto fabric_max_packet_size = tt_fabric::get_tt_fabric_max_payload_size_bytes();
+    auto packet_header_size_bytes = tt_fabric::get_tt_fabric_packet_header_size_bytes();
 
     const auto reserved_packet_header_CB_index = tt::CB::c_in0;
     auto sender_program = std::make_shared<Program>();
@@ -1009,6 +1010,7 @@ std::shared_ptr<Program> create_split_reduce_program(
     auto in1_cb_index = tt::CBIndex::c_4;
 
     // Used to setup fabric connections
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
     const auto& sender0_fabric_node_id =
         control_plane.get_fabric_node_id_from_physical_chip_id(sender0_physical_device_id);
@@ -1160,13 +1162,14 @@ std::shared_ptr<Program> create_reduce_program(
     auto reserved_sender_packet_header_CB_index = tt::CBIndex::c_1;
     auto out_cb_index = tt::CBIndex::c_2;
 
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     // Used to setup fabric connections
-    const auto& sender0_fabric_node_id =
+    const auto sender0_fabric_node_id =
         control_plane.get_fabric_node_id_from_physical_chip_id(sender0_physical_device_id);
-    const auto& sender1_fabric_node_id =
+    const auto sender1_fabric_node_id =
         control_plane.get_fabric_node_id_from_physical_chip_id(sender1_physical_device_id);
-    const auto& recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
-    const auto& reducer_fabric_node_id =
+    const auto recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
+    const auto reducer_fabric_node_id =
         control_plane.get_fabric_node_id_from_physical_chip_id(reducer_physical_device_id);
 
     auto reduce_virtual_coord = reducer->worker_core_from_logical_core(reduce_logical_coord);
@@ -1262,9 +1265,10 @@ std::shared_ptr<Program> create_recv_program(
     auto reserved_packet_header_CB_index = tt::CB::c_in0;
 
     // Used to setup fabric connections
-    const auto& sender_fabric_node_id =
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto sender_fabric_node_id =
         control_plane.get_fabric_node_id_from_physical_chip_id(sender_physical_device_id);
-    const auto& recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
+    const auto recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
 
     auto recv_virtual_coord = output_data_buffer->device()->worker_core_from_logical_core(recv_logical_coord);
     auto output_virtual_coord = output_data_buffer->device()->worker_core_from_logical_core(output_logical_coord);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -880,7 +880,7 @@ void RunTestMCastConnAPI(
     }
     link_idx =
         get_forwarding_link_indices(src_fabric_node_id, get_fabric_node_id_from_physical_chip_id(dst_chip_id))[0];
-    const auto& left_dst_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dst_chip_id);
+    const auto left_dst_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dst_chip_id);
     append_fabric_connection_rt_args(
         src_fabric_node_id,
         left_dst_fabric_node_id,
@@ -900,7 +900,7 @@ void RunTestMCastConnAPI(
     }
     link_idx =
         get_forwarding_link_indices(src_fabric_node_id, get_fabric_node_id_from_physical_chip_id(dst_chip_id))[0];
-    const auto& right_dst_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dst_chip_id);
+    const auto right_dst_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dst_chip_id);
     append_fabric_connection_rt_args(
         src_fabric_node_id,
         right_dst_fabric_node_id,
@@ -1137,7 +1137,7 @@ void RunTestChipMCast1D(
 
     // append the EDM connection rt args for fwd connection
     chip_id_t dst_chip_id = first_hop_phys_chip_id;
-    const auto& dst_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dst_chip_id);
+    const auto dst_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dst_chip_id);
     uint32_t link_idx = get_forwarding_link_indices(src_fabric_node_id, dst_fabric_node_id)[0];
     append_fabric_connection_rt_args(
         src_fabric_node_id, dst_fabric_node_id, link_idx, sender_program, {sender_logical_core}, sender_runtime_args);
@@ -1405,9 +1405,9 @@ TEST_F(Fabric1DFixture, DISABLED_TestEDMConnectionStressTestQuick) {
                         worker_args.push_back(i % packet_sizes.size());
                         worker_args.push_back(i % message_counts.size());
 
-                        const auto& sender_fabric_node_id =
+                        const auto sender_fabric_node_id =
                             tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
-                        const auto& receiver_fabric_node_id =
+                        const auto receiver_fabric_node_id =
                             tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(receiver_device->id());
                         append_fabric_connection_rt_args(
                             sender_fabric_node_id,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -237,7 +237,7 @@ void RunTestLineMcast(
     sender_runtime_args.insert(sender_runtime_args.end(), mcast_header_rtas.begin(), mcast_header_rtas.end());
     // append the EDM connection rt args
     append_fabric_connection_rt_args(
-        sender_phys_id, mcast_start_phys_id, 0, sender_program, {sender_logical_core}, sender_runtime_args);
+        sender_id, mcast_start_id, 0, sender_program, {sender_logical_core}, sender_runtime_args);
 
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
@@ -597,17 +597,12 @@ void run_unicast_test_bw_chips(
         *dst_fabric_node_id.mesh_id};
 
     // append the EDM connection rt args
-    const auto& available_links = get_forwarding_link_indices(src_physical_device_id, dst_physical_device_id);
+    const auto& available_links = get_forwarding_link_indices(src_fabric_node_id, dst_fabric_node_id);
     EXPECT_EQ(available_links.size() > 0, true);
 
     uint32_t link_idx = available_links[0];
     append_fabric_connection_rt_args(
-        src_physical_device_id,
-        dst_physical_device_id,
-        link_idx,
-        sender_program,
-        {sender_logical_core},
-        sender_runtime_args);
+        src_fabric_node_id, dst_fabric_node_id, link_idx, sender_program, {sender_logical_core}, sender_runtime_args);
 
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
@@ -883,10 +878,16 @@ void RunTestMCastConnAPI(
     } else {
         dst_chip_id = left_first_hop_phys_chip_id;
     }
-    link_idx = get_forwarding_link_indices(src_phys_chip_id, dst_chip_id)[0];
+    link_idx =
+        get_forwarding_link_indices(src_fabric_node_id, get_fabric_node_id_from_physical_chip_id(dst_chip_id))[0];
+    const auto& left_dst_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dst_chip_id);
     append_fabric_connection_rt_args(
-        src_phys_chip_id, dst_chip_id, link_idx, sender_program, {sender_logical_core}, sender_runtime_args);
-
+        src_fabric_node_id,
+        left_dst_fabric_node_id,
+        link_idx,
+        sender_program,
+        {sender_logical_core},
+        sender_runtime_args);
     sender_runtime_args.push_back(1); /* bwd_start_distance */
     sender_runtime_args.push_back(bwd_hops); /* bwd_range */
     sender_runtime_args.push_back(right_fabric_node_id.chip_id);
@@ -897,9 +898,16 @@ void RunTestMCastConnAPI(
     } else {
         dst_chip_id = right_first_hop_phys_chip_id;
     }
-    link_idx = get_forwarding_link_indices(src_phys_chip_id, dst_chip_id)[0];
+    link_idx =
+        get_forwarding_link_indices(src_fabric_node_id, get_fabric_node_id_from_physical_chip_id(dst_chip_id))[0];
+    const auto& right_dst_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dst_chip_id);
     append_fabric_connection_rt_args(
-        src_phys_chip_id, dst_chip_id, link_idx, sender_program, {sender_logical_core}, sender_runtime_args);
+        src_fabric_node_id,
+        right_dst_fabric_node_id,
+        link_idx,
+        sender_program,
+        {sender_logical_core},
+        sender_runtime_args);
 
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
@@ -1129,9 +1137,10 @@ void RunTestChipMCast1D(
 
     // append the EDM connection rt args for fwd connection
     chip_id_t dst_chip_id = first_hop_phys_chip_id;
-    uint32_t link_idx = get_forwarding_link_indices(src_phys_chip_id, dst_chip_id)[0];
+    const auto& dst_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dst_chip_id);
+    uint32_t link_idx = get_forwarding_link_indices(src_fabric_node_id, dst_fabric_node_id)[0];
     append_fabric_connection_rt_args(
-        src_phys_chip_id, dst_chip_id, link_idx, sender_program, {sender_logical_core}, sender_runtime_args);
+        src_fabric_node_id, dst_fabric_node_id, link_idx, sender_program, {sender_logical_core}, sender_runtime_args);
 
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
@@ -1396,9 +1405,13 @@ TEST_F(Fabric1DFixture, DISABLED_TestEDMConnectionStressTestQuick) {
                         worker_args.push_back(i % packet_sizes.size());
                         worker_args.push_back(i % message_counts.size());
 
+                        const auto& sender_fabric_node_id =
+                            tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+                        const auto& receiver_fabric_node_id =
+                            tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(receiver_device->id());
                         append_fabric_connection_rt_args(
-                            sender_device->id(),
-                            receiver_device->id(),
+                            sender_fabric_node_id,
+                            receiver_fabric_node_id,
                             0,
                             program,
                             {worker_logical_cores_vec[i]},

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -262,8 +262,8 @@ void create_mux_kernel(
     std::vector<uint32_t> mux_ct_args = mux_kernel_config.get_fabric_mux_compile_time_args();
     std::vector<uint32_t> mux_rt_args = {};
     append_fabric_connection_rt_args(
-        device->id(),
-        dest_device->id(),
+        tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id()),
+        tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dest_device->id()),
         0 /* link_idx (routing plane) */,
         program_handle,
         {mux_logical_core},

--- a/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
@@ -325,10 +325,16 @@ inline void RunPersistent1dFabricLatencyTest(
                 }
             } else {
                 if (is_connected_in_direction) {
+                    const auto& device_fabric_node_id =
+                        tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id());
+                    chip_id_t connected_chip_id = direction == ttnn::ccl::EdmLineFabricOpInterface::FORWARD
+                                                      ? forward_device->id()
+                                                      : backward_device->id();
+                    const auto& connected_device_fabric_node_id =
+                        tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(connected_chip_id);
                     tt::tt_fabric::append_fabric_connection_rt_args(
-                        device->id(),
-                        direction == ttnn::ccl::EdmLineFabricOpInterface::FORWARD ? forward_device->id()
-                                                                                  : backward_device->id(),
+                        device_fabric_node_id,
+                        connected_device_fabric_node_id,
                         0,
                         program,
                         {worker_core_logical},

--- a/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
@@ -325,12 +325,12 @@ inline void RunPersistent1dFabricLatencyTest(
                 }
             } else {
                 if (is_connected_in_direction) {
-                    const auto& device_fabric_node_id =
+                    const auto device_fabric_node_id =
                         tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id());
                     chip_id_t connected_chip_id = direction == ttnn::ccl::EdmLineFabricOpInterface::FORWARD
                                                       ? forward_device->id()
                                                       : backward_device->id();
-                    const auto& connected_device_fabric_node_id =
+                    const auto connected_device_fabric_node_id =
                         tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(connected_chip_id);
                     tt::tt_fabric::append_fabric_connection_rt_args(
                         device_fabric_node_id,

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -2938,8 +2938,17 @@ void Run1DFabricPacketSendTest(
                 rt_args_out.push_back(is_connected_in_direction);
                 if (is_connected_in_direction) {
                     if (use_device_init_fabric) {
+                        const auto& device_fabric_node_id =
+                            tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id());
+                        const auto& connected_device_fabric_node_id =
+                            tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(connected_device->id());
                         tt::tt_fabric::append_fabric_connection_rt_args(
-                            device->id(), connected_device->id(), link, program, {worker_core}, rt_args_out);
+                            device_fabric_node_id,
+                            connected_device_fabric_node_id,
+                            link,
+                            program,
+                            {worker_core},
+                            rt_args_out);
                     } else {
                         const auto connection = local_device_fabric_handle->uniquely_connect_worker(device, direction);
                         const auto new_rt_args = ttnn::ccl::worker_detail::generate_edm_connection_rt_args(
@@ -3381,8 +3390,11 @@ void generate_1d_fabric_on_full_mesh_worker_rt_args(
                                      std::vector<uint32_t>& rt_args_out) {
         rt_args_out.push_back(is_connected_in_direction);
         if (is_connected_in_direction) {
+            const auto& device_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id());
+            const auto& connected_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(connected_device->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                device->id(), connected_device->id(), link, program, {worker_core}, rt_args_out);
+                device_fabric_node_id, connected_device_fabric_node_id, link, program, {worker_core}, rt_args_out);
         }
     };
 
@@ -3987,8 +3999,17 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
                     bool is_connected_in_direction, IDevice* connected_device, std::vector<uint32_t>& rt_args_out) {
                     rt_args_out.push_back(is_connected_in_direction);
                     if (is_connected_in_direction) {
+                        const auto& device_fabric_node_id =
+                            tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id());
+                        const auto& connected_device_fabric_node_id =
+                            tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(connected_device->id());
                         tt::tt_fabric::append_fabric_connection_rt_args(
-                            device->id(), connected_device->id(), l, program, {worker_core}, rt_args_out);
+                            device_fabric_node_id,
+                            connected_device_fabric_node_id,
+                            l,
+                            program,
+                            {worker_core},
+                            rt_args_out);
                     }
                 };
 

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -23,7 +23,7 @@ class MeshDevice;
 }  // namespace tt::tt_metal::distributed
 
 namespace tt::tt_fabric {
-
+class FabricNodeId;
 size_t get_tt_fabric_channel_buffer_size_bytes();
 size_t get_tt_fabric_packet_header_size_bytes();
 size_t get_tt_fabric_max_payload_size_bytes();
@@ -52,13 +52,15 @@ size_t get_tt_fabric_max_payload_size_bytes();
 // connection appropriately. The API will not perform any checks to ensure that the
 // connection is indeed a 1D connection b/w all the workers.
 void append_fabric_connection_rt_args(
-    chip_id_t src_chip_id,
-    chip_id_t dst_chip_id,
+    const FabricNodeId& src_fabric_node_id,
+    const FabricNodeId& dst_fabric_node_id,
     uint32_t link_idx,
     tt::tt_metal::Program& worker_program,
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
     CoreType core_type = CoreType::WORKER);
+
+FabricNodeId get_fabric_node_id_from_physical_chip_id(chip_id_t physical_chip_id);
 
 namespace experimental {
 size_t get_number_of_available_routing_planes(

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -35,11 +35,14 @@ class Program;
 namespace {
 
 // checks if the connection b/w src and dst is a connection b/w TG gateway and a remote chip
-bool is_TG_gateway_connection(const chip_id_t src_chip_id, const chip_id_t dst_chip_id) {
+bool is_TG_gateway_connection(
+    const tt::tt_fabric::FabricNodeId& src_fabric_node_id, const tt::tt_fabric::FabricNodeId& dst_fabric_node_id) {
     if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::ClusterType::TG) {
         return false;
     }
-
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    chip_id_t src_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
+    chip_id_t dst_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(dst_fabric_node_id);
     const auto mmio_chip_id1 =
         tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(src_chip_id);
     const auto mmio_chip_id2 =
@@ -100,17 +103,9 @@ void append_fabric_connection_rt_args(
     const auto topology = fabric_context.get_fabric_topology();
     const bool is_2d_fabric = topology == Topology::Mesh;
 
-    // src_chip_id is still required to get the fabric_router_virtual_core from tt_cluster
-    chip_id_t src_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
-
-    // dst_chip_id is only required for 1D fabric because we can't rely on routing tables for 1D torus
-    chip_id_t dst_chip_id =
-        is_2d_fabric
-            ? 0
-            : control_plane.get_physical_chip_id_from_fabric_node_id(dst_fabric_node_id);  // 0 Initialize if 2D fabric
     // Make an exception for TG gateway connections. TG gateways are on a different mesh compared to remote chips
     // but the routing is simple and doesnt need any special inter-mesh handling
-    if (!is_2d_fabric && !is_TG_gateway_connection(src_chip_id, dst_chip_id)) {
+    if (!is_2d_fabric && !is_TG_gateway_connection(src_fabric_node_id, dst_fabric_node_id)) {
         TT_FATAL(
             src_fabric_node_id.mesh_id == dst_fabric_node_id.mesh_id,
             "Currently only the chips on the same mesh are supported for 1D fabric. Src mesh id: {}, Dst mesh id: {}",
@@ -171,6 +166,9 @@ void append_fabric_connection_rt_args(
 
     const auto fabric_router_channel = candidate_eth_chans[link_idx];
     const auto router_direction = control_plane.routing_direction_to_eth_direction(forwarding_direction.value());
+
+    // src_chip_id is still required to get the fabric_router_virtual_core from tt_cluster
+    chip_id_t src_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
 
     CoreCoord fabric_router_virtual_core =
         tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -16,6 +16,7 @@
 
 namespace tt::tt_fabric {
 
+class FabricNodeId;
 bool is_tt_fabric_config(tt::tt_metal::FabricConfig fabric_config);
 bool is_2d_fabric_config(tt::tt_metal::FabricConfig fabric_config);
 
@@ -28,11 +29,12 @@ void set_routing_mode(Topology topology, tt::tt_metal::FabricConfig fabric_confi
 FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::ClusterType cluster_type);
 
 std::vector<uint32_t> get_forwarding_link_indices_in_direction(
-    chip_id_t src_chip_id, chip_id_t dst_chip_id, RoutingDirection direction);
+    const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id, RoutingDirection direction);
 
 // returns which links on a given src chip are available for forwarding the data to a dst chip
 // these link indices can then be used to establish connection with the fabric routers
-std::vector<uint32_t> get_forwarding_link_indices(chip_id_t src_chip_id, chip_id_t dst_chip_id);
+std::vector<uint32_t> get_forwarding_link_indices(
+    const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id);
 
 void get_optimal_noc_for_edm(
     FabricEriscDatamoverBuilder& edm_builder1,

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
@@ -99,11 +99,13 @@ void RelayMux::GenerateStaticConfigs() {
         // Get the device which is downstream on the specified tunnel
         destination_device_id = tt::tt_metal::FDKernel::GetDownstreamDeviceId(device_id_, tunnel_id_);
     }
-    const auto& available_links = tt_fabric::get_forwarding_link_indices(device_id_, destination_device_id);
+    const auto& src_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device_id_);
+    const auto& dst_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(destination_device_id);
+    const auto& available_links = tt_fabric::get_forwarding_link_indices(src_fabric_node_id, dst_fabric_node_id);
     TT_ASSERT(!available_links.empty());
     tt_fabric::append_fabric_connection_rt_args(
-        device_id_,
-        destination_device_id,
+        src_fabric_node_id,
+        dst_fabric_node_id,
         available_links.back(),
         *program_,
         {logical_core_},

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
@@ -99,8 +99,8 @@ void RelayMux::GenerateStaticConfigs() {
         // Get the device which is downstream on the specified tunnel
         destination_device_id = tt::tt_metal::FDKernel::GetDownstreamDeviceId(device_id_, tunnel_id_);
     }
-    const auto& src_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device_id_);
-    const auto& dst_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(destination_device_id);
+    const auto src_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device_id_);
+    const auto dst_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(destination_device_id);
     const auto& available_links = tt_fabric::get_forwarding_link_indices(src_fabric_node_id, dst_fabric_node_id);
     TT_ASSERT(!available_links.empty());
     tt_fabric::append_fabric_connection_rt_args(

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
@@ -1295,15 +1295,15 @@ void generate_multi_input_command_stream_kernel_rt_args(
     rt_args.push_back(forward_device.has_value() and forward_device.value());
     auto worker_core = corerange_to_cores(worker_core_range).at(0);
     if (forward_device.has_value() and forward_device.value()) {
-        const auto& device_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id());
-        const auto& forward_device_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
+        const auto device_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id());
+        const auto forward_device_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
         tt::tt_fabric::append_fabric_connection_rt_args(device_fabric_node_id, forward_device_fabric_node_id, link, program, {worker_core}, rt_args);
     }
 
     rt_args.push_back(backward_device.has_value() and backward_device.value());
     if (backward_device.has_value() and backward_device.value()) {
-        const auto& device_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id());
-        const auto& backward_device_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
+        const auto device_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id());
+        const auto backward_device_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
         tt::tt_fabric::append_fabric_connection_rt_args(device_fabric_node_id, backward_device_fabric_node_id, link, program, {worker_core}, rt_args);
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
@@ -1295,12 +1295,16 @@ void generate_multi_input_command_stream_kernel_rt_args(
     rt_args.push_back(forward_device.has_value() and forward_device.value());
     auto worker_core = corerange_to_cores(worker_core_range).at(0);
     if (forward_device.has_value() and forward_device.value()) {
-        tt::tt_fabric::append_fabric_connection_rt_args(device->id(), forward_device.value()->id(), link, program, {worker_core}, rt_args);
+        const auto& device_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id());
+        const auto& forward_device_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
+        tt::tt_fabric::append_fabric_connection_rt_args(device_fabric_node_id, forward_device_fabric_node_id, link, program, {worker_core}, rt_args);
     }
 
     rt_args.push_back(backward_device.has_value() and backward_device.value());
     if (backward_device.has_value() and backward_device.value()) {
-        tt::tt_fabric::append_fabric_connection_rt_args(device->id(), backward_device.value()->id(), link, program, {worker_core}, rt_args);
+        const auto& device_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id());
+        const auto& backward_device_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
+        tt::tt_fabric::append_fabric_connection_rt_args(device_fabric_node_id, backward_device_fabric_node_id, link, program, {worker_core}, rt_args);
     }
 
     for (size_t i = 0; i < num_command_streams; i++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
@@ -258,13 +258,21 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
 
         writer_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
+            const auto& sender_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+            const auto& forward_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                sender_device->id(), forward_device.value()->id(), link, program, {core}, writer_rt_args);
+                sender_fabric_node_id, forward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
         writer_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
+            const auto& sender_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+            const auto& backward_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                sender_device->id(), backward_device.value()->id(), link, program, {core}, writer_rt_args);
+                sender_fabric_node_id, backward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
         tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
@@ -258,18 +258,18 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
 
         writer_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
-            const auto& sender_fabric_node_id =
+            const auto sender_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
-            const auto& forward_device_fabric_node_id =
+            const auto forward_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
                 sender_fabric_node_id, forward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
         writer_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
-            const auto& sender_fabric_node_id =
+            const auto sender_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
-            const auto& backward_device_fabric_node_id =
+            const auto backward_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
                 sender_fabric_node_id, backward_device_fabric_node_id, link, program, {core}, writer_rt_args);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -625,12 +625,17 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         writer_forward_rt_args.push_back(false);
         writer_forward_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
-            const auto src_fabric_node_id =
+            const auto sender_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
-            const auto dst_fabric_node_id =
+            const auto backward_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                src_fabric_node_id, dst_fabric_node_id, link, program, sender_worker_cores[1 + 2 * link], writer_forward_rt_args);
+                sender_fabric_node_id,
+                backward_device_fabric_node_id,
+                link,
+                program,
+                sender_worker_cores[1 + 2 * link],
+                writer_forward_rt_args);
         }
         if (fuse_op) {
             fused_op_signaler_sender_workers->push_all_gather_fused_op_rt_args(writer_forward_rt_args, 1, 0, 1);
@@ -657,9 +662,13 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         };
         writer_backward_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
+            const auto sender_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+            const auto forward_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                sender_device->id(),
-                forward_device.value()->id(),
+                sender_fabric_node_id,
+                forward_device_fabric_node_id,
                 link,
                 program,
                 sender_worker_cores[0 + 2 * link],

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -217,18 +217,18 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         }
         writer_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
-            const auto& sender_fabric_node_id =
+            const auto sender_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
-            const auto& forward_device_fabric_node_id =
+            const auto forward_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
                 sender_fabric_node_id, forward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
         writer_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
-            const auto& sender_fabric_node_id =
+            const auto sender_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
-            const auto& backward_device_fabric_node_id =
+            const auto backward_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
                 sender_fabric_node_id, backward_device_fabric_node_id, link, program, {core}, writer_rt_args);
@@ -625,8 +625,9 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         writer_forward_rt_args.push_back(false);
         writer_forward_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
-            auto src_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
-            auto dst_fabric_node_id =
+            const auto src_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+            const auto dst_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
                 src_fabric_node_id, dst_fabric_node_id, link, program, sender_worker_cores[1 + 2 * link], writer_forward_rt_args);
@@ -967,16 +968,18 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
 
         writer_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
-            auto src_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
-            auto dst_fabric_node_id =
+            const auto src_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+            const auto dst_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
                 src_fabric_node_id, dst_fabric_node_id, link, program, {core}, writer_rt_args);
         }
         writer_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
-            auto src_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
-            auto dst_fabric_node_id =
+            const auto src_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+            const auto dst_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
                 src_fabric_node_id, dst_fabric_node_id, link, program, {core}, writer_rt_args);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -217,13 +217,21 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         }
         writer_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
+            const auto& sender_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+            const auto& forward_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                sender_device->id(), forward_device.value()->id(), link, program, {core}, writer_rt_args);
+                sender_fabric_node_id, forward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
         writer_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
+            const auto& sender_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+            const auto& backward_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                sender_device->id(), backward_device.value()->id(), link, program, {core}, writer_rt_args);
+                sender_fabric_node_id, backward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
         tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
     }
@@ -617,13 +625,11 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         writer_forward_rt_args.push_back(false);
         writer_forward_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
+            auto src_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+            auto dst_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                sender_device->id(),
-                backward_device.value()->id(),
-                link,
-                program,
-                sender_worker_cores[1 + 2 * link],
-                writer_forward_rt_args);
+                src_fabric_node_id, dst_fabric_node_id, link, program, sender_worker_cores[1 + 2 * link], writer_forward_rt_args);
         }
         if (fuse_op) {
             fused_op_signaler_sender_workers->push_all_gather_fused_op_rt_args(writer_forward_rt_args, 1, 0, 1);
@@ -961,13 +967,19 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
 
         writer_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
+            auto src_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+            auto dst_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                sender_device->id(), forward_device.value()->id(), link, program, {core}, writer_rt_args);
+                src_fabric_node_id, dst_fabric_node_id, link, program, {core}, writer_rt_args);
         }
         writer_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
+            auto src_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+            auto dst_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                sender_device->id(), backward_device.value()->id(), link, program, {core}, writer_rt_args);
+                src_fabric_node_id, dst_fabric_node_id, link, program, {core}, writer_rt_args);
         }
 
         tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
@@ -524,18 +524,18 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
 
         writer_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
-            const auto& target_device_fabric_node_id =
+            const auto target_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
-            const auto& forward_device_fabric_node_id =
+            const auto forward_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
                 target_device_fabric_node_id, forward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
         writer_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
-            const auto& target_device_fabric_node_id =
+            const auto target_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
-            const auto& backward_device_fabric_node_id =
+            const auto backward_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
                 target_device_fabric_node_id, backward_device_fabric_node_id, link, program, {core}, writer_rt_args);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
@@ -524,13 +524,21 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
 
         writer_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
+            const auto& target_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
+            const auto& forward_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                target_device->id(), forward_device.value()->id(), link, program, {core}, writer_rt_args);
+                target_device_fabric_node_id, forward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
         writer_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
+            const auto& target_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
+            const auto& backward_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                target_device->id(), backward_device.value()->id(), link, program, {core}, writer_rt_args);
+                target_device_fabric_node_id, backward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
 
         tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_minimal_variants.cpp
@@ -447,22 +447,22 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_async_minimal_multi_cor
 
         writer_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
-            const auto& src_fabric_node_id =
+            const auto target_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
-            const auto& dst_fabric_node_id =
+            const auto forward_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                src_fabric_node_id, dst_fabric_node_id, link, program, {core}, writer_rt_args);
+                target_fabric_node_id, forward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
 
         writer_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
-            const auto& src_fabric_node_id =
+            const auto target_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
-            const auto& dst_fabric_node_id =
+            const auto backward_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                src_fabric_node_id, dst_fabric_node_id, link, program, {core}, writer_rt_args);
+                target_fabric_node_id, backward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
 
         tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_minimal_variants.cpp
@@ -447,14 +447,22 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_async_minimal_multi_cor
 
         writer_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
+            const auto& src_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
+            const auto& dst_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                target_device->id(), forward_device.value()->id(), link, program, {core}, writer_rt_args);
+                src_fabric_node_id, dst_fabric_node_id, link, program, {core}, writer_rt_args);
         }
 
         writer_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
+            const auto& src_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
+            const auto& dst_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                target_device->id(), backward_device.value()->id(), link, program, {core}, writer_rt_args);
+                src_fabric_node_id, dst_fabric_node_id, link, program, {core}, writer_rt_args);
         }
 
         tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_program_factory.cpp
@@ -486,18 +486,18 @@ tt::tt_metal::operation::ProgramWithCallbacks all_to_all_async_minimal(
         }
         writer_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
-            const auto& sender_fabric_node_id =
+            const auto sender_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
-            const auto& forward_device_fabric_node_id =
+            const auto forward_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
                 sender_fabric_node_id, forward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
         writer_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
-            const auto& sender_fabric_node_id =
+            const auto sender_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
-            const auto& backward_device_fabric_node_id =
+            const auto backward_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
                 sender_fabric_node_id, backward_device_fabric_node_id, link, program, {core}, writer_rt_args);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_program_factory.cpp
@@ -486,13 +486,21 @@ tt::tt_metal::operation::ProgramWithCallbacks all_to_all_async_minimal(
         }
         writer_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
+            const auto& sender_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+            const auto& forward_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                sender_device->id(), forward_device.value()->id(), link, program, {core}, writer_rt_args);
+                sender_fabric_node_id, forward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
         writer_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
+            const auto& sender_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+            const auto& backward_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                sender_device->id(), backward_device.value()->id(), link, program, {core}, writer_rt_args);
+                sender_fabric_node_id, backward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
         tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
@@ -766,14 +766,32 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at_program_proc
 
             writer_runtime_args.push_back(forward_fabric_connection);
             if (forward_fabric_connection) {
+                const auto& target_device_fabric_node_id =
+                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
+                const auto& forward_device_fabric_node_id =
+                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
                 tt::tt_fabric::append_fabric_connection_rt_args(
-                    target_device->id(), forward_device.value()->id(), link_idx, program, core, writer_runtime_args);
+                    target_device_fabric_node_id,
+                    forward_device_fabric_node_id,
+                    link_idx,
+                    program,
+                    core,
+                    writer_runtime_args);
             }
 
             writer_runtime_args.push_back(backward_fabric_connection);
             if (backward_fabric_connection) {
+                const auto& target_device_fabric_node_id =
+                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
+                const auto& backward_device_fabric_node_id =
+                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
                 tt::tt_fabric::append_fabric_connection_rt_args(
-                    target_device->id(), backward_device.value()->id(), link_idx, program, core, writer_runtime_args);
+                    target_device_fabric_node_id,
+                    backward_device_fabric_node_id,
+                    link_idx,
+                    program,
+                    core,
+                    writer_runtime_args);
             }
 
             link_idx++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
@@ -766,9 +766,9 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at_program_proc
 
             writer_runtime_args.push_back(forward_fabric_connection);
             if (forward_fabric_connection) {
-                const auto& target_device_fabric_node_id =
+                const auto target_device_fabric_node_id =
                     tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
-                const auto& forward_device_fabric_node_id =
+                const auto forward_device_fabric_node_id =
                     tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
                 tt::tt_fabric::append_fabric_connection_rt_args(
                     target_device_fabric_node_id,
@@ -781,9 +781,9 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at_program_proc
 
             writer_runtime_args.push_back(backward_fabric_connection);
             if (backward_fabric_connection) {
-                const auto& target_device_fabric_node_id =
+                const auto target_device_fabric_node_id =
                     tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
-                const auto& backward_device_fabric_node_id =
+                const auto backward_device_fabric_node_id =
                     tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
                 tt::tt_fabric::append_fabric_connection_rt_args(
                     target_device_fabric_node_id,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
@@ -799,9 +799,9 @@ LlamaReduceScatterCreateHeadsDeviceOperation::LlamaReduceScatterCreateHeads::cre
 
             writer_runtime_args.push_back(forward_fabric_connection);
             if (forward_fabric_connection) {
-                const auto& target_device_fabric_node_id =
+                const auto target_device_fabric_node_id =
                     tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
-                const auto& forward_device_fabric_node_id =
+                const auto forward_device_fabric_node_id =
                     tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
                 tt::tt_fabric::append_fabric_connection_rt_args(
                     target_device_fabric_node_id,
@@ -814,9 +814,9 @@ LlamaReduceScatterCreateHeadsDeviceOperation::LlamaReduceScatterCreateHeads::cre
 
             writer_runtime_args.push_back(backward_fabric_connection);
             if (backward_fabric_connection) {
-                const auto& target_device_fabric_node_id =
+                const auto target_device_fabric_node_id =
                     tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
-                const auto& backward_device_fabric_node_id =
+                const auto backward_device_fabric_node_id =
                     tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
                 tt::tt_fabric::append_fabric_connection_rt_args(
                     target_device_fabric_node_id,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
@@ -799,14 +799,32 @@ LlamaReduceScatterCreateHeadsDeviceOperation::LlamaReduceScatterCreateHeads::cre
 
             writer_runtime_args.push_back(forward_fabric_connection);
             if (forward_fabric_connection) {
+                const auto& target_device_fabric_node_id =
+                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
+                const auto& forward_device_fabric_node_id =
+                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
                 tt::tt_fabric::append_fabric_connection_rt_args(
-                    target_device->id(), forward_device.value()->id(), link_idx, program, core, writer_runtime_args);
+                    target_device_fabric_node_id,
+                    forward_device_fabric_node_id,
+                    link_idx,
+                    program,
+                    core,
+                    writer_runtime_args);
             }
 
             writer_runtime_args.push_back(backward_fabric_connection);
             if (backward_fabric_connection) {
+                const auto& target_device_fabric_node_id =
+                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
+                const auto& backward_device_fabric_node_id =
+                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
                 tt::tt_fabric::append_fabric_connection_rt_args(
-                    target_device->id(), backward_device.value()->id(), link_idx, program, core, writer_runtime_args);
+                    target_device_fabric_node_id,
+                    backward_device_fabric_node_id,
+                    link_idx,
+                    program,
+                    core,
+                    writer_runtime_args);
             }
 
             link_idx++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -321,16 +321,24 @@ tt::tt_metal::operation::ProgramWithCallbacks reduce_scatter_minimal_async_helpe
             if (core_idx % num_senders_per_link) {  // forward
                 writer_rt_args.push_back(forward_device.has_value());
                 if (forward_device.has_value()) {
+                    const auto sender_fabric_node_id =
+                        tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+                    const auto forward_device_fabric_node_id =
+                        tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
                     tt::tt_fabric::append_fabric_connection_rt_args(
-                        sender_device->id(), forward_device.value()->id(), link, program, {core}, writer_rt_args);
+                        sender_fabric_node_id, forward_device_fabric_node_id, link, program, {core}, writer_rt_args);
                 }
                 writer_rt_args.push_back(false);
             } else {
                 writer_rt_args.push_back(false);
                 writer_rt_args.push_back(backward_device.has_value());
                 if (backward_device.has_value()) {
+                    const auto sender_fabric_node_id =
+                        tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->id());
+                    const auto backward_device_fabric_node_id =
+                        tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
                     tt::tt_fabric::append_fabric_connection_rt_args(
-                        sender_device->id(), backward_device.value()->id(), link, program, {core}, writer_rt_args);
+                        sender_fabric_node_id, backward_device_fabric_node_id, link, program, {core}, writer_rt_args);
                 }
             }
             tt::tt_metal::SetRuntimeArgs(program, writer_kernel_ids[core_idx], {core}, writer_rt_args);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp
@@ -1050,9 +1050,9 @@ operation::ProgramWithCallbacks frmsnorm_multi_core_sharded(
 
             all_gather_rts.push_back(forward_device.has_value());
             if (forward_device.has_value()) {
-                const auto& target_device_fabric_node_id =
+                const auto target_device_fabric_node_id =
                     tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
-                const auto& forward_device_fabric_node_id =
+                const auto forward_device_fabric_node_id =
                     tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
                 tt::tt_fabric::append_fabric_connection_rt_args(
                     target_device_fabric_node_id, forward_device_fabric_node_id, i, program, {core}, all_gather_rts);
@@ -1060,9 +1060,9 @@ operation::ProgramWithCallbacks frmsnorm_multi_core_sharded(
 
             all_gather_rts.push_back(backward_device.has_value());
             if (backward_device.has_value()) {
-                const auto& target_device_fabric_node_id =
+                const auto target_device_fabric_node_id =
                     tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
-                const auto& backward_device_fabric_node_id =
+                const auto backward_device_fabric_node_id =
                     tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
                 tt::tt_fabric::append_fabric_connection_rt_args(
                     target_device_fabric_node_id, backward_device_fabric_node_id, i, program, {core}, all_gather_rts);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp
@@ -1050,14 +1050,22 @@ operation::ProgramWithCallbacks frmsnorm_multi_core_sharded(
 
             all_gather_rts.push_back(forward_device.has_value());
             if (forward_device.has_value()) {
+                const auto& target_device_fabric_node_id =
+                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
+                const auto& forward_device_fabric_node_id =
+                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
                 tt::tt_fabric::append_fabric_connection_rt_args(
-                    target_device->id(), forward_device.value()->id(), i, program, {core}, all_gather_rts);
+                    target_device_fabric_node_id, forward_device_fabric_node_id, i, program, {core}, all_gather_rts);
             }
 
             all_gather_rts.push_back(backward_device.has_value());
             if (backward_device.has_value()) {
+                const auto& target_device_fabric_node_id =
+                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
+                const auto& backward_device_fabric_node_id =
+                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
                 tt::tt_fabric::append_fabric_connection_rt_args(
-                    target_device->id(), backward_device.value()->id(), i, program, {core}, all_gather_rts);
+                    target_device_fabric_node_id, backward_device_fabric_node_id, i, program, {core}, all_gather_rts);
             }
         }
         // Set writer runtime args

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
@@ -584,9 +584,9 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_create_qkv_heads_minima
 
         writer_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
-            const auto& target_device_fabric_node_id =
+            const auto target_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
-            const auto& forward_device_fabric_node_id =
+            const auto forward_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
                 target_device_fabric_node_id, forward_device_fabric_node_id, link, program, {core}, writer_rt_args);
@@ -594,9 +594,9 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_create_qkv_heads_minima
 
         writer_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
-            const auto& target_device_fabric_node_id =
+            const auto target_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
-            const auto& backward_device_fabric_node_id =
+            const auto backward_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
                 target_device_fabric_node_id, backward_device_fabric_node_id, link, program, {core}, writer_rt_args);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
@@ -584,14 +584,22 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_create_qkv_heads_minima
 
         writer_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
+            const auto& target_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
+            const auto& forward_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(forward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                target_device->id(), forward_device.value()->id(), link, program, {core}, writer_rt_args);
+                target_device_fabric_node_id, forward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
 
         writer_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
+            const auto& target_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(target_device->id());
+            const auto& backward_device_fabric_node_id =
+                tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(backward_device.value()->id());
             tt::tt_fabric::append_fabric_connection_rt_args(
-                target_device->id(), backward_device.value()->id(), link, program, {core}, writer_rt_args);
+                target_device_fabric_node_id, backward_device_fabric_node_id, link, program, {core}, writer_rt_args);
         }
 
         tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);


### PR DESCRIPTION
### Ticket
[#23882 ](https://github.com/tenstorrent/tt-metal/issues/23882)

### Problem description
The current fabric API exposed to the user in `tt_metal/api/tt-metalium/fabric.hpp` to setup a fabric connection between a user kernel (writer/src) running on a tensix core and the destination chip it must write to:
```
void append_fabric_connection_rt_args(
    chip_id_t src_chip_id,
    chip_id_t dst_chip_id,
    uint32_t link_idx,
    tt::tt_metal::Program& worker_program,
    const CoreCoord& worker_core,
    std::vector<uint32_t>& worker_args,
    CoreType core_type = CoreType::WORKER);
```
In a multi-host scenario, the host deploying the writer/src kernel does not know the Physical ID of the destination chip, if this chip is mapped to another host. Additionally, the use of Physical IDs in Fabric APIs is something we want to avoid in the long term. Thus, exposed Fabric APIs should accept FabricNodeIds instead of Physical IDs.

### What's changed

First,  two changes in `tt_metal/api/tt-metalium/fabric.hpp`:

1.  A new API to access the FabricNodeId from the physical id:

```
FabricNodeId get_fabric_node_id_from_physical_chip_id(chip_id_t physical_chip_id);
```

2. Changed append_fabric_connection_rt_args to accept FabricNodeId for src and dst instead of chip_id_t
```
void append_fabric_connection_rt_args(
    const FabricNodeId& src_fabric_node_id,
    const FabricNodeId& dst_fabric_node_id,
    uint32_t link_idx,
    tt::tt_metal::Program& worker_program,
    const CoreCoord& worker_core,
    std::vector<uint32_t>& worker_args,
    CoreType core_type = CoreType::WORKER);
```
Second, the following 2 APIs inside `tt-metal/tt_metal/fabric/fabric_host_utils.hpp` were modified to accept FabricNodeId instead of chip_id_t, as part of the migration to use FabricNodeId instead of physical IDs:

```
std::vector<uint32_t> get_forwarding_link_indices_in_direction(
    const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id, RoutingDirection direction);

std::vector<uint32_t> get_forwarding_link_indices(
    const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id);
```

Third, callers of the modified APIs were adjusted accordingly to support the change.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15884151623)
- [ ] [Single-card perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/15862397926).
- [ ] New/Existing tests provide coverage for changes
- [ ] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15887270144)