### PR TITLE
Only getting active ethernet cores if there are ethernet cores defined

### DIFF
--- a/tests/tt_metal/tt_metal/device/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/device/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(
         test_device_cluster_api.cpp
         test_device_pool.cpp
         test_device.cpp
+        test_simulator_device.cpp
         test_galaxy_cluster_api.cpp
 )
 target_include_directories(

--- a/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/base.h>
+#include <gtest/gtest.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <algorithm>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/buffer_types.hpp>
+#include "impl/dispatch/command_queue_common.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/device.hpp>
+#include "device_fixture.hpp"
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/program.hpp>
+#include "impl/context/metal_context.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include <tt-metalium/utils.hpp>
+
+namespace tt::tt_metal {
+
+using namespace tt;
+using namespace tt::test_utils;
+
+class SimulatorFixture : public DeviceFixture {
+protected:
+    void SetUp() override {
+        // Check if simulator mode is enabled
+        if (!tt::tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled()) {
+            GTEST_SKIP()
+                << "Simulator mode not enabled. Set TT_METAL_SIMULATOR environment variable to run simulator tests.";
+        }
+
+        // Call parent SetUp to initialize devices
+        DeviceFixture::SetUp();
+    }
+};
+
+TEST_F(SimulatorFixture, SimulatorDeviceInitialization) {
+    // Verify that all devices are properly initialized in simulator mode
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        auto device = devices_.at(id);
+
+        // Check that device is valid
+        EXPECT_NE(device, nullptr);
+
+        // Verify device is accessible
+        EXPECT_NO_THROW({
+            auto grid_size = device->logical_grid_size();
+            auto dram_channels = device->num_dram_channels();
+            auto l1_size = device->l1_size_per_core();
+            auto dram_size = device->dram_size_per_channel();
+        });
+
+        // Test that we can access the allocator
+        EXPECT_NE(device->allocator(), nullptr);
+
+        // Verify we can get base addresses
+        EXPECT_GT(device->allocator()->get_base_allocator_addr(HalMemType::L1), 0);
+        EXPECT_GT(device->allocator()->get_base_allocator_addr(HalMemType::DRAM), 0);
+    }
+}
+}  // namespace tt::tt_metal

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1488,10 +1488,18 @@ bool ControlPlane::is_intermesh_enabled() const {
     if (not tt_metal::MetalContext::instance().hal().intermesh_eth_links_enabled()) {
         return false;
     }
-    std::vector<uint32_t> config_data(1, 0);
+
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     auto first_chip_id = *(cluster.all_pci_chip_ids().begin());
-    auto first_eth_core = cluster.get_soc_desc(first_chip_id).logical_eth_core_to_chan_map.begin()->first;
+
+    // Check if there are any ethernet cores available on the first chip
+    const auto& soc_desc = cluster.get_soc_desc(first_chip_id);
+    if (soc_desc.logical_eth_core_to_chan_map.empty()) {
+        return false;
+    }
+
+    std::vector<uint32_t> config_data(1, 0);
+    auto first_eth_core = soc_desc.logical_eth_core_to_chan_map.begin()->first;
     tt_cxy_pair virtual_eth_core(
         first_chip_id,
         cluster.get_virtual_coordinate_from_logical_coordinates(first_chip_id, first_eth_core, CoreType::ETH));
@@ -1551,6 +1559,12 @@ std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(
     std::unordered_set<CoreCoord> active_ethernet_cores;
     const auto& cluster_desc = cluster.get_cluster_desc();
     const auto& soc_desc = cluster.get_soc_desc(chip_id);
+
+    // Check if there are any ethernet cores available on this chip
+    if (soc_desc.logical_eth_core_to_chan_map.empty()) {
+        return active_ethernet_cores;  // Return empty set if no ethernet cores
+    }
+
     if (cluster.arch() == ARCH::BLACKHOLE) {
         // Can't just use `get_ethernet_cores_grouped_by_connected_chips` because there are some active ethernet cores
         // without links. Only risc1 on these cores is available for Metal and should not be classified as idle
@@ -1617,6 +1631,12 @@ std::unordered_set<CoreCoord> ControlPlane::get_inactive_ethernet_cores(chip_id_
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     std::unordered_set<CoreCoord> active_ethernet_cores = this->get_active_ethernet_cores(chip_id);
     std::unordered_set<CoreCoord> inactive_ethernet_cores;
+
+    // Check if there are any ethernet cores available on this chip
+    if (cluster.get_soc_desc(chip_id).logical_eth_core_to_chan_map.empty()) {
+        return inactive_ethernet_cores;  // Return empty set if no ethernet cores
+    }
+
     for (const auto& [eth_core, chan] : cluster.get_soc_desc(chip_id).logical_eth_core_to_chan_map) {
         if (active_ethernet_cores.find(eth_core) == active_ethernet_cores.end()) {
             inactive_ethernet_cores.insert(eth_core);

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1632,11 +1632,6 @@ std::unordered_set<CoreCoord> ControlPlane::get_inactive_ethernet_cores(chip_id_
     std::unordered_set<CoreCoord> active_ethernet_cores = this->get_active_ethernet_cores(chip_id);
     std::unordered_set<CoreCoord> inactive_ethernet_cores;
 
-    // Check if there are any ethernet cores available on this chip
-    if (cluster.get_soc_desc(chip_id).logical_eth_core_to_chan_map.empty()) {
-        return inactive_ethernet_cores;  // Return empty set if no ethernet cores
-    }
-
     for (const auto& [eth_core, chan] : cluster.get_soc_desc(chip_id).logical_eth_core_to_chan_map) {
         if (active_ethernet_cores.find(eth_core) == active_ethernet_cores.end()) {
             inactive_ethernet_cores.insert(eth_core);

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -171,8 +171,14 @@ const core_descriptor_t& get_core_descriptor_config(
 
     CoreCoord grid_size =
         tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
-    auto logical_active_eth_cores =
-        tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id);
+
+    // Check if there are any ethernet cores defined in the SoC descriptor before getting active ethernet cores
+    std::unordered_set<CoreCoord> logical_active_eth_cores;
+    const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
+    if (!soc_desc.logical_eth_core_to_chan_map.empty()) {
+        logical_active_eth_cores =
+            tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id);
+    }
 
     for (const auto& core_node : desc_yaml[dispatch_cores_string]) {
         RelativeCoreCoord coord = {};

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -171,14 +171,8 @@ const core_descriptor_t& get_core_descriptor_config(
 
     CoreCoord grid_size =
         tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
-
-    // Check if there are any ethernet cores defined in the SoC descriptor before getting active ethernet cores
-    std::unordered_set<CoreCoord> logical_active_eth_cores;
-    const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
-    if (!soc_desc.logical_eth_core_to_chan_map.empty()) {
-        logical_active_eth_cores =
-            tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id);
-    }
+    auto logical_active_eth_cores =
+        tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id);
 
     for (const auto& core_node : desc_yaml[dispatch_cores_string]) {
         RelativeCoreCoord coord = {};


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23832)

### Problem description
Dispatcher Core Manager is looking for active ethernet cores in single device simulator runs even though they don't exist.

### What's changed
- [ ] Check SoC descriptor for ethernet cores before looking for active ethernet cores in `get_core_descriptor_config`

### Checklist
- [x] https://github.com/tenstorrent/tt-metal/actions/runs/15903213325
- [ ] https://github.com/tenstorrent/tt-metal/actions/runs/15903237531
- [x] https://github.com/tenstorrent/tt-metal/actions/runs/15903259665 (Failed due to unrelated changes)