### PR TITLE
#0: Use a unified Tensor constructor that accepts `mesh_mapper` argument 

### DIFF
--- a/ttnn/api/ttnn/tensor/serialization.hpp
+++ b/ttnn/api/ttnn/tensor/serialization.hpp
@@ -26,7 +26,6 @@ MemoryConfig load_memory_config(const std::string& file_name);
 // 1. Tensor metadata is serialized and stored as file "header", while the rest of the file is used as a data region for
 //    tensor data.
 // 2. Metadata includes data offsets and sizes for tensor / tensor shards (multi device context).
-// TODO: #22259 - the format is not yet finalized, and is not stable. Avoid using it in production.
 void dump_tensor_flatbuffer(const std::string& file_name, const Tensor& tensor);
 Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::MeshDevice* device = nullptr);
 

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -52,7 +52,7 @@ class MultiDeviceHostStorage {
 public:
     // Constructor that creates a linearized distributed host buffer from a vector of host buffers.
     // The buffer is re-shaped upon a write to device, to fit the actual shape of the device.
-    // TODO: #22169 - Remove this once there are no more usages of this constructor.
+    // TODO: #24115 - Remove this once there are no more usages of this constructor.
     explicit MultiDeviceHostStorage(std::vector<HostBuffer> buffers);
 
     explicit MultiDeviceHostStorage(DistributedHostBuffer buffer);

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -441,7 +441,7 @@ TensorToMesh TensorToMesh::create(const MeshDevice& mesh_device, const MeshMappe
         }
     }();
 
-    // TODO: #22258 - `DistributedTensorConfig` will be replaced by distributed host buffer, which can be used directly
+    // TODO: #24115 - `DistributedTensorConfig` will be replaced by distributed host buffer, which can be used directly
     // in Tensor storage.
     const auto distributed_tensor_config = [&config, &distributed_shape]() -> tt::tt_metal::DistributedTensorConfig {
         if (std::all_of(config.placements.begin(), config.placements.end(), [](const auto& p) {

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -203,7 +203,7 @@ Tensor from_flatbuffer(
                     coord, [host_buffer = std::move(host_buffer)]() mutable { return std::move(host_buffer); });
             }
 
-            // TODO: #22258 - `DistributedTensorConfig` will be replaced by distributed host buffer, which can be used
+            // TODO: #24115 - `DistributedTensorConfig` will be replaced by distributed host buffer, which can be used
             // directly in Tensor storage.
             const auto strategy = [&]() -> tt::tt_metal::DistributedTensorConfig {
                 std::unordered_set<const std::byte*> buffer_addresses;

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -782,7 +782,7 @@ DeviceStorage to_device_mesh_buffer(
                     return shard_to_mesh_buffer(storage.distributed_buffer(), mesh_buffer, cq_id);
                 } else {
                     // Reshape distributed host buffer.
-                    // TODO: #22169 - there are 2 reasons for this code path - legacy serialization path that stored
+                    // TODO: #24115 - there are 2 reasons for this code path - legacy serialization path that stored
                     // multi device host tensors without the necessary metadata, and `aggregate_as_tensor` calls that
                     // similarly lack the metadata to properly distribute the shards across the mesh.
                     auto* mesh_device = mesh_buffer->device();

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -852,59 +852,6 @@ void pytensor_module(py::module& m_tensor) {
                     )
             )doc")
         .def(
-            py::init<>([](const py::object& tensor,
-                          std::optional<DataType> data_type,
-                          const distributed::TensorToMesh* mesh_mapper,
-                          const std::optional<Tile>& optional_tile,
-                          std::optional<Layout> optional_layout,
-                          const std::optional<MemoryConfig>& optional_memory_config,
-                          std::optional<float> pad_value) {
-                return CMAKE_UNIQUE_NAMESPACE::convert_python_tensor_to_tt_tensor(
-                    tensor,
-                    data_type,
-                    optional_layout,
-                    optional_tile,
-                    optional_memory_config.value_or(MemoryConfig{}),
-                    /*device=*/nullptr,
-                    ttnn::DefaultQueueId,
-                    pad_value.value_or(0.0f),
-                    mesh_mapper);
-            }),
-            py::arg("tensor"),
-            py::arg("data_type") = std::nullopt,
-            py::arg("mesh_mapper") = nullptr,
-            py::arg("tile") = std::nullopt,
-            py::arg("layout") = std::nullopt,
-            py::arg("mem_config") = std::nullopt,
-            py::arg("pad_value") = std::nullopt,
-            py::return_value_policy::move,
-            R"doc(
-                +--------------+--------------------------------+
-                | Argument     | Description                    |
-                +==============+================================+
-                | tensor       | Pytorch or Numpy Tensor        |
-                +--------------+--------------------------------+
-                | data_type    | TT Tensor data type (optional) |
-                +--------------+--------------------------------+
-                | mesh_mapper  | TT-NN Mesh Mapper (optional)    |
-                +--------------+--------------------------------+
-                | tile         | TT Tile Spec (optional)        |
-                +--------------+--------------------------------+
-                | layout       | TT Layout (optional)           |
-                +--------------+--------------------------------+
-                | mem_config   | TT Memory Config (optional)    |
-                +--------------+--------------------------------+
-                | pad_value    | Padding value (optional)       |
-                +--------------+--------------------------------+
-
-                Example of creating a TT Tensor that uses torch.Tensor's storage as its own storage:
-
-                .. code-block:: python
-
-                    py_tensor = torch.randn((1, 1, 32, 32))
-                    ttnn.Tensor(py_tensor)
-            )doc")
-        .def(
             py::init<>([](const py::object& python_tensor,
                           std::optional<DataType> data_type,
                           std::optional<MeshDevice*> device,
@@ -912,7 +859,8 @@ void pytensor_module(py::module& m_tensor) {
                           const std::optional<MemoryConfig>& mem_config,
                           const std::optional<Tile>& tile,
                           ttnn::QueueId cq_id,
-                          std::optional<float> pad_value) {
+                          std::optional<float> pad_value,
+                          const distributed::TensorToMesh* mesh_mapper) {
                 return CMAKE_UNIQUE_NAMESPACE::convert_python_tensor_to_tt_tensor(
                     python_tensor,
                     data_type,
@@ -922,7 +870,7 @@ void pytensor_module(py::module& m_tensor) {
                     device.value_or(nullptr),
                     cq_id,
                     pad_value.value_or(0.0f),
-                    /*mesh_mapper=*/nullptr);
+                    mesh_mapper);
             }),
             py::arg("tensor"),
             py::arg("data_type") = std::nullopt,
@@ -932,6 +880,7 @@ void pytensor_module(py::module& m_tensor) {
             py::arg("tile").noconvert() = std::nullopt,
             py::arg("cq_id") = ttnn::DefaultQueueId,
             py::arg("pad_value") = std::nullopt,
+            py::arg("mesh_mapper") = nullptr,
             py::return_value_policy::move,
             R"doc(
                 +--------------+--------------------------------+
@@ -952,6 +901,8 @@ void pytensor_module(py::module& m_tensor) {
                 | cq_id        | TT Command Queue ID (optional) |
                 +--------------+--------------------------------+
                 | pad_value    | Padding value (optional)       |
+                +--------------+--------------------------------+
+                | mesh_mapper  | TT-NN Mesh Mapper (optional)    |
                 +--------------+--------------------------------+
 
                 Example of creating a TT Tensor from numpy tensor:

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -194,8 +194,8 @@ def create_mesh_device(*args, **kwargs):
         close_mesh_device(mesh_device)
 
 
-# TODO: #22258 - Temporary stubs to accomodate migration of Python-based sharding to C++.
-# Remove once migration is complete.
+# Temporary stubs to accomodate migration of Python-based sharding / concatenation to C++.
+# TODO: #24114 - When migration of concatenation is complete, remove these stubs.
 TensorToMesh = ttnn.CppTensorToMesh
 
 

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -281,26 +281,20 @@ def from_torch(
         if layout != ttnn.TILE_LAYOUT:
             raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires TILE_LAYOUT!")
 
-    if memory_config is not None:
-        if device is None:
-            raise RuntimeError("ttnn.from_torch: device must be specified when memory_config is specified")
+    if memory_config is not None and device is None:
+        raise RuntimeError("ttnn.from_torch: device must be specified when memory_config is specified")
 
-    if mesh_mapper:
-        # TODO: #22258 - supply device to pytensor constructor directly.
-        tensor = ttnn.Tensor(
-            tensor,
-            dtype,
-            mesh_mapper.unwrap() if isinstance(mesh_mapper, ttnn.ReplicateTensorToMeshWrapper) else mesh_mapper,
-            tile,
-            layout,
-            memory_config,
-            pad_value,
-        )
-        if device is not None:
-            tensor = ttnn.to_device(tensor, device, memory_config=memory_config, cq_id=cq_id)
-        return tensor
-    else:
-        return ttnn.Tensor(tensor, dtype, device, layout, memory_config, tile, cq_id, pad_value)
+    return ttnn.Tensor(
+        tensor=tensor,
+        dtype=dtype,
+        device=device,
+        mesh_mapper=mesh_mapper.unwrap() if isinstance(mesh_mapper, ttnn.ReplicateTensorToMeshWrapper) else mesh_mapper,
+        layout=layout,
+        memory_config=memory_config,
+        tile=tile,
+        cq_id=cq_id,
+        pad_value=pad_value,
+    )
 
 
 def _golden_function(tensor, *, torch_rank=None, **kwargs):

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -286,14 +286,14 @@ def from_torch(
 
     return ttnn.Tensor(
         tensor=tensor,
-        dtype=dtype,
+        data_type=dtype,
         device=device,
-        mesh_mapper=mesh_mapper.unwrap() if isinstance(mesh_mapper, ttnn.ReplicateTensorToMeshWrapper) else mesh_mapper,
         layout=layout,
-        memory_config=memory_config,
+        mem_config=memory_config,
         tile=tile,
         cq_id=cq_id,
         pad_value=pad_value,
+        mesh_mapper=mesh_mapper.unwrap() if isinstance(mesh_mapper, ttnn.ReplicateTensorToMeshWrapper) else mesh_mapper,
     )
 
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Address a todo for using a unified tensor constructor with `mesh_mapper` argument.

### What's changed
Remove the unnecessary ctor.

Close some todos, redirect to #24115.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15863461153)
- [x] [Single device perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/15863469603)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15863464775)
- [x] New/Existing tests provide coverage for changes