### PR TITLE
Added get_device_fabric_node_id API in MeshDevice

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -45,6 +45,7 @@ TEST(MeshDeviceInitTest, Init1x1Mesh) {
 }
 
 using MeshDeviceTest = T3000MeshDeviceFixture;
+using MeshDeviceTestSuite = GenericMeshDeviceFixture;
 
 TEST_F(MeshDeviceTest, SystemMeshTearDownWithoutClose) {
     auto& sys = SystemMesh::instance();
@@ -136,5 +137,19 @@ TEST(GetOptimalDramBankToLogicalWorkerAssignmentAPI, UnitMeshes) {
     }
 }
 
+TEST_F(MeshDeviceTestSuite, CheckFabricNodeIds) {
+    // Check that the fabric node IDs are correctly assigned to the devices in the mesh. Only works for 2D meshes
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    EXPECT_EQ(mesh_device_->shape().dims(), 2);
+    for (size_t i = 0; i < mesh_device_->shape()[0]; ++i) {
+        for (size_t j = 0; j < mesh_device_->shape()[1]; ++j) {
+            tt_fabric::FabricNodeId fabric_node_id = mesh_device_->get_device_fabric_node_id(MeshCoordinate{i, j});
+            EXPECT_EQ(
+                control_plane.get_fabric_node_id_from_physical_chip_id(
+                    mesh_device_->get_device(MeshCoordinate{i, j})->id()),
+                fabric_node_id);
+        }
+    }
+}
 }  // namespace
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -49,6 +49,9 @@ struct ProgramCache;
 }  // namespace tt_metal
 }  // namespace tt
 
+namespace tt::tt_fabric {
+class FabricNodeId;
+}
 namespace tt::tt_metal {
 
 class SubDeviceManagerTracker;
@@ -258,6 +261,7 @@ public:
     std::vector<IDevice*> get_devices() const;
     IDevice* get_device(chip_id_t physical_device_id) const;
     IDevice* get_device(const MeshCoordinate& coord) const;
+    tt_fabric::FabricNodeId get_device_fabric_node_id(const MeshCoordinate& coord) const;
 
     DeviceIds get_device_ids() const;
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -393,6 +393,11 @@ IDevice* MeshDevice::get_device(size_t row_idx, size_t col_idx) const {
 
 IDevice* MeshDevice::get_device(const MeshCoordinate& coord) const { return view_->get_device(coord); }
 
+tt_fabric::FabricNodeId MeshDevice::get_device_fabric_node_id(const MeshCoordinate& coord) const {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    return control_plane.get_fabric_node_id_from_physical_chip_id(view_->get_device(coord)->id());
+}
+
 MeshCommandQueue& MeshDevice::mesh_command_queue(std::size_t cq_id) const {
     TT_FATAL(cq_id < mesh_command_queues_.size(), "cq_id {} is out of range", cq_id);
     return *(mesh_command_queues_[cq_id]);


### PR DESCRIPTION
### Ticket
[#23755 ](https://github.com/tenstorrent/tt-metal/issues/23755)

### Problem description

With TT-Fabric being exposed to TTNN and op developers, we want the ability to look up the FabricNodeId for a particular MeshCoordinate. TT-Fabric host and device APIs rely on the FabricNodeId, and hence this information will be required by Op developers as they start writing more complex CCL ops.


### What's changed

Created a new API in `tt-metal/tt_metal/api/tt-metalium/mesh_device.hpp`, along with a basic test:
```
tt_fabric::FabricNodeId get_device_fabric_node_id(const MeshCoordinate& coord) const;
```


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15838070248) CI passes
- [ ] [Single-card perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/15861872228)
- [ ] New/Existing tests provide coverage for changes
- [ ] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15838067803)