### PR TITLE
MeshWorkload implementation for CB EnqueueProgram test

### DIFF
--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -76,7 +76,7 @@ protected:
     void CreateDevice(const size_t trace_region_size) { this->create_device(trace_region_size); }
 };
 
-class MeshCommandQueueSingleCardFixture : public DispatchFixture {
+class UnitMeshCommandQueueFixture : public DispatchFixture {
 protected:
     void SetUp() override {
         if (!this->validate_dispatch_mode()) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -517,7 +517,7 @@ bool test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(
 namespace basic_tests {
 namespace dram_tests {
 
-TEST_F(MeshCommandQueueSingleCardFixture, WriteOneTileToDramBank0) {
+TEST_F(UnitMeshCommandQueueFixture, WriteOneTileToDramBank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::DRAM};
     for (auto device : devices_) {
         log_info(tt::LogTest, "Running On Device {}", device->id());
@@ -526,7 +526,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, WriteOneTileToDramBank0) {
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, WriteOneTileToAllDramBanks) {
+TEST_F(UnitMeshCommandQueueFixture, WriteOneTileToAllDramBanks) {
     for (auto device : devices_) {
         TestBufferConfig config = {
             .num_pages = uint32_t(device->allocator()->get_num_banks(BufferType::DRAM)),
@@ -538,7 +538,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, WriteOneTileToAllDramBanks) {
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
+TEST_F(UnitMeshCommandQueueFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
     constexpr uint32_t num_round_robins = 2;
     for (auto device : devices_) {
         TestBufferConfig config = {
@@ -550,7 +550,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, WriteOneTileAcrossAllDramBanksTwiceRou
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, Sending131072Pages) {
+TEST_F(UnitMeshCommandQueueFixture, Sending131072Pages) {
     for (auto device : devices_) {
         TestBufferConfig config = {.num_pages = 131072, .page_size = 128, .buftype = BufferType::DRAM};
         log_info(tt::LogTest, "Running On Device {}", device->id());
@@ -559,7 +559,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, Sending131072Pages) {
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TestPageLargerThanAndUnalignedToTransferPage) {
+TEST_F(UnitMeshCommandQueueFixture, TestPageLargerThanAndUnalignedToTransferPage) {
     constexpr uint32_t num_round_robins = 2;
     for (auto device : devices_) {
         TestBufferConfig config = {
@@ -571,7 +571,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TestPageLargerThanAndUnalignedToTransf
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TestSinglePageLargerThanMaxPrefetchCommandSize) {
+TEST_F(UnitMeshCommandQueueFixture, TestSinglePageLargerThanMaxPrefetchCommandSize) {
     for (auto device : devices_) {
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -582,7 +582,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TestSinglePageLargerThanMaxPrefetchCom
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSize) {
+TEST_F(UnitMeshCommandQueueFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSize) {
     for (auto device : devices_) {
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -614,7 +614,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefet
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TestSingleUnalignedPageLargerThanMaxPrefetchCommandSize) {
+TEST_F(UnitMeshCommandQueueFixture, TestSingleUnalignedPageLargerThanMaxPrefetchCommandSize) {
     for (auto device : devices_) {
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -625,7 +625,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TestSingleUnalignedPageLargerThanMaxPr
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSize) {
+TEST_F(UnitMeshCommandQueueFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSize) {
     for (auto device : devices_) {
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -657,7 +657,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestMultipleUnalignedPagesLargerThan
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TestNon32BAlignedPageSizeForDram) {
+TEST_F(UnitMeshCommandQueueFixture, TestNon32BAlignedPageSizeForDram) {
     TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::DRAM};
 
     for (auto device : devices_) {
@@ -666,7 +666,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TestNon32BAlignedPageSizeForDram) {
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TestNon32BAlignedPageSizeForDram2) {
+TEST_F(UnitMeshCommandQueueFixture, TestNon32BAlignedPageSizeForDram2) {
     // From stable diffusion read buffer
     TestBufferConfig config = {.num_pages = 8 * 1024, .page_size = 80, .buftype = BufferType::DRAM};
 
@@ -695,7 +695,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestWrapHostHugepageOnEnqueueReadBuf
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
+TEST_F(UnitMeshCommandQueueFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
     for (auto device : this->devices_) {
         log_info(tt::LogTest, "Running On Device {}", device->id());
         uint32_t page_size = 2048;
@@ -1223,7 +1223,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestMultipleNonOverlappingWritesShar
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeForL1) {
+TEST_F(UnitMeshCommandQueueFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeForL1) {
     for (auto device : devices_) {
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -1234,7 +1234,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TestMultiplePagesLargerThanMaxPrefetch
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TestSingleUnalignedPageLargerThanMaxPrefetchCommandSizeForL1) {
+TEST_F(UnitMeshCommandQueueFixture, TestSingleUnalignedPageLargerThanMaxPrefetchCommandSizeForL1) {
     for (auto device : devices_) {
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -1245,7 +1245,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TestSingleUnalignedPageLargerThanMaxPr
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeForL1) {
+TEST_F(UnitMeshCommandQueueFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeForL1) {
     for (auto device : devices_) {
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -1365,7 +1365,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBufferLargeOffsetFor
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, WriteOneTileToL1Bank0) {
+TEST_F(UnitMeshCommandQueueFixture, WriteOneTileToL1Bank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::L1};
     for (auto device : devices_) {
         local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
@@ -1373,7 +1373,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, WriteOneTileToL1Bank0) {
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, WriteOneTileToAllL1Banks) {
+TEST_F(UnitMeshCommandQueueFixture, WriteOneTileToAllL1Banks) {
     for (auto device : devices_) {
         auto compute_with_storage_grid = device->compute_with_storage_grid_size();
         TestBufferConfig config = {
@@ -1386,7 +1386,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, WriteOneTileToAllL1Banks) {
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, WriteOneTileToAllL1BanksTwiceRoundRobin) {
+TEST_F(UnitMeshCommandQueueFixture, WriteOneTileToAllL1BanksTwiceRoundRobin) {
     for (auto device : devices_) {
         auto compute_with_storage_grid = device->compute_with_storage_grid_size();
         TestBufferConfig config = {
@@ -1399,7 +1399,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, WriteOneTileToAllL1BanksTwiceRoundRobi
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TestNon32BAlignedPageSizeForL1) {
+TEST_F(UnitMeshCommandQueueFixture, TestNon32BAlignedPageSizeForL1) {
     TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::L1};
 
     for (auto device : devices_) {
@@ -1435,7 +1435,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestBackToBackNon32BAlignedPageSize)
 }
 
 // This case was failing for FD v1.3 design
-TEST_F(MeshCommandQueueSingleCardFixture, TestLargeBuffer4096BPageSize) {
+TEST_F(UnitMeshCommandQueueFixture, TestLargeBuffer4096BPageSize) {
     constexpr BufferType buff_type = BufferType::L1;
 
     for (auto device : devices_) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1050,7 +1050,7 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestArbiterDoesNotHang) {
 }  // namespace compiler_workaround_hardware_bug_tests
 namespace single_core_tests {
 
-TEST_F(MeshCommandQueueSingleCardFixture, TensixTestSingleCbConfigCorrectlySentSingleCore) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestSingleCbConfigCorrectlySentSingleCore) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
@@ -1063,7 +1063,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TensixTestSingleCbConfigCorrectlySentS
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TensixTestMultiCbSeqConfigCorrectlySentSingleCore) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCbSeqConfigCorrectlySentSingleCore) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
@@ -1080,7 +1080,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TensixTestMultiCbSeqConfigCorrectlySen
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TensixTestMultiCbRandomConfigCorrectlySentSingleCore) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCbRandomConfigCorrectlySentSingleCore) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
@@ -1153,7 +1153,7 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestMultiCBSharedAddressSpace
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TensixTestSingleCbConfigCorrectlyUpdateSizeSentSingleCore) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestSingleCbConfigCorrectlyUpdateSizeSentSingleCore) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
@@ -1167,7 +1167,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TensixTestSingleCbConfigCorrectlyUpdat
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TensixTestSingleSemaphoreConfigCorrectlySentSingleCore) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestSingleSemaphoreConfigCorrectlySentSingleCore) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
@@ -1317,7 +1317,7 @@ TEST_F(MultiCommandQueueOnFabricMultiDeviceFixture, TensixTestBasicDispatchFunct
 }  // end namespace single_core_tests
 
 namespace multicore_tests {
-TEST_F(MeshCommandQueueSingleCardFixture, TensixTestAllCbConfigsCorrectlySentMultiCore) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestAllCbConfigsCorrectlySentMultiCore) {
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
     std::vector<CBConfig> cb_config_vector(NUM_CIRCULAR_BUFFERS, cb_config);
@@ -1337,7 +1337,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TensixTestAllCbConfigsCorrectlySentMul
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TensixTestAllCbConfigsCorrectlySentUpdateSizeMultiCore) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestAllCbConfigsCorrectlySentUpdateSizeMultiCore) {
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
     std::vector<CBConfig> cb_config_vector(NUM_CIRCULAR_BUFFERS, cb_config);
@@ -1358,7 +1358,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TensixTestAllCbConfigsCorrectlySentUpd
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TensixTestMultiCbConfigsCorrectlySentUpdateSizeMultiCore) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCbConfigsCorrectlySentUpdateSizeMultiCore) {
     CBConfig cb_config_0 = {.cb_id = 0, .num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
     CBConfig cb_config_1 = {.cb_id = 1, .num_pages = 2, .page_size = 4096, .data_format = tt::DataFormat::Float16_b};
     CBConfig cb_config_2 = {.cb_id = 2, .num_pages = 2, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
@@ -1379,7 +1379,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TensixTestMultiCbConfigsCorrectlySentU
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TensixTestAllCbConfigsCorrectlySentMultipleCoreRanges) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestAllCbConfigsCorrectlySentMultipleCoreRanges) {
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
     std::vector<CBConfig> cb_config_vector(NUM_CIRCULAR_BUFFERS, cb_config);
@@ -1402,7 +1402,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TensixTestAllCbConfigsCorrectlySentMul
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TensixTestAllCbConfigsCorrectlySentUpdateSizeMultipleCoreRanges) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestAllCbConfigsCorrectlySentUpdateSizeMultipleCoreRanges) {
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
     std::vector<CBConfig> cb_config_vector(NUM_CIRCULAR_BUFFERS, cb_config);
@@ -1426,7 +1426,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TensixTestAllCbConfigsCorrectlySentUpd
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TensixTestMultiCbConfigsCorrectlySentUpdateSizeMultipleCoreRanges) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCbConfigsCorrectlySentUpdateSizeMultipleCoreRanges) {
     CBConfig cb_config_0 = {.cb_id = 0, .num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
     CBConfig cb_config_1 = {.cb_id = 1, .num_pages = 2, .page_size = 4096, .data_format = tt::DataFormat::Float16_b};
     CBConfig cb_config_2 = {.cb_id = 2, .num_pages = 2, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
@@ -1450,7 +1450,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TensixTestMultiCbConfigsCorrectlySentU
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TensixTestAllSemConfigsCorrectlySentMultiCore) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestAllSemConfigsCorrectlySentMultiCore) {
     for (auto device : devices_) {
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
 
@@ -1463,7 +1463,7 @@ TEST_F(MeshCommandQueueSingleCardFixture, TensixTestAllSemConfigsCorrectlySentMu
     }
 }
 
-TEST_F(MeshCommandQueueSingleCardFixture, TensixTestAllSemaphoreConfigsCorrectlySentMultipleCoreRanges) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestAllSemaphoreConfigsCorrectlySentMultipleCoreRanges) {
     for (auto device : devices_) {
         CoreRange first_cr({0, 0}, {1, 1});
 


### PR DESCRIPTION
### Problem description
Tests need to be migrated from `Programs` to `MeshWorkloads`
### What's changed
`test_dummy_EnqueueProgram_with_cbs` and `test_dummy_EnqueueProgram_with_cbs_update_size` have been updated to use `MeshWorkloads`.  All tests involving CBs pass successfully. Also changed fixture name `MeshCommandQueueSingleCardFixture` to `UnitMeshCommandQueueFixture`.
### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes