### PR TITLE
Add Dispatch on 2D Fabric

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1317,7 +1317,8 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestRuntimeArgsCorrectlySentS
 auto CommandQueueFabricConfigsToTest = ::testing::Values(
     tt::tt_metal::FabricConfig::FABRIC_1D,
     tt::tt_metal::FabricConfig::FABRIC_1D_RING,
-    tt::tt_metal::FabricConfig::FABRIC_2D);
+    tt::tt_metal::FabricConfig::FABRIC_2D,
+    tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC);
 
 INSTANTIATE_TEST_SUITE_P(CommandQueue, CommandQueueOnFabricMultiDeviceFixture, CommandQueueFabricConfigsToTest);
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -360,7 +360,8 @@ bool test_dummy_EnqueueProgram_with_runtime_args(
     uint32_t num_runtime_args_dm0,
     uint32_t num_runtime_args_dm1,
     uint32_t num_runtime_args_compute,
-    uint32_t num_iterations) {
+    uint32_t num_iterations,
+    bool do_checks = true) {
     Program program;
     bool pass = true;
 
@@ -431,6 +432,11 @@ bool test_dummy_EnqueueProgram_with_runtime_args(
         EnqueueProgram(cq, program, false);
     }
     Finish(cq);
+
+    // Early return to skip slow dispatch path
+    if (!do_checks) {
+        return pass;
+    }
 
     for (const CoreRange& core_range : program_config.cr_set.ranges()) {
         for (const CoreCoord& core_coord : core_range) {
@@ -985,25 +991,51 @@ void test_basic_dispatch_functions(IDevice* device, int cq_id) {
 
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
 
-    log_info(tt::LogTest, "Running On Device {}", device->id());
+    log_info(tt::LogTest, "Running On Device {} CQ{}", device->id(), cq_id);
 
-    std::vector<uint32_t> src_data(k_DataSize / sizeof(uint32_t));
+    // Alternate write patterns
+    std::vector<uint32_t> src_data_1(k_DataSize / sizeof(uint32_t));
+    std::vector<uint32_t> src_data_2(k_DataSize / sizeof(uint32_t));
     for (int i = 0; i < k_DataSize / sizeof(uint32_t); ++i) {
-        src_data[i] = (device->id() + 1) * 0xdeadbeef;
+        src_data_1[i] = (device->id() + rand()) * 0xdeadbeef;
+        src_data_2[i] = (device->id() + rand()) * 0xabcd1234;
     }
     auto buffer = CreateBuffer(InterleavedBufferConfig{device, k_DataSize, k_PageSize, BufferType::L1});
+    auto dram_buffer = CreateBuffer(InterleavedBufferConfig{device, k_DataSize, k_PageSize, BufferType::DRAM});
     auto& cq = device->command_queue(cq_id);
     for (int iteration = 0; iteration < k_Iterations; ++iteration) {
         for (int i = 0; i < k_LoopPerDev; ++i) {
             EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(
-                device, cq, dummy_program_config, 24, 12, 15, k_LoopPerDev));
-            EnqueueWriteBuffer(cq, *buffer, src_data, false);
+                device, cq, dummy_program_config, 24, 12, 15, k_LoopPerDev, false));
 
             std::vector<uint32_t> dst_data;
-            EnqueueReadBuffer(cq, *buffer, dst_data, true);
-            EXPECT_EQ(src_data, dst_data);
+            if (i & 1) {
+                EnqueueWriteBuffer(cq, *buffer, src_data_1, false);
+                EnqueueReadBuffer(cq, *buffer, dst_data, true);
+                EXPECT_EQ(src_data_1, dst_data);
+            } else {
+                EnqueueWriteBuffer(cq, *dram_buffer, src_data_2, false);
+                EnqueueReadBuffer(cq, *dram_buffer, dst_data, true);
+                EXPECT_EQ(src_data_2, dst_data);
+            }
         }
     }
+
+    // non blocking fast data movement APIs
+    for (int iteration = 0; iteration < k_Iterations; ++iteration) {
+        for (int i = 0; i < k_LoopPerDev; ++i) {
+            EnqueueWriteBuffer(cq, *buffer, src_data_1, false);
+        }
+    }
+
+    std::vector<uint32_t> dst_data;
+    for (int iteration = 0; iteration < k_Iterations; ++iteration) {
+        for (int i = 0; i < k_LoopPerDev; ++i) {
+            EnqueueReadBuffer(cq, *buffer, dst_data, false);
+        }
+    }
+
+    Finish(cq);
 }
 
 }  // namespace local_test_functions

--- a/tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp
+++ b/tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp
@@ -26,7 +26,8 @@ WorkerToFabricMuxSender<FABRIC_MUX_CHANNEL_NUM_BUFFERS> build_connection_to_fabr
     size_t fabric_mux_buffer_index_address,
     uint32_t local_flow_control_address,
     uint32_t local_teardown_address,
-    uint32_t local_buffer_index_address) {
+    uint32_t local_buffer_index_address,
+    uint32_t direction = 0) {
     auto get_mux_channel_stream_id_from_channel_id = [](uint8_t fabric_mux_channel_id) -> uint32_t {
         return fabric_mux_channel_id;
     };
@@ -35,8 +36,8 @@ WorkerToFabricMuxSender<FABRIC_MUX_CHANNEL_NUM_BUFFERS> build_connection_to_fabr
 
     auto mux_channel_credits_stream_id = get_mux_channel_stream_id_from_channel_id(fabric_mux_channel_id);
     return WorkerToFabricMuxSender<FABRIC_MUX_CHANNEL_NUM_BUFFERS>(
-        true, /* ignored, connected_to_persistent_fabric */
-        0,    /* ignored, direction */
+        true,      /* ignored, connected_to_persistent_fabric */
+        direction, /* ignored, direction */
         fabric_mux_x,
         fabric_mux_y,
         fabric_mux_channel_base_address,

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -214,8 +214,12 @@ void DispatchKernel::GenerateStaticConfigs() {
         static_config_.is_2d_fabric =
             tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context().get_fabric_topology() ==
             tt_fabric::Topology::Mesh;
+        static_config_.is_2d_fabric_dynamic =
+            tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context().get_fabric_config() ==
+            tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC;
     } else {
         static_config_.is_2d_fabric = false;
+        static_config_.is_2d_fabric_dynamic = false;
     }
 }
 
@@ -534,6 +538,9 @@ void DispatchKernel::CreateKernel() {
         defines["FABRIC_RELAY"] = "1";
         if (static_config_.is_2d_fabric.value_or(false)) {
             defines["FABRIC_2D"] = "1";
+        }
+        if (static_config_.is_2d_fabric_dynamic.value_or(false)) {
+            defines["FABRIC_2D_DYNAMIC"] = "1";
         }
     }
     // Compile at Os on IERISC to fit in code region.

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -52,6 +52,7 @@ struct dispatch_static_config_t {
     std::optional<uint32_t> fabric_header_rb_entries;
     std::optional<uint32_t> my_fabric_sync_status_addr;
     std::optional<bool> is_2d_fabric;
+    std::optional<bool> is_2d_fabric_dynamic;
 
     std::optional<bool> is_d_variant;
     std::optional<bool> is_h_variant;

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -23,6 +23,7 @@
 #include "dispatch_s.hpp"
 #include "eth_router.hpp"
 #include "fabric_edm_types.hpp"
+#include "fabric_types.hpp"
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
@@ -223,8 +224,12 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.is_2d_fabric =
             tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context().get_fabric_topology() ==
             tt_fabric::Topology::Mesh;
+        static_config_.is_2d_fabric_dynamic =
+            tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context().get_fabric_config() ==
+            tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC;
     } else {
         static_config_.is_2d_fabric = false;
+        static_config_.is_2d_fabric_dynamic = false;
     }
 }
 
@@ -501,6 +506,9 @@ void PrefetchKernel::CreateKernel() {
         defines["FABRIC_RELAY"] = "1";
         if (static_config_.is_2d_fabric.value_or(false)) {
             defines["FABRIC_2D"] = "1";
+        }
+        if (static_config_.is_2d_fabric_dynamic.value_or(false)) {
+            defines["FABRIC_2D_DYNAMIC"] = "1";
         }
     }
     // Compile at Os on IERISC to fit in code region.

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -54,6 +54,7 @@ struct prefetch_static_config_t {
     std::optional<uint32_t> my_fabric_sync_status_addr;
 
     std::optional<bool> is_2d_fabric;
+    std::optional<bool> is_2d_fabric_dynamic;
 
     std::optional<bool> is_d_variant;
     std::optional<bool> is_h_variant;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18726

### Problem description
- Dispatch on Fabric only supported 1D Fabric

### What's changed
- Add Dispatch on 2D Fabric
- Update test cases to check 1D, 1D_RING, 2D, and 2D_DYNAMIC
- Dispatch on Fabric can be enabled with `TT_METAL_FD_FABRIC=true`. The default mode is still 1D Fabric. But if the user needs 2D Fabric then Dispatch can work on 2D Fabric as well

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15915589830

TG
https://github.com/tenstorrent/tt-metal/actions/runs/15915593022

T3K
https://github.com/tenstorrent/tt-metal/actions/runs/15915591406

BH
https://github.com/tenstorrent/tt-metal/actions/runs/15918020153