### PR TITLE
Exclude DistributedContext from MetalContext::teardown()

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -197,7 +197,6 @@ void MetalContext::teardown() {
     }
     dispatch_query_manager_.reset();
     dispatch_core_manager_.reset();
-    distributed_context_.reset();
 }
 
 MetalContext& MetalContext::instance() {


### PR DESCRIPTION
### Ticket
None

### Problem description
Spotted by @tt-asaigal.

Error with
```
TT_FATAL(distributed_context_, "Distributed context not initialized.");
```

Problem is that `teardown()` is not exclusively used in the `atexit` handler. Hence, between test runs, `MetalContext::teardown` -> `MetalContext::reinitialize` may be called without re-constructing our DIstributedContext

### What's changed
Option (1): Don't call `.reset()` and receive same treatment as `Hal` and `Cluster`
Option (2): Move DistributedContext constructor to be lazily done in the `initialize` call + keep `.reset()` in the teardown

Option (1) makes the most sense. `initialize`/`teardown` should be paired methods for reconfiguring runtime/dispatch state. For `DistributedContext` should not really change between reconfigurations. 


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15869255299