### PR TITLE
More conv2d factory cleanup

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -70,12 +70,12 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     TT_FATAL(a.layout() == Layout::ROW_MAJOR, "Conv activation should be in row major layout");
     TT_FATAL(a.memory_config().is_sharded(), "Conv activation must be sharded.");
     TT_FATAL(output_channels <= b.padded_shape()[3], "Invalid weight shape. Incorrect weight tensor.");
-    uint32_t act_block_h_ntiles = block_config.act_block_h_ntiles;
-    uint32_t act_block_w_ntiles = block_config.act_block_w_ntiles;
-    uint32_t weight_block_w_ntiles = parallelization_config.per_core_out_matrix_width_ntile;
-    uint32_t out_block_h_ntiles = parallelization_config.per_core_out_matrix_height_ntile;
-    uint32_t out_subblock_h_ntiles = block_config.out_subblock_h_ntiles;
-    uint32_t out_subblock_w_ntiles = block_config.out_subblock_w_ntiles;
+    const uint32_t act_block_h_ntiles = block_config.act_block_h_ntiles;
+    const uint32_t act_block_w_ntiles = block_config.act_block_w_ntiles;
+    const uint32_t weight_block_w_ntiles = parallelization_config.per_core_out_matrix_width_ntile;
+    const uint32_t out_block_h_ntiles = parallelization_config.per_core_out_matrix_height_ntile;
+    const uint32_t out_subblock_h_ntiles = block_config.out_subblock_h_ntiles;
+    const uint32_t out_subblock_w_ntiles = block_config.out_subblock_w_ntiles;
 
     const tt::DataFormat tilized_act_df = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
 
@@ -126,8 +126,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     uint32_t weight_matrix_width = b.padded_shape()[3];
     uint32_t weight_matrix_width_ntiles = weight_matrix_width / tt::constants::TILE_WIDTH;
 
-    auto a_shard_spec = a.shard_spec().value();
-    const auto shard_shape = a.shard_spec().value().shape;
+    const std::array<uint32_t, 2> shard_shape = a.shard_spec().value().shape;
 
     // parallelization config
     const auto& p_config = parallelization_config;
@@ -140,15 +139,11 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     const bool block_sharded = a.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
     const bool height_sharded = a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
 
-    // weight_width_sliced determines is 1d-sysarr-conv or 2d-sysarr-conv
-    bool weight_width_sliced = per_core_out_matrix_width_ntiles < weight_matrix_width_ntiles;
-    uint32_t conv_act_c_blocks = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
-    if (height_sharded) {
-        TT_FATAL(conv_act_c_blocks == 1, "conv_act_c_blocks == 1 in HS, got {}", conv_act_c_blocks);
-    }
-    uint32_t input_channels_padded = 0;
-    if (weight_width_sliced) {
-        conv_act_c_blocks = a_shard_spec.orientation == ShardOrientation::ROW_MAJOR ? num_cores_x : num_cores_y;
+    uint32_t conv_act_c_blocks;
+    uint32_t input_channels_padded;
+    if (block_sharded) {
+        conv_act_c_blocks =
+            a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR ? num_cores_x : num_cores_y;
         if (transpose_mcast) {
             TT_FATAL(conv_act_c_blocks == num_cores_y, "Expected conv_act_c_blocks to be equal to height of grid");
             input_channels_padded = shard_shape[1] * num_cores_y;
@@ -157,6 +152,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             input_channels_padded = shard_shape[1] * num_cores_x;
         }
     } else {
+        conv_act_c_blocks = 1;
         input_channels_padded = shard_shape[1];
     }
     const ttnn::Shape ashape_with_channels_padded({ashape[0], ashape[1], ashape[2], input_channels_padded});
@@ -229,13 +225,11 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     }
 
     // matrix multiplication shape check valid for all convs except depthwise conv1d
-    if (!is_conv_1d_depthwise_conv) {
-        TT_FATAL(
-            act_matrix_width == weight_matrix_height,
-            "The width of tensor a {} needs to match the height of tensor b {}",
-            act_matrix_width,
-            weight_matrix_height);
-    }
+    TT_FATAL(
+        act_matrix_width == weight_matrix_height || is_conv_1d_depthwise_conv,
+        "The width of tensor a {} needs to match the height of tensor b {}",
+        act_matrix_width,
+        weight_matrix_height);
     // Tile size divisibility checks
     TT_FATAL(
         act_matrix_height % tt::constants::TILE_HEIGHT == 0, "Height of activation matrix needs to be divisible by 32");
@@ -259,8 +253,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     }
 
     // Convert tensor dims to tile dims
-    uint32_t act_matrix_height_ntiles = act_matrix_height / tt::constants::TILE_HEIGHT;
-    uint32_t act_matrix_width_ntiles = act_matrix_width / tt::constants::TILE_WIDTH;
+    const uint32_t act_matrix_height_ntiles = act_matrix_height / tt::constants::TILE_HEIGHT;
+    const uint32_t act_matrix_width_ntiles = act_matrix_width / tt::constants::TILE_WIDTH;
 
     TT_FATAL(
         act_matrix_height_ntiles % act_block_h_ntiles == 0,
@@ -283,10 +277,10 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         act_matrix_height_ntiles,
         out_block_h_ntiles);
 
-    uint32_t num_blocks_act_h = act_matrix_height_ntiles / act_block_h_ntiles;
-    uint32_t num_blocks_out_h = act_matrix_height_ntiles / out_block_h_ntiles;
-    uint32_t num_blocks_act_w = a.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ? 1 : filter_h;
-    uint32_t num_blocks_weight_w = weight_matrix_width_ntiles / weight_block_w_ntiles;
+    const uint32_t num_blocks_act_h = act_matrix_height_ntiles / act_block_h_ntiles;
+    const uint32_t num_blocks_out_h = act_matrix_height_ntiles / out_block_h_ntiles;
+    const uint32_t num_blocks_act_w = block_sharded ? 1 : filter_h;
+    const uint32_t num_blocks_weight_w = weight_matrix_width_ntiles / weight_block_w_ntiles;
 
     // act block info
     uint32_t act_block_w_datums = act_matrix_width / num_blocks_act_w;
@@ -319,7 +313,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     uint32_t weight_block_h_ntiles = is_conv_1d_depthwise_conv ? act_block_h_ntiles : act_block_w_ntiles;
     uint32_t weight_block_num_tiles = weight_block_w_ntiles * weight_block_h_ntiles;
 
-    uint32_t num_groups = num_blocks_act_h * num_blocks_act_w * num_blocks_weight_w;
     // writer of conv op partially removes padding on the width
     // it removes the padding done for block width but it doesn't remove padding done for tiled width
     uint32_t output_channels_padded_to_tile_width = tt::round_up(output_channels, tt::constants::TILE_WIDTH);
@@ -338,8 +331,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         "last_block_width_datums {} should be divisible by TILE_WIDTH",
         last_block_width_datums);
 
-    uint32_t out_block_h_datums = out_block_h_ntiles * tt::constants::TILE_HEIGHT;
-
     TT_FATAL(output.is_sharded(), "Output buffer must be sharded!");
 
     // out
@@ -352,10 +343,12 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         act_block_h_ntiles,
         out_subblock_h_ntiles);
 
-    uint32_t act_num_subblocks = act_block_h_ntiles / out_subblock_h_ntiles;
-    uint32_t act_block_num_tiles = act_block_h_ntiles * act_block_w_ntiles;
-    uint32_t act_subblock_h_ntiles = out_subblock_h_ntiles;
-    uint32_t act_subblock_num_tiles = act_subblock_h_ntiles * act_block_w_ntiles;
+    const uint32_t act_num_subblocks = act_block_h_ntiles / out_subblock_h_ntiles;
+    const uint32_t act_block_num_tiles = act_block_h_ntiles * act_block_w_ntiles;
+    const uint32_t act_subblock_h_ntiles = out_subblock_h_ntiles;
+    const uint32_t act_subblock_num_tiles = act_subblock_h_ntiles * act_block_w_ntiles;
+
+    const uint32_t in0_num_blocks_w = block_sharded ? conv_act_c_blocks : num_blocks_act_w;
 
     // weight
     const uint32_t weight_dram_addr = b.buffer()->address();
@@ -371,12 +364,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             bias.value().padded_shape()[3] / tt::constants::TILE_WIDTH;  // TODO: support non tile multiple sizes
     }
 
-    std::map<string, string> reader_defines;
-
-    if (act_matrix_height_unpadded < act_matrix_height) {
-        reader_defines["ACT_BLOCK_HEIGHT_PADDING"] = "1";
-    }
-
     uint32_t output_height_padded_to_tile_height = tt::round_up(act_matrix_height_unpadded, tt::constants::TILE_HEIGHT);
     uint32_t output_height_num_tiles = output_height_padded_to_tile_height / tt::constants::TILE_HEIGHT;
     TT_FATAL(
@@ -385,18 +372,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         output_height_num_tiles,
         act_matrix_height_ntiles);
 
-    uint32_t window_outer;
-    uint32_t window_inner;
-
-    if (weight_width_sliced) {
-        window_outer = 1;
-        window_inner = filter_h;
-    } else {
-        window_outer = num_blocks_act_w;
-        window_inner = filter_h * filter_w / num_blocks_act_w;
-    }
-
-    reader_defines["WINDOW_INNER"] = std::to_string(window_inner);
+    const uint32_t window_outer = block_sharded ? 1 : num_blocks_act_w;
+    const uint32_t window_inner = block_sharded ? filter_h : filter_h * filter_w / num_blocks_act_w;
     log_debug(tt::LogOp, "window_outer: {}, window_inner: {}", window_outer, window_inner);
 
     TT_FATAL(
@@ -410,7 +387,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         per_core_out_matrix_width_ntiles,
         weight_block_w_ntiles);
     uint32_t num_blocks_weight_w_per_core = per_core_out_matrix_width_ntiles / weight_block_w_ntiles;
-    if (not weight_width_sliced) {
+    if (height_sharded) {
         TT_FATAL(
             num_blocks_weight_w_per_core == num_blocks_weight_w,
             "num_blocks_weight_w_per_core {} should be equal to num_blocks_weight_w {}",
@@ -420,7 +397,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     uint32_t num_weight_slices_width = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
     uint32_t total_num_cores_per_weight_slice = 0;
     uint32_t total_num_cores_per_act_slice = 0;  // only used when (BLOCK_SHARDING && !transpose_mcast)
-    if (weight_width_sliced) {
+    if (block_sharded) {
         if (transpose_mcast) {
             TT_FATAL(
                 num_cores_y % num_weight_slices_width == 0,
@@ -518,7 +495,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     TT_FATAL(total_active_num_cores_per_weight_slice <= total_num_cores_per_weight_slice, "Error");
     uint32_t total_noop_cores = total_num_cores_per_weight_slice - total_active_num_cores_per_weight_slice;
     uint32_t total_active_num_cores = total_active_num_cores_per_weight_slice * num_weight_slices_width;
-    if (weight_width_sliced) {
+    if (block_sharded) {
         TT_FATAL(total_noop_cores == 0, "Error");
         TT_FATAL(total_active_num_cores == total_num_cores, "Error");
     }
@@ -576,7 +553,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     uint32_t act_mcast_sender_semaphore_id = 0;
     uint32_t act_mcast_receiver_semaphore_id = 0;
     std::vector<uint32_t> act_mcast_noc_y;
-    if (weight_width_sliced) {
+    if (block_sharded) {
         // 2D mcast
         if (transpose_mcast) {
             mcast_sender_cores = CoreRange(top_left_core, CoreCoord(0, num_cores_y - 1));
@@ -617,12 +594,12 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
 
     uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / conv_act_c_blocks;
     uint32_t act_block_w_extra_align_bytes =
-        block_sharded ? (tt::round_up(a_shard_spec.shape[1] * filter_h * filter_w, tt::constants::TILE_WIDTH) -
-                         (a_shard_spec.shape[1] * filter_h * filter_w)) *
-                            a.element_size()
-                      : (tt::round_up(a_shard_spec.shape[1] * filter_w, tt::constants::TILE_WIDTH) -
-                         (a_shard_spec.shape[1] * filter_w)) *
-                            a.element_size();
+        block_sharded
+            ? (tt::round_up(shard_shape[1] * filter_h * filter_w, tt::constants::TILE_WIDTH) -
+               (shard_shape[1] * filter_h * filter_w)) *
+                  a.element_size()
+            : (tt::round_up(shard_shape[1] * filter_w, tt::constants::TILE_WIDTH) - (shard_shape[1] * filter_w)) *
+                  a.element_size();
     const uint32_t act_block_w_extra_align_scalars = act_block_w_extra_align_bytes / a.element_size();
     // When using block float format, we must handle cases where the data doesn't align to 16-scalar boundaries.
     // If act_block_w_extra_align_bytes contains a number of scalars that isn't a multiple of 16,
@@ -630,12 +607,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     // Failing to do this could allow residual junk data in L1 memory to corrupt valid input data.
     const bool needs_act_block_zero_out =
         act_block_w_extra_align_scalars % 16 != 0 && tt::tt_metal::is_block_float(output.dtype());
-
-    uint32_t in0_block_w = act_block_w_ntiles / conv_act_c_blocks;
-    uint32_t in0_block_num_tiles = act_block_num_tiles / conv_act_c_blocks;
-    uint32_t in1_block_num_tiles = weight_block_num_tiles / conv_act_c_blocks;
-    uint32_t in0_num_blocks_w =
-        num_blocks_act_w * conv_act_c_blocks;  // Fold outer c_block loop together with weight_block_num_tiles = 9
 
     const uint32_t tilized_act_tile_size = tt::tt_metal::detail::TileSize(tilized_act_df);
 
@@ -661,7 +632,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         {filter_h, filter_w},
         conv_config,
         a.dtype(),
-        a.memory_config().shard_spec().value().shape,
+        shard_shape,
         has_bias,
         is_conv_1d_depthwise_conv);
 
@@ -681,13 +652,11 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp";
     string writer_mcast_sender_kernel;
     string writer_mcast_receiver_kernel;
-    bool tilize_in0 = true;
 
     // Input should always be sharded in this conv; always use reader kernel for input shard with halo and padding
     if (filter_h >= 1 and filter_w >= 1) {
-        if (!is_conv_1d_depthwise_conv and weight_width_sliced) {
+        if (!is_conv_1d_depthwise_conv && block_sharded) {
             // Block sharded conv
-            TT_FATAL(weight_width_sliced == true, "weight_width_sliced should be true for this conv");
             reader_kernel =
                 "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
                 "reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp";
@@ -712,9 +681,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                     act_mcast_noc_y.push_back(device->worker_core_from_logical_core({(uint32_t)core_idx_x, 0}).x);
                 }
             }
-
-            // For 2D convs, pre-tilize input and round robin self-mcast tilized act matrix to other cores
-            tilize_in0 = false;
         } else if (is_conv_1d_depthwise_conv) {
             // 1D Depthwise Conv (height sharded)
             TT_FATAL(
@@ -749,21 +715,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         TT_THROW("Sharded input not supported for this conv yet!");
     }
 
-    if (weight_width_sliced) {
-        const uint32_t window_size = filter_h * filter_w;
-        in0_block_w *= window_size;
-        in0_block_num_tiles *= window_size;
-        in1_block_num_tiles *= window_size;
-        in0_num_blocks_w /= window_size;
-    }
     uint32_t reader_arg_act_block_h_datums = (enable_split_reader ? act_block_h_datums_split : act_block_h_datums);
     TT_FATAL(reader_arg_act_block_h_datums % 2 == 0, "2 Indices are packed in one uint32_t word.");
-    if (block_sharded) {
-        in0_block_num_tiles = act_block_num_tiles;
-        in1_block_num_tiles = weight_block_num_tiles;
-        in0_block_w = act_block_w_ntiles;
-        in0_num_blocks_w = 1 * conv_act_c_blocks;
-    }
+
     reader_compile_time_args = {
         (uint32_t)dilation_h,
         (uint32_t)dilation_w,
@@ -778,13 +732,13 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         (uint32_t)conv_act_size_w + (pad_w),
         (uint32_t)act_block_w_extra_align_bytes,                          // only used for 1d systolic variant
         (uint32_t)num_blocks_act_h_per_core,                              // act_num_blocks_h
-        (uint32_t)in0_block_num_tiles,                                    // act_block_num_tiles
+        (uint32_t)act_block_num_tiles,                                    // act_block_num_tiles
         (uint32_t)conv_act_c_blocks,                                      // act_w_num_outer
         (uint32_t)(transpose_mcast ? num_cores_y - 1 : num_cores_x - 1),  // act_mcast_num_dests
         (uint32_t)(transpose_mcast ? num_cores_y - 1 : num_cores_x - 1),  // act_mcast_num_cores
         (uint32_t)act_mcast_sender_semaphore_id,
         (uint32_t)act_mcast_receiver_semaphore_id,
-        (uint32_t)in0_block_num_tiles * tilized_act_tile_size,  // act_mcast_sender_size_bytes
+        (uint32_t)act_block_num_tiles * tilized_act_tile_size,  // act_mcast_sender_size_bytes
         (uint32_t)(transpose_mcast ? 1 : 0),
         (uint32_t)needs_act_block_zero_out,  // zero_out_act_cb
         get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
@@ -795,7 +749,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         get_cb_info_by_name(cb_info, Conv2dCb::L1_ARRAY).index,
     };
 
-    // define for bias
+    std::map<string, string> reader_defines;
     std::map<string, string> writer_defines;
     std::map<string, string> writer_mcast_sender_defines;
     std::map<string, string> compute_defines;
@@ -816,6 +770,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         }
     }
 
+    // For 2D convs, pre-tilize input and round robin self-mcast tilized act matrix to other cores
+    const bool tilize_in0 = height_sharded;
     if (!tilize_in0) {
         compute_defines["PRE_TILIZE"] = "1";
     }
@@ -845,7 +801,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).index,
         get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).index,
         num_blocks_act_w,
-        in1_block_num_tiles,
+        weight_block_num_tiles,
         conv_act_c_blocks,
         weight_block_h_ntiles,
         weight_block_w_ntiles,
@@ -880,14 +836,14 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     }
 
     std::vector<uint32_t> compute_kernel_args = {
-        in0_block_w,
+        act_block_w_ntiles,
         act_num_subblocks,
         act_block_num_tiles,
         act_subblock_num_tiles,
         act_subblock_h_ntiles,
 
         weight_num_subblocks,
-        in1_block_num_tiles,
+        weight_block_num_tiles,
         weight_block_w_ntiles,
 
         num_blocks_act_h_per_core,
@@ -971,7 +927,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
 
         // per core specific args
         uint32_t weight_slice_i;
-        if (weight_width_sliced && transpose_mcast || !weight_width_sliced) {
+        if (block_sharded && transpose_mcast || !block_sharded) {
             weight_slice_i = core_i / total_num_cores_per_weight_slice;
         } else {
             weight_slice_i = core_i % total_num_cores_per_act_slice;
@@ -986,7 +942,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                 bias_ntiles);
         }
 
-        if (weight_width_sliced) {
+        if (block_sharded) {
             bool reader_is_noc_0 = reader_noc == tt::tt_metal::NOC::NOC_0;
 
             if (transpose_mcast) {
@@ -1052,7 +1008,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
 
             (uint32_t)noop_core};
 
-        if (weight_width_sliced) {
+        if (block_sharded) {
             // 2D mcast
             if (transpose_mcast) {
                 CoreCoord right_core = {(std::size_t)num_cores_x - 1, (std::size_t)core_y_i};

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -770,10 +770,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         }
     }
 
-    // For 2D convs, pre-tilize input and round robin self-mcast tilized act matrix to other cores
-    const bool tilize_in0 = height_sharded;
-    if (!tilize_in0) {
-        compute_defines["PRE_TILIZE"] = "1";
+    if (block_sharded) {
+        compute_defines["BLOCK_SHARDED"] = "1";
     }
 
     if (enable_split_reader) {
@@ -854,7 +852,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         out_subblock_w_ntiles,
         out_subblock_num_tiles,
 
-        tilize_in0,
+        height_sharded,
         untilize_out,
 
         bias_ntiles_per_core,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -319,10 +319,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
 
     std::map<string, string> reader_defines;
 
-    if (act_matrix_height_unpadded < act_matrix_height) {
-        reader_defines["ACT_BLOCK_HEIGHT_PADDING"] = "1";
-    }
-
     uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / (input_num_cores * per_core_num_blocks_act_w);
 
     std::string compute_kernel_path =

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -86,7 +86,7 @@ void MAIN {
     constexpr uint32_t out_subblock_h = get_compile_time_arg_val(11);          // inner row block size in tiles
     constexpr uint32_t out_subblock_w = get_compile_time_arg_val(12);          // inner column block size in tiles
     constexpr uint32_t out_subblock_num_tiles = get_compile_time_arg_val(13);  // out_subblock_h * out_subblock_w;
-    constexpr bool tilize_in0 = get_compile_time_arg_val(14);
+    constexpr bool height_sharded = get_compile_time_arg_val(14);
     constexpr bool untilize_out = get_compile_time_arg_val(15);
     constexpr uint32_t in0_cb_id = get_compile_time_arg_val(18);
     constexpr uint32_t in1_cb_id = get_compile_time_arg_val(19);
@@ -116,7 +116,7 @@ void MAIN {
     constexpr uint32_t mm_out_cb_id = untilize_mode_out_cb_id;
 #endif
 
-    constexpr uint32_t mm_in0_cb_id = tilize_in0 ? tilized_in0_cb_id : in0_cb_id;
+    constexpr uint32_t mm_in0_cb_id = height_sharded ? tilized_in0_cb_id : in0_cb_id;
 
 #ifdef SPLIT_READER
     constexpr uint32_t in0_num_subblocks_read_last = in0_num_subblocks / 2;
@@ -134,7 +134,7 @@ void MAIN {
     // in1 num blocks w is the outer loop. Output blocks are computed in col major order.
     for (uint32_t in1_block_w_i = 0; in1_block_w_i < in1_num_blocks_w; ++in1_block_w_i) {
         for (uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
-#ifdef PRE_TILIZE
+#ifdef BLOCK_SHARDED
             reconfig_data_format_srca(in1_cb_id, in0_pretilize_cb_id);
 
             tilize_in(in0_pretilize_cb_id, in0_subblock_h, in0_block_w, in0_num_subblocks, tilized_in0_cb_id);
@@ -167,7 +167,7 @@ void MAIN {
                 }
 #endif
                 bool last_out = (in0_block_w_i == in0_num_blocks_w - 1);
-                if constexpr (tilize_in0) {
+                if constexpr (height_sharded) {
 #if defined PACK_RELU and not defined FUSE_BIAS
                     if (last_out) {
                         // if last block we pack the final result with relu enabled
@@ -464,7 +464,7 @@ void MAIN {
                 reconfig_data_format_srca(matmul_partials_cb, in1_cb_id);
 #endif
 
-                if constexpr (!tilize_in0) {
+                if constexpr (!height_sharded) {
                     mm_block_init_short(mm_in0_cb_id, in1_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
 #ifdef PACK_RELU
                     PACK((llk_pack_relu_config(ReluType::NO_RELU)));

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -12,7 +12,7 @@
 #include "debug/dprint_pages.h"
 #endif
 
-constexpr uint32_t weight_size_h = get_compile_time_arg_val(7);  // Input filter window width
+constexpr uint32_t weight_size_h = get_compile_time_arg_val(7);  // Input filter window height
 constexpr uint32_t weight_size_w = get_compile_time_arg_val(8);  // Input filter window width
 
 template <int window_height, int window_width>
@@ -48,10 +48,9 @@ void read_channels(
     const uint32_t conv_act_c_read_bytes,
     const uint32_t coalesced_read_bytes,
     const uint32_t stride_h_bytes) {
-    constexpr uint32_t unroll_factor = WINDOW_INNER;
     uint32_t act_l1_read_addr_plus_offset = act_l1_read_addr + (reader_channel_idx * conv_act_c_read_bytes);
-#pragma GCC unroll unroll_factor
-    for (uint32_t inner = 0; inner < WINDOW_INNER; inner++) {
+#pragma GCC unroll weight_size_h
+    for (uint32_t inner = 0; inner < weight_size_h; inner++) {
         noc_async_read_one_packet_with_state<true>(act_l1_read_addr_plus_offset, l1_write_addr_act);
         l1_write_addr_act += coalesced_read_bytes;
         // +2 is hard-coded, TODO: generalize


### PR DESCRIPTION
Main change is to set in0_block_num_tiles,
in1_block_num_tiles, in0_block_w, in0_num_blocks_w, once and not mutate them multiple times, to make
code easier to follow.

Removed some dead code.

Removed weight_width_sliced and used block_sharded instead.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15873938130)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15873956713)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15873756509)
- [x] [Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/15861307998)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/15870887212)
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15870871308)