### PR TITLE
#24095: Add arch dependency on tranpose_wh_rm.cpp

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -119,15 +119,17 @@ void MAIN {
     constexpr uint32_t pack_num_pages_last_col = get_compile_time_arg_val(6);
     constexpr uint32_t pack_num_pages_last_row = get_compile_time_arg_val(7);
     constexpr uint32_t pack_num_pages_last_row_col = get_compile_time_arg_val(8);
-// In order to support full_ct_dim > block_ct_dim, we need to have this architecture
-// dependency for now. Should be addressed in tt-metal#24095
-#ifdef ARCH_BLACKHOLE
-    constexpr bool use_narrow_row = last_output_row_num_datums < FACE_WIDTH ? true : false;
-    constexpr uint32_t row_size = last_output_row_num_datums < FACE_WIDTH ? last_output_row_num_datums : TILE_WIDTH;
-#else
+    // In order to support full_ct_dim > block_ct_dim, we would need to change use_narrow_row and row_size conditions to
+    // be:
+    //
+    //     constexpr bool use_narrow_row = last_output_row_num_datums < FACE_WIDTH ? true : false;
+    //     constexpr uint32_t row_size = last_output_row_num_datums < FACE_WIDTH ? last_output_row_num_datums :
+    //     TILE_WIDTH;
+    //
+    // However, changing these conditions makes yolov4 and transpose tests fail with a PCC error. For the error to be
+    // present in BH, it needs to be run in the full model sweep, but for WH_B0 it can be seen in isolation.
     constexpr bool use_narrow_row = last_output_row_num_datums < TILE_WIDTH ? true : false;
     constexpr uint32_t row_size = last_output_row_num_datums < TILE_WIDTH ? last_output_row_num_datums : TILE_WIDTH;
-#endif  // ARCH_BLACKHOLE
 
 #else
     uint32_t num_hw_blocks_per_core = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -119,9 +119,16 @@ void MAIN {
     constexpr uint32_t pack_num_pages_last_col = get_compile_time_arg_val(6);
     constexpr uint32_t pack_num_pages_last_row = get_compile_time_arg_val(7);
     constexpr uint32_t pack_num_pages_last_row_col = get_compile_time_arg_val(8);
-
+// In order to support full_ct_dim > block_ct_dim, we need to have this architecture
+// dependency for now. Should be addressed in tt-metal#24095
+#ifdef ARCH_BLACKHOLE
+    constexpr bool use_narrow_row = last_output_row_num_datums < FACE_WIDTH ? true : false;
+    constexpr uint32_t row_size = last_output_row_num_datums < FACE_WIDTH ? last_output_row_num_datums : TILE_WIDTH;
+#else
     constexpr bool use_narrow_row = last_output_row_num_datums < TILE_WIDTH ? true : false;
     constexpr uint32_t row_size = last_output_row_num_datums < TILE_WIDTH ? last_output_row_num_datums : TILE_WIDTH;
+#endif  // ARCH_BLACKHOLE
+
 #else
     uint32_t num_hw_blocks_per_core = get_arg_val<uint32_t>(0);
 #endif


### PR DESCRIPTION
### Ticket
#24095 

### Problem description
Since BH and WH_B0 handle narrow_row in pack_untilize differently, the pack_untilize support added for `full_ct_dim > block_ct_dim` in this [LLK commit](https://github.com/tenstorrent/tt-llk/commit/a535159e4cf60cd123178f1f970ab89b0eb8e6cd) makes any test using `tranpose_wh_rm.cpp` fail because `use_narrow_row` is checked against 32 datums in a row, not 16 as our convention implies. 

However, if we change the condition, the test yields a PCC error in yolov4 and tranpose test for WH_B0. 

### What's changed
I temporarily added architecture dependence in `tranpose_wh_rm.cpp` to make the tests pass on both architecture, following the mentioned convention. The goal of #24095 is to investigate the cause of this discrepancy. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes