### PR TITLE
Make constEvalFuncWrapper static so it compiles for multiple tests

### DIFF
--- a/tests/ttnn/unit_tests/gtests/emitc/emitc.hpp
+++ b/tests/ttnn/unit_tests/gtests/emitc/emitc.hpp
@@ -69,7 +69,7 @@ private:
 
 // Wrapper to abstract const-eval logic out of runtime funcs to keep them
 // cleaner.  Invokes constEvalFunc iff outputs is empty.
-void constEvalFuncWrapper(
+inline void constEvalFuncWrapper(
     std::function<std::vector<ttnn::Tensor>(std::vector<ttnn::Tensor>)> constEvalFunc,
     const std::vector<ttnn::Tensor>& inputs,
     std::vector<ttnn::Tensor>* outputs) {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Adding a second emitc test in `tests/ttnn/unit_tests/gtests/emitc/` dir would result in compile errors - linker would complain about a duplicate symbol definition: `constEvalFuncWrapper`:
```cpp
FAILED: test/ttnn/unit_tests_ttnn_emitc
: && /usr/bin/clang++-17 -O3 -fuse-ld=lld -Xlinker --dependency-file=tests/ttnn/unit_tests/gtests/CMakeFiles/unit_tests_ttnn_emitc.dir/link.d tests/ttnn/unit_tests/gtests/CMakeFiles/unit_tests_ttnn_emitc.dir/emitc/test_sanity.cpp.o tests/ttnn/unit_tests/gtests/CMakeFiles/unit_tests_ttnn_emitc.dir/emitc/test_program_cache.cpp.o -o test/ttnn/unit_tests_ttnn_emitc  -Wl,-rpath,/localdev/svuckovic/_workspace/repos/tt-metal/build_Release/ttnn:/localdev/svuckovic/_workspace/repos/tt-metal/build_Release/tt_metal:/localdev/svuckovic/_workspace/repos/tt-metal/build_Release/tt_metal/third_party/umd/device  ttnn/_ttnncpp.so  -lpthread  lib/libgmock_main.a  lib/libgmock.a  lib/libgtest.a  tt_metal/libtt_metal.so  tt_metal/third_party/umd/device/libdevice.so  _deps/boost-build/libs/container/libboost_container.a && :
ld.lld: error: duplicate symbol: ttnn::constEvalFuncWrapper(std::function<std::vector<tt::tt_metal::Tensor, std::allocator<tt::tt_metal::Tensor>> (std::vector<tt::tt_metal::Tensor, std::allocator<tt::tt_metal::Tensor>>)>, std::vector<tt::tt_metal::Tensor, std::allocator<tt::tt_metal::Tensor>> const&, std::vector<tt::tt_metal::Tensor, std::allocator<tt::tt_metal::Tensor>>*)
>>> defined at test_sanity.cpp
>>>            tests/ttnn/unit_tests/gtests/CMakeFiles/unit_tests_ttnn_emitc.dir/emitc/test_sanity.cpp.o:(ttnn::constEvalFuncWrapper(std::function<std::vector<tt::tt_metal::Tensor, std::allocator<tt::tt_metal::Tensor>> (std::vector<tt::tt_metal::Tensor, std::allocator<tt::tt_metal::Tensor>>)>, std::vector<tt::tt_metal::Tensor, std::allocator<tt::tt_metal::Tensor>> const&, std::vector<tt::tt_metal::Tensor, std::allocator<tt::tt_metal::Tensor>>*))
>>> defined at test_program_cache.cpp
>>>            tests/ttnn/unit_tests/gtests/CMakeFiles/unit_tests_ttnn_emitc.dir/emitc/test_program_cache.cpp.o:(.text+0x0)
clang++-17: error: linker command failed with exit code 1 (use -v to see invocation)
```

### What's changed
Make `void constEvalFuncWrapper()` static.

Edit:

The issue can be reproed on this branch where an extra test was added: https://github.com/tenstorrent/tt-metal/compare/main...svuckovic/program-cache-perf-test

To build and run (both here and in the branch where issue repros once `static` keyword is removed):
```sh
source python_env/bin/activate
export TT_METAL_HOME=$(pwd)
export PYTHONPATH=$(pwd)

./build_metal.sh --build-ttnn-tests
./build/test/ttnn/unit_tests_ttnn_emitc
```

Tested locally that the tests compile and run with this PR's changes.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes