### PR TITLE
Fix get eth sockets API and downstream usage

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -149,12 +149,7 @@ std::tuple<chip_id_t, CoreCoord> Device::get_connected_ethernet_core(CoreCoord e
 }
 
 std::vector<CoreCoord> Device::get_ethernet_sockets(chip_id_t connected_chip_id) const {
-    if (tt::tt_metal::MetalContext::instance().get_fabric_config() != tt::tt_metal::FabricConfig::DISABLED) {
-        return tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_routers_between_src_and_dest(
-            this->id_, connected_chip_id);
-    } else {
-        return tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_sockets(this->id_, connected_chip_id);
-    }
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_sockets(this->id_, connected_chip_id);
 }
 
 bool Device::is_mmio_capable() const {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -214,7 +214,7 @@ operation::ProgramWithCallbacks ReduceScatterAsync::create_program_at(
         this->ring_size,
         config.device_index,
         this->topology,
-        num_links,
+        num_links.value(),
         this->from_remote_sem,
         this->to_remote_sem,
         this->sub_device_id);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.hpp
@@ -99,7 +99,7 @@ tt::tt_metal::operation::ProgramWithCallbacks build_reduce_scatter_async_program
     uint32_t line_size,
     uint32_t line_index,
     ttnn::ccl::Topology topology,
-    std::optional<size_t> num_links_preferred,
+    size_t num_links,
     const GlobalSemaphore& from_remote_sem,
     const GlobalSemaphore& to_remote_sem,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
@@ -2469,32 +2469,15 @@ operation::ProgramWithCallbacks build_reduce_scatter_async_program(
     const uint32_t line_size,
     const uint32_t line_index,
     ttnn::ccl::Topology topology,
-    std::optional<size_t> num_links_preferred,
+    size_t num_links,
     const tt::tt_metal::GlobalSemaphore& from_remote_sem,
     const tt::tt_metal::GlobalSemaphore& to_remote_sem,
     const std::optional<SubDeviceId>& sub_device_id) {
     auto program = tt::tt_metal::Program();
 
     fabric_lifetime_mode fabric_mode = fabric_lifetime_mode::PERSISTENT;
-    // Link Counting Scheme: By default use all the links between the current device
-    // and its neighbors. If a user specifies a value through num_links_preferred, use
-    // that instead (and cap at the maximum number of physical links).
-    const size_t max_num_links = num_links_preferred.value_or(std::numeric_limits<std::size_t>::max());
-    std::optional<size_t> num_links = std::nullopt;
-    std::array<std::pair<tt::tt_metal::IDevice*, std::optional<tt::tt_metal::IDevice*>>, 2> device_pairs = {
-        std::pair<tt::tt_metal::IDevice*, std::optional<tt::tt_metal::IDevice*>>{target_device, forward_device},
-        std::pair<tt::tt_metal::IDevice*, std::optional<tt::tt_metal::IDevice*>>{target_device, backward_device}};
 
-    for (const auto& pair : device_pairs) {
-        if (!num_links.has_value()) {
-            if (pair.second.has_value()) {
-                auto remote_chip_id = pair.second.value()->id();
-                num_links = std::min(target_device->get_ethernet_sockets(remote_chip_id).size(), max_num_links);
-            }
-        }
-    }
-
-    TT_FATAL(num_links.has_value(), "No links were found between the current device and its neighbors.");
+    TT_FATAL(num_links > 0, "No links were specified for Reduce scatter op.");
     TT_FATAL(fabric_mode == fabric_lifetime_mode::PERSISTENT, "Reduce scatter doesn't support transient fabric mode");
     return reduce_scatter_async_on_instantiated_edm_fabric(
         program,
@@ -2513,7 +2496,7 @@ operation::ProgramWithCallbacks build_reduce_scatter_async_program(
         line_size,
         line_index,
         dim,
-        num_links.value(),
+        num_links,
         ttnn::ccl::Topology::Linear,
         fabric_mode,
         from_remote_sem,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23467)

### Problem description
The `get_ethernet_sockets` API had a workaround/hack to return the number of active fabric routers if fabric was active else return idle cores. This is inconsistent and it should only return idle eth cores.

There is one downstream usage in reduce scatter program (`build_reduce_scatter_async_program`) which was querying that API to figure out the number of links to use for the OP (in case the optional parameter `num_links_preferred` was not specified). The caller of that method `ReduceScatterAsync::create_program_at`, is already populating the num links correctly in case its missing and hence the `num_links_preferred` parameter in `build_reduce_scatter_async_program` no longer needs to be optional and shouldnt require any further modifications.

### What's changed
1. Fixed the device side API implementation
2. Fixed the `num_links_preferred` parameter in `build_reduce_scatter_async_program` to no longer be an optional

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15879995092)
- [x]  [T3K Frequent] (https://github.com/tenstorrent/tt-metal/actions/runs/15880014819)
- [x]  [T3K Nightly] (https://github.com/tenstorrent/tt-metal/actions/runs/15880018234)
- [x]  [T3K Unit] (https://github.com/tenstorrent/tt-metal/actions/runs/15887744738)
- [x]  (Galaxy quick) (https://github.com/tenstorrent/tt-metal/actions/runs/15887816301)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes