### PR TITLE
Ebanerjee/23444/removing all unused functions from tt_metal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,6 @@ add_compile_options(
     # Vars that are used only in Asserts will appear as dead stores in builds
     # where the preprocessor has stripped away the assert.
     "$<$<OR:$<CONFIG:Release>,$<CXX_COMPILER_ID:GNU>>:-Wno-unused-but-set-variable>"
-    -Wno-unused-function
     -Wno-unused-variable
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-c++11-narrowing>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-deprecated-volatile>"

--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -31,14 +31,6 @@ namespace {
 
 using ::testing::SizeIs;
 
-std::vector<chip_id_t> get_physical_device_ids(const MeshDevice& mesh) {
-    std::vector<chip_id_t> device_ids;
-    for (auto* device : mesh.get_devices()) {
-        device_ids.push_back(device->id());
-    }
-    return device_ids;
-}
-
 class T3KReshapeTestFixture : public ::testing::Test {
 public:
     void SetUp() override {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
@@ -30,9 +30,6 @@ using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
-static void RunTest(WatcherFixture* fixture, IDevice* device) {
-}
-
 TEST_F(WatcherFixture, ActiveEthTestWatcherEthLinkCheck) {
     // Eth link retraining only supported on WH for now, this test is also dispatch-agnostic so just pick one.
     if (this->slow_dispatch_ || this->arch_ != tt::ARCH::WORMHOLE_B0 || this->devices_.size() == 1) {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -3215,7 +3215,7 @@ ttnn::ccl::Topology get_topology(FabricTestMode fabric_mode) {
 template <typename T>
 using per_axis_array_t = std::array<T, FullMeshTestParams::MAX_NUM_AXES>;
 
-static void validate_sync_core_is_on_a_worker(
+inline void validate_sync_core_is_on_a_worker(
     const CoreCoord& sync_core_coord,
     const std::unordered_map<size_t, std::vector<CoreCoord>>& worker_cores_per_device) {
     for (const auto& [device, worker_cores_vec] : worker_cores_per_device) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_sharding.cpp
@@ -39,48 +39,6 @@
 #include "ttnn_test_fixtures.hpp"
 
 namespace {
-
-void pretty_print_data_as_shards(
-    const std::vector<float>& data, const Shape2D& shape, const Shape2D& shard_shape, const size_t char_count = 3) {
-    TT_FATAL(
-        data.size() == shape.height() * shape.width(),
-        "Data size {} should be same as shape size {}",
-        data.size(),
-        shape.height() * shape.width());
-
-    const auto [num_shards_height, last_shard_height, num_shards_width, last_shard_width] =
-        tt::tt_metal::compute_shard_division_spec(shape, shard_shape);
-
-    std::cout << "2D shape: " << shape << std::endl;
-    for (size_t shard_height_idx = 0; shard_height_idx < num_shards_height; shard_height_idx++) {
-        const auto num_shard_rows =
-            shard_height_idx == num_shards_height - 1 ? last_shard_height : shard_shape.height();
-        for (size_t shard_row_idx = 0; shard_row_idx < num_shard_rows; shard_row_idx++) {
-            for (size_t shard_width_idx = 0; shard_width_idx < num_shards_width; shard_width_idx++) {
-                const auto num_shard_cols =
-                    shard_width_idx == num_shards_width - 1 ? last_shard_width : shard_shape.width();
-                for (size_t shard_col_idx = 0; shard_col_idx < num_shard_cols; shard_col_idx++) {
-                    const auto data_idx = (shard_height_idx * shard_shape.height() + shard_row_idx) * shape.width() +
-                                          shard_width_idx * shard_shape.width() + shard_col_idx;
-                    std::cout << fmt::format("{:>{}}", data[data_idx], char_count);
-                    if (shard_col_idx < num_shard_cols - 1) {
-                        std::cout << ", ";
-                    } else if (shard_width_idx < num_shards_width - 1) {
-                        std::cout << fmt::format("{:>{}}", "|", char_count);
-                    }
-                }
-                std::cout << " ";
-            }
-            std::cout << std::endl;
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-}
-
-}  // namespace
-
-namespace {
 struct ShardWithAlignmentInputs {
     Shape shape;
     Shape2D logical_shard_shape;

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -27,7 +27,7 @@ struct CoreDescriptorComparator {
 using CoreDescriptorSet = std::set<CoreDescriptor, CoreDescriptorComparator>;
 
 // Helper function to get CoreDescriptors for all debug-relevant cores on device.
-static CoreDescriptorSet GetAllCores(chip_id_t device_id) {
+inline CoreDescriptorSet GetAllCores(chip_id_t device_id) {
     CoreDescriptorSet all_cores;
     // The set of all printable cores is Tensix + Eth cores
     CoreCoord logical_grid_size =
@@ -51,7 +51,7 @@ static CoreDescriptorSet GetAllCores(chip_id_t device_id) {
 
 // Helper function to get CoreDescriptors for all cores that are used for dispatch. Should be a subset of
 // GetAllCores().
-static CoreDescriptorSet GetDispatchCores(chip_id_t device_id) {
+inline CoreDescriptorSet GetDispatchCores(chip_id_t device_id) {
     CoreDescriptorSet dispatch_cores;
     unsigned num_cqs = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_num_hw_cqs();
     const auto& dispatch_core_config =

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
@@ -20,39 +20,6 @@
 namespace tt::tt_metal {
 
 //////////////////////////////////////////////////////////////
-// Debug Code                                               //
-//////////////////////////////////////////////////////////////
-
-namespace {
-// This can be useful for debug. Not all data types are currently supported, can use this during developmenmt.
-void PrintHostDataType(const HostDataType& data) {
-    std::visit(
-        tt::stl::overloaded{
-            [](const std::shared_ptr<std::vector<uint8_t>>& /*value*/) {
-                log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<uint8_t>>");
-            },
-            [](const std::shared_ptr<std::vector<uint16_t>>& /*value*/) {
-                log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<uint16_t>>");
-            },
-            [](const std::shared_ptr<std::vector<int32_t>>& /*value*/) {
-                log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<int32_t>>");
-            },
-            [](const std::shared_ptr<std::vector<uint32_t>>& /*value*/) {
-                log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<uint32_t>>");
-            },
-            [](const std::shared_ptr<std::vector<float>>& /*value*/) {
-                log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<float>>");
-            },
-            [](const std::shared_ptr<std::vector<bfloat16>>& /*value*/) {
-                log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<bfloat16>>");
-            },
-            [](const void* /*value*/) { log_info(tt::LogMetalTrace, "HostDataType contains: const void*"); },
-            [](auto&&) { log_info(tt::LogMetalTrace, "HostDataType contains: Unknown type"); }},
-        data);
-}
-}  // namespace
-
-//////////////////////////////////////////////////////////////
 // Host API tracing helper functions                        //
 //////////////////////////////////////////////////////////////
 

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -31,7 +31,7 @@ static bool coord_found_p(const std::vector<tt::umd::CoreCoord>& coords, CoreCoo
     return false;
 }
 
-static bool coord_found_p(const std::vector<CoreCoord>& coords, CoreCoord core) {
+inline bool coord_found_p(const std::vector<CoreCoord>& coords, CoreCoord core) {
     for (const CoreCoord& item : coords) {
         if (item == core) {
             return true;
@@ -40,7 +40,7 @@ static bool coord_found_p(const std::vector<CoreCoord>& coords, CoreCoord core) 
     return false;
 }
 
-static bool coord_found_p(CoreCoord range, CoreCoord core) {
+inline bool coord_found_p(CoreCoord range, CoreCoord core) {
     return core.x >= 1 && core.x <= range.x && core.y >= 1 && core.y <= range.y;
 }
 

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -325,7 +325,7 @@ Attributes get_attributes(const T& object) {
     }
 }
 
-static std::ostream& operator<<(std::ostream& os, const Attribute& attribute) {
+inline std::ostream& operator<<(std::ostream& os, const Attribute& attribute) {
     os << attribute.to_string();
     return os;
 }

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -163,7 +163,7 @@ private:
 
 inline ProgramHashToOpName program_hash_to_opname_{};
 
-static void start_tracy_zone(const string& source, const string& functName, uint32_t lineNum, uint32_t color = 0) {
+inline void start_tracy_zone(const string& source, const string& functName, uint32_t lineNum, uint32_t color = 0) {
 #if defined(TRACY_ENABLE)
     auto tracySrcLoc =
         ___tracy_alloc_srcloc(lineNum, source.c_str(), source.length(), functName.c_str(), functName.length());
@@ -176,7 +176,7 @@ static void start_tracy_zone(const string& source, const string& functName, uint
 #endif
 }
 
-static bool stop_tracy_zone(const string& name = "", uint32_t color = 0) {
+inline bool stop_tracy_zone(const string& name = "", uint32_t color = 0) {
     bool callStackWasEmpty = true;
 #if defined(TRACY_ENABLE)
     if (!call_stack.empty()) {
@@ -195,11 +195,11 @@ static bool stop_tracy_zone(const string& name = "", uint32_t color = 0) {
     return callStackWasEmpty;
 }
 
-static void tracy_message(const std::string& source, uint32_t color = 0xf0f8ff) {
+inline void tracy_message(const std::string& source, uint32_t color = 0xf0f8ff) {
     TracyMessageC(source.c_str(), source.size(), color);
 }
 
-static void tracy_frame() { FrameMark; }
+inline void tracy_frame() { FrameMark; }
 
 #if defined(TRACY_ENABLE)
 static inline json get_kernels_json(chip_id_t device_id, const Program& program) {

--- a/ttnn/api/ttnn/decorators.hpp
+++ b/ttnn/api/ttnn/decorators.hpp
@@ -31,12 +31,12 @@ static std::string base_name(const std::string& cpp_fully_qualified_name) {
 }
 
 // Convert "ttnn::add" to "add_t"
-static std::string class_name(const std::string& cpp_fully_qualified_name) {
+inline std::string class_name(const std::string& cpp_fully_qualified_name) {
     return base_name(cpp_fully_qualified_name) + "_t";
 }
 
 // Convert "ttnn::add" to "ttnn.add"
-static std::string python_fully_qualified_name(const std::string& cpp_fully_qualified_name) {
+inline std::string python_fully_qualified_name(const std::string& cpp_fully_qualified_name) {
     auto replace = [](const std::string& input, const std::string& from, const std::string& to) {
         if (from.empty()) {
             return input;

--- a/ttnn/api/ttnn/operation.hpp
+++ b/ttnn/api/ttnn/operation.hpp
@@ -249,7 +249,7 @@ struct ProfilerInfo {
 
 inline MemoryConfig DEFAULT_OUTPUT_MEMORY_CONFIG;
 
-static void set_default_operation_output_memory_config(const MemoryConfig& memory_config) {
+inline void set_default_operation_output_memory_config(const MemoryConfig& memory_config) {
     DEFAULT_OUTPUT_MEMORY_CONFIG = memory_config;
 }
 

--- a/ttnn/api/ttnn/types.hpp
+++ b/ttnn/api/ttnn/types.hpp
@@ -56,7 +56,7 @@ struct CoreGrid {
 
 using Buffer = tt::tt_metal::Buffer;
 
-static std::ostream& operator<<(std::ostream& os, const CoreGrid& core_grid) {
+inline std::ostream& operator<<(std::ostream& os, const CoreGrid& core_grid) {
     os << "ttnn.CoreGrid(x=" << core_grid.x << ", y=" << core_grid.y << ")";
     return os;
 }

--- a/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
@@ -7,15 +7,6 @@
 namespace ttnn {
 namespace {
 
-CoreCoord from_flatbuffer(const flatbuffer::CoreCoord* core_coord) {
-    return CoreCoord{core_coord->x(), core_coord->y()};
-}
-
-CoreRange from_flatbuffer(const flatbuffer::CoreRange* core_range) {
-    return CoreRange{
-        {core_range->start()->x(), core_range->start()->y()}, {core_range->end()->x(), core_range->end()->y()}};
-}
-
 CoreRangeSet from_flatbuffer(const flatbuffer::CoreRangeSet* core_range_set) {
     std::vector<CoreRange> ranges;
     for (const auto* range : *core_range_set->ranges()) {
@@ -23,18 +14,6 @@ CoreRangeSet from_flatbuffer(const flatbuffer::CoreRangeSet* core_range_set) {
             CoreCoord{range->start()->x(), range->start()->y()}, CoreCoord{range->end()->x(), range->end()->y()});
     }
     return CoreRangeSet{ranges};
-}
-
-flatbuffers::Offset<flatbuffer::CoreCoord> to_flatbuffer(
-    flatbuffers::FlatBufferBuilder& builder, const CoreCoord& core_coord) {
-    return flatbuffer::CreateCoreCoord(builder, core_coord.x, core_coord.y);
-}
-
-flatbuffers::Offset<flatbuffer::CoreRange> to_flatbuffer(
-    flatbuffers::FlatBufferBuilder& builder, const CoreRange& core_range) {
-    auto start = flatbuffer::CreateCoreCoord(builder, core_range.start_coord.x, core_range.start_coord.y);
-    auto end = flatbuffer::CreateCoreCoord(builder, core_range.end_coord.x, core_range.end_coord.y);
-    return flatbuffer::CreateCoreRange(builder, start, end);
 }
 
 flatbuffers::Offset<flatbuffer::CoreRangeSet> to_flatbuffer(

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -30,28 +30,6 @@
 
 using namespace tt::tt_metal;
 
-namespace {
-
-// Threshold for switch for mmap-based allocations to regular allocations.
-// Determined empirically using a microbenchmark; see https://github.com/tenstorrent/tt-metal/pull/22959 for details.
-constexpr size_t kMmapThresholdBytes = 1 << 20;
-
-// Allocates memory on the host in batch; using either mmap for large allocations or std::vector for small allocations.
-using SharedMemoryPtr = std::shared_ptr<void>;
-SharedMemoryPtr allocate_host_data(size_t size_bytes) {
-    if (size_bytes >= kMmapThresholdBytes) {
-        ZoneScopedN("AllocateBufferMmap");
-        void* ptr = mmap(nullptr, size_bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        TT_FATAL(ptr != MAP_FAILED, "Failed to allocate {} bytes of memory", size_bytes);
-        return SharedMemoryPtr(ptr, [size_bytes](void* p) { madvise(p, size_bytes, MADV_FREE); });
-    } else {
-        auto vec = std::make_shared<std::vector<std::byte>>(size_bytes);
-        return SharedMemoryPtr(vec, vec->data());
-    }
-}
-
-}  // unnamed namespace
-
 namespace tt {
 
 namespace tt_metal {

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -211,7 +211,7 @@ static void emit_sharded_tensor_kernel_rt_args(IDevice* d, Tensor const& tensor,
     std::copy(std::begin(new_args), std::end(new_args), std::back_inserter(args));
 }
 
-static bool shard_grid_is_transposed(Tensor const& t) {
+inline bool shard_grid_is_transposed(const Tensor& t) {
     TT_FATAL(
         t.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
             t.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED ||

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
@@ -410,9 +410,7 @@ std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_sender_kernel_rt_a
 }
 
 
-static void convert_slices_to_ccl_commands() {
 
-}
 
 // Moved to (and updated in) ccl_worker_builder.cpp
 /*

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp
@@ -50,7 +50,6 @@ inline bool is_dram(const Tensor& input_tensor) {
 inline bool is_dram(const std::optional<const Tensor>& input_tensor) {
     return input_tensor.has_value() ? is_dram(input_tensor.value()) : true;
 }
-inline bool is_dram(const Buffer* b) { return b->buffer_type() == BufferType::DRAM; }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.cpp
@@ -179,42 +179,6 @@ Tensor pre_scatter_transform_tensor(
 
 Tensor post_scatter_transform_tensor(
     Tensor& output_tensor,
-    const int32_t dim,
-    const bool is_dim_last_idx,
-    const Shape& original_logical_shape,
-    const Layout& original_layout) {
-    const auto orig_rank = original_logical_shape.rank();
-
-    if (orig_rank == 1) {
-        output_tensor = ttnn::reshape(output_tensor, original_logical_shape);
-    } else if (orig_rank < 4) {
-        output_tensor = ttnn::squeeze_from_4D(output_tensor, orig_rank);
-    } else if (orig_rank > 4) {
-        ttnn::SmallVector<uint32_t> result_shape(original_logical_shape.cbegin(), original_logical_shape.cend());
-        output_tensor = ttnn::reshape(output_tensor, original_logical_shape);
-    }
-
-    // transposing a row-major tensor here
-    if (!is_dim_last_idx) {
-        output_tensor = ttnn::transpose(output_tensor, dim, -1, output_tensor.memory_config());
-    }
-
-    TT_FATAL(
-        output_tensor.get_logical_shape() == original_logical_shape,
-        "Output tensor transformation did not create correct output shape! Got: {}, expected: {}",
-        output_tensor.get_logical_shape(),
-        original_logical_shape);
-
-    // if the output tensor's original layout is not row-major, convert the output tensor back
-    if (original_layout != Layout::ROW_MAJOR) {
-        output_tensor = ttnn::to_layout(output_tensor, original_layout);
-    }
-
-    return output_tensor;
-}
-
-Tensor post_scatter_transform_tensor(
-    Tensor& output_tensor,
     const Shape& after_transpose_shape,
     const int32_t dim,
     const bool is_dim_last_idx,

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -438,7 +438,7 @@ namespace random {
 
 inline auto RANDOM_GENERATOR = std::mt19937(0);
 
-static void seed(std::size_t seed) { RANDOM_GENERATOR = std::mt19937(seed); }
+inline void seed(std::size_t seed) { RANDOM_GENERATOR = std::mt19937(seed); }
 
 template <typename T>
 static Tensor uniform(T low, T high, const ttnn::Shape& shape, const Layout layout = Layout::ROW_MAJOR) {
@@ -468,7 +468,7 @@ static Tensor uniform(T low, T high, const ttnn::Shape& shape, const Layout layo
     return Tensor(tt::tt_metal::HostBuffer(std::move(output_buffer)), spec).to_layout(layout);
 }
 
-static Tensor random(
+inline Tensor random(
     const ttnn::Shape& shape, const DataType data_type = DataType::BFLOAT16, const Layout layout = Layout::ROW_MAJOR) {
     switch (data_type) {
         case DataType::UINT8: return uniform(uint8_t(0), uint8_t(1), shape, layout);
@@ -483,7 +483,7 @@ static Tensor random(
 }  // namespace random
 
 namespace detail {
-static bool nearly_equal(float a, float b, float epsilon = 1e-5f, float abs_threshold = 1e-5f) {
+inline bool nearly_equal(float a, float b, float epsilon = 1e-5f, float abs_threshold = 1e-5f) {
     auto diff = std::abs(a - b);
     auto norm = std::min((std::abs(a) + std::abs(b)), std::numeric_limits<float>::max());
     auto result = diff < std::max(abs_threshold, epsilon * norm);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -27,47 +27,6 @@ inline bool is_dram(const Tensor& input_tensor) {
 inline bool is_dram(const std::optional<const Tensor>& input_tensor) {
     return input_tensor.has_value() ? is_dram(input_tensor.value()) : true;
 }
-inline bool is_dram(const Buffer* b) { return b->buffer_type() == BufferType::DRAM; }
-
-inline bool cbs_fit_in_DRAM(
-    uint32_t in0_CB_size,
-    uint32_t in_CB_size,
-    uint32_t in2_CB_size,
-    uint32_t in3_CB_size,
-    uint32_t in5_CB_size,
-    uint32_t in6_CB_size,
-    uint32_t in_mask_CB_size,
-    uint32_t repack_CB_size,
-    uint32_t x_CB_size,
-    uint32_t xmm_CB_size,
-    uint32_t ex_partial_CB_size,
-    uint32_t ex_global_CB_size,
-    uint32_t ex2_global_CB_size,
-    uint32_t xmm2_CB_size,
-    uint32_t xmm3_CB_size,
-    uint32_t ex2pe_CB_size,
-    uint32_t out_CB_size,
-    uint32_t l1_size) {
-    uint32_t sum = 0;
-    sum += in0_CB_size;
-    sum += in_CB_size;
-    sum += in2_CB_size;
-    sum += in3_CB_size;
-    sum += in5_CB_size;
-    sum += in6_CB_size;
-    sum += in_mask_CB_size;
-    sum += repack_CB_size;
-    sum += x_CB_size;
-    sum += xmm_CB_size;
-    sum += ex_partial_CB_size;
-    sum += ex_global_CB_size;
-    sum += ex2_global_CB_size;
-    sum += xmm2_CB_size;
-    sum += xmm3_CB_size;
-    sum += ex2pe_CB_size;
-    sum += out_CB_size;
-    return sum < l1_size;
-}
 
 int get_max_subblock(uint32_t n, uint32_t max_subblock_w) {
     if (n <= max_subblock_w) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -27,7 +27,6 @@ inline bool is_dram(const Tensor& input_tensor) {
 inline bool is_dram(const std::optional<const Tensor>& input_tensor) {
     return input_tensor.has_value() ? is_dram(input_tensor.value()) : true;
 }
-inline bool is_dram(const Buffer* b) { return b->buffer_type() == BufferType::DRAM; }
 
 inline uint16_t bfloat16(float float_num) {
     uint32_t uint32_data;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
@@ -29,7 +29,6 @@ inline bool is_dram(const Tensor& input_tensor) {
 inline bool is_dram(const std::optional<const Tensor>& input_tensor) {
     return input_tensor.has_value() ? is_dram(input_tensor.value()) : true;
 }
-inline bool is_dram(const Buffer* b) { return b->buffer_type() == BufferType::DRAM; }
 
 inline uint16_t bfloat16(float float_num) {
     uint32_t uint32_data;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
@@ -23,10 +23,6 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 inline bool is_dram(const Tensor& input_tensor) {
     return input_tensor.memory_config().buffer_type() == BufferType::DRAM;
 }
-inline bool is_dram(const std::optional<const Tensor>& input_tensor) {
-    return input_tensor.has_value() ? is_dram(input_tensor.value()) : true;
-}
-inline bool is_dram(const Buffer* b) { return b->buffer_type() == BufferType::DRAM; }
 
 inline uint16_t bfloat16(float float_num) {
     uint32_t uint32_data;

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
@@ -26,13 +26,8 @@ namespace ttnn::operations::normalization {
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
-inline bool is_dram(const Tensor& input_tensor) {
-    return input_tensor.memory_config().buffer_type() == tt::tt_metal::BufferType::DRAM;
-}
-inline bool is_dram(const std::optional<const Tensor>& input_tensor) {
-    return input_tensor.has_value() ? is_dram(input_tensor.value()) : true;
-}
-inline bool is_dram(const tt::tt_metal::Buffer* b) { return b->buffer_type() == tt::tt_metal::BufferType::DRAM; }
+
+
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 // implementation of softmax with optional scale/mask (see the header for input_tensor more detailed description)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23444)

### Problem description
A lot of functions in tt_metal are unused, or are defined as static functions when they aren't actually used in all the files that include them. This PR removes unused functions, as well as making static functions inline functions so that the unused function compiler warnings no longer occur and have to be suppressed. This is the second PR of many to remove all the compiler warnings.

### What's changed
many functions have been deleted or been changed from static to inline so that they don't go unused.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes