### PR TITLE
#0: Fix fabric node id in get_number_of_available_routing_planes

### DIFF
--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -19,7 +19,6 @@
 #include <set>
 #include <vector>
 
-#include "distributed/mesh_socket_utils.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.h>
 
@@ -197,9 +196,8 @@ size_t get_number_of_available_routing_planes(
     size_t row_idx = cluster_axis == 0 ? 0 : row_or_col;
     size_t col_idx = cluster_axis == 0 ? row_or_col : 0;
     auto* first_chip = mesh_device.get_device(row_idx, col_idx);
-    chip_id_t first_chip_id = mesh_device.get_device(row_idx, col_idx)->id();
-    auto mesh_id = tt::tt_metal::distributed::get_physical_mesh_id(&mesh_device, MeshCoordinate{row_idx, col_idx});
-    auto fabric_node_in_row_or_col = FabricNodeId{MeshId{mesh_id}, first_chip_id};
+    chip_id_t first_chip_id = first_chip->id();
+    auto fabric_node_in_row_or_col = control_plane.get_fabric_node_id_from_physical_chip_id(first_chip_id);
 
     // Map cluster axis to routing directions
     constexpr std::array<std::array<RoutingDirection, 2>, 2> cluster_axis_directions_to_check = {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Function was using the physical device id in place of the fabric logical id when constructing the node id.

### What's changed
Change to use `get_fabric_node_id_from_physical_chip_id` to derive the node id from the physical id instead of manually constructing it from other apis.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15882576725
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes
T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/15882574105
TG Unit: https://github.com/tenstorrent/tt-metal/actions/runs/15882589939
Galaxy Quick: https://github.com/tenstorrent/tt-metal/actions/runs/15882861582