### PR TITLE
#24151: [skip ci] Fix superset timestamp for skipped jobs

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -273,10 +273,18 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
     job_submission_ts_dt = get_datetime_from_github_datetime(job_submission_ts)
     job_start_ts_dt = get_datetime_from_github_datetime(job_start_ts)
 
-    if job_submission_ts_dt > job_start_ts_dt:
-        logger.warning(
-            f"Job {github_job_id} seems to have a start time that's earlier than submission. Setting equal for data"
-        )
+    if job_submission_ts_dt > job_start_ts_dt or github_job["conclusion"] == "skipped":
+        if github_job["conclusion"] == "skipped":
+            # When the job is skipped, github may set the start timestamp to an invalid value
+            # In this case, just set the started_at timestamp to the created_at timestamp
+            # See https://github.com/tenstorrent/tt-metal/issues/24151 for an example
+            logger.warning(
+                f"Job {github_job_id} is skipped. Setting start timestamp equal to submission timestamp for data"
+            )
+        else:
+            logger.warning(
+                f"Job {github_job_id} seems to have a start time that's earlier than submission. Setting start timestamp equal to submission timestamp for data"
+            )
         job_submission_ts = job_start_ts
 
     job_end_ts = github_job["completed_at"]

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -281,11 +281,12 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
             logger.warning(
                 f"Job {github_job_id} is skipped. Setting start timestamp equal to submission timestamp for data"
             )
+            job_start_ts = job_submission_ts
         else:
             logger.warning(
                 f"Job {github_job_id} seems to have a start time that's earlier than submission. Setting start timestamp equal to submission timestamp for data"
             )
-        job_submission_ts = job_start_ts
+            job_submission_ts = job_start_ts
 
     job_end_ts = github_job["completed_at"]
 


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-metal/issues/24151

### Problem description
Github sometimes returns a broken start timestamp for skipped jobs.
This breaks the table constraint when data is pushed to postgres

### What's changed
If the job is skipped, set the start timestamp equal to the submission timestamp.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes