### PR TITLE
Reduction ops: Collect better execution times in sweeps

### DIFF
--- a/tests/sweep_framework/sweep_utils/reduction_common.py
+++ b/tests/sweep_framework/sweep_utils/reduction_common.py
@@ -11,7 +11,7 @@ import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
@@ -48,10 +48,10 @@ def run_sum(
         memory_config=input_a_memory_config,
     )
 
-    start_time = start_measuring_time()
-    op_output_tensor = ttnn.sum(input_tensor_a, dim=dim, memory_config=output_memory_config)
+    op_output_tensor, e2e_perf = profile_ttnn_call(
+        ttnn.sum, input_tensor_a, keepdim=keepdim, dim=dim, memory_config=output_memory_config
+    )
     output_tensor = ttnn.to_torch(op_output_tensor)
-    e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
     tensors = [input_tensor_a, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
@@ -86,10 +86,10 @@ def run_prod(
         memory_config=input_a_memory_config,
     )
 
-    start_time = start_measuring_time()
-    op_output_tensor = ttnn.prod(input_tensor_a, dim=dim, keepdim=keepdim, memory_config=output_memory_config)
+    op_output_tensor, e2e_perf = profile_ttnn_call(
+        ttnn.prod, input_tensor_a, keepdim=keepdim, dim=dim, memory_config=output_memory_config
+    )
     output_tensor = ttnn.to_torch(op_output_tensor)
-    e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
     tensors = [input_tensor_a, op_output_tensor]
     assert len(output_tensor.shape) == len(torch_output_tensor.shape)

--- a/tests/sweep_framework/sweep_utils/reduction_common.py
+++ b/tests/sweep_framework/sweep_utils/reduction_common.py
@@ -49,7 +49,7 @@ def run_sum(
     )
 
     op_output_tensor, e2e_perf = profile_ttnn_call(
-        ttnn.sum, input_tensor_a, keepdim=keepdim, dim=dim, memory_config=output_memory_config
+        device, ttnn.sum, input_tensor_a, keepdim=keepdim, dim=dim, memory_config=output_memory_config
     )
     output_tensor = ttnn.to_torch(op_output_tensor)
     expected_pcc = 0.999
@@ -87,7 +87,7 @@ def run_prod(
     )
 
     op_output_tensor, e2e_perf = profile_ttnn_call(
-        ttnn.prod, input_tensor_a, keepdim=keepdim, dim=dim, memory_config=output_memory_config
+        device, ttnn.prod, input_tensor_a, keepdim=keepdim, dim=dim, memory_config=output_memory_config
     )
     output_tensor = ttnn.to_torch(op_output_tensor)
     expected_pcc = 0.999

--- a/tests/sweep_framework/sweep_utils/reduction_common.py
+++ b/tests/sweep_framework/sweep_utils/reduction_common.py
@@ -8,10 +8,9 @@ from functools import partial
 import torch
 import random
 import ttnn
-from tests.sweep_framework.sweep_utils.utils import gen_shapes
+from tests.sweep_framework.sweep_utils.utils import profile_ttnn_call
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 

--- a/tests/sweep_framework/sweep_utils/roofline_utils.py
+++ b/tests/sweep_framework/sweep_utils/roofline_utils.py
@@ -59,7 +59,10 @@ def update_check_result(check_result, metrics):
 def get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts=None):
     check_result = check_with_pcc(torch_output_tensor, output_tensor, expected_pcc)
     metrics = get_roofline_metrics(tensors)
-    metrics.update({"E2E_PERF": e2e_perf})
+    if isinstance(e2e_perf, dict):
+        metrics.update(e2e_perf)
+    else:
+        metrics.update({"E2E_PERF": e2e_perf})
     if flop_counts:
         metrics.update({"FLOP_COUNT": get_product(flop_counts)})
     updated_check_result = update_check_result(check_result, metrics)

--- a/tests/sweep_framework/sweep_utils/roofline_utils.py
+++ b/tests/sweep_framework/sweep_utils/roofline_utils.py
@@ -56,7 +56,8 @@ def update_check_result(check_result, metrics):
     if not status:
         return check_result
     metrics.update({"PCC": message})
-    return status, metrics
+    message = " ".join([f"{key} {value}" for key, value in metrics.items()])
+    return status, message
 
 
 def get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf, flop_counts=None):
@@ -64,6 +65,7 @@ def get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2
     metrics = get_roofline_metrics(tensors)
     if isinstance(e2e_perf, dict):
         metrics.update(e2e_perf)
+        e2e_perf = metrics["E2E_PERF"]
     else:
         metrics.update({"E2E_PERF": e2e_perf})
     if flop_counts:

--- a/tests/sweep_framework/sweep_utils/roofline_utils.py
+++ b/tests/sweep_framework/sweep_utils/roofline_utils.py
@@ -5,6 +5,7 @@
 import ttnn
 from loguru import logger
 from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import is_wormhole_b0
 
 
 def get_product(lst):
@@ -17,10 +18,12 @@ def get_product(lst):
 def get_byte_count(tensor):
     shape = tensor.padded_shape
     dtype = tensor.dtype
-    if dtype == ttnn.float32:
+    if dtype in (ttnn.float32, ttnn.uint32, ttnn.int32):
         count = 4
     elif dtype == ttnn.bfloat16:
         count = 2
+    elif dtype == ttnn.uint8:
+        count = 1
     elif dtype == ttnn.bfloat8_b:
         count = 1.0625
     else:

--- a/tests/sweep_framework/sweep_utils/utils.py
+++ b/tests/sweep_framework/sweep_utils/utils.py
@@ -354,6 +354,7 @@ def profile_ttnn_call(device, function: Callable, *args: List[Any], **kwargs: Di
         for _ in range(IGNORE_RUNS):
             _results = function(*args, **kwargs)
 
+    ttnn.synchronize_device(device)
     start_time = start_measuring_time()
     for _ in range(REPEAT_RUNS):
         results = function(*args, **kwargs)
@@ -362,7 +363,6 @@ def profile_ttnn_call(device, function: Callable, *args: List[Any], **kwargs: Di
 
     # If this is called from pytest, get device time from profiler logs.
     if os.environ.get("PYTEST_CURRENT_TEST"):
-        ttnn.synchronize_device(device)
         ttnn.DumpDeviceProfiler(device)
         opPerfData = get_device_data_generate_report(
             PROFILER_LOGS_DIR, outputFolder=None, date=None, nameAppend=None, export_csv=False, cleanup_device_log=True

--- a/tests/sweep_framework/sweep_utils/utils.py
+++ b/tests/sweep_framework/sweep_utils/utils.py
@@ -14,9 +14,13 @@ import itertools
 from typing import Optional, List, Callable
 import copy
 from functools import partial
+from typing import Tuple, Callable, List, Dict, Any
 
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 from models.utility_functions import torch_random
+from tests.ttnn.utils_for_testing import start_measuring_time, stop_measuring_time
+from tt_metal.tools.profiler.process_ops_logs import get_device_data_generate_report
+from tt_metal.tools.profiler.common import PROFILER_LOGS_DIR
 
 
 def sanitize_shape_rm(input_shape):
@@ -285,7 +289,7 @@ def get_device_grid_size():
     return y, x
 
 
-def gen_pytest_parametrize_args(parameters: dict, invalidate_function: Callable | None = None) -> dict:
+def gen_pytest_parametrize_args(parameters: dict, invalidate_function: Optional[Callable] = None) -> dict:
     """Generate pytest parametrize arguments from a dictionary of parameters."
     Args:
         parameters: A dictionary of parameters. The keys are the config names and the values are dictionaries of parameter values.
@@ -331,3 +335,38 @@ def gen_pytest_parametrize_args(parameters: dict, invalidate_function: Callable 
             )
             test_id2values[id_str] = arg_vals
     return {"argnames": test_argnames, "argvalues": test_id2values.values(), "ids": test_id2values.keys()}
+
+
+IGNORE_RUNS = 1
+"""The number of runs to ignore when measuring the average time."""
+
+
+REPEAT_RUNS = 1
+"""The number of runs to average when measuring performance."""
+
+
+def profile_ttnn_call(device, function: Callable, *args: List[Any], **kwargs: Dict[str, Any]) -> Tuple[Any, float]:
+    """Determine the average time taken for a function call, excluding the first IGNORE_RUNS runs."""
+
+    # If this is called from pytest, we need to ignore the first IGNORE_RUNS runs to avoid the JIT compile time overhead.
+    # This is not a problem when called from sweep framework, because it already ignores the first run.
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        for _ in range(IGNORE_RUNS):
+            _results = function(*args, **kwargs)
+
+    start_time = start_measuring_time()
+    for _ in range(REPEAT_RUNS):
+        results = function(*args, **kwargs)
+    avg_host_time = stop_measuring_time(start_time) / REPEAT_RUNS
+    e2e_perf = {"E2E_PERF": avg_host_time}
+
+    # If this is called from pytest, get device time from profiler logs.
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        ttnn.synchronize_device(device)
+        ttnn.DumpDeviceProfiler(device)
+        opPerfData = get_device_data_generate_report(
+            PROFILER_LOGS_DIR, outputFolder=None, date=None, nameAppend=None, export_csv=False, cleanup_device_log=True
+        )
+        if opPerfData:
+            e2e_perf["AVG_DEVICE_TIME"] = opPerfData[0]["DEVICE KERNEL DURATION [ns]"]
+    return results, e2e_perf

--- a/tests/sweep_framework/sweep_utils/utils.py
+++ b/tests/sweep_framework/sweep_utils/utils.py
@@ -322,6 +322,7 @@ def gen_pytest_parametrize_args(parameters: dict, invalidate_function: Callable 
                 test_vector = {name: val for name, val in zip(test_argnames, arg_vals)}
                 should_skip, _reason = invalidate_function(test_vector)
                 if should_skip:
+                    logger.debug(f"Invalidate function returned {should_skip} for {test_vector} with reason {_reason}")
                     continue
             id_str = (
                 str(param_name)

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
@@ -12,7 +12,7 @@ import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm, gen_pytest_parametrize_args
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import check_with_pcc, profile_ttnn_call
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 from loguru import logger

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
@@ -12,7 +12,7 @@ import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm, gen_pytest_parametrize_args
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import check_with_pcc, profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 from loguru import logger
@@ -128,10 +128,10 @@ def run_argmax(
         memory_config=input_a_memory_config,
     )
 
-    start_time = start_measuring_time()
-    op_output_tensor = ttnn.argmax(input_tensor_a, dim=dim, keepdim=keepdim, memory_config=output_memory_config)
+    op_output_tensor, e2e_perf = profile_ttnn_call(
+        ttnn.argmax, input_tensor_a, dim=dim, keepdim=keepdim, memory_config=output_memory_config
+    )
     output_tensor = ttnn.to_torch(op_output_tensor)
-    e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
     tensors = [input_tensor_a, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
@@ -175,18 +175,6 @@ def test_argmax(
     input_a_memory_config,
     output_memory_config,
 ):
-    test_vector = {
-        "input_shape": input_shape,
-        "dim": dim,
-        "keepdim": keepdim,
-        "input_a_dtype": input_a_dtype,
-        "input_layout": input_layout,
-        "input_a_memory_config": input_a_memory_config,
-        "output_memory_config": output_memory_config,
-    }
-    result, reason = invalidate_vector(test_vector)
-    if result:
-        pytest.skip(reason)
     (result, msg), e2e_perf = run_argmax(
         input_shape,
         dim,

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
@@ -129,7 +129,7 @@ def run_argmax(
     )
 
     op_output_tensor, e2e_perf = profile_ttnn_call(
-        ttnn.argmax, input_tensor_a, dim=dim, keepdim=keepdim, memory_config=output_memory_config
+        device, ttnn.argmax, input_tensor_a, dim=dim, keepdim=keepdim, memory_config=output_memory_config
     )
     output_tensor = ttnn.to_torch(op_output_tensor)
     expected_pcc = 0.999

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
@@ -9,10 +9,14 @@ import pytest
 import torch
 import random
 import ttnn
-from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm, gen_pytest_parametrize_args
+from tests.sweep_framework.sweep_utils.utils import (
+    gen_shapes,
+    sanitize_shape_rm,
+    gen_pytest_parametrize_args,
+    profile_ttnn_call,
+)
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 from loguru import logger

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax_output.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax_output.py
@@ -11,7 +11,7 @@ import ttnn
 from tests.sweep_framework.framework.permutations import *
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 from loguru import logger
@@ -105,10 +105,8 @@ def run_argmax(
         memory_config=output_memory_config,
     )
 
-    start_time = start_measuring_time()
-    op_output_tensor = ttnn.argmax(input_tensor_a, dim=dim, output_tensor=output_tensor)
+    op_output_tensor, e2e_perf = profile_ttnn_call(ttnn.argmax, input_tensor_a, dim=dim, output_tensor=output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
     tensors = [input_tensor_a, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax_output.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax_output.py
@@ -105,7 +105,9 @@ def run_argmax(
         memory_config=output_memory_config,
     )
 
-    op_output_tensor, e2e_perf = profile_ttnn_call(ttnn.argmax, input_tensor_a, dim=dim, output_tensor=output_tensor)
+    op_output_tensor, e2e_perf = profile_ttnn_call(
+        device, ttnn.argmax, input_tensor_a, dim=dim, output_tensor=output_tensor
+    )
     output_tensor = ttnn.to_torch(output_tensor)
     expected_pcc = 0.999
     tensors = [input_tensor_a, op_output_tensor]

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax_output.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax_output.py
@@ -9,9 +9,8 @@ import torch
 import random
 import ttnn
 from tests.sweep_framework.framework.permutations import *
-from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm, profile_ttnn_call
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
-from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 from loguru import logger

--- a/tests/sweep_framework/sweeps/reduction/backward/prod_bw/prod_bw.py
+++ b/tests/sweep_framework/sweeps/reduction/backward/prod_bw/prod_bw.py
@@ -11,7 +11,7 @@ import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import check_with_pcc, profile_ttnn_call
 from models.utility_functions import torch_random
 
 # Override the default timeout in seconds for hang detection.
@@ -140,9 +140,9 @@ def run(
         memory_config=input_a_memory_config,
     )
 
-    start_time = start_measuring_time()
-    output_tensor = ttnn.prod_bw(grad_tensor, input_tensor_a, dim=dim, memory_config=output_memory_config)[0]
-    output_tensor = ttnn.to_torch(output_tensor)
-    e2e_perf = stop_measuring_time(start_time)
+    output_tensor, e2e_perf = profile_ttnn_call(
+        ttnn.prod_bw, grad_tensor, input_tensor_a, dim=dim, memory_config=output_memory_config
+    )
+    output_tensor = ttnn.to_torch(output_tensor[0])
 
     return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/reduction/backward/prod_bw/prod_bw.py
+++ b/tests/sweep_framework/sweeps/reduction/backward/prod_bw/prod_bw.py
@@ -141,7 +141,7 @@ def run(
     )
 
     output_tensor, e2e_perf = profile_ttnn_call(
-        ttnn.prod_bw, grad_tensor, input_tensor_a, dim=dim, memory_config=output_memory_config
+        device, ttnn.prod_bw, grad_tensor, input_tensor_a, dim=dim, memory_config=output_memory_config
     )
     output_tensor = ttnn.to_torch(output_tensor[0])
 

--- a/tests/sweep_framework/sweeps/reduction/backward/prod_bw/prod_bw.py
+++ b/tests/sweep_framework/sweeps/reduction/backward/prod_bw/prod_bw.py
@@ -10,10 +10,10 @@ import pytest
 import torch
 import random
 import ttnn
-from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, profile_ttnn_call
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import check_with_pcc, profile_ttnn_call
+from tests.ttnn.utils_for_testing import check_with_pcc
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 
@@ -204,4 +204,4 @@ def test_prod_bw(
     assert result, msg
     logger.info(msg)
     if e2e_perf:
-        logger.info(f"Perf. metrics: {e2e_perf}")
+        logger.info(f"E2E Perf: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/generality/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/generality/argmax.py
@@ -63,10 +63,10 @@ def run_argmax(device, tensor_shape, dim, keepdim, use_multicore) -> list:
     try:
         if dim is not None:
             op_output_tensor, e2e_perf = profile_ttnn_call(
-                ttnn_op, ttnn_tensor, dim=dim, keepdim=keepdim, use_multicore=use_multicore
+                device, ttnn_op, ttnn_tensor, dim=dim, keepdim=keepdim, use_multicore=use_multicore
             )
         else:
-            op_output_tensor, e2e_perf = profile_ttnn_call(ttnn_op, ttnn_tensor, use_multicore=use_multicore)
+            op_output_tensor, e2e_perf = profile_ttnn_call(device, ttnn_op, ttnn_tensor, use_multicore=use_multicore)
         output_tensor = ttnn.to_torch(ttnn.from_device(op_output_tensor))
     except RuntimeError as e:
         ttnn_errored = True

--- a/tests/sweep_framework/sweeps/reduction/generality/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/generality/argmax.py
@@ -10,7 +10,7 @@ import ttnn
 from loguru import logger
 
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 # Override the default timeout in seconds for hang detection.
@@ -60,18 +60,18 @@ def run_argmax(device, tensor_shape, dim, keepdim, use_multicore) -> list:
 
     ttnn_errored = False
     ttnn_error_msg = ""
-    start_time = start_measuring_time()
     try:
-        op_output_tensor = (
-            ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim, use_multicore=use_multicore)
-            if dim is not None
-            else ttnn_op(ttnn_tensor, use_multicore=use_multicore)
-        )
+        if dim is not None:
+            op_output_tensor, e2e_perf = profile_ttnn_call(
+                ttnn_op, ttnn_tensor, dim=dim, keepdim=keepdim, use_multicore=use_multicore
+            )
+        else:
+            op_output_tensor, e2e_perf = profile_ttnn_call(ttnn_op, ttnn_tensor, use_multicore=use_multicore)
         output_tensor = ttnn.to_torch(ttnn.from_device(op_output_tensor))
     except RuntimeError as e:
         ttnn_errored = True
         ttnn_error_msg = str(e)
-    e2e_perf = stop_measuring_time(start_time)
+        e2e_perf = None
 
     if torch_errored != ttnn_errored:
         return [

--- a/tests/sweep_framework/sweeps/reduction/generality/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/generality/argmax.py
@@ -9,8 +9,7 @@ import torch
 import ttnn
 from loguru import logger
 
-from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
-from tests.ttnn.utils_for_testing import profile_ttnn_call
+from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args, profile_ttnn_call
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 # Override the default timeout in seconds for hang detection.

--- a/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
+++ b/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
@@ -12,7 +12,7 @@ import ttnn
 from loguru import logger
 
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 # Override the default timeout in seconds for hang detection.
@@ -67,13 +67,15 @@ def run_reduction(device, tensor_shape, dim, keepdim, op, dtype) -> list:
         torch_errored = True
 
     ttnn_errored = False
-    start_time = start_measuring_time()
     try:
-        op_output_tensor = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim) if dim is not None else ttnn_op(ttnn_tensor)
+        if dim is not None:
+            op_output_tensor, e2e_perf = profile_ttnn_call(ttnn_op, ttnn_tensor, dim=dim, keepdim=keepdim)
+        else:
+            op_output_tensor, e2e_perf = profile_ttnn_call(ttnn_op, ttnn_tensor)
         output_tensor = ttnn.to_torch(ttnn.from_device(op_output_tensor))
     except RuntimeError:
         ttnn_errored = True
-    e2e_perf = stop_measuring_time(start_time)
+        e2e_perf = None
 
     # Skip the rest of the test if an exception was raised in both
     if torch_errored:

--- a/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
+++ b/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
@@ -69,9 +69,9 @@ def run_reduction(device, tensor_shape, dim, keepdim, op, dtype) -> list:
     ttnn_errored = False
     try:
         if dim is not None:
-            op_output_tensor, e2e_perf = profile_ttnn_call(ttnn_op, ttnn_tensor, dim=dim, keepdim=keepdim)
+            op_output_tensor, e2e_perf = profile_ttnn_call(device, ttnn_op, ttnn_tensor, dim=dim, keepdim=keepdim)
         else:
-            op_output_tensor, e2e_perf = profile_ttnn_call(ttnn_op, ttnn_tensor)
+            op_output_tensor, e2e_perf = profile_ttnn_call(device, ttnn_op, ttnn_tensor)
         output_tensor = ttnn.to_torch(ttnn.from_device(op_output_tensor))
     except RuntimeError:
         ttnn_errored = True

--- a/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
+++ b/tests/sweep_framework/sweeps/reduction/generality/reduction_all_ranks.py
@@ -11,8 +11,7 @@ import torch
 import ttnn
 from loguru import logger
 
-from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
-from tests.ttnn.utils_for_testing import profile_ttnn_call
+from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args, profile_ttnn_call
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 # Override the default timeout in seconds for hang detection.

--- a/tests/sweep_framework/sweeps/reduction/mean/mean.py
+++ b/tests/sweep_framework/sweeps/reduction/mean/mean.py
@@ -12,7 +12,7 @@ import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
@@ -118,10 +118,10 @@ def run(
         memory_config=input_a_memory_config,
     )
 
-    start_time = start_measuring_time()
-    op_output_tensor = ttnn.mean(input_tensor_a, dim=dim, memory_config=output_memory_config)
+    op_output_tensor, e2e_perf = profile_ttnn_call(
+        ttnn.mean, input_tensor_a, dim=dim, memory_config=output_memory_config
+    )
     output_tensor = ttnn.to_torch(op_output_tensor)
-    e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
     tensors = [input_tensor_a, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/reduction/mean/mean.py
+++ b/tests/sweep_framework/sweeps/reduction/mean/mean.py
@@ -119,7 +119,7 @@ def run(
     )
 
     op_output_tensor, e2e_perf = profile_ttnn_call(
-        ttnn.mean, input_tensor_a, dim=dim, memory_config=output_memory_config
+        device, ttnn.mean, input_tensor_a, dim=dim, memory_config=output_memory_config
     )
     output_tensor = ttnn.to_torch(op_output_tensor)
     expected_pcc = 0.999

--- a/tests/sweep_framework/sweeps/reduction/mean/mean.py
+++ b/tests/sweep_framework/sweeps/reduction/mean/mean.py
@@ -5,11 +5,13 @@
 from typing import Optional, Tuple
 from functools import partial
 import numpy as np
+from loguru import logger
+import pytest
 
 import torch
 import random
 import ttnn
-from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args, gen_shapes, sanitize_shape_rm
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import profile_ttnn_call
@@ -82,11 +84,8 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     return False, None
 
 
-# This is the run instructions for the test, defined by the developer.
-# The run function must take the above-defined parameters as inputs.
-# The runner will call this run function with each test vector, and the returned results from this function will be stored.
-# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
-def run(
+def run_mean(
+    device,
     input_shape,
     dim,
     keepdim,
@@ -94,8 +93,6 @@ def run(
     input_layout,
     input_a_memory_config,
     output_memory_config,
-    *,
-    device,
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
@@ -125,3 +122,49 @@ def run(
     expected_pcc = 0.999
     tensors = [input_tensor_a, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    device,
+    input_shape,
+    dim,
+    keepdim,
+    input_a_dtype,
+    input_layout,
+    input_a_memory_config,
+    output_memory_config,
+):
+    return run_mean(
+        device,
+        input_shape,
+        dim,
+        keepdim,
+        input_a_dtype,
+        input_layout,
+        input_a_memory_config,
+        output_memory_config,
+    )
+
+
+@pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters, invalidate_vector))
+def test_mean(
+    device,
+    input_shape,
+    dim,
+    keepdim,
+    input_a_dtype,
+    input_layout,
+    input_a_memory_config,
+    output_memory_config,
+):
+    (result, msg), e2e_perf = run_mean(
+        device, input_shape, dim, keepdim, input_a_dtype, input_layout, input_a_memory_config, output_memory_config
+    )
+    assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"Perf. metrics: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/mean/mean.py
+++ b/tests/sweep_framework/sweeps/reduction/mean/mean.py
@@ -11,10 +11,14 @@ import pytest
 import torch
 import random
 import ttnn
-from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args, gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.utils import (
+    gen_pytest_parametrize_args,
+    gen_shapes,
+    sanitize_shape_rm,
+    profile_ttnn_call,
+)
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
@@ -167,4 +171,4 @@ def test_mean(
     assert result, msg
     logger.info(msg)
     if e2e_perf:
-        logger.info(f"Perf. metrics: {e2e_perf}")
+        logger.info(f"E2E Perf: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/prod.py
+++ b/tests/sweep_framework/sweeps/reduction/prod.py
@@ -10,7 +10,9 @@ import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from loguru import logger
+import pytest
 
+from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 from tests.sweep_framework.sweep_utils.reduction_common import run_prod
 
 # Override the default timeout in seconds for hang detection.
@@ -101,7 +103,24 @@ def run(
     )
 
 
-import pytest
+@pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters, invalidate_vector))
+def test_prod(
+    device,
+    input_shape,
+    dim,
+    keepdim,
+    input_a_dtype,
+    input_a_layout,
+    input_a_memory_config,
+    output_memory_config,
+):
+    (result, msg), e2e_perf = run_prod(
+        input_shape, dim, keepdim, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config, device
+    )
+    assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"Perf. metrics: {e2e_perf}")
 
 
 @pytest.mark.parametrize(

--- a/tests/sweep_framework/sweeps/reduction/prod.py
+++ b/tests/sweep_framework/sweeps/reduction/prod.py
@@ -9,11 +9,8 @@ import torch
 import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
-from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 from loguru import logger
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
-from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.reduction_common import run_prod
 
 # Override the default timeout in seconds for hang detection.

--- a/tests/sweep_framework/sweeps/reduction/prod.py
+++ b/tests/sweep_framework/sweeps/reduction/prod.py
@@ -120,7 +120,7 @@ def test_prod(
     assert result, msg
     logger.info(msg)
     if e2e_perf:
-        logger.info(f"Perf. metrics: {e2e_perf}")
+        logger.info(f"E2E Perf: {e2e_perf}")
 
 
 @pytest.mark.parametrize(

--- a/tests/sweep_framework/sweeps/reduction/std/std.py
+++ b/tests/sweep_framework/sweeps/reduction/std/std.py
@@ -5,11 +5,13 @@
 from typing import Optional, Tuple
 from functools import partial
 import numpy as np
+from loguru import logger
+import pytest
 
 import torch
 import random
 import ttnn
-from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args, gen_shapes, sanitize_shape_rm
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import profile_ttnn_call
@@ -82,11 +84,8 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     return False, None
 
 
-# This is the run instructions for the test, defined by the developer.
-# The run function must take the above-defined parameters as inputs.
-# The runner will call this run function with each test vector, and the returned results from this function will be stored.
-# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
-def run(
+def run_std(
+    device,
     input_shape,
     dim,
     keepdim,
@@ -94,8 +93,6 @@ def run(
     input_layout,
     input_a_memory_config,
     output_memory_config,
-    *,
-    device,
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
@@ -125,3 +122,49 @@ def run(
     expected_pcc = 0.999
     tensors = [input_tensor_a, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    device,
+    input_shape,
+    dim,
+    keepdim,
+    input_a_dtype,
+    input_layout,
+    input_a_memory_config,
+    output_memory_config,
+):
+    return run_std(
+        device,
+        input_shape,
+        dim,
+        keepdim,
+        input_a_dtype,
+        input_layout,
+        input_a_memory_config,
+        output_memory_config,
+    )
+
+
+@pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters, invalidate_vector))
+def test_std(
+    device,
+    input_shape,
+    dim,
+    keepdim,
+    input_a_dtype,
+    input_layout,
+    input_a_memory_config,
+    output_memory_config,
+):
+    (result, msg), e2e_perf = run_std(
+        device, input_shape, dim, keepdim, input_a_dtype, input_layout, input_a_memory_config, output_memory_config
+    )
+    assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"Perf. metrics: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/std/std.py
+++ b/tests/sweep_framework/sweeps/reduction/std/std.py
@@ -119,7 +119,7 @@ def run(
     )
 
     op_output_tensor, e2e_perf = profile_ttnn_call(
-        ttnn.std, input_tensor_a, dim=dim, memory_config=output_memory_config
+        device, ttnn.std, input_tensor_a, dim=dim, memory_config=output_memory_config
     )
     output_tensor = ttnn.to_torch(op_output_tensor)
     expected_pcc = 0.999

--- a/tests/sweep_framework/sweeps/reduction/std/std.py
+++ b/tests/sweep_framework/sweeps/reduction/std/std.py
@@ -12,7 +12,7 @@ import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
@@ -118,10 +118,10 @@ def run(
         memory_config=input_a_memory_config,
     )
 
-    start_time = start_measuring_time()
-    op_output_tensor = ttnn.std(input_tensor_a, dim=dim, memory_config=output_memory_config)
+    op_output_tensor, e2e_perf = profile_ttnn_call(
+        ttnn.std, input_tensor_a, dim=dim, memory_config=output_memory_config
+    )
     output_tensor = ttnn.to_torch(op_output_tensor)
-    e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
     tensors = [input_tensor_a, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/reduction/std/std.py
+++ b/tests/sweep_framework/sweeps/reduction/std/std.py
@@ -11,10 +11,14 @@ import pytest
 import torch
 import random
 import ttnn
-from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args, gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.utils import (
+    gen_pytest_parametrize_args,
+    gen_shapes,
+    sanitize_shape_rm,
+    profile_ttnn_call,
+)
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
@@ -167,4 +171,4 @@ def test_std(
     assert result, msg
     logger.info(msg)
     if e2e_perf:
-        logger.info(f"Perf. metrics: {e2e_perf}")
+        logger.info(f"E2E Perf: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/sum.py
+++ b/tests/sweep_framework/sweeps/reduction/sum.py
@@ -10,11 +10,8 @@ import torch
 import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, gen_pytest_parametrize_args
-from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 from loguru import logger
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
-from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.reduction_common import run_sum
 
 # Override the default timeout in seconds for hang detection.

--- a/tests/sweep_framework/sweeps/reduction/sum.py
+++ b/tests/sweep_framework/sweeps/reduction/sum.py
@@ -5,10 +5,11 @@
 from typing import Optional, Tuple
 from functools import partial
 
+import pytest
 import torch
 import random
 import ttnn
-from tests.sweep_framework.sweep_utils.utils import gen_shapes
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, gen_pytest_parametrize_args
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 from loguru import logger
 
@@ -99,11 +100,28 @@ def run(
     )
 
 
-import pytest
+@pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters, invalidate_vector))
+def test_sum(
+    device,
+    input_shape,
+    dim,
+    keepdim,
+    input_a_dtype,
+    input_a_layout,
+    input_a_memory_config,
+    output_memory_config,
+):
+    (result, msg), e2e_perf = run_sum(
+        input_shape, dim, keepdim, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config, device
+    )
+    assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"Perf. metrics: {e2e_perf}")
 
 
 @pytest.mark.parametrize(
-    "input_shape, dim, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config",
+    "input_shape, dim, keepdim, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config",
     [
         ([7, 32, 4, 96], 3, True, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
     ],

--- a/tests/sweep_framework/sweeps/reduction/sum.py
+++ b/tests/sweep_framework/sweeps/reduction/sum.py
@@ -114,7 +114,7 @@ def test_sum(
     assert result, msg
     logger.info(msg)
     if e2e_perf:
-        logger.info(f"Perf. metrics: {e2e_perf}")
+        logger.info(f"E2E Perf: {e2e_perf}")
 
 
 @pytest.mark.parametrize(

--- a/tests/sweep_framework/sweeps/reduction/topk/topk.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk.py
@@ -4,11 +4,13 @@
 
 from typing import Optional, Tuple
 from functools import partial
+from loguru import logger
+import pytest
 
 import torch
 import random
 import ttnn
-from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape
+from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args, gen_shapes, sanitize_shape
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_topk_simmilarity
@@ -115,11 +117,8 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     return False, None
 
 
-# This is the run instructions for the test, defined by the developer.
-# The run function must take the above-defined parameters as inputs.
-# The runner will call this run function with each test vector, and the returned results from this function will be stored.
-# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
-def run(
+def run_topk(
+    device,
     input_shape,
     dim,
     largest,
@@ -128,8 +127,6 @@ def run(
     input_layout,
     input_a_memory_config,
     output_memory_config,
-    *,
-    device,
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
@@ -169,3 +166,52 @@ def run(
     )
 
     return [(passing, output_str), e2e_perf]
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    device,
+    input_shape,
+    dim,
+    largest,
+    k,
+    input_a_dtype,
+    input_layout,
+    input_a_memory_config,
+    output_memory_config,
+):
+    return run_topk(
+        device,
+        input_shape,
+        dim,
+        largest,
+        k,
+        input_a_dtype,
+        input_layout,
+        input_a_memory_config,
+        output_memory_config,
+    )
+
+
+@pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters, invalidate_vector))
+def test_topk(
+    device,
+    input_shape,
+    dim,
+    largest,
+    k,
+    input_a_dtype,
+    input_layout,
+    input_a_memory_config,
+    output_memory_config,
+):
+    (result, msg), e2e_perf = run_topk(
+        device, input_shape, dim, largest, k, input_a_dtype, input_layout, input_a_memory_config, output_memory_config
+    )
+    assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"Perf. metrics: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/topk/topk.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk.py
@@ -158,7 +158,7 @@ def run(
     )
 
     (output_values, output_indices), e2e_perf = profile_ttnn_call(
-        ttnn.topk, input_tensor_a, k=k, dim=dim, largest=largest, sorted=True
+        device, ttnn.topk, input_tensor_a, k=k, dim=dim, largest=largest, sorted=True
     )
 
     output_values, output_indices = ttnn.to_torch(output_values), ttnn.to_torch(output_indices).to(torch.int64)

--- a/tests/sweep_framework/sweeps/reduction/topk/topk.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk.py
@@ -12,7 +12,7 @@ from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_topk_simmilarity
-from tests.ttnn.utils_for_testing import start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 
 # Override the default timeout in seconds for hang detection.
@@ -157,9 +157,9 @@ def run(
         memory_config=input_a_memory_config,
     )
 
-    start_time = start_measuring_time()
-    output_values, output_indices = ttnn.topk(input_tensor_a, k=k, dim=dim, largest=largest, sorted=True)
-    e2e_perf = stop_measuring_time(start_time)
+    (output_values, output_indices), e2e_perf = profile_ttnn_call(
+        ttnn.topk, input_tensor_a, k=k, dim=dim, largest=largest, sorted=True
+    )
 
     output_values, output_indices = ttnn.to_torch(output_values), ttnn.to_torch(output_indices).to(torch.int64)
     output_gathered_values = torch.gather(torch_input_tensor_a, dim, output_indices)

--- a/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
@@ -126,7 +126,7 @@ def run_topk(
     )
 
     (op_output_values, op_output_indices), e2e_perf = profile_ttnn_call(
-        ttnn.topk, input_tensor_a, k=k, dim=dim, largest=largest, sorted=True
+        device, ttnn.topk, input_tensor_a, k=k, dim=dim, largest=largest, sorted=True
     )
     output_values = ttnn.to_torch(op_output_values)
     output_indices = ttnn.to_torch(op_output_indices).to(torch.int64)

--- a/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
@@ -12,7 +12,7 @@ from tests.sweep_framework.framework.permutations import *
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_topk_simmilarity
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 from loguru import logger
@@ -125,11 +125,11 @@ def run_topk(
         memory_config=output_memory_config,
     )
 
-    start_time = start_measuring_time()
-    ttnn.topk(input_tensor_a, k=k, dim=dim, largest=largest, sorted=True, out=(op_output_values, op_output_indices))
+    (op_output_values, op_output_indices), e2e_perf = profile_ttnn_call(
+        ttnn.topk, input_tensor_a, k=k, dim=dim, largest=largest, sorted=True
+    )
     output_values = ttnn.to_torch(op_output_values)
     output_indices = ttnn.to_torch(op_output_indices).to(torch.int64)
-    e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
     tensors = [input_tensor_a, op_output_values, op_output_indices]
     return get_run_return(torch_output_values, output_values, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
@@ -12,8 +12,8 @@ from tests.sweep_framework.framework.permutations import *
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_topk_simmilarity
-from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.utils import profile_ttnn_call
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 from loguru import logger
 

--- a/tests/sweep_framework/sweeps/reduction/traces/argmax_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/argmax_traces.py
@@ -32,7 +32,7 @@ def run_argmax(device, height, width, dim, dtype, layout):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=layout, device=device)
 
-    op_output_tensor, e2e_perf = profile_ttnn_call(ttnn.argmax, input_tensor, dim=dim)
+    op_output_tensor, e2e_perf = profile_ttnn_call(device, ttnn.argmax, input_tensor, dim=dim)
     output_tensor = ttnn.to_torch(op_output_tensor)
     expected_pcc = 0.999
     tensors = [input_tensor, op_output_tensor]

--- a/tests/sweep_framework/sweeps/reduction/traces/argmax_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/argmax_traces.py
@@ -9,7 +9,7 @@ import torch
 import ttnn
 from loguru import logger
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
@@ -32,10 +32,8 @@ def run_argmax(device, height, width, dim, dtype, layout):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=layout, device=device)
 
-    start_time = start_measuring_time()
-    op_output_tensor = ttnn.argmax(input_tensor, dim=dim)
+    op_output_tensor, e2e_perf = profile_ttnn_call(ttnn.argmax, input_tensor, dim=dim)
     output_tensor = ttnn.to_torch(op_output_tensor)
-    e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
     tensors = [input_tensor, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/reduction/traces/argmax_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/argmax_traces.py
@@ -9,8 +9,8 @@ import torch
 import ttnn
 from loguru import logger
 
-from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.utils import profile_ttnn_call
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 15

--- a/tests/sweep_framework/sweeps/reduction/traces/max_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/max_traces.py
@@ -9,7 +9,7 @@ import torch
 import ttnn
 from loguru import logger
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
@@ -359,10 +359,8 @@ def run_max(device, params, dtype, layout):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=layout, device=device)
 
-    start_time = start_measuring_time()
-    op_output_tensor = ttnn.max(input_tensor, dim=dim, keepdim=keepdim)
+    op_output_tensor, e2e_perf = profile_ttnn_call(ttnn.max, input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(op_output_tensor)
-    e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
     tensors = [input_tensor, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/reduction/traces/max_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/max_traces.py
@@ -359,7 +359,7 @@ def run_max(device, params, dtype, layout):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=layout, device=device)
 
-    op_output_tensor, e2e_perf = profile_ttnn_call(ttnn.max, input_tensor, dim=dim, keepdim=keepdim)
+    op_output_tensor, e2e_perf = profile_ttnn_call(device, ttnn.max, input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(op_output_tensor)
     expected_pcc = 0.999
     tensors = [input_tensor, op_output_tensor]

--- a/tests/sweep_framework/sweeps/reduction/traces/max_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/max_traces.py
@@ -9,8 +9,8 @@ import torch
 import ttnn
 from loguru import logger
 
-from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.utils import profile_ttnn_call
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 15

--- a/tests/sweep_framework/sweeps/reduction/traces/mean_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/mean_traces.py
@@ -9,7 +9,7 @@ import torch
 import ttnn
 from loguru import logger
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
@@ -117,10 +117,8 @@ def run_mean(device, params):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
 
-    start_time = start_measuring_time()
-    op_output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=keepdim)
+    op_output_tensor, e2e_perf = profile_ttnn_call(ttnn.mean, input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(op_output_tensor)
-    e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
     tensors = [input_tensor, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/reduction/traces/mean_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/mean_traces.py
@@ -117,7 +117,7 @@ def run_mean(device, params):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
 
-    op_output_tensor, e2e_perf = profile_ttnn_call(ttnn.mean, input_tensor, dim=dim, keepdim=keepdim)
+    op_output_tensor, e2e_perf = profile_ttnn_call(device, ttnn.mean, input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(op_output_tensor)
     expected_pcc = 0.999
     tensors = [input_tensor, op_output_tensor]

--- a/tests/sweep_framework/sweeps/reduction/traces/mean_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/mean_traces.py
@@ -9,8 +9,8 @@ import torch
 import ttnn
 from loguru import logger
 
-from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.utils import profile_ttnn_call
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 15

--- a/tests/sweep_framework/sweeps/reduction/traces/sum_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/sum_traces.py
@@ -636,7 +636,7 @@ def run_sum(device, params):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
 
-    op_output_tensor, e2e_perf = profile_ttnn_call(ttnn.sum, input_tensor, dim=dim, keepdim=keepdim)
+    op_output_tensor, e2e_perf = profile_ttnn_call(device, ttnn.sum, input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(op_output_tensor)
     expected_pcc = 0.999
     tensors = [input_tensor, op_output_tensor]

--- a/tests/sweep_framework/sweeps/reduction/traces/sum_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/sum_traces.py
@@ -10,7 +10,7 @@ import ttnn
 from loguru import logger
 
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
-from tests.ttnn.utils_for_testing import start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 
 TIMEOUT = 15
@@ -636,10 +636,8 @@ def run_sum(device, params):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
 
-    start_time = start_measuring_time()
-    op_output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    op_output_tensor, e2e_perf = profile_ttnn_call(ttnn.sum, input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(op_output_tensor)
-    e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
     tensors = [input_tensor, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/reduction/traces/sum_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/sum_traces.py
@@ -9,8 +9,8 @@ import torch
 import ttnn
 from loguru import logger
 
+from tests.sweep_framework.sweep_utils.utils import profile_ttnn_call
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
-from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 
 TIMEOUT = 15

--- a/tests/sweep_framework/sweeps/reduction/traces/topk_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/topk_traces.py
@@ -34,7 +34,7 @@ def run_topk(device, params):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
 
-    op_output_tensor, e2e_perf = profile_ttnn_call(ttnn.topk, input_tensor, k)
+    op_output_tensor, e2e_perf = profile_ttnn_call(device, ttnn.topk, input_tensor, k)
     output_tensor = ttnn.to_torch(op_output_tensor)
     expected_pcc = 0.999
     tensors = [input_tensor, op_output_tensor]

--- a/tests/sweep_framework/sweeps/reduction/traces/topk_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/topk_traces.py
@@ -9,7 +9,7 @@ import torch
 import ttnn
 from loguru import logger
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
@@ -34,10 +34,8 @@ def run_topk(device, params):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
 
-    start_time = start_measuring_time()
-    op_output_tensor = ttnn.topk(input_tensor, k)
+    op_output_tensor, e2e_perf = profile_ttnn_call(ttnn.topk, input_tensor, k)
     output_tensor = ttnn.to_torch(op_output_tensor)
-    e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
     tensors = [input_tensor, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/reduction/traces/topk_traces.py
+++ b/tests/sweep_framework/sweeps/reduction/traces/topk_traces.py
@@ -9,8 +9,8 @@ import torch
 import ttnn
 from loguru import logger
 
-from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.utils import profile_ttnn_call
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
 TIMEOUT = 15

--- a/tests/sweep_framework/sweeps/reduction/var/var.py
+++ b/tests/sweep_framework/sweeps/reduction/var/var.py
@@ -122,7 +122,7 @@ def run(
     )
 
     op_output_tensor, e2e_perf = profile_ttnn_call(
-        ttnn.var, input_tensor_a, dim=dim, memory_config=output_memory_config
+        device, ttnn.var, input_tensor_a, dim=dim, memory_config=output_memory_config
     )
     output_tensor = ttnn.to_torch(op_output_tensor)
     expected_pcc = 0.999

--- a/tests/sweep_framework/sweeps/reduction/var/var.py
+++ b/tests/sweep_framework/sweeps/reduction/var/var.py
@@ -4,7 +4,9 @@
 
 from typing import Optional, Tuple
 from functools import partial
+from loguru import logger
 import numpy as np
+import pytest
 
 import torch
 import random
@@ -15,6 +17,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
+from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -89,7 +92,8 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 # The run function must take the above-defined parameters as inputs.
 # The runner will call this run function with each test vector, and the returned results from this function will be stored.
 # If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
-def run(
+def run_var(
+    device,
     input_shape,
     dim,
     keepdim,
@@ -97,8 +101,6 @@ def run(
     input_layout,
     input_a_memory_config,
     output_memory_config,
-    *,
-    device,
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
@@ -128,3 +130,39 @@ def run(
     expected_pcc = 0.999
     tensors = [input_tensor_a, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
+
+
+def run(
+    input_shape,
+    dim,
+    keepdim,
+    input_a_dtype,
+    input_layout,
+    input_a_memory_config,
+    output_memory_config,
+    *,
+    device,
+):
+    return run_var(
+        device, input_shape, dim, keepdim, input_a_dtype, input_layout, input_a_memory_config, output_memory_config
+    )
+
+
+@pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters, invalidate_vector))
+def test_var(
+    device,
+    input_shape,
+    dim,
+    keepdim,
+    input_a_dtype,
+    input_layout,
+    input_a_memory_config,
+    output_memory_config,
+):
+    (result, msg), e2e_perf = run_var(
+        device, input_shape, dim, keepdim, input_a_dtype, input_layout, input_a_memory_config, output_memory_config
+    )
+    assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"Perf. metrics: {e2e_perf}")

--- a/tests/sweep_framework/sweeps/reduction/var/var.py
+++ b/tests/sweep_framework/sweeps/reduction/var/var.py
@@ -12,7 +12,7 @@ import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
@@ -121,10 +121,10 @@ def run(
         memory_config=input_a_memory_config,
     )
 
-    start_time = start_measuring_time()
-    op_output_tensor = ttnn.var(input_tensor_a, dim=dim, memory_config=output_memory_config)
+    op_output_tensor, e2e_perf = profile_ttnn_call(
+        ttnn.var, input_tensor_a, dim=dim, memory_config=output_memory_config
+    )
     output_tensor = ttnn.to_torch(op_output_tensor)
-    e2e_perf = stop_measuring_time(start_time)
     expected_pcc = 0.999
     tensors = [input_tensor_a, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)

--- a/tests/sweep_framework/sweeps/reduction/var/var.py
+++ b/tests/sweep_framework/sweeps/reduction/var/var.py
@@ -14,10 +14,9 @@ import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import profile_ttnn_call
 from models.utility_functions import torch_random
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
-from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
+from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args, profile_ttnn_call
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -165,4 +164,4 @@ def test_var(
     assert result, msg
     logger.info(msg)
     if e2e_perf:
-        logger.info(f"Perf. metrics: {e2e_perf}")
+        logger.info(f"E2E Perf: {e2e_perf}")

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -8,7 +8,7 @@ import time
 
 from loguru import logger
 from models.utility_functions import comp_pcc, comp_allclose, comp_ulp, comp_equal, divup, roundup
-from typing import Tuple, Union
+from typing import Tuple, Union, Callable, List, Dict, Any
 
 import ttnn
 import torch
@@ -260,3 +260,23 @@ def start_measuring_time() -> int:
 
 def stop_measuring_time(start_time) -> int:
     return time.time_ns() - start_time
+
+
+IGNORE_RUNS = 1
+"""The number of runs to ignore when measuring the average time."""
+
+
+REPEAT_RUNS = 1
+"""The number of runs to average when measuring performance."""
+
+
+def profile_ttnn_call(function: Callable, *args: List[Any], **kwargs: Dict[str, Any]) -> Tuple[Any, float]:
+    """Determine the average time taken for a function call, excluding the first IGNORE_RUNS runs."""
+    for _ in range(IGNORE_RUNS):
+        _results = function(*args, **kwargs)
+
+    start_time = start_measuring_time()
+    for _ in range(REPEAT_RUNS):
+        results = function(*args, **kwargs)
+    avg_host_time = stop_measuring_time(start_time) / REPEAT_RUNS
+    return results, avg_host_time

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -9,6 +9,8 @@ import time
 from loguru import logger
 from models.utility_functions import comp_pcc, comp_allclose, comp_ulp, comp_equal, divup, roundup
 from typing import Tuple, Union, Callable, List, Dict, Any
+from tt_metal.tools.profiler.process_ops_logs import get_device_data_generate_report
+from tt_metal.tools.profiler.common import PROFILER_LOGS_DIR
 
 import ttnn
 import torch
@@ -270,7 +272,7 @@ REPEAT_RUNS = 1
 """The number of runs to average when measuring performance."""
 
 
-def profile_ttnn_call(function: Callable, *args: List[Any], **kwargs: Dict[str, Any]) -> Tuple[Any, float]:
+def profile_ttnn_call(device, function: Callable, *args: List[Any], **kwargs: Dict[str, Any]) -> Tuple[Any, float]:
     """Determine the average time taken for a function call, excluding the first IGNORE_RUNS runs."""
     for _ in range(IGNORE_RUNS):
         _results = function(*args, **kwargs)
@@ -279,4 +281,12 @@ def profile_ttnn_call(function: Callable, *args: List[Any], **kwargs: Dict[str, 
     for _ in range(REPEAT_RUNS):
         results = function(*args, **kwargs)
     avg_host_time = stop_measuring_time(start_time) / REPEAT_RUNS
-    return results, avg_host_time
+
+    ttnn.DumpDeviceProfiler(device)
+    opPerfData = get_device_data_generate_report(
+        PROFILER_LOGS_DIR, outputFolder=None, date=None, nameAppend=None, export_csv=False, cleanup_device_log=True
+    )
+    e2e_perf = {"avg_host_time": avg_host_time}
+    if opPerfData:
+        e2e_perf["avg_device_time"] = opPerfData[0]["DEVICE KERNEL DURATION [ns]"]
+    return results, e2e_perf

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -286,7 +286,7 @@ def profile_ttnn_call(device, function: Callable, *args: List[Any], **kwargs: Di
     opPerfData = get_device_data_generate_report(
         PROFILER_LOGS_DIR, outputFolder=None, date=None, nameAppend=None, export_csv=False, cleanup_device_log=True
     )
-    e2e_perf = {"avg_host_time": avg_host_time}
+    e2e_perf = {"AVG_HOST_TIME": avg_host_time}
     if opPerfData:
-        e2e_perf["avg_device_time"] = opPerfData[0]["DEVICE KERNEL DURATION [ns]"]
+        e2e_perf["AVG_DEVICE_TIME"] = opPerfData[0]["DEVICE KERNEL DURATION [ns]"]
     return results, e2e_perf


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23056

### Problem description
To better understand the performance improvements made to reduction ops, we want to collect accurate performance metrics.

### What's changed
This PR adds the following:
1. Adds ability to collect device side execution time by ignoring X runs and averaging over Y runs. This allows us to skip JIT compile time overhead from impacting perf numbers.
2. Adds ability to collect device kernel execution time when profiler is enabled in metalium builds.
3. Fixes reporting of performance numbers when sweeps are run using pytest.
4. Fixes syntax issues in reduction sweeps.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16011861252
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16011863573
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes