### PR TITLE
Fix noc_get_interim_inline_value_addr for dynamic NOC

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -6,10 +6,10 @@
 #include <gtest/gtest.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <numeric>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <map>
 #include <memory>
 #include <string>
 #include <variant>
@@ -422,19 +422,17 @@ TEST_F(DeviceFixture, TensixInlineWriteDedicatedNocMisaligned) {
 
 // Both data movement riscs issue inline writes using the same noc
 TEST_F(DeviceFixture, TensixInlineWriteDynamicNoc) {
-    // #21082
-    auto arch = tt::get_arch_from_string(get_umd_arch_name());
-    if (arch == tt::ARCH::BLACKHOLE) {
-        GTEST_SKIP();
-    }
     CoreCoord writer_core{0, 0};
     CoreCoord receiver_core(0, 1);
     uint32_t value_to_write = 39;
+    uint32_t num_writes_per_risc = 2;
+    uint32_t num_writes_total = num_writes_per_risc * 2;
+    uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
 
     for (tt_metal::IDevice* device : this->devices_) {
         uint32_t receiver_addr0 = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
-        uint32_t receiver_addr2 = receiver_addr0 + (2 * MetalContext::instance().hal().get_alignment(HalMemType::L1));
-        std::vector<uint32_t> readback(80 / sizeof(uint32_t), 0);
+        uint32_t receiver_addr2 = receiver_addr0 + (num_writes_per_risc * l1_alignment);
+        std::vector<uint32_t> readback(num_writes_total * l1_alignment / sizeof(uint32_t), 0);
         tt_metal::detail::WriteToDeviceL1(device, receiver_core, receiver_addr0, readback);
 
         CoreCoord virtual_receiver_core = device->worker_core_from_logical_core(receiver_core);
@@ -457,8 +455,8 @@ TEST_F(DeviceFixture, TensixInlineWriteDynamicNoc) {
              virtual_receiver_core.y,
              receiver_addr0,
              value_to_write,
-             2,
-             MetalContext::instance().hal().get_alignment(HalMemType::L1)});
+             num_writes_per_risc,
+             l1_alignment});
 
         tt_metal::KernelHandle kernel1 = tt_metal::CreateKernel(
             program,
@@ -476,18 +474,23 @@ TEST_F(DeviceFixture, TensixInlineWriteDynamicNoc) {
             {virtual_receiver_core.x,
              virtual_receiver_core.y,
              receiver_addr2,
-             value_to_write + 2,
-             2,
-             MetalContext::instance().hal().get_alignment(HalMemType::L1)});
+             value_to_write + num_writes_per_risc,
+             num_writes_per_risc,
+             l1_alignment});
 
         tt_metal::detail::LaunchProgram(device, program);
 
-        tt_metal::detail::ReadFromDeviceL1(device, receiver_core, receiver_addr0, 64, readback);
-        uint32_t expected_value = value_to_write;
-        for (int i = 0; i < 4; i++) {
-            EXPECT_EQ(readback[i * 4], expected_value);
-            expected_value++;
+        tt_metal::detail::ReadFromDeviceL1(
+            device, receiver_core, receiver_addr0, readback.size() * sizeof(uint32_t), readback);
+        // Pack the sparse values for comparison with expected_values.
+        for (uint32_t i = 1; i < num_writes_total; i++) {
+            readback[i] = readback[i * l1_alignment / sizeof(uint32_t)];
         }
+        readback.resize(num_writes_total);
+
+        std::vector<uint32_t> expected_values(num_writes_total);
+        std::iota(expected_values.begin(), expected_values.end(), value_to_write);
+        EXPECT_EQ(readback, expected_values);
     }
 }
 

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -268,11 +268,11 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMSharded) {
 /* ========== Directed ideal test case; Test id = 3 ========== */
 TEST_F(DeviceFixture, TensixDataMovementDRAMDirectedIdeal) {
     // Parameters
-    uint32_t num_of_transactions = 180;
+    uint32_t num_of_transactions = 179;
     uint32_t transaction_size_pages = 4 * 32;
     uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
     // Max transaction size = 4 * 32 pages = 128 * 32 bytes = 4096 bytes for WH; 8192 bytes for BH
-    // Max total transaction size = 180 * 8192 bytes = 1474560 bytes = 1.4 MB = L1 capacity
+    // Max total transaction size = 179 * 8192 bytes = 1466368 bytes = 1.4 MB = L1 capacity
 
     // Cores
     CoreRange core_range({0, 0}, {0, 0});

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -83,12 +83,10 @@
 // Base address for each noc to store the value to be written will be `MEM_{E,B,NC}RISC_L1_INLINE_BASE + (noc_index *
 // 16)`
 #define MEM_L1_INLINE_SIZE_PER_NOC 16
-#define MEM_BRISC_L1_INLINE_BASE 32   // MEM_L1_ARC_FW_SCRATCH + MEM_L1_ARC_FW_SCRATCH_SIZE
-#define MEM_NCRISC_L1_INLINE_BASE 64  // MEM_BRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2))  // 2 nocs
-#define MEM_ERISC_L1_INLINE_BASE 32   // Use the same memory as BRISC
+#define MEM_L1_INLINE_BASE 32  // MEM_L1_ARC_FW_SCRATCH + MEM_L1_ARC_FW_SCRATCH_SIZE
 
 // Hardcode below due to compiler bug that cannot statically resolve the expression see GH issue #19265
-#define MEM_MAILBOX_BASE 96  // (MEM_NCRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2))  // 2 nocs
+#define MEM_MAILBOX_BASE 96  // (MEM_NCRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2) * 2)  // 2 nocs * 2 (B,NC)
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
 #define MEM_MAILBOX_SIZE 12640
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -80,10 +80,12 @@
 // to allow one memory port to move ahead of another. To workaround this hang, we emulate inline writes on Blackhole by
 // writing the value to be written to local L1 first and then issue a noc async write.
 // Each noc has 16B to store value written out by inline writes.
-// Base address for each noc to store the value to be written will be `MEM_{B,NC}RISC_L1_INLINE_BASE + (noc_index * 16)`
+// Base address for each noc to store the value to be written will be `MEM_{E,B,NC}RISC_L1_INLINE_BASE + (noc_index *
+// 16)`
 #define MEM_L1_INLINE_SIZE_PER_NOC 16
 #define MEM_BRISC_L1_INLINE_BASE 32   // MEM_L1_ARC_FW_SCRATCH + MEM_L1_ARC_FW_SCRATCH_SIZE
 #define MEM_NCRISC_L1_INLINE_BASE 64  // MEM_BRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2))  // 2 nocs
+#define MEM_ERISC_L1_INLINE_BASE 32   // Use the same memory as BRISC
 
 // Hardcode below due to compiler bug that cannot statically resolve the expression see GH issue #19265
 #define MEM_MAILBOX_BASE 96  // (MEM_NCRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2))  // 2 nocs

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -79,12 +79,14 @@
 // time. If one port on the receipient has no back-pressure then the transaction will hang because there is no mechanism
 // to allow one memory port to move ahead of another. To workaround this hang, we emulate inline writes on Blackhole by
 // writing the value to be written to local L1 first and then issue a noc async write.
-#define MEM_L1_INLINE_BASE 32  // MEM_L1_ARC_FW_SCRATCH + MEM_L1_ARC_FW_SCRATCH_SIZE
 // Each noc has 16B to store value written out by inline writes.
-// Base address for each noc to store the value to be written will be `MEM_L1_INLINE_BASE + (noc_index * 16)`
+// Base address for each noc to store the value to be written will be `MEM_{B,NC}RISC_L1_INLINE_BASE + (noc_index * 16)`
 #define MEM_L1_INLINE_SIZE_PER_NOC 16
+#define MEM_BRISC_L1_INLINE_BASE 32   // MEM_L1_ARC_FW_SCRATCH + MEM_L1_ARC_FW_SCRATCH_SIZE
+#define MEM_NCRISC_L1_INLINE_BASE 64  // MEM_BRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2))  // 2 nocs
+
 // Hardcode below due to compiler bug that cannot statically resolve the expression see GH issue #19265
-#define MEM_MAILBOX_BASE 64  // (MEM_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2))  // 2 nocs
+#define MEM_MAILBOX_BASE 96  // (MEM_NCRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2))  // 2 nocs
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
 #define MEM_MAILBOX_SIZE 12640
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -142,7 +142,15 @@ inline __attribute__((always_inline)) uint32_t noc_get_interim_inline_value_addr
     // needs to respect 4B alignment.
     ASSERT((dst_noc_addr & 0x3) == 0);
     uint32_t offset = dst_noc_addr & 0xF;
-    uint32_t src_addr = (uint32_t)MEM_L1_INLINE_BASE + (uint32_t)(noc * MEM_L1_INLINE_SIZE_PER_NOC) + offset;
+    uint32_t src_addr;
+#if defined(COMPILE_FOR_BRISC)
+    src_addr = MEM_BRISC_L1_INLINE_BASE;
+#elif defined(COMPILE_FOR_NCRISC)
+    src_addr = MEM_NCRISC_L1_INLINE_BASE;
+#else
+    ASSERT(0);
+#endif
+    src_addr += noc * MEM_L1_INLINE_SIZE_PER_NOC + offset;
     return src_addr;
 }
 

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -142,15 +142,9 @@ inline __attribute__((always_inline)) uint32_t noc_get_interim_inline_value_addr
     // needs to respect 4B alignment.
     ASSERT((dst_noc_addr & 0x3) == 0);
     uint32_t offset = dst_noc_addr & 0xF;
-    uint32_t src_addr;
-#if defined(COMPILE_FOR_BRISC)
-    src_addr = MEM_BRISC_L1_INLINE_BASE;
-#elif defined(COMPILE_FOR_NCRISC)
-    src_addr = MEM_NCRISC_L1_INLINE_BASE;
-#elif defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
-    src_addr = MEM_ERISC_L1_INLINE_BASE;
-#else
-    ASSERT(0);
+    uint32_t src_addr = MEM_L1_INLINE_BASE + (2 * MEM_L1_INLINE_SIZE_PER_NOC) * proc_type;
+#ifdef COMPILE_FOR_TRISC
+    ASSERT(0);  // we do not have L1 space for inline values for TRISCs.
 #endif
     src_addr += noc * MEM_L1_INLINE_SIZE_PER_NOC + offset;
     return src_addr;

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -147,6 +147,8 @@ inline __attribute__((always_inline)) uint32_t noc_get_interim_inline_value_addr
     src_addr = MEM_BRISC_L1_INLINE_BASE;
 #elif defined(COMPILE_FOR_NCRISC)
     src_addr = MEM_NCRISC_L1_INLINE_BASE;
+#elif defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
+    src_addr = MEM_ERISC_L1_INLINE_BASE;
 #else
     ASSERT(0);
 #endif


### PR DESCRIPTION
### Ticket
#21082

### Problem description
In #18560, an L1 area is reserved for each NOC to store the data for inline noc transactions.
With dynamic noc, both BRISC and NCRISC can use either NOC. If they use the same NOC for an inline transaction, there may be a data race because they may use the same L1 address.

### What's changed
Allocate separate temp storage for BRISC and NCRISC.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15886493624) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15889761819) CI with demo tests passes (if applicable)
- [x] [Blackhole nightly](https://github.com/tenstorrent/tt-metal/actions/runs/15933214214/)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes