### PR TITLE
Bcheemasabir tt/tt metal test migration

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -26,6 +26,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
+#include <tt-metalium/distributed.hpp>
 #include "hostdevcommon/common_values.hpp"
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-logger/tt-logger.hpp>
@@ -52,6 +53,7 @@ constexpr uint32_t MAX_ARGS = 255;
 //////////////////////////////////////////////////////////////////////////////////////////
 using std::vector;
 using namespace tt;
+using namespace tt::tt_metal::distributed;
 
 static bool dump_test_info = false;
 
@@ -220,7 +222,7 @@ void set_runtime_args(
 }
 
 bool initialize_program(
-    const TestInfo& info, tt_metal::IDevice* device, tt_metal::Program& program, uint32_t run_cycles) {
+    const TestInfo& info, std::shared_ptr<MeshDevice> mesh_device, tt_metal::Program& program, uint32_t run_cycles) {
     program = tt_metal::CreateProgram();
 
     std::map<std::string, std::string> defines = {{"KERNEL_BYTES", std::to_string(info.kernel_size)}};
@@ -298,7 +300,7 @@ bool initialize_program(
     }
 
     if (info.erisc_enabled) {
-        auto erisc_cores = device->get_active_ethernet_cores(true);
+        auto erisc_cores = mesh_device->get_device(0, 0)->get_active_ethernet_cores(true);
         if (info.erisc_count > erisc_cores.size()) {
             log_fatal(
                 tt::LogTest,
@@ -392,62 +394,68 @@ static int pgm_dispatch(T& state, TestInfo info) {
     bool pass = true;
     try {
         const chip_id_t device_id = 0;
+        const std::size_t cq_id = 0;
         DispatchCoreType dispatch_core_type = info.dispatch_from_eth ? DispatchCoreType::ETH : DispatchCoreType::WORKER;
-        tt_metal::IDevice* device = tt_metal::CreateDevice(
-            device_id, 1, DEFAULT_L1_SMALL_SIZE, 900000000, DispatchCoreConfig{dispatch_core_type});
-        CommandQueue& cq = device->command_queue();
+        auto mesh_device = MeshDevice::create_unit_mesh(
+            device_id, DEFAULT_L1_SMALL_SIZE, 900000000, 1, DispatchCoreConfig{dispatch_core_type});
+        auto& mesh_cq = mesh_device->mesh_command_queue(cq_id);
 
         tt_metal::Program program[2];
-        if (!initialize_program(info, device, program[0], info.slow_kernel_cycles)) {
+        if (!initialize_program(info, mesh_device, program[0], info.slow_kernel_cycles)) {
             if constexpr (std::is_same_v<T, benchmark::State>) {
                 state.SkipWithError("Program creation failed");
             }
-            tt_metal::CloseDevice(device);
+            mesh_device->close();
             return 1;
         }
-        if (!initialize_program(info, device, program[1], info.fast_kernel_cycles)) {
+        if (!initialize_program(info, mesh_device, program[1], info.fast_kernel_cycles)) {
             if constexpr (std::is_same_v<T, benchmark::State>) {
                 state.SkipWithError("Program creation failed");
             }
-            tt_metal::CloseDevice(device);
+            mesh_device->close();
             return 1;
         }
 
         // Cache stuff
+        MeshWorkload mesh_workload[2];
+        AddProgramToMeshWorkload(
+            mesh_workload[0], std::move(program[0]), MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 0)));
+        AddProgramToMeshWorkload(
+            mesh_workload[1], std::move(program[1]), MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 0)));
         for (int i = 0; i < info.warmup_iterations; i++) {
-            EnqueueProgram(cq, program[0], false);
+            EnqueueMeshWorkload(mesh_cq, mesh_workload[0], false);
             for (int j = 0; j < info.nfast_kernels; j++) {
-                EnqueueProgram(cq, program[1], false);
+                EnqueueMeshWorkload(mesh_cq, mesh_workload[1], false);
             }
         }
 
         auto main_program_loop = [&]() {
             for (int i = 0; i < info.iterations; i++) {
-                EnqueueProgram(cq, program[0], false);
+                EnqueueMeshWorkload(mesh_cq, mesh_workload[0], false);
                 for (int j = 0; j < info.nfast_kernels; j++) {
-                    EnqueueProgram(cq, program[1], false);
+                    EnqueueMeshWorkload(mesh_cq, mesh_workload[1], false);
                 }
             }
         };
-        uint32_t tid = 0;
+        MeshTraceId tid;
         if (info.use_trace) {
-            tid = BeginTraceCapture(device, cq.id());
+            tid = BeginTraceCapture(mesh_device.get(), cq_id);
             main_program_loop();
-            EndTraceCapture(device, cq.id(), tid);
-            Finish(cq);
+            EndTraceCapture(mesh_device.get(), cq_id, tid);
+            Finish(mesh_cq);
         }
 
         for (auto _ : state) {
             auto start = std::chrono::system_clock::now();
             if (info.use_trace) {
-                EnqueueTrace(cq, tid, false);
+                ReplayTrace(mesh_device.get(), cq_id, tid, false);
             } else {
                 main_program_loop();
             }
             if (info.time_just_finish) {
                 start = std::chrono::system_clock::now();
             }
-            Finish(cq);
+            Finish(mesh_cq);
             auto end = std::chrono::system_clock::now();
 
             if constexpr (std::is_same_v<T, benchmark::State>) {
@@ -463,10 +471,11 @@ static int pgm_dispatch(T& state, TestInfo info) {
         if constexpr (std::is_same_v<T, benchmark::State>) {
             state.counters["IterationTime"] = benchmark::Counter(
                 info.iterations, benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
-            state.counters["Clock"] = benchmark::Counter(get_tt_npu_clock(device), benchmark::Counter::kDefaults);
+            state.counters["Clock"] =
+                benchmark::Counter(get_tt_npu_clock(mesh_device->get_device(0, 0)), benchmark::Counter::kDefaults);
         }
 
-        pass &= tt_metal::CloseDevice(device);
+        pass &= mesh_device->close();
     } catch (const std::exception& e) {
         pass = false;
         log_fatal(tt::LogTest, "{}", e.what());


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/22835)
### Problem description
Need to migrate tests to use `EnqueueMeshWorkload` instead of `EnqueueProgram`. This is required to deprecate legacy `CommandQueue` APIs, and is a first step towards this goal.
### What's changed

- Added `UnitMeshCommandQueueFixture` which creates a vector of `MeshDevices` instead of single `IDevices`
- Modified CB and Semaphore tests in `test_EnqueueProgram.cpp` to use `EnqueueMeshWorkloads`
- Modified `test_pgm_dispatch` to use Mesh Data Structures

### Note
`UnitMeshCommandQueueFixture` will eventually be renamed when its made the main TT-Metal test fixture. For now, we have `UnitMeshCommandQueueFixture` and `CommandQueueSingleCardFixture` as we incrementally port changes to `main`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15886723512) CI passes 
- [x]  [T3K Unit Tests](https://github.com/tenstorrent/tt-metal/actions/runs/15939046483) CI passes 
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes