### PR TITLE
[Fabric] Add support for mux over 2D fabric and update tests

### DIFF
--- a/tests/scripts/run_cpp_fabric_tests.sh
+++ b/tests/scripts/run_cpp_fabric_tests.sh
@@ -23,7 +23,7 @@ echo "Running fabric unit tests now...";
 
 TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricMuxFixture.*"
+./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricMux*Fixture.*"
 
 #############################################
 # FABRIC SANITY TESTS                       #

--- a/tests/scripts/run_cpp_fabric_tests.sh
+++ b/tests/scripts/run_cpp_fabric_tests.sh
@@ -23,7 +23,7 @@ echo "Running fabric unit tests now...";
 
 TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricMux*Fixture.*"
+./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric*MuxFixture.*"
 
 #############################################
 # FABRIC SANITY TESTS                       #

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -49,7 +49,7 @@ run_t3000_ttfabric_tests() {
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=T3kCustomMeshGraphFabric2DDynamicTests*
 
   ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-  ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricMux*Fixture.*"
+  ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric*MuxFixture.*"
   ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=T3kCustomMeshGraphFabric2DDynamicTests*
 
   # Unicast tests

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -49,7 +49,7 @@ run_t3000_ttfabric_tests() {
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=T3kCustomMeshGraphFabric2DDynamicTests*
 
   ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-  ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricMuxFixture.*"
+  ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricMux*Fixture.*"
   ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=T3kCustomMeshGraphFabric2DDynamicTests*
 
   # Unicast tests

--- a/tests/scripts/tg/run_tg_unit_tests.sh
+++ b/tests/scripts/tg/run_tg_unit_tests.sh
@@ -73,7 +73,7 @@ run_tg_tests() {
     # TODO: Fix bug and enable Push mode https://github.com/tenstorrent/tt-metal/issues/19999
     #       TG + push mode + fast dispatch has bug at tt::tt_metal::detail::CreateDevices(ids)
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricMuxFixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricMux*Fixture.*"
     TESTS=(
         # Unicast tests
         "1 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16"

--- a/tests/scripts/tg/run_tg_unit_tests.sh
+++ b/tests/scripts/tg/run_tg_unit_tests.sh
@@ -73,7 +73,7 @@ run_tg_tests() {
     # TODO: Fix bug and enable Push mode https://github.com/tenstorrent/tt-metal/issues/19999
     #       TG + push mode + fast dispatch has bug at tt::tt_metal::detail::CreateDevices(ids)
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricMux*Fixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric*MuxFixture.*"
     TESTS=(
         # Unicast tests
         "1 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16"

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_mux_sender_client.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_mux_sender_client.cpp
@@ -7,22 +7,24 @@
 #include "debug/dprint.h"
 #include "tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric.h" // zero_l1_buf
+#include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp"
 // clang-format on
 
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(0);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(1);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(2);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(3);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(4);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(5);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(6);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(7);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(8);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(9);
-constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(10);
+constexpr bool is_2d_fabric = get_compile_time_arg_val(0);
+constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(1);
+constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(2);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(3);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(4);
+constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(5);
+constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(6);
+constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(7);
+constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(8);
+constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(9);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(10);
+constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(11);
 
 void kernel_main() {
     uint32_t rt_args_idx = 0;
@@ -46,6 +48,16 @@ void kernel_main() {
     uint32_t sender_id = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t receiver_noc_xy_encoding = get_arg_val<uint32_t>(rt_args_idx++);
 
+    eth_chan_directions outgoing_direction;
+    uint32_t my_device_id, dst_device_id, dst_mesh_id, mesh_ew_dim;
+    if constexpr (is_2d_fabric) {
+        outgoing_direction = static_cast<eth_chan_directions>(get_arg_val<uint32_t>(rt_args_idx++));
+        my_device_id = get_arg_val<uint32_t>(rt_args_idx++);
+        dst_device_id = get_arg_val<uint32_t>(rt_args_idx++);
+        dst_mesh_id = get_arg_val<uint32_t>(rt_args_idx++);
+        mesh_ew_dim = get_arg_val<uint32_t>(rt_args_idx++);
+    }
+
     auto test_results = reinterpret_cast<tt_l1_ptr uint32_t*>(test_results_address);
     zero_l1_buf(test_results, test_results_size_bytes);
     test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_STARTED;
@@ -66,7 +78,17 @@ void kernel_main() {
         local_buffer_index_address);
 
     auto packet_header = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(packet_header_buffer_address);
-    packet_header->to_chip_unicast(static_cast<uint8_t>(num_hops));
+    if constexpr (is_2d_fabric) {
+        fabric_set_unicast_route(
+            (LowLatencyMeshPacketHeader*)packet_header,
+            outgoing_direction,
+            my_device_id,
+            dst_device_id,
+            dst_mesh_id,  // Ignored since Low Latency Mesh Fabric is not used for Inter-Mesh Routing
+            mesh_ew_dim);
+    } else {
+        packet_header->to_chip_unicast(static_cast<uint8_t>(num_hops));
+    }
 
     uint64_t local_credit_handshake_noc_address = get_noc_addr(0) + credit_handshake_address;
     auto credit_handshake_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(credit_handshake_address);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -265,7 +265,9 @@ void create_mux_kernel(
     tt::tt_metal::Program& program_handle) {
     std::vector<uint32_t> mux_ct_args = mux_kernel_config.get_fabric_mux_compile_time_args();
     std::vector<uint32_t> mux_rt_args = {};
-    const auto& available_links = get_forwarding_link_indices(device->id(), dest_device->id());
+    const auto src_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id());
+    const auto dst_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dest_device->id());
+    const auto& available_links = get_forwarding_link_indices(src_node_id, dst_node_id);
     TT_FATAL(
         available_links.size() > 0,
         "Couldnt find any forwarding routing planes from: {} to: {}",
@@ -273,9 +275,7 @@ void create_mux_kernel(
         dest_device->id());
 
     append_fabric_connection_rt_args(
-        tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id()),
-        tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dest_device->id()),
-        available_links[0], program_handle, {mux_logical_core}, mux_rt_args);
+        src_node_id, dst_node_id, available_links[0], program_handle, {mux_logical_core}, mux_rt_args);
 
     std::vector<std::pair<size_t, size_t>> addresses_to_clear = {
         std::make_pair(mux_kernel_config.get_start_address_to_clear(), mux_kernel_config.get_num_bytes_to_clear())};

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -44,7 +44,9 @@ const auto routing_directions = {
     tt_fabric::RoutingDirection::E,
     tt_fabric::RoutingDirection::W};
 
-using FabricMuxFixture = Fabric1DFixture;
+using FabricMuxBaseFixture = BaseFabricFixture;
+using FabricMux1DFixture = Fabric1DFixture;
+using FabricMux2DFixture = Fabric2DFixture;
 
 struct TestConfig {
     uint32_t num_devices = 0;
@@ -59,6 +61,7 @@ struct TestConfig {
     bool uniform_sender_receiver_split = true;
     uint32_t num_open_close_iters = 0;
     uint32_t num_full_size_channel_iters = 0;
+    bool is_2d_fabric = false;
 };
 
 struct WorkerMemoryMap {
@@ -81,6 +84,7 @@ struct WorkerTestConfig {
     uint32_t num_buffers = 0;
     uint32_t buffer_size_bytes = 0;
     uint8_t num_hops = 0;
+    tt::tt_metal::IDevice* dest_device = nullptr;
     std::string_view kernel_src = sender_kernel_src;
 };
 
@@ -261,13 +265,17 @@ void create_mux_kernel(
     tt::tt_metal::Program& program_handle) {
     std::vector<uint32_t> mux_ct_args = mux_kernel_config.get_fabric_mux_compile_time_args();
     std::vector<uint32_t> mux_rt_args = {};
+    const auto& available_links = get_forwarding_link_indices(device->id(), dest_device->id());
+    TT_FATAL(
+        available_links.size() > 0,
+        "Couldnt find any forwarding routing planes from: {} to: {}",
+        device->id(),
+        dest_device->id());
+
     append_fabric_connection_rt_args(
         tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->id()),
         tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dest_device->id()),
-        0 /* link_idx (routing plane) */,
-        program_handle,
-        {mux_logical_core},
-        mux_rt_args);
+        available_links[0], program_handle, {mux_logical_core}, mux_rt_args);
 
     std::vector<std::pair<size_t, size_t>> addresses_to_clear = {
         std::make_pair(mux_kernel_config.get_start_address_to_clear(), mux_kernel_config.get_num_bytes_to_clear())};
@@ -288,6 +296,7 @@ void create_worker_kernel(
     auto worker_id = worker_test_config.worker_id;
 
     std::vector<uint32_t> worker_ct_args = {
+        test_config.is_2d_fabric,
         mux_virtual_core.x,
         mux_virtual_core.y,
         worker_test_config.num_buffers,
@@ -327,6 +336,36 @@ void create_worker_kernel(
         get_sender_id(worker_logical_core),
         receiver_noc_xy_encoding};
 
+    if (test_config.is_2d_fabric) {
+        const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+        const auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->id());
+        const auto dst_fabric_node_id =
+            control_plane.get_fabric_node_id_from_physical_chip_id(worker_test_config.dest_device->id());
+        const auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
+        const auto forwarding_direction =
+            control_plane.get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
+
+        TT_FATAL(
+            src_fabric_node_id.mesh_id == dst_fabric_node_id.mesh_id,
+            "Fabric Mux tests are not supported for multi-mesh systems yet");
+
+        TT_FATAL(
+            forwarding_direction.has_value(),
+            "Failed to find forwarding direction from: (M{}, D{}) to (M{}, D{})",
+            *src_fabric_node_id.mesh_id,
+            src_fabric_node_id.chip_id,
+            *dst_fabric_node_id.mesh_id,
+            dst_fabric_node_id.chip_id);
+
+        const auto outgoing_router_direction =
+            control_plane.routing_direction_to_eth_direction(forwarding_direction.value());
+        worker_rt_args.push_back(outgoing_router_direction);
+        worker_rt_args.push_back(src_fabric_node_id.chip_id);
+        worker_rt_args.push_back(dst_fabric_node_id.chip_id);
+        worker_rt_args.push_back(*dst_fabric_node_id.mesh_id);
+        worker_rt_args.push_back(mesh_shape[1]);
+    }
+
     std::vector<std::pair<size_t, size_t>> addresses_to_clear = {
         std::make_pair(worker_memory_map->local_flow_control_address, noc_address_padding_bytes),
         std::make_pair(worker_memory_map->local_teardown_address, noc_address_padding_bytes),
@@ -341,7 +380,7 @@ void create_worker_kernel(
         addresses_to_clear);
 }
 
-void run_mux_test_variant(FabricMuxFixture* fixture, TestConfig test_config) {
+void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config) {
     auto num_devices = test_config.num_devices;
     auto chip_seq = get_physical_chip_sequence(num_devices);
     if (chip_seq.empty()) {
@@ -349,25 +388,23 @@ void run_mux_test_variant(FabricMuxFixture* fixture, TestConfig test_config) {
     }
     log_info(LogTest, "Devices: {}", chip_seq);
 
-    std::vector<tt::tt_metal::IDevice*> devices;
-    devices.reserve(chip_seq.size());
-    for (const auto& chip_id : chip_seq) {
-        devices.push_back(DevicePool::instance().get_active_device(chip_id));
-    }
-
-    // dest devices for mux kernel to attach to the fabric routers
-    std::unordered_map<tt::tt_metal::IDevice*, tt::tt_metal::IDevice*> dest_devices;
-    dest_devices[devices[0]] = devices[1];
-    for (auto i = 1; i < num_devices; i++) {
-        dest_devices[devices[i]] = devices[i - 1];
-    }
-
     // TODO: assert on the number of minimum senders/receivers for the device seq
     const uint8_t num_senders = test_config.num_sender_clients;
     const uint8_t num_receivers = test_config.num_sender_clients;
     if (num_senders < num_devices - 1) {
         GTEST_SKIP() << "Not enough senders/receivers for this configuration";
     }
+
+    std::vector<tt::tt_metal::IDevice*> devices;
+    devices.reserve(chip_seq.size());
+    for (const auto& chip_id : chip_seq) {
+        devices.push_back(DevicePool::instance().get_active_device(chip_id));
+    }
+
+    const bool is_2d_fabric =
+        tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context().get_fabric_topology() ==
+        Topology::Mesh;
+    test_config.is_2d_fabric = is_2d_fabric;
 
     // [device] -> {(logical_core, hops)}
     // keeps track of which logical cores will talk to each other and are how many hops away
@@ -440,12 +477,31 @@ void run_mux_test_variant(FabricMuxFixture* fixture, TestConfig test_config) {
     std::vector<tt::tt_metal::Program> program_handles(devices.size());
     std::vector<size_t> mux_termination_signal_addresses;
 
-    size_t buffer_size_bytes_full_size_channel =
-        sizeof(tt::tt_fabric::PacketHeader) + test_config.packet_payload_size_bytes;
-    size_t buffer_size_bytes_header_only_channel = sizeof(tt::tt_fabric::PacketHeader);
+    const auto packet_header_size = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
+    size_t buffer_size_bytes_full_size_channel = packet_header_size + test_config.packet_payload_size_bytes;
+    size_t buffer_size_bytes_header_only_channel = packet_header_size;
+
+    auto get_dest_device_idx = [&](uint32_t src_device_idx, uint32_t hops) -> uint32_t {
+        // for device 0, dest is in forward direction else backward
+        if (is_2d_fabric) {
+            if (src_device_idx == 0) {
+                return hops;
+            } else {
+                return src_device_idx - hops;
+            }
+        } else {
+            // for 1D return the neighboring device only
+            if (src_device_idx == 0) {
+                return 1;
+            } else {
+                return src_device_idx - 1;
+            }
+        }
+    };
 
     for (auto i = 0; i < devices.size(); i++) {
         program_handles[i] = tt_metal::CreateProgram();
+
         // use logical core (0,0) for the mux kernel
         CoreCoord mux_logical_core = worker_logical_cores[0];
         CoreCoord mux_virtual_core = devices[i]->worker_core_from_logical_core(mux_logical_core);
@@ -466,11 +522,14 @@ void run_mux_test_variant(FabricMuxFixture* fixture, TestConfig test_config) {
 
         mux_termination_signal_addresses.push_back(mux_kernel_config.get_termination_signal_address());
 
+        // for mux we always specify the dest device as 1 hop away since its only used for setting up the
+        // connection with the fabric routers
         create_mux_kernel(
-            mux_kernel_config, mux_logical_core, devices[i], dest_devices[devices[i]], program_handles[i]);
+            mux_kernel_config, mux_logical_core, devices[i], devices[get_dest_device_idx(i, 1)], program_handles[i]);
 
         uint32_t sender_id = 0;
         for (const auto& [sender_logical_core, num_hops] : device_senders_map[devices[i]]) {
+            auto* dest_device = devices[get_dest_device_idx(i, num_hops)];
             WorkerTestConfig sender_config = {
                 .memory_map = &worker_memory_map,
                 .worker_logical_core = sender_logical_core,
@@ -479,6 +538,7 @@ void run_mux_test_variant(FabricMuxFixture* fixture, TestConfig test_config) {
                 .num_buffers = test_config.num_buffers_full_size_channel,
                 .buffer_size_bytes = buffer_size_bytes_full_size_channel,
                 .num_hops = num_hops,
+                .dest_device = dest_device,
                 .kernel_src = sender_kernel_src};
             create_worker_kernel(
                 test_config, sender_config, mux_kernel_config, mux_virtual_core, devices[i], program_handles[i]);
@@ -487,6 +547,7 @@ void run_mux_test_variant(FabricMuxFixture* fixture, TestConfig test_config) {
 
         uint32_t receiver_id = 0;
         for (const auto& [receiver_logical_core, num_hops] : device_receivers_map[devices[i]]) {
+            auto* dest_device = devices[get_dest_device_idx(i, num_hops)];
             WorkerTestConfig receiver_config = {
                 .memory_map = &worker_memory_map,
                 .worker_logical_core = receiver_logical_core,
@@ -495,6 +556,7 @@ void run_mux_test_variant(FabricMuxFixture* fixture, TestConfig test_config) {
                 .num_buffers = test_config.num_buffers_header_only_channel,
                 .buffer_size_bytes = buffer_size_bytes_header_only_channel,
                 .num_hops = num_hops,
+                .dest_device = dest_device,
                 .kernel_src = receiver_kernel_src};
             create_worker_kernel(
                 test_config, receiver_config, mux_kernel_config, mux_virtual_core, devices[i], program_handles[i]);
@@ -559,7 +621,7 @@ void run_mux_test_variant(FabricMuxFixture* fixture, TestConfig test_config) {
     }
 }
 
-TEST_F(FabricMuxFixture, TestFabricMuxTwoChipVariant1) {
+TEST_F(FabricMux1DFixture, TestFabricMuxTwoChipVariant1) {
     TestConfig test_config = {
         .num_devices = 2,
         .num_sender_clients = 1,
@@ -577,7 +639,7 @@ TEST_F(FabricMuxFixture, TestFabricMuxTwoChipVariant1) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMuxFixture, TestFabricMuxTwoChipVariant2) {
+TEST_F(FabricMux1DFixture, TestFabricMuxTwoChipVariant2) {
     TestConfig test_config = {
         .num_devices = 2,
         .num_sender_clients = 2,
@@ -595,7 +657,7 @@ TEST_F(FabricMuxFixture, TestFabricMuxTwoChipVariant2) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMuxFixture, TestFabricMuxTwoChipVariant3) {
+TEST_F(FabricMux1DFixture, TestFabricMuxTwoChipVariant3) {
     TestConfig test_config = {
         .num_devices = 2,
         .num_sender_clients = 8,
@@ -613,7 +675,7 @@ TEST_F(FabricMuxFixture, TestFabricMuxTwoChipVariant3) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMuxFixture, TestFabricMuxTwoChipVariant4) {
+TEST_F(FabricMux1DFixture, TestFabricMuxTwoChipVariant4) {
     TestConfig test_config = {
         .num_devices = 2,
         .num_sender_clients = 8,
@@ -631,7 +693,7 @@ TEST_F(FabricMuxFixture, TestFabricMuxTwoChipVariant4) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMuxFixture, TestFabricMuxThreeChipVariant) {
+TEST_F(FabricMux1DFixture, TestFabricMuxThreeChipVariant) {
     TestConfig test_config = {
         .num_devices = 3,
         .num_sender_clients = 8,
@@ -649,7 +711,7 @@ TEST_F(FabricMuxFixture, TestFabricMuxThreeChipVariant) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMuxFixture, TestFabricMuxFourChipVariant1) {
+TEST_F(FabricMux1DFixture, TestFabricMuxFourChipVariant1) {
     TestConfig test_config = {
         .num_devices = 4,
         .num_sender_clients = 8,
@@ -667,7 +729,7 @@ TEST_F(FabricMuxFixture, TestFabricMuxFourChipVariant1) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMuxFixture, TestFabricMuxFourChipVariant2) {
+TEST_F(FabricMux1DFixture, TestFabricMuxFourChipVariant2) {
     TestConfig test_config = {
         .num_devices = 4,
         .num_sender_clients = 8,
@@ -685,7 +747,7 @@ TEST_F(FabricMuxFixture, TestFabricMuxFourChipVariant2) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMuxFixture, TestFabricMuxFiveChipVariant) {
+TEST_F(FabricMux1DFixture, TestFabricMuxFiveChipVariant) {
     TestConfig test_config = {
         .num_devices = 5,
         .num_sender_clients = 8,
@@ -703,7 +765,7 @@ TEST_F(FabricMuxFixture, TestFabricMuxFiveChipVariant) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMuxFixture, TestFabricMuxSixChipVariant) {
+TEST_F(FabricMux1DFixture, TestFabricMuxSixChipVariant) {
     TestConfig test_config = {
         .num_devices = 6,
         .num_sender_clients = 16,
@@ -721,7 +783,7 @@ TEST_F(FabricMuxFixture, TestFabricMuxSixChipVariant) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMuxFixture, TestFabricMuxSevenChipVariant) {
+TEST_F(FabricMux1DFixture, TestFabricMuxSevenChipVariant) {
     TestConfig test_config = {
         .num_devices = 7,
         .num_sender_clients = 20,
@@ -739,7 +801,7 @@ TEST_F(FabricMuxFixture, TestFabricMuxSevenChipVariant) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMuxFixture, TestFabricMuxEightChipVariant) {
+TEST_F(FabricMux1DFixture, TestFabricMuxEightChipVariant) {
     TestConfig test_config = {
         .num_devices = 8,
         .num_sender_clients = 20,
@@ -757,7 +819,7 @@ TEST_F(FabricMuxFixture, TestFabricMuxEightChipVariant) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMuxFixture, TestFabricMuxStressOpenClose) {
+TEST_F(FabricMux1DFixture, TestFabricMuxStressOpenClose) {
     TestConfig test_config = {
         .num_devices = 2,  // running on 2 devices will allow to test on all types of multi-chip systems
         .num_sender_clients = 8,
@@ -775,7 +837,7 @@ TEST_F(FabricMuxFixture, TestFabricMuxStressOpenClose) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMuxFixture, TestFabricMuxNumFullSizeChannelIters) {
+TEST_F(FabricMux1DFixture, TestFabricMuxNumFullSizeChannelIters) {
     TestConfig test_config = {
         .num_devices = 2,  // running on 2 devices will allow to test on all types of multi-chip systems
         .num_sender_clients = 8,
@@ -789,6 +851,60 @@ TEST_F(FabricMuxFixture, TestFabricMuxNumFullSizeChannelIters) {
         .uniform_sender_receiver_split = true,
         .num_open_close_iters = 1,
         .num_full_size_channel_iters = 2,
+    };
+    run_mux_test_variant(this, test_config);
+}
+
+TEST_F(FabricMux2DFixture, TestFabricMux2DTwoChipVariant) {
+    TestConfig test_config = {
+        .num_devices = 2,
+        .num_sender_clients = 8,
+        .num_packets = 5000,
+        .num_credits = 16,
+        .num_return_credits_per_packet = 1,
+        .packet_payload_size_bytes = 2048,
+        .time_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+        .num_buffers_full_size_channel = 8,
+        .num_buffers_header_only_channel = 8,
+        .uniform_sender_receiver_split = true,
+        .num_open_close_iters = 1,
+        .num_full_size_channel_iters = 1,
+    };
+    run_mux_test_variant(this, test_config);
+}
+
+TEST_F(FabricMux2DFixture, TestFabricMux2DThreeChipVariant) {
+    TestConfig test_config = {
+        .num_devices = 3,
+        .num_sender_clients = 8,
+        .num_packets = 5000,
+        .num_credits = 16,
+        .num_return_credits_per_packet = 8,
+        .packet_payload_size_bytes = 2048,
+        .time_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+        .num_buffers_full_size_channel = 8,
+        .num_buffers_header_only_channel = 8,
+        .uniform_sender_receiver_split = true,
+        .num_open_close_iters = 1,
+        .num_full_size_channel_iters = 1,
+    };
+    run_mux_test_variant(this, test_config);
+}
+
+TEST_F(FabricMux2DFixture, TestFabricMux2DFourChipVariant) {
+    TestConfig test_config = {
+        .num_devices = 4,
+        .num_sender_clients = 8,
+        .num_packets = 5000,
+        .num_credits = 16,
+        .num_return_credits_per_packet = 8,
+        .packet_payload_size_bytes = 2048,
+        .time_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+        .num_buffers_full_size_channel = 8,
+        .num_buffers_header_only_channel = 8,
+        .uniform_sender_receiver_split = false,
+        .num_open_close_iters = 1,
+        .num_full_size_channel_iters = 1,
     };
     run_mux_test_variant(this, test_config);
 }

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -45,8 +45,8 @@ const auto routing_directions = {
     tt_fabric::RoutingDirection::W};
 
 using FabricMuxBaseFixture = BaseFabricFixture;
-using FabricMux1DFixture = Fabric1DFixture;
-using FabricMux2DFixture = Fabric2DFixture;
+using Fabric1DMuxFixture = Fabric1DFixture;
+using Fabric2DMuxFixture = Fabric2DFixture;
 
 struct TestConfig {
     uint32_t num_devices = 0;
@@ -621,7 +621,7 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
     }
 }
 
-TEST_F(FabricMux1DFixture, TestFabricMuxTwoChipVariant1) {
+TEST_F(Fabric1DMuxFixture, TestFabricMuxTwoChipVariant1) {
     TestConfig test_config = {
         .num_devices = 2,
         .num_sender_clients = 1,
@@ -639,7 +639,7 @@ TEST_F(FabricMux1DFixture, TestFabricMuxTwoChipVariant1) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux1DFixture, TestFabricMuxTwoChipVariant2) {
+TEST_F(Fabric1DMuxFixture, TestFabricMuxTwoChipVariant2) {
     TestConfig test_config = {
         .num_devices = 2,
         .num_sender_clients = 2,
@@ -657,7 +657,7 @@ TEST_F(FabricMux1DFixture, TestFabricMuxTwoChipVariant2) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux1DFixture, TestFabricMuxTwoChipVariant3) {
+TEST_F(Fabric1DMuxFixture, TestFabricMuxTwoChipVariant3) {
     TestConfig test_config = {
         .num_devices = 2,
         .num_sender_clients = 8,
@@ -675,7 +675,7 @@ TEST_F(FabricMux1DFixture, TestFabricMuxTwoChipVariant3) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux1DFixture, TestFabricMuxTwoChipVariant4) {
+TEST_F(Fabric1DMuxFixture, TestFabricMuxTwoChipVariant4) {
     TestConfig test_config = {
         .num_devices = 2,
         .num_sender_clients = 8,
@@ -693,7 +693,7 @@ TEST_F(FabricMux1DFixture, TestFabricMuxTwoChipVariant4) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux1DFixture, TestFabricMuxThreeChipVariant) {
+TEST_F(Fabric1DMuxFixture, TestFabricMuxThreeChipVariant) {
     TestConfig test_config = {
         .num_devices = 3,
         .num_sender_clients = 8,
@@ -711,7 +711,7 @@ TEST_F(FabricMux1DFixture, TestFabricMuxThreeChipVariant) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux1DFixture, TestFabricMuxFourChipVariant1) {
+TEST_F(Fabric1DMuxFixture, TestFabricMuxFourChipVariant1) {
     TestConfig test_config = {
         .num_devices = 4,
         .num_sender_clients = 8,
@@ -729,7 +729,7 @@ TEST_F(FabricMux1DFixture, TestFabricMuxFourChipVariant1) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux1DFixture, TestFabricMuxFourChipVariant2) {
+TEST_F(Fabric1DMuxFixture, TestFabricMuxFourChipVariant2) {
     TestConfig test_config = {
         .num_devices = 4,
         .num_sender_clients = 8,
@@ -747,7 +747,7 @@ TEST_F(FabricMux1DFixture, TestFabricMuxFourChipVariant2) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux1DFixture, TestFabricMuxFiveChipVariant) {
+TEST_F(Fabric1DMuxFixture, TestFabricMuxFiveChipVariant) {
     TestConfig test_config = {
         .num_devices = 5,
         .num_sender_clients = 8,
@@ -765,7 +765,7 @@ TEST_F(FabricMux1DFixture, TestFabricMuxFiveChipVariant) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux1DFixture, TestFabricMuxSixChipVariant) {
+TEST_F(Fabric1DMuxFixture, TestFabricMuxSixChipVariant) {
     TestConfig test_config = {
         .num_devices = 6,
         .num_sender_clients = 16,
@@ -783,7 +783,7 @@ TEST_F(FabricMux1DFixture, TestFabricMuxSixChipVariant) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux1DFixture, TestFabricMuxSevenChipVariant) {
+TEST_F(Fabric1DMuxFixture, TestFabricMuxSevenChipVariant) {
     TestConfig test_config = {
         .num_devices = 7,
         .num_sender_clients = 20,
@@ -801,7 +801,7 @@ TEST_F(FabricMux1DFixture, TestFabricMuxSevenChipVariant) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux1DFixture, TestFabricMuxEightChipVariant) {
+TEST_F(Fabric1DMuxFixture, TestFabricMuxEightChipVariant) {
     TestConfig test_config = {
         .num_devices = 8,
         .num_sender_clients = 20,
@@ -819,7 +819,7 @@ TEST_F(FabricMux1DFixture, TestFabricMuxEightChipVariant) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux1DFixture, TestFabricMuxStressOpenClose) {
+TEST_F(Fabric1DMuxFixture, TestFabricMuxStressOpenClose) {
     TestConfig test_config = {
         .num_devices = 2,  // running on 2 devices will allow to test on all types of multi-chip systems
         .num_sender_clients = 8,
@@ -837,7 +837,7 @@ TEST_F(FabricMux1DFixture, TestFabricMuxStressOpenClose) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux1DFixture, TestFabricMuxNumFullSizeChannelIters) {
+TEST_F(Fabric1DMuxFixture, TestFabricMuxNumFullSizeChannelIters) {
     TestConfig test_config = {
         .num_devices = 2,  // running on 2 devices will allow to test on all types of multi-chip systems
         .num_sender_clients = 8,
@@ -855,7 +855,7 @@ TEST_F(FabricMux1DFixture, TestFabricMuxNumFullSizeChannelIters) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux2DFixture, TestFabricMux2DTwoChipVariant) {
+TEST_F(Fabric2DMuxFixture, TestFabricMux2DTwoChipVariant) {
     TestConfig test_config = {
         .num_devices = 2,
         .num_sender_clients = 8,
@@ -873,7 +873,7 @@ TEST_F(FabricMux2DFixture, TestFabricMux2DTwoChipVariant) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux2DFixture, TestFabricMux2DThreeChipVariant) {
+TEST_F(Fabric2DMuxFixture, TestFabricMux2DThreeChipVariant) {
     TestConfig test_config = {
         .num_devices = 3,
         .num_sender_clients = 8,
@@ -891,7 +891,7 @@ TEST_F(FabricMux2DFixture, TestFabricMux2DThreeChipVariant) {
     run_mux_test_variant(this, test_config);
 }
 
-TEST_F(FabricMux2DFixture, TestFabricMux2DFourChipVariant) {
+TEST_F(Fabric2DMuxFixture, TestFabricMux2DFourChipVariant) {
     TestConfig test_config = {
         .num_devices = 4,
         .num_sender_clients = 8,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23467)

### Problem description
Fabric Mux was only supporting 1D fabric. But for FD over fabric port, we would need support for 2D as well.

### What's changed
1. Updated mux config to work with 2D
2. Added tests for 2D
3. Updated benchmark tests to init fabric (although its not needed for functionality). This is now needed since the mux config queries fabric context to get the correct packet header and max payload size. In case fabric is not instantiated, we get compile time errors.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15913591275)
- [x]  [Galaxy Quick] (https://github.com/tenstorrent/tt-metal/actions/runs/15889318117)
- [ ]  [ubench] (https://github.com/tenstorrent/tt-metal/actions/runs/15888481515)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes