### PR TITLE
#0: cache routing fields so no need to fetch from L1

### DIFF
--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -1083,7 +1083,9 @@ void run_receiver_channel_step_impl(
             // clear the cached packet header
             receiver_channel_pointers.clear_cached_routing_fields();
         } else {  // cannot process packet, need to cache it
-            receiver_channel_pointers.cache_routing_fields(cached_routing_fields);
+            if (!receiver_channel_pointers.is_cached()) {
+                receiver_channel_pointers.cache_routing_fields(cached_routing_fields);
+            }
         }
     }
 

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -299,7 +299,7 @@ struct ReceiverChannelPointers {
         cached_routing_fields = {routing_fields, true};
     }
 
-    FORCE_INLINE void clear_cached_routing_fields() { cached_routing_fields = {ROUTING_FIELDS_TYPE{}, false}; }
+    FORCE_INLINE void clear_cached_routing_fields() { cached_routing_fields.second = false; }
 
     FORCE_INLINE bool is_cached() const { return cached_routing_fields.second; }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes