### PR TITLE
[skip ci] Update logic in package-and-release workflow

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -10,7 +10,39 @@ permissions:
   contents: write
   packages: write
 
+
+# Some explanation:
+# is-release-candidate is always true, unless the workflow is manually dispatched on a tag
+# should-create-release is used to avoid creating a duplicate release
+# if we are running on main branch, don't upload any artifacts or create a gh release
+
 jobs:
+  get-params:
+    runs-on: ubuntu-latest
+    outputs:
+      is-release-candidate: ${{ steps.get-is-release-candidate.outputs.is-release-candidate }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get is-release-candidate
+        id: get-is-release-candidate
+        run: |
+          # A workflow dispatch on a tag is considered a release run for us.
+          isReleaseCandidate=${{ !(github.ref_type == 'tag' && github.event_name == 'workflow_dispatch') }}
+          echo "is-release-candidate=$isReleaseCandidate" >> "$GITHUB_OUTPUT"
+      - name: Get should-create-release
+        id: get-should-create-release
+        run: |
+          # Run once to check for errors
+          ./scripts/build_scripts/get_should_create_release.sh ${{ fromJSON(steps.get-is-release-candidate.outputs.is-release-candidate) && '--release-candidate' || '' }}
+          shouldCreateRelease=$(scripts/build_scripts/get_should_create_release.sh ${{ fromJSON(steps.get-is-release-candidate.outputs.is-release-candidate) && '--release-candidate' || '' }})
+          if [ "$shouldCreateRelease" != "true" ]; then
+            echo "should-create-release is false, no release needed. Exiting workflow."
+            exit 1
+          fi
+          echo "should-create-release is true, proceeding with release workflow."
   build-artifact:
     needs: create-tag
     uses: ./.github/workflows/build-artifact.yaml
@@ -88,29 +120,6 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  get-params:
-    runs-on: ubuntu-latest
-    outputs:
-      is-release-candidate: ${{ steps.get-is-release-candidate.outputs.is-release-candidate }}
-      should-create-release: ${{ steps.get-should-create-release.outputs.should-create-release }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Get is-release-candidate
-        id: get-is-release-candidate
-        run: |
-          # A workflow dispatch on a tag is considered a release run for us.
-          isReleaseCandidate=${{ !(github.ref_type == 'tag' && github.event_name == 'workflow_dispatch') }}
-          echo "is-release-candidate=$isReleaseCandidate" >> "$GITHUB_OUTPUT"
-      - name: Get should-create-release
-        id: get-should-create-release
-        run: |
-          # Run once to check for errors
-          ./scripts/build_scripts/get_should_create_release.sh ${{ fromJSON(steps.get-is-release-candidate.outputs.is-release-candidate) && '--release-candidate' || '' }}
-          shouldCreateRelease=$(scripts/build_scripts/get_should_create_release.sh ${{ fromJSON(steps.get-is-release-candidate.outputs.is-release-candidate) && '--release-candidate' || '' }})
-          echo "should-create-release=$shouldCreateRelease" >> "$GITHUB_OUTPUT"
   create-tag:
     needs: get-params
     uses: ./.github/workflows/release-verify-or-create-tag.yaml
@@ -174,6 +183,7 @@ jobs:
     # May accidentally create two releases without restricting to 1 job
     concurrency: create_upload_draft_release
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -226,10 +236,11 @@ jobs:
     ]
     uses: ./.github/workflows/publish-release-image.yaml
     secrets: inherit
+    if: github.ref != 'refs/heads/main'
     with:
       base-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       version: ${{ needs.create-tag.outputs.version }}
-      is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}
+      is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' }}
   release-docs:
     needs: [
       build-artifact,
@@ -237,7 +248,7 @@ jobs:
       create-tag,
       create-and-upload-draft-release
     ]
-    if: ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}
+    if: ${{ needs.get-params.outputs.is-release-candidate !='true' }}
     uses: ./.github/workflows/docs-latest-public.yaml
     with:
       version: ${{ needs.create-tag.outputs.version }}
@@ -250,6 +261,7 @@ jobs:
       Publish Python 🐍 distribution 📦 to PyPI
     needs: [build-artifact, test-wheels]
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
     environment:
       name: pypi
       url: https://pypi.org/project/ttnn/

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -193,10 +193,6 @@ jobs:
         uses: qmonnet/git-archive-all-action@791fb850881cf58b1d1fcc9b06c01940080bba0a
         with:
           output-files: tt-metalium.tar.gz
-      - name: Download Wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       - name: Create VERSION
         run: echo ${{ needs.create-tag.outputs.version }} > VERSION
       - name : Download release notes
@@ -207,8 +203,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: changelog
-      - name: Assert wheels exist
-        run: ls -arhl ttnn-*.whl
       - name: Release
         # A major release has not been tagged yet, so we need to do this to avoid
         # Node 16 deprecation warning message
@@ -225,7 +219,6 @@ jobs:
             README.md
             INSTALLING.md
             models/MODEL_UPDATES.md
-            ttnn-*.whl
             tt-metalium.tar.gz
           fail_on_unmatched_files: true
   create-docker-release-image:

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -62,7 +62,8 @@ jobs:
       tracy: true
       build-wheel: true
   test-wheels:
-    needs: build-artifact
+    needs: [build-artifact, get-params]
+    if: needs.get-params.outputs.is-release-candidate == 'true'
     uses: ./.github/workflows/_test-wheels-impl.yaml
     with:
       from-precompiled: true
@@ -77,7 +78,8 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       arch: wormhole_b0
   t3000-demos:
-    needs: build-artifact
+    needs: [build-artifact, get-params]
+    if: needs.get-params.outputs.is-release-candidate == 'true'
     uses: ./.github/workflows/t3000-demo-tests-impl.yaml
     secrets: inherit
     with:
@@ -85,7 +87,8 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   t3000-model-perf:
-    needs: [build-artifact, build-artifact-profiler]
+    needs: [build-artifact, build-artifact-profiler, get-params]
+    if: needs.get-params.outputs.is-release-candidate == 'true'
     uses: ./.github/workflows/t3000-model-perf-tests-impl.yaml
     secrets: inherit
     with:
@@ -95,7 +98,8 @@ jobs:
       wheel-artifact-profiler-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
       build-artifact-profiler-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
   galaxy-4u-demos:
-    needs: build-artifact
+    needs: [build-artifact, get-params]
+    if: needs.get-params.outputs.is-release-candidate == 'true'
     uses: ./.github/workflows/tg-demo-tests-impl.yaml
     secrets: inherit
     with:
@@ -103,7 +107,8 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   galaxy-6u-demos:
-    needs: build-artifact
+    needs: [build-artifact, get-params]
+    if: needs.get-params.outputs.is-release-candidate == 'true'
     uses: ./.github/workflows/tg-demo-tests-impl.yaml
     secrets: inherit
     with:
@@ -112,7 +117,8 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       topology: topology-6u
   blackhole-demos:
-    needs: build-artifact
+    needs: [build-artifact, get-params]
+    if: needs.get-params.outputs.is-release-candidate == 'true'
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
     with:

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -15,6 +15,7 @@ permissions:
 # is-release-candidate is always true, unless the workflow is manually dispatched on a tag
 # should-create-release is used to avoid creating a duplicate release
 # if we are running on main branch, don't upload any artifacts or create a gh release
+# if we are promoting a release candidate, don't rerun the tests
 
 jobs:
   get-params:

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -54,6 +54,7 @@ jobs:
       version: 22.04
       build-wheel: true
   build-artifact-profiler:
+    needs: create-tag
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write


### PR DESCRIPTION
### Ticket
NA

### Problem description
- release page gets cluttered with RCs, from scheduled runs on main
- releases have wheels attached, which is no longer necessary with pypi and TT custom index
- bizarre logic with `should-create-release` ... no need for boolean, we can just fail the workflow if its creating a redundant release
- When promoting a release candidate to a release, we would rerun a bunch of test jobs ... that is unnecessary, and sends a false signal. Lets not retest.

### What's changed
Fix all problems.

### Checklist
- [ ] [Package And Release](https://github.com/tenstorrent/tt-metal/actions/runs/15888443660) CI passes