### PR TITLE
[skip ci] Move T3K fast tests to CIv2

### DIFF
--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -12,10 +12,6 @@ on:
       wheel-artifact-name:
         required: true
         type: string
-      extra-tag:
-        required: false
-        type: string
-        default: "in-service"
 
 jobs:
   t3000-unit-tests:
@@ -23,14 +19,11 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k fabric tests", arch: wormhole_b0, cmd: run_t3000_ttfabric_tests, timeout: 10, label: pipeline-functional, owner_id: UJ45FEC7M}, # Allan Liu
+          { name: "t3k fabric tests", arch: wormhole_b0, cmd: run_t3000_ttfabric_tests, timeout: 10, owner_id: UJ45FEC7M}, # Allan Liu
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:
-      - arch-wormhole_b0
-      - config-t3000
-      - ${{ matrix.test-group.label}}
-      - ${{ inputs.extra-tag }}
+      - tt-beta-ubuntu-2204-N300-llmbox-large-stable
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
T3Ks are backlogged, holding up APC runs.

### What's changed
2 machines are moving over to CIv2, shift the _fast_ T3K runs to CIv2 where we expect to see lower latency for job queues.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15891112947)
- [x] T3K Fast CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15891110424)