### PR TITLE
Fix Clang-20 build and typos

### DIFF
--- a/tt_metal/api/tt-metalium/data_format.hpp
+++ b/tt_metal/api/tt-metalium/data_format.hpp
@@ -20,7 +20,7 @@ enum class ExpPrecision : std::uint8_t {
 
 bool is_valid_conversion(DataFormat input_format, DataFormat output_format);
 bool is_exp_b_format(DataFormat data_format);
-ExpPrecision get_exp_precison(DataFormat data_format);
+ExpPrecision get_exp_precision(DataFormat data_format);
 void dump_data_formats(DataFormat data_format[NUM_CIRCULAR_BUFFERS]);
 
 /*

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -47,7 +47,7 @@ bool is_exp_b_format(DataFormat data_format) {
         (data_format == DataFormat::Bfp2_b));
 }
 
-ExpPrecision get_exp_precison(DataFormat data_format) {
+ExpPrecision get_exp_precision(DataFormat data_format) {
     return (is_exp_b_format(data_format) ? ExpPrecision::B : ExpPrecision::A);
 }
 
@@ -105,7 +105,7 @@ DataFormat check_valid_formats_in_out_data_formats(DataFormat data_format[NUM_CI
 
 ExpPrecision get_data_exp_precision(DataFormat data_formats[NUM_CIRCULAR_BUFFERS]) {
     DataFormat last_valid_format = check_consistent_format_across_buffers(data_formats);
-    return get_exp_precison(last_valid_format);
+    return get_exp_precision(last_valid_format);
 }
 
 std::vector<DataFormat> get_unpack_src_formats(DataFormat data_formats[NUM_CIRCULAR_BUFFERS]) {
@@ -203,9 +203,9 @@ DataFormat get_single_pack_src_format(
     }
 
     DataFormat pack_src_format;
-    const ExpPrecision input_exp_width = get_exp_precison(data_format);
-    const ExpPrecision output_exp_width = get_exp_precison(data_format);
-    const ExpPrecision fp32_condition_exp_width = get_exp_precison(unpack_conditional_dst_format);
+    const ExpPrecision input_exp_width = get_exp_precision(data_format);
+    const ExpPrecision output_exp_width = get_exp_precision(data_format);
+    const ExpPrecision fp32_condition_exp_width = get_exp_precision(unpack_conditional_dst_format);
 
     bool is_input_or_output_float32 = data_format == DataFormat::Float32;
     bool condition_exp_float32_match_output =
@@ -296,7 +296,7 @@ DataFormat get_single_pack_src_format(
             pack_src_format = CONVERT_EXP_WIDTH.at(pack_src_format_tmp);
             if (data_format != DataFormat::Float32) {
                 TT_FATAL(
-                    input_exp_width == get_exp_precison(pack_src_format),
+                    input_exp_width == get_exp_precision(pack_src_format),
                     "Input format exponent width = {}, must match pack src format exponent width = {}",
                     data_format,
                     pack_src_format);

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -210,9 +210,9 @@ public:
         if (shard_dims.empty()) {
             const TensorSpec tensor_spec(shape, layout);
             tt::tt_metal::HostBuffer replicated_buffer;
-            if (const bool pydata_borrowable = tensor_spec.layout() == tt::tt_metal::Layout::ROW_MAJOR &&
-                                               tensor_spec.physical_shape() == tensor_spec.logical_2d_shape() &&
-                                               tensor_spec.data_type() == tt::tt_metal::convert_to_data_type<T>()) {
+            if (tensor_spec.layout() == tt::tt_metal::Layout::ROW_MAJOR &&
+                tensor_spec.physical_shape() == tensor_spec.logical_2d_shape() &&
+                tensor_spec.data_type() == tt::tt_metal::convert_to_data_type<T>()) {
                 replicated_buffer = tt::tt_metal::HostBuffer(span, buffer_pin);
             } else {
                 replicated_buffer = tt::tt_metal::host_buffer::get_host_buffer(Tensor::from_span(


### PR DESCRIPTION
### Ticket
None

### Problem description
Clang-20 detects a new unused variable and fails the build
There's a typo in function name

### What's changed
Remove the unused variable, fix the typo

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15891844574