### PR TITLE
Make ControlPlane Aware of Local vs. Global Distributed Scope

### DIFF
--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(
     distributed_unit_tests
     PRIVATE
         test_auto_mpi_init.cpp
+        test_control_plane_local_mesh_binding.cpp
         test_end_to_end_eltwise.cpp
         test_distributed_host_buffer.cpp
         test_mesh_buffer.cpp

--- a/tests/tt_metal/distributed/test_control_plane_local_mesh_binding.cpp
+++ b/tests/tt_metal/distributed/test_control_plane_local_mesh_binding.cpp
@@ -1,0 +1,461 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <cstdlib>
+#include <fstream>
+#include <optional>
+#include <memory>
+#include <tt-metalium/control_plane.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/multi_mesh_types.hpp>
+#include <impl/context/metal_context.hpp>
+#include "gmock/gmock.h"
+#include <fmt/format.h>
+#include "utils.hpp"
+
+namespace tt::tt_fabric {
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::IsEmpty;
+using ::tt::tt_metal::distributed::MeshShape;
+using ::tt::tt_metal::distributed::MeshCoordinate;
+using ::tt::tt_metal::distributed::MeshCoordinateRange;
+using ::tt::tt_metal::distributed::test::utils::ScopedEnvVar;
+
+// RAII guard for managing mesh binding environment variables
+class ScopedMeshBinding {
+public:
+    ScopedMeshBinding(const char* mesh_id, const char* host_rank)
+        : mesh_id_guard_("TT_MESH_ID", mesh_id),
+          host_rank_guard_("TT_HOST_RANK", host_rank) {}
+
+    // Convenience constructor for numeric values
+    ScopedMeshBinding(uint32_t mesh_id, uint32_t host_rank)
+        : mesh_id_str_(std::to_string(mesh_id)),
+          host_rank_str_(std::to_string(host_rank)),
+          mesh_id_guard_("TT_MESH_ID", mesh_id_str_.c_str()),
+          host_rank_guard_("TT_HOST_RANK", host_rank_str_.c_str()) {}
+
+private:
+    std::string mesh_id_str_;
+    std::string host_rank_str_;
+    ScopedEnvVar mesh_id_guard_;
+    ScopedEnvVar host_rank_guard_;
+};
+
+// RAII helper that combines environment setup and control plane initialization
+class ScopedControlPlane {
+public:
+    ScopedControlPlane(const std::string& mesh_desc,
+                      MeshId mesh_id = MeshId{0},
+                      int num_chips = 1,
+                      std::optional<std::pair<uint32_t, uint32_t>> env_binding = std::nullopt)
+        : mesh_binding_(env_binding ? std::make_unique<ScopedMeshBinding>(env_binding->first, env_binding->second) : nullptr),
+          temp_file_(CreateTempFile(mesh_desc)) {
+
+        auto chip_mapping = CreateChipMapping(mesh_id, num_chips);
+        tt::tt_metal::MetalContext::instance().set_custom_control_plane_mesh_graph(temp_file_, chip_mapping);
+    }
+
+    ~ScopedControlPlane() { std::remove(temp_file_.c_str()); }
+    tt::tt_fabric::ControlPlane& get() { return tt::tt_metal::MetalContext::instance().get_control_plane(); }
+
+private:
+    static std::string CreateTempFile(const std::string& content) {
+        static int counter = 0;
+        std::string filename = "/tmp/test_mesh_desc_scoped_" + std::to_string(counter++) + ".yaml";
+        std::ofstream file(filename);
+        file << content;
+        file.close();
+        return filename;
+    }
+
+    static std::map<FabricNodeId, chip_id_t> CreateChipMapping(MeshId mesh_id, int num_chips) {
+        std::map<FabricNodeId, chip_id_t> mapping;
+        for (int i = 0; i < num_chips; ++i) {
+            mapping[FabricNodeId(mesh_id, i)] = i;
+        }
+        return mapping;
+    }
+
+    std::unique_ptr<ScopedMeshBinding> mesh_binding_;
+    std::string temp_file_;
+};
+
+// Mesh descriptor factory functions
+namespace TestMeshDescriptors {
+
+std::string CreateSingleChipMesh(const std::string& arch = "wormhole_b0", int mesh_id = 0) {
+    return fmt::format(R"yaml(ChipSpec: {{
+  arch: {},
+  ethernet_ports: {{
+    N: 2,
+    E: 2,
+    S: 2,
+    W: 2,
+  }}
+}}
+
+Board: [
+  {{ name: SingleChip,
+    type: Mesh,
+    topology: [1, 1]}}
+]
+
+Mesh: [
+{{
+  id: {},
+  board: SingleChip,
+  device_topology: [1, 1],
+  host_topology: [1, 1],
+  host_ranks: [[0]]}}
+]
+
+Graph: []
+)yaml", arch, mesh_id);
+}
+
+std::string CreateDualHostMesh(int rows = 2, int cols = 2, int mesh_id = 0) {
+    return fmt::format(R"yaml(ChipSpec: {{
+  arch: wormhole_b0,
+  ethernet_ports: {{
+    N: 2,
+    E: 2,
+    S: 2,
+    W: 2,
+  }}
+}}
+
+Board: [
+  {{ name: DualHost,
+    type: Mesh,
+    topology: [1, {}]}}
+]
+
+Mesh: [
+{{
+  id: {},
+  board: DualHost,
+  device_topology: [{}, {}],
+  host_topology: [2, 1],
+  host_ranks: [[0], [1]]}}
+]
+
+Graph: []
+)yaml", cols, mesh_id, rows, cols);
+}
+
+std::string CreateMultiMeshConfig(const std::vector<int>& mesh_ids) {
+    std::string meshes;
+    for (size_t i = 0; i < mesh_ids.size(); ++i) {
+        if (i > 0) meshes += ",\n";
+        meshes += fmt::format(R"({{
+  id: {},
+  board: SingleChip,
+  device_topology: [1, 1],
+  host_topology: [1, 1],
+  host_ranks: [[0]]}})", mesh_ids[i]);
+    }
+
+    return fmt::format(R"yaml(ChipSpec: {{
+  arch: wormhole_b0,
+  ethernet_ports: {{
+    N: 2,
+    E: 2,
+    S: 2,
+    W: 2,
+  }}
+}}
+
+Board: [
+  {{ name: SingleChip,
+    type: Mesh,
+    topology: [1, 1]}}
+]
+
+Mesh: [
+{}
+]
+
+Graph: []
+)yaml", meshes);
+}
+
+// Legacy constants for backward compatibility
+const std::string kSingleChipMeshDesc = CreateSingleChipMesh();
+const std::string kDualHostMeshDesc = CreateDualHostMesh();
+const std::string kMultipleMeshesDesc = CreateMultiMeshConfig({0, 1});
+
+} // namespace TestMeshDescriptors
+
+using namespace TestMeshDescriptors;
+
+// Parameterized test data for MeshScope tests
+struct MeshScopeTestParams {
+    HostRankId host_rank;
+    MeshShape expected_local_shape;
+    MeshCoordinate expected_start;
+    MeshCoordinate expected_end;
+    std::string test_name;
+};
+
+// Test fixture for control plane API tests
+class ControlPlaneLocalMeshBinding : public ::testing::Test {
+protected:
+    ~ControlPlaneLocalMeshBinding() override {
+        // Clean up any temporary files
+        for (const auto& file : temp_files_) {
+            std::remove(file.c_str());
+        }
+    }
+
+    std::string CreateTempMeshDescriptor(const std::string& content) {
+        static int counter = 0;
+        std::string filename = "/tmp/test_mesh_desc_" + std::to_string(counter++) + ".yaml";
+        std::ofstream file(filename);
+        file << content;
+        file.close();
+        temp_files_.push_back(filename);
+        return filename;
+    }
+
+    // Helper to create standard chip mappings
+    std::map<FabricNodeId, chip_id_t> CreateSequentialChipMapping(MeshId mesh_id, int num_chips) {
+        std::map<FabricNodeId, chip_id_t> mapping;
+        for (int i = 0; i < num_chips; ++i) {
+            mapping[FabricNodeId(mesh_id, i)] = i;
+        }
+        return mapping;
+    }
+
+    // Helper function to set up control plane with a mesh descriptor
+    tt::tt_fabric::ControlPlane& SetUpControlPlane(const std::string& mesh_desc, MeshId mesh_id = MeshId{0}, int num_chips = 1) {
+        std::string temp_file = CreateTempMeshDescriptor(mesh_desc);
+        auto chip_mapping = CreateSequentialChipMapping(mesh_id, num_chips);
+        tt::tt_metal::MetalContext::instance().set_custom_control_plane_mesh_graph(temp_file, chip_mapping);
+        return tt::tt_metal::MetalContext::instance().get_control_plane();
+    }
+
+    // Helper to assert local binding matches expected values
+    void AssertLocalBinding(const tt::tt_fabric::ControlPlane& control_plane, MeshId expected_mesh, HostRankId expected_host) {
+        auto mesh_binding = control_plane.get_local_mesh_id_binding();
+        auto host_binding = control_plane.get_local_host_rank_id_binding();
+
+        ASSERT_TRUE(mesh_binding.has_value()) << "Local mesh binding not available";
+        ASSERT_TRUE(host_binding.has_value()) << "Local host binding not available";
+        EXPECT_EQ(*mesh_binding, expected_mesh);
+        EXPECT_EQ(*host_binding, expected_host);
+    }
+
+    // Helper to assert no local binding is present
+    void ExpectNoLocalBinding(const tt::tt_fabric::ControlPlane& control_plane) {
+        EXPECT_FALSE(control_plane.get_local_mesh_id_binding().has_value());
+        EXPECT_FALSE(control_plane.get_local_host_rank_id_binding().has_value());
+    }
+
+    std::vector<std::string> temp_files_;
+};
+
+TEST_F(ControlPlaneLocalMeshBinding, NoEnvironmentVariables) {
+    auto& control_plane = SetUpControlPlane(kSingleChipMeshDesc);
+
+    // Should return nullopt when environment variables are not set
+    ExpectNoLocalBinding(control_plane);
+}
+
+TEST_F(ControlPlaneLocalMeshBinding, WithEnvironmentVariables) {
+    ScopedMeshBinding env_guard(/*mesh_id*/0u, /*host_rank*/0u);
+    auto& control_plane = SetUpControlPlane(kSingleChipMeshDesc);
+    AssertLocalBinding(control_plane, MeshId{0}, HostRankId{0});
+}
+
+TEST_F(ControlPlaneLocalMeshBinding, PartialEnvironmentVariables) {
+    std::string temp_file = CreateTempMeshDescriptor(kSingleChipMeshDesc);
+    auto chip_mapping = CreateSequentialChipMapping(MeshId{0}, 1);
+
+    // Test with only TT_MESH_ID set
+    {
+        ScopedEnvVar mesh_only("TT_MESH_ID", "0");
+
+        tt::tt_metal::MetalContext::instance().set_custom_control_plane_mesh_graph(temp_file, chip_mapping);
+        auto& control_plane1 = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+        // Should return nullopt when only one variable is set
+        ExpectNoLocalBinding(control_plane1);
+    }
+
+    // Test with only TT_HOST_RANK set
+    {
+        ScopedEnvVar host_only("TT_HOST_RANK", "0");
+
+        // Reset control plane to pick up new environment variables
+        tt::tt_metal::MetalContext::instance().set_custom_control_plane_mesh_graph(temp_file, chip_mapping);
+        auto& control_plane2 = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+        // Should return nullopt when only one variable is set
+        ExpectNoLocalBinding(control_plane2);
+    }
+}
+
+TEST_F(ControlPlaneLocalMeshBinding, GetPhysicalMeshShapeWithScopeDualHost) {
+    // Test with host rank 0
+    ScopedControlPlane scoped_cp(kDualHostMeshDesc, MeshId{0}, /*num_chips=*/4, /*env_binding=*/{{/*mesh_id=*/0, /*host_rank=*/0}});
+
+    // Test global mesh shape
+    auto global_shape = scoped_cp.get().get_physical_mesh_shape(MeshId{0}, MeshScope::GLOBAL);
+    EXPECT_EQ(global_shape, MeshShape(2, 2));
+
+    // Verify local bindings
+    AssertLocalBinding(scoped_cp.get(), MeshId{0}, HostRankId{0});
+
+    // Test local mesh shape - should be 1x2 for host rank 0
+    auto local_shape = scoped_cp.get().get_physical_mesh_shape(MeshId{0}, MeshScope::LOCAL);
+    EXPECT_EQ(local_shape, MeshShape(1, 2));
+
+    // Test default parameter (should be GLOBAL)
+    auto default_shape = scoped_cp.get().get_physical_mesh_shape(MeshId{0});
+    EXPECT_EQ(default_shape, global_shape);
+}
+
+TEST_F(ControlPlaneLocalMeshBinding, GetCoordRangeWithScopeDualHost) {
+    // Test with host rank 1
+    ScopedControlPlane scoped_cp(kDualHostMeshDesc, MeshId{0}, /*num_chips=*/4, /*env_binding=*/{{/*mesh_id=*/0, /*host_rank=*/1}});
+
+    // Test global coordinate range
+    auto global_range = scoped_cp.get().get_coord_range(MeshId{0}, MeshScope::GLOBAL);
+    EXPECT_EQ(global_range.start_coord(), MeshCoordinate(0, 0));
+    EXPECT_EQ(global_range.end_coord(), MeshCoordinate(1, 1));
+    EXPECT_EQ(global_range.shape(), MeshShape(2, 2));
+
+    // Verify local bindings
+    AssertLocalBinding(scoped_cp.get(), MeshId{0}, HostRankId{1});
+
+    // Test local coordinate range - should be the bottom row for host rank 1
+    auto local_range = scoped_cp.get().get_coord_range(MeshId{0}, MeshScope::LOCAL);
+    EXPECT_EQ(local_range.start_coord(), MeshCoordinate(1, 0));
+    EXPECT_EQ(local_range.end_coord(), MeshCoordinate(1, 1));
+    EXPECT_EQ(local_range.shape(), MeshShape(1, 2));
+
+    // Test default parameter (should be GLOBAL)
+    auto default_range = scoped_cp.get().get_coord_range(MeshId{0});
+    EXPECT_EQ(default_range, global_range);
+}
+
+TEST_F(ControlPlaneLocalMeshBinding, MultipleMeshes) {
+    // Set environment variables for mesh 1 using RAII guard
+    ScopedMeshBinding env_guard(/*mesh_id*/1, /*host_rank*/0);
+
+    std::string temp_file = CreateTempMeshDescriptor(kMultipleMeshesDesc);
+
+    // Create control plane with physical chip mapping for both meshes
+    std::map<FabricNodeId, chip_id_t> chip_mapping;
+    chip_mapping[FabricNodeId(MeshId{0}, 0)] = 0;
+    chip_mapping[FabricNodeId(MeshId{1}, 0)] = 1;
+
+    tt::tt_metal::MetalContext::instance().set_custom_control_plane_mesh_graph(temp_file, chip_mapping);
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    // Should bind to mesh 1
+    AssertLocalBinding(control_plane, MeshId{1}, HostRankId{0});
+
+    // Test that we can query shapes for both meshes
+    auto mesh0_shape = control_plane.get_physical_mesh_shape(MeshId{0});
+    auto mesh1_shape = control_plane.get_physical_mesh_shape(MeshId{1});
+    EXPECT_EQ(mesh0_shape, MeshShape(1, 1));
+    EXPECT_EQ(mesh1_shape, MeshShape(1, 1));
+}
+
+TEST_F(ControlPlaneLocalMeshBinding, InvalidMeshId) {
+    tt::tt_metal::MetalContext::instance().set_custom_control_plane_mesh_graph(
+      CreateTempMeshDescriptor(kSingleChipMeshDesc),
+      CreateSequentialChipMapping(MeshId{0}, /*num_chips=*/1));
+
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    ExpectNoLocalBinding(control_plane);
+    EXPECT_THROW(control_plane.get_physical_mesh_shape(MeshId{99}, MeshScope::GLOBAL), std::runtime_error);
+}
+
+TEST_F(ControlPlaneLocalMeshBinding, LocalMeshScopeQueryWithoutLocalBinding) {
+    auto& control_plane = SetUpControlPlane(kSingleChipMeshDesc);
+    ExpectNoLocalBinding(control_plane);
+    EXPECT_NO_THROW(control_plane.get_coord_range(MeshId{0}, MeshScope::LOCAL));
+}
+
+// Parameterized test fixture for MeshScope tests
+class MeshScopeParameterizedTest : public ControlPlaneLocalMeshBinding,
+                                   public ::testing::WithParamInterface<MeshScopeTestParams> {};
+
+// Parameterized test for get_physical_mesh_shape with different host ranks
+TEST_P(MeshScopeParameterizedTest, GetPhysicalMeshShape) {
+    const auto& params = GetParam();
+
+    // Set up control plane with specified host rank
+    ScopedControlPlane scoped_cp(kDualHostMeshDesc, MeshId{0}, /*num_chips=*/4, /*env_binding=*/std::pair<uint32_t, uint32_t>{/*mesh_id=*/0, /*host_rank=*/*params.host_rank});
+
+    // Test global mesh shape (always 2x2)
+    auto global_shape = scoped_cp.get().get_physical_mesh_shape(MeshId{0}, MeshScope::GLOBAL);
+    EXPECT_EQ(global_shape, MeshShape(2, 2));
+
+    // Verify local bindings
+    AssertLocalBinding(scoped_cp.get(), MeshId{0}, params.host_rank);
+
+    // Test local mesh shape
+    auto local_shape = scoped_cp.get().get_physical_mesh_shape(MeshId{0}, MeshScope::LOCAL);
+    EXPECT_EQ(local_shape, params.expected_local_shape);
+}
+
+// Parameterized test for get_coord_range with different host ranks
+TEST_P(MeshScopeParameterizedTest, GetCoordRange) {
+    const auto& params = GetParam();
+
+    // Set up control plane with specified host rank
+    ScopedControlPlane scoped_cp(kDualHostMeshDesc, MeshId{0}, /*num_chips=*/4, /*env_binding=*/std::pair<uint32_t, uint32_t>{/*mesh_id=*/0, /*host_rank=*/*params.host_rank});
+
+    // Test global coordinate range (always (0,0) to (1,1))
+    auto global_range = scoped_cp.get().get_coord_range(MeshId{0}, MeshScope::GLOBAL);
+    EXPECT_EQ(global_range.start_coord(), MeshCoordinate(0, 0));
+    EXPECT_EQ(global_range.end_coord(), MeshCoordinate(1, 1));
+    EXPECT_EQ(global_range.shape(), MeshShape(2, 2));
+
+    // Verify local bindings
+    AssertLocalBinding(scoped_cp.get(), MeshId{0}, params.host_rank);
+
+    // Test local coordinate range
+    auto local_range = scoped_cp.get().get_coord_range(MeshId{0}, MeshScope::LOCAL);
+    EXPECT_EQ(local_range.start_coord(), params.expected_start);
+    EXPECT_EQ(local_range.end_coord(), params.expected_end);
+    EXPECT_EQ(local_range.shape(), params.expected_local_shape);
+}
+
+// Test data for dual-host configuration (2x2 mesh with 2 hosts)
+// Host rank 0 owns top row, host rank 1 owns bottom row
+INSTANTIATE_TEST_SUITE_P(
+    DualHostMeshScope,
+    MeshScopeParameterizedTest,
+    ::testing::Values(
+        MeshScopeTestParams{
+            HostRankId{0},
+            MeshShape(1, 2),           // Host 0 owns 1x2 (top row)
+            MeshCoordinate(0, 0),      // Start at (0,0)
+            MeshCoordinate(0, 1),      // End at (0,1)
+            "HostRank0"
+        },
+        MeshScopeTestParams{
+            HostRankId{1},
+            MeshShape(1, 2),           // Host 1 owns 1x2 (bottom row)
+            MeshCoordinate(1, 0),      // Start at (1,0)
+            MeshCoordinate(1, 1),      // End at (1,1)
+            "HostRank1"
+        }
+    ),
+    [](const testing::TestParamInfo<MeshScopeTestParams>& info) {
+        return info.param.test_name;
+    }
+);
+
+}  // namespace
+}  // namespace tt::tt_fabric

--- a/tests/tt_metal/distributed/utils.cpp
+++ b/tests/tt_metal/distributed/utils.cpp
@@ -403,4 +403,29 @@ std::vector<std::shared_ptr<Program>> create_random_programs(
     return programs;
 }
 
+ScopedEnvVar::ScopedEnvVar(const char* name, const char* value) : name_(name) {
+    // Save original value
+    const char* original = std::getenv(name);
+    if (original) {
+        original_value_ = original;
+        had_original_ = true;
+    }
+
+    // Set new value
+    if (value) {
+        setenv(name, value, /*overwrite=*/1);
+    } else {
+        unsetenv(name);
+    }
+}
+
+ScopedEnvVar::~ScopedEnvVar() {
+    // Restore original value
+    if (had_original_) {
+        setenv(name_, original_value_.c_str(), /*overwrite=*/1);
+    } else {
+        unsetenv(name_);
+    }
+}
+
 }  // namespace tt::tt_metal::distributed::test::utils

--- a/tests/tt_metal/distributed/utils.hpp
+++ b/tests/tt_metal/distributed/utils.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <unordered_set>
 #include <vector>
+#include <string>
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/program.hpp>
@@ -36,4 +37,23 @@ std::vector<std::shared_ptr<Program>> create_random_programs(
     CoreCoord worker_grid_size,
     uint32_t seed,
     const std::unordered_set<CoreCoord>& active_eth_cores = {});
+
+// RAII guard for managing a single environment variable
+class ScopedEnvVar {
+public:
+    ScopedEnvVar(const char* name, const char* value);
+    ~ScopedEnvVar();
+
+    // Delete copy/move to ensure RAII semantics
+    ScopedEnvVar(const ScopedEnvVar&) = delete;
+    ScopedEnvVar& operator=(const ScopedEnvVar&) = delete;
+    ScopedEnvVar(ScopedEnvVar&&) = delete;
+    ScopedEnvVar& operator=(ScopedEnvVar&&) = delete;
+
+private:
+    const char* name_;
+    std::string original_value_;
+    bool had_original_ = false;
+};
+
 }  // namespace tt::tt_metal::distributed::test::utils

--- a/tests/tt_metal/distributed/utils.hpp
+++ b/tests/tt_metal/distributed/utils.hpp
@@ -56,4 +56,28 @@ private:
     bool had_original_ = false;
 };
 
+// RAII class to create and delete a temporary file.
+class TemporaryFile {
+public:
+    explicit TemporaryFile(const std::string& filename) :
+        path_(std::filesystem::temp_directory_path() / filename) {}
+
+    ~TemporaryFile() {
+        if (std::filesystem::exists(path_)) {
+            std::filesystem::remove(path_);
+        }
+    }
+
+    TemporaryFile(const TemporaryFile&) = delete;
+    TemporaryFile& operator=(const TemporaryFile&) = delete;
+    TemporaryFile(TemporaryFile&&) = delete;
+    TemporaryFile& operator=(TemporaryFile&&) = delete;
+
+    std::string string() const { return path_.string(); }
+    const std::filesystem::path& path() const { return path_; }
+
+private:
+    std::filesystem::path path_;
+};
+
 }  // namespace tt::tt_metal::distributed::test::utils

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
@@ -5,6 +5,7 @@
 #include <gmock/gmock.h>
 
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include "tt_metal/distributed/utils.hpp"
 
 #include "ttnn/tensor/serialization.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -23,36 +24,13 @@ using ::testing::ElementsAre;
 using ::testing::FloatEq;
 using ::testing::Pointwise;
 using ::testing::SizeIs;
+using ::tt::tt_metal::distributed::test::utils::TemporaryFile;
 
 using namespace tt::tt_metal;
 
 TensorSpec get_tensor_spec(const ttnn::Shape& shape, DataType dtype) {
     return TensorSpec(shape, TensorLayout(dtype, Layout::ROW_MAJOR, MemoryConfig{}));
 }
-
-// RAII class to create and delete a temporary file.
-class TemporaryFile {
-public:
-    explicit TemporaryFile(const std::string& suffix = ".bin") :
-        path_(std::filesystem::temp_directory_path() / ("test_tensor_" + suffix)) {}
-
-    ~TemporaryFile() {
-        if (std::filesystem::exists(path_)) {
-            std::filesystem::remove(path_);
-        }
-    }
-
-    TemporaryFile(const TemporaryFile&) = delete;
-    TemporaryFile& operator=(const TemporaryFile&) = delete;
-    TemporaryFile(TemporaryFile&&) = delete;
-    TemporaryFile& operator=(TemporaryFile&&) = delete;
-
-    std::string string() const { return path_.string(); }
-    const std::filesystem::path& path() const { return path_; }
-
-private:
-    std::filesystem::path path_;
-};
 
 using TensorSerializationFlatbufferTest = GenericMeshDeviceFixture;
 

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -23,6 +23,21 @@ namespace tt::tt_fabric {
 
 class FabricContext;
 
+// This struct provides information for how a process binds to a particular
+// mesh and local mesh rank (HostRankId rename - #24178) in the mesh graph
+// descriptor.
+struct LocalMeshBinding {
+    MeshId mesh_id;
+    HostRankId host_rank;
+};
+
+// In multi-host context, APIs parameterized with MeshScope, can return
+// results for local mesh or global mesh.
+enum class MeshScope {
+    LOCAL,
+    GLOBAL,
+};
+
 class ControlPlane {
 public:
     explicit ControlPlane(const std::string& mesh_graph_desc_yaml_file);
@@ -47,7 +62,14 @@ public:
     chip_id_t get_physical_chip_id_from_fabric_node_id(const FabricNodeId& fabric_node_id) const;
 
     std::vector<MeshId> get_user_physical_mesh_ids() const;
-    MeshShape get_physical_mesh_shape(MeshId mesh_id) const;
+
+    // Query for the MeshId and HostRankId of the local mesh; returns std::nullopt if binding is not set
+    std::optional<MeshId> get_local_mesh_id_binding() const;
+    std::optional<HostRankId> get_local_host_rank_id_binding() const;
+
+    // Queries that are MeshScope-aware (i.e. return results for local mesh or global mesh)
+    MeshShape get_physical_mesh_shape(MeshId mesh_id, MeshScope scope = MeshScope::GLOBAL) const;
+    MeshCoordinateRange get_coord_range(MeshId mesh_id, MeshScope scope = MeshScope::GLOBAL) const;
 
     // Return valid ethernet channels on the specificed routing plane
     std::vector<chan_id_t> get_valid_eth_chans_on_routing_plane(
@@ -211,7 +233,12 @@ private:
     // Check if intermesh links are available by reading SPI ROM config from first chip
     bool is_intermesh_enabled() const;
 
+    // Initialize the local mesh binding from the environment variables
+    // Returns std::nullopt if not in multi-host context
+    std::optional<LocalMeshBinding> initialize_local_mesh_binding();
+
     std::unique_ptr<FabricContext> fabric_context_;
+    std::optional<LocalMeshBinding> local_mesh_binding_;
 };
 
 class GlobalControlPlane {

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -64,8 +64,8 @@ public:
     std::vector<MeshId> get_user_physical_mesh_ids() const;
 
     // Query for the MeshId and HostRankId of the local mesh; returns std::nullopt if binding is not set
-    std::optional<MeshId> get_local_mesh_id_binding() const;
-    std::optional<HostRankId> get_local_host_rank_id_binding() const;
+    MeshId get_local_mesh_id_binding() const;
+    HostRankId get_local_host_rank_id_binding() const;
 
     // Queries that are MeshScope-aware (i.e. return results for local mesh or global mesh)
     MeshShape get_physical_mesh_shape(MeshId mesh_id, MeshScope scope = MeshScope::GLOBAL) const;
@@ -235,10 +235,10 @@ private:
 
     // Initialize the local mesh binding from the environment variables
     // Returns std::nullopt if not in multi-host context
-    std::optional<LocalMeshBinding> initialize_local_mesh_binding();
+    LocalMeshBinding initialize_local_mesh_binding();
 
     std::unique_ptr<FabricContext> fabric_context_;
-    std::optional<LocalMeshBinding> local_mesh_binding_;
+    LocalMeshBinding local_mesh_binding_;
 };
 
 class GlobalControlPlane {

--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -108,6 +108,7 @@ public:
     chip_id_t coordinate_to_chip(MeshId mesh_id, MeshCoordinate coordinate) const;
 
 private:
+    void validate_mesh_id(MeshId mesh_id) const;
     std::unordered_map<chip_id_t, RouterEdge> get_valid_connections(
         chip_id_t src_chip_id, std::uint32_t row_size, std::uint32_t num_chips_in_mesh, FabricType fabric_type) const;
     void initialize_from_yaml(const std::string& mesh_graph_desc_file_path);

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -283,9 +283,7 @@ std::optional<LocalMeshBinding> ControlPlane::initialize_local_mesh_binding() {
         return coord_rank_pair.value() == local_mesh_binding.host_rank;
     }) != host_ranks.end();
 
-    if (!is_valid_host_rank) {
-        TT_THROW("Invalid TT_HOST_RANK: Local mesh binding host_rank {} not found in mesh graph descriptor", local_mesh_binding.host_rank);
-    }
+    TT_FATAL(is_valid_host_rank, "Invalid TT_HOST_RANK: Local mesh binding host_rank {} not found in mesh graph descriptor", local_mesh_binding.host_rank);
 
     return local_mesh_binding;
 }

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -430,8 +430,7 @@ void MeshGraph::print_connectivity() const {
 }
 
 void MeshGraph::validate_mesh_id(MeshId mesh_id) const {
-    auto mesh_ids = this->get_mesh_ids();
-    if (std::find(mesh_ids.begin(), mesh_ids.end(), mesh_id) == mesh_ids.end()) {
+    if (this->mesh_to_chip_ids_.find(mesh_id) == this->mesh_to_chip_ids_.end()) {
         TT_THROW("Invalid mesh_id {} in get_mesh_shape", mesh_id);
     }
 }

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -429,7 +429,16 @@ void MeshGraph::print_connectivity() const {
     log_debug(tt::LogFabric, "{}", ss.str());
 }
 
+void MeshGraph::validate_mesh_id(MeshId mesh_id) const {
+    auto mesh_ids = this->get_mesh_ids();
+    if (std::find(mesh_ids.begin(), mesh_ids.end(), mesh_id) == mesh_ids.end()) {
+        TT_THROW("Invalid mesh_id {} in get_mesh_shape", mesh_id);
+    }
+}
+
 MeshShape MeshGraph::get_mesh_shape(MeshId mesh_id, std::optional<HostRankId> host_rank) const {
+    this->validate_mesh_id(mesh_id);
+
     if (host_rank.has_value()) {
         return this->mesh_host_rank_coord_ranges_.at(std::make_pair(mesh_id, *host_rank)).shape();
     }
@@ -438,6 +447,8 @@ MeshShape MeshGraph::get_mesh_shape(MeshId mesh_id, std::optional<HostRankId> ho
 }
 
 MeshCoordinateRange MeshGraph::get_coord_range(MeshId mesh_id, std::optional<HostRankId> host_rank) const {
+    this->validate_mesh_id(mesh_id);
+
     if (host_rank.has_value()) {
         return this->mesh_host_rank_coord_ranges_.at(std::make_pair(mesh_id, *host_rank));
     }


### PR DESCRIPTION
### Ticket
None

### Problem description
When we launch processes with MPI, that process needs to be tied to a specific MeshID and offset into the multi-host mesh as defined by the MeshGraphDescriptor. We need some supporting infra to virtualize ControlPlane across multi-host while providing useful accessors to go between local vs. global view of the mesh.

### What's changed
These belong to the "big-mesh" changes to be ported back into main. This provides the supporting changes to allow processes launched with MPI to be bound to a particular {MeshId, HostRankId} as defined in the MeshGraphDescriptor.

This is implemented in same mechanism as MPI/torch.distributed by configuring custom process specific environment variables that can be made available.

These changes enable single-process to be launched with `TT_MESH_ID` and `TT_HOST_RANK` to emulate process running on part of a larger mesh.

The next set of changes for process launcher will perform automatic MPI rank to {MeshId, HostRankId} binding + support for multi-process testing.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15965699270
- [x] T3K Unit Tests: https://github.com/tenstorrent/tt-metal/actions/runs/15965706212, https://github.com/tenstorrent/tt-metal/actions/runs/15966435889