### PR TITLE
Migrate frac as LLK op

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -598,24 +598,6 @@ def test_unary_logical_not_ttnn(input_shapes, device):
 @pytest.mark.parametrize(
     "input_shapes",
     (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
-def test_unary_frac(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1e6, 1e6, device)
-    output_tensor = ttnn.frac(input_tensor)
-    golden_function = ttnn.get_golden_function(ttnn.frac)
-    golden_tensor = golden_function(in_data)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
         (torch.Size([1, 1, 32, 64])),  # Single core
         (torch.Size([1, 3, 320, 32 * 8])),  # Multi core
     ),

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -983,3 +983,46 @@ def test_unary_hardshrink_edge_case_ttnn(input_shapes, param, device):
 
     assert_with_ulp(output_tensor, golden_tensor)
     assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_unary_frac_ttnn(input_shapes, device):
+    in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.frac(input_tensor)
+    golden_function = ttnn.get_golden_function(ttnn.frac)
+    golden_tensor = golden_function(in_data)
+
+    assert_with_ulp(output_tensor, golden_tensor)
+    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_unary_frac_ttnn_opt(input_shapes, device):
+    in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+    cq_id = 0
+    ttnn.frac(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
+    golden_function = ttnn.get_golden_function(ttnn.frac)
+    golden_tensor = golden_function(in_data)
+
+    assert_with_ulp(output_tensor, golden_tensor)
+    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rounding_ops.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rounding_ops.h
@@ -58,4 +58,16 @@ inline void llk_math_eltwise_unary_sfpu_round(uint dst_index, int decimals, int 
         ckernel::sfpu::_calculate_round_<APPROXIMATE>, dst_index, vector_mode, decimals);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_frac(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::_calculate_frac_<APPROXIMATE>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_frac_float32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::_calculate_frac_<APPROXIMATE, true>, dst_index, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rounding_ops.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rounding_ops.h
@@ -60,13 +60,13 @@ inline void llk_math_eltwise_unary_sfpu_round(uint dst_index, int decimals, int 
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_frac(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_frac_<APPROXIMATE>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_frac_float32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_frac_<APPROXIMATE, true>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -96,6 +96,7 @@ enum SfpuType {
     right_shift,
     floor,
     trunc,
+    frac,
     left_shift,
     remainder,
     fmod,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rounding_ops.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rounding_ops.h
@@ -58,4 +58,16 @@ inline void llk_math_eltwise_unary_sfpu_round(uint dst_index, int decimals, int 
         ckernel::sfpu::_calculate_round_<APPROXIMATE>, dst_index, vector_mode, decimals);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_frac(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::_calculate_frac_<APPROXIMATE>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_frac_float32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::_calculate_frac_<APPROXIMATE, true>, dst_index, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rounding_ops.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rounding_ops.h
@@ -60,13 +60,13 @@ inline void llk_math_eltwise_unary_sfpu_round(uint dst_index, int decimals, int 
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_frac(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_frac_<APPROXIMATE>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_frac_float32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_frac_<APPROXIMATE, true>, dst_index, vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -99,6 +99,7 @@ enum SfpuType {
     right_shift,
     floor,
     trunc,
+    frac,
     left_shift,
     remainder,
     fmod,

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/rounding.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/rounding.h
@@ -135,4 +135,36 @@ ALWI void round_tile(uint32_t idst, int32_t decimals) {
     MATH((llk_math_eltwise_unary_sfpu_round<APPROX>(idst, decimals)));
 }
 
+// clang-format off
+/**
+ * Performs frac operation on each row of a tile.
+ * in DST register at index tile_index. The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform trunc operation    | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void frac_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_frac<APPROX>(idst))); }
+
+// clang-format off
+/**
+ * Performs frac operation on each row of a tile.
+ * in DST register at index tile_index. The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform trunc operation    | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void frac_tile_float32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_frac_float32<APPROX>(idst))); }
+
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/rounding.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/rounding.h
@@ -22,7 +22,7 @@ ALWI void rounding_op_tile_init() { MATH((llk_math_eltwise_unary_sfpu_rounding_o
 
 // clang-format off
 /**
- * Performs ceil operation on each row of a tile.
+ * Performs element-wise ceil computation on input x , where x is each element of a tile
  * in DST register at index tile_index. The DST register buffer must be in
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
@@ -38,7 +38,7 @@ ALWI void ceil_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_ceil<APPR
 
 // clang-format off
 /**
- * Performs ceil operation on each row of a tile.
+ * Performs element-wise ceil computation on input x , where x is each element of a tile
  * in DST register at index tile_index. The DST register buffer must be in
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
@@ -54,7 +54,7 @@ ALWI void ceil_tile_float32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_c
 
 // clang-format off
 /**
- * Performs floor operation on each row of a tile.
+ * Performs element-wise floor computation on input x , where x is each element of a tile
  * in DST register at index tile_index. The DST register buffer must be in
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
@@ -70,7 +70,7 @@ ALWI void floor_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_floor<AP
 
 // clang-format off
 /**
- * Performs floor operation on each row of a tile.
+ * Performs element-wise floor computation on input x , where x is each element of a tile
  * in DST register at index tile_index. The DST register buffer must be in
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
@@ -86,7 +86,7 @@ ALWI void floor_tile_float32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_
 
 // clang-format off
 /**
- * Performs trunc operation on each row of a tile.
+ * Performs element-wise trunc computation on input x , where x is each element of a tile
  * in DST register at index tile_index. The DST register buffer must be in
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
@@ -102,7 +102,7 @@ ALWI void trunc_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_trunc<AP
 
 // clang-format off
 /**
- * Performs trunc operation on each row of a tile.
+ * Performs element-wise trunc computation on input x , where x is each element of a tile
  * in DST register at index tile_index. The DST register buffer must be in
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
@@ -137,7 +137,7 @@ ALWI void round_tile(uint32_t idst, int32_t decimals) {
 
 // clang-format off
 /**
- * Performs frac operation on each row of a tile.
+ * Performs element-wise frac computation on input x , where x is each element of a tile
  * in DST register at index tile_index. The DST register buffer must be in
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
@@ -146,14 +146,14 @@ ALWI void round_tile(uint32_t idst, int32_t decimals) {
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform trunc operation    | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst            | The index of the tile in DST register buffer to perform frac operation     | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
 ALWI void frac_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_frac<APPROX>(idst))); }
 
 // clang-format off
 /**
- * Performs frac operation on each row of a tile.
+ * Performs element-wise frac computation on input x , where x is each element of a tile
  * in DST register at index tile_index. The DST register buffer must be in
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
@@ -162,7 +162,7 @@ ALWI void frac_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_frac<APPR
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform trunc operation    | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst            | The index of the tile in DST register buffer to perform frac operation     | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
 ALWI void frac_tile_float32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_frac_float32<APPROX>(idst))); }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -89,6 +89,7 @@ enum class UnaryOpType {
     FLOOR,
     CEIL,
     TRUNC,
+    FRAC,
     ROUND,
     LEFT_SHIFT,
     REMAINDER,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -35,6 +35,7 @@ std::string get_macro_definition(UnaryOpType op_type) {
         case UnaryOpType::FLOOR:
         case UnaryOpType::CEIL:
         case UnaryOpType::TRUNC:
+        case UnaryOpType::FRAC:
         case UnaryOpType::ROUND: return "SFPU_OP_ROUND_FAMILY_INCLUDE";
         case UnaryOpType::RDIV:
         case UnaryOpType::RSUB: return "SFPU_OP_REVERSE_FAMILY_INCLUDE";
@@ -519,6 +520,15 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
                 op_init_and_name = {"rounding_op_tile_init();", fmt::format("trunc_tile_float32({});", idst)};
             } else {
                 op_init_and_name = {"rounding_op_tile_init();", fmt::format("trunc_tile({});", idst)};
+            }
+            break;
+        case UnaryOpType::FRAC:
+            TT_FATAL(
+                input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
+            if (input_dtype == DataType::FLOAT32) {
+                op_init_and_name = {"rounding_op_tile_init();", fmt::format("frac_tile_float32({});", idst)};
+            } else {
+                op_init_and_name = {"rounding_op_tile_init();", fmt::format("frac_tile({});", idst)};
             }
             break;
         case UnaryOpType::RELU6:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -709,10 +709,4 @@ Tensor _normalize_global(const Tensor& y, const std::optional<MemoryConfig>& out
     return _make_global_from_hw_impl(_normalize, y, output_mem_config);
 }
 
-Tensor _frac(const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
-    Tensor trunc_res = ttnn::trunc(input);
-    Tensor result = ttnn::subtract(input, trunc_res, std::nullopt, output_mem_config);
-    return result;
-}
-
 }  // namespace ttnn::operations::unary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -121,6 +121,7 @@ template struct ExecuteUnary<UnaryOpType::ALT_COMPLEX_ROTATE90>;
 template struct ExecuteUnary<UnaryOpType::CEIL>;
 template struct ExecuteUnary<UnaryOpType::FLOOR>;
 template struct ExecuteUnary<UnaryOpType::TRUNC>;
+template struct ExecuteUnary<UnaryOpType::FRAC>;
 
 template <UnaryOpType unary_op_type>
 Tensor ExecuteUnaryWithFastAndApproximateMode<unary_op_type>::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -159,6 +159,14 @@ struct Trunc {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
+struct Frac {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input_tensor,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
 struct Ceil {
     static Tensor invoke(
         QueueId queue_id,
@@ -363,6 +371,7 @@ REGISTER_UNARY_OPERATION(alt_complex_rotate90, ALT_COMPLEX_ROTATE90);
 REGISTER_UNARY_OPERATION(floor, FLOOR);
 REGISTER_UNARY_OPERATION(ceil, CEIL);
 REGISTER_UNARY_OPERATION(trunc, TRUNC);
+REGISTER_UNARY_OPERATION(frac, FRAC);
 
 // Unaries with fast_and_approximate_mode
 REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(exp, EXP);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -244,8 +244,5 @@ constexpr auto rpow = ttnn::register_operation<
 constexpr auto normalize_global = ttnn::register_operation<
     "ttnn::normalize_global",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::NORMALIZE_GLOBAL>>();
-constexpr auto frac = ttnn::register_operation<
-    "ttnn::frac",
-    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::FRAC>>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -1729,6 +1729,12 @@ void py_module(py::module& module) {
         R"doc(FLOAT32, BFLOAT16, BFLOAT8_B)doc");
     bind_unary_operation(
         module,
+        ttnn::frac,
+        R"doc(\mathrm{{output\_tensor}}_i = \verb|frac|(\mathrm{{input\_tensor}}_i))doc",
+        "",
+        R"doc(FLOAT32, BFLOAT16, BFLOAT8_B)doc");
+    bind_unary_operation(
+        module,
         ttnn::eqz,
         R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor_i\ == 0}}))doc",
         "",
@@ -2147,12 +2153,6 @@ void py_module(py::module& module) {
         R"doc(4)doc",
         "",
         R"doc(torch.rand([1, 1, 32, 32], dtype=torch.bfloat16))doc");
-    bind_unary_composite(
-        module,
-        ttnn::frac,
-        R"doc(Performs frac function on :attr:`input_tensor`.)doc",
-        "",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
 
     bind_unary_composite_floats_with_default(
         module, ttnn::hardswish, "scale", "Scale value", 1.0f / 6.0f, "shift", "Shift value", 0.5f);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22132

### Problem description
frac implemented as composite op

### What's changed
Migrate it as LLK op

DEVICE KERNEL DURATION [ns]
<img width="231" alt="Screenshot 2025-06-26 at 1 59 23 PM" src="https://github.com/user-attachments/assets/60a3bb6b-00c1-4f4a-9cb0-6455c54a148a" />

Edge case behaviour:
| Input | DataType | Torch output | TT output     |
|-------|----------|--------------|---------------|
| inf   | bfloat16 | inf          | inf           |
| -inf  | bfloat16 | -inf         | -inf          |
| nan   | bfloat16 | nan          | inf           |
| inf   | float32  | inf          | 2147483648    |
| -inf  | float32  | -inf         | -2147483648   |
| nan   | float32  | nan          | 2147483648    |

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/16134099843
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/16134098674
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes