### PR TITLE
Adjust test marks to add missing mark to E2E test and remove per-module device perf tests from CI

### DIFF
--- a/models/demos/segformer/tests/test_e2e_performant.py
+++ b/models/demos/segformer/tests/test_e2e_performant.py
@@ -22,6 +22,7 @@ from models.utility_functions import run_for_wormhole_b0
     "batch_size",
     ((1),),
 )
+@pytest.mark.models_performance_bare_metal
 def test_run_segformer_trace_2cqs_inference(
     device,
     batch_size,

--- a/models/demos/segformer/tests/test_perf_device_modules.py
+++ b/models/demos/segformer/tests/test_perf_device_modules.py
@@ -7,7 +7,6 @@ import pytest
 import models.perf.device_perf_utils as perf_utils
 
 
-@pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "module, filter, num_iterations, expected_perf",
     [


### PR DESCRIPTION
### Ticket
None

### Problem description
Recent commit accidentally removed @pytest.mark.models_performance_bare_metal from the E2E test, this PR adds it back.

@pytest.mark.models_device_performance_bare_metal was removed from per-module device perf tests. Removal of these tests was requested as they clutter the performance report with a dozen different entries for each one of Segformer's modules as well as the whole model test, in addition to taking up a decent chunk of CI time. Whole-model device perf still has the mark.

### What's changed
-added missing mark to E2E test
-removed Pytest mark that makes the CI workflow pick up the device perf tests. Tests are still able to run locally if desired for whatever reason.