### PR TITLE
Fix `GetOptimalDramBankToLogicalWorkerAssignmentAPI` unit test for 4U…

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -127,9 +127,8 @@ TEST_F(MeshDeviceT3000Test, CreateSubmeshes) {
 }
 
 TEST(GetOptimalDramBankToLogicalWorkerAssignmentAPI, UnitMeshes) {
-    auto num_devices = GetNumAvailableDevices();
-    std::vector<int> device_ids(num_devices);
-    std::iota(device_ids.begin(), device_ids.end(), 0);
+    auto device_ids_set = tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids();
+    std::vector<int> device_ids(device_ids_set.begin(), device_ids_set.end());
     auto devs = tt::tt_metal::distributed::MeshDevice::create_unit_meshes(device_ids);
     for (auto& [_, dev] : devs) {
         auto assignment = dev->get_optimal_dram_bank_to_logical_worker_assignment();


### PR DESCRIPTION
### Ticket
None

### Problem description
`GetNumAvailableDevices` API is not the right one to use for Galaxy. We must use the one that filters for "user visible device ids". This fixes failing unit test that was newly added a couple days ago.

### What's changed
Use `tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()` API instead

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/15912837163
- [x] TG Unit Test: https://github.com/tenstorrent/tt-metal/actions/runs/15912847647