### PR TITLE
Created Public header fabric_node_id.hpp and cpp files for FabricNodeId

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/fabric_node_id.hpp>
 
 namespace tt::tt_fabric::fabric_router_tests {
 

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(
             api/tt-metalium/event.hpp
             api/tt-metalium/fabric_host_interface.h
             api/tt-metalium/fabric_edm_packet_header.hpp
+            api/tt-metalium/fabric_node_id.hpp
             api/tt-metalium/global_circular_buffer.hpp
             api/tt-metalium/global_semaphore.hpp
             api/tt-metalium/graph_tracking.hpp

--- a/tt_metal/api/tt-metalium/fabric_node_id.hpp
+++ b/tt_metal/api/tt-metalium/fabric_node_id.hpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <string>
+#include <cstdint>
+#include <tt-metalium/fabric_types.hpp>
+
+namespace tt::tt_fabric {
+
+/**
+ * @brief Represents a unique identifier for a node in the tt_fabric network.
+ *
+ * FabricNodeId combines a mesh identifier and a physical chip identifier to uniquely
+ * identify a specific node within tt_fabric, regardless of the physical topology.
+ */
+class FabricNodeId {
+public:
+    /**
+     * @brief Constructs a FabricNodeId with the specified mesh and chip identifiers.
+     * @param mesh_id The identifier of the mesh this node belongs to
+     * @param chip_id The physical identifier of the chip within the mesh
+     */
+    explicit FabricNodeId(MeshId mesh_id, std::uint32_t chip_id);
+
+    MeshId mesh_id{0};          ///< The mesh this node belongs to
+    std::uint32_t chip_id = 0;  ///< The physical chip identifier within the mesh
+};
+
+bool operator==(const FabricNodeId& lhs, const FabricNodeId& rhs);
+bool operator!=(const FabricNodeId& lhs, const FabricNodeId& rhs);
+bool operator<(const FabricNodeId& lhs, const FabricNodeId& rhs);
+bool operator>(const FabricNodeId& lhs, const FabricNodeId& rhs);
+bool operator<=(const FabricNodeId& lhs, const FabricNodeId& rhs);
+bool operator>=(const FabricNodeId& lhs, const FabricNodeId& rhs);
+std::ostream& operator<<(std::ostream& os, const FabricNodeId& fabric_node_id);
+
+}  // namespace tt::tt_fabric
+
+namespace std {
+template <>
+struct hash<tt::tt_fabric::FabricNodeId> {
+    size_t operator()(const tt::tt_fabric::FabricNodeId& fabric_node_id) const noexcept {
+        return tt::stl::hash::hash_objects_with_default_seed(fabric_node_id.mesh_id, fabric_node_id.chip_id);
+    }
+};
+}  // namespace std

--- a/tt_metal/api/tt-metalium/routing_table_generator.hpp
+++ b/tt_metal/api/tt-metalium/routing_table_generator.hpp
@@ -13,6 +13,7 @@
 
 #include <tt-metalium/mesh_graph.hpp>
 #include <tt-metalium/fabric_types.hpp>
+#include <tt-metalium/fabric_node_id.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 
 namespace tt::tt_fabric {
@@ -22,20 +23,6 @@ using RoutingTable =
 
 // TODO: first pass at switching over MeshId/chip_id_t to proper struct
 // Need to update the usage in routing table generator
-class FabricNodeId {
-public:
-    explicit FabricNodeId(MeshId mesh_id, std::uint32_t chip_id);
-    MeshId mesh_id{0};
-    std::uint32_t chip_id = 0;
-};
-
-bool operator==(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator!=(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator<(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator>(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator<=(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator>=(const FabricNodeId& lhs, const FabricNodeId& rhs);
-std::ostream& operator<<(std::ostream& os, const FabricNodeId& fabric_node_id);
 
 class RoutingTableGenerator {
 public:
@@ -70,12 +57,3 @@ private:
 };
 
 }  // namespace tt::tt_fabric
-
-namespace std {
-template <>
-struct hash<tt::tt_fabric::FabricNodeId> {
-    size_t operator()(const tt::tt_fabric::FabricNodeId& fabric_node_id) const noexcept {
-        return tt::stl::hash::hash_objects_with_default_seed(fabric_node_id.mesh_id, fabric_node_id.chip_id);
-    }
-};
-}  // namespace std

--- a/tt_metal/distributed/coordinate_translation.cpp
+++ b/tt_metal/distributed/coordinate_translation.cpp
@@ -16,6 +16,7 @@
 #include "mesh_coord.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/cluster_descriptor_types.h>
+#include <tt-metalium/fabric_node_id.hpp>
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -48,6 +48,7 @@
 #include "dispatch/launch_message_ring_buffer_state.hpp"
 #include "sub_device/sub_device_manager_tracker.hpp"
 #include <umd/device/types/xy_pair.h>
+#include <tt-metalium/fabric_node_id.hpp>
 
 enum class CoreType;
 namespace tt {

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(
         fabric.cpp
         fabric_host_utils.cpp
         fabric_context.cpp
+        fabric_node_id.cpp
         serialization/intermesh_link_table.cpp
 )
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -39,6 +39,7 @@
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/xy_pair.h>
 #include "tt_metal/fabric/fabric_context.hpp"
+#include <tt-metalium/fabric_node_id.hpp>
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -29,6 +29,7 @@
 #include "fabric_edm_types.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <umd/device/tt_core_coordinates.h>
+#include <tt-metalium/fabric_node_id.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -14,6 +14,7 @@
 #include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "impl/context/metal_context.hpp"
+#include <tt-metalium/fabric_node_id.hpp>
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/fabric/fabric_node_id.cpp
+++ b/tt_metal/fabric/fabric_node_id.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "fabric_node_id.hpp"
+#include <ostream>
+namespace tt::tt_fabric {
+
+FabricNodeId::FabricNodeId(MeshId mesh_id, std::uint32_t chip_id) {
+    this->mesh_id = mesh_id;
+    this->chip_id = chip_id;
+}
+
+bool operator==(const FabricNodeId& lhs, const FabricNodeId& rhs) {
+    return lhs.mesh_id == rhs.mesh_id && lhs.chip_id == rhs.chip_id;
+}
+bool operator!=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(lhs == rhs); }
+bool operator<(const FabricNodeId& lhs, const FabricNodeId& rhs) {
+    return lhs.mesh_id < rhs.mesh_id || (lhs.mesh_id == rhs.mesh_id && lhs.chip_id < rhs.chip_id);
+}
+bool operator>(const FabricNodeId& lhs, const FabricNodeId& rhs) { return rhs < lhs; }
+bool operator<=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(rhs > lhs); }
+bool operator>=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(lhs < rhs); }
+std::ostream& operator<<(std::ostream& os, const FabricNodeId& fabric_node_id) {
+    using ::operator<<;  // Enable ADL for StrongType operator<<
+    os << "M" << fabric_node_id.mesh_id << "D" << fabric_node_id.chip_id;
+    return os;
+}
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -17,27 +17,6 @@
 
 namespace tt::tt_fabric {
 
-FabricNodeId::FabricNodeId(MeshId mesh_id, std::uint32_t chip_id) {
-    this->mesh_id = mesh_id;
-    this->chip_id = chip_id;
-}
-
-bool operator==(const FabricNodeId& lhs, const FabricNodeId& rhs) {
-    return lhs.mesh_id == rhs.mesh_id && lhs.chip_id == rhs.chip_id;
-}
-bool operator!=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(lhs == rhs); }
-bool operator<(const FabricNodeId& lhs, const FabricNodeId& rhs) {
-    return lhs.mesh_id < rhs.mesh_id || (lhs.mesh_id == rhs.mesh_id && lhs.chip_id < rhs.chip_id);
-}
-bool operator>(const FabricNodeId& lhs, const FabricNodeId& rhs) { return rhs < lhs; }
-bool operator<=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(rhs > lhs); }
-bool operator>=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(lhs < rhs); }
-std::ostream& operator<<(std::ostream& os, const FabricNodeId& fabric_node_id) {
-    using ::operator<<;  // Enable ADL for StrongType operator<<
-    os << "M" << fabric_node_id.mesh_id << "D" << fabric_node_id.chip_id;
-    return os;
-}
-
 RoutingTableGenerator::RoutingTableGenerator(const std::string& mesh_graph_desc_yaml_file) {
     this->mesh_graph = std::make_unique<MeshGraph>(mesh_graph_desc_yaml_file);
     // Use IntraMeshConnectivity to size all variables

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -22,6 +22,7 @@
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include <filesystem>
 #include <tt-metalium/device_pool.hpp>
+#include <tt-metalium/fabric_node_id.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -45,6 +45,7 @@
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_xy_pair.h>
 #include "utils.hpp"
+#include <tt-metalium/fabric_node_id.hpp>
 
 // hack for test_basic_fabric_apis.cpp
 // https://github.com/tenstorrent/tt-metal/issues/20000


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24177)

### Problem description
The `FabricNodeId` class is currently `tt_metal/api/tt-metalium/routing_table_generator.hpp`

```
class FabricNodeId {
public:
    explicit FabricNodeId(MeshId mesh_id, std::uint32_t chip_id);
    MeshId mesh_id{0};
    std::uint32_t chip_id = 0;
};
```

As more and more APIs shift to use `FabricNodeId` instead of physical IDs (due to multi-host integration), as well as more usage of FabricNodeId, FabricNodeId should be in its own header public file.
### What's changed

Move the declaration of `FabricNodeId` to its own header file:
`tt_metal/api/tt-metalium/fabric_node_id.hpp`
Move constructor and related functions (operator==) to its own cpp file:
`tt_metal/fabric/fabric_node_id.cpp`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15889702388) CI passes
- [ ] New/Existing tests provide coverage for changes
- [ ] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15889705288)