### PR TITLE
#24155 Binary op make flag use_legacy optional except typecast and block format

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_add_uint32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_add_uint32.py
@@ -54,7 +54,7 @@ def test_binary_add_uint32_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, use_legacy=None)
     output_tensor = ttnn.to_torch(output_tensor, dtype=torch.int32)
 
     assert torch.equal(output_tensor, torch_output_tensor)
@@ -124,7 +124,7 @@ def test_binary_add_uint32_sharded(a_shape, b_shape, sharded_config, device):
     golden_function = ttnn.get_golden_function(ttnn.add)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
 
-    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=sharded_config, use_legacy=False)
+    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=sharded_config, use_legacy=None)
     output_tensor = ttnn.to_torch(output_tensor, dtype=torch.int32)
 
     assert torch.equal(output_tensor, torch_output_tensor)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -13,7 +13,7 @@ from models.utility_functions import torch_random
 from itertools import product as parameters
 from functools import partial
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
-
+from tests.ttnn.utils_for_testing import assert_with_pcc
 
 binary_fns = {
     "ge",
@@ -153,30 +153,41 @@ def test_binary_scalar_ops(a_shape, b_shape, ttnn_fn, activations, device):
     a_pt, a_tt = rand_bf16_gen(a_shape, device)
     b_pt, b_tt = rand_bf16_gen(b_shape, device, min=min, max=max)
 
-    out_tt = ttnn_op(
-        a_tt, b_tt, input_tensor_a_activations=lhs, input_tensor_b_activations=rhs, activations=post, use_legacy=False
-    )
+    try:
+        out_tt = ttnn_op(
+            a_tt,
+            b_tt,
+            input_tensor_a_activations=lhs,
+            input_tensor_b_activations=rhs,
+            activations=post,
+            use_legacy=None,
+        )
+        for golden_activation in golden_lhs:
+            a_pt = golden_activation(a_pt).bfloat16()
 
-    for golden_activation in golden_lhs:
-        a_pt = golden_activation(a_pt).bfloat16()
+        for golden_activation in golden_rhs:
+            b_pt = golden_activation(b_pt).bfloat16()
 
-    for golden_activation in golden_rhs:
-        b_pt = golden_activation(b_pt).bfloat16()
+        golden_fn = ttnn.get_golden_function(ttnn_op)
+        out_pt = golden_fn(a_pt, b_pt).bfloat16()
 
-    golden_fn = ttnn.get_golden_function(ttnn_op)
-    out_pt = golden_fn(a_pt, b_pt).bfloat16()
+        for golden_activation in golden_post:
+            out_pt = golden_activation(out_pt).bfloat16()
 
-    for golden_activation in golden_post:
-        out_pt = golden_activation(out_pt).bfloat16()
+        def compare(tt, pt):
+            imprecise_cases = {
+                *parameters({"bias_gelu"}, {square_lhs, floor_lhs_ceil_rhs_cos_post}),
+                *parameters({"ge", "gt", "le", "lt"}, {sin_rhs}),
+            }
+            return compare_pcc(tt, pt, 0.98) if (ttnn_fn, activations) in imprecise_cases else compare_pcc(tt, pt)
 
-    def compare(tt, pt):
-        imprecise_cases = {
-            *parameters({"bias_gelu"}, {square_lhs, floor_lhs_ceil_rhs_cos_post}),
-            *parameters({"ge", "gt", "le", "lt"}, {sin_rhs}),
-        }
-        return compare_pcc(tt, pt, 0.98) if (ttnn_fn, activations) in imprecise_cases else compare_pcc(tt, pt)
-
-    assert compare([out_tt], [out_pt])
+        assert compare([out_tt], [out_pt])
+    except RuntimeError as e:
+        allowed = ("lhs_activations.size() <= 1", "rhs_activations.empty()")
+        if any(msg in str(e) for msg in allowed):
+            pass
+        else:
+            raise
 
 
 activation_with_param_fns = {
@@ -219,7 +230,7 @@ def test_binary_scalar_ops_with_unary_param(a_shape, b_shape, ttnn_fn, post_acti
     a_pt, a_tt = rand_bf16_gen(a_shape, device)
     b_pt, b_tt = rand_bf16_gen(b_shape, device, min=min, max=max)
 
-    out_tt = ttnn_op(a_tt, b_tt, activations=post, use_legacy=False)
+    out_tt = ttnn_op(a_tt, b_tt, activations=post, use_legacy=None)
 
     golden_fn = ttnn.get_golden_function(ttnn_op)
     out_pt = golden_fn(a_pt, b_pt).bfloat16()
@@ -251,7 +262,7 @@ def test_binary_scalar_ops_invalid_bcast(a_shape, b_shape, ttnn_fn, device):
 
     with pytest.raises(RuntimeError) as e:
         cq_id = 0
-        _ = ttnn_op(a_tt, b_tt, queue_id=cq_id, use_legacy=False)
+        _ = ttnn_op(a_tt, b_tt, queue_id=cq_id, use_legacy=None)
         assert "Broadcasting rule violation" in str(e.value)
 
 
@@ -278,7 +289,7 @@ def test_unequal_ranks(a_shape, b_shape, device):
 
     torch_output_tensor = torch_input_tensor_a + torch_input_tensor_b
 
-    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=False)
+    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert output_tensor.shape == torch_output_tensor.shape
@@ -313,7 +324,7 @@ def test_01_volume_tensors(device, a, b, c_golden, memory_config_a, memory_confi
 
     ttnn_a = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memory_config_a)
     ttnn_b = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memory_config_b)
-    ttnn_c = ttnn.add(ttnn_a, ttnn_b, use_legacy=False)
+    ttnn_c = ttnn.add(ttnn_a, ttnn_b, use_legacy=None)
     c = ttnn.to_torch(ttnn_c).reshape((-1))
 
     assert c.tolist() == c_golden
@@ -333,7 +344,7 @@ def test_binary_invalid_rank(device, a_shape, b_shape):
     pt_b, tt_b = rand_bf16_gen(b_shape, device)
 
     with pytest.raises(RuntimeError):
-        tt_c = ttnn.add(tt_a, tt_b, use_legacy=False)
+        tt_c = ttnn.add(tt_a, tt_b, use_legacy=None)
 
 
 height_sharded_memory_config = ttnn.create_sharded_memory_config(
@@ -432,11 +443,11 @@ def test_binary_sharded(a_shape, b_shape, sharded_config, dtype_pt, dtype_tt, de
         )
 
         out_pt = torch.add(a_pt, b_pt)
-        out_tt_interleaved = ttnn.add(a_tt, b_tt, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=False)
+        out_tt_interleaved = ttnn.add(a_tt, b_tt, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
         out_tt_interleaved = ttnn.to_torch(out_tt_interleaved)
         assert ttnn.pearson_correlation_coefficient(out_tt_interleaved, out_pt) >= 0.99988
 
-        out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=sharded_config, use_legacy=False)
+        out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=sharded_config, use_legacy=None)
         out_tt_sharded = ttnn.to_torch(out_tt_sharded)
         assert ttnn.pearson_correlation_coefficient(out_tt_sharded, out_pt) >= 0.99988
 
@@ -486,11 +497,11 @@ def test_binary_sharded_core_grid(device, a_shape, b_shape, sharded_core_grid, m
 
     out_pt = torch.add(a_pt, b_pt)
 
-    out_tt_interleaved = ttnn.add(a_tt, b_tt, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=False)
+    out_tt_interleaved = ttnn.add(a_tt, b_tt, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
     out_tt_interleaved = ttnn.to_torch(out_tt_interleaved)
     assert ttnn.pearson_correlation_coefficient(out_tt_interleaved, out_pt) >= 0.99988
 
-    out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=sharded_config, use_legacy=False)
+    out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=sharded_config, use_legacy=None)
     out_tt_sharded = ttnn.to_torch(out_tt_sharded)
     assert ttnn.pearson_correlation_coefficient(out_tt_sharded, out_pt) >= 0.99988
 
@@ -553,7 +564,7 @@ def test_binary_sfpu_ops(input_shapes, dtype, ttnn_fn, device):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     cq_id = 0
-    out_tt = ttnn_fn(a_tt, b_tt, queue_id=cq_id, use_legacy=False)
+    out_tt = ttnn_fn(a_tt, b_tt, queue_id=cq_id, use_legacy=None)
     tt_out = ttnn.to_torch(out_tt)
 
     golden_fn = ttnn.get_golden_function(ttnn_fn)
@@ -628,7 +639,7 @@ def test_binary_sfpu_opt_out(input_shapes, dtype, ttnn_fn, device):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     cq_id = 0
-    ttnn_fn(a_tt, b_tt, queue_id=cq_id, output_tensor=out_tt, use_legacy=False)
+    ttnn_fn(a_tt, b_tt, queue_id=cq_id, output_tensor=out_tt, use_legacy=None)
     tt_out = ttnn.to_torch(out_tt)
 
     golden_fn = ttnn.get_golden_function(ttnn_fn)
@@ -681,7 +692,7 @@ def test_binary_sfpu_bitwise_ops(input_shapes, dtype, ttnn_fn, device):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     cq_id = 0
-    out_tt = ttnn_fn(a_tt, b_tt, queue_id=cq_id, use_legacy=False)
+    out_tt = ttnn_fn(a_tt, b_tt, queue_id=cq_id, use_legacy=None)
     tt_out = ttnn.to_torch(out_tt)
 
     golden_fn = ttnn.get_golden_function(ttnn_fn)
@@ -743,7 +754,7 @@ def test_bitwise_opt_output(input_shapes, dtype, ttnn_fn, device):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     cq_id = 0
-    ttnn_fn(a_tt, b_tt, queue_id=cq_id, output_tensor=out_tt, use_legacy=False)
+    ttnn_fn(a_tt, b_tt, queue_id=cq_id, output_tensor=out_tt, use_legacy=None)
     tt_out = ttnn.to_torch(out_tt)
 
     golden_fn = ttnn.get_golden_function(ttnn_fn)
@@ -848,7 +859,7 @@ def test_inplace_binary_ops_with_tensor(a_shape, b_shape, ttnn_fn, activations, 
         input_tensor_a_activations=lhs,
         input_tensor_b_activations=rhs,
         activations=post,
-        use_legacy=False,
+        use_legacy=None,
     )
     output_tensor = ttnn.to_torch(input_tensor_a)
     assert output_tensor.shape == torch_output_tensor.shape
@@ -963,7 +974,7 @@ def test_inplace_binary_ops_fp32(input_shapes, ttnn_fn, device):
     )
 
     cq_id = 0
-    ttnn_op(input_tensor_a, input_tensor_b, queue_id=cq_id, use_legacy=False)
+    ttnn_op(input_tensor_a, input_tensor_b, queue_id=cq_id, use_legacy=None)
     output_tensor = ttnn.to_torch(input_tensor_a)
 
     golden_fn = ttnn.get_golden_function(ttnn_op)
@@ -994,7 +1005,7 @@ def test_inplace_binary_ops_invalid_bcast(a_shape, b_shape, ttnn_fn, device):
 
     with pytest.raises(RuntimeError):
         cq_id = 0
-        ttnn_op(input_tensor_a, input_tensor_b, queue_id=cq_id, use_legacy=False)
+        ttnn_op(input_tensor_a, input_tensor_b, queue_id=cq_id, use_legacy=None)
 
 
 @pytest.mark.parametrize(
@@ -1042,7 +1053,7 @@ def test_inplace_binary_with_scalar(a_shape, scalar, ttnn_fn, device):
     golden_function = ttnn.get_golden_function(ttnn_op)
     torch_output_tensor = golden_function(torch_input_tensor_a, scalar)
 
-    ttnn_op(input_tensor_a, scalar, use_legacy=False)
+    ttnn_op(input_tensor_a, scalar, use_legacy=None)
     output_tensor = ttnn.to_torch(input_tensor_a)
     assert output_tensor.shape == torch_output_tensor.shape
     assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.99
@@ -1072,7 +1083,7 @@ def test_binary_opt_output_invalid_bcast(a_shape, b_shape, out_shape, ttnn_fn, d
         RuntimeError, match=r"Shape of Output tensor.+ provided does not match the broadcasted output shape .+"
     ):
         cq_id = 0
-        ttnn_op(input_tensor_a, input_tensor_b, queue_id=cq_id, output_tensor=out_tt, use_legacy=False)
+        ttnn_op(input_tensor_a, input_tensor_b, queue_id=cq_id, output_tensor=out_tt, use_legacy=None)
 
 
 @pytest.mark.parametrize(
@@ -1129,11 +1140,11 @@ def test_binary_sharded_bcast_w(device, dtype_pt, dtype_tt):
         )
 
         out_pt = torch.add(a_pt, b_pt)
-        out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=False)
+        out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
         out_tt_sharded = ttnn.to_torch(out_tt_sharded)
         torch.testing.assert_close(out_tt_sharded, out_pt)
 
-        out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=a_sharded_config, use_legacy=False)
+        out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=a_sharded_config, use_legacy=None)
         out_tt_sharded = ttnn.to_torch(out_tt_sharded)
         torch.testing.assert_close(out_tt_sharded, out_pt)
 
@@ -1221,7 +1232,7 @@ def test_binary_sharded_small_tile(a_shape, b_shape, shard_type, shard_size, cor
     )
 
     out_pt = torch.add(a_pt, b_pt)
-    out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=shard_config, use_legacy=False)
+    out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=shard_config, use_legacy=None)
     out_tt_sharded = ttnn.to_torch(out_tt_sharded)
     assert ttnn.pearson_correlation_coefficient(out_tt_sharded, out_pt) >= 0.99988
 
@@ -1344,11 +1355,11 @@ def test_binary_sharded_col_major(a_shape, b_shape, shard_type, shard_size, core
 
         out_pt = golden_function(a_pt, b_pt)
 
-        out_tt_sharded = ttnn_fn(a_tt, b_tt, memory_config=shard_config, use_legacy=False)
+        out_tt_sharded = ttnn_fn(a_tt, b_tt, memory_config=shard_config, use_legacy=None)
         out_tt_sharded = ttnn.to_torch(out_tt_sharded)
         assert ttnn.pearson_correlation_coefficient(out_tt_sharded, out_pt) >= 0.99988
 
-        out_tt_interleaved = ttnn_fn(a_tt, b_tt, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=False)
+        out_tt_interleaved = ttnn_fn(a_tt, b_tt, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
         out_tt_interleaved = ttnn.to_torch(out_tt_interleaved)
         assert ttnn.pearson_correlation_coefficient(out_tt_interleaved, out_pt) >= 0.99988
 
@@ -1393,7 +1404,7 @@ def test_binary_sharded_auto(a_shape, b_shape, shard_type, core_coord, device):
     )
 
     out_pt = torch.add(a_pt, b_pt)
-    out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=shard_config, use_legacy=False)
+    out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=shard_config, use_legacy=None)
     out_tt_sharded = ttnn.to_torch(out_tt_sharded)
     assert ttnn.pearson_correlation_coefficient(out_tt_sharded, out_pt) >= 0.99988
 
@@ -1434,7 +1445,7 @@ def test_binary_sharded_uneven(a_shape, b_shape, shard_type, shard_size, core_ra
     )
 
     out_pt = torch.add(a_pt, b_pt)
-    out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=shard_config, use_legacy=False)
+    out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=shard_config, use_legacy=None)
     out_tt_sharded = ttnn.to_torch(out_tt_sharded)
     assert ttnn.pearson_correlation_coefficient(out_tt_sharded, out_pt) >= 0.99988
 
@@ -1525,11 +1536,11 @@ def test_binary_sharded_scalar(scalar, a_shape, shard_type, shard_size, core_ran
     )
 
     out_pt = torch.add(a_pt, scalar)
-    out_tt_sharded = ttnn.add(a_tt, scalar, memory_config=a_sharded_config, use_legacy=False)
+    out_tt_sharded = ttnn.add(a_tt, scalar, memory_config=a_sharded_config, use_legacy=None)
     out_tt_sharded = ttnn.to_torch(out_tt_sharded)
     torch.testing.assert_close(out_tt_sharded, out_pt)
 
-    out_tt_interleaved = ttnn.add(a_tt, scalar, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=False)
+    out_tt_interleaved = ttnn.add(a_tt, scalar, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
     out_tt_interleaved = ttnn.to_torch(out_tt_interleaved)
     torch.testing.assert_close(out_tt_interleaved, out_pt)
 
@@ -1580,7 +1591,7 @@ def test_binary_sharded_scalar_invalid_row_major(scalar, a_shape, shard_type, sh
             memory_config=a_sharded_config,
         )
 
-        tt_out = ttnn.add(a_tt, scalar, memory_config=a_sharded_config, use_legacy=False)
+        tt_out = ttnn.add(a_tt, scalar, memory_config=a_sharded_config, use_legacy=None)
 
 
 @pytest.mark.parametrize("scalar", [-0.25, -16.5, 0.0, 0.05, 1.7, 19.0])
@@ -1616,7 +1627,7 @@ def test_binary_sharded_scalar_col_major(scalar, a_shape, shard_type, shard_size
             memory_config=a_sharded_config,
         )
 
-        tt_out = ttnn.add(a_tt, scalar, memory_config=a_sharded_config, use_legacy=False)
+        tt_out = ttnn.add(a_tt, scalar, memory_config=a_sharded_config, use_legacy=None)
 
 
 @pytest.mark.parametrize(
@@ -1688,7 +1699,7 @@ def test_binary_sharded_bcast_w_size(a_shape, b_shape, a_shard_size, b_shard_siz
     )
 
     out_pt = torch.add(a_pt, b_pt)
-    out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=a_shard_config, use_legacy=False)
+    out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=a_shard_config, use_legacy=None)
     out_tt_sharded = ttnn.to_torch(out_tt_sharded)
     torch.testing.assert_close(out_tt_sharded, out_pt)
 
@@ -1731,7 +1742,7 @@ def test_binary_sharded_invalid_spec(
     b_pt, b_tt = rand_bf16_gen(b_shape, device, memory_config=b_sharded_config)
 
     with pytest.raises(RuntimeError):
-        _ = ttnn.add(a_tt, b_tt, memory_config=a_sharded_config, use_legacy=False)
+        _ = ttnn.add(a_tt, b_tt, memory_config=a_sharded_config, use_legacy=None)
 
 
 @pytest.mark.parametrize(
@@ -1810,7 +1821,7 @@ def test_binary_sharded_invalid_row_major_layout(
             memory_config=b_sharded_config,
         )
 
-        _ = ttnn.add(a_tt, b_tt, memory_config=a_sharded_config, use_legacy=False)
+        _ = ttnn.add(a_tt, b_tt, memory_config=a_sharded_config, use_legacy=None)
 
 
 @pytest.mark.skip(reason="Skipping test for dchen/23538-sharded_ND")
@@ -1877,7 +1888,7 @@ def test_binary_sharded_row_major_layout(
         memory_config=b_sharded_config,
     )
     out_pt = torch.add(a_pt, b_pt)
-    out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=a_sharded_config, use_legacy=False)
+    out_tt_sharded = ttnn.add(a_tt, b_tt, memory_config=a_sharded_config, use_legacy=None)
     out_tt_sharded = ttnn.to_torch(out_tt_sharded)
     torch.testing.assert_close(out_tt_sharded, out_pt)
 
@@ -1906,7 +1917,7 @@ def test_binary_subtile_no_bcast(a_shape, b_shape, device):
 
     torch_output_tensor = torch_input_tensor_a + torch_input_tensor_b
 
-    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=False)
+    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert output_tensor.shape == torch_output_tensor.shape
@@ -2030,7 +2041,7 @@ def test_binary_subtile_col_bcast(a_shape, b_shape, device):
 
     torch_output_tensor = torch_input_tensor_a + torch_input_tensor_b
 
-    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=False)
+    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert output_tensor.shape == torch_output_tensor.shape
@@ -2066,7 +2077,7 @@ def test_binary_subtile_scalar_bcast(a_shape, b_shape, device):
 
     torch_output_tensor = torch_input_tensor_a + torch_input_tensor_b
 
-    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=False)
+    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert output_tensor.shape == torch_output_tensor.shape
@@ -2361,7 +2372,7 @@ def test_yolov8_add_small(device):
     #  print("with typecast")
     #  tt_a = ttnn.typecast(tt_a, dtype=ttnn.float32)
     print("add")
-    result = ttnn.add(tt_a, tt_b, use_legacy=False)
+    result = ttnn.add(tt_a, tt_b, use_legacy=None)
 
     tt_res = ttnn.to_torch(result)
     #  print("tt_res", tt_res)
@@ -2395,7 +2406,7 @@ def test_binary_mixed_add(dtype_pt_a, dtype_tt_a, dtype_pt_b, dtype_tt_b, device
 
     golden_fn = ttnn.get_golden_function(ttnn.add)
 
-    out_tt = ttnn.add(a_tt, b_tt, use_legacy=False)
+    out_tt = ttnn.add(a_tt, b_tt, use_legacy=None)
     out_pt = golden_fn(a_pt, b_pt)
 
     assert compare_pcc([out_tt], [out_pt])
@@ -2412,3 +2423,19 @@ def test_add_1m(device):
     tc = ttnn.add(ta, tb)
 
     assert torch.allclose(c, ttnn.to_torch(tc)), f"{c} != {ttnn.to_torch(tc)}"
+
+
+def test_add_i32(device):
+    torch.manual_seed(2024)
+    a = torch.cat([torch.zeros(128, dtype=torch.int32), torch.ones(128, dtype=torch.int32)])
+    a = torch.reshape(a, (1, 1, 1, 256))
+    b = torch.zeros((1, 1, 256, 256))
+
+    torch_add = a + b
+
+    input_tensor_a = ttnn.from_torch(a, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(b, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, use_legacy=None)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert torch.equal(torch_add, output_tensor)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -2439,3 +2439,21 @@ def test_add_i32(device):
 
     output_tensor = ttnn.to_torch(output_tensor)
     assert torch.equal(torch_add, output_tensor)
+
+
+def test_add_error(device):
+    pytest.skip("Test is skipped because issue not fixed yet")
+    # Create input tensors with specified shapes
+    input_shape = [1, 1, 1, 39576]
+    bias_shape = [1, 39576]
+
+    # Create random tensors
+    torch_input = torch.randn(*input_shape, dtype=torch.bfloat16)
+    torch_bias = torch.randn(*bias_shape, dtype=torch.bfloat16)
+
+    # Convert to TTNN tensors with tile layout
+    ttnn_input = ttnn.from_torch(torch_input, device=device, layout=ttnn.TILE_LAYOUT)
+    ttnn_bias = ttnn.from_torch(torch_bias, device=device, layout=ttnn.TILE_LAYOUT)
+
+    # Perform the add operation with the specified memory config
+    ttnn_result = ttnn.add(ttnn_input, ttnn_bias, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG, use_legacy=None)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast_tcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast_tcast.py
@@ -19,6 +19,7 @@ from models.utility_functions import torch_random
         (torch.Size([5, 1, 64, 1]), torch.Size([1, 3, 1, 128])),
         (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1])),
         (torch.Size([5, 1, 1]), torch.Size([1, 32, 128])),
+        (torch.Size([5, 32, 32]), torch.Size([5, 32, 32])),
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -133,7 +133,7 @@ def test_binary_int32_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    output_tensor = ttnn_op(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn_op(input_tensor_a, input_tensor_b, use_legacy=None)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert torch.equal(output_tensor, torch_output_tensor)
@@ -207,7 +207,7 @@ def test_binary_logical_int32_sharded(a_shape, b_shape, sharded_config, ttnn_fn,
     golden_function = ttnn.get_golden_function(ttnn_op)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
 
-    output_tensor = ttnn_op(input_tensor_a, input_tensor_b, memory_config=sharded_config, use_legacy=False)
+    output_tensor = ttnn_op(input_tensor_a, input_tensor_b, memory_config=sharded_config, use_legacy=None)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert torch.equal(output_tensor, torch_output_tensor)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
@@ -141,7 +141,7 @@ def test_binary_max_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    tt_result = ttnn.maximum(tt_in_a, tt_in_b, use_legacy=False)
+    tt_result = ttnn.maximum(tt_in_a, tt_in_b, use_legacy=None)
     output_tensor = ttnn.to_torch(tt_result)
     assert torch.equal(golden, output_tensor)
 
@@ -437,7 +437,7 @@ def test_binary_max_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    tt_result = ttnn.maximum(tt_in_a, tt_in_b, use_legacy=False)
+    tt_result = ttnn.maximum(tt_in_a, tt_in_b, use_legacy=None)
     comp_pass = compare_equal([tt_result], [golden])
     assert comp_pass
 
@@ -486,7 +486,7 @@ def test_binary_max_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    tt_result = ttnn.maximum(tt_in_a, tt_in_b, use_legacy=False)
+    tt_result = ttnn.maximum(tt_in_a, tt_in_b, use_legacy=None)
     result = ttnn.to_torch(tt_result)
     assert_with_pcc(golden, result, 0.999)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
@@ -141,7 +141,7 @@ def test_binary_min_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    tt_result = ttnn.minimum(tt_in_a, tt_in_b, use_legacy=False)
+    tt_result = ttnn.minimum(tt_in_a, tt_in_b, use_legacy=None)
     output_tensor = ttnn.to_torch(tt_result)
     assert torch.equal(golden, output_tensor)
 
@@ -437,7 +437,7 @@ def test_binary_min_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    tt_result = ttnn.minimum(tt_in_a, tt_in_b, use_legacy=False)
+    tt_result = ttnn.minimum(tt_in_a, tt_in_b, use_legacy=None)
     comp_pass = compare_equal([tt_result], [golden])
     assert comp_pass
 
@@ -486,7 +486,7 @@ def test_binary_min_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    tt_result = ttnn.minimum(tt_in_a, tt_in_b, use_legacy=False)
+    tt_result = ttnn.minimum(tt_in_a, tt_in_b, use_legacy=None)
     result = ttnn.to_torch(tt_result)
     assert_with_pcc(golden, result, 0.999)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
@@ -54,7 +54,7 @@ def test_binary_add_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, use_legacy=None)
     # Since to_torch converts ttnn.uint16 to int16 and then to int32, there will be an output mismatch
     # We can typecast ttnn.uint16 to ttnn.uint32 to avoid this mismatch
     output_tensor = ttnn.typecast(output_tensor, dtype=ttnn.uint32)
@@ -158,7 +158,7 @@ def test_binary_uint16_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device
     golden_function = ttnn.get_golden_function(ttnn_op)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
 
-    output_tensor_sharded = ttnn_op(input_tensor_a, input_tensor_b, memory_config=sharded_config, use_legacy=False)
+    output_tensor_sharded = ttnn_op(input_tensor_a, input_tensor_b, memory_config=sharded_config, use_legacy=None)
     # Since typecast does not support sharded config, we can convert the sharded tensor to interleaved
     output_tensor = ttnn.to_memory_config(output_tensor_sharded, ttnn.DRAM_MEMORY_CONFIG)
     output_tensor = ttnn.typecast(output_tensor, dtype=ttnn.uint32)
@@ -214,7 +214,7 @@ def test_binary_sub_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    output_tensor = ttnn.sub(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.sub(input_tensor_a, input_tensor_b, use_legacy=None)
     output_tensor = ttnn.typecast(output_tensor, dtype=ttnn.uint32)
     output_tensor = ttnn.to_torch(output_tensor, dtype=torch.int32)
 
@@ -289,7 +289,7 @@ def test_binary_sub_uint16_sharded(a_shape, b_shape, sharded_config, device):
     golden_function = ttnn.get_golden_function(ttnn.sub)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
 
-    output_tensor_sharded = ttnn.sub(input_tensor_a, input_tensor_b, memory_config=sharded_config, use_legacy=False)
+    output_tensor_sharded = ttnn.sub(input_tensor_a, input_tensor_b, memory_config=sharded_config, use_legacy=None)
     output_tensor = ttnn.to_memory_config(output_tensor_sharded, ttnn.DRAM_MEMORY_CONFIG)
     output_tensor = ttnn.typecast(output_tensor, dtype=ttnn.uint32)
     output_tensor = ttnn.to_torch(output_tensor, dtype=torch.int32)
@@ -356,7 +356,7 @@ def test_binary_bitwise_op_uint16(a_shape, b_shape, low_a, high_a, low_b, high_b
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    output_tensor = bitwise_op(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = bitwise_op(input_tensor_a, input_tensor_b, use_legacy=None)
     # Since to_torch converts ttnn.uint16 to int16 and then to int32, there will be an output mismatch
     # We can typecast ttnn.uint16 to ttnn.uint32 to avoid this mismatch
     output_tensor = ttnn.typecast(output_tensor, dtype=ttnn.uint32)
@@ -416,7 +416,7 @@ def test_bitwise_op_uint16_sharded(a_shape, b_shape, sharded_config, bitwise_op,
     golden_function = ttnn.get_golden_function(bitwise_op)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
 
-    output_tensor_sharded = bitwise_op(input_tensor_a, input_tensor_b, memory_config=sharded_config, use_legacy=False)
+    output_tensor_sharded = bitwise_op(input_tensor_a, input_tensor_b, memory_config=sharded_config, use_legacy=None)
     # Since typecast does not support sharded config, we can convert the sharded tensor to interleaved
     output_tensor = ttnn.to_memory_config(output_tensor_sharded, ttnn.DRAM_MEMORY_CONFIG)
     output_tensor = ttnn.typecast(output_tensor, dtype=ttnn.uint32)
@@ -478,7 +478,7 @@ def test_binary_mul_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    output_tensor = ttnn.mul(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.mul(input_tensor_a, input_tensor_b, use_legacy=None)
     output_tensor = ttnn.typecast(output_tensor, dtype=ttnn.uint32)
     output_tensor = ttnn.to_torch(output_tensor, dtype=torch.int32)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py
@@ -83,7 +83,7 @@ def test_ND_subtile_bcast(device, shapes, ttnn_fn):
         torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )
 
-    output_tensor = ttnn_fn(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=False)
+    output_tensor = ttnn_fn(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999
@@ -137,7 +137,7 @@ def test_ND_scalar_bcast(device, shapes, ttnn_fn):
     )
     input_tensor_b = torch_input_tensor_b
 
-    output_tensor = ttnn_fn(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=False)
+    output_tensor = ttnn_fn(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.99988

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
@@ -15,7 +15,7 @@ def test_sub_fp32(device):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_sub = ttnn.sub(x_tt, y_tt, use_legacy=False)
+    z_tt_sub = ttnn.sub(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_sub)
 
     status = torch.allclose(z_torch, tt_out, atol=1e-10, rtol=1e-5, equal_nan=False)
@@ -29,7 +29,7 @@ def test_rsub_fp32(device):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_sub = ttnn.rsub(x_tt, y_tt, use_legacy=False)
+    z_tt_sub = ttnn.rsub(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_sub)
 
     status = torch.allclose(z_torch, tt_out, atol=1e-10, rtol=1e-5, equal_nan=False)
@@ -43,7 +43,7 @@ def test_add_fp32(device):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_add = ttnn.add(x_tt, y_tt, use_legacy=False)
+    z_tt_add = ttnn.add(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_add)
 
     status = torch.allclose(z_torch, tt_out, atol=1e-10, rtol=1e-5, equal_nan=False)
@@ -57,7 +57,7 @@ def test_add_int32(device):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_add = ttnn.add(x_tt, y_tt, use_legacy=False)
+    z_tt_add = ttnn.add(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_add)
 
     status = torch.allclose(z_torch, tt_out, atol=1e-10, rtol=1e-5, equal_nan=False)
@@ -71,7 +71,7 @@ def test_mul_fp32(device):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_out = ttnn.multiply(x_tt, y_tt, use_legacy=False)
+    z_tt_out = ttnn.multiply(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_out)
 
     status = torch.allclose(z_torch, tt_out, atol=1e-10, rtol=1e-5, equal_nan=False)
@@ -91,7 +91,7 @@ def test_div_fp32(device):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_div = ttnn.divide(x_tt, y_tt, use_legacy=False)
+    z_tt_div = ttnn.divide(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_div)
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
@@ -142,7 +142,7 @@ def test_div_bf16(device):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_div = ttnn.divide(x_tt, y_tt, use_legacy=False)  # bf16 runs FPU
+    z_tt_div = ttnn.divide(x_tt, y_tt, use_legacy=None)  # bf16 runs FPU
     tt_out = ttnn.to_torch(z_tt_div)
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
@@ -169,7 +169,7 @@ def test_add_fp32_activ(device):
     z_torch = torch.square(x_torch + y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_add = ttnn.add(x_tt, y_tt, activations=[ttnn.UnaryOpType.SQUARE], use_legacy=False)
+    z_tt_add = ttnn.add(x_tt, y_tt, activations=[ttnn.UnaryOpType.SQUARE], use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_add)
 
     status = torch.allclose(z_torch, tt_out, atol=1e-10, rtol=1e-5, equal_nan=False)
@@ -196,7 +196,7 @@ def test_add_fp32_input_activ(device, shape):
         y_tt,
         input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
         activations=[ttnn.UnaryOpType.SQUARE],
-        use_legacy=False,
+        use_legacy=None,
     )
     tt_out = ttnn.to_torch(z_tt_add)
 
@@ -211,7 +211,7 @@ def test_logaddexp_fp32(device):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_out = ttnn.logaddexp(x_tt, y_tt, use_legacy=False)
+    z_tt_out = ttnn.logaddexp(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_out)
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
@@ -225,7 +225,7 @@ def test_logaddexp2_fp32(device):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_out = ttnn.logaddexp2(x_tt, y_tt, use_legacy=False)
+    z_tt_out = ttnn.logaddexp2(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_out)
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
@@ -239,7 +239,7 @@ def test_ldexp_fp32(device):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_out = ttnn.ldexp(x_tt, y_tt, use_legacy=False)
+    z_tt_out = ttnn.ldexp(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_out)
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
@@ -253,7 +253,7 @@ def test_bias_gelu_fp32(device):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_out = ttnn.bias_gelu(x_tt, y_tt, use_legacy=False)
+    z_tt_out = ttnn.bias_gelu(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_out)
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
@@ -267,7 +267,7 @@ def test_squared_difference_fp32(device):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_out = ttnn.squared_difference(x_tt, y_tt, use_legacy=False)
+    z_tt_out = ttnn.squared_difference(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_out)
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
@@ -289,7 +289,7 @@ def test_logical_fp32(device, ttnn_function):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_out = ttnn_function(x_tt, y_tt, use_legacy=False)
+    z_tt_out = ttnn_function(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_out)
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
@@ -314,7 +314,7 @@ def test_relational_fp32(device, ttnn_function):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_out = ttnn_function(x_tt, y_tt, use_legacy=False)
+    z_tt_out = ttnn_function(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_out)
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
@@ -336,7 +336,7 @@ def test_bitwise(device, ttnn_function):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_out = ttnn_function(x_tt, y_tt, use_legacy=False)
+    z_tt_out = ttnn_function(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_out)
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.9999
@@ -350,7 +350,7 @@ def test_bitwise_left_shift(device):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_out = ttnn.bitwise_left_shift(x_tt, y_tt, use_legacy=False)
+    z_tt_out = ttnn.bitwise_left_shift(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_out)
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
@@ -364,7 +364,7 @@ def test_bitwise_right_shift(device):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_out = ttnn.bitwise_right_shift(x_tt, y_tt, use_legacy=False)
+    z_tt_out = ttnn.bitwise_right_shift(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_out)
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
@@ -388,7 +388,7 @@ def test_ng_scalar_fp32(device, ttnn_function):
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = y_torch
-    z_tt_out = ttnn_function(x_tt, y_tt, use_legacy=False)
+    z_tt_out = ttnn_function(x_tt, y_tt, use_legacy=None)
     tt_out = ttnn.to_torch(z_tt_out)
 
     status = torch.allclose(z_torch, tt_out, atol=1e-10, rtol=1e-5, equal_nan=False)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_gcd.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_gcd.py
@@ -187,7 +187,7 @@ def test_binary_gcd_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    tt_result = ttnn.gcd(tt_in_a, tt_in_b, use_legacy=False)
+    tt_result = ttnn.gcd(tt_in_a, tt_in_b, use_legacy=None)
     output_tensor = ttnn.to_torch(tt_result)
     assert torch.equal(golden, output_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_lcm.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_lcm.py
@@ -211,7 +211,7 @@ def test_binary_lcm_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    tt_result = ttnn.lcm(tt_in_a, tt_in_b, use_legacy=False)
+    tt_result = ttnn.lcm(tt_in_a, tt_in_b, use_legacy=None)
     output_tensor = ttnn.to_torch(tt_result)
     assert torch.equal(golden, output_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_pow.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_pow.py
@@ -232,7 +232,7 @@ def test_binary_ng_pow(device, input_a, input_b, dtype):
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output = ttnn.pow(input_tensor_a, input_tensor_b, use_legacy=False)
+    output = ttnn.pow(input_tensor_a, input_tensor_b, use_legacy=None)
     output = ttnn.to_torch(output)
 
     pcc = ttnn.pearson_correlation_coefficient(torch_output_tensor, output)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_relational.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_relational.py
@@ -399,7 +399,7 @@ def test_binary_relational_scalar_ttnn(device, input_shapes, scalar, ttnn_functi
     in_data = torch.randint(-100, 100, input_shapes, dtype=torch.int32)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn_function(input_tensor, scalar, use_legacy=False)
+    output_tensor = ttnn_function(input_tensor, scalar, use_legacy=None)
     output_tensor = ttnn.to_torch(output_tensor)
     golden_function = ttnn.get_golden_function(ttnn_function)
     golden_tensor = golden_function(in_data, scalar)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
@@ -52,7 +52,7 @@ def test_add_and_apply_activations(device, shape, activations, torch_dtype):
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
-    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, activations=activations, use_legacy=False)
+    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, activations=activations, use_legacy=None)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, 0.99988)
     assert output_tensor.shape == shape

--- a/tests/ttnn/unit_tests/operations/test_repeat.py
+++ b/tests/ttnn/unit_tests/operations/test_repeat.py
@@ -124,7 +124,7 @@ def test_pc_with_different_shapes_in_sequence(device):
     x_tt = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
     ttnn.repeat(y_tt, [4, 1, 1, 1])
-    z_tt = ttnn.add(x_tt, y_tt, use_legacy=False)
+    z_tt = ttnn.add(x_tt, y_tt)
     z_tt = x_tt + y_tt
 
     for i in range(num_iters):
@@ -141,7 +141,7 @@ def test_pc_with_different_shapes_in_sequence(device):
         assert (
             device.num_program_cache_entries() == base_program_cache_entries
         ), "program cache entries differ on same configs"
-        z_tt = ttnn.add(x_tt, y_tt, use_legacy=False)
+        z_tt = ttnn.add(x_tt, y_tt)
         z_tt = x_tt + y_tt
 
         for i in range(num_iters):

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -187,21 +187,6 @@ inline auto any_row_broadcasted(const Tensor& a, const auto& b) {
 
     return false;
 }
-
-inline auto any_sharded_scalar(const Tensor& a, const auto& b) {
-    if constexpr (requires {
-                      b.get_logical_shape();
-                      b.is_sharded();
-                  }) {
-        const auto& a_shape = a.get_logical_shape();
-        const auto& b_shape = b.get_logical_shape();
-        return (a.is_sharded() or b.is_sharded()) and
-               ((a_shape[-2] == 1 and a_shape[-1] == 1) or (b_shape[-2] == 1 and b_shape[-1] == 1));
-    }
-
-    return false;
-}
-
 inline auto any_sharded_block_format(const Tensor& a, const auto& b) {
     if (a.is_sharded() and is_block_format(a.get_dtype())) {
         return true;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -338,8 +338,9 @@ inline auto is_binary_ng_only(const Tensor& a, const auto& b, BinaryOpType binar
             return true;
         }
 
-        if ((a.is_sharded() or b.is_sharded()) and (a.dtype() == DataType::FLOAT32 or b.dtype() == DataType::FLOAT32 or
-                                                    a.dtype() == DataType::INT32 or b.dtype() == DataType::INT32)) {
+        if ((a.is_sharded() or b.is_sharded()) and
+            (/*a.dtype() == DataType::FLOAT32 or b.dtype() == DataType::FLOAT32 or*/
+             a.dtype() == DataType::INT32 or b.dtype() == DataType::INT32)) {
             return true;
         }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -188,6 +188,20 @@ inline auto any_row_broadcasted(const Tensor& a, const auto& b) {
     return false;
 }
 
+inline auto any_sharded_scalar(const Tensor& a, const auto& b) {
+    if constexpr (requires {
+                      b.get_logical_shape();
+                      b.is_sharded();
+                  }) {
+        const auto& a_shape = a.get_logical_shape();
+        const auto& b_shape = b.get_logical_shape();
+        return (a.is_sharded() or b.is_sharded()) and
+               ((a_shape[-2] == 1 and a_shape[-1] == 1) or (b_shape[-2] == 1 and b_shape[-1] == 1));
+    }
+
+    return false;
+}
+
 inline auto any_sharded_block_format(const Tensor& a, const auto& b) {
     if (a.is_sharded() and is_block_format(a.get_dtype())) {
         return true;
@@ -222,11 +236,11 @@ inline auto any_subtile_broadcasted_block_format(const Tensor& a, const auto& b)
 }
 
 inline auto any_sharded_scalar(const Tensor& a, const auto& b) {
-    const auto& a_shape = a.get_logical_shape();
     if constexpr (requires {
                       b.get_logical_shape();
                       b.is_sharded();
                   }) {
+        const auto& a_shape = a.get_logical_shape();
         const auto& b_shape = b.get_logical_shape();
         return (a.is_sharded() or b.is_sharded()) and
                ((a_shape[-2] == 1 and a_shape[-1] == 1) or (b_shape[-2] == 1 and b_shape[-1] == 1));
@@ -235,19 +249,30 @@ inline auto any_sharded_scalar(const Tensor& a, const auto& b) {
     return false;
 }
 
-inline auto any_non_height_sharded(const Tensor& a, const auto& b, const MemoryConfig& c) {
+inline auto is_w_bcast(const Tensor& a, const auto& b) {
+    if constexpr (requires { b.get_padded_shape(); }) {
+        const auto& shape_a = a.get_padded_shape();
+        const auto& shape_b = b.get_padded_shape();
+        return (shape_a[-1] == 1 and shape_b[-1] > 1) or (shape_b[-1] == 1 and shape_a[-1] > 1);
+    }
+    return false;
+}
+
+inline auto any_non_height_sharded_w_bcast(const Tensor& a, const auto& b, const MemoryConfig& c) {
+    // NOTE: currently with sharded tensor, broadcast is on w dimension only,
+    // so only check for w dimension, not all dimensions
     if (a.is_sharded()) {
-        return a.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED;
+        return a.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED and is_w_bcast(a, b);
     }
 
     if constexpr (requires { b.is_sharded(); }) {
         if (b.is_sharded()) {
-            return b.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED;
+            return b.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED and is_w_bcast(a, b);
         }
     }
 
     if (c.is_sharded()) {
-        return c.memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED;
+        return c.memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED and is_w_bcast(a, b);
     }
 
     return false;
@@ -282,6 +307,59 @@ inline auto any_uneven(const Tensor& a, const auto& b, const std::optional<Tenso
     return false;
 }
 
+inline auto is_binary_ng_only(const Tensor& a, const auto& b, BinaryOpType binary_op_type) {
+    if constexpr (requires {
+                      b.dtype();
+                      b.is_sharded();
+                      b.get_logical_shape();
+                  }) {
+        if (a.dtype() == DataType::INT32 or b.dtype() == DataType::INT32) {
+            if (any_row_broadcasted(a, b)) {
+                return true;
+            }
+            if (binary_op_type == BinaryOpType::NE or binary_op_type == BinaryOpType::EQ or
+                binary_op_type == BinaryOpType::GTE or binary_op_type == BinaryOpType::LTE or
+                binary_op_type == BinaryOpType::GT or binary_op_type == BinaryOpType::LT) {
+                return true;
+            }
+        }
+
+        if ((a.is_sharded() or b.is_sharded()) and (a.dtype() == DataType::UINT16 or b.dtype() == DataType::UINT16)) {
+            return true;
+        }
+
+        if (any_row_broadcasted(a, b) and
+            (/*binary_op_type == BinaryOpType::POWER*/ binary_op_type != BinaryOpType::ADD and
+             binary_op_type != BinaryOpType::SUB and binary_op_type != BinaryOpType::MUL)) {
+            return true;
+        }
+
+        if (a.get_logical_shape().rank() > 4 or b.get_logical_shape().rank() > 4) {
+            return true;
+        }
+
+        if ((a.is_sharded() or b.is_sharded()) and (a.dtype() == DataType::FLOAT32 or b.dtype() == DataType::FLOAT32 or
+                                                    a.dtype() == DataType::INT32 or b.dtype() == DataType::INT32)) {
+            return true;
+        }
+
+        if (a.get_logical_shape()[-2] == 1 && b.get_logical_shape()[-2] > 1 && a.get_logical_shape()[-1] > 1 &&
+            b.get_logical_shape()[-1] == 1) {
+            return true;
+        }
+        if (b.get_logical_shape()[-2] == 1 && a.get_logical_shape()[-2] > 1 && b.get_logical_shape()[-1] > 1 &&
+            a.get_logical_shape()[-1] == 1) {
+            return true;
+        }
+
+        if (any_row_broadcasted(a, b) and (is_block_format(a.get_dtype()) or is_block_format(b.get_dtype()))) {
+            // TODO
+            // return true;
+        }
+    }
+    return false;
+}
+
 }  // namespace detail
 
 bool is_legacy_only(
@@ -295,7 +373,7 @@ bool is_legacy_only(
 
     if (detail::any_row_broadcasted(lhs, rhs) or detail::any_sharded_block_format(lhs, rhs) or
         detail::any_subtile_broadcasted_block_format(lhs, rhs) or
-        detail::any_non_height_sharded(lhs, rhs, output_mem_cfg) or detail::any_uneven(lhs, rhs, output) or
+        detail::any_non_height_sharded_w_bcast(lhs, rhs, output_mem_cfg) or detail::any_uneven(lhs, rhs, output) or
         detail::any_sharded_scalar(lhs, rhs)) {
         TT_FATAL(
             lhs_activations.size() <= 1,
@@ -351,18 +429,20 @@ inline auto invoke_binary_ng(
     const std::optional<bool>& use_legacy) {
     if (use_legacy ? *use_legacy
                    : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations)) {
-        const std::vector activations(post_activations.begin(), post_activations.end());
-        const std::optional lhs_activation =
-            lhs_activations.empty() ? std::nullopt : std::optional{lhs_activations.front()};
+        if ((not detail::is_binary_ng_only(lhs, rhs, binary_op_type)) or *use_legacy) {
+            const std::vector activations(post_activations.begin(), post_activations.end());
+            const std::optional lhs_activation =
+                lhs_activations.empty() ? std::nullopt : std::optional{lhs_activations.front()};
 
-        if constexpr (requires { detail::preprocess_inputs(binary_op_type, lhs, rhs); }) {
-            auto [a, b] = detail::preprocess_inputs(binary_op_type, lhs, rhs);
+            if constexpr (requires { detail::preprocess_inputs(binary_op_type, lhs, rhs); }) {
+                auto [a, b] = detail::preprocess_inputs(binary_op_type, lhs, rhs);
 
-            return ttnn::prim::binary(
-                queue_id, a, b, binary_op_type, dtype, memory_config, output, activations, lhs_activation);
-        } else {
-            return ttnn::prim::binary(
-                queue_id, lhs, rhs, binary_op_type, dtype, memory_config, output, activations, lhs_activation);
+                return ttnn::prim::binary(
+                    queue_id, a, b, binary_op_type, dtype, memory_config, output, activations, lhs_activation);
+            } else {
+                return ttnn::prim::binary(
+                    queue_id, lhs, rhs, binary_op_type, dtype, memory_config, output, activations, lhs_activation);
+            }
         }
     }
 
@@ -530,7 +610,9 @@ Tensor RelationalBinary<binary_op_type>::invoke(
     const std::optional<bool>& use_legacy) {
     if (use_legacy ? *use_legacy
                    : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations)) {
-        return detail::binary_impl(DefaultQueueId, binary_op_type, lhs, rhs, dtype, memory_config, output);
+        if ((not detail::is_binary_ng_only(lhs, rhs, binary_op_type)) or *use_legacy) {
+            return detail::binary_impl(DefaultQueueId, binary_op_type, lhs, rhs, dtype, memory_config, output);
+        }
     }
 
     return detail::invoke_binary_ng(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -313,34 +313,19 @@ inline auto is_binary_ng_only(const Tensor& a, const auto& b, BinaryOpType binar
                       b.is_sharded();
                       b.get_logical_shape();
                   }) {
-        if (a.dtype() == DataType::INT32 or b.dtype() == DataType::INT32) {
-            if (any_row_broadcasted(a, b)) {
-                return true;
-            }
-            if (binary_op_type == BinaryOpType::NE or binary_op_type == BinaryOpType::EQ or
-                binary_op_type == BinaryOpType::GTE or binary_op_type == BinaryOpType::LTE or
-                binary_op_type == BinaryOpType::GT or binary_op_type == BinaryOpType::LT) {
-                return true;
-            }
-        }
-
-        if ((a.is_sharded() or b.is_sharded()) and (a.dtype() == DataType::UINT16 or b.dtype() == DataType::UINT16)) {
+        if (a.dtype() == DataType::INT32 or b.dtype() == DataType::INT32 or a.dtype() == DataType::UINT32 or
+            b.dtype() == DataType::UINT32 or a.dtype() == DataType::UINT16 or b.dtype() == DataType::UINT16 or
+            a.dtype() == DataType::UINT8 or b.dtype() == DataType::UINT8) {
             return true;
         }
 
         if (any_row_broadcasted(a, b) and
-            (/*binary_op_type == BinaryOpType::POWER*/ binary_op_type != BinaryOpType::ADD and
-             binary_op_type != BinaryOpType::SUB and binary_op_type != BinaryOpType::MUL)) {
+            (binary_op_type != BinaryOpType::ADD and binary_op_type != BinaryOpType::SUB and
+             binary_op_type != BinaryOpType::MUL)) {
             return true;
         }
 
         if (a.get_logical_shape().rank() > 4 or b.get_logical_shape().rank() > 4) {
-            return true;
-        }
-
-        if ((a.is_sharded() or b.is_sharded()) and
-            (/*a.dtype() == DataType::FLOAT32 or b.dtype() == DataType::FLOAT32 or*/
-             a.dtype() == DataType::INT32 or b.dtype() == DataType::INT32)) {
             return true;
         }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -414,21 +414,20 @@ inline auto invoke_binary_ng(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     if (use_legacy ? *use_legacy
-                   : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations)) {
-        if ((not detail::is_binary_ng_only(lhs, rhs, binary_op_type)) or *use_legacy) {
-            const std::vector activations(post_activations.begin(), post_activations.end());
-            const std::optional lhs_activation =
-                lhs_activations.empty() ? std::nullopt : std::optional{lhs_activations.front()};
+                   : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations) and
+                         (not detail::is_binary_ng_only(lhs, rhs, binary_op_type))) {
+        const std::vector activations(post_activations.begin(), post_activations.end());
+        const std::optional lhs_activation =
+            lhs_activations.empty() ? std::nullopt : std::optional{lhs_activations.front()};
 
-            if constexpr (requires { detail::preprocess_inputs(binary_op_type, lhs, rhs); }) {
-                auto [a, b] = detail::preprocess_inputs(binary_op_type, lhs, rhs);
+        if constexpr (requires { detail::preprocess_inputs(binary_op_type, lhs, rhs); }) {
+            auto [a, b] = detail::preprocess_inputs(binary_op_type, lhs, rhs);
 
-                return ttnn::prim::binary(
-                    queue_id, a, b, binary_op_type, dtype, memory_config, output, activations, lhs_activation);
-            } else {
-                return ttnn::prim::binary(
-                    queue_id, lhs, rhs, binary_op_type, dtype, memory_config, output, activations, lhs_activation);
-            }
+            return ttnn::prim::binary(
+                queue_id, a, b, binary_op_type, dtype, memory_config, output, activations, lhs_activation);
+        } else {
+            return ttnn::prim::binary(
+                queue_id, lhs, rhs, binary_op_type, dtype, memory_config, output, activations, lhs_activation);
         }
     }
 
@@ -595,8 +594,9 @@ Tensor RelationalBinary<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     if (use_legacy ? *use_legacy
-                   : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations)) {
-        if ((not detail::is_binary_ng_only(lhs, rhs, binary_op_type)) or *use_legacy) {
+                   : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations) and
+                         (not detail::is_binary_ng_only(lhs, rhs, binary_op_type))) {
+        {
             return detail::binary_impl(DefaultQueueId, binary_op_type, lhs, rhs, dtype, memory_config, output);
         }
     }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24155)

### Problem description
Currently a lot of test cases require binary ops with flag use_legacy=False, because they only work with binary_ng. We need to add new heuristics as following to make sure without the flag, it still direct to binary_ng.

### What's changed
Add new heuristics to handle following cases. It also fixed https://github.com/tenstorrent/tt-metal/issues/23310 in the same time.

- Int type, int32, uint32, uint16, uint8
- Rank > 4
- Row_broadcast other than ADD, SUB, MUL
- Lhs_activations >1 or rhs_activiations is not empty (runtime error, sad path)
- Subtile broadcast type row_a_col_b, col_a_row_b

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes