### PR TITLE
Rewrite `install_dependencies.sh` for broader distro support

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -130,7 +130,7 @@ jobs:
       run: cmake --version
     - name: Install Build Dependencies
       if: steps.find-changes.outputs.cmake-changed == 'true'
-      run: sudo ./install_dependencies.sh --mode build
+      run: sudo ./install_dependencies.sh --docker
     - name: Check CMake compatibility
       if: steps.find-changes.outputs.cmake-changed == 'true'
       env:

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -102,6 +102,7 @@ jobs:
           MANYLINUX_HASH=$(cat \
             .github/workflows/build-docker-artifact.yaml \
             dockerfile/Dockerfile.manylinux \
+            install_dependencies.sh \
             tt_metal/sfpi-version.sh \
             | sha1sum | cut -d' ' -f1)
           echo "manylinux-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.MANYLINUX_IMAGE_NAME }}:${MANYLINUX_HASH}" >> $GITHUB_OUTPUT

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -11,13 +11,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install runtime deps
 COPY /install_dependencies.sh /opt/tt_metal_infra/scripts/docker/install_dependencies.sh
 COPY /tt_metal/sfpi-version.sh /opt/tt_metal_infra/scripts/docker/sfpi-version.sh
-RUN /bin/bash /opt/tt_metal_infra/scripts/docker/install_dependencies.sh --docker --mode runtime
+RUN /bin/bash /opt/tt_metal_infra/scripts/docker/install_dependencies.sh --docker
 
 #############################################################
 
 FROM base AS ci-build
-
-RUN /bin/bash /opt/tt_metal_infra/scripts/docker/install_dependencies.sh --docker --mode build
 
 # Install ccache from upstream; Apt's version for 20.04 predates remote_storage support
 RUN mkdir -p /usr/local/bin && wget -O /tmp/ccache.tar.xz https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz && \

--- a/dockerfile/Dockerfile.manylinux
+++ b/dockerfile/Dockerfile.manylinux
@@ -6,42 +6,36 @@ RUN FILES=(/etc/yum.repos.d/*.repo) && \
 
 RUN dnf remove -y epel-release || true
 
-# Install system dependencies
-# This should be changed to use install_dependencies.sh so that our
-# dependency lists come from as few sources as possible, after
-# https://github.com/tenstorrent/tt-metal/issues/23060 is resolved
-RUN dnf update -y && \
-    dnf install -y \
+# Copy install dependencies script and required files
+COPY install_dependencies.sh /tmp/install_dependencies.sh
+COPY tt_metal/sfpi-version.sh /tmp/tt_metal/sfpi-version.sh
+
+# Install system dependencies using the install_dependencies.sh script
+# Use --docker flag for Docker-specific optimizations and --no-distributed
+# since we build OpenMPI from source with ULFM support
+RUN chmod +x /tmp/install_dependencies.sh && \
+    /tmp/install_dependencies.sh --docker --no-distributed && \
+    rm -rf /tmp/install_dependencies.sh /tmp/tt_metal
+
+# Install additional packages needed for manylinux builds and OpenMPI compilation
+# that are not covered by the install_dependencies.sh script
+RUN dnf install -y \
     autoconf \
     automake \
     bison \
     ca-certificates \
-    capstone \
-    capstone-devel \
-    clang \
-    cmake3 \
     expat-devel \
     flex \
-    gcc \
-    gcc-c++ \
     gfortran \
-    git \
     gmp-devel \
     gawk \
-    hwloc-devel \
     libevent-devel \
     libibverbs-devel \
     libmpc-devel \
     libzstd-devel \
-    make \
     mpfr-devel \
-    ninja-build \
-    numactl-devel \
     patchutils \
-    pkgconf-pkg-config \
     pmix-devel \
-    python3 \
-    tbb-devel \
     texinfo \
     wget \
     zlib-devel \
@@ -87,15 +81,6 @@ RUN git clone --branch ${OMPI_TAG} --depth 1 https://github.com/open-mpi/ompi.gi
     cd .. && \
     rm -rf ompi-src
 
-COPY tt_metal/sfpi-version.sh /tmp/sfpi-version.sh
-WORKDIR /tmp
-RUN set -x && sfpi_arch_os=$(uname -m)_$(uname -s) && source /tmp/sfpi-version.sh && \
-    sfpi_rpm_md5=$(eval echo "\$sfpi_${sfpi_arch_os}_rpm_md5") && \
-    test "${sfpi_rpm_md5}" && \
-    wget ${sfpi_url}/${sfpi_version}/sfpi-${sfpi_arch_os}.rpm && \
-    test "${sfpi_rpm_md5}" == "$(md5sum -b sfpi-${sfpi_arch_os}.rpm | cut -d' ' -f1)" && \
-    dnf -y install ./sfpi-${sfpi_arch_os}.rpm && \
-    rm -f sfpi-${sfpi_arch_os}.rpm sfpi-version.sh
 
 # ENV needed
 ENV PATH=${OMPI_PREFIX}/bin:$PATH

--- a/infra/VERSION
+++ b/infra/VERSION
@@ -1,3 +1,3 @@
 # This VERSION file is not the official source of the software version
 # This is solely for helping with version management via our release system
-v0.60.0
+v99.60.0

--- a/infra/VERSION
+++ b/infra/VERSION
@@ -1,3 +1,3 @@
 # This VERSION file is not the official source of the software version
 # This is solely for helping with version management via our release system
-v99.60.0
+v0.60.0

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -188,6 +188,7 @@ init_packages() {
                 "libcapstone-dev"
                 "libc++-17-dev"
                 "libc++abi-17-dev"
+                "wget"
             )
             if [ "$distributed" -eq 1 ]; then
                 PACKAGES+=("openmpi-bin" "libopenmpi-dev")
@@ -214,6 +215,7 @@ init_packages() {
                 "boost-devel"
                 "tbb-devel"
                 "capstone-devel"
+                "wget"
             )
             if [ "$distributed" -eq 1 ]; then
                 PACKAGES+=("openmpi" "openmpi-devel")

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -202,7 +202,7 @@ init_packages() {
                 "clang"
                 "cmake"
                 "ninja-build"
-                "pkgconfig"
+                "pkgconf-pkg-config"
                 "cargo"
                 "pandoc"
                 "xz"

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -204,11 +204,9 @@ init_packages() {
                 "ninja-build"
                 "pkgconf-pkg-config"
                 "cargo"
-                "pandoc"
                 "xz"
                 "python3-devel"
                 "python3-pip"
-                "python3-virtualenv"
                 "hwloc-devel"
                 "numactl-devel"
                 "libatomic"
@@ -216,8 +214,6 @@ init_packages() {
                 "boost-devel"
                 "tbb-devel"
                 "capstone-devel"
-                "libcxx-devel"
-                "libcxxabi-devel"
             )
             if [ "$distributed" -eq 1 ]; then
                 PACKAGES+=("openmpi" "openmpi-devel")

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -21,7 +21,7 @@ detect_os() {
         . /etc/os-release
         OS_ID="$ID"
         OS_VERSION="$VERSION_ID"
-        OS_CODENAME="${VERSION_CODENAME:-}"
+        OS_CODENAME="${UBUNTU_CODENAME:VERSION_CODENAME}"
         OS_ID_LIKE="$ID_LIKE"
     else
         echo "Error: /etc/os-release not found. Unsupported system."

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2024 Tenstorrent, Inc. All rights reserved.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 set -e
 
@@ -13,177 +13,244 @@ usage()
     echo "[--validate, -v]            Validate that required packages are installed"
     echo "[--docker, -d]              Specialize execution for docker"
     echo "[--no-distributed]          Don't install distributed compute dependencies (OpenMPI)"
-    echo "[--mode, -m <mode>]         Select installation mode: runtime, build, baremetal"
     exit 1
 }
 
-FLAVOR=`grep '^ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
-VERSION=`grep '^VERSION_ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
-MAJOR=${VERSION%.*}
-ARCH=`uname -m`
+detect_os() {
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        OS_ID="$ID"
+        OS_VERSION="$VERSION_ID"
+        OS_CODENAME="${VERSION_CODENAME:-}"
+        OS_ID_LIKE="$ID_LIKE"
+    else
+        echo "Error: /etc/os-release not found. Unsupported system."
+        exit 1
+    fi
 
-if [ $FLAVOR != "ubuntu" ]; then
-    echo "Error: Only Ubuntu is supported"
-    exit 1
-fi
+    # Detect package manager
+    for mgr in apt dnf yum; do
+        if command -v "$mgr" >/dev/null 2>&1; then
+            PKG_MANAGER="$mgr"
+            break
+        fi
+    done
+    if [ -z "$PKG_MANAGER" ]; then
+        echo "Error: No supported package manager found"
+        exit 1
+    fi
 
-UBUNTU_CODENAME=$(grep '^VERSION_CODENAME=' /etc/os-release | awk -F= '{print $2}' | tr -d '"')
-export UBUNTU_CODENAME
+    echo "Detected OS: $OS_ID $OS_VERSION ($PKG_MANAGER)"
+}
 
-if [ "$EUID" -ne 0 ]; then
-    echo "This script must be run as root. Please use sudo."
-    usage
-fi
-
-validate=0
-docker=0
-distributed=1
-mode="baremetal"
-
-while [ $# -gt 0 ]; do
-    case "$1" in
-        --help|-h)
-            usage
+is_supported_os() {
+    case "$OS_ID" in
+        ubuntu|debian)
+            return 0
             ;;
-        --validate|-v)
-            validate=1
-            shift
-            ;;
-        --docker|-d)
-            docker=1
-            shift
-            ;;
-        --no-distributed)
-            distributed=0
-            shift
-            ;;
-	--mode|-m)
-            mode="$2"
-            shift 2
+        fedora|centos|rhel|rocky|almalinux)
+            return 0
             ;;
         *)
-            echo "Unknown option: $1"
-            usage
+            if [[ "$OS_ID_LIKE" == *"debian"* ]] || [[ "$OS_ID_LIKE" == *"ubuntu"* ]]; then
+                return 0
+            elif [[ "$OS_ID_LIKE" == *"rhel"* ]] || [[ "$OS_ID_LIKE" == *"fedora"* ]]; then
+                return 0
+            else
+                return 1
+            fi
             ;;
     esac
-done
-
-# libc++ runtime dependency could eventually go away
-# It is favored on Ubuntu20.04 for C++20 support
-
-# At the time of this writing the following libraries are linked at runtime by sfpi cross compiler
-# libmpc, libmfpr, libgmp, libz
-# For the time being it will be assumed that these packages come from the base Ubuntu image
-
-# I would prefer to not be using -dev packages for runtime dependencies
-# But I have not been able to verify any alternative package
-
-# Packages needed at runtime and therefore needed by release docker image
-ub_runtime_packages()
-{
-    UB_RUNTIME_LIST=(\
-     python3-dev \
-     python3-pip \
-     python3-venv \
-     libhwloc-dev \
-     libnuma-dev \
-     libatomic1 \
-     libc++-17-dev \
-     libc++abi-17-dev \
-     libstdc++6 \
-    )
-
-    if [ "$distributed" -eq 1 ]; then
-        UB_RUNTIME_LIST+=(openmpi-bin)
-    fi
 }
 
-ub_buildtime_packages()
-{
-    UB_BUILDTIME_LIST=(\
-     git \
-     python3-dev \
-     pkg-config \
-     cargo \
-     cmake \
-     ninja-build \
-     libboost-dev \
-     libhwloc-dev \
-     libc++-17-dev \
-     libc++abi-17-dev \
-     build-essential \
-     xz-utils \
-     pandoc \
-     libtbb-dev \
-     libcapstone-dev \
-     pkg-config \
-    )
-
-    if [ "$distributed" -eq 1 ]; then
-        UB_BUILDTIME_LIST+=(libopenmpi-dev)
-    fi
+update_package_cache() {
+    echo "[INFO] Updating package cache..."
+    case "$PKG_MANAGER" in
+        apt)
+            apt-get update
+            ;;
+        dnf)
+            dnf makecache
+            ;;
+        yum)
+            yum makecache
+            ;;
+    esac
 }
 
-# Packages needed to setup a baremetal machine to build from source and run
-
-ub_baremetal_packages() {
-    ub_runtime_packages
-    ub_buildtime_packages
-    UB_BAREMETAL_LIST=("${UB_RUNTIME_LIST[@]}" "${UB_BUILDTIME_LIST[@]}")
+install_packages() {
+    echo "[INFO] Installing packages: ${PACKAGES[*]}"
+    case "$PKG_MANAGER" in
+        apt)
+            DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends "${PACKAGES[@]}"
+            ;;
+        dnf)
+            dnf install -y "${PACKAGES[@]}"
+            ;;
+        yum)
+            yum install -y "${PACKAGES[@]}"
+            ;;
+    esac
 }
 
-update_package_list()
-{
-    if [ $FLAVOR == "ubuntu" ]; then
-	case "$mode" in
-            runtime)
-                ub_runtime_packages
-                PKG_LIST=("${UB_RUNTIME_LIST[@]}")
-                ;;
-            build)
-                ub_buildtime_packages
-                PKG_LIST=("${UB_BUILDTIME_LIST[@]}")
-                ;;
-            baremetal)
-                ub_baremetal_packages
-                PKG_LIST=("${UB_BAREMETAL_LIST[@]}")
-                ;;
-            *)
-                echo "Invalid mode: $mode"
-                usage
-                ;;
-        esac
-    fi
+validate_packages() {
+    echo "[INFO] Validating packages: ${PACKAGES[*]}"
+    case "$PKG_MANAGER" in
+        apt)
+            dpkg -l "${PACKAGES[@]}"
+            ;;
+        dnf|yum)
+            rpm -q "${PACKAGES[@]}"
+            ;;
+    esac
 }
 
-validate_packages()
-{
-    if [ $FLAVOR == "ubuntu" ]; then
-        dpkg -l "${PKG_LIST[@]}"
-    fi
+cleanup_package_cache() {
+    echo "[INFO] Cleaning up package cache..."
+    case "$PKG_MANAGER" in
+        apt)
+            apt-get clean && rm -rf /var/lib/apt/lists/*
+            ;;
+        dnf)
+            dnf clean all
+            ;;
+        yum)
+            yum clean all
+            ;;
+    esac
 }
 
-prep_ubuntu_runtime()
-{
-    echo "Preparing ubuntu ..."
-    # Update the list of available packages
+# Initialize packages
+init_packages() {
+    # Determine package family based on OS
+    local pkg_family=""
+    case "$OS_ID" in
+        ubuntu|debian)
+            pkg_family="debian"
+            ;;
+        fedora|centos|rhel|rocky|almalinux)
+            pkg_family="redhat"
+            ;;
+        *)
+            # For distributions that are similar to supported ones
+            if [[ "$OS_ID_LIKE" == *"debian"* ]] || [[ "$OS_ID_LIKE" == *"ubuntu"* ]]; then
+                pkg_family="debian"
+            elif [[ "$OS_ID_LIKE" == *"rhel"* ]] || [[ "$OS_ID_LIKE" == *"fedora"* ]]; then
+                pkg_family="redhat"
+            else
+                echo "[ERROR] No package list available for $OS_ID (ID_LIKE: $OS_ID_LIKE)"
+                exit 1
+            fi
+            ;;
+    esac
+
+    # Set packages based on determined family
+    case "$pkg_family" in
+        debian)
+            # All packages needed for TT-Metal development
+            PACKAGES=(
+                "git"
+                "build-essential"
+                "cmake"
+                "ninja-build"
+                "pkg-config"
+                "cargo"
+                "g++"
+                "pandoc"
+                "xz-utils"
+                "python3-dev"
+                "python3-pip"
+                "python3-venv"
+                "libhwloc-dev"
+                "libnuma-dev"
+                "libatomic1"
+                "libstdc++6"
+                "libboost-dev"
+                "libtbb-dev"
+                "libcapstone-dev"
+                "libc++-17-dev"
+                "libc++abi-17-dev"
+            )
+            if [ "$distributed" -eq 1 ]; then
+                PACKAGES+=("openmpi-bin" "libopenmpi-dev")
+            fi
+            ;;
+        redhat)
+            PACKAGES=(
+                "git"
+                "gcc"
+                "gcc-c++"
+                "make"
+                "clang"
+                "cmake"
+                "ninja-build"
+                "pkgconfig"
+                "cargo"
+                "pandoc"
+                "xz"
+                "python3-devel"
+                "python3-pip"
+                "python3-virtualenv"
+                "hwloc-devel"
+                "numactl-devel"
+                "libatomic"
+                "libstdc++"
+                "boost-devel"
+                "tbb-devel"
+                "capstone-devel"
+                "libcxx-devel"
+                "libcxxabi-devel"
+            )
+            if [ "$distributed" -eq 1 ]; then
+                PACKAGES+=("openmpi" "openmpi-devel")
+            fi
+            ;;
+    esac
+}
+
+prep_system() {
+    echo "[INFO] Preparing system for TT-Metal development ($OS_ID)..."
+
+    case "$OS_ID" in
+        ubuntu|debian)
+            prep_ubuntu_system
+            ;;
+        fedora|centos|rhel|rocky|almalinux)
+            prep_redhat_system
+            ;;
+        *)
+            # For distributions that are similar to supported ones
+            if [[ "$OS_ID_LIKE" == *"debian"* ]] || [[ "$OS_ID_LIKE" == *"ubuntu"* ]]; then
+                prep_ubuntu_system
+            elif [[ "$OS_ID_LIKE" == *"rhel"* ]] || [[ "$OS_ID_LIKE" == *"fedora"* ]]; then
+                prep_redhat_system
+            else
+                echo "[WARNING] No specific system preparation for $OS_ID"
+            fi
+            ;;
+    esac
+}
+
+prep_ubuntu_system() {
+    echo "[INFO] Preparing Ubuntu/Debian system..."
+    # Update package lists and install basic tools
     apt-get update
     apt-get install -y --no-install-recommends ca-certificates gpg lsb-release wget software-properties-common gnupg jq
+
+    # Add LLVM repository for Clang 17
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-    echo "deb http://apt.llvm.org/$UBUNTU_CODENAME/ llvm-toolchain-$UBUNTU_CODENAME-17 main" | tee /etc/apt/sources.list.d/llvm-17.list
+    echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-17 main" | tee /etc/apt/sources.list.d/llvm-17.list
+
+    # Add Kitware repository for latest CMake
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $OS_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+
     apt-get update
 }
 
-prep_ubuntu_build()
-{
-    echo "Preparing ubuntu ..."
-    # Update the list of available packages
-    apt-get update
-    apt-get install -y --no-install-recommends ca-certificates gpg lsb-release wget software-properties-common gnupg jq
-    # The below is to bring cmake from kitware
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $UBUNTU_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-    apt-get update
+prep_redhat_system() {
+    echo "[INFO] Preparing Red Hat family system..."
+    # TODO: Implement Red Hat family system preparation
 }
 
 # We currently have an affinity to clang as it is more thoroughly tested in CI
@@ -191,11 +258,11 @@ prep_ubuntu_build()
 
 install_llvm() {
     LLVM_VERSION="17"
-    echo "Checking if LLVM $LLVM_VERSION is already installed..."
+    echo "[INFO] Checking if LLVM $LLVM_VERSION is already installed..."
     if command -v clang-$LLVM_VERSION &> /dev/null; then
-        echo "LLVM $LLVM_VERSION is already installed. Skipping installation."
+        echo "[INFO] LLVM $LLVM_VERSION is already installed. Skipping installation."
     else
-        echo "Installing LLVM $LLVM_VERSION..."
+        echo "[INFO] Installing LLVM $LLVM_VERSION..."
         TEMP_DIR=$(mktemp -d)
         wget -P $TEMP_DIR https://apt.llvm.org/llvm.sh
         chmod u+x $TEMP_DIR/llvm.sh
@@ -204,41 +271,12 @@ install_llvm() {
     fi
 }
 
-install_gcc() {
-    case "$VERSION" in
-        "22.04")
-            GCC_VER=12
-            ;;
-        "24.04")
-            GCC_VER=14
-            ;;
-        *)
-            echo "Unknown or unsupported Ubuntu version: $VERSION"
-            echo "Falling back to installing default g++..."
-            apt-get install -y --no-install-recommends g++
-            echo "Using g++ version: $(g++ --version | head -n1)"
-            return
-            ;;
-    esac
-
-    echo "Detected Ubuntu $VERSION, installing g++-$GCC_VER..."
-
-    apt-get install -y --no-install-recommends g++-$GCC_VER gcc-$GCC_VER
-
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$GCC_VER $GCC_VER
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$GCC_VER $GCC_VER
-    update-alternatives --set gcc /usr/bin/gcc-$GCC_VER
-    update-alternatives --set g++ /usr/bin/g++-$GCC_VER
-
-    echo "Using g++ version: $(g++ --version | head -n1)"
-}
-
 install_sfpi() {
     local version_file=$(dirname $0)/tt_metal/sfpi-version.sh
     if ! [[ -r $version_file ]] ; then
 	version_file=$(dirname $0)/sfpi-version.sh
 	if ! [[ -r $version_file ]] ; then
-	    echo "sfpi-version.sh not found" >&2
+	    echo "[ERROR] sfpi-version.sh not found" >&2
 	    exit 1
 	fi
     fi
@@ -249,21 +287,21 @@ install_sfpi() {
     elif rpm -q --qf '%{VERSION}' glibc >/dev/null 2>&1 ; then
 	pkg=rpm
     else
-	echo "Unknown packaging system" >&2
+	echo "[ERROR] Unknown packaging system" >&2
 	exit 1
     fi
     local $(grep -v '^#' $version_file)
     local sfpi_arch_os=$(uname -m)_$(uname -s)
     local sfpi_pkg_md5=$(eval echo "\$sfpi_${sfpi_arch_os}_${pkg}_md5")
     if [ -z $(eval echo "$sfpi_${pkg}_md5") ] ; then
-	echo "SFPI $pkg package for ${sfpi_arch_os} is not available" >&2
+	echo "[ERROR] SFPI $pkg package for ${sfpi_arch_os} is not available" >&2
 	exit 1
     fi
     local TEMP_DIR=$(mktemp -d)
     wget -P $TEMP_DIR "$sfpi_url/$sfpi_version/sfpi-${sfpi_arch_os}.${pkg}"
     if [ $(md5sum -b "${TEMP_DIR}/sfpi-${sfpi_arch_os}.${pkg}" | cut -d' ' -f1) \
 	     != "$sfpi_pkg_md5" ] ; then
-	echo "SFPI sfpi-${sfpi_arch_os}.${pkg} md5 mismatch" >&2
+	echo "[ERROR] SFPI sfpi-${sfpi_arch_os}.${pkg} md5 mismatch" >&2
 	rm -rf $TEMP_DIR
 	exit 1
     fi
@@ -282,15 +320,24 @@ install_sfpi() {
 install_mpi_ulfm(){
     # Only install if distributed flag is set
     if [ "$distributed" -ne 1 ]; then
-        echo "→ Skipping MPI ULFM installation (distributed mode not enabled)"
+        echo "[INFO] Skipping MPI ULFM installation (distributed mode not enabled)"
         return
+    fi
+
+    # Check if OS is Ubuntu/Debian-based
+    if [[ "$OS_ID" != "ubuntu" && "$OS_ID" != "debian" ]]; then
+        if [[ "$OS_ID_LIKE" != *"ubuntu"* && "$OS_ID_LIKE" != *"debian"* ]]; then
+            echo "[WARNING] MPI ULFM installation is currently only supported on Ubuntu/Debian-based distributions"
+            echo "[WARNING] This function needs to be expanded to support $OS_ID"
+            return
+        fi
     fi
 
     # Only install MPI ULFM for Ubuntu 24.04 or older
     local VERSION_NUM=$(echo "$VERSION" | sed 's/\.//')
 
     if [ "$VERSION_NUM" -gt "2404" ]; then
-        echo "→ Skipping MPI ULFM installation for Ubuntu $VERSION (only needed for 24.04 or older)"
+        echo "[INFO] Skipping MPI ULFM installation for Ubuntu $VERSION (only needed for 24.04 or older)"
         return
     fi
 
@@ -299,14 +346,14 @@ install_mpi_ulfm(){
 
     # 1. Create temp workspace
     TMP_DIR="$(mktemp -d)"
-    cleanup() { rm -rf "$TMP_DIR"; }
-    trap cleanup EXIT INT TERM
+    cleanup_mpi_temp() { rm -rf "$TMP_DIR"; }
+    trap cleanup_mpi_temp EXIT INT TERM
 
-    echo "→ Downloading $DEB_FILE …"
+    echo "[INFO] Downloading $DEB_FILE …"
     wget -q --show-progress -O "$TMP_DIR/$DEB_FILE" "$DEB_URL"
 
     # 2. Install
-    echo "→ Installing $DEB_FILE …"
+    echo "[INFO] Installing $DEB_FILE …"
     apt-get update -qq
     apt-get install -f -y "$TMP_DIR/$DEB_FILE"
 }
@@ -315,11 +362,20 @@ install_mpi_ulfm(){
 # This could be removed in the future
 
 configure_hugepages() {
+    # Check if OS is Ubuntu/Debian-based
+    if [[ "$OS_ID" != "ubuntu" && "$OS_ID" != "debian" ]]; then
+        if [[ "$OS_ID_LIKE" != *"ubuntu"* && "$OS_ID_LIKE" != *"debian"* ]]; then
+            echo "[WARNING] Hugepages configuration is currently only supported on Ubuntu/Debian-based distributions"
+            echo "[WARNING] This function needs to be expanded to support $OS_ID"
+            return
+        fi
+    fi
+
     # Fetch the lastest tt-tools release link and name of package
     TT_TOOLS_LINK=$(wget -qO- https://api.github.com/repos/tenstorrent/tt-system-tools/releases/latest | jq -r '.assets[] | select(.name | endswith(".deb")) | .browser_download_url')
     TT_TOOLS_NAME=$(wget -qO- https://api.github.com/repos/tenstorrent/tt-system-tools/releases/latest | jq -r '.assets[] | select(.name | endswith(".deb")) | .name')
 
-    echo "Installing Tenstorrent Hugepages Service $TT_TOOLS_NAME..."
+    echo "[INFO] Installing Tenstorrent Hugepages Service $TT_TOOLS_NAME..."
     TEMP_DIR=$(mktemp -d)
     wget -P $TEMP_DIR $TT_TOOLS_LINK
     apt-get install -y --no-install-recommends $TEMP_DIR/$TT_TOOLS_NAME
@@ -328,43 +384,81 @@ configure_hugepages() {
 }
 
 install() {
-    if [ $FLAVOR == "ubuntu" ]; then
-        echo "Installing packages..."
-	case "$mode" in
-            runtime)
-                prep_ubuntu_runtime
-                install_sfpi
-                install_mpi_ulfm
-                ;;
-            build)
-                prep_ubuntu_build
-                install_llvm
-                install_gcc
-                install_mpi_ulfm
-                ;;
-            baremetal)
-                prep_ubuntu_runtime
-                install_sfpi
-                prep_ubuntu_build
-                install_llvm
-                install_gcc
-                configure_hugepages
-                install_mpi_ulfm
-                ;;
-        esac
+    echo "[INFO] Installing TT-Metalium dependencies for $OS_ID ($PKG_MANAGER)..."
 
-	DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends "${PKG_LIST[@]}"
+    # Update package cache first
+    update_package_cache
 
+    # Prepare system (repositories, keys, etc.)
+    prep_system
+
+    # Install core packages
+    install_packages
+
+    # Install specialized components
+    install_sfpi
+    install_llvm
+    install_mpi_ulfm
+
+    # Configure system (hugepages, etc.) - only for baremetal (not docker)
+    if [ "$docker" -ne 1 ]; then
+        configure_hugepages
     fi
 }
 
 cleanup() {
-    if [ $FLAVOR == "ubuntu" ]; then
-        rm -rf /var/lib/apt/lists/*
+    if [ "$docker" -eq 1 ]; then
+        cleanup_package_cache
     fi
 }
 
-update_package_list
+# Alright, lets run some things!
+
+if [ "$EUID" -ne 0 ]; then
+    echo "This script must be run as root. Please use sudo."
+    usage
+fi
+
+VERSION=`grep '^VERSION_ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
+
+# Initialize OS detection and validation
+detect_os
+
+if ! is_supported_os; then
+    echo "Error: $OS_ID is not currently supported."
+    echo "Supported distributions: Ubuntu, Debian, Fedora, CentOS, RHEL, Rocky Linux, AlmaLinux"
+    exit 1
+fi
+
+validate=0
+docker=0
+distributed=1
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --help|-h)
+            usage
+            ;;
+        --validate|-v)
+            validate=1
+            shift
+            ;;
+        --docker|-d)
+            docker=1
+            shift
+            ;;
+        --no-distributed)
+            distributed=0
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+init_packages
 
 if [ "$validate" -eq 1 ]; then
     validate_packages
@@ -372,6 +466,6 @@ else
     install
 fi
 
-if [ "$docker" -eq 1 ]; then
-    cleanup
-fi
+cleanup
+
+echo "[INFO] TT-Metalium dependencies installed successfully!"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18294
closes https://github.com/tenstorrent/tt-metal/issues/23060

### Problem description
- `install_dependencies.sh` assumed Ubuntu 22.04 or 24.04.
- Implementation was perhaps overly complex, in that it tried to split dependencies between runtime phase and build time phase, to minimize the size of release docker images. The complexity is likely not worth the space savings, and really complicates supporting multiple distros.

### What's changed
Complete rewrite of the script in question.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15985898745) CI passes
- [x] New/Existing tests provide coverage for changes