### PR TITLE
skip testing pad_multi_core

### DIFF
--- a/tests/scripts/run_tt_metal.py
+++ b/tests/scripts/run_tt_metal.py
@@ -134,7 +134,6 @@ PROGRAMMING_EXAMPLE_ENTRIES = (
     # Does not work on WH yet.
     # TestEntry("programming_examples/matmul_multicore_reuse_mcast", "programming_examples/matmul_multicore_reuse_mcast"),
     TestEntry("programming_examples/contributed/vecadd", "programming_examples/contributed/vecadd"),
-    TestEntry("programming_examples/pad_multi_core", "programming_examples/pad_multi_core"),
 )
 
 


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/pull/23759 resulted in a failure in APC:
https://github.com/tenstorrent/tt-metal/actions/runs/15912535441/job/44886504994

This PR skips the failing programming example test case. 

