### PR TITLE
Add T3K unit tests to run with Dispatch on Fabric

### DIFF
--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k fabric tests", arch: wormhole_b0, cmd: run_t3000_ttfabric_tests, timeout: 10, owner_id: UJ45FEC7M}, # Allan Liu
+          { name: "t3k fabric tests", arch: wormhole_b0, cmd: run_t3000_ttfabric_tests, timeout: 15, owner_id: UJ45FEC7M}, # Allan Liu
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -52,9 +52,9 @@ run_t3000_ttfabric_tests() {
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=T3k*MeshGraphFabric2DDynamicTests*
 
-  ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-  ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric*MuxFixture.*"
-  ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=T3k*MeshGraphFabric2DDynamicTests*
+  TT_METAL_FD_FABRIC=true ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+  TT_METAL_FD_FABRIC=true ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric*MuxFixture.*"
+  TT_METAL_FD_FABRIC=true ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=T3k*MeshGraphFabric2DDynamicTests*
 
   # Unicast tests
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
@@ -87,7 +87,7 @@ run_t3000_ttnn_tests() {
   echo "LOG_METAL: Running run_t3000_ttnn_tests"
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./build/test/ttnn/unit_tests_ttnn
   ./build/test/ttnn/unit_tests_ttnn_ccl
-  ./build/test/ttnn/unit_tests_ttnn_ccl_multi_tensor
+  TT_METAL_FD_FABRIC=true ./build/test/ttnn/unit_tests_ttnn_ccl_multi_tensor
   ./build/test/ttnn/unit_tests_ttnn_ccl_ops
   ./build/test/ttnn/test_ccl_multi_cq_multi_device
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
@@ -135,7 +135,7 @@ run_t3000_falcon40b_tests() {
 
   echo "LOG_METAL: Running run_t3000_falcon40b_tests"
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py ; fail+=$?
 
 
   # Record the end time
@@ -194,13 +194,13 @@ run_t3000_llama3.2-11b_tests() {
   # Llama3.2-11B weights
   llama11b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-11B-Vision-Instruct/
 
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention.py ; fail+=$?
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention_prefill.py ; fail+=$?
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_embedding.py ; fail+=$?
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_mlp.py ; fail+=$?
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_rms_norm.py ; fail+=$?
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder.py ; fail+=$?
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder_prefill.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention_prefill.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_embedding.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_mlp.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_rms_norm.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder_prefill.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -114,9 +114,9 @@ run_t3000_falcon7b_tests() {
 
   echo "LOG_METAL: Running run_t3000_falcon7b_tests"
 
-  pytest -n auto models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_mlp.py ; fail+=$?
-  pytest -n auto models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_attention.py ; fail+=$?
-  pytest -n auto models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_decoder.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true pytest -n auto models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_mlp.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true pytest -n auto models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_attention.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true pytest -n auto models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_decoder.py ; fail+=$?
   #pytest models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
 
   # Record the end time
@@ -164,13 +164,13 @@ run_t3000_llama3-small_tests() {
 
   # Run all Llama3 tests for 1B, 3B and 8B weights
   for llama_dir in "$llama1b" "$llama3b" "$llama8b"; do
-    LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention.py ; fail+=$?
-    LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention_prefill.py ; fail+=$?
-    LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_embedding.py ; fail+=$?
-    LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_mlp.py ; fail+=$?
-    LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_rms_norm.py ; fail+=$?
-    LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder.py ; fail+=$?
-    LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder_prefill.py ; fail+=$?
+    TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention.py ; fail+=$?
+    TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention_prefill.py ; fail+=$?
+    TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_embedding.py ; fail+=$?
+    TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_mlp.py ; fail+=$?
+    TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_rms_norm.py ; fail+=$?
+    TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder.py ; fail+=$?
+    TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder_prefill.py ; fail+=$?
     echo "LOG_METAL: Llama3 tests for $llama_dir completed"
   done
 
@@ -222,13 +222,13 @@ run_t3000_llama3.1-70b_tests() {
   # Llama3.1-70B weights
   llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/
 
-  LLAMA_DIR=$llama70b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention.py ; fail+=$?
-  LLAMA_DIR=$llama70b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention_prefill.py ; fail+=$?
-  LLAMA_DIR=$llama70b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_embedding.py ; fail+=$?
-  LLAMA_DIR=$llama70b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_mlp.py ; fail+=$?
-  LLAMA_DIR=$llama70b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_rms_norm.py ; fail+=$?
-  LLAMA_DIR=$llama70b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder.py ; fail+=$?
-  LLAMA_DIR=$llama70b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder_prefill.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama70b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama70b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention_prefill.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama70b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_embedding.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama70b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_mlp.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama70b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_rms_norm.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama70b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama70b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder_prefill.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
@@ -251,13 +251,13 @@ run_t3000_llama3.2-90b_tests() {
   # use repacked weights to shorten unit test time by loading only the necessary weights
   llama90b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-90B-Vision-Instruct/repacked/
 
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention.py ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention_prefill.py ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_embedding.py ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_mlp.py ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_rms_norm.py ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder.py ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder_prefill.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_attention_prefill.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_embedding.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_mlp.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_rms_norm.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_decoder_prefill.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
@@ -277,13 +277,13 @@ run_t3000_mistral_tests() {
   tt_cache_path="/mnt/MLPerf/tt_dnn-models/Mistral/TT_CACHE/Mistral-7B-Instruct-v0.3"
   hf_model="/mnt/MLPerf/tt_dnn-models/Mistral/hub/models--mistralai--Mistral-7B-Instruct-v0.3/snapshots/e0bc86c23ce5aae1db576c8cca6f06f1f73af2db"
 
-  WH_ARCH_YAML=$wh_arch_yaml TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest -n auto models/tt_transformers/tests/test_attention.py
-  WH_ARCH_YAML=$wh_arch_yaml TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest -n auto models/tt_transformers/tests/test_attention_prefill.py
-  WH_ARCH_YAML=$wh_arch_yaml TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest -n auto models/tt_transformers/tests/test_embedding.py
-  WH_ARCH_YAML=$wh_arch_yaml TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest -n auto models/tt_transformers/tests/test_mlp.py
-  WH_ARCH_YAML=$wh_arch_yaml TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest -n auto models/tt_transformers/tests/test_rms_norm.py
-  WH_ARCH_YAML=$wh_arch_yaml TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest -n auto models/tt_transformers/tests/test_decoder.py
-  WH_ARCH_YAML=$wh_arch_yaml TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest -n auto models/tt_transformers/tests/test_decoder_prefill.py
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=$wh_arch_yaml TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest -n auto models/tt_transformers/tests/test_attention.py
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=$wh_arch_yaml TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest -n auto models/tt_transformers/tests/test_attention_prefill.py
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=$wh_arch_yaml TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest -n auto models/tt_transformers/tests/test_embedding.py
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=$wh_arch_yaml TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest -n auto models/tt_transformers/tests/test_mlp.py
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=$wh_arch_yaml TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest -n auto models/tt_transformers/tests/test_rms_norm.py
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=$wh_arch_yaml TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest -n auto models/tt_transformers/tests/test_decoder.py
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=$wh_arch_yaml TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest -n auto models/tt_transformers/tests/test_decoder_prefill.py
 
 }
 
@@ -298,15 +298,15 @@ run_t3000_llama3.2-11b-vision_unit_tests() {
   # Llama3.2-11B
   llama11b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-11B-Vision-Instruct/
 
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_mlp.py ; fail+=$?
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_attention.py ; fail+=$?
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_block.py ; fail+=$?
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_cross_attention.py -k "batch_1" ; fail+=$?
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_cross_block.py -k "batch_1" ; fail+=$?
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_conv2d_patch.py ; fail+=$?
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_class_embedding.py ; fail+=$?
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_tile_position_embedding.py ; fail+=$?
-  LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_positional_embedding.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_mlp.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_attention.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_block.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_cross_attention.py -k "batch_1" ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_cross_block.py -k "batch_1" ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_conv2d_patch.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_class_embedding.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_tile_position_embedding.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_positional_embedding.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
@@ -330,15 +330,15 @@ run_t3000_spoof_n300_llama3.2-11b-vision_unit_tests() {
   # Use MESH_DEVICE env variable to run on an N300 mesh
   mesh_device=N300
 
-  MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_mlp.py ; fail+=$?
-  MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_attention.py ; fail+=$?
-  MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_block.py ; fail+=$?
-  MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_cross_attention.py -k "batch_1" ; fail+=$?
-  MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_cross_block.py -k "batch_1" ; fail+=$?
-  MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_conv2d_patch.py ; fail+=$?
-  MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_class_embedding.py ; fail+=$?
-  MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_tile_position_embedding.py ; fail+=$?
-  MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_positional_embedding.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_mlp.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_attention.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_block.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_cross_attention.py -k "batch_1" ; fail+=$?
+  TT_METAL_FD_FABRIC=true MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_cross_block.py -k "batch_1" ; fail+=$?
+  TT_METAL_FD_FABRIC=true MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_conv2d_patch.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_class_embedding.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_tile_position_embedding.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true MESH_DEVICE=$mesh_device LLAMA_DIR=$llama11b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_positional_embedding.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
@@ -360,15 +360,15 @@ run_t3000_llama3.2-90b-vision_unit_tests() {
   # use repacked weights to shorten unit test time by loading only the necessary weights
   llama90b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-90B-Vision-Instruct/repacked/
 
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_mlp.py ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_attention.py ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_block.py ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_cross_attention.py -k "batch_1" ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_cross_block.py -k "batch_1" ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_conv2d_patch.py ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_class_embedding.py ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_tile_position_embedding.py ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_positional_embedding.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_mlp.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_attention.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_image_block.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_cross_attention.py -k "batch_1" ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_cross_block.py -k "batch_1" ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_conv2d_patch.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_class_embedding.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_tile_position_embedding.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/multimodal/test_llama_positional_embedding.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
@@ -386,15 +386,15 @@ run_t3000_mixtral_tests() {
 
   echo "LOG_METAL: Running run_t3000_mixtral_tests"
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py ; fail+=$?
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py ; fail+=$?
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py ; fail+=$?
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py ; fail+=$?
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py ; fail+=$?
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py ; fail+=$?
   # Mixtral prefill tests
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp_prefill.py ; fail+=$?
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe_prefill.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp_prefill.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe_prefill.py ; fail+=$?
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
@@ -411,10 +411,10 @@ run_t3000_grok_tests() {
 
   echo "LOG_METAL: Running run_t3000_grok_tests"
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/grok/tests/test_grok_rms_norm.py ; fail+=$?
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/grok/tests/test_grok_attention.py ; fail+=$?
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/grok/tests/test_grok_mlp.py --timeout=500; fail+=$?
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/grok/tests/test_grok_moe.py --timeout=600; fail+=$?
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/grok/tests/test_grok_rms_norm.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/grok/tests/test_grok_attention.py ; fail+=$?
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/grok/tests/test_grok_mlp.py --timeout=500; fail+=$?
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/grok/tests/test_grok_moe.py --timeout=600; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
@@ -432,7 +432,7 @@ run_t3000_unet_shallow_tests() {
 
   echo "LOG_METAL: Running run_t3000_unet_shallow_tests"
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests/test_unet_multi_device.py; fail+=$?
+  TT_METAL_FD_FABRIC=true WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests/test_unet_multi_device.py; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -1,4 +1,4 @@
-
+(
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -64,704 +64,742 @@
 #include "ttnn/tensor/types.hpp"
 #include "umd/device/types/arch.h"
 
-////////////////////////////////////////////////////////////////////
-///  MESSAGE COUNT TERMINATION MODE
-////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////
+    ///  MESSAGE COUNT TERMINATION MODE
+    ////////////////////////////////////////////////////////////////////
 
-// -------------------------
-// Persistent Fabric
-// -------------------------
+    // -------------------------
+    // Persistent Fabric
+    // -------------------------
 
-TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_SingleMessage_PersistentFabric) {
-    const uint32_t page_size = 2048;
-    const uint32_t num_pages_total = 1;
-    const bool src_is_dram = true;
-    const bool dest_is_dram = true;
+    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_SingleMessage_PersistentFabric) {
+        const uint32_t page_size = 2048;
+        const uint32_t num_pages_total = 1;
+        const bool src_is_dram = true;
+        const bool dest_is_dram = true;
 
-    auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
-    ASSERT_EQ(result, 0);
-}
+        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
+        ASSERT_EQ(result, 0);
+    }
 
-// Will wrapp sender but not receiver buffers
-TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_2_messages_PersistentFabric) {
-    const uint32_t page_size = 2048;
-    const uint32_t num_pages_total = 2;
-    const bool src_is_dram = true;
-    const bool dest_is_dram = true;
+    // Will wrapp sender but not receiver buffers
+    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_2_messages_PersistentFabric) {
+        const uint32_t page_size = 2048;
+        const uint32_t num_pages_total = 2;
+        const bool src_is_dram = true;
+        const bool dest_is_dram = true;
 
-    auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
-    ASSERT_EQ(result, 0);
-}
-// Will wrapp sender but not receiver buffers
-TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_10_messages_PersistentFabric) {
-    const uint32_t page_size = 2048;
-    const uint32_t num_pages_total = 10;
-    const bool src_is_dram = true;
-    const bool dest_is_dram = true;
+        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
+        ASSERT_EQ(result, 0);
+    }
+#ifdef ARCH_WORMHOLE
+    // Will wrapp sender but not receiver buffers
+    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_2_messages_PersistentFabric_Scatter) {
+        const uint32_t page_size = 2048;
+        const uint32_t num_pages_total = 2;
+        const bool src_is_dram = true;
+        const bool dest_is_dram = true;
 
-    auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
-    ASSERT_EQ(result, 0);
-}
+        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram, true);
+        ASSERT_EQ(result, 0);
+    } TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_3_messages_PersistentFabric_Scatter) {
+        const uint32_t page_size = 2048;
+        const uint32_t num_pages_total = 3;
+        const bool src_is_dram = true;
+        const bool dest_is_dram = true;
 
-// Will wrapp sender and receiver buffers
-TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_20_messages_PersistentFabric) {
-    const uint32_t page_size = 2048;
-    const uint32_t num_pages_total = 20;
-    const bool src_is_dram = true;
-    const bool dest_is_dram = true;
+        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram, true);
+        ASSERT_EQ(result, 0);
+    }
+    // Will wrapp sender but not receiver buffers
+    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_10_messages_PersistentFabric_Scatter) {
+        const uint32_t page_size = 2048;
+        const uint32_t num_pages_total = 10;
+        const bool src_is_dram = true;
+        const bool dest_is_dram = true;
 
-    auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
-    ASSERT_EQ(result, 0);
-}
+        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram, true);
+        ASSERT_EQ(result, 0);
+    }
+    // Will wrapp sender and receiver buffers
+    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_20_messages_PersistentFabric_Scatter) {
+        const uint32_t page_size = 2048;
+        const uint32_t num_pages_total = 20;
+        const bool src_is_dram = true;
+        const bool dest_is_dram = true;
 
-TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_PersistentFabric) {
-    const uint32_t page_size = 2048;
-    const uint32_t num_pages_total = 10000;
-    const bool src_is_dram = true;
-    const bool dest_is_dram = true;
+        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram, true);
+        ASSERT_EQ(result, 0);
+    }
+#endif
+    // Will wrapp sender but not receiver buffers
+    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_10_messages_PersistentFabric) {
+        const uint32_t page_size = 2048;
+        const uint32_t num_pages_total = 10;
+        const bool src_is_dram = true;
+        const bool dest_is_dram = true;
 
-    auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
-    ASSERT_EQ(result, 0);
-}
+        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
+        ASSERT_EQ(result, 0);
+    }
 
-////////////////////////////////
+    // Will wrapp sender and receiver buffers
+    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_20_messages_PersistentFabric) {
+        const uint32_t page_size = 2048;
+        const uint32_t num_pages_total = 20;
+        const bool src_is_dram = true;
+        const bool dest_is_dram = true;
 
-TEST(WorkerFabricEdmDatapath, LineFabricMcast_SingleMessage_SingleSource_PersistentFabric) {
-    const uint32_t page_size = 2048;
-    const uint32_t num_pages_total = 1;
-    const bool src_is_dram = true;
-    const bool dest_is_dram = true;
-    const size_t mcast_first_chip = 1;
-    const size_t mcast_last_chip = 3;
+        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
+        ASSERT_EQ(result, 0);
+    }
 
-    auto result = TestLineFabricEntrypoint(
-        mcast_first_chip, mcast_last_chip, page_size, num_pages_total, src_is_dram, dest_is_dram);
+    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_PersistentFabric) {
+        const uint32_t page_size = 2048;
+        const uint32_t num_pages_total = 10000;
+        const bool src_is_dram = true;
+        const bool dest_is_dram = true;
 
-    ASSERT_EQ(result, 0);
-}
+        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
+        ASSERT_EQ(result, 0);
+    }
 
-// Non-functional on harvested parts. Needs testing on unharvested parts.
-TEST(WorkerFabricEdmDatapath, LineFabricMcast_ManyMessages_SingleSource_PersistentFabric) {
-    const uint32_t page_size = 2048;
-    const uint32_t num_pages_total = 10000;
-    const bool src_is_dram = true;
-    const bool dest_is_dram = true;
-    const size_t mcast_first_chip = 1;
-    const size_t mcast_last_chip = 3;
+    ////////////////////////////////
 
-    auto result = TestLineFabricEntrypoint(
-        mcast_first_chip, mcast_last_chip, page_size, num_pages_total, src_is_dram, dest_is_dram);
+    TEST(WorkerFabricEdmDatapath, LineFabricMcast_SingleMessage_SingleSource_PersistentFabric) {
+        const uint32_t page_size = 2048;
+        const uint32_t num_pages_total = 1;
+        const bool src_is_dram = true;
+        const bool dest_is_dram = true;
+        const size_t mcast_first_chip = 1;
+        const size_t mcast_last_chip = 3;
 
-    ASSERT_EQ(result, 0);
-}
+        auto result = TestLineFabricEntrypoint(
+            mcast_first_chip, mcast_last_chip, page_size, num_pages_total, src_is_dram, dest_is_dram);
 
-////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////
-////               LOCAL CHIP TENSOR READ?WRITE (2 INPUT)
-////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////
+        ASSERT_EQ(result, 0);
+    }
 
-TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_SinglePageTile) {
-    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-        ttnn::Shape({1, 1, 32, 32}),
-        Layout::TILE,
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-    ASSERT_TRUE(pass);
-}
+    // Non-functional on harvested parts. Needs testing on unharvested parts.
+    TEST(WorkerFabricEdmDatapath, LineFabricMcast_ManyMessages_SingleSource_PersistentFabric) {
+        const uint32_t page_size = 2048;
+        const uint32_t num_pages_total = 10000;
+        const bool src_is_dram = true;
+        const bool dest_is_dram = true;
+        const size_t mcast_first_chip = 1;
+        const size_t mcast_last_chip = 3;
 
-TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0) {
-    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-        ttnn::Shape({1, 1, 32, 64}),
-        Layout::TILE,
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-    ASSERT_TRUE(pass);
-}
+        auto result = TestLineFabricEntrypoint(
+            mcast_first_chip, mcast_last_chip, page_size, num_pages_total, src_is_dram, dest_is_dram);
 
-TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded) {
-    ttnn::Shape tensor_shape({1, 1, 32, 64});
-    auto mem_config = MemoryConfig(
-        TensorMemoryLayout::WIDTH_SHARDED,
-        BufferType::L1,
-        ShardSpec(
-            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}}},
-            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3]},
-            ShardOrientation::ROW_MAJOR,
-            ShardMode::LOGICAL));
-    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-        tensor_shape,
-        Layout::TILE,
-        mem_config,
-        mem_config,
-        mem_config,
-        mem_config,
-        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-    ASSERT_TRUE(pass);
-}
-TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded1) {
-    ttnn::Shape tensor_shape({1, 1, 32, 128});
-    auto mem_config = MemoryConfig(
-        TensorMemoryLayout::WIDTH_SHARDED,
-        BufferType::L1,
-        ShardSpec(
-            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}}},
-            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3]},
-            ShardOrientation::ROW_MAJOR,
-            ShardMode::LOGICAL));
-    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-        tensor_shape,
-        Layout::TILE,
-        mem_config,
-        mem_config,
-        mem_config,
-        mem_config,
-        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-    ASSERT_TRUE(pass);
-}
-TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded2) {
-    ttnn::Shape tensor_shape({1, 1, 32, 128});
-    auto mem_config = MemoryConfig(
-        TensorMemoryLayout::WIDTH_SHARDED,
-        BufferType::L1,
-        ShardSpec(
-            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}}},
-            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / 4},
-            ShardOrientation::ROW_MAJOR,
-            ShardMode::LOGICAL));
-    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-        tensor_shape,
-        Layout::TILE,
-        mem_config,
-        mem_config,
-        mem_config,
-        mem_config,
-        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-    ASSERT_TRUE(pass);
-}
-TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded3) {
-    ttnn::Shape tensor_shape({1, 1, 32, 8192});
-    size_t ncores_x = 8;
-    size_t ncores_y = 4;
-    auto mem_config = MemoryConfig(
-        TensorMemoryLayout::WIDTH_SHARDED,
-        BufferType::L1,
-        ShardSpec(
-            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{ncores_x - 1, ncores_y - 1}}}},
-            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / (ncores_x * ncores_y)},
-            ShardOrientation::ROW_MAJOR,
-            ShardMode::LOGICAL));
-    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-        tensor_shape,
-        Layout::TILE,
-        mem_config,
-        mem_config,
-        mem_config,
-        mem_config,
-        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-    ASSERT_TRUE(pass);
-}
-TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded4) {
-    ttnn::Shape tensor_shape({1, 1, 32, 1024});
-    size_t ncores_x = 8;
-    size_t ncores_y = 4;
-    auto mem_config = MemoryConfig(
-        TensorMemoryLayout::WIDTH_SHARDED,
-        BufferType::L1,
-        ShardSpec(
-            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{ncores_x - 1, ncores_y - 1}}}},
-            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / (ncores_x * ncores_y)},
-            ShardOrientation::ROW_MAJOR,
-            ShardMode::LOGICAL));
-    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-        tensor_shape,
-        Layout::TILE,
-        mem_config,
-        mem_config,
-        mem_config,
-        mem_config,
-        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-    ASSERT_TRUE(pass);
-}
+        ASSERT_EQ(result, 0);
+    }
 
-TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded_WithReshard0) {
-    ttnn::Shape tensor_shape({1, 1, 32, 128});
-    const Layout layout = Layout::TILE;
-    auto input_mem_config = MemoryConfig(
-        TensorMemoryLayout::WIDTH_SHARDED,
-        BufferType::L1,
-        ShardSpec(
-            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}}},
-            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3]},
-            ShardOrientation::ROW_MAJOR,
-            ShardMode::LOGICAL));
-    auto output_mem_config = MemoryConfig(
-        TensorMemoryLayout::WIDTH_SHARDED,
-        BufferType::L1,
-        ShardSpec(
-            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}}},
-            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / 4},
-            ShardOrientation::ROW_MAJOR,
-            ShardMode::LOGICAL));
-    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-        tensor_shape,
-        Layout::TILE,
-        input_mem_config,
-        input_mem_config,
-        output_mem_config,
-        output_mem_config,
-        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-    ASSERT_TRUE(pass);
-}
+    ////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////
+    ////               LOCAL CHIP TENSOR READ?WRITE (2 INPUT)
+    ////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////
 
-TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded_WithReshard0_UniquePerStream) {
-    ttnn::Shape tensor_shape({1, 1, 32, 128});
-    const Layout layout = Layout::TILE;
-    size_t in_shard_grid_x = 1;
-    size_t in_shard_grid_y = 1;
-    size_t out_shard_grid_x = 4;
-    size_t out_shard_grid_y = 1;
-    auto mem_config0 = MemoryConfig(
-        TensorMemoryLayout::WIDTH_SHARDED,
-        BufferType::L1,
-        ShardSpec(
-            CoreRangeSet{
-                std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{in_shard_grid_x - 1, in_shard_grid_y - 1}}}},
-            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2],
-             tensor_shape[3] / (in_shard_grid_x * in_shard_grid_y)},
-            ShardOrientation::ROW_MAJOR,
-            ShardMode::LOGICAL));
-    auto mem_config1 = MemoryConfig(
-        TensorMemoryLayout::WIDTH_SHARDED,
-        BufferType::L1,
-        ShardSpec(
-            CoreRangeSet{
-                std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{out_shard_grid_x - 1, out_shard_grid_y - 1}}}},
-            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2],
-             tensor_shape[3] / (out_shard_grid_x * out_shard_grid_y)},
-            ShardOrientation::ROW_MAJOR,
-            ShardMode::LOGICAL));
-    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-        tensor_shape,
-        Layout::TILE,
-        mem_config0,
-        mem_config1,
-        mem_config1,
-        mem_config0,
-        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-    ASSERT_TRUE(pass);
-}
+    TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_SinglePageTile) {
+        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+            ttnn::Shape({1, 1, 32, 32}),
+            Layout::TILE,
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+        ASSERT_TRUE(pass);
+    }
 
-// Copying even slightly large tensors exposes issues in underlying tensor code
-// that isn't under test here
-TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage1) {
-    ttnn::Shape tensor_shape({1, 1, 256, 256});
-    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-        tensor_shape,
-        Layout::TILE,
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-    ASSERT_TRUE(pass);
-}
+    TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0) {
+        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+            ttnn::Shape({1, 1, 32, 64}),
+            Layout::TILE,
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+        ASSERT_TRUE(pass);
+    }
 
-// TODO: update the test infra to be able to properly compare tensors if we are only
-// doing a slice of the larger tensor
+    TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded) {
+        ttnn::Shape tensor_shape({1, 1, 32, 64});
+        auto mem_config = MemoryConfig(
+            TensorMemoryLayout::WIDTH_SHARDED,
+            BufferType::L1,
+            ShardSpec(
+                CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}}},
+                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3]},
+                ShardOrientation::ROW_MAJOR,
+                ShardMode::LOGICAL));
+        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+            tensor_shape,
+            Layout::TILE,
+            mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
+            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+        ASSERT_TRUE(pass);
+    } TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded1) {
+        ttnn::Shape tensor_shape({1, 1, 32, 128});
+        auto mem_config = MemoryConfig(
+            TensorMemoryLayout::WIDTH_SHARDED,
+            BufferType::L1,
+            ShardSpec(
+                CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}}},
+                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3]},
+                ShardOrientation::ROW_MAJOR,
+                ShardMode::LOGICAL));
+        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+            tensor_shape,
+            Layout::TILE,
+            mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
+            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+        ASSERT_TRUE(pass);
+    } TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded2) {
+        ttnn::Shape tensor_shape({1, 1, 32, 128});
+        auto mem_config = MemoryConfig(
+            TensorMemoryLayout::WIDTH_SHARDED,
+            BufferType::L1,
+            ShardSpec(
+                CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}}},
+                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / 4},
+                ShardOrientation::ROW_MAJOR,
+                ShardMode::LOGICAL));
+        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+            tensor_shape,
+            Layout::TILE,
+            mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
+            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+        ASSERT_TRUE(pass);
+    } TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded3) {
+        ttnn::Shape tensor_shape({1, 1, 32, 8192});
+        size_t ncores_x = 8;
+        size_t ncores_y = 4;
+        auto mem_config = MemoryConfig(
+            TensorMemoryLayout::WIDTH_SHARDED,
+            BufferType::L1,
+            ShardSpec(
+                CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{ncores_x - 1, ncores_y - 1}}}},
+                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / (ncores_x * ncores_y)},
+                ShardOrientation::ROW_MAJOR,
+                ShardMode::LOGICAL));
+        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+            tensor_shape,
+            Layout::TILE,
+            mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
+            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+        ASSERT_TRUE(pass);
+    } TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded4) {
+        ttnn::Shape tensor_shape({1, 1, 32, 1024});
+        size_t ncores_x = 8;
+        size_t ncores_y = 4;
+        auto mem_config = MemoryConfig(
+            TensorMemoryLayout::WIDTH_SHARDED,
+            BufferType::L1,
+            ShardSpec(
+                CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{ncores_x - 1, ncores_y - 1}}}},
+                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / (ncores_x * ncores_y)},
+                ShardOrientation::ROW_MAJOR,
+                ShardMode::LOGICAL));
+        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+            tensor_shape,
+            Layout::TILE,
+            mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
+            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+        ASSERT_TRUE(pass);
+    }
 
-// ////////////////////////////////////////////////////////////////////
-// ////////////////////////////////////////////////////////////////////
-// ////               FABRIC UNICAST TENSOR WRITE (2 INPUT)
-// ////////////////////////////////////////////////////////////////////
-// ////////////////////////////////////////////////////////////////////
+    TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded_WithReshard0) {
+        ttnn::Shape tensor_shape({1, 1, 32, 128});
+        const Layout layout = Layout::TILE;
+        auto input_mem_config = MemoryConfig(
+            TensorMemoryLayout::WIDTH_SHARDED,
+            BufferType::L1,
+            ShardSpec(
+                CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}}},
+                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3]},
+                ShardOrientation::ROW_MAJOR,
+                ShardMode::LOGICAL));
+        auto output_mem_config = MemoryConfig(
+            TensorMemoryLayout::WIDTH_SHARDED,
+            BufferType::L1,
+            ShardSpec(
+                CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}}},
+                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / 4},
+                ShardOrientation::ROW_MAJOR,
+                ShardMode::LOGICAL));
+        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+            tensor_shape,
+            Layout::TILE,
+            input_mem_config,
+            input_mem_config,
+            output_mem_config,
+            output_mem_config,
+            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+        ASSERT_TRUE(pass);
+    }
 
-TEST(WorkerCclCommandProcessingKernelFabricUnicastMode, MultiInputReader_SinglePageTile_OneHop_PersistentFabric) {
-    ttnn::Shape tensor_shape({1, 1, 32, 32});
-    constexpr size_t distance_dest_device = 1;
-    constexpr size_t num_devices = 4;
-    const Layout layout = Layout::TILE;
-    const MemoryConfig in0_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
-    const MemoryConfig in1_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
-    const MemoryConfig out0_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
-    const MemoryConfig out1_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
+    TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded_WithReshard0_UniquePerStream) {
+        ttnn::Shape tensor_shape({1, 1, 32, 128});
+        const Layout layout = Layout::TILE;
+        size_t in_shard_grid_x = 1;
+        size_t in_shard_grid_y = 1;
+        size_t out_shard_grid_x = 4;
+        size_t out_shard_grid_y = 1;
+        auto mem_config0 = MemoryConfig(
+            TensorMemoryLayout::WIDTH_SHARDED,
+            BufferType::L1,
+            ShardSpec(
+                CoreRangeSet{std::set<CoreRange>{
+                    CoreRange{CoreCoord{0, 0}, CoreCoord{in_shard_grid_x - 1, in_shard_grid_y - 1}}}},
+                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2],
+                 tensor_shape[3] / (in_shard_grid_x * in_shard_grid_y)},
+                ShardOrientation::ROW_MAJOR,
+                ShardMode::LOGICAL));
+        auto mem_config1 = MemoryConfig(
+            TensorMemoryLayout::WIDTH_SHARDED,
+            BufferType::L1,
+            ShardSpec(
+                CoreRangeSet{std::set<CoreRange>{
+                    CoreRange{CoreCoord{0, 0}, CoreCoord{out_shard_grid_x - 1, out_shard_grid_y - 1}}}},
+                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2],
+                 tensor_shape[3] / (out_shard_grid_x * out_shard_grid_y)},
+                ShardOrientation::ROW_MAJOR,
+                ShardMode::LOGICAL));
+        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+            tensor_shape,
+            Layout::TILE,
+            mem_config0,
+            mem_config1,
+            mem_config1,
+            mem_config0,
+            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+        ASSERT_TRUE(pass);
+    }
 
-    auto num_elems = std::reduce(tensor_shape.cbegin(), tensor_shape.cend(), 1, std::multiplies<uint32_t>());
-    Tensor input_tensor0 =
-        ttnn::experimental::view(ttnn::arange(0, num_elems, 1, DataType::UINT32), tensor_shape).to_layout(layout);
-    Tensor input_tensor1 =
-        ttnn::experimental::view(ttnn::arange(num_elems, 2 * num_elems, 1, DataType::UINT32), tensor_shape)
-            .to_layout(layout);
-    Tensor output_tensor0 = ttnn::experimental::view(ttnn::ones(tensor_shape, DataType::UINT32, layout), tensor_shape);
-    Tensor output_tensor1 = ttnn::experimental::view(ttnn::ones(tensor_shape, DataType::UINT32, layout), tensor_shape);
+    // Copying even slightly large tensors exposes issues in underlying tensor code
+    // that isn't under test here
+    TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage1) {
+        ttnn::Shape tensor_shape({1, 1, 256, 256});
+        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+            tensor_shape,
+            Layout::TILE,
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+        ASSERT_TRUE(pass);
+    }
 
-    size_t page_size = tile_size(DataFormat::RawUInt32);
+    // TODO: update the test infra to be able to properly compare tensors if we are only
+    // doing a slice of the larger tensor
 
-    ttnn::ccl::Shape4D<uint32_t> tensor_shape_in_pages = shape_to_shape_in_tiles(tensor_shape);
-    ttnn::ccl::Shape4D<uint32_t> tensor_slice_shape_in_pages = tensor_shape_in_pages;
-    ttnn::ccl::Shape4D<uint32_t> tensor_slice_offset = {0, 0, 0, 0};
-    ttnn::ccl::Shape4D<uint32_t> worker_slice_shape = tensor_shape_in_pages;
-    ttnn::ccl::Shape4D<uint32_t> worker_slice_offset = {0, 0, 0, 0};
+    // ////////////////////////////////////////////////////////////////////
+    // ////////////////////////////////////////////////////////////////////
+    // ////               FABRIC UNICAST TENSOR WRITE (2 INPUT)
+    // ////////////////////////////////////////////////////////////////////
+    // ////////////////////////////////////////////////////////////////////
 
-    ttnn::ccl::v2::TensorSlice tensor_slice{
-        tensor_shape_in_pages,
-        tensor_slice_shape_in_pages,
-        tensor_slice_offset,
-        worker_slice_shape,
-        worker_slice_offset};
+    TEST(WorkerCclCommandProcessingKernelFabricUnicastMode, MultiInputReader_SinglePageTile_OneHop_PersistentFabric) {
+        ttnn::Shape tensor_shape({1, 1, 32, 32});
+        constexpr size_t distance_dest_device = 1;
+        constexpr size_t num_devices = 4;
+        const Layout layout = Layout::TILE;
+        const MemoryConfig in0_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
+        const MemoryConfig in1_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
+        const MemoryConfig out0_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
+        const MemoryConfig out1_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
 
-    const auto in0_tensor_slice = tensor_slice;
-    const auto in1_tensor_slice = tensor_slice;
-    const auto out0_tensor_slice = tensor_slice;
-    const auto out1_tensor_slice = tensor_slice;
+        auto num_elems = std::reduce(tensor_shape.cbegin(), tensor_shape.cend(), 1, std::multiplies<uint32_t>());
+        Tensor input_tensor0 =
+            ttnn::experimental::view(ttnn::arange(0, num_elems, 1, DataType::UINT32), tensor_shape).to_layout(layout);
+        Tensor input_tensor1 =
+            ttnn::experimental::view(ttnn::arange(num_elems, 2 * num_elems, 1, DataType::UINT32), tensor_shape)
+                .to_layout(layout);
+        Tensor output_tensor0 =
+            ttnn::experimental::view(ttnn::ones(tensor_shape, DataType::UINT32, layout), tensor_shape);
+        Tensor output_tensor1 =
+            ttnn::experimental::view(ttnn::ones(tensor_shape, DataType::UINT32, layout), tensor_shape);
 
-    ttnn::ccl::cmd::CclCommandDestArgs dest_args = ttnn::ccl::cmd::UnicastCommandDestArgs{distance_dest_device, true};
-    auto pass = TestMultiInputReaderKernel(
-        num_devices,
-        input_tensor0,
-        in0_memory_config,
-        input_tensor1,
-        in1_memory_config,
-        output_tensor0,
-        out0_memory_config,
-        output_tensor1,
-        out1_memory_config,
+        size_t page_size = tile_size(DataFormat::RawUInt32);
 
-        in0_tensor_slice,
-        in1_tensor_slice,
-        out0_tensor_slice,
-        out1_tensor_slice,
+        ttnn::ccl::Shape4D<uint32_t> tensor_shape_in_pages = shape_to_shape_in_tiles(tensor_shape);
+        ttnn::ccl::Shape4D<uint32_t> tensor_slice_shape_in_pages = tensor_shape_in_pages;
+        ttnn::ccl::Shape4D<uint32_t> tensor_slice_offset = {0, 0, 0, 0};
+        ttnn::ccl::Shape4D<uint32_t> worker_slice_shape = tensor_shape_in_pages;
+        ttnn::ccl::Shape4D<uint32_t> worker_slice_offset = {0, 0, 0, 0};
 
-        page_size,
-        TwoInputReaderKernelWriteMode::FABRIC_UNICAST,
-        dest_args);
+        ttnn::ccl::v2::TensorSlice tensor_slice{
+            tensor_shape_in_pages,
+            tensor_slice_shape_in_pages,
+            tensor_slice_offset,
+            worker_slice_shape,
+            worker_slice_offset};
 
-    ASSERT_TRUE(pass);
-}
+        const auto in0_tensor_slice = tensor_slice;
+        const auto in1_tensor_slice = tensor_slice;
+        const auto out0_tensor_slice = tensor_slice;
+        const auto out1_tensor_slice = tensor_slice;
 
-// ////////////////////////////////////////////////////////////////////
-// ////////////////////////////////////////////////////////////////////
-// ////               FABRIC MCAST TENSOR WRITE (2 INPUT)
-// ////////////////////////////////////////////////////////////////////
-// ////////////////////////////////////////////////////////////////////
+        ttnn::ccl::cmd::CclCommandDestArgs dest_args =
+            ttnn::ccl::cmd::UnicastCommandDestArgs{distance_dest_device, true};
+        auto pass = TestMultiInputReaderKernel(
+            num_devices,
+            input_tensor0,
+            in0_memory_config,
+            input_tensor1,
+            in1_memory_config,
+            output_tensor0,
+            out0_memory_config,
+            output_tensor1,
+            out1_memory_config,
 
-TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_SinglePageTile_SingleHop_PersistentFabric) {
-    ttnn::Shape tensor_shape({1, 1, 32, 32});
-    constexpr size_t distance_dest_device = 1;
-    constexpr size_t num_devices = 4;
-    RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
-}
+            in0_tensor_slice,
+            in1_tensor_slice,
+            out0_tensor_slice,
+            out1_tensor_slice,
 
-TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_SinglePageTile_TwoHop_PersistentFabric) {
-    ttnn::Shape tensor_shape({1, 1, 32, 32});
-    constexpr size_t distance_dest_device = 2;
-    constexpr size_t num_devices = 4;
-    RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
-}
-TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_SinglePageTile_ThreeHop_PersistentFabric) {
-    ttnn::Shape tensor_shape({1, 1, 32, 32});
-    constexpr size_t distance_dest_device = 3;
-    constexpr size_t num_devices = 4;
-    RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
-}
+            page_size,
+            TwoInputReaderKernelWriteMode::FABRIC_UNICAST,
+            dest_args);
 
-TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_4PageTile_SingleHop_PersistentFabric) {
-    ttnn::Shape tensor_shape({1, 1, 32, 128});
-    constexpr size_t distance_dest_device = 1;
-    constexpr size_t num_devices = 4;
-    RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
-}
-TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, DMultiInputReader_4PageTile_TwoHop_PersistentFabric) {
-    ttnn::Shape tensor_shape({1, 1, 128, 32});
-    constexpr size_t distance_dest_device = 2;
-    constexpr size_t num_devices = 4;
-    RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
-}
-TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_4PageTile_ThreeHop_PersistentFabric) {
-    ttnn::Shape tensor_shape({1, 1, 64, 64});
-    constexpr size_t distance_dest_device = 3;
-    constexpr size_t num_devices = 4;
-    RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
-}
-TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_lotsPageTile_ThreeHop_PersistentFabric) {
-    ttnn::Shape tensor_shape({1, 1, 64, 16384});
-    constexpr size_t distance_dest_device = 3;
-    constexpr size_t num_devices = 4;
-    RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
-}
+        ASSERT_TRUE(pass);
+    }
 
-TEST(WorkerCclCommandProcessingKernels, ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly0) {
-    ttnn::Shape tensor_shape({1, 1, 64, 16384});
-    const size_t split_dim = 3;
+    // ////////////////////////////////////////////////////////////////////
+    // ////////////////////////////////////////////////////////////////////
+    // ////               FABRIC MCAST TENSOR WRITE (2 INPUT)
+    // ////////////////////////////////////////////////////////////////////
+    // ////////////////////////////////////////////////////////////////////
 
-    // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
-    constexpr size_t num_stages = 4;
-    const size_t slices_per_stage = 4;
-    const size_t cb_packet_size_in_pages = 4;
-    const size_t num_packets_per_cb = 4;
-    auto layout = Layout::TILE;
-    const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
-    const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
-    std::vector<size_t> num_workers_per_stage = {1, 1, 1, 1};
+    TEST(
+        WorkerCclCommandProcessingKernelFabricMulticastMode,
+        MultiInputReader_SinglePageTile_SingleHop_PersistentFabric) {
+        ttnn::Shape tensor_shape({1, 1, 32, 32});
+        constexpr size_t distance_dest_device = 1;
+        constexpr size_t num_devices = 4;
+        RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
+    }
 
-    std::vector<std::vector<size_t>> worker_chunk_read_order = {
-        {0, 1, 2, 3},  // first input
-        {3, 2, 1, 0},  // read in reverse order
-        {2, 0, 3, 1},  // read in non-sequential order
-        {1, 2, 3, 0}   // read in non-sequential order
-    };
-    std::vector<MemoryConfig> mem_configs{
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)};
+    TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_SinglePageTile_TwoHop_PersistentFabric) {
+        ttnn::Shape tensor_shape({1, 1, 32, 32});
+        constexpr size_t distance_dest_device = 2;
+        constexpr size_t num_devices = 4;
+        RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
+    } TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_SinglePageTile_ThreeHop_PersistentFabric) {
+        ttnn::Shape tensor_shape({1, 1, 32, 32});
+        constexpr size_t distance_dest_device = 3;
+        constexpr size_t num_devices = 4;
+        RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
+    }
 
-    auto pass = RunPipelinedWorkersTest(
+    TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_4PageTile_SingleHop_PersistentFabric) {
+        ttnn::Shape tensor_shape({1, 1, 32, 128});
+        constexpr size_t distance_dest_device = 1;
+        constexpr size_t num_devices = 4;
+        RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
+    } TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, DMultiInputReader_4PageTile_TwoHop_PersistentFabric) {
+        ttnn::Shape tensor_shape({1, 1, 128, 32});
+        constexpr size_t distance_dest_device = 2;
+        constexpr size_t num_devices = 4;
+        RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
+    } TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_4PageTile_ThreeHop_PersistentFabric) {
+        ttnn::Shape tensor_shape({1, 1, 64, 64});
+        constexpr size_t distance_dest_device = 3;
+        constexpr size_t num_devices = 4;
+        RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
+    } TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_lotsPageTile_ThreeHop_PersistentFabric) {
+        ttnn::Shape tensor_shape({1, 1, 64, 16384});
+        constexpr size_t distance_dest_device = 3;
+        constexpr size_t num_devices = 4;
+        RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
+    }
 
-        tensor_shape,
-        split_dim,
-
-        // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
-        num_stages,
-        num_workers_per_stage,
-        slices_per_stage,
-        data_format,
-        page_size_bytes,
-        cb_packet_size_in_pages,
-        num_packets_per_cb,
-        layout,
-
-        worker_chunk_read_order,
-        mem_configs);
-
-    ASSERT_TRUE(pass);
-}
-TEST(WorkerCclCommandProcessingKernels, ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly1) {
-    ttnn::Shape tensor_shape({1, 1, 64, 128});
-    const size_t split_dim = 3;
-
-    // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
-    constexpr size_t num_stages = 4;
-    const size_t slices_per_stage = 4;
-    const size_t cb_packet_size_in_pages = 4;
-    const size_t num_packets_per_cb = 4;
-    auto layout = Layout::TILE;
-    const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
-    const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
-    std::vector<size_t> num_workers_per_stage = {1, 1, 1, 1};
-
-    std::vector<std::vector<size_t>> worker_chunk_read_order = {
-        {0, 1, 2, 3},  // first input
-        {3, 2, 1, 0},  // read in reverse order
-        {2, 0, 3, 1},  // read in non-sequential order
-        {1, 2, 3, 0}   // read in non-sequential order
-    };
-    std::vector<MemoryConfig> mem_configs{
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)};
-
-    auto pass = RunPipelinedWorkersTest(
-
-        tensor_shape,
-        split_dim,
+    TEST(WorkerCclCommandProcessingKernels, ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly0) {
+        ttnn::Shape tensor_shape({1, 1, 64, 16384});
+        const size_t split_dim = 3;
 
         // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
-        num_stages,
-        num_workers_per_stage,
-        slices_per_stage,
-        data_format,
-        page_size_bytes,
-        cb_packet_size_in_pages,
-        num_packets_per_cb,
-        layout,
+        constexpr size_t num_stages = 4;
+        const size_t slices_per_stage = 4;
+        const size_t cb_packet_size_in_pages = 4;
+        const size_t num_packets_per_cb = 4;
+        auto layout = Layout::TILE;
+        const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
+        const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
+        std::vector<size_t> num_workers_per_stage = {1, 1, 1, 1};
 
-        worker_chunk_read_order,
-        mem_configs);
-
-    ASSERT_TRUE(pass);
-}
-TEST(WorkerCclCommandProcessingKernels, ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly2) {
-    ttnn::Shape tensor_shape({1, 1, 64, 8192});
-    const size_t split_dim = 3;
-
-    // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
-    constexpr size_t num_stages = 4;
-    const size_t slices_per_stage = 2;
-    const size_t cb_packet_size_in_pages = 4;
-    const size_t num_packets_per_cb = 4;
-    auto layout = Layout::TILE;
-    const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
-    const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
-    std::vector<size_t> num_workers_per_stage = {1, 1, 1, 1};
-
-    std::vector<std::vector<size_t>> worker_chunk_read_order = {
-        {0, 1},  // first input
-        {1, 0},  // read in reverse order
-        {1, 0},  // read in non-sequential order
-        {0, 1}   // read in non-sequential order
-    };
-    std::vector<MemoryConfig> mem_configs{
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)};
-
-    auto pass = RunPipelinedWorkersTest(
-
-        tensor_shape,
-        split_dim,
-
-        // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
-        num_stages,
-        num_workers_per_stage,
-        slices_per_stage,
-        data_format,
-        page_size_bytes,
-        cb_packet_size_in_pages,
-        num_packets_per_cb,
-        layout,
-
-        worker_chunk_read_order,
-        mem_configs);
-
-    ASSERT_TRUE(pass);
-}
-
-// Hits issues with input tensor copy-back
-TEST(
-    WorkerCclCommandProcessingKernels,
-    DISABLED_ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly_SmallSweep) {
-    std::vector<ttnn::Shape> tensor_shapes = {
-        ttnn::Shape({1, 1, 64, 8192}),
-        ttnn::Shape({1, 4, 64, 768}),
-        ttnn::Shape({4, 1, 64, 768}),
-        ttnn::Shape({4, 4, 64, 768}),
-        ttnn::Shape({1, 1, 64, 768}),
-        ttnn::Shape({5, 3, 64, 768})};
-
-    const size_t split_dim = 3;
-
-    // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
-    constexpr size_t num_stages = 4;
-    const std::vector<size_t> slices_per_stage_sweep = {2, 3, 4};
-    const size_t cb_packet_size_in_pages = 4;
-    const size_t num_packets_per_cb = 4;
-    auto layout = Layout::TILE;
-    const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
-    const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
-    std::vector<std::vector<size_t>> num_workers_per_stage_sweep = {
-        {1, 1, 1, 1}, {2, 2, 2, 2}, {3, 3, 3, 3}, {4, 4, 4, 4}};
-
-    std::vector<std::vector<std::vector<size_t>>> worker_chunk_read_order = {
-        {{}},
-        {
-            {0},
-            {0},
-            {0},
-            {0},
-        },
-        {
-            {0, 1},
-            {1, 0},
-            {1, 0},
-            {0, 1},
-        },
-        {
-            {2, 0, 1},
-            {1, 0, 2},
-            {0, 1, 2},
-            {2, 1, 0},
-        },
-        {
+        std::vector<std::vector<size_t>> worker_chunk_read_order = {
             {0, 1, 2, 3},  // first input
             {3, 2, 1, 0},  // read in reverse order
             {2, 0, 3, 1},  // read in non-sequential order
             {1, 2, 3, 0}   // read in non-sequential order
-        }};
-    std::vector<std::vector<MemoryConfig>> mem_configs_sweep = {
-        {
+        };
+        std::vector<MemoryConfig> mem_configs{
             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)};
+
+        auto pass = RunPipelinedWorkersTest(
+
+            tensor_shape,
+            split_dim,
+
+            // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be
+            // configurable)
+            num_stages,
+            num_workers_per_stage,
+            slices_per_stage,
+            data_format,
+            page_size_bytes,
+            cb_packet_size_in_pages,
+            num_packets_per_cb,
+            layout,
+
+            worker_chunk_read_order,
+            mem_configs);
+
+        ASSERT_TRUE(pass);
+    } TEST(WorkerCclCommandProcessingKernels, ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly1) {
+        ttnn::Shape tensor_shape({1, 1, 64, 128});
+        const size_t split_dim = 3;
+
+        // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
+        constexpr size_t num_stages = 4;
+        const size_t slices_per_stage = 4;
+        const size_t cb_packet_size_in_pages = 4;
+        const size_t num_packets_per_cb = 4;
+        auto layout = Layout::TILE;
+        const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
+        const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
+        std::vector<size_t> num_workers_per_stage = {1, 1, 1, 1};
+
+        std::vector<std::vector<size_t>> worker_chunk_read_order = {
+            {0, 1, 2, 3},  // first input
+            {3, 2, 1, 0},  // read in reverse order
+            {2, 0, 3, 1},  // read in non-sequential order
+            {1, 2, 3, 0}   // read in non-sequential order
+        };
+        std::vector<MemoryConfig> mem_configs{
             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-        },
-        {MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1)},
-        {MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)},
-        {MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)},
-    };
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)};
 
-    for (auto& tensor_shape : tensor_shapes) {
-        for (auto& num_workers_per_stage : num_workers_per_stage_sweep) {
-            for (size_t slices_per_stage : slices_per_stage_sweep) {
-                for (auto& mem_configs : mem_configs_sweep) {
-                    log_info(
-                        tt::LogTest,
-                        "tensor shape {} and workers stage {} slices_per_stage {}",
-                        tensor_shape,
-                        num_workers_per_stage,
-                        slices_per_stage);
-                    auto pass = RunPipelinedWorkersTest(
+        auto pass = RunPipelinedWorkersTest(
 
-                        tensor_shape,
-                        split_dim,
+            tensor_shape,
+            split_dim,
 
-                        // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will
-                        // be configurable)
-                        num_stages,
-                        num_workers_per_stage,
-                        slices_per_stage,
-                        data_format,
-                        page_size_bytes,
-                        cb_packet_size_in_pages,
-                        num_packets_per_cb,
-                        layout,
+            // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be
+            // configurable)
+            num_stages,
+            num_workers_per_stage,
+            slices_per_stage,
+            data_format,
+            page_size_bytes,
+            cb_packet_size_in_pages,
+            num_packets_per_cb,
+            layout,
 
-                        worker_chunk_read_order[slices_per_stage],
-                        mem_configs);
+            worker_chunk_read_order,
+            mem_configs);
 
-                    ASSERT_TRUE(pass);
+        ASSERT_TRUE(pass);
+    } TEST(WorkerCclCommandProcessingKernels, ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly2) {
+        ttnn::Shape tensor_shape({1, 1, 64, 8192});
+        const size_t split_dim = 3;
+
+        // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
+        constexpr size_t num_stages = 4;
+        const size_t slices_per_stage = 2;
+        const size_t cb_packet_size_in_pages = 4;
+        const size_t num_packets_per_cb = 4;
+        auto layout = Layout::TILE;
+        const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
+        const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
+        std::vector<size_t> num_workers_per_stage = {1, 1, 1, 1};
+
+        std::vector<std::vector<size_t>> worker_chunk_read_order = {
+            {0, 1},  // first input
+            {1, 0},  // read in reverse order
+            {1, 0},  // read in non-sequential order
+            {0, 1}   // read in non-sequential order
+        };
+        std::vector<MemoryConfig> mem_configs{
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)};
+
+        auto pass = RunPipelinedWorkersTest(
+
+            tensor_shape,
+            split_dim,
+
+            // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be
+            // configurable)
+            num_stages,
+            num_workers_per_stage,
+            slices_per_stage,
+            data_format,
+            page_size_bytes,
+            cb_packet_size_in_pages,
+            num_packets_per_cb,
+            layout,
+
+            worker_chunk_read_order,
+            mem_configs);
+
+        ASSERT_TRUE(pass);
+    }
+
+    // Hits issues with input tensor copy-back
+    TEST(
+        WorkerCclCommandProcessingKernels,
+        DISABLED_ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly_SmallSweep) {
+        std::vector<ttnn::Shape> tensor_shapes = {
+            ttnn::Shape({1, 1, 64, 8192}),
+            ttnn::Shape({1, 4, 64, 768}),
+            ttnn::Shape({4, 1, 64, 768}),
+            ttnn::Shape({4, 4, 64, 768}),
+            ttnn::Shape({1, 1, 64, 768}),
+            ttnn::Shape({5, 3, 64, 768})};
+
+        const size_t split_dim = 3;
+
+        // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
+        constexpr size_t num_stages = 4;
+        const std::vector<size_t> slices_per_stage_sweep = {2, 3, 4};
+        const size_t cb_packet_size_in_pages = 4;
+        const size_t num_packets_per_cb = 4;
+        auto layout = Layout::TILE;
+        const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
+        const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
+        std::vector<std::vector<size_t>> num_workers_per_stage_sweep = {
+            {1, 1, 1, 1}, {2, 2, 2, 2}, {3, 3, 3, 3}, {4, 4, 4, 4}};
+
+        std::vector<std::vector<std::vector<size_t>>> worker_chunk_read_order = {
+            {{}},
+            {
+                {0},
+                {0},
+                {0},
+                {0},
+            },
+            {
+                {0, 1},
+                {1, 0},
+                {1, 0},
+                {0, 1},
+            },
+            {
+                {2, 0, 1},
+                {1, 0, 2},
+                {0, 1, 2},
+                {2, 1, 0},
+            },
+            {
+                {0, 1, 2, 3},  // first input
+                {3, 2, 1, 0},  // read in reverse order
+                {2, 0, 3, 1},  // read in non-sequential order
+                {1, 2, 3, 0}   // read in non-sequential order
+            }};
+        std::vector<std::vector<MemoryConfig>> mem_configs_sweep = {
+            {
+                MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+                MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+                MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+                MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+                MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+            },
+            {MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1)},
+            {MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)},
+            {MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)},
+        };
+
+        for (auto& tensor_shape : tensor_shapes) {
+            for (auto& num_workers_per_stage : num_workers_per_stage_sweep) {
+                for (size_t slices_per_stage : slices_per_stage_sweep) {
+                    for (auto& mem_configs : mem_configs_sweep) {
+                        log_info(
+                            tt::LogTest,
+                            "tensor shape {} and workers stage {} slices_per_stage {}",
+                            tensor_shape,
+                            num_workers_per_stage,
+                            slices_per_stage);
+                        auto pass = RunPipelinedWorkersTest(
+
+                            tensor_shape,
+                            split_dim,
+
+                            // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will
+                            // be configurable)
+                            num_stages,
+                            num_workers_per_stage,
+                            slices_per_stage,
+                            data_format,
+                            page_size_bytes,
+                            cb_packet_size_in_pages,
+                            num_packets_per_cb,
+                            layout,
+
+                            worker_chunk_read_order[slices_per_stage],
+                            mem_configs);
+
+                        ASSERT_TRUE(pass);
+                    }
                 }
             }
         }
     }
-}
 
-TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast) {
-    const size_t num_mcasts = 1;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    params.line_size = 2;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
+    TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast) {
+        const size_t num_mcasts = 1;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        params.line_size = 2;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    }
 
 //
 // The routing plane for fast dispatch uses 1 eth core in each direction
@@ -775,626 +813,590 @@ TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast) {
         GTEST_SKIP() << "Not enough eth cores for 2 links";                   \
     }
 
-TEST(EdmFabric, BasicMcastThroughputTest_SingleMcast) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 1;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_SingleWorker_2Device) {
-    const size_t num_mcasts = 9;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const size_t line_size = 2;
-    const bool line_sync = false;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_size = line_size;
-    params.line_sync = line_sync;
-    params.num_devices_with_workers = 1;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_2Device) {
-    const size_t num_mcasts = 9;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const size_t line_size = 2;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_size = line_size;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_SingleWorker_4Device) {
-    const size_t num_mcasts = 9;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const size_t line_size = 4;
-    const bool line_sync = false;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_size = line_size;
-    params.line_sync = line_sync;
-    params.num_devices_with_workers = 1;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_TwoWorkers_4Device) {
-    const size_t num_mcasts = 9;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const size_t line_size = 4;
-    const bool line_sync = false;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_size = line_size;
-    params.line_sync = line_sync;
-    params.num_devices_with_workers = 2;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap) {
-    const size_t num_mcasts = 9;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_SingleWorker_2Device) {
-    const size_t num_mcasts = 10;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const size_t line_size = 2;
-    const bool line_sync = false;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_size = line_size;
-    params.line_sync = line_sync;
-    params.num_devices_with_workers = 1;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_2Device) {
-    const size_t num_mcasts = 10;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const size_t line_size = 2;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_size = line_size;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap) {
-    const size_t num_mcasts = 10;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2Device) {
-    const size_t num_mcasts = 18;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const size_t line_size = 2;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_size = line_size;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled) {
-    const size_t num_mcasts = 18;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderTwoWrap_ReceiverOneWrap) {
-    const size_t num_mcasts = 19;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-
-TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast_LineSync) {
-    const size_t num_mcasts = 1;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-
-TEST(EdmFabric, BasicMcastThroughputTest_SingleMcast_LineSync) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 1;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_LineSync) {
-    const size_t num_mcasts = 9;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_2Device_LineSync) {
-    const size_t num_mcasts = 10;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const size_t line_size = 2;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_size = line_size;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_LineSync) {
-    const size_t num_mcasts = 10;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2Device_LineSync) {
-    const size_t num_mcasts = 18;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const size_t line_size = 2;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_size = line_size;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_LineSync) {
-    const size_t num_mcasts = 18;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_2Device_1Worker) {
-    const size_t num_mcasts = 36;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const size_t line_size = 2;
-    const bool line_sync = false;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_size = line_size;
-    params.line_sync = line_sync;
-    params.num_devices_with_workers = 1;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_2Device_LineSync) {
-    const size_t num_mcasts = 36;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const size_t line_size = 2;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_size = line_size;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_LineSync) {
-    const size_t num_mcasts = 36;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SenderTwoWrap_ReceiverOneWrap_LineSync) {
-    const size_t num_mcasts = 19;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-
-TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf_2Device) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 70;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-    const size_t line_size = 2;
-    const bool report_performance = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = report_performance;
-    params.line_size = line_size;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-
-TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf0) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 70;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = true;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf1) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 70;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = true;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-
-TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_0) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 100;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = false;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_size = 2;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_1) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 1000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = false;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_2) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 50000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_3_SingleLink) {
-    const size_t num_mcasts = 200000;
-    const size_t num_unicasts = 0;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_3) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 200000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_3_onehop) {
-    const size_t num_mcasts = 200000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    params.line_size = 2;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_4) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 800000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-}
-
-TEST(EdmFabric, BasicMcastThroughputTest_5) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 1;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 20000;
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-}
-// DISABLED due to long runtime
-TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_6) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 100;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 8000;
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-}
-// DISABLED due to long runtime
-TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_7) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 1000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1000;
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-}
-// DISABLED due to long runtime
-TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_8) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 50000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 200;
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-}
-// DISABLED due to long runtime
-TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_9) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 200000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 150;
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-}
-// DISABLED due to long runtime
-TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_10) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 800000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 50;
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_6_Short) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 100;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 100;
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_7_Short) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 1000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 50;
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_8_Short) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 50000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 20;
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_9_Short) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 200000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 10;
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_10_Short) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 800000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 5;
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-}
-
-TEST(EdmFabric, BasicMcastThroughputTest_0_WithLineSync) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 100;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_1_WithLineSync) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 1000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_2_WithLineSync) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 50000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_3_WithLineSync) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 200000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-TEST(EdmFabric, BasicMcastThroughputTest_4_WithLineSync) {
-    CHECK_TWO_LINKS_AVAILABLE();
-    const size_t num_mcasts = 800000;
-    const size_t num_unicasts = 2;
-    const size_t num_links = 2;
-    const size_t num_op_invocations = 1;
-    const bool line_sync = true;
-    WriteThroughputStabilityTestWithPersistentFabricParams params;
-    params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWithPersistentFabric(
-        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-}
-
-TEST(EdmFabric, RingDeadlockStabilityTest) {
-    constexpr size_t num_mcasts = 200000;
-    constexpr size_t num_op_invocations = 5;
-    constexpr bool line_sync = true;
-    size_t num_links = 1;
-    std::vector<size_t> num_devices_vec;
-    auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
-    if (cluster_type == tt::ClusterType::GALAXY) {
-        num_devices_vec = {4, 8};
-        num_links = 4;
-    } else {
-        num_devices_vec = {8};
+    TEST(EdmFabric, BasicMcastThroughputTest_SingleMcast) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 1;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_SingleWorker_2Device) {
+        const size_t num_mcasts = 9;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const size_t line_size = 2;
+        const bool line_sync = false;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_size = line_size;
+        params.line_sync = line_sync;
+        params.num_devices_with_workers = 1;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_2Device) {
+        const size_t num_mcasts = 9;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const size_t line_size = 2;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_size = line_size;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_SingleWorker_4Device) {
+        const size_t num_mcasts = 9;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const size_t line_size = 4;
+        const bool line_sync = false;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_size = line_size;
+        params.line_sync = line_sync;
+        params.num_devices_with_workers = 1;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_TwoWorkers_4Device) {
+        const size_t num_mcasts = 9;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const size_t line_size = 4;
+        const bool line_sync = false;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_size = line_size;
+        params.line_sync = line_sync;
+        params.num_devices_with_workers = 2;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap) {
+        const size_t num_mcasts = 9;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_SingleWorker_2Device) {
+        const size_t num_mcasts = 10;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const size_t line_size = 2;
+        const bool line_sync = false;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_size = line_size;
+        params.line_sync = line_sync;
+        params.num_devices_with_workers = 1;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_2Device) {
+        const size_t num_mcasts = 10;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const size_t line_size = 2;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_size = line_size;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap) {
+        const size_t num_mcasts = 10;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2Device) {
+        const size_t num_mcasts = 18;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const size_t line_size = 2;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_size = line_size;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled) {
+        const size_t num_mcasts = 18;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderTwoWrap_ReceiverOneWrap) {
+        const size_t num_mcasts = 19;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
     }
-    for (const auto& num_devices : num_devices_vec) {
-        log_trace(
-            tt::LogTest, "Running RingDeadlockStabilityTest with forward mcast only with {} devices", num_devices);
-        RunRingDeadlockStabilityTestWithPersistentFabric(
-            num_mcasts, num_links, num_devices, num_op_invocations, true, false);
-        log_trace(
-            tt::LogTest, "Running RingDeadlockStabilityTest with backward mcast only with {} devices", num_devices);
-        RunRingDeadlockStabilityTestWithPersistentFabric(
-            num_mcasts, num_links, num_devices, num_op_invocations, false, true);
-        log_trace(
-            tt::LogTest,
-            "Running RingDeadlockStabilityTest with forward and backward mcast with {} devices",
-            num_devices);
-        RunRingDeadlockStabilityTestWithPersistentFabric(
-            num_mcasts, num_links, num_devices, num_op_invocations, true, true);
-    }
-}
 
-TEST(EdmFabric, RingDeadlockStabilityTest_RelaxedFabricStrictness) {
-    constexpr size_t num_mcasts = 200000;
-    constexpr size_t num_op_invocations = 5;
-    constexpr bool line_sync = true;
-    // Set to however many links are available
-    std::optional<size_t> num_links = std::nullopt;
-    std::vector<size_t> num_devices;
-    auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+    TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast_LineSync) {
+        const size_t num_mcasts = 1;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    }
 
-    if (cluster_type != tt::ClusterType::GALAXY) {
-        return;
+    TEST(EdmFabric, BasicMcastThroughputTest_SingleMcast_LineSync) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 1;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_LineSync) {
+        const size_t num_mcasts = 9;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_2Device_LineSync) {
+        const size_t num_mcasts = 10;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const size_t line_size = 2;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_size = line_size;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_LineSync) {
+        const size_t num_mcasts = 10;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2Device_LineSync) {
+        const size_t num_mcasts = 18;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const size_t line_size = 2;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_size = line_size;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_LineSync) {
+        const size_t num_mcasts = 18;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_2Device_1Worker) {
+        const size_t num_mcasts = 36;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const size_t line_size = 2;
+        const bool line_sync = false;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_size = line_size;
+        params.line_sync = line_sync;
+        params.num_devices_with_workers = 1;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_2Device_LineSync) {
+        const size_t num_mcasts = 36;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const size_t line_size = 2;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_size = line_size;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_LineSync) {
+        const size_t num_mcasts = 36;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SenderTwoWrap_ReceiverOneWrap_LineSync) {
+        const size_t num_mcasts = 19;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
     }
-    num_devices = {4, 8};
-    for (size_t offset = 0; offset < num_devices[1]; offset++) {
-        RunRingDeadlockStabilityTestWithPersistentFabric<Fabric1DRingRelaxedDeviceInitFixture>(
-            num_mcasts,
-            num_links,
-            num_devices[0],
-            num_op_invocations,
-            true,
-            false,
-            tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes,
-            offset);
+
+    TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf_2Device) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 70;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+        const size_t line_size = 2;
+        const bool report_performance = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = report_performance;
+        params.line_size = line_size;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
     }
-    for (size_t offset = 0; offset < num_devices[0]; offset++) {
-        RunRingDeadlockStabilityTestWithPersistentFabric<Fabric1DRingRelaxedDeviceInitFixture>(
-            num_mcasts,
-            num_links,
-            num_devices[1],
-            num_op_invocations,
-            true,
-            false,
-            tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes,
-            offset);
+
+    TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf0) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 70;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = true;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf1) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 70;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = true;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
     }
-}
+
+    TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_0) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 100;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = false;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_size = 2;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_1) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 1000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = false;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_2) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 50000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+
+        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    } TEST(EdmFabric, BasicMcastThroughputTest_3_SingleLink) {
+        const size_t num_mcasts = 200000;
+        const size_t num_unicasts = 0;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_3) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 200000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_3_onehop) {
+        const size_t num_mcasts = 200000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 1;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        params.line_size = 2;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_4) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 800000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    }
+
+    TEST(EdmFabric, BasicMcastThroughputTest_5) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 1;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 20000;
+        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    }
+    // DISABLED due to long runtime
+    TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_6) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 100;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 8000;
+        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    }
+    // DISABLED due to long runtime
+    TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_7) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 1000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1000;
+        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    }
+    // DISABLED due to long runtime
+    TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_8) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 50000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 200;
+        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    }
+    // DISABLED due to long runtime
+    TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_9) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 200000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 150;
+        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    }
+    // DISABLED due to long runtime
+    TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_10) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 800000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 50;
+        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    } TEST(EdmFabric, BasicMcastThroughputTest_6_Short) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 100;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 100;
+        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    } TEST(EdmFabric, BasicMcastThroughputTest_7_Short) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 1000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 50;
+        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    } TEST(EdmFabric, BasicMcastThroughputTest_8_Short) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 50000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 20;
+        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    } TEST(EdmFabric, BasicMcastThroughputTest_9_Short) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 200000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 10;
+        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    } TEST(EdmFabric, BasicMcastThroughputTest_10_Short) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 800000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 5;
+        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    }
+
+    TEST(EdmFabric, BasicMcastThroughputTest_0_WithLineSync) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 100;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_1_WithLineSync) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 1000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_2_WithLineSync) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 50000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_3_WithLineSync) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 200000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    } TEST(EdmFabric, BasicMcastThroughputTest_4_WithLineSync) {
+        CHECK_TWO_LINKS_AVAILABLE();
+        const size_t num_mcasts = 800000;
+        const size_t num_unicasts = 2;
+        const size_t num_links = 2;
+        const size_t num_op_invocations = 1;
+        const bool line_sync = true;
+        WriteThroughputStabilityTestWithPersistentFabricParams params;
+        params.line_sync = line_sync;
+        RunWriteThroughputStabilityTestWithPersistentFabric(
+            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+    }
+
+    TEST(EdmFabric, RingDeadlockStabilityTest) {
+        constexpr size_t num_mcasts = 200000;
+        constexpr size_t num_op_invocations = 5;
+        constexpr bool line_sync = true;
+        size_t num_links = 1;
+        std::vector<size_t> num_devices_vec;
+        auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+        if (cluster_type == tt::ClusterType::GALAXY) {
+            num_devices_vec = {4, 8};
+            num_links = 4;
+        } else {
+            num_devices_vec = {8};
+        }
+        for (const auto& num_devices : num_devices_vec) {
+            log_trace(
+                tt::LogTest, "Running RingDeadlockStabilityTest with forward mcast only with {} devices", num_devices);
+            RunRingDeadlockStabilityTestWithPersistentFabric(
+                num_mcasts, num_links, num_devices, num_op_invocations, true, false);
+            log_trace(
+                tt::LogTest, "Running RingDeadlockStabilityTest with backward mcast only with {} devices", num_devices);
+            RunRingDeadlockStabilityTestWithPersistentFabric(
+                num_mcasts, num_links, num_devices, num_op_invocations, false, true);
+            log_trace(
+                tt::LogTest,
+                "Running RingDeadlockStabilityTest with forward and backward mcast with {} devices",
+                num_devices);
+            RunRingDeadlockStabilityTestWithPersistentFabric(
+                num_mcasts, num_links, num_devices, num_op_invocations, true, true);
+        }
+    }
+
+    TEST(EdmFabric, RingDeadlockStabilityTest_RelaxedFabricStrictness) {
+        constexpr size_t num_mcasts = 200000;
+        constexpr size_t num_op_invocations = 5;
+        constexpr bool line_sync = true;
+        // Set to however many links are available
+        std::optional<size_t> num_links = std::nullopt;
+        std::vector<size_t> num_devices;
+        auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+
+        if (cluster_type != tt::ClusterType::GALAXY) {
+            return;
+        }
+        num_devices = {4, 8};
+        for (size_t offset = 0; offset < num_devices[1]; offset++) {
+            RunRingDeadlockStabilityTestWithPersistentFabric<Fabric1DRingRelaxedDeviceInitFixture>(
+                num_mcasts,
+                num_links,
+                num_devices[0],
+                num_op_invocations,
+                true,
+                false,
+                tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes,
+                offset);
+        }
+        for (size_t offset = 0; offset < num_devices[0]; offset++) {
+            RunRingDeadlockStabilityTestWithPersistentFabric<Fabric1DRingRelaxedDeviceInitFixture>(
+                num_mcasts,
+                num_links,
+                num_devices[1],
+                num_op_invocations,
+                true,
+                false,
+                tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes,
+                offset);
+        }
+    })

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -1,4 +1,4 @@
-(
+
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -36,7 +36,6 @@
 #include <tt-metalium/shape_base.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/sub_device_types.hpp>
-#include "context/metal_context.hpp"
 #include "tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp"
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
@@ -64,742 +63,744 @@
 #include "ttnn/tensor/types.hpp"
 #include "umd/device/types/arch.h"
 
-    ////////////////////////////////////////////////////////////////////
-    ///  MESSAGE COUNT TERMINATION MODE
-    ////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////
+///  MESSAGE COUNT TERMINATION MODE
+////////////////////////////////////////////////////////////////////
 
-    // -------------------------
-    // Persistent Fabric
-    // -------------------------
+// -------------------------
+// Persistent Fabric
+// -------------------------
 
-    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_SingleMessage_PersistentFabric) {
-        const uint32_t page_size = 2048;
-        const uint32_t num_pages_total = 1;
-        const bool src_is_dram = true;
-        const bool dest_is_dram = true;
+TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_SingleMessage_PersistentFabric) {
+    const uint32_t page_size = 2048;
+    const uint32_t num_pages_total = 1;
+    const bool src_is_dram = true;
+    const bool dest_is_dram = true;
 
-        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
-        ASSERT_EQ(result, 0);
-    }
+    auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
+    ASSERT_EQ(result, 0);
+}
 
-    // Will wrapp sender but not receiver buffers
-    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_2_messages_PersistentFabric) {
-        const uint32_t page_size = 2048;
-        const uint32_t num_pages_total = 2;
-        const bool src_is_dram = true;
-        const bool dest_is_dram = true;
+// Will wrapp sender but not receiver buffers
+TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_2_messages_PersistentFabric) {
+    const uint32_t page_size = 2048;
+    const uint32_t num_pages_total = 2;
+    const bool src_is_dram = true;
+    const bool dest_is_dram = true;
 
-        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
-        ASSERT_EQ(result, 0);
-    }
+    auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
+    ASSERT_EQ(result, 0);
+}
 #ifdef ARCH_WORMHOLE
-    // Will wrapp sender but not receiver buffers
-    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_2_messages_PersistentFabric_Scatter) {
-        const uint32_t page_size = 2048;
-        const uint32_t num_pages_total = 2;
-        const bool src_is_dram = true;
-        const bool dest_is_dram = true;
+// Will wrapp sender but not receiver buffers
+TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_2_messages_PersistentFabric_Scatter) {
+    const uint32_t page_size = 2048;
+    const uint32_t num_pages_total = 2;
+    const bool src_is_dram = true;
+    const bool dest_is_dram = true;
 
-        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram, true);
-        ASSERT_EQ(result, 0);
-    } TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_3_messages_PersistentFabric_Scatter) {
-        const uint32_t page_size = 2048;
-        const uint32_t num_pages_total = 3;
-        const bool src_is_dram = true;
-        const bool dest_is_dram = true;
+    auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram, true);
+    ASSERT_EQ(result, 0);
+}
+TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_3_messages_PersistentFabric_Scatter) {
+    const uint32_t page_size = 2048;
+    const uint32_t num_pages_total = 3;
+    const bool src_is_dram = true;
+    const bool dest_is_dram = true;
 
-        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram, true);
-        ASSERT_EQ(result, 0);
-    }
-    // Will wrapp sender but not receiver buffers
-    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_10_messages_PersistentFabric_Scatter) {
-        const uint32_t page_size = 2048;
-        const uint32_t num_pages_total = 10;
-        const bool src_is_dram = true;
-        const bool dest_is_dram = true;
+    auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram, true);
+    ASSERT_EQ(result, 0);
+}
+// Will wrapp sender but not receiver buffers
+TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_10_messages_PersistentFabric_Scatter) {
+    const uint32_t page_size = 2048;
+    const uint32_t num_pages_total = 10;
+    const bool src_is_dram = true;
+    const bool dest_is_dram = true;
 
-        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram, true);
-        ASSERT_EQ(result, 0);
-    }
-    // Will wrapp sender and receiver buffers
-    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_20_messages_PersistentFabric_Scatter) {
-        const uint32_t page_size = 2048;
-        const uint32_t num_pages_total = 20;
-        const bool src_is_dram = true;
-        const bool dest_is_dram = true;
+    auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram, true);
+    ASSERT_EQ(result, 0);
+}
+// Will wrapp sender and receiver buffers
+TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_20_messages_PersistentFabric_Scatter) {
+    const uint32_t page_size = 2048;
+    const uint32_t num_pages_total = 20;
+    const bool src_is_dram = true;
+    const bool dest_is_dram = true;
 
-        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram, true);
-        ASSERT_EQ(result, 0);
-    }
+    auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram, true);
+    ASSERT_EQ(result, 0);
+}
 #endif
-    // Will wrapp sender but not receiver buffers
-    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_10_messages_PersistentFabric) {
-        const uint32_t page_size = 2048;
-        const uint32_t num_pages_total = 10;
-        const bool src_is_dram = true;
-        const bool dest_is_dram = true;
+// Will wrapp sender but not receiver buffers
+TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_10_messages_PersistentFabric) {
+    const uint32_t page_size = 2048;
+    const uint32_t num_pages_total = 10;
+    const bool src_is_dram = true;
+    const bool dest_is_dram = true;
 
-        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
-        ASSERT_EQ(result, 0);
-    }
+    auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
+    ASSERT_EQ(result, 0);
+}
+// Will wrapp sender and receiver buffers
+TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_20_messages_PersistentFabric) {
+    const uint32_t page_size = 2048;
+    const uint32_t num_pages_total = 20;
+    const bool src_is_dram = true;
+    const bool dest_is_dram = true;
 
-    // Will wrapp sender and receiver buffers
-    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_20_messages_PersistentFabric) {
-        const uint32_t page_size = 2048;
-        const uint32_t num_pages_total = 20;
-        const bool src_is_dram = true;
-        const bool dest_is_dram = true;
+    auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
+    ASSERT_EQ(result, 0);
+}
 
-        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
-        ASSERT_EQ(result, 0);
-    }
+TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_PersistentFabric) {
+    const uint32_t page_size = 2048;
+    const uint32_t num_pages_total = 10000;
+    const bool src_is_dram = true;
+    const bool dest_is_dram = true;
 
-    TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_PersistentFabric) {
-        const uint32_t page_size = 2048;
-        const uint32_t num_pages_total = 10000;
-        const bool src_is_dram = true;
-        const bool dest_is_dram = true;
+    auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
+    ASSERT_EQ(result, 0);
+}
 
-        auto result = TestLoopbackEntrypoint(page_size, num_pages_total, src_is_dram, dest_is_dram);
-        ASSERT_EQ(result, 0);
-    }
+////////////////////////////////
 
-    ////////////////////////////////
+TEST(WorkerFabricEdmDatapath, LineFabricMcast_SingleMessage_SingleSource_PersistentFabric) {
+    const uint32_t page_size = 2048;
+    const uint32_t num_pages_total = 1;
+    const bool src_is_dram = true;
+    const bool dest_is_dram = true;
+    const size_t mcast_first_chip = 1;
+    const size_t mcast_last_chip = 3;
 
-    TEST(WorkerFabricEdmDatapath, LineFabricMcast_SingleMessage_SingleSource_PersistentFabric) {
-        const uint32_t page_size = 2048;
-        const uint32_t num_pages_total = 1;
-        const bool src_is_dram = true;
-        const bool dest_is_dram = true;
-        const size_t mcast_first_chip = 1;
-        const size_t mcast_last_chip = 3;
+    auto result = TestLineFabricEntrypoint(
+        mcast_first_chip, mcast_last_chip, page_size, num_pages_total, src_is_dram, dest_is_dram);
 
-        auto result = TestLineFabricEntrypoint(
-            mcast_first_chip, mcast_last_chip, page_size, num_pages_total, src_is_dram, dest_is_dram);
+    ASSERT_EQ(result, 0);
+}
 
-        ASSERT_EQ(result, 0);
-    }
+// Non-functional on harvested parts. Needs testing on unharvested parts.
+TEST(WorkerFabricEdmDatapath, LineFabricMcast_ManyMessages_SingleSource_PersistentFabric) {
+    const uint32_t page_size = 2048;
+    const uint32_t num_pages_total = 10000;
+    const bool src_is_dram = true;
+    const bool dest_is_dram = true;
+    const size_t mcast_first_chip = 1;
+    const size_t mcast_last_chip = 3;
 
-    // Non-functional on harvested parts. Needs testing on unharvested parts.
-    TEST(WorkerFabricEdmDatapath, LineFabricMcast_ManyMessages_SingleSource_PersistentFabric) {
-        const uint32_t page_size = 2048;
-        const uint32_t num_pages_total = 10000;
-        const bool src_is_dram = true;
-        const bool dest_is_dram = true;
-        const size_t mcast_first_chip = 1;
-        const size_t mcast_last_chip = 3;
+    auto result = TestLineFabricEntrypoint(
+        mcast_first_chip, mcast_last_chip, page_size, num_pages_total, src_is_dram, dest_is_dram);
 
-        auto result = TestLineFabricEntrypoint(
-            mcast_first_chip, mcast_last_chip, page_size, num_pages_total, src_is_dram, dest_is_dram);
+    ASSERT_EQ(result, 0);
+}
 
-        ASSERT_EQ(result, 0);
-    }
+////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////
+////               LOCAL CHIP TENSOR READ?WRITE (2 INPUT)
+////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////
 
-    ////////////////////////////////////////////////////////////////////
-    ////////////////////////////////////////////////////////////////////
-    ////               LOCAL CHIP TENSOR READ?WRITE (2 INPUT)
-    ////////////////////////////////////////////////////////////////////
-    ////////////////////////////////////////////////////////////////////
+TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_SinglePageTile) {
+    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+        ttnn::Shape({1, 1, 32, 32}),
+        Layout::TILE,
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+    ASSERT_TRUE(pass);
+}
 
-    TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_SinglePageTile) {
-        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-            ttnn::Shape({1, 1, 32, 32}),
-            Layout::TILE,
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-        ASSERT_TRUE(pass);
-    }
+TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0) {
+    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+        ttnn::Shape({1, 1, 32, 64}),
+        Layout::TILE,
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+    ASSERT_TRUE(pass);
+}
 
-    TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0) {
-        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-            ttnn::Shape({1, 1, 32, 64}),
-            Layout::TILE,
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-        ASSERT_TRUE(pass);
-    }
+TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded) {
+    ttnn::Shape tensor_shape({1, 1, 32, 64});
+    auto mem_config = MemoryConfig(
+        TensorMemoryLayout::WIDTH_SHARDED,
+        BufferType::L1,
+        ShardSpec(
+            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}}},
+            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3]},
+            ShardOrientation::ROW_MAJOR,
+            ShardMode::LOGICAL));
+    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+        tensor_shape,
+        Layout::TILE,
+        mem_config,
+        mem_config,
+        mem_config,
+        mem_config,
+        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+    ASSERT_TRUE(pass);
+}
+TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded1) {
+    ttnn::Shape tensor_shape({1, 1, 32, 128});
+    auto mem_config = MemoryConfig(
+        TensorMemoryLayout::WIDTH_SHARDED,
+        BufferType::L1,
+        ShardSpec(
+            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}}},
+            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3]},
+            ShardOrientation::ROW_MAJOR,
+            ShardMode::LOGICAL));
+    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+        tensor_shape,
+        Layout::TILE,
+        mem_config,
+        mem_config,
+        mem_config,
+        mem_config,
+        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+    ASSERT_TRUE(pass);
+}
+TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded2) {
+    ttnn::Shape tensor_shape({1, 1, 32, 128});
+    auto mem_config = MemoryConfig(
+        TensorMemoryLayout::WIDTH_SHARDED,
+        BufferType::L1,
+        ShardSpec(
+            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}}},
+            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / 4},
+            ShardOrientation::ROW_MAJOR,
+            ShardMode::LOGICAL));
+    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+        tensor_shape,
+        Layout::TILE,
+        mem_config,
+        mem_config,
+        mem_config,
+        mem_config,
+        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+    ASSERT_TRUE(pass);
+}
+TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded3) {
+    ttnn::Shape tensor_shape({1, 1, 32, 8192});
+    size_t ncores_x = 8;
+    size_t ncores_y = 4;
+    auto mem_config = MemoryConfig(
+        TensorMemoryLayout::WIDTH_SHARDED,
+        BufferType::L1,
+        ShardSpec(
+            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{ncores_x - 1, ncores_y - 1}}}},
+            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / (ncores_x * ncores_y)},
+            ShardOrientation::ROW_MAJOR,
+            ShardMode::LOGICAL));
+    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+        tensor_shape,
+        Layout::TILE,
+        mem_config,
+        mem_config,
+        mem_config,
+        mem_config,
+        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+    ASSERT_TRUE(pass);
+}
+TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded4) {
+    ttnn::Shape tensor_shape({1, 1, 32, 1024});
+    size_t ncores_x = 8;
+    size_t ncores_y = 4;
+    auto mem_config = MemoryConfig(
+        TensorMemoryLayout::WIDTH_SHARDED,
+        BufferType::L1,
+        ShardSpec(
+            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{ncores_x - 1, ncores_y - 1}}}},
+            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / (ncores_x * ncores_y)},
+            ShardOrientation::ROW_MAJOR,
+            ShardMode::LOGICAL));
+    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+        tensor_shape,
+        Layout::TILE,
+        mem_config,
+        mem_config,
+        mem_config,
+        mem_config,
+        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+    ASSERT_TRUE(pass);
+}
 
-    TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded) {
-        ttnn::Shape tensor_shape({1, 1, 32, 64});
-        auto mem_config = MemoryConfig(
-            TensorMemoryLayout::WIDTH_SHARDED,
-            BufferType::L1,
-            ShardSpec(
-                CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}}},
-                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3]},
-                ShardOrientation::ROW_MAJOR,
-                ShardMode::LOGICAL));
-        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-            tensor_shape,
-            Layout::TILE,
-            mem_config,
-            mem_config,
-            mem_config,
-            mem_config,
-            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-        ASSERT_TRUE(pass);
-    } TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded1) {
-        ttnn::Shape tensor_shape({1, 1, 32, 128});
-        auto mem_config = MemoryConfig(
-            TensorMemoryLayout::WIDTH_SHARDED,
-            BufferType::L1,
-            ShardSpec(
-                CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}}},
-                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3]},
-                ShardOrientation::ROW_MAJOR,
-                ShardMode::LOGICAL));
-        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-            tensor_shape,
-            Layout::TILE,
-            mem_config,
-            mem_config,
-            mem_config,
-            mem_config,
-            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-        ASSERT_TRUE(pass);
-    } TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded2) {
-        ttnn::Shape tensor_shape({1, 1, 32, 128});
-        auto mem_config = MemoryConfig(
-            TensorMemoryLayout::WIDTH_SHARDED,
-            BufferType::L1,
-            ShardSpec(
-                CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}}},
-                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / 4},
-                ShardOrientation::ROW_MAJOR,
-                ShardMode::LOGICAL));
-        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-            tensor_shape,
-            Layout::TILE,
-            mem_config,
-            mem_config,
-            mem_config,
-            mem_config,
-            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-        ASSERT_TRUE(pass);
-    } TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded3) {
-        ttnn::Shape tensor_shape({1, 1, 32, 8192});
-        size_t ncores_x = 8;
-        size_t ncores_y = 4;
-        auto mem_config = MemoryConfig(
-            TensorMemoryLayout::WIDTH_SHARDED,
-            BufferType::L1,
-            ShardSpec(
-                CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{ncores_x - 1, ncores_y - 1}}}},
-                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / (ncores_x * ncores_y)},
-                ShardOrientation::ROW_MAJOR,
-                ShardMode::LOGICAL));
-        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-            tensor_shape,
-            Layout::TILE,
-            mem_config,
-            mem_config,
-            mem_config,
-            mem_config,
-            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-        ASSERT_TRUE(pass);
-    } TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded4) {
-        ttnn::Shape tensor_shape({1, 1, 32, 1024});
-        size_t ncores_x = 8;
-        size_t ncores_y = 4;
-        auto mem_config = MemoryConfig(
-            TensorMemoryLayout::WIDTH_SHARDED,
-            BufferType::L1,
-            ShardSpec(
-                CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{ncores_x - 1, ncores_y - 1}}}},
-                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / (ncores_x * ncores_y)},
-                ShardOrientation::ROW_MAJOR,
-                ShardMode::LOGICAL));
-        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-            tensor_shape,
-            Layout::TILE,
-            mem_config,
-            mem_config,
-            mem_config,
-            mem_config,
-            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-        ASSERT_TRUE(pass);
-    }
+TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded_WithReshard0) {
+    ttnn::Shape tensor_shape({1, 1, 32, 128});
+    const Layout layout = Layout::TILE;
+    auto input_mem_config = MemoryConfig(
+        TensorMemoryLayout::WIDTH_SHARDED,
+        BufferType::L1,
+        ShardSpec(
+            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}}},
+            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3]},
+            ShardOrientation::ROW_MAJOR,
+            ShardMode::LOGICAL));
+    auto output_mem_config = MemoryConfig(
+        TensorMemoryLayout::WIDTH_SHARDED,
+        BufferType::L1,
+        ShardSpec(
+            CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}}},
+            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / 4},
+            ShardOrientation::ROW_MAJOR,
+            ShardMode::LOGICAL));
+    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+        tensor_shape,
+        Layout::TILE,
+        input_mem_config,
+        input_mem_config,
+        output_mem_config,
+        output_mem_config,
+        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+    ASSERT_TRUE(pass);
+}
 
-    TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded_WithReshard0) {
-        ttnn::Shape tensor_shape({1, 1, 32, 128});
-        const Layout layout = Layout::TILE;
-        auto input_mem_config = MemoryConfig(
-            TensorMemoryLayout::WIDTH_SHARDED,
-            BufferType::L1,
-            ShardSpec(
-                CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}}},
-                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3]},
-                ShardOrientation::ROW_MAJOR,
-                ShardMode::LOGICAL));
-        auto output_mem_config = MemoryConfig(
-            TensorMemoryLayout::WIDTH_SHARDED,
-            BufferType::L1,
-            ShardSpec(
-                CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}}},
-                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2], tensor_shape[3] / 4},
-                ShardOrientation::ROW_MAJOR,
-                ShardMode::LOGICAL));
-        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-            tensor_shape,
-            Layout::TILE,
-            input_mem_config,
-            input_mem_config,
-            output_mem_config,
-            output_mem_config,
-            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-        ASSERT_TRUE(pass);
-    }
+TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded_WithReshard0_UniquePerStream) {
+    ttnn::Shape tensor_shape({1, 1, 32, 128});
+    const Layout layout = Layout::TILE;
+    size_t in_shard_grid_x = 1;
+    size_t in_shard_grid_y = 1;
+    size_t out_shard_grid_x = 4;
+    size_t out_shard_grid_y = 1;
+    auto mem_config0 = MemoryConfig(
+        TensorMemoryLayout::WIDTH_SHARDED,
+        BufferType::L1,
+        ShardSpec(
+            CoreRangeSet{
+                std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{in_shard_grid_x - 1, in_shard_grid_y - 1}}}},
+            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2],
+             tensor_shape[3] / (in_shard_grid_x * in_shard_grid_y)},
+            ShardOrientation::ROW_MAJOR,
+            ShardMode::LOGICAL));
+    auto mem_config1 = MemoryConfig(
+        TensorMemoryLayout::WIDTH_SHARDED,
+        BufferType::L1,
+        ShardSpec(
+            CoreRangeSet{
+                std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{out_shard_grid_x - 1, out_shard_grid_y - 1}}}},
+            {tensor_shape[0] * tensor_shape[1] * tensor_shape[2],
+             tensor_shape[3] / (out_shard_grid_x * out_shard_grid_y)},
+            ShardOrientation::ROW_MAJOR,
+            ShardMode::LOGICAL));
+    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+        tensor_shape,
+        Layout::TILE,
+        mem_config0,
+        mem_config1,
+        mem_config1,
+        mem_config0,
+        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+    ASSERT_TRUE(pass);
+}
 
-    TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage0_Sharded_WithReshard0_UniquePerStream) {
-        ttnn::Shape tensor_shape({1, 1, 32, 128});
-        const Layout layout = Layout::TILE;
-        size_t in_shard_grid_x = 1;
-        size_t in_shard_grid_y = 1;
-        size_t out_shard_grid_x = 4;
-        size_t out_shard_grid_y = 1;
-        auto mem_config0 = MemoryConfig(
-            TensorMemoryLayout::WIDTH_SHARDED,
-            BufferType::L1,
-            ShardSpec(
-                CoreRangeSet{std::set<CoreRange>{
-                    CoreRange{CoreCoord{0, 0}, CoreCoord{in_shard_grid_x - 1, in_shard_grid_y - 1}}}},
-                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2],
-                 tensor_shape[3] / (in_shard_grid_x * in_shard_grid_y)},
-                ShardOrientation::ROW_MAJOR,
-                ShardMode::LOGICAL));
-        auto mem_config1 = MemoryConfig(
-            TensorMemoryLayout::WIDTH_SHARDED,
-            BufferType::L1,
-            ShardSpec(
-                CoreRangeSet{std::set<CoreRange>{
-                    CoreRange{CoreCoord{0, 0}, CoreCoord{out_shard_grid_x - 1, out_shard_grid_y - 1}}}},
-                {tensor_shape[0] * tensor_shape[1] * tensor_shape[2],
-                 tensor_shape[3] / (out_shard_grid_x * out_shard_grid_y)},
-                ShardOrientation::ROW_MAJOR,
-                ShardMode::LOGICAL));
-        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-            tensor_shape,
-            Layout::TILE,
-            mem_config0,
-            mem_config1,
-            mem_config1,
-            mem_config0,
-            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-        ASSERT_TRUE(pass);
-    }
+// Copying even slightly large tensors exposes issues in underlying tensor code
+// that isn't under test here
+TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage1) {
+    ttnn::Shape tensor_shape({1, 1, 256, 256});
+    auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
+        tensor_shape,
+        Layout::TILE,
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
+    ASSERT_TRUE(pass);
+}
 
-    // Copying even slightly large tensors exposes issues in underlying tensor code
-    // that isn't under test here
-    TEST(WorkerCclCommandProcessingKernelLocalMode, MultiInputReader_MultiPage1) {
-        ttnn::Shape tensor_shape({1, 1, 256, 256});
-        auto pass = RunMultiInputReaderTestPropagateFullTensorIn(
-            tensor_shape,
-            Layout::TILE,
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK);
-        ASSERT_TRUE(pass);
-    }
+// TODO: update the test infra to be able to properly compare tensors if we are only
+// doing a slice of the larger tensor
 
-    // TODO: update the test infra to be able to properly compare tensors if we are only
-    // doing a slice of the larger tensor
+// ////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////
+// ////               FABRIC UNICAST TENSOR WRITE (2 INPUT)
+// ////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////
 
-    // ////////////////////////////////////////////////////////////////////
-    // ////////////////////////////////////////////////////////////////////
-    // ////               FABRIC UNICAST TENSOR WRITE (2 INPUT)
-    // ////////////////////////////////////////////////////////////////////
-    // ////////////////////////////////////////////////////////////////////
+TEST(WorkerCclCommandProcessingKernelFabricUnicastMode, MultiInputReader_SinglePageTile_OneHop_PersistentFabric) {
+    ttnn::Shape tensor_shape({1, 1, 32, 32});
+    constexpr size_t distance_dest_device = 1;
+    constexpr size_t num_devices = 4;
+    const Layout layout = Layout::TILE;
+    const MemoryConfig in0_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
+    const MemoryConfig in1_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
+    const MemoryConfig out0_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
+    const MemoryConfig out1_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
 
-    TEST(WorkerCclCommandProcessingKernelFabricUnicastMode, MultiInputReader_SinglePageTile_OneHop_PersistentFabric) {
-        ttnn::Shape tensor_shape({1, 1, 32, 32});
-        constexpr size_t distance_dest_device = 1;
-        constexpr size_t num_devices = 4;
-        const Layout layout = Layout::TILE;
-        const MemoryConfig in0_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
-        const MemoryConfig in1_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
-        const MemoryConfig out0_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
-        const MemoryConfig out1_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
+    auto num_elems = std::reduce(tensor_shape.cbegin(), tensor_shape.cend(), 1, std::multiplies<uint32_t>());
+    Tensor input_tensor0 =
+        ttnn::experimental::view(ttnn::arange(0, num_elems, 1, DataType::UINT32), tensor_shape).to_layout(layout);
+    Tensor input_tensor1 =
+        ttnn::experimental::view(ttnn::arange(num_elems, 2 * num_elems, 1, DataType::UINT32), tensor_shape)
+            .to_layout(layout);
+    Tensor output_tensor0 = ttnn::experimental::view(ttnn::ones(tensor_shape, DataType::UINT32, layout), tensor_shape);
+    Tensor output_tensor1 = ttnn::experimental::view(ttnn::ones(tensor_shape, DataType::UINT32, layout), tensor_shape);
 
-        auto num_elems = std::reduce(tensor_shape.cbegin(), tensor_shape.cend(), 1, std::multiplies<uint32_t>());
-        Tensor input_tensor0 =
-            ttnn::experimental::view(ttnn::arange(0, num_elems, 1, DataType::UINT32), tensor_shape).to_layout(layout);
-        Tensor input_tensor1 =
-            ttnn::experimental::view(ttnn::arange(num_elems, 2 * num_elems, 1, DataType::UINT32), tensor_shape)
-                .to_layout(layout);
-        Tensor output_tensor0 =
-            ttnn::experimental::view(ttnn::ones(tensor_shape, DataType::UINT32, layout), tensor_shape);
-        Tensor output_tensor1 =
-            ttnn::experimental::view(ttnn::ones(tensor_shape, DataType::UINT32, layout), tensor_shape);
+    size_t page_size = tile_size(DataFormat::RawUInt32);
 
-        size_t page_size = tile_size(DataFormat::RawUInt32);
+    ttnn::ccl::Shape4D<uint32_t> tensor_shape_in_pages = shape_to_shape_in_tiles(tensor_shape);
+    ttnn::ccl::Shape4D<uint32_t> tensor_slice_shape_in_pages = tensor_shape_in_pages;
+    ttnn::ccl::Shape4D<uint32_t> tensor_slice_offset = {0, 0, 0, 0};
+    ttnn::ccl::Shape4D<uint32_t> worker_slice_shape = tensor_shape_in_pages;
+    ttnn::ccl::Shape4D<uint32_t> worker_slice_offset = {0, 0, 0, 0};
 
-        ttnn::ccl::Shape4D<uint32_t> tensor_shape_in_pages = shape_to_shape_in_tiles(tensor_shape);
-        ttnn::ccl::Shape4D<uint32_t> tensor_slice_shape_in_pages = tensor_shape_in_pages;
-        ttnn::ccl::Shape4D<uint32_t> tensor_slice_offset = {0, 0, 0, 0};
-        ttnn::ccl::Shape4D<uint32_t> worker_slice_shape = tensor_shape_in_pages;
-        ttnn::ccl::Shape4D<uint32_t> worker_slice_offset = {0, 0, 0, 0};
+    ttnn::ccl::v2::TensorSlice tensor_slice{
+        tensor_shape_in_pages,
+        tensor_slice_shape_in_pages,
+        tensor_slice_offset,
+        worker_slice_shape,
+        worker_slice_offset};
 
-        ttnn::ccl::v2::TensorSlice tensor_slice{
-            tensor_shape_in_pages,
-            tensor_slice_shape_in_pages,
-            tensor_slice_offset,
-            worker_slice_shape,
-            worker_slice_offset};
+    const auto in0_tensor_slice = tensor_slice;
+    const auto in1_tensor_slice = tensor_slice;
+    const auto out0_tensor_slice = tensor_slice;
+    const auto out1_tensor_slice = tensor_slice;
 
-        const auto in0_tensor_slice = tensor_slice;
-        const auto in1_tensor_slice = tensor_slice;
-        const auto out0_tensor_slice = tensor_slice;
-        const auto out1_tensor_slice = tensor_slice;
+    ttnn::ccl::cmd::CclCommandDestArgs dest_args = ttnn::ccl::cmd::UnicastCommandDestArgs{distance_dest_device, true};
+    auto pass = TestMultiInputReaderKernel(
+        num_devices,
+        input_tensor0,
+        in0_memory_config,
+        input_tensor1,
+        in1_memory_config,
+        output_tensor0,
+        out0_memory_config,
+        output_tensor1,
+        out1_memory_config,
 
-        ttnn::ccl::cmd::CclCommandDestArgs dest_args =
-            ttnn::ccl::cmd::UnicastCommandDestArgs{distance_dest_device, true};
-        auto pass = TestMultiInputReaderKernel(
-            num_devices,
-            input_tensor0,
-            in0_memory_config,
-            input_tensor1,
-            in1_memory_config,
-            output_tensor0,
-            out0_memory_config,
-            output_tensor1,
-            out1_memory_config,
+        in0_tensor_slice,
+        in1_tensor_slice,
+        out0_tensor_slice,
+        out1_tensor_slice,
 
-            in0_tensor_slice,
-            in1_tensor_slice,
-            out0_tensor_slice,
-            out1_tensor_slice,
+        page_size,
+        TwoInputReaderKernelWriteMode::FABRIC_UNICAST,
+        dest_args);
 
-            page_size,
-            TwoInputReaderKernelWriteMode::FABRIC_UNICAST,
-            dest_args);
+    ASSERT_TRUE(pass);
+}
 
-        ASSERT_TRUE(pass);
-    }
+// ////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////
+// ////               FABRIC MCAST TENSOR WRITE (2 INPUT)
+// ////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////
 
-    // ////////////////////////////////////////////////////////////////////
-    // ////////////////////////////////////////////////////////////////////
-    // ////               FABRIC MCAST TENSOR WRITE (2 INPUT)
-    // ////////////////////////////////////////////////////////////////////
-    // ////////////////////////////////////////////////////////////////////
+TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_SinglePageTile_SingleHop_PersistentFabric) {
+    ttnn::Shape tensor_shape({1, 1, 32, 32});
+    constexpr size_t distance_dest_device = 1;
+    constexpr size_t num_devices = 4;
+    RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
+}
 
-    TEST(
-        WorkerCclCommandProcessingKernelFabricMulticastMode,
-        MultiInputReader_SinglePageTile_SingleHop_PersistentFabric) {
-        ttnn::Shape tensor_shape({1, 1, 32, 32});
-        constexpr size_t distance_dest_device = 1;
-        constexpr size_t num_devices = 4;
-        RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
-    }
+TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_SinglePageTile_TwoHop_PersistentFabric) {
+    ttnn::Shape tensor_shape({1, 1, 32, 32});
+    constexpr size_t distance_dest_device = 2;
+    constexpr size_t num_devices = 4;
+    RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
+}
+TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_SinglePageTile_ThreeHop_PersistentFabric) {
+    ttnn::Shape tensor_shape({1, 1, 32, 32});
+    constexpr size_t distance_dest_device = 3;
+    constexpr size_t num_devices = 4;
+    RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
+}
 
-    TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_SinglePageTile_TwoHop_PersistentFabric) {
-        ttnn::Shape tensor_shape({1, 1, 32, 32});
-        constexpr size_t distance_dest_device = 2;
-        constexpr size_t num_devices = 4;
-        RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
-    } TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_SinglePageTile_ThreeHop_PersistentFabric) {
-        ttnn::Shape tensor_shape({1, 1, 32, 32});
-        constexpr size_t distance_dest_device = 3;
-        constexpr size_t num_devices = 4;
-        RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
-    }
+TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_4PageTile_SingleHop_PersistentFabric) {
+    ttnn::Shape tensor_shape({1, 1, 32, 128});
+    constexpr size_t distance_dest_device = 1;
+    constexpr size_t num_devices = 4;
+    RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
+}
+TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, DMultiInputReader_4PageTile_TwoHop_PersistentFabric) {
+    ttnn::Shape tensor_shape({1, 1, 128, 32});
+    constexpr size_t distance_dest_device = 2;
+    constexpr size_t num_devices = 4;
+    RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
+}
+TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_4PageTile_ThreeHop_PersistentFabric) {
+    ttnn::Shape tensor_shape({1, 1, 64, 64});
+    constexpr size_t distance_dest_device = 3;
+    constexpr size_t num_devices = 4;
+    RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
+}
+TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_lotsPageTile_ThreeHop_PersistentFabric) {
+    ttnn::Shape tensor_shape({1, 1, 64, 16384});
+    constexpr size_t distance_dest_device = 3;
+    constexpr size_t num_devices = 4;
+    RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
+}
 
-    TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_4PageTile_SingleHop_PersistentFabric) {
-        ttnn::Shape tensor_shape({1, 1, 32, 128});
-        constexpr size_t distance_dest_device = 1;
-        constexpr size_t num_devices = 4;
-        RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
-    } TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, DMultiInputReader_4PageTile_TwoHop_PersistentFabric) {
-        ttnn::Shape tensor_shape({1, 1, 128, 32});
-        constexpr size_t distance_dest_device = 2;
-        constexpr size_t num_devices = 4;
-        RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
-    } TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_4PageTile_ThreeHop_PersistentFabric) {
-        ttnn::Shape tensor_shape({1, 1, 64, 64});
-        constexpr size_t distance_dest_device = 3;
-        constexpr size_t num_devices = 4;
-        RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
-    } TEST(WorkerCclCommandProcessingKernelFabricMulticastMode, MultiInputReader_lotsPageTile_ThreeHop_PersistentFabric) {
-        ttnn::Shape tensor_shape({1, 1, 64, 16384});
-        constexpr size_t distance_dest_device = 3;
-        constexpr size_t num_devices = 4;
-        RunFabricMcastFullTensorPropagateTest(tensor_shape, distance_dest_device, num_devices);
-    }
+TEST(WorkerCclCommandProcessingKernels, ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly0) {
+    ttnn::Shape tensor_shape({1, 1, 64, 16384});
+    const size_t split_dim = 3;
 
-    TEST(WorkerCclCommandProcessingKernels, ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly0) {
-        ttnn::Shape tensor_shape({1, 1, 64, 16384});
-        const size_t split_dim = 3;
+    // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
+    constexpr size_t num_stages = 4;
+    const size_t slices_per_stage = 4;
+    const size_t cb_packet_size_in_pages = 4;
+    const size_t num_packets_per_cb = 4;
+    auto layout = Layout::TILE;
+    const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
+    const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
+    std::vector<size_t> num_workers_per_stage = {1, 1, 1, 1};
+
+    std::vector<std::vector<size_t>> worker_chunk_read_order = {
+        {0, 1, 2, 3},  // first input
+        {3, 2, 1, 0},  // read in reverse order
+        {2, 0, 3, 1},  // read in non-sequential order
+        {1, 2, 3, 0}   // read in non-sequential order
+    };
+    std::vector<MemoryConfig> mem_configs{
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)};
+
+    auto pass = RunPipelinedWorkersTest(
+
+        tensor_shape,
+        split_dim,
 
         // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
-        constexpr size_t num_stages = 4;
-        const size_t slices_per_stage = 4;
-        const size_t cb_packet_size_in_pages = 4;
-        const size_t num_packets_per_cb = 4;
-        auto layout = Layout::TILE;
-        const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
-        const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
-        std::vector<size_t> num_workers_per_stage = {1, 1, 1, 1};
+        num_stages,
+        num_workers_per_stage,
+        slices_per_stage,
+        data_format,
+        page_size_bytes,
+        cb_packet_size_in_pages,
+        num_packets_per_cb,
+        layout,
 
-        std::vector<std::vector<size_t>> worker_chunk_read_order = {
+        worker_chunk_read_order,
+        mem_configs);
+
+    ASSERT_TRUE(pass);
+}
+TEST(WorkerCclCommandProcessingKernels, ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly1) {
+    ttnn::Shape tensor_shape({1, 1, 64, 128});
+    const size_t split_dim = 3;
+
+    // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
+    constexpr size_t num_stages = 4;
+    const size_t slices_per_stage = 4;
+    const size_t cb_packet_size_in_pages = 4;
+    const size_t num_packets_per_cb = 4;
+    auto layout = Layout::TILE;
+    const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
+    const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
+    std::vector<size_t> num_workers_per_stage = {1, 1, 1, 1};
+
+    std::vector<std::vector<size_t>> worker_chunk_read_order = {
+        {0, 1, 2, 3},  // first input
+        {3, 2, 1, 0},  // read in reverse order
+        {2, 0, 3, 1},  // read in non-sequential order
+        {1, 2, 3, 0}   // read in non-sequential order
+    };
+    std::vector<MemoryConfig> mem_configs{
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)};
+
+    auto pass = RunPipelinedWorkersTest(
+
+        tensor_shape,
+        split_dim,
+
+        // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
+        num_stages,
+        num_workers_per_stage,
+        slices_per_stage,
+        data_format,
+        page_size_bytes,
+        cb_packet_size_in_pages,
+        num_packets_per_cb,
+        layout,
+
+        worker_chunk_read_order,
+        mem_configs);
+
+    ASSERT_TRUE(pass);
+}
+TEST(WorkerCclCommandProcessingKernels, ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly2) {
+    ttnn::Shape tensor_shape({1, 1, 64, 8192});
+    const size_t split_dim = 3;
+
+    // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
+    constexpr size_t num_stages = 4;
+    const size_t slices_per_stage = 2;
+    const size_t cb_packet_size_in_pages = 4;
+    const size_t num_packets_per_cb = 4;
+    auto layout = Layout::TILE;
+    const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
+    const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
+    std::vector<size_t> num_workers_per_stage = {1, 1, 1, 1};
+
+    std::vector<std::vector<size_t>> worker_chunk_read_order = {
+        {0, 1},  // first input
+        {1, 0},  // read in reverse order
+        {1, 0},  // read in non-sequential order
+        {0, 1}   // read in non-sequential order
+    };
+    std::vector<MemoryConfig> mem_configs{
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+        MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)};
+
+    auto pass = RunPipelinedWorkersTest(
+
+        tensor_shape,
+        split_dim,
+
+        // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
+        num_stages,
+        num_workers_per_stage,
+        slices_per_stage,
+        data_format,
+        page_size_bytes,
+        cb_packet_size_in_pages,
+        num_packets_per_cb,
+        layout,
+
+        worker_chunk_read_order,
+        mem_configs);
+
+    ASSERT_TRUE(pass);
+}
+
+// Hits issues with input tensor copy-back
+TEST(
+    WorkerCclCommandProcessingKernels,
+    DISABLED_ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly_SmallSweep) {
+    std::vector<ttnn::Shape> tensor_shapes = {
+        ttnn::Shape({1, 1, 64, 8192}),
+        ttnn::Shape({1, 4, 64, 768}),
+        ttnn::Shape({4, 1, 64, 768}),
+        ttnn::Shape({4, 4, 64, 768}),
+        ttnn::Shape({1, 1, 64, 768}),
+        ttnn::Shape({5, 3, 64, 768})};
+
+    const size_t split_dim = 3;
+
+    // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
+    constexpr size_t num_stages = 4;
+    const std::vector<size_t> slices_per_stage_sweep = {2, 3, 4};
+    const size_t cb_packet_size_in_pages = 4;
+    const size_t num_packets_per_cb = 4;
+    auto layout = Layout::TILE;
+    const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
+    const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
+    std::vector<std::vector<size_t>> num_workers_per_stage_sweep = {
+        {1, 1, 1, 1}, {2, 2, 2, 2}, {3, 3, 3, 3}, {4, 4, 4, 4}};
+
+    std::vector<std::vector<std::vector<size_t>>> worker_chunk_read_order = {
+        {{}},
+        {
+            {0},
+            {0},
+            {0},
+            {0},
+        },
+        {
+            {0, 1},
+            {1, 0},
+            {1, 0},
+            {0, 1},
+        },
+        {
+            {2, 0, 1},
+            {1, 0, 2},
+            {0, 1, 2},
+            {2, 1, 0},
+        },
+        {
             {0, 1, 2, 3},  // first input
             {3, 2, 1, 0},  // read in reverse order
             {2, 0, 3, 1},  // read in non-sequential order
             {1, 2, 3, 0}   // read in non-sequential order
-        };
-        std::vector<MemoryConfig> mem_configs{
+        }};
+    std::vector<std::vector<MemoryConfig>> mem_configs_sweep = {
+        {
             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)};
-
-        auto pass = RunPipelinedWorkersTest(
-
-            tensor_shape,
-            split_dim,
-
-            // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be
-            // configurable)
-            num_stages,
-            num_workers_per_stage,
-            slices_per_stage,
-            data_format,
-            page_size_bytes,
-            cb_packet_size_in_pages,
-            num_packets_per_cb,
-            layout,
-
-            worker_chunk_read_order,
-            mem_configs);
-
-        ASSERT_TRUE(pass);
-    } TEST(WorkerCclCommandProcessingKernels, ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly1) {
-        ttnn::Shape tensor_shape({1, 1, 64, 128});
-        const size_t split_dim = 3;
-
-        // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
-        constexpr size_t num_stages = 4;
-        const size_t slices_per_stage = 4;
-        const size_t cb_packet_size_in_pages = 4;
-        const size_t num_packets_per_cb = 4;
-        auto layout = Layout::TILE;
-        const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
-        const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
-        std::vector<size_t> num_workers_per_stage = {1, 1, 1, 1};
-
-        std::vector<std::vector<size_t>> worker_chunk_read_order = {
-            {0, 1, 2, 3},  // first input
-            {3, 2, 1, 0},  // read in reverse order
-            {2, 0, 3, 1},  // read in non-sequential order
-            {1, 2, 3, 0}   // read in non-sequential order
-        };
-        std::vector<MemoryConfig> mem_configs{
             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)};
+        },
+        {MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1)},
+        {MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)},
+        {MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
+         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
+         MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)},
+    };
 
-        auto pass = RunPipelinedWorkersTest(
+    for (auto& tensor_shape : tensor_shapes) {
+        for (auto& num_workers_per_stage : num_workers_per_stage_sweep) {
+            for (size_t slices_per_stage : slices_per_stage_sweep) {
+                for (auto& mem_configs : mem_configs_sweep) {
+                    log_info(
+                        tt::LogTest,
+                        "tensor shape {} and workers stage {} slices_per_stage {}",
+                        tensor_shape,
+                        num_workers_per_stage,
+                        slices_per_stage);
+                    auto pass = RunPipelinedWorkersTest(
 
-            tensor_shape,
-            split_dim,
+                        tensor_shape,
+                        split_dim,
 
-            // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be
-            // configurable)
-            num_stages,
-            num_workers_per_stage,
-            slices_per_stage,
-            data_format,
-            page_size_bytes,
-            cb_packet_size_in_pages,
-            num_packets_per_cb,
-            layout,
+                        // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will
+                        // be configurable)
+                        num_stages,
+                        num_workers_per_stage,
+                        slices_per_stage,
+                        data_format,
+                        page_size_bytes,
+                        cb_packet_size_in_pages,
+                        num_packets_per_cb,
+                        layout,
 
-            worker_chunk_read_order,
-            mem_configs);
+                        worker_chunk_read_order[slices_per_stage],
+                        mem_configs);
 
-        ASSERT_TRUE(pass);
-    } TEST(WorkerCclCommandProcessingKernels, ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly2) {
-        ttnn::Shape tensor_shape({1, 1, 64, 8192});
-        const size_t split_dim = 3;
-
-        // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
-        constexpr size_t num_stages = 4;
-        const size_t slices_per_stage = 2;
-        const size_t cb_packet_size_in_pages = 4;
-        const size_t num_packets_per_cb = 4;
-        auto layout = Layout::TILE;
-        const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
-        const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
-        std::vector<size_t> num_workers_per_stage = {1, 1, 1, 1};
-
-        std::vector<std::vector<size_t>> worker_chunk_read_order = {
-            {0, 1},  // first input
-            {1, 0},  // read in reverse order
-            {1, 0},  // read in non-sequential order
-            {0, 1}   // read in non-sequential order
-        };
-        std::vector<MemoryConfig> mem_configs{
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)};
-
-        auto pass = RunPipelinedWorkersTest(
-
-            tensor_shape,
-            split_dim,
-
-            // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be
-            // configurable)
-            num_stages,
-            num_workers_per_stage,
-            slices_per_stage,
-            data_format,
-            page_size_bytes,
-            cb_packet_size_in_pages,
-            num_packets_per_cb,
-            layout,
-
-            worker_chunk_read_order,
-            mem_configs);
-
-        ASSERT_TRUE(pass);
-    }
-
-    // Hits issues with input tensor copy-back
-    TEST(
-        WorkerCclCommandProcessingKernels,
-        DISABLED_ChainOfCommandProcessorsWithVaryingDataReadOrders_LocalOnly_SmallSweep) {
-        std::vector<ttnn::Shape> tensor_shapes = {
-            ttnn::Shape({1, 1, 64, 8192}),
-            ttnn::Shape({1, 4, 64, 768}),
-            ttnn::Shape({4, 1, 64, 768}),
-            ttnn::Shape({4, 4, 64, 768}),
-            ttnn::Shape({1, 1, 64, 768}),
-            ttnn::Shape({5, 3, 64, 768})};
-
-        const size_t split_dim = 3;
-
-        // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will be configurable)
-        constexpr size_t num_stages = 4;
-        const std::vector<size_t> slices_per_stage_sweep = {2, 3, 4};
-        const size_t cb_packet_size_in_pages = 4;
-        const size_t num_packets_per_cb = 4;
-        auto layout = Layout::TILE;
-        const tt::DataFormat data_format = tt::DataFormat::RawUInt32;
-        const size_t page_size_bytes = tile_size(DataFormat::RawUInt32);
-        std::vector<std::vector<size_t>> num_workers_per_stage_sweep = {
-            {1, 1, 1, 1}, {2, 2, 2, 2}, {3, 3, 3, 3}, {4, 4, 4, 4}};
-
-        std::vector<std::vector<std::vector<size_t>>> worker_chunk_read_order = {
-            {{}},
-            {
-                {0},
-                {0},
-                {0},
-                {0},
-            },
-            {
-                {0, 1},
-                {1, 0},
-                {1, 0},
-                {0, 1},
-            },
-            {
-                {2, 0, 1},
-                {1, 0, 2},
-                {0, 1, 2},
-                {2, 1, 0},
-            },
-            {
-                {0, 1, 2, 3},  // first input
-                {3, 2, 1, 0},  // read in reverse order
-                {2, 0, 3, 1},  // read in non-sequential order
-                {1, 2, 3, 0}   // read in non-sequential order
-            }};
-        std::vector<std::vector<MemoryConfig>> mem_configs_sweep = {
-            {
-                MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-                MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-                MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-                MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-                MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-            },
-            {MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1)},
-            {MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)},
-            {MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM),
-             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1),
-             MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM)},
-        };
-
-        for (auto& tensor_shape : tensor_shapes) {
-            for (auto& num_workers_per_stage : num_workers_per_stage_sweep) {
-                for (size_t slices_per_stage : slices_per_stage_sweep) {
-                    for (auto& mem_configs : mem_configs_sweep) {
-                        log_info(
-                            tt::LogTest,
-                            "tensor shape {} and workers stage {} slices_per_stage {}",
-                            tensor_shape,
-                            num_workers_per_stage,
-                            slices_per_stage);
-                        auto pass = RunPipelinedWorkersTest(
-
-                            tensor_shape,
-                            split_dim,
-
-                            // In this test we will have n stages with anywhere from 1 to 8 workers per stage (this will
-                            // be configurable)
-                            num_stages,
-                            num_workers_per_stage,
-                            slices_per_stage,
-                            data_format,
-                            page_size_bytes,
-                            cb_packet_size_in_pages,
-                            num_packets_per_cb,
-                            layout,
-
-                            worker_chunk_read_order[slices_per_stage],
-                            mem_configs);
-
-                        ASSERT_TRUE(pass);
-                    }
+                    ASSERT_TRUE(pass);
                 }
             }
         }
     }
+}
 
-    TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast) {
-        const size_t num_mcasts = 1;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        params.line_size = 2;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    }
+TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast) {
+    const size_t num_mcasts = 1;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    params.line_size = 2;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
 
 //
 // The routing plane for fast dispatch uses 1 eth core in each direction
@@ -813,590 +814,626 @@
         GTEST_SKIP() << "Not enough eth cores for 2 links";                   \
     }
 
-    TEST(EdmFabric, BasicMcastThroughputTest_SingleMcast) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 1;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_SingleWorker_2Device) {
-        const size_t num_mcasts = 9;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const size_t line_size = 2;
-        const bool line_sync = false;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_size = line_size;
-        params.line_sync = line_sync;
-        params.num_devices_with_workers = 1;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_2Device) {
-        const size_t num_mcasts = 9;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const size_t line_size = 2;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_size = line_size;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_SingleWorker_4Device) {
-        const size_t num_mcasts = 9;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const size_t line_size = 4;
-        const bool line_sync = false;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_size = line_size;
-        params.line_sync = line_sync;
-        params.num_devices_with_workers = 1;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_TwoWorkers_4Device) {
-        const size_t num_mcasts = 9;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const size_t line_size = 4;
-        const bool line_sync = false;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_size = line_size;
-        params.line_sync = line_sync;
-        params.num_devices_with_workers = 2;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap) {
-        const size_t num_mcasts = 9;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_SingleWorker_2Device) {
-        const size_t num_mcasts = 10;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const size_t line_size = 2;
-        const bool line_sync = false;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_size = line_size;
-        params.line_sync = line_sync;
-        params.num_devices_with_workers = 1;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_2Device) {
-        const size_t num_mcasts = 10;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const size_t line_size = 2;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_size = line_size;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap) {
-        const size_t num_mcasts = 10;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2Device) {
-        const size_t num_mcasts = 18;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const size_t line_size = 2;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_size = line_size;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled) {
-        const size_t num_mcasts = 18;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderTwoWrap_ReceiverOneWrap) {
-        const size_t num_mcasts = 19;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    }
+TEST(EdmFabric, BasicMcastThroughputTest_SingleMcast) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 1;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_SingleWorker_2Device) {
+    const size_t num_mcasts = 9;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 2;
+    const bool line_sync = false;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    params.num_devices_with_workers = 1;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_2Device) {
+    const size_t num_mcasts = 9;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 2;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_SingleWorker_4Device) {
+    const size_t num_mcasts = 9;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 4;
+    const bool line_sync = false;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    params.num_devices_with_workers = 1;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_TwoWorkers_4Device) {
+    const size_t num_mcasts = 9;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 4;
+    const bool line_sync = false;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    params.num_devices_with_workers = 2;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap) {
+    const size_t num_mcasts = 9;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_SingleWorker_2Device) {
+    const size_t num_mcasts = 10;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 2;
+    const bool line_sync = false;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    params.num_devices_with_workers = 1;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_2Device) {
+    const size_t num_mcasts = 10;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 2;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap) {
+    const size_t num_mcasts = 10;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2Device) {
+    const size_t num_mcasts = 18;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 2;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled) {
+    const size_t num_mcasts = 18;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderTwoWrap_ReceiverOneWrap) {
+    const size_t num_mcasts = 19;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
 
-    TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast_LineSync) {
-        const size_t num_mcasts = 1;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    }
+TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast_LineSync) {
+    const size_t num_mcasts = 1;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
 
-    TEST(EdmFabric, BasicMcastThroughputTest_SingleMcast_LineSync) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 1;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_LineSync) {
-        const size_t num_mcasts = 9;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_2Device_LineSync) {
-        const size_t num_mcasts = 10;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const size_t line_size = 2;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_size = line_size;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_LineSync) {
-        const size_t num_mcasts = 10;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2Device_LineSync) {
-        const size_t num_mcasts = 18;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const size_t line_size = 2;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_size = line_size;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_LineSync) {
-        const size_t num_mcasts = 18;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_2Device_1Worker) {
-        const size_t num_mcasts = 36;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const size_t line_size = 2;
-        const bool line_sync = false;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_size = line_size;
-        params.line_sync = line_sync;
-        params.num_devices_with_workers = 1;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_2Device_LineSync) {
-        const size_t num_mcasts = 36;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const size_t line_size = 2;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_size = line_size;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_LineSync) {
-        const size_t num_mcasts = 36;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SenderTwoWrap_ReceiverOneWrap_LineSync) {
-        const size_t num_mcasts = 19;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    }
+TEST(EdmFabric, BasicMcastThroughputTest_SingleMcast_LineSync) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 1;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_LineSync) {
+    const size_t num_mcasts = 9;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_2Device_LineSync) {
+    const size_t num_mcasts = 10;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 2;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_LineSync) {
+    const size_t num_mcasts = 10;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2Device_LineSync) {
+    const size_t num_mcasts = 18;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 2;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_LineSync) {
+    const size_t num_mcasts = 18;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_2Device_1Worker) {
+    const size_t num_mcasts = 36;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 2;
+    const bool line_sync = false;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    params.num_devices_with_workers = 1;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_2Device_LineSync) {
+    const size_t num_mcasts = 36;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 2;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_LineSync) {
+    const size_t num_mcasts = 36;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SenderTwoWrap_ReceiverOneWrap_LineSync) {
+    const size_t num_mcasts = 19;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
 
-    TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf_2Device) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 70;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
-        const size_t line_size = 2;
-        const bool report_performance = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = report_performance;
-        params.line_size = line_size;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    }
+TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf_2Device) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 70;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 2;
+    const bool report_performance = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = report_performance;
+    params.line_size = line_size;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
 
-    TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf0) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 70;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = true;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf1) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 70;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = true;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    }
+TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf0) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 70;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = true;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf1) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 70;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = true;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
 
-    TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_0) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 100;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = false;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_size = 2;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_1) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 1000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = false;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_2) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 50000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_0) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 100;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = false;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = 2;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_1) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 1000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = false;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_2) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 50000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
 
-        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-    } TEST(EdmFabric, BasicMcastThroughputTest_3_SingleLink) {
-        const size_t num_mcasts = 200000;
-        const size_t num_unicasts = 0;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_3) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 200000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_3_onehop) {
-        const size_t num_mcasts = 200000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 1;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        params.line_size = 2;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_4) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 800000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
-        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-    }
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_3_SingleLink) {
+    const size_t num_mcasts = 200000;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_3) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 200000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_3_onehop) {
+    const size_t num_mcasts = 200000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    params.line_size = 2;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_4) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 800000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
 
-    TEST(EdmFabric, BasicMcastThroughputTest_5) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 1;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 20000;
-        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-    }
-    // DISABLED due to long runtime
-    TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_6) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 100;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 8000;
-        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-    }
-    // DISABLED due to long runtime
-    TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_7) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 1000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1000;
-        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-    }
-    // DISABLED due to long runtime
-    TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_8) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 50000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 200;
-        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-    }
-    // DISABLED due to long runtime
-    TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_9) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 200000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 150;
-        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-    }
-    // DISABLED due to long runtime
-    TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_10) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 800000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 50;
-        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-    } TEST(EdmFabric, BasicMcastThroughputTest_6_Short) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 100;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 100;
-        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-    } TEST(EdmFabric, BasicMcastThroughputTest_7_Short) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 1000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 50;
-        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-    } TEST(EdmFabric, BasicMcastThroughputTest_8_Short) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 50000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 20;
-        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-    } TEST(EdmFabric, BasicMcastThroughputTest_9_Short) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 200000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 10;
-        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-    } TEST(EdmFabric, BasicMcastThroughputTest_10_Short) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 800000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 5;
-        RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
-    }
+TEST(EdmFabric, BasicMcastThroughputTest_5) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 1;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 20000;
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+// DISABLED due to long runtime
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_6) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 100;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 8000;
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+// DISABLED due to long runtime
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_7) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 1000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1000;
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+// DISABLED due to long runtime
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_8) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 50000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 200;
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+// DISABLED due to long runtime
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_9) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 200000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 150;
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+// DISABLED due to long runtime
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_10) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 800000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 50;
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_6_Short) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 100;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 100;
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_7_Short) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 1000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 50;
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_8_Short) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 50000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 20;
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_9_Short) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 200000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 10;
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_10_Short) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 800000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 5;
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
 
-    TEST(EdmFabric, BasicMcastThroughputTest_0_WithLineSync) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 100;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_1_WithLineSync) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 1000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_2_WithLineSync) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 50000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_3_WithLineSync) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 200000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
-    } TEST(EdmFabric, BasicMcastThroughputTest_4_WithLineSync) {
-        CHECK_TWO_LINKS_AVAILABLE();
-        const size_t num_mcasts = 800000;
-        const size_t num_unicasts = 2;
-        const size_t num_links = 2;
-        const size_t num_op_invocations = 1;
-        const bool line_sync = true;
-        WriteThroughputStabilityTestWithPersistentFabricParams params;
-        params.line_sync = line_sync;
-        RunWriteThroughputStabilityTestWithPersistentFabric(
-            num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+TEST(EdmFabric, BasicMcastThroughputTest_0_WithLineSync) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 100;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_1_WithLineSync) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 1000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_2_WithLineSync) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 50000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_3_WithLineSync) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 200000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_4_WithLineSync) {
+    CHECK_TWO_LINKS_AVAILABLE();
+    const size_t num_mcasts = 800000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+
+TEST(EdmFabric, RingDeadlockStabilityTest) {
+    constexpr size_t num_mcasts = 200000;
+    constexpr size_t num_op_invocations = 5;
+    constexpr bool line_sync = true;
+    size_t num_links = 1;
+    std::vector<size_t> num_devices_vec;
+    auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+    if (cluster_type == tt::ClusterType::GALAXY) {
+        num_devices_vec = {4, 8};
+        num_links = 4;
+    } else {
+        num_devices_vec = {8};
     }
-
-    TEST(EdmFabric, RingDeadlockStabilityTest) {
-        constexpr size_t num_mcasts = 200000;
-        constexpr size_t num_op_invocations = 5;
-        constexpr bool line_sync = true;
-        size_t num_links = 1;
-        std::vector<size_t> num_devices_vec;
-        auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
-        if (cluster_type == tt::ClusterType::GALAXY) {
-            num_devices_vec = {4, 8};
-            num_links = 4;
-        } else {
-            num_devices_vec = {8};
-        }
-        for (const auto& num_devices : num_devices_vec) {
-            log_trace(
-                tt::LogTest, "Running RingDeadlockStabilityTest with forward mcast only with {} devices", num_devices);
-            RunRingDeadlockStabilityTestWithPersistentFabric(
-                num_mcasts, num_links, num_devices, num_op_invocations, true, false);
-            log_trace(
-                tt::LogTest, "Running RingDeadlockStabilityTest with backward mcast only with {} devices", num_devices);
-            RunRingDeadlockStabilityTestWithPersistentFabric(
-                num_mcasts, num_links, num_devices, num_op_invocations, false, true);
-            log_trace(
-                tt::LogTest,
-                "Running RingDeadlockStabilityTest with forward and backward mcast with {} devices",
-                num_devices);
-            RunRingDeadlockStabilityTestWithPersistentFabric(
-                num_mcasts, num_links, num_devices, num_op_invocations, true, true);
-        }
+    for (const auto& num_devices : num_devices_vec) {
+        log_trace(
+            tt::LogTest, "Running RingDeadlockStabilityTest with forward mcast only with {} devices", num_devices);
+        RunRingDeadlockStabilityTestWithPersistentFabric(
+            num_mcasts, num_links, num_devices, num_op_invocations, true, false);
+        log_trace(
+            tt::LogTest, "Running RingDeadlockStabilityTest with backward mcast only with {} devices", num_devices);
+        RunRingDeadlockStabilityTestWithPersistentFabric(
+            num_mcasts, num_links, num_devices, num_op_invocations, false, true);
+        log_trace(
+            tt::LogTest,
+            "Running RingDeadlockStabilityTest with forward and backward mcast with {} devices",
+            num_devices);
+        RunRingDeadlockStabilityTestWithPersistentFabric(
+            num_mcasts, num_links, num_devices, num_op_invocations, true, true);
     }
+}
 
-    TEST(EdmFabric, RingDeadlockStabilityTest_RelaxedFabricStrictness) {
-        constexpr size_t num_mcasts = 200000;
-        constexpr size_t num_op_invocations = 5;
-        constexpr bool line_sync = true;
-        // Set to however many links are available
-        std::optional<size_t> num_links = std::nullopt;
-        std::vector<size_t> num_devices;
-        auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+TEST(EdmFabric, RingDeadlockStabilityTest_RelaxedFabricStrictness) {
+    constexpr size_t num_mcasts = 200000;
+    constexpr size_t num_op_invocations = 5;
+    constexpr bool line_sync = true;
+    // Set to however many links are available
+    std::optional<size_t> num_links = std::nullopt;
+    std::vector<size_t> num_devices;
+    auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
 
-        if (cluster_type != tt::ClusterType::GALAXY) {
-            return;
-        }
-        num_devices = {4, 8};
-        for (size_t offset = 0; offset < num_devices[1]; offset++) {
-            RunRingDeadlockStabilityTestWithPersistentFabric<Fabric1DRingRelaxedDeviceInitFixture>(
-                num_mcasts,
-                num_links,
-                num_devices[0],
-                num_op_invocations,
-                true,
-                false,
-                tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes,
-                offset);
-        }
-        for (size_t offset = 0; offset < num_devices[0]; offset++) {
-            RunRingDeadlockStabilityTestWithPersistentFabric<Fabric1DRingRelaxedDeviceInitFixture>(
-                num_mcasts,
-                num_links,
-                num_devices[1],
-                num_op_invocations,
-                true,
-                false,
-                tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes,
-                offset);
-        }
-    })
+    if (cluster_type != tt::ClusterType::GALAXY) {
+        return;
+    }
+    num_devices = {4, 8};
+    for (size_t offset = 0; offset < num_devices[1]; offset++) {
+        RunRingDeadlockStabilityTestWithPersistentFabric<Fabric1DRingRelaxedDeviceInitFixture>(
+            num_mcasts,
+            num_links,
+            num_devices[0],
+            num_op_invocations,
+            true,
+            false,
+            tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes,
+            offset);
+    }
+    for (size_t offset = 0; offset < num_devices[0]; offset++) {
+        RunRingDeadlockStabilityTestWithPersistentFabric<Fabric1DRingRelaxedDeviceInitFixture>(
+            num_mcasts,
+            num_links,
+            num_devices[1],
+            num_op_invocations,
+            true,
+            false,
+            tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes,
+            offset);
+    }
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18726

### Problem description
- Rolling out dispatch on fabric

### What's changed
- Enable select test suites to run with Dispatch on Fabric enabled
- Some tests skipped due to only 1 link being available now as Fabric will create a router in each direction for DIspatch even if it's not being used.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes