### PR TITLE
Move DPrint singleton under MetalContext

### DIFF
--- a/tests/scripts/run_tools_tests.sh
+++ b/tests/scripts/run_tools_tests.sh
@@ -17,7 +17,7 @@ if [[ -z "$TT_METAL_SLOW_DISPATCH_MODE" ]] ; then
     echo "Running watcher dump tool tests..."
 
     # Run a test that populates basic fields but not watcher fields
-    ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter=*PrintHanging
+    TT_METAL_WATCHER_KEEP_ERRORS=1 ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter=*PrintHanging
 
     # Run dump tool w/ minimum data - no error expected.
     ./build/tools/watcher_dump -d=0 -w -c

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
@@ -15,7 +15,6 @@
 #include "debug_tools_fixture.hpp"
 #include "debug_tools_test_utils.hpp"
 #include <tt-metalium/device.hpp>
-#include "dprint_server.hpp"
 #include "gtest/gtest.h"
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-logger/tt-logger.hpp>
@@ -94,7 +93,7 @@ void RunTest(
         );
 
         // Clear the log file for the next core's test
-        DPrintServerClearLogFile();
+        MetalContext::instance().dprint_server()->clear_log_file();
     }
 }
 }

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_mute_device.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_mute_device.cpp
@@ -39,32 +39,6 @@ using namespace tt::tt_metal;
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
-const std::string golden_output =
-R"(Test Debug Print: Data0
-Basic Types:
-101-1.618@0.122559
-e5551234569123456789
--17-343-44444-5123456789
-SETPRECISION/FIXED/DEFAULTFLOAT:
-3.1416
-3.14159012
-3.14159
-3.141590118
-SETW:
-    123456123456  ab
-HEX/OCT/DEC:
-1e240361100123456
-SLICE:
-0.122558594 0.127929688 0.490234375 0.51171875
-0.245117188 0.255859375 0.98046875 1.0234375
-1.9609375 2.046875 7.84375 8.1875
-3.921875 4.09375 15.6875 16.375
-0.122558594 0.124511719 0.127929688 0.131835938 0.490234375 0.498046875 0.51171875 0.52734375
-0.182617188 0.186523438 0.190429688 0.194335938 0.73046875 0.74609375 0.76171875 0.77734375
-0.245117188 0.249023438 0.255859375 0.263671875 0.98046875 0.99609375 1.0234375 1.0546875
-0.365234375 0.373046875 0.380859375 0.388671875 1.4609375 1.4921875 1.5234375 1.5546875
-<TileSlice data truncated due to exceeding max count (32)>)";
-
 void RunTest(DPrintFixture* fixture, IDevice* device) {
     // Set up program and command queue
     constexpr CoreCoord core = {0, 0}; // Print on first core only
@@ -97,7 +71,7 @@ void RunTest(DPrintFixture* fixture, IDevice* device) {
     EXPECT_TRUE(OpenFile(file_name, log_file, std::fstream::in));
     EXPECT_TRUE(log_file.peek() == std::ifstream::traits_type::eof());
 }
-}
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }
 
 TEST_F(DPrintDisableDevicesFixture, TensixTestPrintMuteDevice) {

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_mute_print_server.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_mute_print_server.cpp
@@ -13,7 +13,6 @@
 #include <tt-metalium/data_types.hpp>
 #include "debug_tools_fixture.hpp"
 #include "debug_tools_test_utils.hpp"
-#include "dprint_server.hpp"
 #include "gtest/gtest.h"
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
@@ -65,11 +64,11 @@ void RunTest(DPrintFixture* fixture, IDevice* device) {
     run_program(0);
 
     // Disable the printing and run the program again.
-    DprintServerSetMute(true);
+    MetalContext::instance().dprint_server()->set_mute(true);
     run_program(1);
 
     // Re-enable prints and run the program one more time.
-    DprintServerSetMute(false);
+    MetalContext::instance().dprint_server()->set_mute(false);
     run_program(2);
 
     // Check the print log against golden output.

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_hanging.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_hanging.cpp
@@ -83,9 +83,4 @@ TEST_F(DPrintFixture, TensixTestPrintHanging) {
 
     // Since the dprint server gets killed from a timeout, only run on one device.
     this->RunTestOnDevice(CMAKE_UNIQUE_NAMESPACE::RunTest, this->devices_[0]);
-    // Since the dprint server exited with an exception, detach manually
-    auto num_devices = tt::tt_metal::GetNumAvailableDevices();
-    for (unsigned int id = 0; id < num_devices; id++) {
-        DprintServerDetach(id);
-    }
 }

--- a/tests/tt_metal/tt_metal/test_compile_args.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_args.cpp
@@ -10,7 +10,6 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include "dprint_server.hpp"
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/jit_build/build_env_manager.hpp"
 

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -17,6 +17,7 @@
 #include <impl/dispatch/dispatch_core_manager.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
 #include <impl/dispatch/dispatch_query_manager.hpp>
+#include <impl/debug/dprint_server.hpp>
 
 #include <array>
 #include <unordered_set>
@@ -57,6 +58,7 @@ public:
     inspector::Data* get_inspector_data() const {
         return inspector_data_.get();
     }
+    std::unique_ptr<DPrintServer>& dprint_server() { return dprint_server_; }
 
     void initialize(
         const DispatchCoreConfig& dispatch_core_config,
@@ -136,6 +138,7 @@ private:
     std::unique_ptr<dispatch_core_manager> dispatch_core_manager_;
     std::unique_ptr<DispatchQueryManager> dispatch_query_manager_;
     std::unique_ptr<inspector::Data> inspector_data_;
+    std::unique_ptr<DPrintServer> dprint_server_;
     std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
     std::unique_ptr<tt::tt_fabric::GlobalControlPlane> global_control_plane_;
     tt_metal::FabricConfig fabric_config_ = tt_metal::FabricConfig::DISABLED;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -51,7 +51,6 @@
 #include "trace/trace.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch/dispatch_settings.hpp"
-#include "dprint_server.hpp"
 #include "hal_types.hpp"
 #include "jit_build/build.hpp"
 #include "dispatch/launch_message_ring_buffer_state.hpp"

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -22,7 +22,6 @@
 #include "core_coord.hpp"
 #include "device_impl.hpp"
 #include "dispatch/dispatch_settings.hpp"
-#include "dprint_server.hpp"
 #include "env_lib.hpp"
 #include "erisc_datamover_builder.hpp"
 #include "fabric_edm_packet_header.hpp"

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -29,7 +29,6 @@
 #include "dispatch_settings.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/host_runtime_commands.hpp"
-#include "dprint_server.hpp"
 #include "event/dispatch.hpp"
 #include "hal_types.hpp"
 #include <tt-logger/tt-logger.hpp>
@@ -722,7 +721,8 @@ void HWCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids) {
     this->enqueue_record_event(event, sub_device_ids);
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_test_mode_enabled()) {
         while (this->num_entries_in_completion_q_ > this->num_completed_completion_q_reads_) {
-            if (DPrintServerHangDetected()) {
+            if (MetalContext::instance().dprint_server() and
+                MetalContext::instance().dprint_server()->hang_detected()) {
                 // DPrint Server hang, early exit. We're in test mode, so main thread will assert.
                 this->set_exit_condition();
                 return;

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -26,7 +26,6 @@
 #include "device.hpp"
 #include "dispatch/device_command.hpp"
 #include "impl/context/metal_context.hpp"
-#include "dprint_server.hpp"
 #include "hal_types.hpp"
 #include "lightmetal/host_api_capture_helpers.hpp"
 #include "tt-metalium/program.hpp"
@@ -342,7 +341,7 @@ void Finish(CommandQueue& cq, tt::stl::Span<const SubDeviceId> sub_device_ids) {
     // If in testing mode, don't need to check dprint/watcher errors, since the tests will induce/handle them.
     if (!MetalContext::instance().rtoptions().get_test_mode_enabled()) {
         TT_FATAL(
-            !(DPrintServerHangDetected()),
+            !(MetalContext::instance().dprint_server() and MetalContext::instance().dprint_server()->hang_detected()),
             "Command Queue could not finish: device hang due to unanswered DPRINT WAIT.");
         TT_FATAL(
             !(tt::watcher_server_killed_due_to_error()),

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -15,7 +15,6 @@
 #include "dispatch/kernel_config/relay_mux.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch_s.hpp"
-#include "dprint_server.hpp"
 #include "eth_router.hpp"
 #include "eth_tunneler.hpp"
 #include "fabric_types.hpp"
@@ -167,7 +166,8 @@ KernelHandle FDKernel::configure_kernel_variant(
     if (rt_options.watcher_dispatch_disabled()) {
         defines["FORCE_WATCHER_OFF"] = "1";
     }
-    if (!DPrintServerReadsDispatchCores(device_->id())) {
+    if (!(MetalContext::instance().dprint_server() and
+          MetalContext::instance().dprint_server()->reads_dispatch_cores(device_->id()))) {
         defines["FORCE_DPRINT_OFF"] = "1";
     }
     defines.insert(defines_in.begin(), defines_in.end());

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -36,7 +36,6 @@
 #include "core_coord.hpp"
 #include "data_types.hpp"
 #include "dev_msgs.h"
-#include "dprint_server.hpp"
 #include "hal_types.hpp"
 #include "hostdevcommon/profiler_common.h"
 #include "impl/context/metal_context.hpp"
@@ -769,7 +768,9 @@ void DumpDeviceProfileResults(
             return;
         }
 
-        TT_FATAL(DprintServerIsRunning() == false, "Debug print server is running, cannot dump device profiler data");
+        TT_FATAL(
+            not tt::tt_metal::MetalContext::instance().dprint_server(),
+            "Debug print server is running, cannot dump device profiler data");
 
         auto profiler_it = tt_metal_device_profiler_map.find(device->id());
         if (profiler_it != tt_metal_device_profiler_map.end()) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -47,7 +47,6 @@
 #include "dev_msgs.h"
 #include "impl/context/metal_context.hpp"
 #include "dispatch_core_common.hpp"
-#include "dprint_server.hpp"
 #include "hal.hpp"
 #include "hal_types.hpp"
 #include "jit_build/build.hpp"
@@ -1389,7 +1388,6 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
 
     bool profile_kernel = getDeviceProfilerState();
     std::vector<std::shared_future<void>> events;
-    DprintServerSetProfilerState(profile_kernel);
 
     auto sync_events = [&events] {
         for (auto& event : events) {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -320,7 +320,11 @@ public:
     // Returns the string representation for hash computation.
     inline std::string get_feature_hash_string(RunTimeDebugFeatures feature) const {
         switch (feature) {
-            case RunTimeDebugFeatureDprint: return std::to_string(get_feature_enabled(feature));
+            case RunTimeDebugFeatureDprint: {
+                std::string hash_str = std::to_string(get_feature_enabled(feature));
+                hash_str += std::to_string(get_feature_all_chips(feature));
+                return hash_str;
+            }
             case RunTimeDebugFeatureReadDebugDelay:
             case RunTimeDebugFeatureWriteDebugDelay:
             case RunTimeDebugFeatureAtomicDebugDelay:


### PR DESCRIPTION
More cleanup, this time removing the DPrint server singleton and putting it under MetalContext.

https://github.com/tenstorrent/tt-metal/actions/runs/15981958139