### PR TITLE
[Fabric] fix host side to properly handle Scatter Write

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
@@ -50,10 +50,8 @@ static std::tuple<tt::tt_fabric::NocSendType, bool> get_noc_send_type(const std:
     } else if (message_noc_type == "noc_fused_unicast_write_no_flush_atomic_inc") {
         noc_send_type = tt::tt_fabric::NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC;
         flush = false;
-#ifdef ARCH_WORMHOLE
     } else if (message_noc_type == "noc_unicast_scatter_write") {
         noc_send_type = tt::tt_fabric::NocSendType::NOC_UNICAST_SCATTER_WRITE;
-#endif
     } else {
         TT_THROW("Invalid message type: {}", message_noc_type.c_str());
     }

--- a/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
@@ -51,20 +51,12 @@ enum EDMStatus : uint32_t {
 enum NocSendType : uint8_t {
     NOC_UNICAST_WRITE = 0,
     NOC_UNICAST_INLINE_WRITE = 1,
-#ifdef ARCH_WORMHOLE
     NOC_UNICAST_ATOMIC_INC = 2,
     NOC_FUSED_UNICAST_ATOMIC_INC = 3,
     NOC_UNICAST_SCATTER_WRITE = 4,
     NOC_MULTICAST_WRITE = 5,       // mcast has bug
     NOC_MULTICAST_ATOMIC_INC = 6,  // mcast has bug
     NOC_SEND_TYPE_LAST = NOC_UNICAST_SCATTER_WRITE
-#else
-    NOC_MULTICAST_WRITE = 2,
-    NOC_UNICAST_ATOMIC_INC = 3,
-    NOC_FUSED_UNICAST_ATOMIC_INC = 4,
-    NOC_MULTICAST_ATOMIC_INC = 5,
-    NOC_SEND_TYPE_LAST = NOC_MULTICAST_ATOMIC_INC
-#endif
 };
 // How to send the payload across the cluster
 // 1 bit

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -213,8 +213,9 @@ __attribute__((optimize("jump-tables"))) FORCE_INLINE void execute_chip_unicast_
                 offset += chunk_size;
             }
         } break;
+#else
+        case tt::tt_fabric::NocSendType::NOC_UNICAST_SCATTER_WRITE:
 #endif
-
         case tt::tt_fabric::NocSendType::NOC_MULTICAST_WRITE:
         case tt::tt_fabric::NocSendType::NOC_MULTICAST_ATOMIC_INC:
         default: {

--- a/tt_metal/tools/profiler/experimental/fabric_event_profiler.hpp
+++ b/tt_metal/tools/profiler/experimental/fabric_event_profiler.hpp
@@ -60,7 +60,6 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
                 fabric_header_ptr->routing_fields.value);
             break;
         }
-#ifdef ARCH_WORMHOLE
         case tt::tt_fabric::NocSendType::NOC_UNICAST_SCATTER_WRITE: {
             const volatile auto& unicast_write_cmd = fabric_header_ptr->get_command_fields().unicast_scatter_write;
             noc_event_profiler::recordFabricNocEvent(
@@ -71,7 +70,6 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
                 fabric_header_ptr->routing_fields.value);
             break;
         }
-#endif
         case tt::tt_fabric::NocSendType::NOC_MULTICAST_WRITE: {
             const volatile auto& mcast_write_cmd = fabric_header_ptr->get_command_fields().mcast_write;
             noc_event_profiler::recordFabricNocEventMulticast(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21218

### Problem description
tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp is host code, so `#ifdef ARCH_WORMHOLE` doesn't work


### What's changed
Remove the `ifdef` and make NOC_UNICAST_SCATTER_WRITE visible to any archtecture.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes