### PR TITLE
Revert rand changes to fix cmake generated unit tests

### DIFF
--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -455,12 +455,12 @@ static Tensor uniform(T low, T high, const ttnn::Shape& shape, const Layout layo
     TensorSpec spec(shape, TensorLayout(data_type, PageConfig(layout), MemoryConfig{}));
     auto output_buffer = std::vector<T>(spec.padded_shape().volume());
 
-    if constexpr (IntType<T>) {
+    if constexpr (std::is_same_v<T, uint32_t>) {
         auto rand_value = std::bind(std::uniform_int_distribution<T>(low, high), RANDOM_GENERATOR);
         for (auto index = 0; index < output_buffer.size(); index++) {
             output_buffer[index] = rand_value();
         }
-    } else if constexpr (std::floating_point<T>) {
+    } else if constexpr (std::is_same_v<T, float>) {
         auto rand_value = std::bind(std::uniform_real_distribution<T>(low, high), RANDOM_GENERATOR);
         for (auto index = 0; index < output_buffer.size(); index++) {
             output_buffer[index] = rand_value();
@@ -471,14 +471,6 @@ static Tensor uniform(T low, T high, const ttnn::Shape& shape, const Layout layo
         for (auto index = 0; index < output_buffer.size(); index++) {
             output_buffer[index] = ::bfloat16(rand_value());
         }
-    } else if constexpr (std::is_same_v<T, uint8_t>) {
-        // TODO: It is quick fix, but uniform_int_distribution can't be used with uint8_t
-        auto rand_value = std::bind(std::uniform_int_distribution<T>(low, high), RANDOM_GENERATOR);
-        for (auto index = 0; index < output_buffer.size(); index++) {
-            output_buffer[index] = rand_value();
-        }
-    } else {
-        static_assert(false, "random::random(...) error: DataType not supported!");
     }
 
     return Tensor(tt::tt_metal::HostBuffer(std::move(output_buffer)), spec);

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -471,6 +471,12 @@ static Tensor uniform(T low, T high, const ttnn::Shape& shape, const Layout layo
         for (auto index = 0; index < output_buffer.size(); index++) {
             output_buffer[index] = ::bfloat16(rand_value());
         }
+    } else if constexpr (std::is_same_v<T, uint8_t>) {
+        // TODO: It is quick fix, but uniform_int_distribution can't be used with uint8_t
+        auto rand_value = std::bind(std::uniform_int_distribution<T>(low, high), RANDOM_GENERATOR);
+        for (auto index = 0; index < output_buffer.size(); index++) {
+            output_buffer[index] = rand_value();
+        }
     } else {
         static_assert(false, "random::random(...) error: DataType not supported!");
     }
@@ -481,6 +487,7 @@ static Tensor uniform(T low, T high, const ttnn::Shape& shape, const Layout layo
 inline Tensor random(
     const ttnn::Shape& shape, const DataType data_type = DataType::BFLOAT16, const Layout layout = Layout::ROW_MAJOR) {
     switch (data_type) {
+        case DataType::UINT8: return uniform(uint8_t(0), uint8_t(1), shape, layout);
         case DataType::UINT16: return uniform(uint16_t(0), uint16_t(1), shape, layout);
         case DataType::UINT32: return uniform(0u, 1u, shape, layout);
         case DataType::FLOAT32: return uniform(0.0f, 1.0f, shape, layout);


### PR DESCRIPTION
### Ticket
Quick fix for rand function

### Problem description
function::rand function doesn't initialize tensors if type is not one of the following : uint32_t, float, bfloat16
Fixing that issue lead to the error:

```
ttnn/CMakeFiles/ttnn.dir/Unity/unity_22_cxx.cxx.o.d -o ttnn/CMakeFiles/ttnn.dir/Unity/unity_22_cxx.cxx.o -c /work/build/ttnn/CMakeFiles/ttnn.dir/Unity/unity_22_cxx.cxx
In file included from /work/ttnn/cpp/ttnn/operations/creation.hpp:16,
                 from /work/ttnn/cpp/ttnn-pybind/operations/creation.cpp:18,
                 from /work/build/ttnn/CMakeFiles/ttnn.dir/Unity/unity_22_cxx.cxx:37:
/work/ttnn/cpp/ttnn/operations/functions.hpp: In function 'ttnn::Tensor ttnn::random::uniform(T, T, const tt::tt_metal::Shape&, tt::tt_metal::Layout)':
/work/ttnn/cpp/ttnn/operations/functions.hpp:475:23: error: static assertion failed: random::random(...) error: DataType not supported!
  475 |         static_assert(false, "random::random(...) error: DataType not supported!");
      |                       ^~~~~

```
It's unclear where the template is instantiated with a type that doesn't meet the int/float requirements(can't build string with type name during compile time). The issue can't be reproduced locally, and a text search didn't help either.

To unblock the main branch, I’ve reverted my changes related to the rand operation.


### What's changed
Reverted changes for random() function from function.hpp file

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes