### PR TITLE
Customize Fabric Router Context switching for dispatch

### DIFF
--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -71,7 +71,7 @@ enum class FabricEriscDatamoverAxis : std::size_t {
     Invalid = 2,
 };
 
-enum class FabricEriscDatamoverContextSwitchType {
+enum class FabricEriscDatamoverContextSwitchType : uint8_t {
     // Context switch at the interval only if idle for a certain number of cycles
     WAIT_FOR_IDLE = 0,
     // Context switch every interval

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -71,6 +71,13 @@ enum class FabricEriscDatamoverAxis : std::size_t {
     Invalid = 2,
 };
 
+enum class FabricEriscDatamoverContextSwitchType {
+    // Context switch at the interval only if idle for a certain number of cycles
+    WAIT_FOR_IDLE = 0,
+    // Context switch every interval
+    INTERVAL = 1,
+};
+
 struct FabricRouterBufferConfig {
     bool enable_dateline_sender_extra_buffer_slots = false;
     bool enable_dateline_receiver_extra_buffer_slots = false;
@@ -306,6 +313,7 @@ size_t log_worker_to_fabric_edm_sender_rt_args(const std::vector<uint32_t>& args
 class FabricEriscDatamoverBuilder {
 public:
     static constexpr size_t default_firmware_context_switch_interval = 10000;
+    static constexpr auto default_firmware_context_switch_type = FabricEriscDatamoverContextSwitchType::WAIT_FOR_IDLE;
     // payload only, no header
     static constexpr size_t default_packet_payload_size_bytes = tt::tile_size(tt::DataFormat::Bfp8_b) * 4;
     static constexpr size_t default_mesh_packet_payload_size_bytes = tt::tile_size(tt::DataFormat::Bfp8_b) * 2;
@@ -379,6 +387,7 @@ public:
             tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE) const;
 
     void set_firmware_context_switch_interval(size_t interval);
+    void set_firmware_context_switch_type(FabricEriscDatamoverContextSwitchType type);
     void set_wait_for_host_signal(bool wait_for_host_signal);
 
     //    protected:
@@ -443,6 +452,7 @@ public:
 
     bool build_in_worker_connection_mode = false;
     size_t firmware_context_switch_interval = default_firmware_context_switch_interval;
+    FabricEriscDatamoverContextSwitchType firmware_context_switch_type = default_firmware_context_switch_type;
     bool enable_first_level_ack = false;
     bool fuse_receiver_flush_and_completion_ptr = true;
     bool dateline_connection = false;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -898,6 +898,8 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         default_num_eth_txq_data_packet_accept_ahead,
 
         default_handshake_context_switch_timeout,
+        static_cast<uint32_t>(
+            this->firmware_context_switch_type == FabricEriscDatamoverContextSwitchType::WAIT_FOR_IDLE),
         // Special marker to help with identifying misalignment bugs
         0x00c0ffee};
 
@@ -1302,6 +1304,10 @@ void FabricEriscDatamoverBuilder::set_firmware_context_switch_interval(size_t in
 
 void FabricEriscDatamoverBuilder::set_wait_for_host_signal(bool wait_for_host_signal) {
     this->wait_for_host_signal = wait_for_host_signal;
+}
+
+void FabricEriscDatamoverBuilder::set_firmware_context_switch_type(FabricEriscDatamoverContextSwitchType type) {
+    this->firmware_context_switch_type = type;
 }
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "compile_time_args.h"
 #include "dataflow_api.h"
 
 #include "tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp"
@@ -297,8 +298,9 @@ constexpr size_t DEFAULT_NUM_ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD = get_compile_time
 
 // Context switch timeouts
 constexpr size_t DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 12);
+constexpr bool IDLE_CONTEXT_SWITCHING = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 13) != 0;
 
-constexpr size_t SPECIAL_MARKER_0_IDX = MAIN_CT_ARGS_IDX_5 + 13;
+constexpr size_t SPECIAL_MARKER_0_IDX = MAIN_CT_ARGS_IDX_5 + 14;
 constexpr size_t SPECIAL_MARKER_0 = 0x00c0ffee;
 static_assert(
     !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(SPECIAL_MARKER_0_IDX) == SPECIAL_MARKER_0,

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -1269,12 +1269,19 @@ void run_fabric_edm_main_loop(
         }
 
         if constexpr (enable_context_switch) {
-            if (did_something) {
-                did_nothing_count = 0;
+            // shouldn't do noc counter sync since we are not incrementing them
+            if constexpr (IDLE_CONTEXT_SWITCHING) {
+                if (did_something) {
+                    did_nothing_count = 0;
+                } else {
+                    if (did_nothing_count++ > SWITCH_INTERVAL) {
+                        did_nothing_count = 0;
+                        run_routing_without_noc_sync();
+                    }
+                }
             } else {
                 if (did_nothing_count++ > SWITCH_INTERVAL) {
                     did_nothing_count = 0;
-                    // shouldn't do noc counter sync since we are not incrementing them
                     run_routing_without_noc_sync();
                 }
             }

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1364,7 +1364,7 @@ void build_tt_fabric_program(
         if (!tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
             return;
         }
-        constexpr uint32_t k_DispatchFabricRouterContextSwitchInterval = 32;
+        constexpr uint32_t k_DispatchFabricRouterContextSwitchInterval = 64;
         // Dispatch requires a higher context switching freq to service slow dispatch / UMD / debug tools
         edm_builder.set_firmware_context_switch_interval(k_DispatchFabricRouterContextSwitchInterval);
         edm_builder.set_firmware_context_switch_type(FabricEriscDatamoverContextSwitchType::INTERVAL);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18726

### Problem description
- Debug tools, UMD, and Slow Dispatch path is required to enable dispatch on fabric
- Fabric EDM rarely context switches as it's always busy. Dispatch routing plane must context switch even if not idle to service other components such as UMD / SD APIs, debug tools (e.g., watcher, dprint, tt-lens)

### What's changed
- Add a `FabricEriscDatamoverContextSwitchType` to the Fabric Erisc Datamover builder
- Dispatch operates on the last link index. Customize the context switch setting in topology.

### Checklist
Results same as main
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15932737625
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/15917713192
https://github.com/tenstorrent/tt-metal/actions/runs/15917715053
T3K Model Perf
https://github.com/tenstorrent/tt-metal/actions/runs/15917716475
TG
https://github.com/tenstorrent/tt-metal/actions/runs/15917715053
TG Model Perf
https://github.com/tenstorrent/tt-metal/actions/runs/15917719511
Single Card
https://github.com/tenstorrent/tt-metal/actions/runs/15917757288
