### PR TITLE
Remove program_cache argument.

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avg_pool2d_sweeps.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avg_pool2d_sweeps.py
@@ -70,7 +70,6 @@ def test_ttnn_pytorch_sweep(device, tensor_map, input_spec):
 
     run_avg_pool2d(
         device=device,
-        True,
         tensor_map=tensor_map,
         input_shape=(in_n, in_c, in_h, in_w),
         kernel_size=(kernel_h, kernel_w),


### PR DESCRIPTION
### Problem description
In https://github.com/tenstorrent/tt-metal/pull/24210 , program_cache argument is removed from run_avg_pool2d but is set as true in test_avg_pool2d_sweeps.py call.
### What's changed
Remove it from test_avg_pool2d_sweeps.py

### Checklist
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15918865416/job/44901660175)
