### PR TITLE
#13930: Unsupported dtypes bf8 and bf4 check for logaddexp-bw

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -45,10 +45,6 @@ void preallocated_tensors_check(
     }
 }
 
-bool is_block_format_dtype(const Tensor& tensor) {
-    return (tensor.dtype() == ttnn::DataType::BFLOAT8_B || tensor.dtype() == ttnn::DataType::BFLOAT4_B);
-}
-
 std::vector<ttnn::Tensor> ExecuteBackwardAtan2::invoke(
     const Tensor& grad,
     const Tensor& input,
@@ -332,7 +328,7 @@ std::vector<ttnn::Tensor> ExecuteBackwardLogaddexp::invoke(
     const Tensor& other,
     const std::optional<MemoryConfig>& output_mem_config) {
     TT_FATAL(
-        !(is_block_format_dtype(input_a) || is_block_format_dtype(grad) || is_block_format_dtype(other)),
+        !(is_block_float(input_a.dtype()) || is_block_float(grad.dtype()) || is_block_float(other.dtype())),
         "BFLOAT8_B/BFLOAT4_B dtypes are not supported !!");
 
     std::vector<Tensor> grad_tensor;
@@ -366,7 +362,7 @@ std::vector<ttnn::Tensor> ExecuteBackwardLogaddexp2::invoke(
     const Tensor& other,
     const std::optional<MemoryConfig>& output_mem_config) {
     TT_FATAL(
-        !(is_block_format_dtype(input_a) || is_block_format_dtype(grad) || is_block_format_dtype(other)),
+        !(is_block_float(input_a.dtype()) || is_block_float(grad.dtype()) || is_block_float(other.dtype())),
         "BFLOAT8_B/BFLOAT4_B dtypes are not supported !!");
 
     std::vector<Tensor> grad_tensor;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -331,6 +331,10 @@ std::vector<ttnn::Tensor> ExecuteBackwardLogaddexp::invoke(
     const Tensor& input_a,
     const Tensor& other,
     const std::optional<MemoryConfig>& output_mem_config) {
+    TT_FATAL(
+        !(is_block_format_dtype(input_a) || is_block_format_dtype(grad) || is_block_format_dtype(other)),
+        "BFLOAT8_B/BFLOAT4_B dtypes are not supported !!");
+
     std::vector<Tensor> grad_tensor;
     Tensor opexp = ttnn::add(
         ttnn::exp(ttnn::subtract(other, input_a, std::nullopt, output_mem_config), false, output_mem_config),


### PR DESCRIPTION
### Ticket
Link to Github Issue
#13930 

### Problem description
Low pcc due to unsupported BFLOAT8_B dtype for exp and recip in logaddexp_bw.

### What's changed
Updated implementation to check for BFLOAT8_B/BFLOAT4_B dtypeS in logaddexp_bw in binary_backward.cpp.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15928505737) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15928511394) CI with demo tests passes (if applicable)