### PR TITLE
Configure 6U CI pipelines to run nightly

### DIFF
--- a/.github/workflows/galaxy-frequent-tests.yaml
+++ b/.github/workflows/galaxy-frequent-tests.yaml
@@ -3,7 +3,7 @@ name: "Galaxy frequent tests"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 5'  # Runs every Friday at 12am UTC
+    - cron: '0 3 * * *'  # Every day at 3:00 UTC
 
 jobs:
   build-artifact:

--- a/.github/workflows/galaxy-model-perf-tests.yaml
+++ b/.github/workflows/galaxy-model-perf-tests.yaml
@@ -3,7 +3,7 @@ name: "Galaxy model perf tests"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * 4" # Runs every Thursday at 12am UTC
+    - cron: '0 3 * * *'  # Every day at 3:00 UTC
 
 jobs:
   build-artifact-profiler:

--- a/.github/workflows/galaxy-nightly-tests.yaml
+++ b/.github/workflows/galaxy-nightly-tests.yaml
@@ -3,7 +3,7 @@ name: "Galaxy nightly tests"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * 3" # Runs every Wednesday at 12am UTC
+    - cron: "0 0 * * 6" # Runs every Saturday at 12am UTC
 
 jobs:
   build-artifact:

--- a/.github/workflows/galaxy-unit-tests.yaml
+++ b/.github/workflows/galaxy-unit-tests.yaml
@@ -3,7 +3,7 @@ name: "Galaxy unit tests"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 3 * * *'  # Every day at 3:00 UTC
+    - cron: "0 0 * * 6" # Runs every Saturday at 12am UTC
 
 jobs:
   build-artifact:

--- a/.github/workflows/galaxy-unit-tests.yaml
+++ b/.github/workflows/galaxy-unit-tests.yaml
@@ -3,7 +3,7 @@ name: "Galaxy unit tests"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * 2" # Runs every Tuesday at 12am UTC
+    - cron: '0 3 * * *'  # Every day at 3:00 UTC
 
 jobs:
   build-artifact:


### PR DESCRIPTION
### Problem description
After adding specific 6U optimisations we want to monitor 6U pipelines and not only 4U. This enables tracking perf in superset for 6U as it's our end goal to show perf on this type of machine and also catch issues that are 6U specific since we have more and more 6U specific implementation

### What's changed
Galaxy frequent, model-perf pipelines changed to execute nightly instead of weekly.
Unit and nightly (long stress test) execute on Saturday morning to relax potential workload on working days. 

Total workload of nightly pipelines should be <5hrs which is fine for the beginning. We will monitor and if it clogs CI I will reduce frequency for some pipelines.