### PR TITLE
#24052: SDXL trace implementation

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -13,15 +13,21 @@ from models.experimental.stable_diffusion_xl_base.tt.tt_euler_discrete_scheduler
 from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
 from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     SDXL_L1_SMALL_SIZE,
+    SDXL_TRACE_REGION_SIZE,
     retrieve_timesteps,
     run_tt_image_gen,
+    prepare_input_tensors,
+    allocate_input_tensors,
+    create_user_tensors,
 )
 import os
 from models.utility_functions import profiler
 
 
 @torch.no_grad()
-def run_demo_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, vae_on_device, evaluation_range):
+def run_demo_inference(
+    ttnn_device, is_ci_env, prompts, num_inference_steps, vae_on_device, evaluation_range, capture_trace
+):
     batch_size = ttnn_device.get_num_devices()
 
     start_from, _ = evaluation_range
@@ -116,28 +122,32 @@ def run_demo_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, vae
 
     prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds = zip(*all_embeds)
 
-    prompt_embeds_torch = torch.cat(prompt_embeds, dim=0)
-    negative_prompt_embeds_torch = torch.cat(negative_prompt_embeds, dim=0)
-    pooled_prompt_embeds_torch = torch.cat(pooled_prompt_embeds, dim=0)
-    negative_pooled_prompt_embeds_torch = torch.cat(negative_pooled_prompt_embeds, dim=0)
+    prompt_embeds_torch = torch.split(torch.cat(prompt_embeds, dim=0), batch_size, dim=0)
+    negative_prompt_embeds_torch = torch.split(torch.cat(negative_prompt_embeds, dim=0), batch_size, dim=0)
+    pooled_prompt_embeds_torch = torch.split(torch.cat(pooled_prompt_embeds, dim=0), batch_size, dim=0)
+    negative_pooled_prompt_embeds_torch = torch.split(
+        torch.cat(negative_pooled_prompt_embeds, dim=0), batch_size, dim=0
+    )
 
     # Prepare timesteps
-    timesteps, num_inference_steps = retrieve_timesteps(pipeline.scheduler, num_inference_steps, cpu_device, None, None)
+    ttnn_timesteps, num_inference_steps = retrieve_timesteps(
+        pipeline.scheduler, num_inference_steps, cpu_device, None, None
+    )
 
     # Convert timesteps to ttnn
-    ttnn_timesteps = []
-    for t in timesteps:
-        scalar_tensor = torch.tensor(t).unsqueeze(0)
-        ttnn_timesteps.append(
-            ttnn.from_torch(
-                scalar_tensor,
-                dtype=ttnn.bfloat16,
-                device=ttnn_device,
-                layout=ttnn.TILE_LAYOUT,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device),
-            )
-        )
+    # ttnn_timesteps = []
+    # for t in timesteps:
+    #     scalar_tensor = torch.tensor(t).unsqueeze(0)
+    #     ttnn_timesteps.append(
+    #         ttnn.from_torch(
+    #             scalar_tensor,
+    #             dtype=ttnn.bfloat16,
+    #             device=ttnn_device,
+    #             layout=ttnn.TILE_LAYOUT,
+    #             memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    #             mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device),
+    #         )
+    #     )
 
     num_channels_latents = pipeline.unet.config.in_channels
     assert num_channels_latents == 4, f"num_channels_latents is {num_channels_latents}, but it should be 4"
@@ -172,49 +182,49 @@ def run_demo_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, vae
     )
     negative_add_time_ids = add_time_ids
 
-    torch_prompt_embeds = torch.stack([negative_prompt_embeds_torch, prompt_embeds_torch], dim=1)
-    torch_add_text_embeds = torch.stack([negative_pooled_prompt_embeds_torch, pooled_prompt_embeds_torch], dim=1)
-    ttnn_prompt_embeds = ttnn.from_torch(
-        torch_prompt_embeds,
-        dtype=ttnn.bfloat16,
-        device=ttnn_device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0),
-    )
-    ttnn_add_text_embeds = ttnn.from_torch(
-        torch_add_text_embeds,
-        dtype=ttnn.bfloat16,
-        device=ttnn_device,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0),
-    )
+    # torch_prompt_embeds = torch.stack([negative_prompt_embeds_torch, prompt_embeds_torch], dim=1)
+    # torch_add_text_embeds = torch.stack([negative_pooled_prompt_embeds_torch, pooled_prompt_embeds_torch], dim=1)
+    # ttnn_prompt_embeds = ttnn.from_torch(
+    #     torch_prompt_embeds,
+    #     dtype=ttnn.bfloat16,
+    #     device=ttnn_device,
+    #     layout=ttnn.TILE_LAYOUT,
+    #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    #     mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0),
+    # )
+    # ttnn_add_text_embeds = ttnn.from_torch(
+    #     torch_add_text_embeds,
+    #     dtype=ttnn.bfloat16,
+    #     device=ttnn_device,
+    #     layout=ttnn.ROW_MAJOR_LAYOUT,
+    #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    #     mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0),
+    # )
 
-    ttnn_add_time_id1 = ttnn.from_torch(
-        negative_add_time_ids.squeeze(0),
-        dtype=ttnn.bfloat16,
-        device=ttnn_device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device),
-    )
-    ttnn_add_time_id2 = ttnn.from_torch(
-        add_time_ids.squeeze(0),
-        dtype=ttnn.bfloat16,
-        device=ttnn_device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device),
-    )
-    ttnn_time_ids = [ttnn_add_time_id1, ttnn_add_time_id2]
-    ttnn_text_embeds = [
-        [
-            ttnn_add_text_embed[0],
-            ttnn_add_text_embed[1],
-        ]
-        for ttnn_add_text_embed in ttnn_add_text_embeds
-    ]
+    # ttnn_add_time_id1 = ttnn.from_torch(
+    #     negative_add_time_ids.squeeze(0),
+    #     dtype=ttnn.bfloat16,
+    #     device=ttnn_device,
+    #     layout=ttnn.TILE_LAYOUT,
+    #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    #     mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device),
+    # )
+    # ttnn_add_time_id2 = ttnn.from_torch(
+    #     add_time_ids.squeeze(0),
+    #     dtype=ttnn.bfloat16,
+    #     device=ttnn_device,
+    #     layout=ttnn.TILE_LAYOUT,
+    #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    #     mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device),
+    # )
+    # ttnn_time_ids = [ttnn_add_time_id1, ttnn_add_time_id2]
+    # ttnn_text_embeds = [
+    #     [
+    #         ttnn_add_text_embed[0],
+    #         ttnn_add_text_embed[1],
+    #     ]
+    #     for ttnn_add_text_embed in ttnn_add_text_embeds
+    # ]
 
     scaling_factor = ttnn.from_torch(
         torch.Tensor([pipeline.vae.config.scaling_factor]),
@@ -228,32 +238,70 @@ def run_demo_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, vae
     B, C, H, W = latents.shape
 
     # All device code will work with channel last tensors
-    latents = torch.permute(latents, (0, 2, 3, 1))
-    latents = latents.reshape(1, 1, B * H * W, C)
-
-    latents_clone = latents.clone()
-
-    latents = ttnn.from_torch(
-        latents,
-        dtype=ttnn.bfloat16,
-        device=ttnn_device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device),
+    tt_latents = torch.permute(latents, (0, 2, 3, 1))
+    tt_latents = tt_latents.reshape(1, 1, B * H * W, C)
+    tt_latents, tt_prompt_embeds, tt_add_text_embeds = create_user_tensors(
+        ttnn_device=ttnn_device,
+        latents=tt_latents,
+        negative_prompt_embeds=negative_prompt_embeds_torch,
+        prompt_embeds=prompt_embeds_torch,
+        negative_pooled_prompt_embeds=negative_pooled_prompt_embeds_torch,
+        add_text_embeds=pooled_prompt_embeds_torch,
     )
 
+    tt_latents_device, tt_prompt_embeds_device, tt_text_embeds_device, tt_time_ids_device = allocate_input_tensors(
+        ttnn_device=ttnn_device,
+        tt_latents=tt_latents,
+        tt_prompt_embeds=tt_prompt_embeds,
+        tt_text_embeds=tt_add_text_embeds,
+        tt_time_ids=[negative_add_time_ids, add_time_ids],
+    )
+
+    ttnn_added_cond_kwargs = [
+        [
+            {
+                "text_embeds": ttnn_add_text_embed[0],
+                "time_ids": tt_time_ids_device[0],
+            },
+            {
+                "text_embeds": ttnn_add_text_embed[1],
+                "time_ids": tt_time_ids_device[1],
+            },
+        ]
+        for ttnn_add_text_embed in tt_add_text_embeds
+    ]
+    # latents_clone = latents.clone()
+
+    # latents = ttnn.from_torch(
+    #     latents,
+    #     dtype=ttnn.bfloat16,
+    #     device=ttnn_device,
+    #     layout=ttnn.TILE_LAYOUT,
+    #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    #     mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device),
+    # )
+
     # UNet will deallocate the input tensor
-    latent_model_input = ttnn.clone(latents)
+    # latent_model_input = ttnn.clone(latents)
 
     logger.info("Performing warmup run, to make use of program caching in actual inference...")
+    prepare_input_tensors(
+        [
+            tt_latents,
+            *tt_prompt_embeds[0],
+            ttnn_added_cond_kwargs[0][0]["text_embeds"],
+            ttnn_added_cond_kwargs[0][1]["text_embeds"],
+        ],
+        [tt_latents_device, *tt_prompt_embeds_device, *tt_text_embeds_device],
+    )
     run_tt_image_gen(
         ttnn_device,
         tt_unet,
         tt_scheduler,
-        latent_model_input,
-        ttnn_prompt_embeds,
-        ttnn_time_ids,
-        ttnn_text_embeds,
+        tt_latents_device,
+        tt_prompt_embeds_device,
+        tt_time_ids_device,
+        tt_text_embeds_device,
         [ttnn_timesteps[0]],
         extra_step_kwargs,
         guidance_scale,
@@ -261,8 +309,37 @@ def run_demo_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, vae
         [B, C, H, W],
         tt_vae if vae_on_device else pipeline.vae,
         batch_size,
-        0,
+        capture_trace=False,
     )
+
+    tid = None
+    if capture_trace:
+        prepare_input_tensors(
+            [
+                tt_latents,
+                *tt_prompt_embeds[0],
+                ttnn_added_cond_kwargs[0][0]["text_embeds"],
+                ttnn_added_cond_kwargs[0][1]["text_embeds"],
+            ],
+            [tt_latents_device, *tt_prompt_embeds_device, *tt_text_embeds_device],
+        )
+        _, tid = run_tt_image_gen(
+            ttnn_device,
+            tt_unet,
+            tt_scheduler,
+            tt_latents_device,
+            tt_prompt_embeds_device,
+            tt_time_ids_device,
+            tt_text_embeds_device,
+            [ttnn_timesteps[0]],
+            extra_step_kwargs,
+            guidance_scale,
+            scaling_factor,
+            [B, C, H, W],
+            tt_vae if vae_on_device else pipeline.vae,
+            batch_size,
+            capture_trace=True,
+        )
     profiler.clear()
 
     if not is_ci_env and not os.path.exists("output"):
@@ -274,14 +351,23 @@ def run_demo_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, vae
         logger.info(
             f"Running inference for prompts {iter * batch_size + 1}-{iter * batch_size + batch_size}/{len(prompts)}"
         )
-        imgs = run_tt_image_gen(
+        prepare_input_tensors(
+            [
+                tt_latents,
+                *tt_prompt_embeds[iter],
+                ttnn_added_cond_kwargs[iter][0]["text_embeds"],
+                ttnn_added_cond_kwargs[iter][1]["text_embeds"],
+            ],
+            [tt_latents_device, *tt_prompt_embeds_device, *tt_text_embeds_device],
+        )
+        imgs, tid = run_tt_image_gen(
             ttnn_device,
             tt_unet,
             tt_scheduler,
-            latents,
-            ttnn_prompt_embeds,
-            ttnn_time_ids,
-            ttnn_text_embeds,
+            tt_latents_device,
+            tt_prompt_embeds_device,
+            tt_time_ids_device,
+            tt_text_embeds_device,
             ttnn_timesteps,
             extra_step_kwargs,
             guidance_scale,
@@ -289,7 +375,7 @@ def run_demo_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, vae
             [B, C, H, W],
             tt_vae if vae_on_device else pipeline.vae,
             batch_size,
-            iter,
+            tid=tid,
         )
 
         logger.info(
@@ -310,20 +396,22 @@ def run_demo_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, vae
                 img.save(f"output/output{len(images) + start_from}.png")
                 logger.info(f"Image saved to output/output{len(images) + start_from}.png")
 
-        latents = latents_clone.clone()
-        latents = ttnn.from_torch(
-            latents,
-            dtype=ttnn.bfloat16,
-            device=ttnn_device,
-            layout=ttnn.TILE_LAYOUT,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device),
-        )
+        # latents = latents_clone.clone()
+        # latents = ttnn.from_torch(
+        #     latents,
+        #     dtype=ttnn.bfloat16,
+        #     device=ttnn_device,
+        #     layout=ttnn.TILE_LAYOUT,
+        #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        #     mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device),
+        # )
 
     return images
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE, "trace_region_size": SDXL_TRACE_REGION_SIZE}], indirect=True
+)
 @pytest.mark.parametrize(
     "prompt",
     (("An astronaut riding a green horse"),),
@@ -340,12 +428,23 @@ def run_demo_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, vae
     ],
     ids=("device_vae", "host_vae"),
 )
+@pytest.mark.parametrize(
+    "capture_trace",
+    [
+        (True),
+        (False),
+    ],
+    ids=("with_trace", "no_trace"),
+)
 def test_demo(
     mesh_device,
     is_ci_env,
     prompt,
     num_inference_steps,
     vae_on_device,
+    capture_trace,
     evaluation_range,
 ):
-    return run_demo_inference(mesh_device, is_ci_env, prompt, num_inference_steps, vae_on_device, evaluation_range)
+    return run_demo_inference(
+        mesh_device, is_ci_env, prompt, num_inference_steps, vae_on_device, evaluation_range, capture_trace
+    )

--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -298,14 +298,14 @@ def run_demo_inference(
             tid_vae=tid_vae,
         )
 
-        logger.info(f"Image gen for {batch_size} prompts completed in {profiler.get('image_gen')[-1]:.2f} seconds")
+        logger.info(f"Image gen for {batch_size} prompts completed in {profiler.times['image_gen'][-1]:.2f} seconds")
         logger.info(
             f"Denoising loop for {batch_size} promts completed in {profiler.times['denoising_loop'][-1]:.2f} seconds"
         )
         logger.info(
             f"{'On device VAE' if vae_on_device else 'Host VAE'} decoding completed in {profiler.times['vae_decode'][-1]:.2f} seconds"
         )
-        
+
         for idx, img in enumerate(imgs):
             if iter == len(prompts) // batch_size - 1 and idx >= batch_size - needed_padding:
                 break

--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -329,14 +329,7 @@ def run_demo_inference(
 )
 @pytest.mark.parametrize(
     "prompt",
-    (
-        (
-            [
-                "An astronaut riding a green horse",
-                "A futuristic cityscape at sunset, with flying cars and glowing skyscrapers, ultra-detailed, cinematic lighting, 4k",
-            ]
-        ),
-    ),
+    (("An astronaut riding a green horse"),),
 )
 @pytest.mark.parametrize(
     "num_inference_steps",

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_euler_discrete_scheduler.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_euler_discrete_scheduler.py
@@ -84,7 +84,7 @@ def test_euler_discrete_scheduler(device, input_shape, num_inference_steps, is_c
         for i, t in enumerate(scheduler.timesteps):
             signpost(f"euler_discrete_scheduler_step {i=}")
             ref_scaled_latent = scheduler.scale_model_input(ref_latent, scheduler.timesteps[i])
-            tt_scaled_latent = tt_scheduler.scale_model_input(tt_latent, tt_scheduler.tt_timesteps[i])
+            tt_scaled_latent = tt_scheduler.scale_model_input(tt_latent, None)
             torch_scaled_latent = ttnn.from_device(tt_scaled_latent).to_torch()
             passed, msg = assert_with_pcc(ref_scaled_latent, torch_scaled_latent, 0.999)
             logger.debug(f"{i}: scaled_model_input pcc passed: {msg}")
@@ -96,8 +96,10 @@ def test_euler_discrete_scheduler(device, input_shape, num_inference_steps, is_c
                 noise_pred, scheduler.timesteps[i], ref_scaled_latent, return_dict=False
             )
             tt_prev_sample, tt_pred_original_sample = tt_scheduler.step(
-                tt_noise_pred, scheduler.timesteps[i], tt_scaled_latent, return_dict=False
+                tt_noise_pred, None, tt_scaled_latent, return_dict=False
             )
+            if i < (len(scheduler.timesteps) - 1):
+                tt_scheduler.inc_step_index()
             torch_prev_sample = ttnn.from_device(tt_prev_sample).to_torch()
             torch_pred_original_sample = ttnn.from_device(tt_pred_original_sample).to_torch()
             passed, msg = assert_with_pcc(ref_prev_sample, torch_prev_sample, 0.999)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_euler_discrete_scheduler.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_euler_discrete_scheduler.py
@@ -65,7 +65,9 @@ def test_euler_discrete_scheduler(device, input_shape, num_inference_steps, is_c
         scheduler.set_timesteps(num_inference_steps=_num_inference_steps)
         tt_scheduler.set_timesteps(num_inference_steps=_num_inference_steps)
 
-        assert_with_pcc(scheduler.timesteps, tt_scheduler.timesteps, 0.999)
+        assert_with_pcc(
+            scheduler.timesteps, torch.cat([ttnn.to_torch(t).unsqueeze(0) for t in tt_scheduler.timesteps]), 0.999
+        )
         assert_with_pcc(scheduler.alphas, tt_scheduler.alphas, 0.999)
         assert_with_pcc(scheduler.alphas_cumprod, tt_scheduler.alphas_cumprod, 0.999)
         assert_with_pcc(scheduler.betas, tt_scheduler.betas, 0.999)
@@ -101,8 +103,8 @@ def test_euler_discrete_scheduler(device, input_shape, num_inference_steps, is_c
             if i < (len(scheduler.timesteps) - 1):
                 tt_scheduler.inc_step_index()
             torch_prev_sample = ttnn.from_device(tt_prev_sample).to_torch()
-            torch_pred_original_sample = ttnn.from_device(tt_pred_original_sample).to_torch()
+            # torch_pred_original_sample = ttnn.from_device(tt_pred_original_sample).to_torch()
             passed, msg = assert_with_pcc(ref_prev_sample, torch_prev_sample, 0.999)
             logger.debug(f"{i}: prev_sample pcc passed: {msg}")
-            passed, msg = assert_with_pcc(ref_pred_original_sample, torch_pred_original_sample, 0.999)
-            logger.debug(f"{i}: pred_original_sample pcc passed: {msg}")
+            # passed, msg = assert_with_pcc(ref_pred_original_sample, torch_pred_original_sample, 0.999)
+            # logger.debug(f"{i}: pred_original_sample pcc passed: {msg}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_euler_discrete_scheduler.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_euler_discrete_scheduler.py
@@ -94,17 +94,12 @@ def test_euler_discrete_scheduler(device, input_shape, num_inference_steps, is_c
             noise_pred = torch.randn(input_shape, dtype=torch.float32)  # this comes from unet
             tt_noise_pred = ttnn.from_torch(noise_pred, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT).to(device=device)
 
-            ref_prev_sample, ref_pred_original_sample = scheduler.step(
+            ref_prev_sample, _ = scheduler.step(
                 noise_pred, scheduler.timesteps[i], ref_scaled_latent, return_dict=False
             )
-            tt_prev_sample, tt_pred_original_sample = tt_scheduler.step(
-                tt_noise_pred, None, tt_scaled_latent, return_dict=False
-            )
+            tt_prev_sample, _ = tt_scheduler.step(tt_noise_pred, None, tt_scaled_latent, return_dict=False)
             if i < (len(scheduler.timesteps) - 1):
                 tt_scheduler.inc_step_index()
             torch_prev_sample = ttnn.from_device(tt_prev_sample).to_torch()
-            # torch_pred_original_sample = ttnn.from_device(tt_pred_original_sample).to_torch()
             passed, msg = assert_with_pcc(ref_prev_sample, torch_prev_sample, 0.999)
             logger.debug(f"{i}: prev_sample pcc passed: {msg}")
-            # passed, msg = assert_with_pcc(ref_pred_original_sample, torch_pred_original_sample, 0.999)
-            # logger.debug(f"{i}: pred_original_sample pcc passed: {msg}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
@@ -117,12 +117,6 @@ def run_unet_inference(
     if isinstance(prompts, str):
         prompts = [prompts]
 
-    # In case of classifier free guidance this is set:
-    # - guidance_scale = 5.0
-    # - 2 runs of unet per iteration
-    # For non classifier free guidance do:
-    # - guidance_scale = 1.0
-    # - 1 run of unet per iteration
     guidance_scale = 5.0
 
     # 0. Set up default height and width for unet
@@ -260,20 +254,6 @@ def run_unet_inference(
         tt_time_ids=[negative_add_time_ids, add_time_ids],
     )
 
-    ttnn_added_cond_kwargs = [
-        [
-            {
-                "text_embeds": ttnn_add_text_embed[0],
-                "time_ids": tt_time_ids_device[0],
-            },
-            {
-                "text_embeds": ttnn_add_text_embed[1],
-                "time_ids": tt_time_ids_device[1],
-            },
-        ]
-        for ttnn_add_text_embed in tt_add_text_embeds
-    ]
-
     prompt_embeds = [torch.cat([t1, t2], dim=0) for t1, t2 in zip(negative_prompt_embeds, prompt_embeds)]
     add_text_embeds = [torch.cat([t1, t2], dim=0) for t1, t2 in zip(negative_pooled_prompt_embeds, add_text_embeds)]
     add_time_ids = [torch.cat([t1, t2], dim=0) for t1, t2 in zip(negative_add_time_ids, add_time_ids)]
@@ -285,8 +265,8 @@ def run_unet_inference(
         [
             tt_latents,
             *tt_prompt_embeds[0],
-            ttnn_added_cond_kwargs[0][0]["text_embeds"],
-            ttnn_added_cond_kwargs[0][1]["text_embeds"],
+            tt_add_text_embeds[0][0],
+            tt_add_text_embeds[0][1],
         ],
         [tt_latents_device, *tt_prompt_embeds_device, *tt_text_embeds_device],
     )
@@ -310,8 +290,8 @@ def run_unet_inference(
         [
             tt_latents,
             *tt_prompt_embeds[0],
-            ttnn_added_cond_kwargs[0][0]["text_embeds"],
-            ttnn_added_cond_kwargs[0][1]["text_embeds"],
+            tt_add_text_embeds[0][0],
+            tt_add_text_embeds[0][1],
         ],
         [tt_latents_device, *tt_prompt_embeds_device, *tt_text_embeds_device],
     )
@@ -339,8 +319,8 @@ def run_unet_inference(
             [
                 tt_latents,
                 *tt_prompt_embeds[iter],
-                ttnn_added_cond_kwargs[iter][0]["text_embeds"],
-                ttnn_added_cond_kwargs[iter][1]["text_embeds"],
+                tt_add_text_embeds[iter][0]["text_embeds"],
+                tt_add_text_embeds[iter][1]["text_embeds"],
             ],
             [tt_latents_device, *tt_prompt_embeds_device, *tt_text_embeds_device],
         )

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
@@ -15,6 +15,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     SDXL_L1_SMALL_SIZE,
     retrieve_timesteps,
     run_tt_iteration,
+    prepare_input_tensors,
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc, comp_pcc
 import matplotlib.pyplot as plt
@@ -22,57 +23,60 @@ from models.utility_functions import is_wormhole_b0
 
 
 def run_tt_denoising(
-    tt_latents,
-    iter,
     ttnn_device,
+    tt_latents_device,
+    tt_latents_output,
     tt_unet,
     tt_scheduler,
     input_shape,
     ttnn_prompt_embeds,
-    ttnn_added_cond_kwargs,
-    tt_t,
-    classifier_free_guidance,
+    ttnn_add_text_embeds,
+    ttnn_add_time_ids,
     guidance_scale,
     extra_step_kwargs,
+    tid=None,
+    compile_run=False,
 ):
     B, C, H, W = input_shape
-    unet_outputs = []
-    for unet_slice in range(len(ttnn_prompt_embeds[iter])):
-        tt_latent_model_input = tt_latents
-        noise_pred, noise_shape = run_tt_iteration(
-            ttnn_device,
-            tt_unet,
-            tt_scheduler,
-            tt_latent_model_input,
-            [B, C, H, W],
-            ttnn_prompt_embeds[iter][unet_slice],
-            ttnn_added_cond_kwargs[iter][unet_slice]["time_ids"],
-            ttnn_added_cond_kwargs[iter][unet_slice]["text_embeds"],
-            tt_t,
-            iter,
-        )
-        C, H, W = noise_shape
+    # compile_run=True
+    if tid is None:
+        tid = ttnn.begin_trace_capture(ttnn_device, cq_id=0) if not compile_run else None
+        unet_outputs = []
+        tt_latents = tt_latents_device
+        print(tt_latents.buffer_address())
+        for unet_slice in range(len(ttnn_prompt_embeds)):
+            tt_latent_model_input = tt_latents
+            noise_pred, noise_shape = run_tt_iteration(
+                tt_unet,
+                tt_scheduler,
+                tt_latent_model_input,
+                [B, C, H, W],
+                ttnn_prompt_embeds[unet_slice],
+                ttnn_add_time_ids[unet_slice],
+                ttnn_add_text_embeds[unet_slice],
+            )
+            C, H, W = noise_shape
 
-        unet_outputs.append(noise_pred)
+            unet_outputs.append(noise_pred)
+            print(noise_pred.buffer_address())
 
-    # perform guidance
-    if classifier_free_guidance:
         noise_pred_uncond, noise_pred_text = unet_outputs
-        noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+        noise_pred_text = ttnn.sub_(noise_pred_text, noise_pred_uncond)
+        noise_pred_text = ttnn.mul_(noise_pred_text, guidance_scale)
+        noise_pred = ttnn.add_(noise_pred_uncond, noise_pred_text)
+        print(noise_pred.buffer_address())
+
+        tt_latents = tt_scheduler.step(noise_pred, None, tt_latents, **extra_step_kwargs, return_dict=False)[0]
 
         ttnn.deallocate(noise_pred_uncond)
         ttnn.deallocate(noise_pred_text)
+        print(tt_latents.buffer_address())
+
+        if not compile_run:
+            ttnn.end_trace_capture(ttnn_device, tid, cq_id=0)
     else:
-        noise_pred = unet_outputs[0]
-
-    tt_latents = tt_scheduler.step(
-        noise_pred, tt_scheduler.timesteps[iter], tt_latents, **extra_step_kwargs, return_dict=False
-    )[0]
-
-    ttnn.deallocate(noise_pred)
-    tt_latents = ttnn.move(tt_latents)
-
-    return tt_latents, [C, H, W]
+        ttnn.execute_trace(ttnn_device, tid, cq_id=0, blocking=True)
+    return tid, tt_latents_device, tt_latents_output, [C, H, W]
 
 
 def run_torch_denoising(
@@ -82,11 +86,10 @@ def run_torch_denoising(
     prompt_embeds,
     added_cond_kwargs,
     t,
-    classifier_free_guidance,
     guidance_scale,
     extra_step_kwargs,
 ):
-    latent_model_input = torch.cat([latents] * 2) if classifier_free_guidance else latents
+    latent_model_input = torch.cat([latents] * 2)
 
     latent_model_input = pipeline.scheduler.scale_model_input(latent_model_input, t)
 
@@ -100,9 +103,8 @@ def run_torch_denoising(
         return_dict=False,
     )[0]
 
-    if classifier_free_guidance:
-        noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
-        noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+    noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+    noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
 
     latents = pipeline.scheduler.step(noise_pred, t, latents, **extra_step_kwargs, return_dict=False)[0]
     return latents
@@ -110,7 +112,7 @@ def run_torch_denoising(
 
 @torch.no_grad()
 def run_unet_inference(
-    ttnn_device, is_ci_env, prompts, num_inference_steps, model_location_generator, classifier_free_guidance=True
+    ttnn_device, is_ci_env, prompts, num_inference_steps, model_location_generator,
 ):
     torch.manual_seed(0)
 
@@ -123,10 +125,7 @@ def run_unet_inference(
     # For non classifier free guidance do:
     # - guidance_scale = 1.0
     # - 1 run of unet per iteration
-    if classifier_free_guidance == True:
-        guidance_scale = 5.0
-    else:
-        guidance_scale = 1.0
+    guidance_scale = 5.0
 
     # 0. Set up default height and width for unet
     height = 1024
@@ -188,7 +187,7 @@ def run_unet_inference(
             prompt_2=None,
             device=cpu_device,
             num_images_per_prompt=1,
-            do_classifier_free_guidance=classifier_free_guidance,
+            do_classifier_free_guidance=True,
             negative_prompt=None,
             negative_prompt_2=None,
             prompt_embeds=None,
@@ -205,21 +204,9 @@ def run_unet_inference(
 
     # Prepare timesteps
     timesteps, num_inference_steps = retrieve_timesteps(pipeline.scheduler, num_inference_steps, cpu_device, None, None)
-    tt_timesteps, tt_num_inference_steps = retrieve_timesteps(tt_scheduler, num_inference_steps, cpu_device, None, None)
-
-    # Convert timesteps to ttnn
-    ttnn_timesteps = []
-    for t in tt_timesteps:
-        scalar_tensor = torch.tensor(t).unsqueeze(0)
-        ttnn_timesteps.append(
-            ttnn.from_torch(
-                scalar_tensor,
-                dtype=ttnn.bfloat16,
-                device=ttnn_device,
-                layout=ttnn.TILE_LAYOUT,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            )
-        )
+    ttnn_timesteps, tt_num_inference_steps = retrieve_timesteps(
+        tt_scheduler, num_inference_steps, cpu_device, None, None
+    )
 
     num_channels_latents = pipeline.unet.config.in_channels
     assert num_channels_latents == 4, f"num_channels_latents is {num_channels_latents}, but it should be 4"
@@ -254,113 +241,69 @@ def run_unet_inference(
     )
     negative_add_time_ids = add_time_ids
 
-    if classifier_free_guidance:
-        ttnn_prompt_embeds = [
-            [
-                ttnn.from_torch(
-                    negative_prompt_embed,
-                    dtype=ttnn.bfloat16,
-                    device=ttnn_device,
-                    layout=ttnn.TILE_LAYOUT,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                ),
-                ttnn.from_torch(
-                    prompt_embed,
-                    dtype=ttnn.bfloat16,
-                    device=ttnn_device,
-                    layout=ttnn.TILE_LAYOUT,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                ),
-            ]
-            for negative_prompt_embed, prompt_embed in zip(negative_prompt_embeds, prompt_embeds)
-        ]
-        ttnn_add_text_embeds = [
-            [
-                ttnn.from_torch(
-                    negative_pooled_prompt_embed,
-                    dtype=ttnn.bfloat16,
-                    device=ttnn_device,
-                    layout=ttnn.ROW_MAJOR_LAYOUT,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                ),
-                ttnn.from_torch(
-                    add_text_embed,
-                    dtype=ttnn.bfloat16,
-                    device=ttnn_device,
-                    layout=ttnn.ROW_MAJOR_LAYOUT,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                ),
-            ]
-            for negative_pooled_prompt_embed, add_text_embed in zip(negative_pooled_prompt_embeds, add_text_embeds)
-        ]
-        ttnn_add_time_ids = [
+    ttnn_prompt_embeds = [
+        [
             ttnn.from_torch(
-                negative_add_time_ids.squeeze(0),
+                negative_prompt_embed,
                 dtype=ttnn.bfloat16,
-                device=ttnn_device,
                 layout=ttnn.TILE_LAYOUT,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
             ),
             ttnn.from_torch(
-                add_time_ids.squeeze(0),
+                prompt_embed,
                 dtype=ttnn.bfloat16,
-                device=ttnn_device,
                 layout=ttnn.TILE_LAYOUT,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
             ),
         ]
-        ttnn_added_cond_kwargs = [
-            [
-                {
-                    "text_embeds": ttnn_add_text_embed[0],
-                    "time_ids": ttnn_add_time_ids[0],
-                },
-                {
-                    "text_embeds": ttnn_add_text_embed[1],
-                    "time_ids": ttnn_add_time_ids[1],
-                },
-            ]
-            for ttnn_add_text_embed in ttnn_add_text_embeds
-        ]
-    else:
-        ttnn_prompt_embeds = [
+        for negative_prompt_embed, prompt_embed in zip(negative_prompt_embeds, prompt_embeds)
+    ]
+    ttnn_add_text_embeds = [
+        [
             ttnn.from_torch(
-                prompt_embeds,
+                negative_pooled_prompt_embed,
                 dtype=ttnn.bfloat16,
-                device=ttnn_device,
-                layout=ttnn.TILE_LAYOUT,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            )
-        ]
-        ttnn_add_text_embeds = [
-            ttnn.from_torch(
-                add_text_embeds,
-                dtype=ttnn.bfloat16,
-                device=ttnn_device,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            )
-        ]
-        ttnn_add_time_ids = [
+            ),
             ttnn.from_torch(
-                add_time_ids.squeeze(0),
+                add_text_embed,
                 dtype=ttnn.bfloat16,
-                device=ttnn_device,
-                layout=ttnn.TILE_LAYOUT,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            )
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+            ),
         ]
-        ttnn_added_cond_kwargs = [
+        for negative_pooled_prompt_embed, add_text_embed in zip(negative_pooled_prompt_embeds, add_text_embeds)
+    ]
+    ttnn_add_time_ids = [
+        ttnn.from_torch(
+            negative_add_time_ids.squeeze(0),
+            dtype=ttnn.bfloat16,
+            device=ttnn_device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        ),
+        ttnn.from_torch(
+            add_time_ids.squeeze(0),
+            dtype=ttnn.bfloat16,
+            device=ttnn_device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        ),
+    ]
+    ttnn_added_cond_kwargs = [
+        [
             {
-                "text_embeds": ttnn_add_text_embeds[0],
+                "text_embeds": ttnn_add_text_embed[0],
                 "time_ids": ttnn_add_time_ids[0],
-            }
+            },
+            {
+                "text_embeds": ttnn_add_text_embed[1],
+                "time_ids": ttnn_add_time_ids[1],
+            },
         ]
+        for ttnn_add_text_embed in ttnn_add_text_embeds
+    ]
 
-    if classifier_free_guidance:
-        prompt_embeds = [torch.cat([t1, t2], dim=0) for t1, t2 in zip(negative_prompt_embeds, prompt_embeds)]
-        add_text_embeds = [torch.cat([t1, t2], dim=0) for t1, t2 in zip(negative_pooled_prompt_embeds, add_text_embeds)]
-        add_time_ids = [torch.cat([t1, t2], dim=0) for t1, t2 in zip(negative_add_time_ids, add_time_ids)]
+    prompt_embeds = [torch.cat([t1, t2], dim=0) for t1, t2 in zip(negative_prompt_embeds, prompt_embeds)]
+    add_text_embeds = [torch.cat([t1, t2], dim=0) for t1, t2 in zip(negative_pooled_prompt_embeds, add_text_embeds)]
+    add_time_ids = [torch.cat([t1, t2], dim=0) for t1, t2 in zip(negative_add_time_ids, add_time_ids)]
     added_cond_kwargs = [{"text_embeds": t1, "time_ids": t2} for t1, t2 in zip(add_text_embeds, add_time_ids)]
 
     logger.info("Performing warmup run, to make use of program caching in actual inference...")
@@ -373,45 +316,104 @@ def run_unet_inference(
     tt_latents = ttnn.from_torch(
         tt_latents,
         dtype=ttnn.bfloat16,
-        device=ttnn_device,
         layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    # UNet will deallocate the input tensor
-    tt_latent_model_input = ttnn.clone(tt_latents)
-
-    # Compile run of Scheduler and UNet
-    run_tt_iteration(
+    tt_latents_device = ttnn.allocate_tensor_on_device(
+        tt_latents.shape,
+        tt_latents.dtype,
+        tt_latents.layout,
         ttnn_device,
-        tt_unet,
-        tt_scheduler,
-        tt_latent_model_input,
-        [B, C, H, W],
-        ttnn_prompt_embeds[0][0],
-        ttnn_added_cond_kwargs[0][0]["time_ids"],
-        ttnn_added_cond_kwargs[0][0]["text_embeds"],
-        ttnn_timesteps[0],
-        0,
+        ttnn.DRAM_MEMORY_CONFIG,
     )
+    ttnn_add_text_embeds_device = [
+        ttnn.allocate_tensor_on_device(
+            ttnn_add_text_embeds[0][0].shape,
+            ttnn_add_text_embeds[0][0].dtype,
+            ttnn_add_text_embeds[0][0].layout,
+            ttnn_device,
+            ttnn.DRAM_MEMORY_CONFIG,
+        ),
+        ttnn.allocate_tensor_on_device(
+            ttnn_add_text_embeds[0][1].shape,
+            ttnn_add_text_embeds[0][1].dtype,
+            ttnn_add_text_embeds[0][1].layout,
+            ttnn_device,
+            ttnn.DRAM_MEMORY_CONFIG,
+        ),
+    ]
+    ttnn_prompt_embeds_device = [
+        ttnn.allocate_tensor_on_device(
+            ttnn_prompt_embeds[0][0].shape,
+            ttnn_prompt_embeds[0][0].dtype,
+            ttnn_prompt_embeds[0][0].layout,
+            ttnn_device,
+            ttnn.DRAM_MEMORY_CONFIG,
+        ),
+        ttnn.allocate_tensor_on_device(
+            ttnn_prompt_embeds[0][1].shape,
+            ttnn_prompt_embeds[0][1].dtype,
+            ttnn_prompt_embeds[0][1].layout,
+            ttnn_device,
+            ttnn.DRAM_MEMORY_CONFIG,
+        ),
+    ]
+
+    prepare_input_tensors(
+        [
+            tt_latents,
+            *ttnn_prompt_embeds[0],
+            ttnn_added_cond_kwargs[0][0]["text_embeds"],
+            ttnn_added_cond_kwargs[0][1]["text_embeds"],
+        ],
+        [tt_latents_device, *ttnn_prompt_embeds_device, *ttnn_add_text_embeds_device],
+    )
+    run_tt_denoising(
+        ttnn_device=ttnn_device,
+        tt_latents_device=tt_latents_device,
+        tt_latents_output=None,
+        tt_unet=tt_unet,
+        tt_scheduler=tt_scheduler,
+        input_shape=[B, C, H, W],
+        ttnn_prompt_embeds=ttnn_prompt_embeds_device,
+        ttnn_add_text_embeds=ttnn_add_text_embeds_device,
+        ttnn_add_time_ids=ttnn_add_time_ids,
+        guidance_scale=guidance_scale,
+        extra_step_kwargs=extra_step_kwargs,
+        tid=None,
+        compile_run=True,
+    )
+    tt_scheduler.set_step_index(0)
+    ttnn.synchronize_device(ttnn_device)
     pcc_per_iter = []
+    tid = None
+    tt_latents_output = None
     logger.info("Starting ttnn inference...")
     for iter in range(len(prompts)):
+        prepare_input_tensors(
+            [
+                tt_latents,
+                *ttnn_prompt_embeds[iter],
+                ttnn_added_cond_kwargs[iter][0]["text_embeds"],
+                ttnn_added_cond_kwargs[iter][1]["text_embeds"],
+            ],
+            [tt_latents_device, *ttnn_prompt_embeds_device, *ttnn_add_text_embeds_device],
+        )
         logger.info(f"Running inference for prompt {iter + 1}/{len(prompts)}: {prompts[iter]}")
         for i, (t, tt_t) in tqdm(enumerate(zip(timesteps, ttnn_timesteps)), total=len(ttnn_timesteps)):
-            tt_latents, [C, H, W] = run_tt_denoising(
-                tt_latents=tt_latents,
-                iter=iter,
+            tid, tt_latents_device, tt_latents_output, [C, H, W] = run_tt_denoising(
                 ttnn_device=ttnn_device,
+                tt_latents_device=tt_latents_device,
+                tt_latents_output=tt_latents_output,
                 tt_unet=tt_unet,
                 tt_scheduler=tt_scheduler,
                 input_shape=[B, C, H, W],
-                ttnn_prompt_embeds=ttnn_prompt_embeds,
-                ttnn_added_cond_kwargs=ttnn_added_cond_kwargs,
-                tt_t=tt_t,
-                classifier_free_guidance=classifier_free_guidance,
+                ttnn_prompt_embeds=ttnn_prompt_embeds_device,
+                ttnn_add_text_embeds=ttnn_add_text_embeds_device,
+                ttnn_add_time_ids=ttnn_add_time_ids,
                 guidance_scale=guidance_scale,
                 extra_step_kwargs=extra_step_kwargs,
+                tid=tid,
             )
             latents = run_torch_denoising(
                 latents=latents,
@@ -420,12 +422,15 @@ def run_unet_inference(
                 prompt_embeds=prompt_embeds,
                 added_cond_kwargs=added_cond_kwargs,
                 t=t,
-                classifier_free_guidance=classifier_free_guidance,
                 guidance_scale=guidance_scale,
                 extra_step_kwargs=extra_step_kwargs,
             )
 
-            torch_tt_latents = ttnn.to_torch(tt_latents)
+            if i < (len(ttnn_timesteps) - 1):
+                tt_scheduler.inc_step_index()
+
+            ttnn.synchronize_device(ttnn_device)
+            torch_tt_latents = ttnn.to_torch(tt_latents_device)
             torch_tt_latents = torch.reshape(torch_tt_latents, (B, H, W, C))
             torch_tt_latents = torch.permute(torch_tt_latents, (0, 3, 1, 2))
 
@@ -434,7 +439,7 @@ def run_unet_inference(
             pcc_per_iter.append(float(pcc_message))
 
         tt_scheduler.set_step_index(0)
-
+    ttnn.release_trace(ttnn_device, tid)
     if not is_ci_env:
         plt.plot(pcc_per_iter, marker="o")
         plt.title("PCC per iteration")
@@ -449,26 +454,20 @@ def run_unet_inference(
 
 
 @pytest.mark.skipif(not is_wormhole_b0(), reason="SDXL supported on WH only")
-@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE, "trace_region_size": 25933824}], indirect=True
+)
 @pytest.mark.parametrize(
     "prompt",
     (("An astronaut riding a green horse"),),
-)
-@pytest.mark.parametrize(
-    "classifier_free_guidance",
-    [
-        (True),
-    ],
-    ids=("with_classifier_free_guidance",),
 )
 def test_unet_loop(
     device,
     is_ci_env,
     prompt,
     loop_iter_num,
-    classifier_free_guidance,
     model_location_generator,
 ):
     return run_unet_inference(
-        device, is_ci_env, prompt, loop_iter_num, model_location_generator, classifier_free_guidance
+        device, is_ci_env, prompt, loop_iter_num, model_location_generator
     )

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
@@ -109,9 +109,7 @@ def run_torch_denoising(
 
 
 @torch.no_grad()
-def run_unet_inference(
-    ttnn_device, is_ci_env, prompts, num_inference_steps, model_location_generator,
-):
+def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps):
     torch.manual_seed(0)
 
     if isinstance(prompts, str):
@@ -393,8 +391,5 @@ def test_unet_loop(
     is_ci_env,
     prompt,
     loop_iter_num,
-    model_location_generator,
 ):
-    return run_unet_inference(
-        device, is_ci_env, prompt, loop_iter_num, model_location_generator
-    )
+    return run_unet_inference(device, is_ci_env, prompt, loop_iter_num)

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -16,7 +16,7 @@ import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
 
 SDXL_L1_SMALL_SIZE = 47000
-SDXL_TRACE_REGION_SIZE = 31969280
+SDXL_TRACE_REGION_SIZE = 33575936
 SDXL_CI_WEIGHTS_PATH = "/mnt/MLPerf/tt_dnn-models/hf_home"
 
 
@@ -172,9 +172,10 @@ def run_tt_image_gen(
 
     ttnn.synchronize_device(ttnn_device)
 
-    profiler.end("denoising_loop")
     # reset scheduler
     tt_scheduler.set_step_index(0)
+
+    profiler.end("denoising_loop")
 
     vae_on_device = isinstance(vae, TtAutoencoderKL)
 

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -16,7 +16,7 @@ import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
 
 SDXL_L1_SMALL_SIZE = 47000
-SDXL_TRACE_REGION_SIZE = 31968256
+SDXL_TRACE_REGION_SIZE = 31969280
 SDXL_CI_WEIGHTS_PATH = "/mnt/MLPerf/tt_dnn-models/hf_home"
 
 
@@ -170,8 +170,7 @@ def run_tt_image_gen(
         if i < (len(tt_timesteps) - 1):
             tt_scheduler.inc_step_index()
 
-    if tid_vae is None:
-        ttnn.synchronize_device(ttnn_device)
+    ttnn.synchronize_device(ttnn_device)
 
     profiler.end("denoising_loop")
     # reset scheduler

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -16,6 +16,7 @@ import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
 
 SDXL_L1_SMALL_SIZE = 47000
+SDXL_TRACE_REGION_SIZE = 25933824
 SDXL_CI_WEIGHTS_PATH = "/mnt/MLPerf/tt_dnn-models/hf_home"
 
 
@@ -122,42 +123,47 @@ def run_tt_image_gen(
     input_shape,
     vae,  # can be host vae or tt vae
     batch_size,
-    iter,
+    tid=None,
+    capture_trace=False,
 ):
+    assert not (capture_trace and len(tt_timesteps) > 1), "Trace should capture only 1 iteration"
     profiler.start("denoising_loop")
     for i, t in tqdm(enumerate(tt_timesteps), total=len(tt_timesteps)):
         unet_outputs = []
-        for unet_slice in range(len(tt_time_ids)):
-            latent_model_input = tt_latents
-            noise_pred, noise_shape = run_tt_iteration(
-                ttnn_device,
-                tt_unet,
-                tt_scheduler,
-                latent_model_input,
-                input_shape,
-                tt_prompt_embeds[iter][unet_slice],
-                tt_time_ids[unet_slice],
-                ttnn.unsqueeze(tt_text_embeds[iter][unet_slice], dim=0),
-                t,
-                i,
-            )
-            C, H, W = noise_shape
+        if tid is None or capture_trace:
+            tid = ttnn.begin_trace_capture(ttnn_device, cq_id=0) if capture_trace else None
+            for unet_slice in range(len(tt_time_ids)):
+                latent_model_input = tt_latents
+                noise_pred, _ = run_tt_iteration(
+                    tt_unet,
+                    tt_scheduler,
+                    latent_model_input,
+                    input_shape,
+                    tt_prompt_embeds[unet_slice],
+                    tt_time_ids[unet_slice],
+                    tt_text_embeds[unet_slice],
+                )
 
-            unet_outputs.append(noise_pred)
+                unet_outputs.append(noise_pred)
 
-        # perform guidance
-        noise_pred_uncond, noise_pred_text = unet_outputs
-        noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+            # perform guidance
+            noise_pred_uncond, noise_pred_text = unet_outputs
+            noise_pred_text = ttnn.sub_(noise_pred_text, noise_pred_uncond)
+            noise_pred_text = ttnn.mul_(noise_pred_text, guidance_scale)
+            noise_pred = ttnn.add_(noise_pred_uncond, noise_pred_text)
 
-        ttnn.deallocate(noise_pred_uncond)
-        ttnn.deallocate(noise_pred_text)
+            tt_latents = tt_scheduler.step(noise_pred, None, tt_latents, **tt_extra_step_kwargs, return_dict=False)[0]
 
-        tt_latents = tt_scheduler.step(
-            noise_pred, tt_scheduler.timesteps[i], tt_latents, **tt_extra_step_kwargs, return_dict=False
-        )[0]
+            ttnn.deallocate(noise_pred_uncond)
+            ttnn.deallocate(noise_pred_text)
 
-        ttnn.deallocate(noise_pred)
-        tt_latents = ttnn.move(tt_latents)
+            if capture_trace:
+                ttnn.end_trace_capture(ttnn_device, tid, cq_id=0)
+        else:
+            ttnn.execute_trace(ttnn_device, tid, cq_id=0, blocking=False)
+
+        if i < (len(tt_timesteps) - 1):
+            tt_scheduler.inc_step_index()
 
     # reset scheduler
     tt_scheduler.set_step_index(0)
@@ -193,8 +199,125 @@ def run_tt_image_gen(
         gc.collect()
     profiler.end("vae_decode")
 
-    return imgs
+    return imgs, tid
+
 
 def prepare_input_tensors(host_tensors, device_tensors):
     for host_tensor, device_tensor in zip(host_tensors, device_tensors):
         ttnn.copy_host_to_device_tensor(host_tensor, device_tensor)
+
+
+def allocate_input_tensors(ttnn_device, tt_latents, tt_prompt_embeds, tt_text_embeds, tt_time_ids):
+    is_mesh_device = isinstance(ttnn_device, ttnn._ttnn.multi_device.MeshDevice)
+    tt_latents_device = ttnn.allocate_tensor_on_device(
+        tt_latents.shape,
+        tt_latents.dtype,
+        tt_latents.layout,
+        ttnn_device,
+        ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_prompt_embeds_device = [
+        ttnn.allocate_tensor_on_device(
+            tt_prompt_embeds[0][0].shape,
+            tt_prompt_embeds[0][0].dtype,
+            tt_prompt_embeds[0][0].layout,
+            ttnn_device,
+            ttnn.DRAM_MEMORY_CONFIG,
+        ),
+        ttnn.allocate_tensor_on_device(
+            tt_prompt_embeds[0][1].shape,
+            tt_prompt_embeds[0][1].dtype,
+            tt_prompt_embeds[0][1].layout,
+            ttnn_device,
+            ttnn.DRAM_MEMORY_CONFIG,
+        ),
+    ]
+
+    tt_text_embeds_device = [
+        ttnn.allocate_tensor_on_device(
+            tt_text_embeds[0][0].shape,
+            tt_text_embeds[0][0].dtype,
+            tt_text_embeds[0][0].layout,
+            ttnn_device,
+            ttnn.DRAM_MEMORY_CONFIG,
+        ),
+        ttnn.allocate_tensor_on_device(
+            tt_text_embeds[0][1].shape,
+            tt_text_embeds[0][1].dtype,
+            tt_text_embeds[0][1].layout,
+            ttnn_device,
+            ttnn.DRAM_MEMORY_CONFIG,
+        ),
+    ]
+
+    tt_time_ids_device = [
+        ttnn.from_torch(
+            tt_time_ids[0].squeeze(0),
+            dtype=ttnn.bfloat16,
+            device=ttnn_device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device) if is_mesh_device else None,
+        ),
+        ttnn.from_torch(
+            tt_time_ids[1].squeeze(0),
+            dtype=ttnn.bfloat16,
+            device=ttnn_device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device) if is_mesh_device else None,
+        ),
+    ]
+
+    return tt_latents_device, tt_prompt_embeds_device, tt_text_embeds_device, tt_time_ids_device
+
+
+def create_user_tensors(
+    ttnn_device, latents, negative_prompt_embeds, prompt_embeds, negative_pooled_prompt_embeds, add_text_embeds
+):
+    is_mesh_device = isinstance(ttnn_device, ttnn._ttnn.multi_device.MeshDevice)
+    tt_latents = ttnn.from_torch(
+        latents,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device) if is_mesh_device else None,
+    )
+
+    tt_prompt_embeds = [
+        [
+            ttnn.from_torch(
+                negative_prompt_embed,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0) if is_mesh_device else None,
+            ),
+            ttnn.from_torch(
+                prompt_embed,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0) if is_mesh_device else None,
+            ),
+        ]
+        for negative_prompt_embed, prompt_embed in zip(negative_prompt_embeds, prompt_embeds)
+    ]
+
+    tt_add_text_embeds = [
+        [
+            ttnn.from_torch(
+                negative_pooled_prompt_embed,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0) if is_mesh_device else None,
+            ),
+            ttnn.from_torch(
+                add_text_embed,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0) if is_mesh_device else None,
+            ),
+        ]
+        for negative_pooled_prompt_embed, add_text_embed in zip(negative_pooled_prompt_embeds, add_text_embeds)
+    ]
+
+    return tt_latents, tt_prompt_embeds, tt_add_text_embeds

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -11,7 +11,7 @@ import urllib
 from loguru import logger
 import statistics
 from models.experimental.stable_diffusion_xl_base.utils.fid_score import calculate_fid_score
-from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
+from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE, SDXL_TRACE_REGION_SIZE
 import json
 from models.utility_functions import profiler
 
@@ -20,7 +20,9 @@ COCO_CAPTIONS_DOWNLOAD_PATH = "https://github.com/mlcommons/inference/raw/4b1d11
 OUT_ROOT, RESULTS_FILE_NAME = "test_reports", "sdxl_test_results.json"
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE, "trace_region_size": SDXL_TRACE_REGION_SIZE}], indirect=True
+)
 @pytest.mark.parametrize(
     "num_inference_steps",
     ((50),),
@@ -33,6 +35,14 @@ OUT_ROOT, RESULTS_FILE_NAME = "test_reports", "sdxl_test_results.json"
     ],
     ids=("device_vae", "host_vae"),
 )
+@pytest.mark.parametrize(
+    "capture_trace",
+    [
+        (True),
+        (False),
+    ],
+    ids=("with_trace", "no_trace"),
+)
 @pytest.mark.parametrize("captions_path", ["models/experimental/stable_diffusion_xl_base/coco_data/captions.tsv"])
 @pytest.mark.parametrize("coco_statistics_path", ["models/experimental/stable_diffusion_xl_base/coco_data/val2014.npz"])
 def test_accuracy_sdxl(
@@ -40,6 +50,7 @@ def test_accuracy_sdxl(
     is_ci_env,
     num_inference_steps,
     vae_on_device,
+    capture_trace,
     captions_path,
     coco_statistics_path,
     evaluation_range,
@@ -60,6 +71,7 @@ def test_accuracy_sdxl(
         prompts,
         num_inference_steps,
         vae_on_device,
+        capture_trace,
         evaluation_range,
     )
 

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy_with_reset.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy_with_reset.py
@@ -36,11 +36,20 @@ IMAGES_PATH, IMAGE_NAME_BASE = "output", "output"
     ],
     ids=("device_vae", "host_vae"),
 )
+@pytest.mark.parametrize(
+    "capture_trace",
+    [
+        (True),
+        (False),
+    ],
+    ids=("with_trace", "no_trace"),
+)
 @pytest.mark.parametrize("captions_path", ["models/experimental/stable_diffusion_xl_base/coco_data/captions.tsv"])
 @pytest.mark.parametrize("coco_statistics_path", ["models/experimental/stable_diffusion_xl_base/coco_data/val2014.npz"])
 @pytest.mark.skipif(is_6u() or IS_RING_6U_LOCAL, reason="skip when 6u, as it does not support reset")
 def test_accuracy_with_reset(
     vae_on_device,
+    capture_trace,
     captions_path,
     coco_statistics_path,
     evaluation_range,
@@ -56,9 +65,10 @@ def test_accuracy_with_reset(
         reset_period = num_prompts
 
     vae_str = "device_vae" if vae_on_device else "host_vae"
+    trace_str = "with_trace" if capture_trace else "no_trace"
 
     logger.info(
-        f"Running test_accuracy_with_reset with vae_on_device={vae_on_device}, reset_bool={reset_bool}, reset_period={reset_period}"
+        f"Running test_accuracy_with_reset with vae_on_device={vae_on_device}, capture_trace={capture_trace}, reset_bool={reset_bool}, reset_period={reset_period}"
     )
     logger.info(f"start_from: {start_from}, num_prompts: {num_prompts}")
 
@@ -90,7 +100,7 @@ def test_accuracy_with_reset(
                 "--num-prompts",
                 str(current_num_prompts),
                 "-k",
-                vae_str,
+                f"{vae_str} and {trace_str}",
             ]
         )
         subprocess.run(command, check=True)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_euler_discrete_scheduler.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_euler_discrete_scheduler.py
@@ -271,18 +271,10 @@ class TtEulerDiscreteScheduler(nn.Module):
         # Upcast to avoid precision issues when computing prev_sample
         # sample = sample.to(torch.float32)
 
-        # leaving gamma calculus just in case we hit it
-        # sigma = self.sigmas[self.step_index]
-        # gamma = min(s_churn / (len(self.sigmas) - 1), 2**0.5 - 1) if s_tmin <= sigma <= s_tmax else 0.0
-        # assert gamma == 0, "gamma > 0 is not supported in this version"
-        # tt_sigma = self.tt_sigmas[self.step_index]
-        # sigma_hat = ttnn.to_layout(tt_sigma, layout=ttnn.TILE_LAYOUT)
-
         # 1. compute predicted original sample (x_0) from sigma-scaled predicted noise
         # NOTE: "original_sample" should not be an expected prediction_type but is left in for
         # backwards compatibility
         assert self.prediction_type == "epsilon"
-        # pred_original_sample = sample - model_output * self.tt_sigma_step
 
         # 2. Convert to an ODE derivative
         rec = ttnn.reciprocal(self.tt_sigma_step)
@@ -295,12 +287,7 @@ class TtEulerDiscreteScheduler(nn.Module):
 
         prev_sample = ttnn.add_(sample, model_output)
 
-        # Cast sample back to model compatible dtype
-        # prev_sample = prev_sample.to(model_output.dtype)
-
-        # Note: Host code is done separately because of tracing
-        # upon completion increase step index by one
-        # self.step_index += 1
+        # Note: Step index inc moved out of step func as it is done on host
 
         # Note: We return None for pred_original_sample since it is never used
         return (prev_sample, None)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_euler_discrete_scheduler.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_euler_discrete_scheduler.py
@@ -57,7 +57,6 @@ class TtEulerDiscreteScheduler(nn.Module):
         self.timestep_spacing = timestep_spacing
         timesteps = np.linspace(0, num_train_timesteps - 1, num_train_timesteps, dtype=float)[::-1].copy()
         timesteps = torch.from_numpy(timesteps).to(dtype=torch.float32)
-        self.timesteps = timesteps
         assert timestep_type == "discrete", "timestep_type {timestep_type} is not supported in this version"
         self.timestep_type = timestep_type
         self.steps_offset = steps_offset
@@ -74,28 +73,95 @@ class TtEulerDiscreteScheduler(nn.Module):
         self.step_index = None
         self.begin_index = None
         self.device = device
+        self.create_ttnn_timesteps(timesteps)
+        self.create_ttnn_sigmas("sigmas")
 
-        # self.update_device_tensor("sigmas")
+    def inc_step_index(self):
+        self.set_step_index(self.step_index + 1)
 
     def set_step_index(self, step_index: int):
         self.step_index = step_index
+        self.update_device_sigmas()
+        self.update_device_timestep()
+        self.update_device_norm_factor()
 
-    def update_device_tensor(self, tensor_name):
+    def create_ttnn_sigmas(self, tensor_name):
         array = getattr(self, tensor_name)
         setattr(self, "tt_" + tensor_name, [])
         tt_array = getattr(self, "tt_" + tensor_name)
 
         for val in array:
             tt_array.append(
-                ttnn.to_memory_config(
-                    ttnn.from_torch(
-                        val,
-                        dtype=ttnn.bfloat16,
-                        layout=ttnn.ROW_MAJOR_LAYOUT,
-                    ).to(device=self.device),
-                    ttnn.L1_MEMORY_CONFIG,
+                ttnn.from_torch(
+                    val,
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.TILE_LAYOUT,
                 ),
             )
+        sigma_step = self.tt_sigmas[0]
+        self.tt_sigma_step = ttnn.allocate_tensor_on_device(
+            sigma_step.shape,
+            sigma_step.dtype,
+            sigma_step.layout,
+            self.device,
+            ttnn.DRAM_MEMORY_CONFIG,
+        )
+        sigma_next_step = self.tt_sigmas[1]
+        self.tt_sigma_next_step = ttnn.allocate_tensor_on_device(
+            sigma_next_step.shape,
+            sigma_next_step.dtype,
+            sigma_next_step.layout,
+            self.device,
+            ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def update_device_sigmas(self):
+        ttnn.copy_host_to_device_tensor(self.tt_sigmas[self.step_index], self.tt_sigma_step)
+        ttnn.copy_host_to_device_tensor(self.tt_sigmas[self.step_index + 1], self.tt_sigma_next_step)
+
+    def create_ttnn_timesteps(self, timesteps):
+        self.timesteps = []
+        for t in timesteps:
+            self.timesteps.append(
+                ttnn.from_torch(
+                    t,
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.TILE_LAYOUT,
+                ),
+            )
+        tt_timestep_step = self.timesteps[0]
+        self.tt_timestep = ttnn.allocate_tensor_on_device(
+            tt_timestep_step.shape,
+            tt_timestep_step.dtype,
+            tt_timestep_step.layout,
+            self.device,
+            ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def update_device_timestep(self):
+        ttnn.copy_host_to_device_tensor(self.timesteps[self.step_index], self.tt_timestep)
+
+    def create_ttnn_norm_factor(self, variance_normalization_factor):
+        self.variance_normalization_factor = []
+        for val in variance_normalization_factor:
+            self.variance_normalization_factor.append(
+                ttnn.from_torch(
+                    val,
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.TILE_LAYOUT,
+                ),
+            )
+        tt_val_step = self.variance_normalization_factor[0]
+        self.tt_norm_factor = ttnn.allocate_tensor_on_device(
+            tt_val_step.shape,
+            tt_val_step.dtype,
+            tt_val_step.layout,
+            self.device,
+            ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def update_device_norm_factor(self):
+        ttnn.copy_host_to_device_tensor(self.variance_normalization_factor[self.step_index], self.tt_norm_factor)
 
     # pipeline_stable_diffusion_xl.py __call__() step #4
     def set_timesteps(
@@ -134,19 +200,18 @@ class TtEulerDiscreteScheduler(nn.Module):
         sigmas = torch.from_numpy(sigmas).to(dtype=torch.float32, device=device)
 
         assert self.timestep_type == "discrete"
-        self.timesteps = torch.from_numpy(timesteps.astype(np.float32)).to(device=device)
+        timesteps = torch.from_numpy(timesteps.astype(np.float32)).to(device=device)
+        self.create_ttnn_timesteps(timesteps)
 
         self.begin_index = 0
-        self.step_index = self.begin_index
 
         self.sigmas = sigmas
-        self.variance_normalization_factor = (sigmas**2 + 1) ** 0.5
+        variance_normalization_factor = (sigmas**2 + 1) ** 0.5
+        self.create_ttnn_norm_factor(variance_normalization_factor)
 
-        self.update_device_tensor("sigmas")
-        self.update_device_tensor("timesteps")
-        self.update_device_tensor("variance_normalization_factor")
+        self.create_ttnn_sigmas("sigmas")
+        self.set_step_index(self.begin_index)
 
-    # pipeline_stable_diffusion_xl.py prepare_latents() step # 5
     @property
     def init_noise_sigma(self):
         """
@@ -158,11 +223,6 @@ class TtEulerDiscreteScheduler(nn.Module):
         ), "timestep_spacing {self.timestep_spacing} is not supported in this version"
         return (max_sigma**2 + 1) ** 0.5
 
-        # no need to do this in ttnn
-        # max_sigma = ttnn.max(self.tt_sigmas, dim=0, keepdim=False)
-        # return ttnn.sqrt((ttnn.pow(max_sigma,2) + 1))
-
-    # pipeline_stable_diffusion_xl.py __call__() step #9
     def scale_model_input(
         self, sample: ttnn._ttnn.tensor.Tensor, timestep: Union[float, ttnn._ttnn.tensor.Tensor]
     ) -> ttnn._ttnn.tensor.Tensor:
@@ -171,13 +231,11 @@ class TtEulerDiscreteScheduler(nn.Module):
         current timestep. Scales the denoising model input by `(sigma**2 + 1) ** 0.5` to match the Euler algorithm.
         """
         # timestep is not used in this implementation, step_index is already initialized at set_timesteps()
-        sigma_normalization_factor = self.variance_normalization_factor[self.step_index]
-        sample = sample / sigma_normalization_factor
+        sample = ttnn.div(sample, self.tt_norm_factor)
 
         self.is_scale_input_called = True
         return sample
 
-    # pipeline_stable_diffusion_xl.py __call__() step #9
     def step(
         self,
         model_output: ttnn._ttnn.tensor.Tensor,
@@ -195,15 +253,6 @@ class TtEulerDiscreteScheduler(nn.Module):
         process from the learned model outputs (most often the predicted noise).
         """
 
-        if isinstance(timestep, (int, torch.IntTensor, torch.LongTensor)):
-            raise ValueError(
-                (
-                    "Passing integer indices (e.g. from `enumerate(timesteps)`) as timesteps to"
-                    " `EulerDiscreteScheduler.step()` is not supported. Make sure to pass"
-                    " one of the `scheduler.timesteps` as a timestep."
-                ),
-            )
-
         if not self.is_scale_input_called:
             logger.warning(
                 "The `scale_model_input` function should be called before `step` to ensure correct denoising. "
@@ -219,29 +268,32 @@ class TtEulerDiscreteScheduler(nn.Module):
         # sample = sample.to(torch.float32)
 
         # leaving gamma calculus just in case we hit it
-        sigma = self.sigmas[self.step_index]
-        gamma = min(s_churn / (len(self.sigmas) - 1), 2**0.5 - 1) if s_tmin <= sigma <= s_tmax else 0.0
-        assert gamma == 0, "gamma > 0 is not supported in this version"
-        tt_sigma = self.tt_sigmas[self.step_index]
-        sigma_hat = ttnn.to_layout(tt_sigma, layout=ttnn.TILE_LAYOUT)
+        # sigma = self.sigmas[self.step_index]
+        # gamma = min(s_churn / (len(self.sigmas) - 1), 2**0.5 - 1) if s_tmin <= sigma <= s_tmax else 0.0
+        # assert gamma == 0, "gamma > 0 is not supported in this version"
+        # tt_sigma = self.tt_sigmas[self.step_index]
+        # sigma_hat = ttnn.to_layout(tt_sigma, layout=ttnn.TILE_LAYOUT)
 
         # 1. compute predicted original sample (x_0) from sigma-scaled predicted noise
         # NOTE: "original_sample" should not be an expected prediction_type but is left in for
         # backwards compatibility
         assert self.prediction_type == "epsilon"
-        pred_original_sample = sample - model_output * sigma_hat
+        # pred_original_sample = sample - model_output * self.tt_sigma_step
 
         # 2. Convert to an ODE derivative
-        derivative = (sample - pred_original_sample) * ttnn.reciprocal(sigma_hat)
+        rec = ttnn.reciprocal(self.tt_sigma_step)
+        model_output = ttnn.mul_(model_output, self.tt_sigma_step)
+        model_output = ttnn.mul_(model_output, rec)
 
-        dt = ttnn.to_layout(self.tt_sigmas[self.step_index + 1], layout=ttnn.TILE_LAYOUT) - sigma_hat
+        dt = self.tt_sigma_next_step - self.tt_sigma_step
+        model_output = ttnn.mul_(model_output, dt)
 
-        prev_sample = sample + derivative * dt
+        prev_sample = ttnn.add_(sample, model_output)
 
         # Cast sample back to model compatible dtype
         # prev_sample = prev_sample.to(model_output.dtype)
 
         # upon completion increase step index by one
-        self.step_index += 1
+        # self.step_index += 1
 
-        return (prev_sample, pred_original_sample)
+        return (prev_sample, None)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_euler_discrete_scheduler.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_euler_discrete_scheduler.py
@@ -257,6 +257,8 @@ class TtEulerDiscreteScheduler(nn.Module):
         process from the learned model outputs (most often the predicted noise).
         """
 
+        assert timestep is None, "timestep is expected to be None"
+
         if not self.is_scale_input_called:
             logger.warning(
                 "The `scale_model_input` function should be called before `step` to ensure correct denoising. "
@@ -270,6 +272,10 @@ class TtEulerDiscreteScheduler(nn.Module):
         # this is a potential accuracy pitfall
         # Upcast to avoid precision issues when computing prev_sample
         # sample = sample.to(torch.float32)
+
+        sigma = self.sigmas[self.step_index]
+        gamma = min(s_churn / (len(self.sigmas) - 1), 2**0.5 - 1) if s_tmin <= sigma <= s_tmax else 0.0
+        assert gamma == 0, "gamma > 0 is not supported in this version"
 
         # 1. compute predicted original sample (x_0) from sigma-scaled predicted noise
         # NOTE: "original_sample" should not be an expected prediction_type but is left in for

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
@@ -57,8 +57,12 @@ def test_vae(device, input_shape, pcc, is_ci_env, reset_seeds):
     ttnn_input_tensor = ttnn.reshape(ttnn_input_tensor, (B, 1, H * W, C))
 
     logger.info("Running TT model")
-    output_tensor = tt_vae.forward(ttnn_input_tensor, [B, C, H, W])
+    output_tensor, [C, H, W] = tt_vae.forward(ttnn_input_tensor, [B, C, H, W])
     logger.info("TT model done")
+
+    output_tensor = ttnn.to_torch(output_tensor, mesh_composer=ttnn.ConcatMeshToTensor(device, dim=0)).float()
+    output_tensor = output_tensor.reshape(B, H, W, C)
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
 
     del vae
     gc.collect()

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_decoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_decoder.py
@@ -59,8 +59,12 @@ def test_vae_decoder(device, input_shape, pcc, is_ci_env, reset_seeds):
     ttnn_input_tensor = ttnn.reshape(ttnn_input_tensor, (B, 1, H * W, C))
 
     logger.info("Running TT model")
-    output_tensor = tt_vae.forward(ttnn_input_tensor, [B, C, H, W])
+    output_tensor, [C, H, W] = tt_vae.forward(ttnn_input_tensor, [B, C, H, W])
     logger.info("TT model done")
+
+    output_tensor = ttnn.to_torch(output_tensor, mesh_composer=ttnn.ConcatMeshToTensor(device, dim=0)).float()
+    output_tensor = output_tensor.reshape(B, H, W, C)
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
 
     del vae
     gc.collect()

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_autoencoder_kl.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_autoencoder_kl.py
@@ -41,6 +41,6 @@ class TtAutoencoderKL(nn.Module):
         ttnn.deallocate(pre_conv_hidden_states)
 
         hidden_states = ttnn.sharded_to_interleaved(hidden_states, ttnn.L1_MEMORY_CONFIG)
-        hidden_states = self.decoder(hidden_states, [B, C, H, W])
+        hidden_states, [C, H, W] = self.decoder(hidden_states, [B, C, H, W])
 
-        return hidden_states
+        return hidden_states, [C, H, W]

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
-import torch
 import torch.nn as nn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_midblock2d import TtUNetMidBlock2D
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_upblock2d import TtUpDecoderBlock2D
@@ -177,9 +176,4 @@ class TtDecoder(nn.Module):
         )
         C = self.conv_out_params["output_channels"]
 
-        # Convert to torch
-        hidden_states = ttnn.to_torch(hidden_states, mesh_composer=ttnn.ConcatMeshToTensor(self.device, dim=0)).float()
-        hidden_states = hidden_states.reshape(self.batch_size * B, H, W, C)
-        hidden_states = torch.permute(hidden_states, (0, 3, 1, 2))
-
-        return hidden_states
+        return hidden_states, [C, H, W]


### PR DESCRIPTION
### Ticket
#24052 

### What's changed
Added option to run demo, accuracy test and unet loop with trace. We record 2 traces:

- 1 denoising loop trace (which is replayed `num_iterations` times)
- VAE trace

Because of tracing  and its requirements for permanent input addresses logic for allocating user tensors is modified. We preallocate device input tensors and copy over user tensors for each (DP batch) image gen. Additionally, `TtEulerDiscreteScheduler` is adapted to copy adequate timestep, sigma and norm factor tensors between UNet iterations.

All host code is removed from SDXL components since it will not be executed during trace replay.

### Checklist

- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15936183609) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15936176766) CI passes
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/15936187977) CI passes 