### PR TITLE
24067: enable int32 for scatter

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_scatter.py
+++ b/tests/ttnn/unit_tests/operations/test_scatter.py
@@ -53,11 +53,10 @@ def select_torch_dtype(ttnn_dtype):
         ([1, 2, 3, 4, 5, 6, 7, 8], 0, [1, 2, 3, 4, 5, 6, 7, 8], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.ROW_MAJOR),
         ([10, 50, 10, 50, 100], -1, [10, 50, 10, 50, 100], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
         ([50, 200], -1, [50, 200], ttnn.bfloat16, ttnn.uint16, ttnn.Layout.TILE),
-        ##################
-        # these cases fail due to the int32 transpose issue
-        # ([50, 200], 0, [50, 200], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
+        ([50, 200], 0, [50, 200], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
+        # this fails due to https://github.com/tenstorrent/tt-metal/issues/24287
         # ([10, 50, 10, 50, 100], 0, [10, 50, 10, 50, 100], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
-        # ([50, 200], 0, [50, 200], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
+        ([50, 200], 0, [50, 200], ttnn.bfloat16, ttnn.int32, ttnn.Layout.TILE),
         ##################
         # these cases fail due to the to_layout precision issue (fp32 tiled <-> row-major) : #23405
         # ([10, 50, 10, 50, 100], -1, [10, 50, 10, 50, 100], ttnn.float32, ttnn.uint16, ttnn.Layout.TILE),

--- a/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scatter/scatter.cpp
@@ -79,22 +79,6 @@ void check_support(
     const auto& input_shape = input_tensor.get_logical_shape();
     const auto& index_shape = index_tensor.get_logical_shape();
     const auto& source_shape = source_tensor.get_logical_shape();
-    // check if transpose int garbage case
-    TT_FATAL(
-        !(is_i32(input_dtype) && !is_last_dim(input_shape, dim)),
-        "Scatter doesn't work for i32 tensors and dim != -1 yet (see int32 transpose issues) - input tensor is {}.",
-        magic_enum::enum_name(input_dtype)
-    );
-    TT_FATAL(
-        !(is_i32(index_dtype) && !is_last_dim(index_shape, dim)),
-        "Scatter doesn't work for i32 tensors and dim != -1 yet (see int32 transpose issues) - index tensor is {}.",
-        magic_enum::enum_name(index_dtype)
-    );
-    TT_FATAL(
-        !(is_i32(source_dtype) && !is_last_dim(source_shape, dim)),
-        "Scatter doesn't work for i32 tensors and dim != -1 yet (see int32 transpose issues) - source tensor is {}.",
-        magic_enum::enum_name(source_dtype)
-    );
     // check if to_layout fp32 tiled precision case
     TT_FATAL(
         !(input_dtype == DataType::FLOAT32 && input_layout == Layout::TILE),


### PR DESCRIPTION
### Ticket
#24067

### Problem description
Enable int32 for scatter

### What's changed
- removed validation against int32,
- removed fail check-up test cases for int32,
- unlocked test cases for int32

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes