### PR TITLE
Fix for vit inference throughput

### DIFF
--- a/models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_throughput.py
+++ b/models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_throughput.py
@@ -129,7 +129,6 @@ def test_vit(device):
         output = ttnn_optimized_sharded_vit_wh.vit(
             config,
             pixel_values,
-            head_masks,
             cls_token,
             position_embeddings,
             parameters=parameters,


### PR DESCRIPTION
### Ticket
This PR is a fix for failing pytest for `demo_vit_ttnn_inference_throughput.py`

### Problem description
`pytest models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_throughput.py` fails in main

This ticket is aimed at fixing that

### What's changed
model initialization passes an argument that is not required and is removed.