### PR TITLE
Re-enable softmax test

### DIFF
--- a/tests/tt_eager/ops/test_softmax_op.cpp
+++ b/tests/tt_eager/ops/test_softmax_op.cpp
@@ -40,8 +40,6 @@ int main(int argc, char** argv) {
         int device_id = 0;
         auto device_owner = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
         auto device = device_owner.get();
-        // https://github.com/tenstorrent/tt-metal/issues/23824
-        device->disable_and_clear_program_cache();
 
         run_softmax(device, Shape({1, 1, TILE_HEIGHT, TILE_WIDTH}));
         run_softmax(device, Shape({1, 1, TILE_HEIGHT * 2, TILE_WIDTH * 2}));

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.cpp
@@ -184,6 +184,7 @@ tt::tt_metal::operation::Hash Softmax::compute_program_hash(
     return tt::tt_metal::operation::hash_operation<Softmax>(
         input_tensors.at(0).memory_config(),
         input_tensors.at(0).dtype(),
+        input_tensors.at(0).padded_shape(),
         optional_input_tensors.at(0).has_value() ? std::optional{optional_input_tensors.at(0).value().memory_config()}
                                                  : std::nullopt,
         optional_input_tensors.at(0).has_value() ? std::optional{optional_input_tensors.at(0).value().dtype()}


### PR DESCRIPTION
### Ticket
Closes #23824

### Problem description
Softmax test failed while enabling program cache, with invalid memory accesses performed. This occurred because the softmax hashing function didn't check for input tensor dimension, so it could incorrectly reuse the same compiled program.

### What's changed
Hashing function for softmax now includes the input tensor shape, and caching was re-enabled for the softmax test.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16371666019)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16371669154)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes