### PR TITLE
tt-fabric 2D Mcast implementation

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -195,9 +195,7 @@ void RunTestChipMCast1D(
     uint32_t range,
     bool enable_fabric_tracing = false);
 
-
-void RunTestLineMcast(
-    BaseFabricFixture* fixture, RoutingDirection unicast_dir, const std::vector<McastRoutingInfo>& mcast_routing_info);
+void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRoutingInfo>& mcast_routing_info);
 
 }  // namespace fabric_router_tests
 }  // namespace tt::tt_fabric

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -181,12 +181,20 @@ void RunTestMCastConnAPI(
     RoutingDirection bwd_dir = RoutingDirection::E,
     uint32_t bwd_hops = 1);
 
+void RunTest2DMCastConnAPI(
+    BaseFabricFixture* fixture,
+    RoutingDirection trunk_dir,
+    uint32_t trunk_hops,
+    uint32_t branch_east_hops,
+    uint32_t branch_west_hops);
+
 void RunTestChipMCast1D(
     BaseFabricFixture* fixture,
     RoutingDirection dir,
     uint32_t start_distance,
     uint32_t range,
     bool enable_fabric_tracing = false);
+
 
 void RunTestLineMcast(
     BaseFabricFixture* fixture, RoutingDirection unicast_dir, const std::vector<McastRoutingInfo>& mcast_routing_info);

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -120,7 +120,19 @@ protected:
     static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }
 };
 
+class NightlyFabric2DFixture : public BaseFabricFixture {
+protected:
+    static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_metal::FabricConfig::FABRIC_2D); }
+    static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }
+};
+
 class Fabric2DDynamicFixture : public BaseFabricFixture {
+protected:
+    static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC); }
+    static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }
+};
+
+class NightlyFabric2DDynamicFixture : public BaseFabricFixture {
 protected:
     static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC); }
     static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -1191,9 +1191,12 @@ void RunTest2DMCastConnAPI(
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
         worker_mem_map.target_address,
+        0 /* use_dram_dst */,
         mcast_mode,
         topology == Topology::Mesh,
-        fabric_config == tt_metal::FabricConfig::FABRIC_2D_DYNAMIC};
+        fabric_config == tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
+        1 /* is_chip_multicast */,
+        1 /* additional_dir */};
 
     std::map<std::string, std::string> defines = {};
     defines["FABRIC_2D"] = "";

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -134,8 +134,7 @@ void get_mcast_receivers(
     }
 }
 
-void RunTestLineMcast(
-    BaseFabricFixture* fixture, RoutingDirection unicast_dir, const std::vector<McastRoutingInfo>& mcast_routing_info) {
+void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRoutingInfo>& mcast_routing_info) {
     auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     auto user_meshes = control_plane.get_user_physical_mesh_ids();
     bool system_accomodates_mcast = false;

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -1195,7 +1195,7 @@ void RunTest2DMCastConnAPI(
         topology == Topology::Mesh,
         fabric_config == tt_metal::FabricConfig::FABRIC_2D_DYNAMIC};
 
-    std::map<string, string> defines = {};
+    std::map<std::string, std::string> defines = {};
     defines["FABRIC_2D"] = "";
 
     // Create the sender program

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -109,6 +109,31 @@ std::shared_ptr<tt_metal::Program> create_receiver_program(
     return recv_program;
 }
 
+void get_mcast_receivers(
+    std::unordered_map<RoutingDirection, std::vector<FabricNodeId>>& mcast_ref,
+    std::vector<chip_id_t>& mcast_receiver_physical_device_ids,
+    RoutingDirection trunk_direction,
+    RoutingDirection branch_direction)
+{
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    if (mcast_ref.find(branch_direction) != mcast_ref.end()) {
+        auto node_ids = mcast_ref[branch_direction];
+        for (auto node : node_ids) {
+            auto curr_fabric_node_id = node;
+            for (uint32_t i = 0; i < mcast_ref[trunk_direction].size(); i++) {
+                auto neighbors = control_plane.get_intra_chip_neighbors(curr_fabric_node_id, trunk_direction);
+                if (neighbors.size() > 0) {
+                    FabricNodeId rx_node_id(MeshId{curr_fabric_node_id.mesh_id}, neighbors[0]);
+                    mcast_receiver_physical_device_ids.push_back(
+                        control_plane.get_physical_chip_id_from_fabric_node_id(rx_node_id));
+                    curr_fabric_node_id = rx_node_id;
+                    log_info(tt::LogTest, "Mcast Rx MeshId {} ChipId {}", rx_node_id.mesh_id, rx_node_id.chip_id);
+                }
+            }
+        }
+    }
+}
+
 void RunTestLineMcast(
     BaseFabricFixture* fixture, RoutingDirection unicast_dir, const std::vector<McastRoutingInfo>& mcast_routing_info) {
     auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
@@ -126,40 +151,65 @@ void RunTestLineMcast(
         GTEST_SKIP() << "No mesh found for line mcast test";
     }
     // Setup mcast path
-    chip_id_t mcast_start_phys_id;                              // Physical ID for chip starting mcast
-    FabricNodeId mcast_start_id(MeshId{0}, 0);                          // Mesh ID for chip starting mcast
+    chip_id_t mcast_start_phys_id = 0;                          // Physical ID for chip starting mcast
+    FabricNodeId mcast_start_id(MeshId{0}, 0);                  // Mesh ID for chip starting mcast
+    chip_id_t sender_phys_id;
+    FabricNodeId sender_id(MeshId{0}, 0);                       // Mesh/Chip ID of mcast sender
     std::unordered_map<RoutingDirection, uint32_t> mcast_hops;  // Specify mcast path from mcast src chip
     std::unordered_map<RoutingDirection, std::vector<FabricNodeId>>
         mcast_group;  // Mesh IDs for chips involved in mcast
     std::unordered_map<RoutingDirection, std::vector<chip_id_t>>
         mcast_group_phys_ids_per_dir;  // Physical IDs for chips involved in mcast
-
+    bool spine_hops = false;
+    bool branch_hops = false;
     for (const auto& routing_info : mcast_routing_info) {
         mcast_hops[routing_info.mcast_dir] = routing_info.num_mcast_hops;
+        if (routing_info.mcast_dir == RoutingDirection::E or routing_info.mcast_dir == RoutingDirection::W) {
+            branch_hops = true;
+        }
+        if (routing_info.mcast_dir == RoutingDirection::N or routing_info.mcast_dir == RoutingDirection::S) {
+            spine_hops = true;
+        }
     }
 
     bool mcast_group_found = find_device_with_neighbor_in_multi_direction(
         fixture,
-        mcast_start_id,
+        sender_id,
         mcast_group,
-        mcast_start_phys_id,
+        sender_phys_id,
         mcast_group_phys_ids_per_dir,
-        mcast_hops,
-        unicast_dir);
+        mcast_hops);
 
     if (!mcast_group_found) {
         GTEST_SKIP() << "Mcast group not found for line mcast test";
     }
 
-    // Compute coordinates of the remote chip that sends an mcast request to the mcast sender
-    FabricNodeId sender_id =
-        FabricNodeId(mcast_start_id.mesh_id, control_plane.get_intra_chip_neighbors(mcast_start_id, unicast_dir)[0]);
-    auto sender_phys_id = control_plane.get_physical_chip_id_from_fabric_node_id(sender_id);
     // Compute physical IDs for mcast group chips
     std::vector<chip_id_t> mcast_group_phys_ids = {};
-    for (const auto& routing_info : mcast_routing_info) {
-        for (auto phys_id : mcast_group_phys_ids_per_dir[routing_info.mcast_dir]) {
-            mcast_group_phys_ids.push_back(phys_id);
+    if (spine_hops) {
+        if (mcast_group_phys_ids_per_dir.find(RoutingDirection::N) != mcast_group_phys_ids_per_dir.end()) {
+            mcast_start_phys_id = mcast_group_phys_ids_per_dir[RoutingDirection::N][0];
+            mcast_start_id = mcast_group[RoutingDirection::N][0];
+            mcast_group_phys_ids.insert(mcast_group_phys_ids.end(), mcast_group_phys_ids_per_dir[RoutingDirection::N].begin(), mcast_group_phys_ids_per_dir[RoutingDirection::N].end());
+            get_mcast_receivers(mcast_group, mcast_group_phys_ids, RoutingDirection::N, RoutingDirection::E);
+            get_mcast_receivers(mcast_group, mcast_group_phys_ids, RoutingDirection::N, RoutingDirection::W);
+        } else {
+            mcast_start_phys_id = mcast_group_phys_ids_per_dir[RoutingDirection::S][0];
+            mcast_start_id = mcast_group[RoutingDirection::S][0];
+            mcast_group_phys_ids.insert(mcast_group_phys_ids.end(), mcast_group_phys_ids_per_dir[RoutingDirection::S].begin(), mcast_group_phys_ids_per_dir[RoutingDirection::S].end());
+            get_mcast_receivers(mcast_group, mcast_group_phys_ids, RoutingDirection::S, RoutingDirection::E);
+            get_mcast_receivers(mcast_group, mcast_group_phys_ids, RoutingDirection::S, RoutingDirection::W);
+        }
+    } else if (branch_hops) {
+        if (mcast_group_phys_ids_per_dir.find(RoutingDirection::E) != mcast_group_phys_ids_per_dir.end()) {
+            mcast_start_phys_id = mcast_group_phys_ids_per_dir[RoutingDirection::E][0];
+            mcast_start_id = mcast_group[RoutingDirection::E][0];
+            mcast_group_phys_ids.insert(mcast_group_phys_ids.end(), mcast_group_phys_ids_per_dir[RoutingDirection::E].begin(), mcast_group_phys_ids_per_dir[RoutingDirection::E].end());
+
+        } else {
+            mcast_start_phys_id = mcast_group_phys_ids_per_dir[RoutingDirection::W][0];
+            mcast_start_id = mcast_group[RoutingDirection::W][0];
+            mcast_group_phys_ids.insert(mcast_group_phys_ids.end(), mcast_group_phys_ids_per_dir[RoutingDirection::W].begin(), mcast_group_phys_ids_per_dir[RoutingDirection::W].end());
         }
     }
 
@@ -170,19 +220,6 @@ void RunTestLineMcast(
     const auto topology = fabric_context.get_fabric_topology();
     const auto& edm_config = fabric_context.get_fabric_router_config();
     uint32_t is_2d_fabric = edm_config.topology == Topology::Mesh;
-
-    auto routers = control_plane.get_forwarding_eth_chans_to_chip(sender_id, mcast_start_id);
-    if (routers.size() == 0) {
-        log_info(
-            tt::LogTest,
-            "No fabric routers between Src MeshId {} ChipId {} - Dst MeshId {} ChipId {}",
-            sender_id.mesh_id,
-            sender_id.chip_id,
-            mcast_start_id.mesh_id,
-            mcast_start_id.chip_id);
-
-        GTEST_SKIP() << "Skipping Test";
-    }
 
     auto* sender_device = DevicePool::instance().get_active_device(sender_phys_id);
     auto* mcast_start_device = DevicePool::instance().get_active_device(mcast_start_phys_id);
@@ -254,8 +291,7 @@ void RunTestLineMcast(
     // Create the receiver programs for validation on all devices involved in the Mcast
     std::vector<uint32_t> receiver_runtime_args = {worker_mem_map.packet_payload_size_bytes, num_packets, time_seed};
     std::unordered_map<tt_metal::IDevice*, std::shared_ptr<tt_metal::Program>> recv_programs;
-    recv_programs[mcast_start_device] =
-        create_receiver_program(compile_time_args, receiver_runtime_args, receiver_logical_core);
+
     for (const auto& dev : mcast_group_devices) {
         recv_programs[dev] = create_receiver_program(compile_time_args, receiver_runtime_args, receiver_logical_core);
     }
@@ -1022,6 +1058,259 @@ void RunTestMCastConnAPI(
 
             EXPECT_EQ(sender_bytes, recv_bytes);
         }
+    }
+}
+
+void RunTest2DMCastConnAPI(
+    BaseFabricFixture* fixture,
+    RoutingDirection trunk_dir,
+    uint32_t trunk_hops,
+    uint32_t branch_east_hops,
+    uint32_t branch_west_hops) {
+    CoreCoord sender_logical_core = {0, 0};
+    CoreCoord receiver_logical_core = {1, 0};
+    std::vector<tt_metal::Program> receiver_programs;
+
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    // use control plane to find a mesh with 3 devices
+    auto user_meshes = control_plane.get_user_physical_mesh_ids();
+    std::optional<MeshId> mesh_id;
+    for (const auto& mesh : user_meshes) {
+        auto mesh_shape = control_plane.get_physical_mesh_shape(mesh);
+        if (mesh_shape.mesh_size() >= 3) {
+            mesh_id = mesh;
+            break;
+        }
+    }
+    if (!mesh_id.has_value()) {
+        GTEST_SKIP() << "No mesh found for 3 chip mcast test";
+    }
+
+    // Find a device num_hops away in specified direction.
+    FabricNodeId src_fabric_node_id(MeshId{0}, 0);
+    std::unordered_map<RoutingDirection, uint32_t> fabric_hops;
+    std::unordered_map<RoutingDirection, uint32_t> branch_hops;
+
+    std::unordered_map<RoutingDirection, std::vector<FabricNodeId>> end_fabric_node_ids_by_dir;
+    chip_id_t src_phys_chip_id;
+    std::unordered_map<RoutingDirection, std::vector<chip_id_t>> physical_end_device_ids_by_dir;
+
+    fabric_hops[trunk_dir] = trunk_hops;
+    fabric_hops[RoutingDirection::E] = branch_east_hops;
+    fabric_hops[RoutingDirection::W] = branch_west_hops;
+
+    tt::tt_metal::distributed::MeshShape mesh_shape;
+    const auto topology = control_plane.get_fabric_context().get_fabric_topology();
+    uint32_t is_2d_fabric = topology == Topology::Mesh;
+
+    if (!is_2d_fabric) {
+        GTEST_SKIP() << "Need 2D Fabric for this test.";
+    }
+
+    // Get the mcast sender device and mcast receiver devices that satisfy the input number of trunk hops
+    if (!find_device_with_neighbor_in_multi_direction(
+            fixture,
+            src_fabric_node_id,
+            end_fabric_node_ids_by_dir,
+            src_phys_chip_id,
+            physical_end_device_ids_by_dir,
+            fabric_hops)) {
+        log_info(
+            tt::LogTest,
+            "No Mcast destinations found for {} hops in trunk direction {} with {} East and {} West branch hops.",
+            trunk_hops,
+            trunk_dir,
+            branch_east_hops,
+            branch_west_hops);
+        GTEST_SKIP() << "Skipping Test";
+    }
+
+    mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
+    uint32_t ew_dim = mesh_shape[1];
+    auto device_offset = trunk_dir == RoutingDirection::N ? -1 : 1;
+    auto east_fabric_node_id = end_fabric_node_ids_by_dir[RoutingDirection::E][branch_east_hops - 1];
+    east_fabric_node_id.chip_id += device_offset * ew_dim;
+    auto left_recv_phys_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(east_fabric_node_id);
+    auto west_fabric_node_id = end_fabric_node_ids_by_dir[RoutingDirection::W][branch_west_hops - 1];
+    west_fabric_node_id.chip_id += device_offset * ew_dim;
+    auto right_recv_phys_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(west_fabric_node_id);
+
+    std::vector<uint32_t> rx_physical_device_ids;
+    uint32_t trunk_hop = 1;
+    for (auto trunk_node : end_fabric_node_ids_by_dir[trunk_dir]) {
+        rx_physical_device_ids.push_back(control_plane.get_physical_chip_id_from_fabric_node_id(trunk_node));
+        for (auto east_node : end_fabric_node_ids_by_dir[RoutingDirection::E]) {
+            east_node.chip_id += device_offset * trunk_hop * ew_dim;
+            rx_physical_device_ids.push_back(control_plane.get_physical_chip_id_from_fabric_node_id(east_node));
+        }
+        for (auto west_node : end_fabric_node_ids_by_dir[RoutingDirection::W]) {
+            west_node.chip_id += device_offset * trunk_hop * ew_dim;
+            rx_physical_device_ids.push_back(control_plane.get_physical_chip_id_from_fabric_node_id(west_node));
+        }
+        trunk_hop++;
+    }
+
+    log_info(tt::LogTest, "mesh dimensions {:x}", mesh_shape.dims());
+    log_info(tt::LogTest, "mesh dimension 0 {:x}", mesh_shape[0]);
+    log_info(tt::LogTest, "mesh dimension 1 {:x}", ew_dim);
+    log_info(tt::LogTest, "Mcast Src MeshId {} ChipId {}", src_fabric_node_id.mesh_id, src_fabric_node_id.chip_id);
+    log_info(
+        tt::LogTest,
+        "Mcast East Branch Dst MeshId {} ChipId {}",
+        east_fabric_node_id.mesh_id,
+        east_fabric_node_id.chip_id);
+    log_info(
+        tt::LogTest, "Mcast East Branch Dst Device is {} hops in direction: RoutingDirection::E", branch_east_hops);
+    log_info(
+        tt::LogTest,
+        "Mcast West Branch Dst MeshId {} ChipId {}",
+        west_fabric_node_id.mesh_id,
+        west_fabric_node_id.chip_id);
+    log_info(
+        tt::LogTest, "Mcast West Branch Dst Device is {} hops in direction: RoutingDirection::W", branch_west_hops);
+
+    auto* sender_device = DevicePool::instance().get_active_device(src_phys_chip_id);
+    auto* left_recv_device = DevicePool::instance().get_active_device(left_recv_phys_chip_id);
+
+    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
+    CoreCoord receiver_virtual_core = left_recv_device->worker_core_from_logical_core(receiver_logical_core);
+
+    auto receiver_noc_encoding =
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
+
+    // test parameters
+    auto worker_mem_map = generate_worker_mem_map(sender_device, topology);
+    uint32_t num_packets = 100;
+    uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
+
+    const auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+
+    uint32_t mcast_mode = trunk_dir == RoutingDirection::N ? 1 : 2;
+    // common compile time args for sender and receiver
+    std::vector<uint32_t> compile_time_args = {
+        worker_mem_map.test_results_address,
+        worker_mem_map.test_results_size_bytes,
+        worker_mem_map.target_address,
+        mcast_mode,
+        topology == Topology::Mesh,
+        fabric_config == tt_metal::FabricConfig::FABRIC_2D_DYNAMIC};
+
+    std::map<string, string> defines = {};
+    defines["FABRIC_2D"] = "";
+
+    // Create the sender program
+    auto sender_program = tt_metal::CreateProgram();
+    auto sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_2d_mcast_tx.cpp",
+        {sender_logical_core},
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = compile_time_args,
+            .defines = defines});
+
+    std::vector<uint32_t> sender_runtime_args = {
+        worker_mem_map.packet_header_address,
+        worker_mem_map.source_l1_buffer_address,
+        worker_mem_map.packet_payload_size_bytes,
+        num_packets,
+        receiver_noc_encoding,
+        time_seed,
+        ew_dim,
+        src_fabric_node_id.chip_id,
+        east_fabric_node_id.chip_id,
+        *mesh_id.value(),
+        trunk_hops,
+        (branch_west_hops << 16) | branch_east_hops,
+    };
+
+    // append the EDM connection rt args for fwd connection
+    uint32_t link_idx;
+
+    link_idx = get_forwarding_link_indices(src_fabric_node_id, east_fabric_node_id)[0];
+    append_fabric_connection_rt_args(
+        src_fabric_node_id, east_fabric_node_id, link_idx, sender_program, {sender_logical_core}, sender_runtime_args);
+    sender_runtime_args.push_back(west_fabric_node_id.chip_id);
+    sender_runtime_args.push_back(trunk_hops);
+    sender_runtime_args.push_back((branch_west_hops << 16) | branch_east_hops);
+
+    link_idx = get_forwarding_link_indices(src_fabric_node_id, west_fabric_node_id)[0];
+    append_fabric_connection_rt_args(
+        src_fabric_node_id, west_fabric_node_id, link_idx, sender_program, {sender_logical_core}, sender_runtime_args);
+
+    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
+
+    std::vector<uint32_t> receiver_runtime_args = {worker_mem_map.packet_payload_size_bytes, num_packets, time_seed};
+
+    // Create and launch the receiver program for validation on all mcast receiver devices
+    for (auto physical_end_device_id : rx_physical_device_ids) {
+        auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_id);
+        // Create the receiver program for validation
+        auto receiver_program = tt_metal::CreateProgram();
+        auto receiver_kernel = tt_metal::CreateKernel(
+            receiver_program,
+            "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_rx.cpp",
+            {receiver_logical_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = compile_time_args});
+
+        tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
+        fixture->RunProgramNonblocking(receiver_device, receiver_program);
+        receiver_programs.push_back(std::move(receiver_program));
+        log_info(tt::LogTest, "Rx Launched on physical device {}", physical_end_device_id);
+    }
+
+    // Launch sender program and wait for sender to finish
+    fixture->RunProgramNonblocking(sender_device, sender_program);
+    fixture->WaitForSingleProgramDone(sender_device, sender_program);
+
+    // Wait for receivers to finish
+    for (uint32_t i = 0; i < rx_physical_device_ids.size(); i++) {
+        auto* receiver_device = DevicePool::instance().get_active_device(rx_physical_device_ids[i]);
+        fixture->WaitForSingleProgramDone(receiver_device, receiver_programs[i]);
+    }
+    log_info(tt::LogTest, "All Receivers Finished");
+
+    // Validate the status and packets processed by sender and receiver
+    std::vector<uint32_t> sender_status;
+    std::vector<uint32_t> left_recv_status;
+    std::vector<uint32_t> right_recv_status;
+
+    tt_metal::detail::ReadFromDeviceL1(
+        sender_device,
+        sender_logical_core,
+        worker_mem_map.test_results_address,
+        worker_mem_map.test_results_size_bytes,
+        sender_status,
+        CoreType::WORKER);
+
+    EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+
+    uint64_t sender_bytes =
+        ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
+
+    for (uint32_t i = 0; i < rx_physical_device_ids.size(); i++) {
+        log_info(tt::LogTest, "Checking Status of Rx on physical device {}", rx_physical_device_ids[i]);
+
+        auto* receiver_device = DevicePool::instance().get_active_device(rx_physical_device_ids[i]);
+        std::vector<uint32_t> recv_status;
+
+        tt_metal::detail::ReadFromDeviceL1(
+            receiver_device,
+            receiver_logical_core,
+            worker_mem_map.test_results_address,
+            worker_mem_map.test_results_size_bytes,
+            recv_status,
+            CoreType::WORKER);
+        EXPECT_EQ(recv_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+        uint64_t recv_bytes =
+            ((uint64_t)recv_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | recv_status[TT_FABRIC_WORD_CNT_INDEX];
+
+        EXPECT_EQ(sender_bytes, recv_bytes);
     }
 }
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -938,203 +938,203 @@ TEST_F(Fabric2DDynamicFixture, TestUnicastConnAPIDRAM) { RunTestUnicastConnAPI(t
 // 2D Dynamic Routing Unidirectional mcast tests (no turns)
 TEST_F(Fabric2DDynamicFixture, TestLineMcastE2Hops) {
     auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 2};
-    RunTestLineMcast(this, RoutingDirection::W, {routing_info});
+    RunTestLineMcast(this, {routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastE3Hops) {
     auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
-    RunTestLineMcast(this, RoutingDirection::W, {routing_info});
+    RunTestLineMcast(this, {routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastE7Hops) {
     auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
-    RunTestLineMcast(this, RoutingDirection::W, {routing_info});
+    RunTestLineMcast(this, {routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastW2Hops) {
     auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 2};
-    RunTestLineMcast(this, RoutingDirection::E, {routing_info});
+    RunTestLineMcast(this, {routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastW3Hops) {
     auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
-    RunTestLineMcast(this, RoutingDirection::E, {routing_info});
+    RunTestLineMcast(this, {routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastW7Hops) {
     auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 7};
-    RunTestLineMcast(this, RoutingDirection::E, {routing_info});
+    RunTestLineMcast(this, {routing_info});
 }
 
 // 2D Dynamic Routing Unidirectional mcast tests (with turns)
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopE3Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, n_routing_info});
+    RunTestLineMcast(this, {e_routing_info, n_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopE7Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, n_routing_info});
+    RunTestLineMcast(this, {e_routing_info, n_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN2HopE3Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 2};
-    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, n_routing_info});
+    RunTestLineMcast(this, {e_routing_info, n_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN2HopE7Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 2};
-    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, n_routing_info});
+    RunTestLineMcast(this, {e_routing_info, n_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopE3Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, s_routing_info});
+    RunTestLineMcast(this, {e_routing_info, s_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopE7Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, s_routing_info});
+    RunTestLineMcast(this, {e_routing_info, s_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS2HopE3Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 2};
-    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, s_routing_info});
+    RunTestLineMcast(this, {e_routing_info, s_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS2HopE7Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 2};
-    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, s_routing_info});
+    RunTestLineMcast(this, {e_routing_info, s_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopW3Hops) {
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::S, {w_routing_info, n_routing_info});
+    RunTestLineMcast(this, {w_routing_info, n_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopW7Hops) {
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 7};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::S, {w_routing_info, n_routing_info});
+    RunTestLineMcast(this, {w_routing_info, n_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopW3Hops) {
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::S, {w_routing_info, s_routing_info});
+    RunTestLineMcast(this, {w_routing_info, s_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopW7Hops) {
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 7};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::S, {w_routing_info, s_routing_info});
+    RunTestLineMcast(this, {w_routing_info, s_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopE1HopW1Hop) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 1};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 1};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, s_routing_info});
+    RunTestLineMcast(this, {e_routing_info, w_routing_info, s_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopE1HopW1Hop) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 1};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 1};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, w_routing_info, n_routing_info});
+    RunTestLineMcast(this, {e_routing_info, w_routing_info, n_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopE2HopsW1Hop) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 2};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 1};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, s_routing_info});
+    RunTestLineMcast(this, {e_routing_info, w_routing_info, s_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopE2HopsW1Hop) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 2};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 1};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, n_routing_info});
+    RunTestLineMcast(this, {e_routing_info, w_routing_info, n_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopE1HopW2Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 1};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 2};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, s_routing_info});
+    RunTestLineMcast(this, {e_routing_info, w_routing_info, s_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopE1HopW2Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 1};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 2};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, n_routing_info});
+    RunTestLineMcast(this, {e_routing_info, w_routing_info, n_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS2HopsE4HopsW3Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 4};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 2};
-    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, s_routing_info});
+    RunTestLineMcast(this, {e_routing_info, w_routing_info, s_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS2HopsE3HopsW4Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 4};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 2};
-    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, s_routing_info});
+    RunTestLineMcast(this, {e_routing_info, w_routing_info, s_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS3HopsE4HopsW3Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 4};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 3};
-    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, s_routing_info});
+    RunTestLineMcast(this, {e_routing_info, w_routing_info, s_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS3HopsE3HopsW4Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 4};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 3};
-    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, s_routing_info});
+    RunTestLineMcast(this, {e_routing_info, w_routing_info, s_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN2HopsE4HopsW3Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 4};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 2};
-    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, n_routing_info});
+    RunTestLineMcast(this, {e_routing_info, w_routing_info, n_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN2HopsE3HopsW4Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 4};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 2};
-    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, n_routing_info});
+    RunTestLineMcast(this, {e_routing_info, w_routing_info, n_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN3HopsE4HopsW3Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 4};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 3};
-    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, n_routing_info});
+    RunTestLineMcast(this, {e_routing_info, w_routing_info, n_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN3HopsE3HopsW4Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 4};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 3};
-    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, n_routing_info});
+    RunTestLineMcast(this, {e_routing_info, w_routing_info, n_routing_info});
 }
 
 }  // namespace fabric_router_tests

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -832,6 +832,46 @@ TEST_F(Fabric2DFixture, TestMCastConnAPI_2N1S) {
     RunTestMCastConnAPI(this, RoutingDirection::N, 2, RoutingDirection::S, 1);
 }
 
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_1S1E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 1, 1, 1); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_1S2E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 1, 2, 1); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_1S1E2W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 1, 1, 2); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2S1E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 2, 1, 1); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2S2E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 2, 2, 1); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2S1E2W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 2, 1, 2); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2S1E6W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 2, 1, 6); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2S6E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 2, 6, 1); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_3S1E6W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 3, 1, 6); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_3S6E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 3, 6, 1); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_1N1E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 1, 1, 1); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_1N2E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 1, 2, 1); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_1N1E2W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 1, 1, 2); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2N1E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 2, 1, 1); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2N2E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 2, 2, 1); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2N1E2W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 2, 1, 2); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2N1E6W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 2, 1, 6); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2N6E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 2, 6, 1); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_3N1E6W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 3, 1, 6); }
+
+TEST_F(Fabric2DFixture, Test2DMCastConnAPI_3N6E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 3, 6, 1); }
+
 TEST_F(Fabric2DFixture, DISABLED_TestAtomicInc) { RunAtomicIncTest(this, fabric_mode::PUSH); }
 
 TEST_F(Fabric2DFixture, DISABLED_TestAsyncWriteAtomicInc) {
@@ -896,19 +936,19 @@ TEST_F(Fabric2DDynamicFixture, TestUnicastConnAPI) { RunTestUnicastConnAPI(this,
 TEST_F(Fabric2DDynamicFixture, TestUnicastConnAPIDRAM) { RunTestUnicastConnAPI(this, 1, RoutingDirection::E, true); }
 
 // 2D Dynamic Routing Unidirectional mcast tests (no turns)
-TEST_F(Fabric2DDynamicFixture, TestLineMcastE1Hop) {
-    auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::W, {routing_info});
-}
-
 TEST_F(Fabric2DDynamicFixture, TestLineMcastE2Hops) {
     auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 2};
     RunTestLineMcast(this, RoutingDirection::W, {routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastW1Hop) {
-    auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::E, {routing_info});
+TEST_F(Fabric2DDynamicFixture, TestLineMcastE3Hops) {
+    auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
+    RunTestLineMcast(this, RoutingDirection::W, {routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastE7Hops) {
+    auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
+    RunTestLineMcast(this, RoutingDirection::W, {routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastW2Hops) {
@@ -916,49 +956,185 @@ TEST_F(Fabric2DDynamicFixture, TestLineMcastW2Hops) {
     RunTestLineMcast(this, RoutingDirection::E, {routing_info});
 }
 
+TEST_F(Fabric2DDynamicFixture, TestLineMcastW3Hops) {
+    auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
+    RunTestLineMcast(this, RoutingDirection::E, {routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastW7Hops) {
+    auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 7};
+    RunTestLineMcast(this, RoutingDirection::E, {routing_info});
+}
+
 // 2D Dynamic Routing Unidirectional mcast tests (with turns)
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopE3Hops) {
-    auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
-    RunTestLineMcast(this, RoutingDirection::N, {routing_info});
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
+    auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
+    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, n_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopE7Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
+    auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
+    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, n_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastN2HopE3Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
+    auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 2};
+    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, n_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastN2HopE7Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
+    auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 2};
+    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, n_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopE3Hops) {
-    auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
-    RunTestLineMcast(this, RoutingDirection::S, {routing_info});
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
+    auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
+    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, s_routing_info});
 }
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopE7Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
+    auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
+    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, s_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastS2HopE3Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
+    auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 2};
+    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, s_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastS2HopE7Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
+    auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 2};
+    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, s_routing_info});
+}
+
 TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopW3Hops) {
-    auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
-    RunTestLineMcast(this, RoutingDirection::N, {routing_info});
+    auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
+    auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
+    RunTestLineMcast(this, RoutingDirection::S, {w_routing_info, n_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopW7Hops) {
+    auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 7};
+    auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
+    RunTestLineMcast(this, RoutingDirection::S, {w_routing_info, n_routing_info});
 }
 
 TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopW3Hops) {
-    auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
-    RunTestLineMcast(this, RoutingDirection::S, {routing_info});
+    auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
+    auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
+    RunTestLineMcast(this, RoutingDirection::S, {w_routing_info, s_routing_info});
 }
 
-// 2D Dynamic Routing Bidirectional Mcast Tests, with turns
-TEST_F(Fabric2DDynamicFixture, TestBiDirLineMcastS1HopE1HopW1Hop) {
+TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopW7Hops) {
+    auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 7};
+    auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
+    RunTestLineMcast(this, RoutingDirection::S, {w_routing_info, s_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopE1HopW1Hop) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 1};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, w_routing_info});
+    auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
+    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, s_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestBiDirLineMcastN1HopE1HopW1Hop) {
+TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopE1HopW1Hop) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 1};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info});
+    auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
+    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, w_routing_info, n_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestBiDirLineMcastS1HopE2HopsW1Hop) {
+TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopE2HopsW1Hop) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 2};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 1};
-    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, w_routing_info});
+    auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
+    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, s_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestBiDirLineMcastS1HopE1HopW2Hops) {
+TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopE2HopsW1Hop) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 2};
+    auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 1};
+    auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
+    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, n_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopE1HopW2Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 1};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 2};
-    RunTestLineMcast(this, RoutingDirection::S, {e_routing_info, w_routing_info});
+    auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
+    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, s_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopE1HopW2Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 1};
+    auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 2};
+    auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
+    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, n_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastS2HopsE4HopsW3Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 4};
+    auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
+    auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 2};
+    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, s_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastS2HopsE3HopsW4Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
+    auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 4};
+    auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 2};
+    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, s_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastS3HopsE4HopsW3Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 4};
+    auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
+    auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 3};
+    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, s_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastS3HopsE3HopsW4Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
+    auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 4};
+    auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 3};
+    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, s_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastN2HopsE4HopsW3Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 4};
+    auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
+    auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 2};
+    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, n_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastN2HopsE3HopsW4Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
+    auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 4};
+    auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 2};
+    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, n_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastN3HopsE4HopsW3Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 4};
+    auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
+    auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 3};
+    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, n_routing_info});
+}
+
+TEST_F(Fabric2DDynamicFixture, TestLineMcastN3HopsE3HopsW4Hops) {
+    auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
+    auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 4};
+    auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 3};
+    RunTestLineMcast(this, RoutingDirection::N, {e_routing_info, w_routing_info, n_routing_info});
 }
 
 }  // namespace fabric_router_tests

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -844,13 +844,13 @@ TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2S2E1W) { RunTest2DMCastConnAPI(this,
 
 TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2S1E2W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 2, 1, 2); }
 
-TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2S1E6W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 2, 1, 6); }
+TEST_F(NightlyFabric2DFixture, Test2DMCastConnAPI_2S1E6W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 2, 1, 6); }
 
-TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2S6E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 2, 6, 1); }
+TEST_F(NightlyFabric2DFixture, Test2DMCastConnAPI_2S6E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 2, 6, 1); }
 
-TEST_F(Fabric2DFixture, Test2DMCastConnAPI_3S1E6W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 3, 1, 6); }
+TEST_F(NightlyFabric2DFixture, Test2DMCastConnAPI_3S1E6W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 3, 1, 6); }
 
-TEST_F(Fabric2DFixture, Test2DMCastConnAPI_3S6E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 3, 6, 1); }
+TEST_F(NightlyFabric2DFixture, Test2DMCastConnAPI_3S6E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::S, 3, 6, 1); }
 
 TEST_F(Fabric2DFixture, Test2DMCastConnAPI_1N1E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 1, 1, 1); }
 
@@ -864,13 +864,13 @@ TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2N2E1W) { RunTest2DMCastConnAPI(this,
 
 TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2N1E2W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 2, 1, 2); }
 
-TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2N1E6W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 2, 1, 6); }
+TEST_F(NightlyFabric2DFixture, Test2DMCastConnAPI_2N1E6W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 2, 1, 6); }
 
-TEST_F(Fabric2DFixture, Test2DMCastConnAPI_2N6E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 2, 6, 1); }
+TEST_F(NightlyFabric2DFixture, Test2DMCastConnAPI_2N6E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 2, 6, 1); }
 
-TEST_F(Fabric2DFixture, Test2DMCastConnAPI_3N1E6W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 3, 1, 6); }
+TEST_F(NightlyFabric2DFixture, Test2DMCastConnAPI_3N1E6W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 3, 1, 6); }
 
-TEST_F(Fabric2DFixture, Test2DMCastConnAPI_3N6E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 3, 6, 1); }
+TEST_F(NightlyFabric2DFixture, Test2DMCastConnAPI_3N6E1W) { RunTest2DMCastConnAPI(this, RoutingDirection::N, 3, 6, 1); }
 
 TEST_F(Fabric2DFixture, DISABLED_TestAtomicInc) { RunAtomicIncTest(this, fabric_mode::PUSH); }
 
@@ -946,7 +946,7 @@ TEST_F(Fabric2DDynamicFixture, TestLineMcastE3Hops) {
     RunTestLineMcast(this, {routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastE7Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastE7Hops) {
     auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
     RunTestLineMcast(this, {routing_info});
 }
@@ -961,7 +961,7 @@ TEST_F(Fabric2DDynamicFixture, TestLineMcastW3Hops) {
     RunTestLineMcast(this, {routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastW7Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastW7Hops) {
     auto routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 7};
     RunTestLineMcast(this, {routing_info});
 }
@@ -973,7 +973,7 @@ TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopE3Hops) {
     RunTestLineMcast(this, {e_routing_info, n_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopE7Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastN1HopE7Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
     RunTestLineMcast(this, {e_routing_info, n_routing_info});
@@ -985,7 +985,7 @@ TEST_F(Fabric2DDynamicFixture, TestLineMcastN2HopE3Hops) {
     RunTestLineMcast(this, {e_routing_info, n_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastN2HopE7Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastN2HopE7Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 2};
     RunTestLineMcast(this, {e_routing_info, n_routing_info});
@@ -997,7 +997,7 @@ TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopE3Hops) {
     RunTestLineMcast(this, {e_routing_info, s_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopE7Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastS1HopE7Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
     RunTestLineMcast(this, {e_routing_info, s_routing_info});
@@ -1009,7 +1009,7 @@ TEST_F(Fabric2DDynamicFixture, TestLineMcastS2HopE3Hops) {
     RunTestLineMcast(this, {e_routing_info, s_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastS2HopE7Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastS2HopE7Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 7};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 2};
     RunTestLineMcast(this, {e_routing_info, s_routing_info});
@@ -1021,7 +1021,7 @@ TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopW3Hops) {
     RunTestLineMcast(this, {w_routing_info, n_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastN1HopW7Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastN1HopW7Hops) {
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 7};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1};
     RunTestLineMcast(this, {w_routing_info, n_routing_info});
@@ -1033,7 +1033,7 @@ TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopW3Hops) {
     RunTestLineMcast(this, {w_routing_info, s_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastS1HopW7Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastS1HopW7Hops) {
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 7};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1};
     RunTestLineMcast(this, {w_routing_info, s_routing_info});
@@ -1088,49 +1088,49 @@ TEST_F(Fabric2DDynamicFixture, TestLineMcastS2HopsE4HopsW3Hops) {
     RunTestLineMcast(this, {e_routing_info, w_routing_info, s_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastS2HopsE3HopsW4Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastS2HopsE3HopsW4Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 4};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 2};
     RunTestLineMcast(this, {e_routing_info, w_routing_info, s_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastS3HopsE4HopsW3Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastS3HopsE4HopsW3Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 4};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 3};
     RunTestLineMcast(this, {e_routing_info, w_routing_info, s_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastS3HopsE3HopsW4Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastS3HopsE3HopsW4Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 4};
     auto s_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 3};
     RunTestLineMcast(this, {e_routing_info, w_routing_info, s_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastN2HopsE4HopsW3Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastN2HopsE4HopsW3Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 4};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 2};
     RunTestLineMcast(this, {e_routing_info, w_routing_info, n_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastN2HopsE3HopsW4Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastN2HopsE3HopsW4Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 4};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 2};
     RunTestLineMcast(this, {e_routing_info, w_routing_info, n_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastN3HopsE4HopsW3Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastN3HopsE4HopsW3Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 4};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 3};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 3};
     RunTestLineMcast(this, {e_routing_info, w_routing_info, n_routing_info});
 }
 
-TEST_F(Fabric2DDynamicFixture, TestLineMcastN3HopsE3HopsW4Hops) {
+TEST_F(NightlyFabric2DDynamicFixture, TestLineMcastN3HopsE3HopsW4Hops) {
     auto e_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 3};
     auto w_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 4};
     auto n_routing_info = McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 3};

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_2d_mcast_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_2d_mcast_tx.cpp
@@ -24,9 +24,9 @@ constexpr uint32_t test_results_size_bytes = get_compile_time_arg_val(1);
 tt_l1_ptr uint32_t* const test_results = reinterpret_cast<tt_l1_ptr uint32_t*>(test_results_addr_arg);
 
 constexpr uint32_t target_address = get_compile_time_arg_val(2);
-constexpr uint32_t mcast_mode = get_compile_time_arg_val(3);
-constexpr bool is_2d_fabric = get_compile_time_arg_val(4);
-constexpr bool use_dynamic_routing = get_compile_time_arg_val(5);
+constexpr uint32_t mcast_mode = get_compile_time_arg_val(4);
+constexpr bool is_2d_fabric = get_compile_time_arg_val(5);
+constexpr bool use_dynamic_routing = get_compile_time_arg_val(6);
 
 inline void setup_connection_and_headers(
     tt::tt_fabric::WorkerToFabricEdmSender& connection,

--- a/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
@@ -554,17 +554,31 @@ public:
     }
 };
 
-struct LowLatencyMeshRoutingFields {
+union LowLatencyMeshRoutingFields {
     static constexpr uint32_t FIELD_WIDTH = 8;
     static constexpr uint32_t FIELD_MASK = 0b1111;
     static constexpr uint32_t NOOP = 0b0000;
     static constexpr uint32_t FORWARD_EAST = 0b0001;
     static constexpr uint32_t FORWARD_WEST = 0b0010;
-    static constexpr uint32_t FORWARD_NORTH = 0b0100;
-    static constexpr uint32_t FORWARD_SOUTH = 0b1000;
     static constexpr uint32_t WRITE_AND_FORWARD_EW = 0b0011;
+    static constexpr uint32_t FORWARD_NORTH = 0b0100;
+    static constexpr uint32_t WRITE_AND_FORWARD_NE = 0b0101;
+    static constexpr uint32_t WRITE_AND_FORWARD_NW = 0b0110;
+    static constexpr uint32_t WRITE_AND_FORWARD_NEW = 0b0111;
+    static constexpr uint32_t FORWARD_SOUTH = 0b1000;
+    static constexpr uint32_t WRITE_AND_FORWARD_SE = 0b1001;
+    static constexpr uint32_t WRITE_AND_FORWARD_SW = 0b1010;
+    static constexpr uint32_t WRITE_AND_FORWARD_SEW = 0b1011;
     static constexpr uint32_t WRITE_AND_FORWARD_NS = 0b1100;
+    static constexpr uint32_t WRITE_AND_FORWARD_NSE = 0b1101;
+    static constexpr uint32_t WRITE_AND_FORWARD_NSW = 0b1110;
+    static constexpr uint32_t WRITE_AND_FORWARD_NSEW = 0b1111;
     uint32_t value;
+    struct {
+        uint16_t hop_index;
+        uint8_t branch_east_offset;
+        uint8_t branch_west_offset;
+    };
 };
 
 struct LowLatencyMeshPacketHeader : public PacketHeaderBase<LowLatencyMeshPacketHeader> {
@@ -582,6 +596,7 @@ struct MeshPacketHeader : public PacketHeaderBase<MeshPacketHeader> {
     uint16_t dst_start_mesh_id;
     uint16_t mcast_params[4];
     uint8_t is_mcast_active;
+    uint8_t reserved[7];
     void to_chip_unicast_impl(uint8_t distance_in_hops) {}
     void to_chip_multicast_impl(const MulticastRoutingCommandHeader& chip_multicast_command_header) {}
 
@@ -594,7 +609,8 @@ static_assert(sizeof(PacketHeader) == 32, "sizeof(PacketHeader) is not equal to 
 // Host code still hardcoded to sizeof(PacketHeader) so we need to keep this check
 static_assert(
     sizeof(LowLatencyPacketHeader) == sizeof(PacketHeader), "sizeof(LowLatencyPacketHeader) is not equal to 32B");
-static_assert(sizeof(LowLatencyMeshPacketHeader) == 64, "sizeof(LowLatencyPacketHeader) is not equal to 64B");
+static_assert(sizeof(LowLatencyMeshPacketHeader) == 64, "sizeof(LowLatencyMeshPacketHeader) is not equal to 64B");
+static_assert(sizeof(MeshPacketHeader) == 48, "sizeof(MeshPacketHeader) is not equal to 48B");
 
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)

--- a/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
@@ -554,7 +554,7 @@ public:
     }
 };
 
-union LowLatencyMeshRoutingFields {
+struct LowLatencyMeshRoutingFields {
     static constexpr uint32_t FIELD_WIDTH = 8;
     static constexpr uint32_t FIELD_MASK = 0b1111;
     static constexpr uint32_t NOOP = 0b0000;
@@ -573,11 +573,16 @@ union LowLatencyMeshRoutingFields {
     static constexpr uint32_t WRITE_AND_FORWARD_NSE = 0b1101;
     static constexpr uint32_t WRITE_AND_FORWARD_NSW = 0b1110;
     static constexpr uint32_t WRITE_AND_FORWARD_NSEW = 0b1111;
-    uint32_t value;
-    struct {
-        uint16_t hop_index;
-        uint8_t branch_east_offset;
-        uint8_t branch_west_offset;
+
+    union {
+        uint32_t value;  // Referenced for fast increment when updating hop count in packet header.
+                         // Also used when doing noc inline dword write to update packet header in next hop
+                         // router.
+        struct {
+            uint16_t hop_index;
+            uint8_t branch_east_offset;  // Referenced when updating hop index for mcast east branch
+            uint8_t branch_west_offset;  // Referenced when updating hop index for mcast east branch
+        };
     };
 };
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -119,11 +119,16 @@ FORCE_INLINE void flush_write_to_noc_pipeline(uint8_t rx_channel_id) {
 
 // Since we unicast to local, we must omit the packet header
 // This function only does reads, and within scope there are no modifications to the packet header
-__attribute__((optimize("jump-tables"))) FORCE_INLINE void execute_chip_unicast_to_local_chip(
-    tt_l1_ptr PACKET_HEADER_TYPE* const packet_start,
-    uint16_t payload_size_bytes,
-    uint32_t transaction_id,
-    uint8_t rx_channel_id) {
+__attribute__((optimize("jump-tables")))
+#ifndef FABRIC_2D
+FORCE_INLINE
+#endif
+    void
+    execute_chip_unicast_to_local_chip(
+        tt_l1_ptr PACKET_HEADER_TYPE* const packet_start,
+        uint16_t payload_size_bytes,
+        uint32_t transaction_id,
+        uint8_t rx_channel_id) {
     const auto& header = *packet_start;
     uint32_t payload_start_address = reinterpret_cast<size_t>(packet_start) + sizeof(PACKET_HEADER_TYPE);
 
@@ -251,6 +256,25 @@ FORCE_INLINE void update_packet_header_for_next_hop(
     packet_header->routing_fields.value = cached_routing_fields.value + 1;
 }
 
+template <uint8_t NUM_SENDER_BUFFERS>
+void update_packet_header_for_next_hop(
+    tt::tt_fabric::EdmToEdmSender<NUM_SENDER_BUFFERS>& downstream_edm_interface, uint32_t value) {
+#if defined(DYNAMIC_ROUTING_ENABLED)
+    tt::tt_fabric::MeshPacketHeader* packet_base = nullptr;
+    // Clear north/south when turning from trunk->branch
+    downstream_edm_interface.template update_edm_buffer_slot_word<false>(
+        reinterpret_cast<std::uintptr_t>(&(packet_base->mcast_params[tt::tt_fabric::eth_chan_directions::NORTH])),
+        0,
+        tt::tt_fabric::edm_to_downstream_noc);
+    std::uintptr_t offset =
+        reinterpret_cast<std::uintptr_t>(&(packet_base->mcast_params[tt::tt_fabric::eth_chan_directions::EAST]));
+#else
+    tt::tt_fabric::LowLatencyMeshPacketHeader* packet_base = nullptr;
+    std::uintptr_t offset = reinterpret_cast<std::uintptr_t>(&(packet_base->routing_fields));
+#endif
+    downstream_edm_interface.template update_edm_buffer_slot_word(offset, value, tt::tt_fabric::edm_to_downstream_noc);
+}
+
 FORCE_INLINE void update_packet_header_for_next_hop(
     volatile tt_l1_ptr tt::tt_fabric::MeshPacketHeader* packet_header,
     tt::tt_fabric::LowLatencyMeshRoutingFields cached_routing_fields) {}
@@ -265,8 +289,11 @@ FORCE_INLINE void update_packet_header_for_next_hop(
 // !!!WARNING!!! * ENSURE DOWNSTREAM EDM HAS SPACE FOR PACKET BEFORE CALLING
 // !!!WARNING!!!
 // This function does a write, so needs to be volatile to avoid compiler optimizations
-template <bool enable_ring_support, bool stateful_api, uint8_t NUM_SENDER_BUFFERS>
-FORCE_INLINE void forward_payload_to_downstream_edm(
+template <bool enable_ring_support, bool stateful_api, bool increment_pointers = true, uint8_t NUM_SENDER_BUFFERS>
+#ifndef FABRIC_2D
+FORCE_INLINE
+#endif
+void forward_payload_to_downstream_edm(
     volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header,
     uint16_t payload_size_bytes,
     ROUTING_FIELDS_TYPE cached_routing_fields,
@@ -277,10 +304,16 @@ FORCE_INLINE void forward_payload_to_downstream_edm(
 
     // This is a good place to print the packet header for debug if you are trying to inspect packets
     // because it is before we start manipulating the header for forwarding
-    update_packet_header_for_next_hop(packet_header, cached_routing_fields);
+    if constexpr (increment_pointers) {
+        update_packet_header_for_next_hop(packet_header, cached_routing_fields);
+    }
     downstream_edm_interface.template send_payload_non_blocking_from_address_with_trid<
         enable_ring_support,
         tt::tt_fabric::edm_to_downstream_noc,
-        stateful_api>(
+        stateful_api,
+        increment_pointers>(
         reinterpret_cast<size_t>(packet_header), payload_size_bytes + sizeof(PACKET_HEADER_TYPE), transaction_id);
+    if constexpr (!increment_pointers) {
+        update_packet_header_for_next_hop(downstream_edm_interface, cached_routing_fields.value);
+    }
 }

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -591,6 +591,96 @@ FORCE_INLINE __attribute__((optimize("jump-tables"))) bool can_forward_packet_co
                 ret_val = downstream_edm_interface[eth_chan_directions::SOUTH].edm_has_space_for_packet();
             }
             break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NSEW:
+            // 2D Mcast Spine: North<->South
+            // 2D Mcast Branch: East and/or West
+            if constexpr (my_direction == eth_chan_directions::SOUTH) {  // packet dest + forward North
+                ret_val = downstream_edm_interface[eth_chan_directions::NORTH].edm_has_space_for_packet();
+            } else {  // packet dest + forward South
+                ret_val = downstream_edm_interface[eth_chan_directions::SOUTH].edm_has_space_for_packet();
+            }
+            // Check space in branch forwarding edms
+            ret_val &= downstream_edm_interface[eth_chan_directions::EAST].edm_has_space_for_packet();
+            ret_val &= downstream_edm_interface[eth_chan_directions::WEST].edm_has_space_for_packet();
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NSE:
+            // 2D Mcast Spine: North<->South
+            // 2D Mcast Branch: East and/or West
+            if constexpr (my_direction == eth_chan_directions::SOUTH) {  // packet dest + forward North
+                ret_val = downstream_edm_interface[eth_chan_directions::NORTH].edm_has_space_for_packet();
+            } else {  // packet dest + forward South
+                ret_val = downstream_edm_interface[eth_chan_directions::SOUTH].edm_has_space_for_packet();
+            }
+            // Check space in branch forwarding edm
+            ret_val &= downstream_edm_interface[eth_chan_directions::EAST].edm_has_space_for_packet();
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NSW:
+            // 2D Mcast Spine: North<->South
+            // 2D Mcast Branch: East and/or West
+            if constexpr (my_direction == eth_chan_directions::SOUTH) {  // packet dest + forward North
+                ret_val = downstream_edm_interface[eth_chan_directions::NORTH].edm_has_space_for_packet();
+            } else {  // packet dest + forward South
+                ret_val = downstream_edm_interface[eth_chan_directions::SOUTH].edm_has_space_for_packet();
+            }
+            // Check space in branch forwarding edm
+            ret_val &= downstream_edm_interface[eth_chan_directions::WEST].edm_has_space_for_packet();
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_SEW:
+            // Check space in branch forwarding edms
+            ret_val = downstream_edm_interface[eth_chan_directions::EAST].edm_has_space_for_packet();
+            ret_val &= downstream_edm_interface[eth_chan_directions::WEST].edm_has_space_for_packet();
+            // 2D Mcast Spine: North<->South
+            // 2D Mcast Branch: East and/or West
+            if constexpr (my_direction == eth_chan_directions::NORTH) {  // packet dest + forward North
+                ret_val &= downstream_edm_interface[eth_chan_directions::SOUTH].edm_has_space_for_packet();
+            }
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NEW:
+            // Check space in branch forwarding edms
+            ret_val = downstream_edm_interface[eth_chan_directions::EAST].edm_has_space_for_packet();
+            ret_val &= downstream_edm_interface[eth_chan_directions::WEST].edm_has_space_for_packet();
+            // 2D Mcast Spine: North<->South
+            // 2D Mcast Branch: East and/or West
+            if constexpr (my_direction == eth_chan_directions::SOUTH) {  // packet dest + forward North
+                ret_val &= downstream_edm_interface[eth_chan_directions::NORTH].edm_has_space_for_packet();
+            }
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_SE:
+            // Check space in branch forwarding edms
+            ret_val = downstream_edm_interface[eth_chan_directions::EAST].edm_has_space_for_packet();
+            // 2D Mcast Spine: North<->South
+            // 2D Mcast Branch: East and/or West
+            if constexpr (my_direction == eth_chan_directions::NORTH) {  // packet dest + forward North
+                ret_val &= downstream_edm_interface[eth_chan_directions::SOUTH].edm_has_space_for_packet();
+            }
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_SW:
+            // Check space in branch forwarding edms
+            ret_val = downstream_edm_interface[eth_chan_directions::WEST].edm_has_space_for_packet();
+            // 2D Mcast Spine: North<->South
+            // 2D Mcast Branch: East and/or West
+            if constexpr (my_direction == eth_chan_directions::NORTH) {  // packet dest + forward North
+                ret_val &= downstream_edm_interface[eth_chan_directions::SOUTH].edm_has_space_for_packet();
+            }
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NE:
+            // Check space in branch forwarding edm
+            ret_val = downstream_edm_interface[eth_chan_directions::EAST].edm_has_space_for_packet();
+            // 2D Mcast Spine: North<->South
+            // 2D Mcast Branch: East and/or West
+            if constexpr (my_direction == eth_chan_directions::SOUTH) {  // packet dest + forward North
+                ret_val &= downstream_edm_interface[eth_chan_directions::NORTH].edm_has_space_for_packet();
+            }
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NW:
+            // Check space in branch forwarding edm
+            ret_val = downstream_edm_interface[eth_chan_directions::WEST].edm_has_space_for_packet();
+            // 2D Mcast Spine: North<->South
+            // 2D Mcast Branch: East and/or West
+            if constexpr (my_direction == eth_chan_directions::SOUTH) {  // packet dest + forward North
+                ret_val &= downstream_edm_interface[eth_chan_directions::NORTH].edm_has_space_for_packet();
+            }
+            break;
         default: __builtin_unreachable();
     }
     return ret_val;
@@ -681,14 +771,72 @@ FORCE_INLINE __attribute__((optimize("jump-tables"))) void receiver_forward_pack
             execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id, rx_channel_id);
             if (mcast_active) {
                 // This packet is in an active mcast
-                for (size_t i = eth_chan_directions::EAST; i < eth_chan_directions::COUNT; i++) {
-                    if (packet_start->mcast_params[i] and i != my_direction) {
-                        packet_start->mcast_params[i]--;
+                if constexpr (
+                    my_direction == eth_chan_directions::NORTH || my_direction == eth_chan_directions::SOUTH) {
+                    if constexpr (my_direction == eth_chan_directions::NORTH) {
+                        if (packet_start->mcast_params[eth_chan_directions::SOUTH]) {
+                            packet_start->mcast_params[eth_chan_directions::SOUTH]--;
+                            forward_payload_to_downstream_edm<enable_ring_support, false>(
+                                packet_start,
+                                payload_size_bytes,
+                                cached_routing_fields,
+                                downstream_edm_interface[eth_chan_directions::SOUTH],
+                                transaction_id);
+                        }
+                    } else if constexpr (my_direction == eth_chan_directions::SOUTH) {
+                        if (packet_start->mcast_params[eth_chan_directions::NORTH]) {
+                            packet_start->mcast_params[eth_chan_directions::NORTH]--;
+                            forward_payload_to_downstream_edm<enable_ring_support, false>(
+                                packet_start,
+                                payload_size_bytes,
+                                cached_routing_fields,
+                                downstream_edm_interface[eth_chan_directions::NORTH],
+                                transaction_id);
+                        }
+                    }
+                    // Trunk routers check for east/west mcast branch forwarding.
+                    if (packet_start->mcast_params[eth_chan_directions::EAST]) {
+                        // decrement east hop count
+                        cached_routing_fields.value = packet_start->mcast_params[eth_chan_directions::EAST] - 1;
+                        // north/south hop counts will be cleared when making trunk->branch trun.
+                        forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                            packet_start,
+                            payload_size_bytes,
+                            cached_routing_fields,
+                            downstream_edm_interface[eth_chan_directions::EAST],
+                            transaction_id);
+                    }
+                    if (packet_start->mcast_params[eth_chan_directions::WEST]) {
+                        // decrement west hop count
+                        cached_routing_fields.value = (packet_start->mcast_params[eth_chan_directions::WEST] - 1) << 16;
+                        // north/south hop counts will be cleared when making trunk->branch trun.
+                        forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                            packet_start,
+                            payload_size_bytes,
+                            cached_routing_fields,
+                            downstream_edm_interface[eth_chan_directions::WEST],
+                            transaction_id);
+                    }
+                } else if constexpr (my_direction == eth_chan_directions::EAST) {
+                    if (packet_start->mcast_params[eth_chan_directions::WEST]) {
+                        // decrement west hop count
+                        packet_start->mcast_params[eth_chan_directions::WEST]--;
                         forward_payload_to_downstream_edm<enable_ring_support, false>(
                             packet_start,
                             payload_size_bytes,
                             cached_routing_fields,
-                            downstream_edm_interface[i],
+                            downstream_edm_interface[eth_chan_directions::WEST],
+                            transaction_id);
+                    }
+                } else if constexpr (my_direction == eth_chan_directions::WEST) {
+                    if (packet_start->mcast_params[eth_chan_directions::EAST]) {
+                        // decrement east hop count
+                        packet_start->mcast_params[eth_chan_directions::EAST]--;
+                        forward_payload_to_downstream_edm<enable_ring_support, false>(
+                            packet_start,
+                            payload_size_bytes,
+                            cached_routing_fields,
+                            downstream_edm_interface[eth_chan_directions::EAST],
                             transaction_id);
                     }
                 }
@@ -804,6 +952,225 @@ FORCE_INLINE __attribute__((optimize("jump-tables"))) void receiver_forward_pack
                     transaction_id);
             }
             execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id, rx_channel_id);
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NSEW:
+            cached_routing_fields.value++;
+            if constexpr (my_direction == eth_chan_directions::SOUTH) {
+                forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                    packet_start,
+                    payload_size_bytes,
+                    cached_routing_fields,
+                    downstream_edm_interface[eth_chan_directions::NORTH],
+                    transaction_id);
+            } else {
+                forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                    packet_start,
+                    payload_size_bytes,
+                    cached_routing_fields,
+                    downstream_edm_interface[eth_chan_directions::SOUTH],
+                    transaction_id);
+            }
+            cached_routing_fields.hop_index = cached_routing_fields.branch_east_offset;
+            forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                packet_start,
+                payload_size_bytes,
+                cached_routing_fields,
+                downstream_edm_interface[eth_chan_directions::EAST],
+                transaction_id);
+            cached_routing_fields.hop_index = cached_routing_fields.branch_west_offset;
+            forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                packet_start,
+                payload_size_bytes,
+                cached_routing_fields,
+                downstream_edm_interface[eth_chan_directions::WEST],
+                transaction_id);
+            execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id, rx_channel_id);
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NSE:
+            cached_routing_fields.value++;
+            if constexpr (my_direction == eth_chan_directions::SOUTH) {
+                forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                    packet_start,
+                    payload_size_bytes,
+                    cached_routing_fields,
+                    downstream_edm_interface[eth_chan_directions::NORTH],
+                    transaction_id);
+            } else {
+                forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                    packet_start,
+                    payload_size_bytes,
+                    cached_routing_fields,
+                    downstream_edm_interface[eth_chan_directions::SOUTH],
+                    transaction_id);
+            }
+            cached_routing_fields.hop_index = cached_routing_fields.branch_east_offset;
+            forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                packet_start,
+                payload_size_bytes,
+                cached_routing_fields,
+                downstream_edm_interface[eth_chan_directions::EAST],
+                transaction_id);
+            execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id, rx_channel_id);
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NSW:
+            cached_routing_fields.value++;
+            if constexpr (my_direction == eth_chan_directions::SOUTH) {
+                forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                    packet_start,
+                    payload_size_bytes,
+                    cached_routing_fields,
+                    downstream_edm_interface[eth_chan_directions::NORTH],
+                    transaction_id);
+            } else {
+                forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                    packet_start,
+                    payload_size_bytes,
+                    cached_routing_fields,
+                    downstream_edm_interface[eth_chan_directions::SOUTH],
+                    transaction_id);
+            }
+            cached_routing_fields.hop_index = cached_routing_fields.branch_west_offset;
+            forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                packet_start,
+                payload_size_bytes,
+                cached_routing_fields,
+                downstream_edm_interface[eth_chan_directions::WEST],
+                transaction_id);
+            execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id, rx_channel_id);
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NEW:
+            if constexpr (my_direction == eth_chan_directions::SOUTH) {
+                cached_routing_fields.value++;
+                forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                    packet_start,
+                    payload_size_bytes,
+                    cached_routing_fields,
+                    downstream_edm_interface[eth_chan_directions::NORTH],
+                    transaction_id);
+            } else {
+                execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id, rx_channel_id);
+            }
+            cached_routing_fields.hop_index = cached_routing_fields.branch_east_offset;
+            forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                packet_start,
+                payload_size_bytes,
+                cached_routing_fields,
+                downstream_edm_interface[eth_chan_directions::EAST],
+                transaction_id);
+            cached_routing_fields.hop_index = cached_routing_fields.branch_west_offset;
+            forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                packet_start,
+                payload_size_bytes,
+                cached_routing_fields,
+                downstream_edm_interface[eth_chan_directions::WEST],
+                transaction_id);
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_SEW:
+            if constexpr (my_direction == eth_chan_directions::NORTH) {
+                cached_routing_fields.value++;
+                forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                    packet_start,
+                    payload_size_bytes,
+                    cached_routing_fields,
+                    downstream_edm_interface[eth_chan_directions::SOUTH],
+                    transaction_id);
+            } else {
+                execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id, rx_channel_id);
+            }
+            cached_routing_fields.hop_index = cached_routing_fields.branch_east_offset;
+            forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                packet_start,
+                payload_size_bytes,
+                cached_routing_fields,
+                downstream_edm_interface[eth_chan_directions::EAST],
+                transaction_id);
+            cached_routing_fields.hop_index = cached_routing_fields.branch_west_offset;
+            forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                packet_start,
+                payload_size_bytes,
+                cached_routing_fields,
+                downstream_edm_interface[eth_chan_directions::WEST],
+                transaction_id);
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NE:
+            if constexpr (my_direction == eth_chan_directions::SOUTH) {
+                cached_routing_fields.value++;
+                forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                    packet_start,
+                    payload_size_bytes,
+                    cached_routing_fields,
+                    downstream_edm_interface[eth_chan_directions::NORTH],
+                    transaction_id);
+            } else {
+                execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id, rx_channel_id);
+            }
+            cached_routing_fields.hop_index = cached_routing_fields.branch_east_offset;
+            forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                packet_start,
+                payload_size_bytes,
+                cached_routing_fields,
+                downstream_edm_interface[eth_chan_directions::EAST],
+                transaction_id);
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NW:
+            if constexpr (my_direction == eth_chan_directions::SOUTH) {
+                cached_routing_fields.value++;
+                forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                    packet_start,
+                    payload_size_bytes,
+                    cached_routing_fields,
+                    downstream_edm_interface[eth_chan_directions::NORTH],
+                    transaction_id);
+            } else {
+                execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id, rx_channel_id);
+            }
+            cached_routing_fields.hop_index = cached_routing_fields.branch_west_offset;
+            forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                packet_start,
+                payload_size_bytes,
+                cached_routing_fields,
+                downstream_edm_interface[eth_chan_directions::WEST],
+                transaction_id);
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_SE:
+            if constexpr (my_direction == eth_chan_directions::NORTH) {
+                cached_routing_fields.value++;
+                forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                    packet_start,
+                    payload_size_bytes,
+                    cached_routing_fields,
+                    downstream_edm_interface[eth_chan_directions::SOUTH],
+                    transaction_id);
+            } else {
+                execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id, rx_channel_id);
+            }
+            cached_routing_fields.hop_index = cached_routing_fields.branch_east_offset;
+            forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                packet_start,
+                payload_size_bytes,
+                cached_routing_fields,
+                downstream_edm_interface[eth_chan_directions::EAST],
+                transaction_id);
+            break;
+        case LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_SW:
+            if constexpr (my_direction == eth_chan_directions::NORTH) {
+                cached_routing_fields.value++;
+                forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                    packet_start,
+                    payload_size_bytes,
+                    cached_routing_fields,
+                    downstream_edm_interface[eth_chan_directions::SOUTH],
+                    transaction_id);
+            } else {
+                execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id, rx_channel_id);
+            }
+            cached_routing_fields.hop_index = cached_routing_fields.branch_west_offset;
+            forward_payload_to_downstream_edm<enable_ring_support, false, false>(
+                packet_start,
+                payload_size_bytes,
+                cached_routing_fields,
+                downstream_edm_interface[eth_chan_directions::WEST],
+                transaction_id);
             break;
         default: __builtin_unreachable();
     }
@@ -1035,7 +1402,7 @@ void run_receiver_channel_step_impl(
                 can_forward_packet_completely(packet_header, downstream_edm_interface, port_direction_table);
 #elif defined(FABRIC_2D)
             // need this ifdef since the packet header for 1D does not have router_buffer field in it.
-            hop_cmd = packet_header->route_buffer[cached_routing_fields.value];
+            hop_cmd = packet_header->route_buffer[cached_routing_fields.hop_index];
             can_send_to_all_local_chip_receivers = can_forward_packet_completely(hop_cmd, downstream_edm_interface);
 #endif
         } else {

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -857,6 +857,7 @@ FORCE_INLINE __attribute__((optimize("jump-tables"))) void receiver_forward_pack
 }
 #endif
 
+#if defined(FABRIC_2D)
 // !!!WARNING!!! - MAKE SURE CONSUMER HAS SPACE BEFORE CALLING
 template <uint8_t rx_channel_id, uint8_t SENDER_NUM_BUFFERS>
 FORCE_INLINE __attribute__((optimize("jump-tables"))) void receiver_forward_packet(
@@ -1175,6 +1176,7 @@ FORCE_INLINE __attribute__((optimize("jump-tables"))) void receiver_forward_pack
         default: __builtin_unreachable();
     }
 }
+#endif
 
 template <typename EdmChannelWorkerIFs>
 FORCE_INLINE void establish_edm_connection(

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -1418,10 +1418,10 @@ void run_receiver_channel_step_impl(
             uint8_t trid = receiver_channel_trid_tracker.update_buffer_slot_to_next_trid_and_advance_trid_counter(
                 receiver_buffer_index);
             if constexpr (is_2d_fabric) {
-#if defined(DYNAMIC_ROUTING_ENABLED)
+#if defined(FABRIC_2D) && defined(DYNAMIC_ROUTING_ENABLED)
                 receiver_forward_packet<receiver_channel>(
                     packet_header, cached_routing_fields, downstream_edm_interface, trid, port_direction_table);
-#else
+#elif defined(FABRIC_2D)
                 receiver_forward_packet<receiver_channel>(
                     packet_header, cached_routing_fields, downstream_edm_interface, trid, hop_cmd);
 #endif


### PR DESCRIPTION
2D Mcast propagates on N/S trunk and branhes E/W.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes