### PR TITLE
#24114: Optimize C++ concatenation algorithm

### DIFF
--- a/tests/ttnn/distributed/test_distributed_tensor.py
+++ b/tests/ttnn/distributed/test_distributed_tensor.py
@@ -219,7 +219,7 @@ def test_concat_to_tensor_mesh_torch_comparison(mesh_device, dtype):
 
     num_shards = mesh_device.get_num_devices()
 
-    unconcatenated_ttnn_tensor = generate_ttnn_tensor_of_shards(num_shards, dtype)
+    unconcatenated_ttnn_tensor = generate_ttnn_tensor_of_shards(num_shards, dtype).to(mesh_device)
 
     torch_concat_tensor = ttnn.to_torch(unconcatenated_ttnn_tensor, mesh_composer=torch_composer)
 
@@ -247,7 +247,9 @@ def test_concat2d_to_tensor_mesh_torch_comparison(M, K, N, dtype, mesh_shape, me
 
     num_shards = 4
 
-    unconcatenated_ttnn_tensor = generate_2d_sharded_ttnn_tensor(num_shards, dtype, M, K, mesh_shape, shard_dim)
+    unconcatenated_ttnn_tensor = generate_2d_sharded_ttnn_tensor(num_shards, dtype, M, K, mesh_shape, shard_dim).to(
+        mesh_device
+    )
 
     torch_composer = ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape, dims=concat_dim)
     torch_concat_tensor = ttnn.to_torch(unconcatenated_ttnn_tensor, mesh_composer=torch_composer)
@@ -451,7 +453,9 @@ def test_concat2d_to_tensor(M, K, N, dtype, mesh_shape, mesh_device):
     shard_dim = (3, 0)
     concat_dim = (1, 3)
 
-    unconcatenated_ttnn_tensor = generate_2d_sharded_ttnn_tensor(num_shards, dtype, M, K, mesh_shape, shard_dim)
+    unconcatenated_ttnn_tensor = generate_2d_sharded_ttnn_tensor(num_shards, dtype, M, K, mesh_shape, shard_dim).to(
+        mesh_device
+    )
 
     rows, cols = mesh_shape
     row_dim, col_dim = concat_dim

--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -196,6 +196,46 @@ TEST_F(TensorDistributionT3000Test, Shard1D) {
     EXPECT_TRUE(ttnn::allclose<float>(concatenated_tensor, expected_tensor));
 }
 
+TEST_F(TensorDistributionT3000Test, PartialConcat) {
+    constexpr int kNumRows = 2;
+    constexpr int kNumCols = 4;
+    std::vector<float> test_data;
+    for (int i = 0; i < kNumRows; i++) {
+        test_data.insert(test_data.end(), {i * 10 + 0, i * 10 + 1, i * 10 + 2});
+    }
+    Tensor input_tensor =
+        Tensor::from_vector(test_data, get_tensor_spec(ttnn::Shape{1, kNumRows, 1, 3}, DataType::FLOAT32));
+
+    auto mapper = create_mesh_mapper(
+        *mesh_device_,
+        MeshMapperConfig{
+            .placements = {MeshMapperConfig::Shard{1}, MeshMapperConfig::Replicate{}},
+        });
+    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    EXPECT_EQ(count_unique_buffers(sharded_tensor), kNumRows);
+
+    auto composer = create_mesh_composer(
+        *mesh_device_,
+        MeshComposerConfig{
+            .dims = {-1, 0},
+            .mesh_shape_override = MeshShape(2, 1),
+        });
+    Tensor concatenated_tensor = aggregate_tensor(sharded_tensor, *composer);
+
+    Tensor expected_tensor = Tensor::from_vector(
+        std::vector<float>{// Shard at (0, 0):
+                           0,
+                           1,
+                           2,
+                           // Shard at (1, 0):
+                           10,
+                           11,
+                           12},
+        get_tensor_spec(ttnn::Shape{1, 1, 1, 6}, DataType::FLOAT32));
+    EXPECT_TRUE(ttnn::allclose<float>(concatenated_tensor, expected_tensor));
+}
+
 class TensorDistributionT3000Test2D : public TensorDistributionT3000Test,
                                       public ::testing::WithParamInterface<MeshShape> {};
 
@@ -378,24 +418,6 @@ TEST_F(TensorDistributionT3000Test, NdComposerInvalidDims) {
         MeshComposerConfig{
             .dims = {0, 1, 2, 3},
         }));
-}
-
-TEST_F(TensorDistributionT3000Test, NdComposerUnevenComposition) {
-    Tensor input_tensor = Tensor::from_vector(
-        std::vector<float>{42.F, 13.F, -99.F}, get_tensor_spec(ttnn::Shape{1, 1, 1, 3}, DataType::FLOAT32));
-    auto mapper = replicate_tensor_to_mesh_mapper(*mesh_device_);
-    Tensor replicated_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
-
-    std::vector<Tensor> device_tensors = get_device_tensors(replicated_tensor);
-
-    auto composer = create_mesh_composer(
-        *mesh_device_,
-        MeshComposerConfig{
-            .dims = {0, 1},
-            .mesh_shape_override = MeshShape(2, 3),
-        });
-
-    EXPECT_ANY_THROW({ Tensor aggregated_tensor = aggregate_tensor(replicated_tensor, *composer); });
 }
 
 TEST_F(TensorDistributionT3000Test, NdMapperShard3D) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
@@ -104,10 +104,10 @@ TEST(PartitionTest, DefaultAxis) {
     xt::xarray<double> b = {{5.0, 6.0}, {7.0, 8.0}};
     std::vector<xt::xarray<double>> input = {a, b};
 
-    xt::xarray<double> result = concat(input);  // axis=0 by default
+    auto result = concat(input);  // axis=0 by default
     xt::xarray<double> expected = {{1.0, 2.0}, {3.0, 4.0}, {5.0, 6.0}, {7.0, 8.0}};
 
-    EXPECT_TRUE(xt::allclose(result, expected));
+    EXPECT_TRUE(xt::allclose(result.expr(), expected));
 }
 
 TEST(PartitionTest, AxisOne) {
@@ -115,10 +115,10 @@ TEST(PartitionTest, AxisOne) {
     xt::xarray<int> y = {{7, 8, 9}, {10, 11, 12}};
     std::vector<xt::xarray<int>> input = {x, y};
 
-    xt::xarray<int> result = concat(input, 1);
+    auto result = concat(input, 1);
     xt::xarray<int> expected = {{1, 2, 3, 7, 8, 9}, {4, 5, 6, 10, 11, 12}};
 
-    EXPECT_TRUE(xt::allclose(result, expected));
+    EXPECT_TRUE(xt::allclose(result.expr(), expected));
 }
 
 TEST(PartitionTest, ConcatNegativeDim) {
@@ -126,10 +126,10 @@ TEST(PartitionTest, ConcatNegativeDim) {
     xt::xarray<int> y = {{7, 8, 9}, {10, 11, 12}};
     std::vector<xt::xarray<int>> input = {x, y};
 
-    xt::xarray<int> result = concat(input, -1);
+    auto result = concat(input, -1);
     xt::xarray<int> expected = {{1, 2, 3, 7, 8, 9}, {4, 5, 6, 10, 11, 12}};
 
-    EXPECT_TRUE(xt::allclose(result, expected));
+    EXPECT_TRUE(xt::allclose(result.expr(), expected));
 }
 
 TEST(PartitionTest, MultipleArraysAxis0) {
@@ -138,10 +138,10 @@ TEST(PartitionTest, MultipleArraysAxis0) {
     xt::xarray<float> c = {5.0f, 6.0f};
     std::vector<xt::xarray<float>> input = {a, b, c};
 
-    xt::xarray<float> result = concat(input, 0);
+    auto result = concat(input, 0);
     xt::xarray<float> expected = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
 
-    EXPECT_TRUE(xt::allclose(result, expected));
+    EXPECT_TRUE(xt::allclose(result.expr(), expected));
 }
 
 TEST(PartitionTest, EmptyArray) {
@@ -149,7 +149,7 @@ TEST(PartitionTest, EmptyArray) {
     xt::xarray<int> b;  // Empty
     std::vector<xt::xarray<int>> input = {a, b};
 
-    EXPECT_ANY_THROW({ xt::xarray<int> result = concat(input, 0); });
+    EXPECT_ANY_THROW({ auto result = concat(input, 0); });
 }
 
 TEST(PartitionTest, HigherDimensions) {
@@ -159,12 +159,12 @@ TEST(PartitionTest, HigherDimensions) {
     arr2.reshape({2, 2, 2});
 
     std::vector<xt::xarray<int>> input = {arr1, arr2};
-    xt::xarray<int> result = concat(input, 0);
+    auto result = concat(input, 0);
 
     // Expected: shape (4,2,2) with arr1 stacked over arr2 along axis 0
     xt::xarray<int> expected = xt::concatenate(xt::xtuple(arr1, arr2), 0);
 
-    EXPECT_TRUE(xt::allclose(result, expected));
+    EXPECT_TRUE(xt::allclose(result.expr(), expected));
 }
 
 TEST(PartitionTest, HigherAxis) {
@@ -173,11 +173,11 @@ TEST(PartitionTest, HigherAxis) {
     // Both have shape (2,2,2)
 
     std::vector<xt::xarray<int>> input = {arr1, arr2};
-    xt::xarray<int> result = concat(input, 2);
+    auto result = concat(input, 2);
     // Expected shape: (2,2,4)
     xt::xarray<int> expected = {{{1, 2, 9, 10}, {3, 4, 11, 12}}, {{5, 6, 13, 14}, {7, 8, 15, 16}}};
 
-    EXPECT_TRUE(xt::allclose(result, expected));
+    EXPECT_TRUE(xt::allclose(result.expr(), expected));
 }
 
 TEST(PartitionTest, UnmatchedDimensions) {
@@ -214,7 +214,7 @@ TEST(PartitionTest, DimensionOutofRange) {
 TEST(PartitionTest, EmptyInput) {
     std::vector<xt::xarray<int>> input;
     EXPECT_NO_THROW(concat(input, 0));
-    EXPECT_TRUE(xt::allclose(concat(input, 0), xt::xarray<int>{}));
+    EXPECT_TRUE(xt::allclose(concat(input, 0).expr(), xt::xarray<int>{}));
 }
 
 TEST(PartitionTest, ChunkDoesNotAccessData) {
@@ -482,8 +482,8 @@ TEST(PartitionTest, ConcatNdimBasic) {
     auto result = concat_ndim(expressions, {2, 2}, {0, 1});
 
     // Expected shape: (4, 6)
-    EXPECT_EQ(result.shape()[0], 4u);
-    EXPECT_EQ(result.shape()[1], 6u);
+    EXPECT_EQ(result.expr().shape()[0], 4u);
+    EXPECT_EQ(result.expr().shape()[1], 6u);
 
     // Verify content - should be arranged as:
     // a b
@@ -493,14 +493,13 @@ TEST(PartitionTest, ConcatNdimBasic) {
         {4.0f, 5.0f, 6.0f, 10.0f, 11.0f, 12.0f},
         {13.0f, 14.0f, 15.0f, 19.0f, 20.0f, 21.0f},
         {16.0f, 17.0f, 18.0f, 22.0f, 23.0f, 24.0f}};
-    EXPECT_TRUE(xt::allclose(result, expected));
+    EXPECT_TRUE(xt::allclose(result.expr(), expected));
 }
 
 TEST(PartitionTest, ConcatNdimEmpty) {
     std::vector<xt::xarray<int>> expressions;
     auto result = concat_ndim(expressions, {}, {});
-    EXPECT_EQ(result.size(), 1u);
-    EXPECT_TRUE(xt::allclose(result[0], xt::xarray<int>()));
+    EXPECT_EQ(result.expr().size(), 0u);
 }
 
 TEST(PartitionTest, ConcatNdimSingleExpression) {
@@ -508,7 +507,7 @@ TEST(PartitionTest, ConcatNdimSingleExpression) {
     std::vector<xt::xarray<int>> expressions = {a};
 
     auto result = concat_ndim(expressions, {}, {});
-    EXPECT_TRUE(xt::allclose(result, a));
+    EXPECT_TRUE(xt::allclose(result.expr(), a));
 }
 
 TEST(PartitionTest, ConcatNdimMismatchedSizes) {
@@ -558,7 +557,7 @@ TEST(PartitionTest, ConcatNdimNegativeDims) {
     auto result = concat_ndim(expressions, {2, 2}, {-2, -1});
 
     xt::xarray<int> expected = {{1, 2, 3, 4}, {5, 6, 7, 8}};
-    EXPECT_TRUE(xt::allclose(result, expected));
+    EXPECT_TRUE(xt::allclose(result.expr(), expected));
 }
 
 TEST(PartitionTest, ConcatNdimNonUniqueDims) {
@@ -588,7 +587,7 @@ TEST(PartitionTest, ConcatNdimSingleDimension) {
     auto result_ndim = concat_ndim(expressions, {3}, {0});
     auto result_regular = concat(expressions, 0);
 
-    EXPECT_TRUE(xt::allclose(result_ndim, result_regular));
+    EXPECT_TRUE(xt::allclose(result_ndim.expr(), result_regular.expr()));
 }
 
 TEST(PartitionTest, ConcatNdimThreeDimensions) {
@@ -603,13 +602,13 @@ TEST(PartitionTest, ConcatNdimThreeDimensions) {
     auto result = concat_ndim(expressions, {2, 2, 2}, {0, 1, 2});
 
     // Expected shape: (2, 2, 4)
-    EXPECT_EQ(result.shape()[0], 2u);
-    EXPECT_EQ(result.shape()[1], 2u);
-    EXPECT_EQ(result.shape()[2], 4u);
+    EXPECT_EQ(result.expr().shape()[0], 2u);
+    EXPECT_EQ(result.expr().shape()[1], 2u);
+    EXPECT_EQ(result.expr().shape()[2], 4u);
 
     // Verify row-major ordering
     xt::xarray<int> expected = {{{0, 1, 2, 3}, {4, 5, 6, 7}}, {{8, 9, 10, 11}, {12, 13, 14, 15}}};
-    EXPECT_TRUE(xt::allclose(result, expected));
+    EXPECT_TRUE(xt::allclose(result.expr(), expected));
 }
 
 TEST(PartitionTest, ConcatNdimNonContiguousDims) {
@@ -625,16 +624,16 @@ TEST(PartitionTest, ConcatNdimNonContiguousDims) {
     auto result = concat_ndim(expressions, {2, 2}, {0, 2});
 
     // Expected shape: (2, 2, 2, 3)
-    EXPECT_EQ(result.shape()[0], 2u);
-    EXPECT_EQ(result.shape()[1], 2u);
-    EXPECT_EQ(result.shape()[2], 2u);
-    EXPECT_EQ(result.shape()[3], 3u);
+    EXPECT_EQ(result.expr().shape()[0], 2u);
+    EXPECT_EQ(result.expr().shape()[1], 2u);
+    EXPECT_EQ(result.expr().shape()[2], 2u);
+    EXPECT_EQ(result.expr().shape()[3], 3u);
 
     // Verify dimensions 1 and 3 remain unchanged
-    EXPECT_TRUE(xt::allclose(xt::view(result, xt::range(0, 1), xt::all(), xt::range(0, 1), xt::all()), a));
-    EXPECT_TRUE(xt::allclose(xt::view(result, xt::range(0, 1), xt::all(), xt::range(1, 2), xt::all()), b));
-    EXPECT_TRUE(xt::allclose(xt::view(result, xt::range(1, 2), xt::all(), xt::range(0, 1), xt::all()), c));
-    EXPECT_TRUE(xt::allclose(xt::view(result, xt::range(1, 2), xt::all(), xt::range(1, 2), xt::all()), d));
+    EXPECT_TRUE(xt::allclose(xt::view(result.expr(), xt::range(0, 1), xt::all(), xt::range(0, 1), xt::all()), a));
+    EXPECT_TRUE(xt::allclose(xt::view(result.expr(), xt::range(0, 1), xt::all(), xt::range(1, 2), xt::all()), b));
+    EXPECT_TRUE(xt::allclose(xt::view(result.expr(), xt::range(1, 2), xt::all(), xt::range(0, 1), xt::all()), c));
+    EXPECT_TRUE(xt::allclose(xt::view(result.expr(), xt::range(1, 2), xt::all(), xt::range(1, 2), xt::all()), d));
 }
 
 TEST(PartitionTest, ConcatNdimInverseOfChunkNdim) {
@@ -655,7 +654,7 @@ TEST(PartitionTest, ConcatNdimInverseOfChunkNdim) {
     auto reconstructed = concat_ndim(expressions, {2, 3}, {0, 2});
 
     // Should get back the original
-    EXPECT_TRUE(xt::allclose(reconstructed, original));
+    EXPECT_TRUE(xt::allclose(reconstructed.expr(), original));
 }
 
 TEST(PartitionTest, ConcatNdimRowMajorOrder) {
@@ -673,7 +672,7 @@ TEST(PartitionTest, ConcatNdimRowMajorOrder) {
     // 0, 1, 2, 3, 4, 5
     // 6, 7, 8, 9, 10, 11
     xt::xarray<int> expected = {{0, 1, 2, 3, 4, 5}, {6, 7, 8, 9, 10, 11}};
-    EXPECT_TRUE(xt::allclose(result, expected));
+    EXPECT_TRUE(xt::allclose(result.expr(), expected));
 }
 
 }  // namespace

--- a/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
@@ -40,6 +40,7 @@ using ::tt::tt_metal::Tensor;
 using ::ttnn::experimental::xtensor::chunk;
 using ::ttnn::experimental::xtensor::chunk_ndim;
 using ::ttnn::experimental::xtensor::concat;
+using ::ttnn::experimental::xtensor::concat_ndim;
 
 TEST(PartitionTest, ChunkBasicNonDivisible3) {
     // Create a 1D tensor: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -111,22 +112,22 @@ TEST(PartitionTest, DefaultAxis) {
 
 TEST(PartitionTest, AxisOne) {
     xt::xarray<int> x = {{1, 2, 3}, {4, 5, 6}};
-    xt::xarray<int> y = {{7, 8}, {9, 10}};
+    xt::xarray<int> y = {{7, 8, 9}, {10, 11, 12}};
     std::vector<xt::xarray<int>> input = {x, y};
 
     xt::xarray<int> result = concat(input, 1);
-    xt::xarray<int> expected = {{1, 2, 3, 7, 8}, {4, 5, 6, 9, 10}};
+    xt::xarray<int> expected = {{1, 2, 3, 7, 8, 9}, {4, 5, 6, 10, 11, 12}};
 
     EXPECT_TRUE(xt::allclose(result, expected));
 }
 
 TEST(PartitionTest, ConcatNegativeDim) {
     xt::xarray<int> x = {{1, 2, 3}, {4, 5, 6}};
-    xt::xarray<int> y = {{7, 8}, {9, 10}};
+    xt::xarray<int> y = {{7, 8, 9}, {10, 11, 12}};
     std::vector<xt::xarray<int>> input = {x, y};
 
     xt::xarray<int> result = concat(input, -1);
-    xt::xarray<int> expected = {{1, 2, 3, 7, 8}, {4, 5, 6, 9, 10}};
+    xt::xarray<int> expected = {{1, 2, 3, 7, 8, 9}, {4, 5, 6, 10, 11, 12}};
 
     EXPECT_TRUE(xt::allclose(result, expected));
 }
@@ -183,14 +184,11 @@ TEST(PartitionTest, UnmatchedDimensions) {
     xt::xarray<int> arr1 = {{{1, 2}, {3, 4}}, {{5, 6}, {7, 8}}};
     xt::xarray<int> arr2 = {{{9, 10}, {11, 12}}, {{13, 14}, {15, 16}}, {{17, 18}, {19, 20}}};
     // arr1 has shape (2,2,2), arr2 has shape (3,2,2)
-    xt::xarray<int> result_dim0 = xt::concatenate(xt::xtuple(arr1, arr2), 0);
 
     std::vector<xt::xarray<int>> input = {arr1, arr2};
-    EXPECT_NO_THROW(concat(input, 0));
-    EXPECT_TRUE(xt::allclose(concat(input, 0), result_dim0));
-
-    EXPECT_ANY_THROW(concat(input, 1));  // Should throw for axis 1
-    EXPECT_ANY_THROW(concat(input, 2));  // Should throw for axis 2
+    EXPECT_ANY_THROW(concat(input, 0));
+    EXPECT_ANY_THROW(concat(input, 1));
+    EXPECT_ANY_THROW(concat(input, 2));
 }
 
 TEST(PartitionTest, UnmatchedDimensionCount) {
@@ -199,9 +197,9 @@ TEST(PartitionTest, UnmatchedDimensionCount) {
     // arr1 has shape (2,2), arr2 has shape (2,2,2)
 
     std::vector<xt::xarray<int>> input = {arr1, arr2};
-    EXPECT_ANY_THROW(concat(input, 0));  // Should throw for axis 0
-    EXPECT_ANY_THROW(concat(input, 1));  // Should throw for axis 1
-    EXPECT_ANY_THROW(concat(input, 2));  // Should throw for axis 2
+    EXPECT_ANY_THROW(concat(input, 0));
+    EXPECT_ANY_THROW(concat(input, 1));
+    EXPECT_ANY_THROW(concat(input, 2));
 }
 
 TEST(PartitionTest, DimensionOutofRange) {
@@ -469,6 +467,213 @@ TEST(PartitionTest, ChunkNdimNonContiguousDims) {
     EXPECT_TRUE(xt::allclose(chunks[1], xt::view(tensor, xt::range(0, 1), xt::all(), xt::range(2, 4), xt::all())));
     EXPECT_TRUE(xt::allclose(chunks[2], xt::view(tensor, xt::range(1, 2), xt::all(), xt::range(0, 2), xt::all())));
     EXPECT_TRUE(xt::allclose(chunks[3], xt::view(tensor, xt::range(1, 2), xt::all(), xt::range(2, 4), xt::all())));
+}
+
+TEST(PartitionTest, ConcatNdimBasic) {
+    // Create 4 2x3 arrays to concatenate in a 2x2 grid
+    xt::xarray<float> a = {{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}};
+    xt::xarray<float> b = {{7.0f, 8.0f, 9.0f}, {10.0f, 11.0f, 12.0f}};
+    xt::xarray<float> c = {{13.0f, 14.0f, 15.0f}, {16.0f, 17.0f, 18.0f}};
+    xt::xarray<float> d = {{19.0f, 20.0f, 21.0f}, {22.0f, 23.0f, 24.0f}};
+
+    std::vector<xt::xarray<float>> expressions = {a, b, c, d};
+
+    // Concatenate along dimensions [0, 1] with 2 chunks each
+    auto result = concat_ndim(expressions, {2, 2}, {0, 1});
+
+    // Expected shape: (4, 6)
+    EXPECT_EQ(result.shape()[0], 4u);
+    EXPECT_EQ(result.shape()[1], 6u);
+
+    // Verify content - should be arranged as:
+    // a b
+    // c d
+    xt::xarray<float> expected = {
+        {1.0f, 2.0f, 3.0f, 7.0f, 8.0f, 9.0f},
+        {4.0f, 5.0f, 6.0f, 10.0f, 11.0f, 12.0f},
+        {13.0f, 14.0f, 15.0f, 19.0f, 20.0f, 21.0f},
+        {16.0f, 17.0f, 18.0f, 22.0f, 23.0f, 24.0f}};
+    EXPECT_TRUE(xt::allclose(result, expected));
+}
+
+TEST(PartitionTest, ConcatNdimEmpty) {
+    std::vector<xt::xarray<int>> expressions;
+    auto result = concat_ndim(expressions, {}, {});
+    EXPECT_EQ(result.size(), 1u);
+    EXPECT_TRUE(xt::allclose(result[0], xt::xarray<int>()));
+}
+
+TEST(PartitionTest, ConcatNdimSingleExpression) {
+    xt::xarray<int> a = {{1, 2, 3}, {4, 5, 6}};
+    std::vector<xt::xarray<int>> expressions = {a};
+
+    auto result = concat_ndim(expressions, {}, {});
+    EXPECT_TRUE(xt::allclose(result, a));
+}
+
+TEST(PartitionTest, ConcatNdimMismatchedSizes) {
+    xt::xarray<float> a = {1.0f, 2.0f};
+    std::vector<xt::xarray<float>> expressions = {a};
+
+    // Mismatched num_chunks and dims sizes
+    EXPECT_ANY_THROW(concat_ndim(expressions, {2, 2}, {0}));
+    EXPECT_ANY_THROW(concat_ndim(expressions, {2}, {0, 1}));
+}
+
+TEST(PartitionTest, ConcatNdimInvalidNumChunks) {
+    xt::xarray<double> a = {{1.0, 2.0}, {3.0, 4.0}};
+    std::vector<xt::xarray<double>> expressions = {a};
+
+    // Zero or negative num_chunks
+    EXPECT_ANY_THROW(concat_ndim(expressions, {0}, {0}));
+    EXPECT_ANY_THROW(concat_ndim(expressions, {-1}, {0}));
+    EXPECT_ANY_THROW(concat_ndim(expressions, {2, 0}, {0, 1}));
+}
+
+TEST(PartitionTest, ConcatNdimWrongNumberOfExpressions) {
+    xt::xarray<int> a = {1, 2, 3};
+    xt::xarray<int> b = {4, 5, 6};
+    std::vector<xt::xarray<int>> expressions = {a, b};
+
+    // Expected 4 expressions (2*2) but only have 2
+    EXPECT_ANY_THROW(concat_ndim(expressions, {2, 2}, {0, 1}));
+}
+
+TEST(PartitionTest, ConcatNdimMismatchedShapes) {
+    xt::xarray<float> a = {{1.0f, 2.0f}, {3.0f, 4.0f}};
+    xt::xarray<float> b = {5.0f, 6.0f, 7.0f};  // Different shape
+    std::vector<xt::xarray<float>> expressions = {a, b};
+
+    EXPECT_ANY_THROW(concat_ndim(expressions, {2}, {0}));
+}
+
+TEST(PartitionTest, ConcatNdimNegativeDims) {
+    xt::xarray<int> a = {{1, 2}};
+    xt::xarray<int> b = {{3, 4}};
+    xt::xarray<int> c = {{5, 6}};
+    xt::xarray<int> d = {{7, 8}};
+    std::vector<xt::xarray<int>> expressions = {a, b, c, d};
+
+    // Use negative dimensions
+    auto result = concat_ndim(expressions, {2, 2}, {-2, -1});
+
+    xt::xarray<int> expected = {{1, 2, 3, 4}, {5, 6, 7, 8}};
+    EXPECT_TRUE(xt::allclose(result, expected));
+}
+
+TEST(PartitionTest, ConcatNdimNonUniqueDims) {
+    xt::xarray<int> a = {1, 2, 3};
+    std::vector<xt::xarray<int>> expressions = {a};
+
+    // Duplicate dimensions
+    EXPECT_ANY_THROW(concat_ndim(expressions, {2, 2}, {0, 0}));
+    EXPECT_ANY_THROW(concat_ndim(expressions, {2, 2}, {1, -1}));  // Both refer to last dim
+}
+
+TEST(PartitionTest, ConcatNdimDimsOutOfRange) {
+    xt::xarray<double> a = {{1.0, 2.0}, {3.0, 4.0}};
+    std::vector<xt::xarray<double>> expressions = {a};
+
+    EXPECT_ANY_THROW(concat_ndim(expressions, {2}, {3}));
+    EXPECT_ANY_THROW(concat_ndim(expressions, {2}, {-3}));
+}
+
+TEST(PartitionTest, ConcatNdimSingleDimension) {
+    // Should behave like regular concat
+    xt::xarray<int> a = {1, 2, 3};
+    xt::xarray<int> b = {4, 5, 6};
+    xt::xarray<int> c = {7, 8, 9};
+    std::vector<xt::xarray<int>> expressions = {a, b, c};
+
+    auto result_ndim = concat_ndim(expressions, {3}, {0});
+    auto result_regular = concat(expressions, 0);
+
+    EXPECT_TRUE(xt::allclose(result_ndim, result_regular));
+}
+
+TEST(PartitionTest, ConcatNdimThreeDimensions) {
+    // Create 8 small tensors of shape (1, 1, 2)
+    std::vector<xt::xarray<int>> expressions;
+    for (int i = 0; i < 8; ++i) {
+        xt::xarray<int> tensor = {{{i * 2, i * 2 + 1}}};
+        expressions.push_back(tensor);
+    }
+
+    // Concatenate along all 3 dimensions with 2 chunks each
+    auto result = concat_ndim(expressions, {2, 2, 2}, {0, 1, 2});
+
+    // Expected shape: (2, 2, 4)
+    EXPECT_EQ(result.shape()[0], 2u);
+    EXPECT_EQ(result.shape()[1], 2u);
+    EXPECT_EQ(result.shape()[2], 4u);
+
+    // Verify row-major ordering
+    xt::xarray<int> expected = {{{0, 1, 2, 3}, {4, 5, 6, 7}}, {{8, 9, 10, 11}, {12, 13, 14, 15}}};
+    EXPECT_TRUE(xt::allclose(result, expected));
+}
+
+TEST(PartitionTest, ConcatNdimNonContiguousDims) {
+    // Create 4 tensors of shape (1, 2, 1, 3)
+    xt::xarray<float> a = {{{{1.0f, 2.0f, 3.0f}}, {{4.0f, 5.0f, 6.0f}}}};
+    xt::xarray<float> b = {{{{7.0f, 8.0f, 9.0f}}, {{10.0f, 11.0f, 12.0f}}}};
+    xt::xarray<float> c = {{{{13.0f, 14.0f, 15.0f}}, {{16.0f, 17.0f, 18.0f}}}};
+    xt::xarray<float> d = {{{{19.0f, 20.0f, 21.0f}}, {{22.0f, 23.0f, 24.0f}}}};
+
+    std::vector<xt::xarray<float>> expressions = {a, b, c, d};
+
+    // Concatenate along dimensions 0 and 2 (skipping 1 and 3)
+    auto result = concat_ndim(expressions, {2, 2}, {0, 2});
+
+    // Expected shape: (2, 2, 2, 3)
+    EXPECT_EQ(result.shape()[0], 2u);
+    EXPECT_EQ(result.shape()[1], 2u);
+    EXPECT_EQ(result.shape()[2], 2u);
+    EXPECT_EQ(result.shape()[3], 3u);
+
+    // Verify dimensions 1 and 3 remain unchanged
+    EXPECT_TRUE(xt::allclose(xt::view(result, xt::range(0, 1), xt::all(), xt::range(0, 1), xt::all()), a));
+    EXPECT_TRUE(xt::allclose(xt::view(result, xt::range(0, 1), xt::all(), xt::range(1, 2), xt::all()), b));
+    EXPECT_TRUE(xt::allclose(xt::view(result, xt::range(1, 2), xt::all(), xt::range(0, 1), xt::all()), c));
+    EXPECT_TRUE(xt::allclose(xt::view(result, xt::range(1, 2), xt::all(), xt::range(1, 2), xt::all()), d));
+}
+
+TEST(PartitionTest, ConcatNdimInverseOfChunkNdim) {
+    // Create a tensor and chunk it
+    xt::xarray<double> original = xt::arange<double>(120);
+    original.reshape({4, 5, 6});
+
+    // Chunk along dimensions 0 and 2
+    auto chunks = chunk_ndim(original, {2, 3}, {0, 2});
+
+    // Convert to vector of xarrays for concat_ndim
+    std::vector<xt::xarray<double>> expressions;
+    for (const auto& chunk : chunks) {
+        expressions.push_back(xt::xarray<double>(chunk));
+    }
+
+    // Concatenate back
+    auto reconstructed = concat_ndim(expressions, {2, 3}, {0, 2});
+
+    // Should get back the original
+    EXPECT_TRUE(xt::allclose(reconstructed, original));
+}
+
+TEST(PartitionTest, ConcatNdimRowMajorOrder) {
+    // Create 6 small tensors of shape (1, 2)
+    std::vector<xt::xarray<int>> expressions;
+    for (int i = 0; i < 6; ++i) {
+        xt::xarray<int> tensor = {{i * 2, i * 2 + 1}};
+        expressions.push_back(tensor);
+    }
+
+    // Concatenate with 2 chunks along dim 0, 3 chunks along dim 1
+    auto result = concat_ndim(expressions, {2, 3}, {0, 1});
+
+    // Expected row-major order:
+    // 0, 1, 2, 3, 4, 5
+    // 6, 7, 8, 9, 10, 11
+    xt::xarray<int> expected = {{0, 1, 2, 3, 4, 5}, {6, 7, 8, 9, 10, 11}};
+    EXPECT_TRUE(xt::allclose(result, expected));
 }
 
 }  // namespace

--- a/tt-train/sources/ttml/core/xtensor_utils.hpp
+++ b/tt-train/sources/ttml/core/xtensor_utils.hpp
@@ -67,7 +67,7 @@ auto xtensor_to_span(const xt::xarray<T>& xtensor) {
 
 template <typename T>
 xt::xarray<T> concat(const std::vector<xt::xarray<T>>& v, size_t axis = 0) {
-    return ttnn::experimental::xtensor::concat(v, axis);
+    return ttnn::experimental::xtensor::concat(v, axis).expr();
 }
 
 }  // namespace ttml::core

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -85,6 +85,10 @@ public:
     static TensorToMesh create(const MeshDevice& mesh_device, const MeshMapperConfig& config);
 
     // Distributes a tensor onto a mesh.
+    // The input tensor is expected to be a "single device" tensor with `HostStorage`; the output tensor will be a
+    // distributed tensor with `MultiDeviceHostStorage`.
+    // TODO: #15840 - eliminate the distinction between `HostStorage` and `MultiDeviceHostStorage`. This means possibly
+    // removing this API, and instead relying on the overload that accepts the span of logical data.
     Tensor operator()(const Tensor& tensor) const;
 
     // Overload that takes in a span of logical data; used in situations where the tensor object might not be
@@ -143,6 +147,10 @@ public:
     static MeshToTensor create(const MeshDevice& mesh_device, const MeshComposerConfig& config);
 
     // Composes multi-device tensor into a single tensor.
+    // The input tensor is expected to be distributed over a mesh; the output tensor will be a "single device" tensor
+    // with `HostStorage`.
+    // TODO: #15840 - eliminate the distinction between `HostStorage` and `MultiDeviceHostStorage`. This means possibly
+    // removing this API, and instead relying on the overload that returns the vector of logical data.
     Tensor compose(const Tensor& tensor) const;
 
     // Overload that returns a pair of logical data composed of a multi-device tensor and its shape.

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -142,7 +142,12 @@ public:
 
     static MeshToTensor create(const MeshDevice& mesh_device, const MeshComposerConfig& config);
 
-    Tensor compose(const std::vector<Tensor>& tensors) const;
+    // Composes multi-device tensor into a single tensor.
+    Tensor compose(const Tensor& tensor) const;
+
+    // Overload that returns a pair of logical data composed from multi-device tensor and its shape.
+    template <typename T>
+    std::pair<std::vector<T>, Shape> compose(const Tensor& tensor) const;
 
 private:
     class Impl;
@@ -184,5 +189,7 @@ Tensor create_distributed_tensor(
 
 // Aggregates a multi-device tensor into a host tensor according to the `composer`.
 Tensor aggregate_tensor(const Tensor& tensor, const MeshToTensor& composer);
+
+// TODO: another high level API that returns a pair of logical data and shape.
 
 }  // namespace ttnn::distributed

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -145,7 +145,7 @@ public:
     // Composes multi-device tensor into a single tensor.
     Tensor compose(const Tensor& tensor) const;
 
-    // Overload that returns a pair of logical data composed from multi-device tensor and its shape.
+    // Overload that returns a pair of logical data composed of a multi-device tensor and its shape.
     template <typename T>
     std::pair<std::vector<T>, Shape> compose(const Tensor& tensor) const;
 

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -190,6 +190,4 @@ Tensor create_distributed_tensor(
 // Aggregates a multi-device tensor into a host tensor according to the `composer`.
 Tensor aggregate_tensor(const Tensor& tensor, const MeshToTensor& composer);
 
-// TODO: another high level API that returns a pair of logical data and shape.
-
 }  // namespace ttnn::distributed

--- a/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
@@ -22,6 +22,41 @@ ttnn::Shape get_shape_from_xarray(const E& xarr) {
     return ttnn::Shape(shape_dims);
 }
 
+// Returns the type of an adapted xtensor expression for a given data type `T`.
+template <typename T>
+using AdaptedView = decltype(xt::adapt(
+    std::declval<T*>(), std::declval<size_t>(), xt::no_ownership(), std::declval<std::vector<size_t>>()));
+
+// Returns `AdaptedView<T>` for a span of data.
+// Does not take ownership of the data.
+template <typename T>
+auto adapt(tt::stl::Span<T> data, std::vector<size_t> shape_vec) {
+    return xt::adapt(data.data(), data.size(), xt::no_ownership(), std::move(shape_vec));
+}
+
+// Adapts a vector of data to an xtensor expression.
+// Allows accessing the data as either a vector or an xtensor expression.
+template <typename T>
+class XtensorAdapter {
+public:
+    XtensorAdapter(std::vector<T>&& data, std::vector<size_t> shape_vec) :
+        data_(std::move(data)), expr_(adapt(tt::stl::make_span(data_), std::move(shape_vec))) {}
+
+    // Returns a reference to the underlying xtensor expression.
+    auto& expr() & { return expr_; }
+    const auto& expr() const& { return expr_; }
+
+    // Returns a reference to the underlying data.
+    std::vector<T>& data() & { return data_; }
+    const std::vector<T>& data() const& { return data_; }
+    std::vector<T> data() && { return std::move(data_); }
+    std::vector<T> data() const&& = delete;
+
+private:
+    std::vector<T> data_;
+    AdaptedView<T> expr_;
+};
+
 // Converts a span to an xtensor view.
 // IMPORTANT: the lifetime of the returned xtensor view is tied to the lifetime of the underlying buffer.
 template <typename T>

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tt_stl/small_vector.hpp>
+#include <vector>
 #include <xtensor/views/xstrided_view.hpp>
 #include "ttnn/tensor/tensor.hpp"
 
@@ -39,10 +41,15 @@ StridedViews<T> chunk_ndim(
     const xt::xexpression<T>& expr, const tt::stl::SmallVector<int>& num_chunks, const tt::stl::SmallVector<int>& dims);
 
 // Concatenates a list of tensors along the specified dimension.
-tt::tt_metal::Tensor concat(const std::vector<tt::tt_metal::Tensor>& tensors, int dim = 0);
-
-// Overload for `xt::xarray`.
 template <typename T>
 xt::xarray<T> concat(const std::vector<xt::xarray<T>>& v, int dim = 0);
+
+// Overload that performs multi-dimensional concatenation.
+// `expressions` are assumed to be laid out in row-major order relative to the supplied `dims`.
+template <typename T>
+xt::xarray<T> concat_ndim(
+    const std::vector<xt::xarray<T>>& expressions,
+    const tt::stl::SmallVector<int>& num_chunks,
+    const tt::stl::SmallVector<int>& dims);
 
 }  // namespace ttnn::experimental::xtensor

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -13,42 +13,44 @@ namespace ttnn::experimental::xtensor {
 namespace detail {
 
 // Helper to compute the type of an unowned strided view over an `xt::xexpression`.
-template <typename T>
+template <typename Expression>
 auto compute_strided_view() -> decltype(xt::strided_view(
-    std::declval<const xt::xexpression<T>&>().derived_cast(), std::declval<xt::xstrided_slice_vector>()));
+    std::declval<const xt::xexpression<Expression>&>().derived_cast(), std::declval<xt::xstrided_slice_vector>()));
 
 }  // namespace detail
 
-template <typename T>
-using StridedView = decltype(detail::compute_strided_view<T>());
+template <typename Expression>
+using StridedView = decltype(detail::compute_strided_view<Expression>());
 
-template <typename T>
-using StridedViews = std::vector<StridedView<T>>;
+template <typename Expression>
+using StridedViews = std::vector<StridedView<Expression>>;
 
 // IMPORTANT: `chunk` and `concatenate` are not yet part of the public ttnn API.
 //
 // Splits an xtensor expression into chunks along the specified dimension, and returns a vector of un-owned strided
 // views.
-template <typename T>
-StridedViews<T> chunk(const xt::xexpression<T>& expr, int num_chunks, int dim = 0);
+template <typename Expression>
+StridedViews<Expression> chunk(const xt::xexpression<Expression>& expr, int num_chunks, int dim = 0);
 
 // Overload that performs multi-dimensional chunking.
 // Chunking is done in row-major order relative to the supplied `dims`, and returned in the vector in the same order.
 // `num_chunks` and `dims` must have the same length. When empty, no chunking is performed, and the entire tensor is
 // returned as a single chunk.
-template <typename T>
-StridedViews<T> chunk_ndim(
-    const xt::xexpression<T>& expr, const tt::stl::SmallVector<int>& num_chunks, const tt::stl::SmallVector<int>& dims);
+template <typename Expression>
+StridedViews<Expression> chunk_ndim(
+    const xt::xexpression<Expression>& expr,
+    const tt::stl::SmallVector<int>& num_chunks,
+    const tt::stl::SmallVector<int>& dims);
 
 // Concatenates a list of tensors along the specified dimension.
-template <typename T>
-xt::xarray<T> concat(const std::vector<xt::xarray<T>>& v, int dim = 0);
+template <typename Expression>
+xt::xarray<typename Expression::value_type> concat(const std::vector<Expression>& v, int dim = 0);
 
 // Overload that performs multi-dimensional concatenation.
 // `expressions` are assumed to be laid out in row-major order relative to the supplied `dims`.
-template <typename T>
-xt::xarray<T> concat_ndim(
-    const std::vector<xt::xarray<T>>& expressions,
+template <typename Expression>
+xt::xarray<typename Expression::value_type> concat_ndim(
+    const std::vector<Expression>& expressions,
     const tt::stl::SmallVector<int>& num_chunks,
     const tt::stl::SmallVector<int>& dims);
 

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <tt_stl/small_vector.hpp>
+#include <ttnn/tensor/xtensor/conversion_utils.hpp>
 #include <vector>
 #include <xtensor/views/xstrided_view.hpp>
 #include "ttnn/tensor/tensor.hpp"
@@ -44,12 +45,12 @@ StridedViews<Expression> chunk_ndim(
 
 // Concatenates a list of tensors along the specified dimension.
 template <typename Expression>
-xt::xarray<typename Expression::value_type> concat(const std::vector<Expression>& v, int dim = 0);
+XtensorAdapter<typename Expression::value_type> concat(const std::vector<Expression>& v, int dim = 0);
 
 // Overload that performs multi-dimensional concatenation.
 // `expressions` are assumed to be laid out in row-major order relative to the supplied `dims`.
 template <typename Expression>
-xt::xarray<typename Expression::value_type> concat_ndim(
+XtensorAdapter<typename Expression::value_type> concat_ndim(
     const std::vector<Expression>& expressions,
     const tt::stl::SmallVector<int>& num_chunks,
     const tt::stl::SmallVector<int>& dims);

--- a/ttnn/core/tensor/xtensor/partition.cpp
+++ b/ttnn/core/tensor/xtensor/partition.cpp
@@ -38,8 +38,18 @@ tt::stl::SmallVector<int> normalize_dims(const tt::stl::SmallVector<int>& dims, 
     return normalized_dims;
 }
 
+// Helper to compute adapted types for explicit instantiations per data type `T`.
+template <typename T>
+auto compute_adapted_type() -> decltype(xt::adapt(
+    std::declval<T*>(), std::declval<size_t>(), xt::no_ownership(), std::declval<std::vector<size_t>>()));
+
+template <typename T>
+using AdaptedType = decltype(compute_adapted_type<T>());
+
+}  // namespace
+
 template <typename Expression>
-auto chunk_ndim_impl(
+StridedViews<Expression> chunk_ndim(
     const xt::xexpression<Expression>& expr_base,
     const tt::stl::SmallVector<int>& num_chunks,
     const tt::stl::SmallVector<int>& dims) {
@@ -110,32 +120,9 @@ auto chunk_ndim_impl(
     return chunk_views;
 }
 
-// Helper to compute adapted types for explicit instantiations per data type `T`.
-template <typename T>
-auto compute_adapted_type() -> decltype(xt::adapt(
-    std::declval<T*>(), std::declval<size_t>(), xt::no_ownership(), std::declval<std::vector<size_t>>()));
-
-template <typename T>
-using AdaptedType = decltype(compute_adapted_type<T>());
-
-}  // namespace
-
 template <typename Expression>
 StridedViews<Expression> chunk(const xt::xexpression<Expression>& expr, int num_chunks, int dim) {
-    return chunk_ndim_impl(expr, {num_chunks}, {dim});
-}
-
-template <typename Expression>
-StridedViews<Expression> chunk_ndim(
-    const xt::xexpression<Expression>& expr,
-    const tt::stl::SmallVector<int>& num_chunks,
-    const tt::stl::SmallVector<int>& dims) {
-    return chunk_ndim_impl(expr, num_chunks, dims);
-}
-
-template <typename Expression>
-xt::xarray<typename Expression::value_type> concat(const std::vector<Expression>& v, int dim) {
-    return concat_ndim<Expression>(v, {v.size()}, {dim});
+    return chunk_ndim(expr, {num_chunks}, {dim});
 }
 
 template <typename Expression>
@@ -216,6 +203,11 @@ xt::xarray<typename Expression::value_type> concat_ndim(
     }
 
     return result;
+}
+
+template <typename Expression>
+xt::xarray<typename Expression::value_type> concat(const std::vector<Expression>& v, int dim) {
+    return concat_ndim<Expression>(v, {v.size()}, {dim});
 }
 
 // Explicit instantiations for the public API.


### PR DESCRIPTION
### Ticket
#24114
#17343

### Problem description
Migration of torch sharding requires optimizing C++ path. Currently there is a big performance gap due to unnecessary copying of data.

In addition, there is an opportunity to parallelize data processing (physical -> logical conversion).

### What's changed
* Re-wrote the algorithm to perform concatenation of multi-dimensional chunks of data in lock step. Similar to how chunking is done.
* Added new utils for xtensor conversion: `XtensorAdapter`, `adapt`, and `AdaptedView`. 
* Re-wrote concatenation implementation to rely on the new multi-dimensional path, switched from `get_device_tensors` function to manipulating `DistributedHostBuffer` directly.
* Added an overload `std::pair<std::vector<T>, Shape> MeshToTensor::compose(const Tensor& tensor) const` - this will be adopted on the `to_torch` conversion path in `pytensor.cpp`.

### Checklist (pending)
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15935984889)
- [x] [T3K unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/15935987767)
- [x] New/Existing tests provide coverage for changes