### PR TITLE
#15944: Delete create_sub_device_manager_with_fabric

### DIFF
--- a/tests/ttnn/unit_tests/test_sub_device.py
+++ b/tests/ttnn/unit_tests/test_sub_device.py
@@ -7,7 +7,7 @@ import torch
 import ttnn
 
 
-def run_sub_devices(device, create_fabric_sub_device=False):
+def run_sub_devices(device):
     tensix_cores0 = ttnn.CoreRangeSet(
         {
             ttnn.CoreRange(
@@ -28,14 +28,8 @@ def run_sub_devices(device, create_fabric_sub_device=False):
     sub_device_2 = ttnn.SubDevice([tensix_cores1])
     sub_devices_1 = [sub_device_1, sub_device_2]
     sub_devices_2 = [sub_device_2]
-    if create_fabric_sub_device:
-        sub_device_manager1, fabric_sub_device_id1 = device.create_sub_device_manager_with_fabric(sub_devices_1, 3200)
-        sub_device_manager2, fabric_sub_device_id2 = device.create_sub_device_manager_with_fabric(sub_devices_2, 3200)
-        assert fabric_sub_device_id1 == ttnn.SubDeviceId(len(sub_devices_1))
-        assert fabric_sub_device_id2 == ttnn.SubDeviceId(len(sub_devices_2))
-    else:
-        sub_device_manager1 = device.create_sub_device_manager(sub_devices_1, 3200)
-        sub_device_manager2 = device.create_sub_device_manager(sub_devices_2, 3200)
+    sub_device_manager1 = device.create_sub_device_manager(sub_devices_1, 3200)
+    sub_device_manager2 = device.create_sub_device_manager(sub_devices_2, 3200)
     device.load_sub_device_manager(sub_device_manager1)
     ttnn.synchronize_device(device, sub_device_ids=[ttnn.SubDeviceId(1)])
     ttnn.synchronize_device(device, sub_device_ids=[ttnn.SubDeviceId(0), ttnn.SubDeviceId(1)])
@@ -50,7 +44,7 @@ def run_sub_devices(device, create_fabric_sub_device=False):
     device.remove_sub_device_manager(sub_device_manager2)
 
 
-def run_sub_devices_program(device, create_fabric_sub_device=False):
+def run_sub_devices_program(device):
     is_mesh_device = isinstance(device, ttnn.MeshDevice)
     if is_mesh_device:
         inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
@@ -79,11 +73,7 @@ def run_sub_devices_program(device, create_fabric_sub_device=False):
     sub_device_1 = ttnn.SubDevice([tensix_cores0])
     sub_device_2 = ttnn.SubDevice([tensix_cores1])
     sub_devices = [sub_device_1, sub_device_2]
-    if create_fabric_sub_device:
-        sub_device_manager, fabric_sub_device_id = device.create_sub_device_manager_with_fabric(sub_devices, 3200)
-        assert fabric_sub_device_id == ttnn.SubDeviceId(len(sub_devices))
-    else:
-        sub_device_manager = device.create_sub_device_manager(sub_devices, 3200)
+    sub_device_manager = device.create_sub_device_manager(sub_devices, 3200)
     device.load_sub_device_manager(sub_device_manager)
 
     x = torch.randn(num_devices, 1, 64, 64, dtype=torch.bfloat16)
@@ -137,21 +127,17 @@ def run_sub_devices_program(device, create_fabric_sub_device=False):
     device.remove_sub_device_manager(sub_device_manager)
 
 
-@pytest.mark.parametrize("create_fabric_sub_device", (False, True))
-def test_sub_devices(device, create_fabric_sub_device):
-    run_sub_devices(device, create_fabric_sub_device)
+def test_sub_devices(device):
+    run_sub_devices(device)
 
 
-@pytest.mark.parametrize("create_fabric_sub_device", (False, True))
-def test_sub_devices_mesh(mesh_device, create_fabric_sub_device):
-    run_sub_devices(mesh_device, create_fabric_sub_device)
+def test_sub_devices_mesh(mesh_device):
+    run_sub_devices(mesh_device)
 
 
-@pytest.mark.parametrize("create_fabric_sub_device", (False, True))
-def test_sub_device_program(device, create_fabric_sub_device):
-    run_sub_devices_program(device, create_fabric_sub_device)
+def test_sub_device_program(device):
+    run_sub_devices_program(device)
 
 
-@pytest.mark.parametrize("create_fabric_sub_device", (False, True))
-def test_sub_device_program_mesh(mesh_device, create_fabric_sub_device):
-    run_sub_devices_program(mesh_device, create_fabric_sub_device)
+def test_sub_device_program_mesh(mesh_device):
+    run_sub_devices_program(mesh_device)

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -216,10 +216,6 @@ public:
     virtual uint32_t num_sub_devices() const = 0;
     virtual uint32_t num_virtual_eth_cores(SubDeviceId sub_device_id) = 0;
 
-    // TODO #15944: Temporary api until migration to actual fabric is complete
-    virtual std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
-        tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) = 0;
-
     virtual bool is_mmio_capable() const = 0;
 
     // Allowing to get corresponding MeshDevice for a given device to properly schedule programs / create buffers for

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -249,9 +249,6 @@ public:
     void set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) override;
     void reset_sub_device_stall_group() override;
     uint32_t num_sub_devices() const override;
-    // TODO #16526: Temporary api until migration to actual fabric is complete
-    std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
-        tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) override;
     bool is_mmio_capable() const override;
     std::shared_ptr<distributed::MeshDevice> get_mesh_device() override;
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -565,10 +565,6 @@ void MeshDevice::load_sub_device_manager(SubDeviceManagerId sub_device_manager_i
 }
 void MeshDevice::clear_loaded_sub_device_manager() { sub_device_manager_tracker_->clear_loaded_sub_device_manager(); }
 
-std::tuple<SubDeviceManagerId, SubDeviceId> MeshDevice::create_sub_device_manager_with_fabric(
-    tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
-    return sub_device_manager_tracker_->create_sub_device_manager_with_fabric(sub_devices, local_l1_size);
-}
 CoreCoord MeshDevice::dram_grid_size() const {
     return validate_and_get_reference_value(
         this->get_devices(), [](const auto* device) { return device->dram_grid_size(); });

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -825,10 +825,6 @@ SubDeviceManagerId Device::create_sub_device_manager(tt::stl::Span<const SubDevi
     return sub_device_manager_tracker_->create_sub_device_manager(sub_devices, local_l1_size);
 }
 
-std::tuple<SubDeviceManagerId, SubDeviceId> Device::create_sub_device_manager_with_fabric(tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
-    return sub_device_manager_tracker_->create_sub_device_manager_with_fabric(sub_devices, local_l1_size);
-}
-
 void Device::load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
     sub_device_manager_tracker_->load_sub_device_manager(sub_device_manager_id);
 }

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -179,9 +179,6 @@ public:
     void set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) override;
     void reset_sub_device_stall_group() override;
     uint32_t num_sub_devices() const override;
-    // TODO #15944: Temporary api until migration to actual fabric is complete
-    std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
-        tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) override;
 
     bool is_mmio_capable() const override;
     // TODO #20966: Remove these APIs

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -58,18 +58,6 @@ SubDeviceManagerId SubDeviceManagerTracker::create_sub_device_manager(
     return sub_device_manager_id;
 }
 
-std::tuple<SubDeviceManagerId, SubDeviceId> SubDeviceManagerTracker::create_sub_device_manager_with_fabric(
-    tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
-    auto fabric_sub_device = SubDevice(std::array{
-        CoreRangeSet(),
-        default_sub_device_manager_->sub_device(SubDeviceId{0}).cores(HalProgrammableCoreType::ACTIVE_ETH)});
-    auto new_sub_devices = std::vector<SubDevice>(sub_devices.begin(), sub_devices.end());
-    new_sub_devices.push_back(fabric_sub_device);
-    auto fabric_sub_device_id = SubDeviceId{static_cast<uint32_t>(new_sub_devices.size() - 1)};
-    auto sub_device_manager_id = this->create_sub_device_manager(new_sub_devices, local_l1_size);
-    return {sub_device_manager_id, fabric_sub_device_id};
-}
-
 void SubDeviceManagerTracker::reset_sub_device_state(const std::unique_ptr<SubDeviceManager>& sub_device_manager) {
     auto num_sub_devices = sub_device_manager->num_sub_devices();
     // Dynamic resolution of device types is unclean and poor design. This will be cleaned up

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.hpp
@@ -37,9 +37,6 @@ public:
 
     SubDeviceManagerId create_sub_device_manager(tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size);
 
-    std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
-        tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size);
-
     void load_sub_device_manager(SubDeviceManagerId sub_device_manager_id);
 
     void clear_loaded_sub_device_manager();

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -323,28 +323,6 @@ void py_module(py::module& module) {
                    SubDeviceManagerId: The ID of the created sub-device manager.
            )doc")
         .def(
-            "create_sub_device_manager_with_fabric",
-            [](MeshDevice& self, const std::vector<SubDevice>& sub_devices, DeviceAddr local_l1_size) {
-                return self.create_sub_device_manager_with_fabric(sub_devices, local_l1_size);
-            },
-            py::arg("sub_devices"),
-            py::arg("local_l1_size"),
-            R"doc(
-               Creates a sub-device manager for the given mesh device. This will automatically create a sub-device of ethernet cores for use with fabric.
-               Note that this is a temporary API until migration to actual fabric is complete.
-
-
-               Args:
-                   sub_devices (List[ttnn.SubDevice]): The sub-devices to include in the sub-device manager. No ethernet cores should be included in this list.
-                   This configuration will be used for each device in the MeshDevice.
-                   local_l1_size (int): The size of the local allocators of each sub-device. The global allocator will be shrunk by this amount.
-
-
-               Returns:
-                   SubDeviceManagerId: The ID of the created sub-device manager.
-                   SubDeviceId: The ID of the sub-device that will be used for fabric.
-           )doc")
-        .def(
             "load_sub_device_manager",
             &MeshDevice::load_sub_device_manager,
             py::arg("sub_device_manager_id"),


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15944

### Problem description
API is no longer needed now that we have true fabric.

### What's changed
Delete create_sub_device_manager_with_fabric

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15936502183
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes