### PR TITLE
#21967: Support 5D broadcast

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -283,10 +283,10 @@ void BinaryNgDeviceOperation::validate_on_program_cache_hit(
             a_dim,
             b_dim);
 
-        if (i <= -5) {
+        if (i <= -6) {
             TT_FATAL(
                 a_dim == b_dim,
-                "Broadcasting rule violation for rank >= 5 : dim {}, Broadcast is supported upto rank 4, dim a: {}, "
+                "Broadcasting rule violation for rank >= 6 : dim {}, Broadcast is supported up to rank 5, dim a: {}, "
                 "dim b: {}",
                 i,
                 a_dim,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_col_bcast.cpp
@@ -14,30 +14,34 @@ void kernel_main() {
     const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
     const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
     const uint32_t nD_stride = get_arg_val<uint32_t>(5);
-    const uint32_t n_stride = get_arg_val<uint32_t>(6);
-    const uint32_t c_stride = get_arg_val<uint32_t>(7);
-    const uint32_t N = get_arg_val<uint32_t>(8);
-    const uint32_t C = get_arg_val<uint32_t>(9);
-    const uint32_t Ht = get_arg_val<uint32_t>(10);
-    const uint32_t Wt = get_arg_val<uint32_t>(11);
-    const uint32_t cND = get_arg_val<uint32_t>(12);  // collapsed dims > 4
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
     const uint32_t HtWt = Ht * Wt;
 
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
 
     constexpr uint32_t onetile = 1;
 
-    const uint32_t tiles_per_depth = N * C * HtWt;
-    uint32_t start_d = start_tile_id / tiles_per_depth;  // ND index
-    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
-    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
-    uint32_t tiles_per_channel = HtWt;
-    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
-    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
-    uint32_t start_th = start_t / Wt;                          // H index
-    uint32_t start_tw = start_t % Wt;                          // W index
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
 #if !SRC_SHARDED
@@ -47,37 +51,43 @@ void kernel_main() {
         .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
-    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
 #endif
 
     uint32_t num_tiles_read = 0;
-    for (uint32_t nd = start_d; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_n = 0) {
-        for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
-            for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
-                for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th, start_tw = 0) {
-                    cb_reserve_back(cb_id_src, onetile);
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th, start_tw = 0) {
+                        cb_reserve_back(cb_id_src, onetile);
 #if !SRC_SHARDED
-                uint32_t l1_write_addr = get_write_ptr(cb_id_src);
-                noc_async_read_tile(tile_offset + th, src, l1_write_addr);
-                noc_async_read_barrier();
+                        uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+                        noc_async_read_tile(tile_offset + th, src, l1_write_addr);
+                        noc_async_read_barrier();
 #endif
-                FILL_TILE_WITH_FIRST_COLUMN(cb_id_src);
-                cb_push_back(cb_id_src, onetile);
+                        FILL_TILE_WITH_FIRST_COLUMN(cb_id_src);
+                        cb_push_back(cb_id_src, onetile);
 
-                num_tiles_read += Wt - start_tw;
+                        num_tiles_read += Wt - start_tw;
+                    }
+#if !SRC_SHARDED
+                    tile_offset += c_stride;
+#endif
                 }
 #if !SRC_SHARDED
-            tile_offset += c_stride;
+                tile_offset += next_n_shift;
 #endif
             }
 #if !SRC_SHARDED
-        tile_offset += next_batch_shift;
+            tile_offset += next_d_shift;
 #endif
         }
 #if !SRC_SHARDED
-        tile_offset += next_depth_shift;
+        tile_offset += next_nd_shift;
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
@@ -13,13 +13,15 @@ void kernel_main() {
     const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
     const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
     const uint32_t nD_stride = get_arg_val<uint32_t>(5);
-    const uint32_t n_stride = get_arg_val<uint32_t>(6);
-    const uint32_t c_stride = get_arg_val<uint32_t>(7);
-    const uint32_t N = get_arg_val<uint32_t>(8);
-    const uint32_t C = get_arg_val<uint32_t>(9);
-    const uint32_t Ht = get_arg_val<uint32_t>(10);
-    const uint32_t Wt = get_arg_val<uint32_t>(11);
-    const uint32_t cND = get_arg_val<uint32_t>(12);  // collapsed dims > 4
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
 
@@ -37,49 +39,56 @@ void kernel_main() {
     constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
     const uint32_t HtWt = Ht * Wt;
 
-    const uint32_t tiles_per_depth = N * C * HtWt;
-    uint32_t start_d = start_tile_id / tiles_per_depth;  // ND index
-    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
-    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
-    uint32_t tiles_per_channel = HtWt;
-    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
-    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
-    uint32_t start_th = start_t / Wt;                          // H index
-    uint32_t start_tw = start_t % Wt;                          // W index
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
     uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride + start_th * Wt;
-    uint32_t next_channel_shift = c_stride - HtWt;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
-    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+    uint32_t tile_offset =
+        start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride + start_th * Wt;
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
 
     uint32_t num_tiles_read = 0;
-    for (uint32_t nd = start_d; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_n = 0) {
-        for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
-            for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
-                for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
-                    for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
-                         ++tw, ++num_tiles_read) {
-                        cb_reserve_back(cb_id_src, onetile);
-                        uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-                        noc_async_read_tile(tile_offset + tw, src, l1_write_addr_src);
-                        noc_async_read_barrier();
-                        cb_push_back(cb_id_src, onetile);
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+                            cb_reserve_back(cb_id_src, onetile);
+                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            noc_async_read_tile(tile_offset + tw, src, l1_write_addr_src);
+                            noc_async_read_barrier();
+                            cb_push_back(cb_id_src, onetile);
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+                        tile_offset += Wt;
                     }
-                    if constexpr (!has_sharding) {
-                        // next row of tiles should start at the first column
-                        start_tw = 0;
-                    }
-                    tile_offset += Wt;
+                    tile_offset += next_c_shift;
                 }
-                tile_offset += next_channel_shift;
+                tile_offset += next_n_shift;
             }
-            tile_offset += next_batch_shift;
+            tile_offset += next_d_shift;
         }
-        tile_offset += next_depth_shift;
+        tile_offset += next_nd_shift;
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_row_bcast.cpp
@@ -14,13 +14,15 @@ void kernel_main() {
     const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
     const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
     const uint32_t nD_stride = get_arg_val<uint32_t>(5);
-    const uint32_t n_stride = get_arg_val<uint32_t>(6);
-    const uint32_t c_stride = get_arg_val<uint32_t>(7);
-    const uint32_t N = get_arg_val<uint32_t>(8);
-    const uint32_t C = get_arg_val<uint32_t>(9);
-    const uint32_t Ht = get_arg_val<uint32_t>(10);
-    const uint32_t Wt = get_arg_val<uint32_t>(11);
-    const uint32_t cND = get_arg_val<uint32_t>(12);  // collapsed dims > 4
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
     const uint32_t HtWt = Ht * Wt;
 
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
@@ -33,41 +35,48 @@ void kernel_main() {
     const InterleavedAddrGenFast<src_is_dram> src = {
         .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
 
-    const uint32_t tiles_per_depth = N * C * HtWt;
-    uint32_t start_d = start_tile_id / tiles_per_depth;  // ND index
-    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
-    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
-    uint32_t tiles_per_channel = HtWt;
-    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
-    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
-    uint32_t start_th = start_t / Wt;                          // H index
-    uint32_t start_tw = start_t % Wt;                          // W index
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
-    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
 
     uint32_t num_tiles_read = 0;
-    for (uint32_t nd = start_d; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_n = 0) {
-        for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
-            for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
-                for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th, start_tw = 0) {
-                    for (uint32_t tw = start_tw; tw < Wt && num_tiles_read < dst_num_tiles; ++tw, ++num_tiles_read) {
-                        cb_reserve_back(cb_id_src, onetile);
-                        uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-                        noc_async_read_tile(tile_offset + tw, src, l1_write_addr_src);
-                        noc_async_read_barrier();
-                        FILL_TILE_WITH_FIRST_ROW(cb_id_src);
-                        cb_push_back(cb_id_src, onetile);
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th, start_tw = 0) {
+                        for (uint32_t tw = start_tw; tw < Wt && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+                            cb_reserve_back(cb_id_src, onetile);
+                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            noc_async_read_tile(tile_offset + tw, src, l1_write_addr_src);
+                            noc_async_read_barrier();
+                            FILL_TILE_WITH_FIRST_ROW(cb_id_src);
+                            cb_push_back(cb_id_src, onetile);
+                        }
                     }
+                    tile_offset += c_stride;
                 }
-                tile_offset += c_stride;
+                tile_offset += next_n_shift;
             }
-            tile_offset += next_batch_shift;
+            tile_offset += next_d_shift;
         }
-        tile_offset += next_depth_shift;
+        tile_offset += next_nd_shift;
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_scalar_bcast.cpp
@@ -14,13 +14,15 @@ void kernel_main() {
     const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
     const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
     const uint32_t nD_stride = get_arg_val<uint32_t>(5);
-    const uint32_t n_stride = get_arg_val<uint32_t>(6);
-    const uint32_t c_stride = get_arg_val<uint32_t>(7);
-    const uint32_t N = get_arg_val<uint32_t>(8);
-    const uint32_t C = get_arg_val<uint32_t>(9);
-    const uint32_t Ht = get_arg_val<uint32_t>(10);
-    const uint32_t Wt = get_arg_val<uint32_t>(11);
-    const uint32_t cND = get_arg_val<uint32_t>(12);  // collapsed dims > 4
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
     const uint32_t HtWt = Ht * Wt;
 
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
@@ -33,37 +35,43 @@ void kernel_main() {
     const InterleavedAddrGenFast<src_is_dram> src = {
         .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
 
-    const uint32_t tiles_per_depth = N * C * HtWt;
-    uint32_t start_d = start_tile_id / tiles_per_depth;  // D index
-    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
-    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
-    uint32_t tiles_per_channel = HtWt;
-    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
-    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_t = offset_n % HtWt;
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
-    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
 
     uint32_t num_tiles_read = 0;
-    for (uint32_t nd = start_d; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_n = 0) {
-        for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
-            for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_t = 0) {
-                cb_reserve_back(cb_id_src, onetile);
-                uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-                noc_async_read_tile(tile_offset, src, l1_write_addr_src);
-                noc_async_read_barrier();
-                FILL_TILE_WITH_FIRST_ELEMENT(cb_id_src);
-                cb_push_back(cb_id_src, onetile);
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_t = 0) {
+                    cb_reserve_back(cb_id_src, onetile);
+                    uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                    noc_async_read_tile(tile_offset, src, l1_write_addr_src);
+                    noc_async_read_barrier();
+                    FILL_TILE_WITH_FIRST_ELEMENT(cb_id_src);
+                    cb_push_back(cb_id_src, onetile);
 
-                num_tiles_read += HtWt - start_t;
-                tile_offset += c_stride;
+                    num_tiles_read += HtWt - start_t;
+                    tile_offset += c_stride;
+                }
+                tile_offset += next_n_shift;
             }
-            tile_offset += next_batch_shift;
+            tile_offset += next_d_shift;
         }
-        tile_offset += next_depth_shift;
+        tile_offset += next_nd_shift;
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_col_bcast.cpp
@@ -15,28 +15,32 @@ void kernel_main() {
     const uint32_t dst_num_tiles = get_arg_val<uint32_t>(4);
     const uint32_t dst_shard_width = get_arg_val<uint32_t>(5);
     const uint32_t nD_stride = get_arg_val<uint32_t>(6);
-    const uint32_t n_stride = get_arg_val<uint32_t>(7);
-    const uint32_t c_stride = get_arg_val<uint32_t>(8);
-    const uint32_t N = get_arg_val<uint32_t>(9);
-    const uint32_t C = get_arg_val<uint32_t>(10);
-    const uint32_t Ht = get_arg_val<uint32_t>(11);
-    const uint32_t Wt = get_arg_val<uint32_t>(12);
-    const uint32_t cND = get_arg_val<uint32_t>(13);  // collapsed dims > 4
+    const uint32_t d_stride = get_arg_val<uint32_t>(7);
+    const uint32_t n_stride = get_arg_val<uint32_t>(8);
+    const uint32_t c_stride = get_arg_val<uint32_t>(9);
+    const uint32_t D = get_arg_val<uint32_t>(10);
+    const uint32_t N = get_arg_val<uint32_t>(11);
+    const uint32_t C = get_arg_val<uint32_t>(12);
+    const uint32_t Ht = get_arg_val<uint32_t>(13);
+    const uint32_t Wt = get_arg_val<uint32_t>(14);
+    const uint32_t cND = get_arg_val<uint32_t>(15);  // collapsed dims > 5
     const uint32_t HtWt = Ht * Wt;
 
     constexpr uint32_t onetile = 1;
 
-    const uint32_t tiles_per_depth = N * C * HtWt;
-    uint32_t start_d = start_tile_id / tiles_per_depth;  // collapsed ND index
-    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
-    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
-    uint32_t tiles_per_channel = HtWt;
-    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
-    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
-    uint32_t start_th = start_t / Wt;                          // H index
-    uint32_t start_tw = start_t % Wt;                          // W index
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
 
     constexpr auto cb_id_src = tt::CBIndex::c_1;
 #if !SRC_SHARDED
@@ -48,9 +52,10 @@ void kernel_main() {
         .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
-    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
 #endif
 
     constexpr auto cb_id_dst = tt::CBIndex::c_2;
@@ -64,41 +69,47 @@ void kernel_main() {
 #endif
 
     uint32_t num_tiles_written = 0;
-    for (uint32_t nd = start_d; nd < cND && num_tiles_written < dst_num_tiles; ++nd, start_n = 0) {
-        for (uint32_t n = start_n; n < N && num_tiles_written < dst_num_tiles; ++n, start_c = 0) {
-            for (uint32_t c = start_c; c < C && num_tiles_written < dst_num_tiles; ++c, start_th = 0) {
-                for (uint32_t th = start_th; th < Ht && num_tiles_written < dst_num_tiles; ++th, start_tw = 0) {
-                    // read a tile from src
-                    cb_reserve_back(cb_id_src, onetile);
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_written < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_written < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_written < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_written < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_written < dst_num_tiles; ++th, start_tw = 0) {
+                        // read a tile from src
+                        cb_reserve_back(cb_id_src, onetile);
 #if !SRC_SHARDED
-                uint32_t l1_write_addr = get_write_ptr(cb_id_src);
-                noc_async_read_tile(tile_offset + th, src, l1_write_addr);
-                noc_async_read_barrier();
+                        uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+                        noc_async_read_tile(tile_offset + th, src, l1_write_addr);
+                        noc_async_read_barrier();
 #endif
-                FILL_TILE_WITH_FIRST_COLUMN(cb_id_src);
-                cb_push_back(cb_id_src, onetile);
+                        FILL_TILE_WITH_FIRST_COLUMN(cb_id_src);
+                        cb_push_back(cb_id_src, onetile);
 
-                for (uint32_t tw = start_tw; tw < Wt && num_tiles_written < dst_num_tiles; ++tw, ++num_tiles_written) {
-                    // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
-                    cb_wait_front(cb_id_dst, onetile);
+                        for (uint32_t tw = start_tw; tw < Wt && num_tiles_written < dst_num_tiles;
+                             ++tw, ++num_tiles_written) {
+                            // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                            cb_wait_front(cb_id_dst, onetile);
 #if !DST_SHARDED
-                    uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
-                    noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
-                    noc_async_write_barrier();
-                    cb_pop_front(cb_id_dst, onetile);
+                            uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
+                            noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                            noc_async_write_barrier();
+                            cb_pop_front(cb_id_dst, onetile);
+#endif
+                        }
+                    }
+#if !SRC_SHARDED
+                    tile_offset += c_stride;
 #endif
                 }
-                }
 #if !SRC_SHARDED
-            tile_offset += c_stride;
+                tile_offset += next_n_shift;
 #endif
             }
 #if !SRC_SHARDED
-        tile_offset += next_batch_shift;
+            tile_offset += next_d_shift;
 #endif
         }
 #if !SRC_SHARDED
-        tile_offset += next_depth_shift;
+        tile_offset += next_nd_shift;
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast.cpp
@@ -14,13 +14,15 @@ void kernel_main() {
     const uint32_t dst_num_tiles = get_arg_val<uint32_t>(4);
     const uint32_t dst_shard_width = get_arg_val<uint32_t>(5);
     const uint32_t nD_stride = get_arg_val<uint32_t>(6);
-    const uint32_t n_stride = get_arg_val<uint32_t>(7);
-    const uint32_t c_stride = get_arg_val<uint32_t>(8);
-    const uint32_t N = get_arg_val<uint32_t>(9);
-    const uint32_t C = get_arg_val<uint32_t>(10);
-    const uint32_t Ht = get_arg_val<uint32_t>(11);
-    const uint32_t Wt = get_arg_val<uint32_t>(12);
-    const uint32_t cND = get_arg_val<uint32_t>(13);  // collapsed dims > 4
+    const uint32_t d_stride = get_arg_val<uint32_t>(7);
+    const uint32_t n_stride = get_arg_val<uint32_t>(8);
+    const uint32_t c_stride = get_arg_val<uint32_t>(9);
+    const uint32_t D = get_arg_val<uint32_t>(10);
+    const uint32_t N = get_arg_val<uint32_t>(11);
+    const uint32_t C = get_arg_val<uint32_t>(12);
+    const uint32_t Ht = get_arg_val<uint32_t>(13);
+    const uint32_t Wt = get_arg_val<uint32_t>(14);
+    const uint32_t cND = get_arg_val<uint32_t>(15);  // collapsed dims > 5
 
     constexpr uint32_t onetile = 1;
 
@@ -51,66 +53,73 @@ void kernel_main() {
     constexpr bool has_sharding = get_compile_time_arg_val(2) == 1;
     const uint32_t HtWt = Ht * Wt;
 
-    const uint32_t tiles_per_depth = N * C * HtWt;
-    uint32_t start_d = start_tile_id / tiles_per_depth;  // collapsed ND index
-    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
-    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
-    uint32_t tiles_per_channel = HtWt;
-    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
-    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
-    uint32_t start_th = start_t / Wt;                          // H index
-    uint32_t start_tw = start_t % Wt;                          // W index
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
     uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride + start_th * Wt;
-    uint32_t next_channel_shift = c_stride - HtWt;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
-    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+    uint32_t tile_offset =
+        start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride + start_th * Wt;
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
 
     uint32_t num_tiles_written = 0;
     uint32_t dst_tile_offset = start_tile_id;
 
-    for (uint32_t nd = start_d; nd < cND && num_tiles_written < dst_num_tiles; ++nd, start_n = 0) {
-        for (uint32_t n = start_n; n < N && num_tiles_written < dst_num_tiles; ++n, start_c = 0) {
-            for (uint32_t c = start_c; c < C && num_tiles_written < dst_num_tiles; ++c, start_th = 0) {
-                for (uint32_t th = start_th; th < Ht && num_tiles_written < dst_num_tiles; ++th) {
-                    for (uint32_t tw = start_tw; tw < end_tw && num_tiles_written < dst_num_tiles;
-                         ++tw, ++num_tiles_written) {
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_written < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_written < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_written < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_written < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_written < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_written < dst_num_tiles;
+                             ++tw, ++num_tiles_written) {
 #if !SRC_SHARDED
-                        // read a tile from src
-                        cb_reserve_back(cb_id_src, onetile);
-                        uint32_t l1_write_addr = get_write_ptr(cb_id_src);
-                        noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
-                        noc_async_read_barrier();
-                        cb_push_back(cb_id_src, onetile);
+                            // read a tile from src
+                            cb_reserve_back(cb_id_src, onetile);
+                            uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+                            noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
+                            noc_async_read_barrier();
+                            cb_push_back(cb_id_src, onetile);
 #endif
 
 #if !DST_SHARDED
-                        // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
-                        cb_wait_front(cb_id_dst, onetile);
-                        uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
-                        noc_async_write_tile(dst_tile_offset + num_tiles_written, dst, l1_read_addr);
-                        noc_async_write_barrier();
-                        cb_pop_front(cb_id_dst, onetile);
+                            // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                            cb_wait_front(cb_id_dst, onetile);
+                            uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
+                            noc_async_write_tile(dst_tile_offset + num_tiles_written, dst, l1_read_addr);
+                            noc_async_write_barrier();
+                            cb_pop_front(cb_id_dst, onetile);
 #endif
+                        }
+                        tile_offset += Wt;
+                        if constexpr (has_sharding) {
+                            // adjust the output tile offset since we had to skip parts of the row
+                            dst_tile_offset += (Wt - dst_shard_width);
+                        } else {
+                            // otherwise, next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
                     }
-                    tile_offset += Wt;
-                    if constexpr (has_sharding) {
-                        // adjust the output tile offset since we had to skip parts of the row
-                        dst_tile_offset += (Wt - dst_shard_width);
-                    } else {
-                        // otherwise, next row of tiles should start at the first column
-                        start_tw = 0;
-                    }
+                    tile_offset += next_c_shift;
                 }
-                tile_offset += next_channel_shift;
+                tile_offset += next_n_shift;
             }
-            tile_offset += next_batch_shift;
+            tile_offset += next_d_shift;
         }
-        tile_offset += next_depth_shift;
+        tile_offset += next_nd_shift;
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_row_bcast.cpp
@@ -15,13 +15,14 @@ void kernel_main() {
     const uint32_t dst_num_tiles = get_arg_val<uint32_t>(4);
     const uint32_t dst_shard_width = get_arg_val<uint32_t>(5);
     const uint32_t nD_stride = get_arg_val<uint32_t>(6);
-    const uint32_t n_stride = get_arg_val<uint32_t>(7);
-    const uint32_t c_stride = get_arg_val<uint32_t>(8);
-    const uint32_t N = get_arg_val<uint32_t>(9);
-    const uint32_t C = get_arg_val<uint32_t>(10);
-    const uint32_t Ht = get_arg_val<uint32_t>(11);
-    const uint32_t Wt = get_arg_val<uint32_t>(12);
-    const uint32_t cND = get_arg_val<uint32_t>(13);  // collapsed dims > 4
+    const uint32_t d_stride = get_arg_val<uint32_t>(7);
+    const uint32_t n_stride = get_arg_val<uint32_t>(8);
+    const uint32_t c_stride = get_arg_val<uint32_t>(9);
+    const uint32_t D = get_arg_val<uint32_t>(10);
+    const uint32_t N = get_arg_val<uint32_t>(11);
+    const uint32_t C = get_arg_val<uint32_t>(12);
+    const uint32_t Ht = get_arg_val<uint32_t>(13);
+    const uint32_t Wt = get_arg_val<uint32_t>(14);
     const uint32_t HtWt = Ht * Wt;
 
     constexpr uint32_t onetile = 1;
@@ -42,50 +43,56 @@ void kernel_main() {
     const InterleavedAddrGenFast<dst_is_dram> dst = {
         .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
 
-    const uint32_t tiles_per_depth = N * C * HtWt;
-    uint32_t start_d = start_tile_id / tiles_per_depth;  // ND index
-    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
-    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
-    uint32_t tiles_per_channel = HtWt;
-    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
-    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
-    uint32_t start_th = start_t / Wt;                          // H index
-    uint32_t start_tw = start_t % Wt;                          // W index
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
-    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
 
     uint32_t num_tiles_written = 0;
-    for (uint32_t nd = start_d; nd < cND && num_tiles_written < dst_num_tiles; ++nd, start_n = 0) {
-        for (uint32_t n = start_n; n < N && num_tiles_written < dst_num_tiles; ++n, start_c = 0) {
-            for (uint32_t c = start_c; c < C && num_tiles_written < dst_num_tiles; ++c, start_th = 0) {
-                for (uint32_t th = start_th; th < Ht && num_tiles_written < dst_num_tiles; ++th, start_tw = 0) {
-                    for (uint32_t tw = start_tw; tw < Wt && num_tiles_written < dst_num_tiles;
-                         ++tw, ++num_tiles_written) {
-                        // read a tile from src
-                        cb_reserve_back(cb_id_src, onetile);
-                        uint32_t l1_write_addr = get_write_ptr(cb_id_src);
-                        noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
-                        noc_async_read_barrier();
-                        FILL_TILE_WITH_FIRST_ROW(cb_id_src);
-                        cb_push_back(cb_id_src, onetile);
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_written < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_written < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_written < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_written < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_written < dst_num_tiles; ++th, start_tw = 0) {
+                        for (uint32_t tw = start_tw; tw < Wt && num_tiles_written < dst_num_tiles;
+                             ++tw, ++num_tiles_written) {
+                            // read a tile from src
+                            cb_reserve_back(cb_id_src, onetile);
+                            uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+                            noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
+                            noc_async_read_barrier();
+                            FILL_TILE_WITH_FIRST_ROW(cb_id_src);
+                            cb_push_back(cb_id_src, onetile);
 
-                        // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
-                        cb_wait_front(cb_id_dst, onetile);
-                        uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
-                        noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
-                        noc_async_write_barrier();
-                        cb_pop_front(cb_id_dst, onetile);
+                            // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                            cb_wait_front(cb_id_dst, onetile);
+                            uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
+                            noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                            noc_async_write_barrier();
+                            cb_pop_front(cb_id_dst, onetile);
+                        }
                     }
+                    tile_offset += c_stride;
                 }
-                tile_offset += c_stride;
+                tile_offset += next_n_shift;
             }
-            tile_offset += next_batch_shift;
+            tile_offset += next_d_shift;
         }
-        tile_offset += next_depth_shift;
+        tile_offset += next_nd_shift;
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_bcast.cpp
@@ -15,13 +15,15 @@ void kernel_main() {
     const uint32_t dst_num_tiles = get_arg_val<uint32_t>(4);
     const uint32_t dst_shard_width = get_arg_val<uint32_t>(5);
     const uint32_t nD_stride = get_arg_val<uint32_t>(6);
-    const uint32_t n_stride = get_arg_val<uint32_t>(7);
-    const uint32_t c_stride = get_arg_val<uint32_t>(8);
-    const uint32_t N = get_arg_val<uint32_t>(9);
-    const uint32_t C = get_arg_val<uint32_t>(10);
-    const uint32_t Ht = get_arg_val<uint32_t>(11);
-    const uint32_t Wt = get_arg_val<uint32_t>(12);
-    const uint32_t cND = get_arg_val<uint32_t>(13);  // collapsed dims > 4
+    const uint32_t d_stride = get_arg_val<uint32_t>(7);
+    const uint32_t n_stride = get_arg_val<uint32_t>(8);
+    const uint32_t c_stride = get_arg_val<uint32_t>(9);
+    const uint32_t D = get_arg_val<uint32_t>(10);
+    const uint32_t N = get_arg_val<uint32_t>(11);
+    const uint32_t C = get_arg_val<uint32_t>(12);
+    const uint32_t Ht = get_arg_val<uint32_t>(13);
+    const uint32_t Wt = get_arg_val<uint32_t>(14);
+    const uint32_t cND = get_arg_val<uint32_t>(15);  // collapsed dims > 5
     const uint32_t HtWt = Ht * Wt;
 
     constexpr uint32_t onetile = 1;
@@ -42,45 +44,52 @@ void kernel_main() {
     const InterleavedAddrGenFast<dst_is_dram> dst = {
         .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
 
-    const uint32_t tiles_per_depth = N * C * HtWt;
-    uint32_t start_d = start_tile_id / tiles_per_depth;  // ND index
-    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
-    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
-    uint32_t tiles_per_channel = HtWt;
-    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
-    uint32_t start_t = start_remaining_2 % tiles_per_channel;
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_t = offset_n % HtWt;
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
-    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
 
     uint32_t num_tiles_written = 0;
-    for (uint32_t nd = start_d; nd < cND && num_tiles_written < dst_num_tiles; ++nd, start_n = 0) {
-        for (uint32_t n = start_n; n < N && num_tiles_written < dst_num_tiles; ++n, start_c = 0) {
-            for (uint32_t c = start_c; c < C && num_tiles_written < dst_num_tiles; ++c, start_t = 0) {
-                // read a tile from src
-                cb_reserve_back(cb_id_src, onetile);
-                uint32_t l1_write_addr = get_write_ptr(cb_id_src);
-                noc_async_read_tile(tile_offset, src, l1_write_addr);
-                noc_async_read_barrier();
-                FILL_TILE_WITH_FIRST_ELEMENT(cb_id_src);
-                cb_push_back(cb_id_src, onetile);
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_written < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_written < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_written < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_written < dst_num_tiles; ++c, start_t = 0) {
+                    // read a tile from src
+                    cb_reserve_back(cb_id_src, onetile);
+                    uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+                    noc_async_read_tile(tile_offset, src, l1_write_addr);
+                    noc_async_read_barrier();
+                    FILL_TILE_WITH_FIRST_ELEMENT(cb_id_src);
+                    cb_push_back(cb_id_src, onetile);
 
-                for (uint32_t t = start_t; t < HtWt && num_tiles_written < dst_num_tiles; ++t, ++num_tiles_written) {
-                    // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
-                    cb_wait_front(cb_id_dst, onetile);
-                    uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
-                    noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
-                    noc_async_write_barrier();
-                    cb_pop_front(cb_id_dst, onetile);
+                    for (uint32_t t = start_t; t < HtWt && num_tiles_written < dst_num_tiles;
+                         ++t, ++num_tiles_written) {
+                        // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                        cb_wait_front(cb_id_dst, onetile);
+                        uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
+                        noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                        noc_async_write_barrier();
+                        cb_pop_front(cb_id_dst, onetile);
+                    }
+                    tile_offset += c_stride;
                 }
-                tile_offset += c_stride;
+                tile_offset += next_n_shift;
             }
-            tile_offset += next_batch_shift;
+            tile_offset += next_d_shift;
         }
-        tile_offset += next_depth_shift;
+        tile_offset += next_nd_shift;
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp
@@ -14,18 +14,21 @@ void kernel_main() {
     const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
     const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
     const uint32_t nD_stride = get_arg_val<uint32_t>(5);
-    const uint32_t n_stride = get_arg_val<uint32_t>(6);
-    const uint32_t c_stride = get_arg_val<uint32_t>(7);
-    const uint32_t N = get_arg_val<uint32_t>(8);
-    const uint32_t C = get_arg_val<uint32_t>(9);
-    const uint32_t Ht = get_arg_val<uint32_t>(10);
-    const uint32_t Wt = get_arg_val<uint32_t>(11);
-    const uint32_t cND = get_arg_val<uint32_t>(12);  // collapsed dims > 4
-    const uint32_t src_addr_b = get_arg_val<uint32_t>(13);
-    const uint32_t nD_stride_b = get_arg_val<uint32_t>(14);
-    const uint32_t n_stride_b = get_arg_val<uint32_t>(15);
-    const uint32_t c_stride_b = get_arg_val<uint32_t>(16);
-    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(17);
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(15);
+    const uint32_t nD_stride_b = get_arg_val<uint32_t>(16);
+    const uint32_t d_stride_b = get_arg_val<uint32_t>(17);
+    const uint32_t n_stride_b = get_arg_val<uint32_t>(18);
+    const uint32_t c_stride_b = get_arg_val<uint32_t>(19);
+    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(20);
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
@@ -47,125 +50,138 @@ void kernel_main() {
     constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
     const uint32_t HtWt = Ht * Wt;
 
-    const uint32_t tiles_per_depth = N * C * HtWt;
-    uint32_t start_d = start_tile_id / tiles_per_depth;  // ND index
-    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
-    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
-    uint32_t tiles_per_channel = HtWt;
-    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
-    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
-    uint32_t start_th = start_t / Wt;                          // H index
-    uint32_t start_tw = start_t % Wt;                          // W index
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
     uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride;
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
 #if !SRC_BCAST
     tile_offset += start_th * Wt;
 #endif
-    uint32_t next_channel_shift = c_stride - HtWt;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
-    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
 
-    uint32_t tile_offset_b = start_d * nD_stride_b + start_n * n_stride_b + start_c * c_stride_b;
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b;
 #if !SRC_BCAST_B
     tile_offset_b += start_th * Wt;
 #endif
-    uint32_t next_channel_shift_b = c_stride_b - HtWt;
-    uint32_t next_batch_shift_b = n_stride_b - c_stride_b * C;
-    uint32_t next_depth_shift_b = nD_stride_b - (n_stride_b * N);
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
 
     uint32_t num_tiles_read = 0;
-    for (uint32_t nd = start_d; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_n = 0) {
-        for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
-            for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
-                for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
 #if SRC_BCAST
-                    cb_reserve_back(cb_id_src, onetile);
-#if !SRC_SHARDED
-                    uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-                    noc_async_read_tile(tile_offset + th, src, l1_write_addr_src);
-                    noc_async_read_barrier();
-#endif
-                    FILL_TILE_WITH_FIRST_COLUMN(cb_id_src);
-                    cb_push_back(cb_id_src, onetile);
-#endif
-#if SRC_BCAST_B
-                    cb_reserve_back(cb_id_src_b, onetile);
-#if !SRC_SHARDED_B
-                    uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
-                    noc_async_read_tile(tile_offset_b + th, src_b, l1_write_addr_src_b);
-                    noc_async_read_barrier();
-#endif
-                    FILL_TILE_WITH_FIRST_COLUMN_B(cb_id_src_b);
-                    cb_push_back(cb_id_src_b, onetile);
-#endif
-                    for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
-                         ++tw, ++num_tiles_read) {
-#if !SRC_BCAST
                         cb_reserve_back(cb_id_src, onetile);
 #if !SRC_SHARDED
-                        uint32_t l1_write_addr = get_write_ptr(cb_id_src);
-                        noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
+                        uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                        noc_async_read_tile(tile_offset + th, src, l1_write_addr_src);
                         noc_async_read_barrier();
 #endif
+                        FILL_TILE_WITH_FIRST_COLUMN(cb_id_src);
                         cb_push_back(cb_id_src, onetile);
 #endif
-#if !SRC_BCAST_B
+#if SRC_BCAST_B
                         cb_reserve_back(cb_id_src_b, onetile);
 #if !SRC_SHARDED_B
-                        uint32_t l1_write_addr_b = get_write_ptr(cb_id_src_b);
-                        noc_async_read_tile(tile_offset_b + tw, src_b, l1_write_addr_b);
+                        uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+                        noc_async_read_tile(tile_offset_b + th, src_b, l1_write_addr_src_b);
                         noc_async_read_barrier();
 #endif
-#if !SRC_SHARDED_B
+                        FILL_TILE_WITH_FIRST_COLUMN_B(cb_id_src_b);
                         cb_push_back(cb_id_src_b, onetile);
 #endif
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+#if !SRC_BCAST
+                            cb_reserve_back(cb_id_src, onetile);
+#if !SRC_SHARDED
+                            uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+                            noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
+                            noc_async_read_barrier();
 #endif
-                    }
-                    if constexpr (!has_sharding) {
-                        // next row of tiles should start at the first column
-                        start_tw = 0;
-                    }
+                            cb_push_back(cb_id_src, onetile);
+#endif
+#if !SRC_BCAST_B
+                            cb_reserve_back(cb_id_src_b, onetile);
+#if !SRC_SHARDED_B
+                            uint32_t l1_write_addr_b = get_write_ptr(cb_id_src_b);
+                            noc_async_read_tile(tile_offset_b + tw, src_b, l1_write_addr_b);
+                            noc_async_read_barrier();
+#endif
+#if !SRC_SHARDED_B
+                            cb_push_back(cb_id_src_b, onetile);
+#endif
+#endif
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
 #if !SRC_BCAST && !SRC_SHARDED
-                    tile_offset += Wt;
+                        tile_offset += Wt;
 #endif
 #if !SRC_BCAST_B && !SRC_SHARDED_B
-                    tile_offset_b += Wt;
+                        tile_offset_b += Wt;
+#endif
+                    }
+#if !SRC_SHARDED
+#if SRC_BCAST
+                    // same as following logically
+                    // tile_offset += HtWt;
+                    // tile_offset += next_c_shift;
+                    tile_offset += c_stride;
+#else
+                    tile_offset += next_c_shift;
+#endif
+#endif
+#if !SRC_SHARDED_B
+#if SRC_BCAST_B
+                    tile_offset_b += c_stride_b;
+#else
+                    tile_offset_b += next_c_shift_b;
+#endif
 #endif
                 }
 #if !SRC_SHARDED
-#if SRC_BCAST
-                // same as following logically
-                // tile_offset += HtWt;
-                // tile_offset += next_channel_shift;
-                tile_offset += c_stride;
-#else
-                tile_offset += next_channel_shift;
-#endif
+                tile_offset += next_n_shift;
 #endif
 #if !SRC_SHARDED_B
-#if SRC_BCAST_B
-                tile_offset_b += c_stride_b;
-#else
-                tile_offset_b += next_channel_shift_b;
-#endif
+                tile_offset_b += next_n_shift_b;
 #endif
             }
 #if !SRC_SHARDED
-            tile_offset += next_batch_shift;
+            tile_offset += next_d_shift;
 #endif
 #if !SRC_SHARDED_B
-            tile_offset_b += next_batch_shift_b;
+            tile_offset_b += next_d_shift_b;
 #endif
         }
 #if !SRC_SHARDED
-        tile_offset += next_depth_shift;
+        tile_offset += next_nd_shift;
 #endif
 #if !SRC_SHARDED_B
-        tile_offset_b += next_depth_shift_b;
+        tile_offset_b += next_nd_shift_b;
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast.cpp
@@ -13,18 +13,21 @@ void kernel_main() {
     const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
     const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
     const uint32_t nD_stride = get_arg_val<uint32_t>(5);
-    const uint32_t n_stride = get_arg_val<uint32_t>(6);
-    const uint32_t c_stride = get_arg_val<uint32_t>(7);
-    const uint32_t N = get_arg_val<uint32_t>(8);
-    const uint32_t C = get_arg_val<uint32_t>(9);
-    const uint32_t Ht = get_arg_val<uint32_t>(10);
-    const uint32_t Wt = get_arg_val<uint32_t>(11);
-    const uint32_t cND = get_arg_val<uint32_t>(12);  // collapsed dims > 4
-    const uint32_t src_addr_b = get_arg_val<uint32_t>(13);
-    const uint32_t nD_stride_b = get_arg_val<uint32_t>(14);
-    const uint32_t n_stride_b = get_arg_val<uint32_t>(15);
-    const uint32_t c_stride_b = get_arg_val<uint32_t>(16);
-    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(17);
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(15);
+    const uint32_t nD_stride_b = get_arg_val<uint32_t>(16);
+    const uint32_t d_stride_b = get_arg_val<uint32_t>(17);
+    const uint32_t n_stride_b = get_arg_val<uint32_t>(18);
+    const uint32_t c_stride_b = get_arg_val<uint32_t>(19);
+    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(20);
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
@@ -55,75 +58,83 @@ void kernel_main() {
     constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
     const uint32_t HtWt = Ht * Wt;
 
-    const uint32_t tiles_per_depth = N * C * HtWt;
-    uint32_t start_d = start_tile_id / tiles_per_depth;  // ND index
-    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
-    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
-    uint32_t tiles_per_channel = HtWt;
-    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
-    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
-    uint32_t start_th = start_t / Wt;                          // H index
-    uint32_t start_tw = start_t % Wt;                          // W index
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
     uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride;
-    tile_offset += start_th * Wt;
-    uint32_t next_channel_shift = c_stride - HtWt;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
-    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+    uint32_t tile_offset =
+        start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride + start_th * Wt;
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
 
-    uint32_t tile_offset_b = start_d * nD_stride_b + start_n * n_stride_b + start_c * c_stride_b;
-    tile_offset_b += start_th * Wt;
-    uint32_t next_channel_shift_b = c_stride_b - HtWt;
-    uint32_t next_batch_shift_b = n_stride_b - c_stride_b * C;
-    uint32_t next_depth_shift_b = nD_stride_b - (n_stride_b * N);
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b + start_th * Wt;
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
 
     uint32_t num_tiles_read = 0;
-    for (uint32_t nd = start_d; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_n = 0) {
-        for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
-            for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
-                for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
-                    for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
-                         ++tw, ++num_tiles_read) {
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
 #if !SRC_SHARDED
-                        cb_reserve_back(cb_id_src, onetile);
-                        uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-                        noc_async_read_tile(tile_offset + tw, src, l1_write_addr_src);
+                            cb_reserve_back(cb_id_src, onetile);
+                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            noc_async_read_tile(tile_offset + tw, src, l1_write_addr_src);
 #endif
 #if !SRC_SHARDED_B
-                        // read a tile from src_b
-                        cb_reserve_back(cb_id_src_b, onetile);
-                        uint32_t l1_write_addr_b = get_write_ptr(cb_id_src_b);
-                        noc_async_read_tile(tile_offset_b + tw, src_b, l1_write_addr_b);
+                            // read a tile from src_b
+                            cb_reserve_back(cb_id_src_b, onetile);
+                            uint32_t l1_write_addr_b = get_write_ptr(cb_id_src_b);
+                            noc_async_read_tile(tile_offset_b + tw, src_b, l1_write_addr_b);
 #endif
 #if !SRC_SHARDED || !SRC_SHARDED_B
-                        noc_async_read_barrier();
+                            noc_async_read_barrier();
 #endif
 #if !SRC_SHARDED
-                        cb_push_back(cb_id_src, onetile);
+                            cb_push_back(cb_id_src, onetile);
 #endif
 #if !SRC_SHARDED_B
-                        cb_push_back(cb_id_src_b, onetile);
+                            cb_push_back(cb_id_src_b, onetile);
 #endif
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+                        tile_offset += Wt;
+                        tile_offset_b += Wt;
                     }
-                    if constexpr (!has_sharding) {
-                        // next row of tiles should start at the first column
-                        start_tw = 0;
-                    }
-                    tile_offset += Wt;
-                    tile_offset_b += Wt;
+                    tile_offset += next_c_shift;
+                    tile_offset_b += next_c_shift_b;
                 }
-                tile_offset += next_channel_shift;
-                tile_offset_b += next_channel_shift_b;
+                tile_offset += next_n_shift;
+                tile_offset_b += next_n_shift_b;
             }
-            tile_offset += next_batch_shift;
-            tile_offset_b += next_batch_shift_b;
+            tile_offset += next_d_shift;
+            tile_offset_b += next_d_shift_b;
         }
-        tile_offset += next_depth_shift;
-        tile_offset_b += next_depth_shift_b;
+        tile_offset += next_nd_shift;
+        tile_offset_b += next_nd_shift_b;
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp
@@ -14,18 +14,21 @@ void kernel_main() {
     const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
     const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
     const uint32_t nD_stride = get_arg_val<uint32_t>(5);
-    const uint32_t n_stride = get_arg_val<uint32_t>(6);
-    const uint32_t c_stride = get_arg_val<uint32_t>(7);
-    const uint32_t N = get_arg_val<uint32_t>(8);
-    const uint32_t C = get_arg_val<uint32_t>(9);
-    const uint32_t Ht = get_arg_val<uint32_t>(10);
-    const uint32_t Wt = get_arg_val<uint32_t>(11);
-    const uint32_t cND = get_arg_val<uint32_t>(12);  // collapsed dims > 4
-    const uint32_t src_addr_b = get_arg_val<uint32_t>(13);
-    const uint32_t nD_stride_b = get_arg_val<uint32_t>(14);
-    const uint32_t n_stride_b = get_arg_val<uint32_t>(15);
-    const uint32_t c_stride_b = get_arg_val<uint32_t>(16);
-    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(17);
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(15);
+    const uint32_t nD_stride_b = get_arg_val<uint32_t>(16);
+    const uint32_t d_stride_b = get_arg_val<uint32_t>(17);
+    const uint32_t n_stride_b = get_arg_val<uint32_t>(18);
+    const uint32_t c_stride_b = get_arg_val<uint32_t>(19);
+    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(20);
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
@@ -54,100 +57,109 @@ void kernel_main() {
     constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
     const uint32_t HtWt = Ht * Wt;
 
-    const uint32_t tiles_per_depth = N * C * HtWt;
-    uint32_t start_d = start_tile_id / tiles_per_depth;  // ND index
-    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
-    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
-    uint32_t tiles_per_channel = HtWt;
-    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
-    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
-    uint32_t start_th = start_t / Wt;                          // H index
-    uint32_t start_tw = start_t % Wt;                          // W index
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
     uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride;
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
 #if !SRC_BCAST
     tile_offset += start_th * Wt;
 #endif
-    uint32_t next_channel_shift = c_stride - HtWt;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
-    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
 
-    uint32_t tile_offset_b = start_d * nD_stride_b + start_n * n_stride_b + start_c * c_stride_b;
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b;
 #if !SRC_BCAST_B
     tile_offset_b += start_th * Wt;
 #endif
-    uint32_t next_channel_shift_b = c_stride_b - HtWt;
-    uint32_t next_batch_shift_b = n_stride_b - c_stride_b * C;
-    uint32_t next_depth_shift_b = nD_stride_b - (n_stride_b * N);
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
 
     uint32_t num_tiles_read = 0;
-    for (uint32_t nd = start_d; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_n = 0) {
-        for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
-            for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
-                for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
-                    for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
-                         ++tw, ++num_tiles_read) {
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
 #if !SRC_SHARDED
-                        cb_reserve_back(cb_id_src, onetile);
-                        uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-                        noc_async_read_tile(tile_offset + tw, src, l1_write_addr_src);
+                            cb_reserve_back(cb_id_src, onetile);
+                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            noc_async_read_tile(tile_offset + tw, src, l1_write_addr_src);
 #endif
 #if !SRC_SHARDED_B
-                        // read a tile from src_b
-                        cb_reserve_back(cb_id_src_b, onetile);
-                        uint32_t l1_write_addr_b = get_write_ptr(cb_id_src_b);
-                        noc_async_read_tile(tile_offset_b + tw, src_b, l1_write_addr_b);
+                            // read a tile from src_b
+                            cb_reserve_back(cb_id_src_b, onetile);
+                            uint32_t l1_write_addr_b = get_write_ptr(cb_id_src_b);
+                            noc_async_read_tile(tile_offset_b + tw, src_b, l1_write_addr_b);
 #endif
 #if !SRC_SHARDED || !SRC_SHARDED_B
-                        noc_async_read_barrier();
+                            noc_async_read_barrier();
 #endif
 #if SRC_BCAST  // no sharding support for row bcast yet
-                        FILL_TILE_WITH_FIRST_ROW(cb_id_src);
+                            FILL_TILE_WITH_FIRST_ROW(cb_id_src);
 #endif
 #if SRC_BCAST_B  // no sharding support for row bcast yet
-                        FILL_TILE_WITH_FIRST_ROW_B(cb_id_src_b);
+                            FILL_TILE_WITH_FIRST_ROW_B(cb_id_src_b);
 #endif
 #if !SRC_SHARDED
-                        cb_push_back(cb_id_src, onetile);
+                            cb_push_back(cb_id_src, onetile);
 #endif
 #if !SRC_SHARDED_B
-                        cb_push_back(cb_id_src_b, onetile);
+                            cb_push_back(cb_id_src_b, onetile);
 #endif
-                    }
-                    if constexpr (!has_sharding) {
-                        // next row of tiles should start at the first column
-                        start_tw = 0;
-                    }
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
 #if !SRC_BCAST
-                    tile_offset += Wt;
+                        tile_offset += Wt;
 #endif
 #if !SRC_BCAST_B
-                    tile_offset_b += Wt;
+                        tile_offset_b += Wt;
 #endif
-                }
+                    }
 #if SRC_BCAST
-                // same as following logically
-                // tile_offset += HtWt;
-                // tile_offset += next_channel_shift;
-                tile_offset += c_stride;
+                    // same as following logically
+                    // tile_offset += HtWt;
+                    // tile_offset += next_c_shift;
+                    tile_offset += c_stride;
 #else
-                tile_offset += next_channel_shift;
+                    tile_offset += next_c_shift;
 #endif
 #if SRC_BCAST_B
-                tile_offset_b += c_stride_b;
+                    tile_offset_b += c_stride_b;
 #else
-                tile_offset_b += next_channel_shift_b;
+                    tile_offset_b += next_c_shift_b;
 #endif
+                }
+                tile_offset += next_n_shift;
+                tile_offset_b += next_n_shift_b;
             }
-            tile_offset += next_batch_shift;
-            tile_offset_b += next_batch_shift_b;
+            tile_offset += next_d_shift;
+            tile_offset_b += next_d_shift_b;
         }
-        tile_offset += next_depth_shift;
-        tile_offset_b += next_depth_shift_b;
+        tile_offset += next_nd_shift;
+        tile_offset_b += next_nd_shift_b;
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp
@@ -14,18 +14,21 @@ void kernel_main() {
     const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
     const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
     const uint32_t nD_stride = get_arg_val<uint32_t>(5);
-    const uint32_t n_stride = get_arg_val<uint32_t>(6);
-    const uint32_t c_stride = get_arg_val<uint32_t>(7);
-    const uint32_t N = get_arg_val<uint32_t>(8);
-    const uint32_t C = get_arg_val<uint32_t>(9);
-    const uint32_t Ht = get_arg_val<uint32_t>(10);
-    const uint32_t Wt = get_arg_val<uint32_t>(11);
-    const uint32_t cND = get_arg_val<uint32_t>(12);  // collapsed dims > 4
-    const uint32_t src_addr_b = get_arg_val<uint32_t>(13);
-    const uint32_t nD_stride_b = get_arg_val<uint32_t>(14);
-    const uint32_t n_stride_b = get_arg_val<uint32_t>(15);
-    const uint32_t c_stride_b = get_arg_val<uint32_t>(16);
-    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(17);
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(15);
+    const uint32_t nD_stride_b = get_arg_val<uint32_t>(16);
+    const uint32_t d_stride_b = get_arg_val<uint32_t>(17);
+    const uint32_t n_stride_b = get_arg_val<uint32_t>(18);
+    const uint32_t c_stride_b = get_arg_val<uint32_t>(19);
+    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(20);
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
@@ -47,111 +50,124 @@ void kernel_main() {
     constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
     const uint32_t HtWt = Ht * Wt;
 
-    const uint32_t tiles_per_depth = N * C * HtWt;
-    uint32_t start_d = start_tile_id / tiles_per_depth;  // ND index
-    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
-    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
-    uint32_t tiles_per_channel = HtWt;
-    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
-    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
-    uint32_t start_th = start_t / Wt;                          // H index
-    uint32_t start_tw = start_t % Wt;                          // W index
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
     uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride;
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
 
-    uint32_t next_channel_shift = c_stride - HtWt;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
-    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
 
-    uint32_t tile_offset_b = start_d * nD_stride_b + start_n * n_stride_b + start_c * c_stride_b;
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b;
 
-    uint32_t next_channel_shift_b = c_stride_b - HtWt;
-    uint32_t next_batch_shift_b = n_stride_b - c_stride_b * C;
-    uint32_t next_depth_shift_b = nD_stride_b - (n_stride_b * N);
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
 
     uint32_t num_tiles_read = 0;
-    for (uint32_t nd = start_d; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_n = 0) {
-        for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
-            for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
-                for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
 #if SRC_BCAST_COL
-                    cb_reserve_back(cb_id_src, onetile);
+                        cb_reserve_back(cb_id_src, onetile);
 #if !SRC_SHARDED
-                    uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-                    noc_async_read_tile(tile_offset + th, src, l1_write_addr_src);
-                    noc_async_read_barrier();
+                        uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                        noc_async_read_tile(tile_offset + th, src, l1_write_addr_src);
+                        noc_async_read_barrier();
 #endif
-                    FILL_TILE_WITH_FIRST_COLUMN(cb_id_src);
-                    cb_push_back(cb_id_src, onetile);
+                        FILL_TILE_WITH_FIRST_COLUMN(cb_id_src);
+                        cb_push_back(cb_id_src, onetile);
 #else
-                    cb_reserve_back(cb_id_src_b, onetile);
-#if !SRC_SHARDED_B
-                    uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
-                    noc_async_read_tile(tile_offset_b + th, src_b, l1_write_addr_src_b);
-                    noc_async_read_barrier();
-#endif
-                    FILL_TILE_WITH_FIRST_COLUMN_B(cb_id_src_b);
-                    cb_push_back(cb_id_src_b, onetile);
-#endif
-                    for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
-                         ++tw, ++num_tiles_read) {
-#if SRC_BCAST_ROW_B
-                        // read a tile from src_b
                         cb_reserve_back(cb_id_src_b, onetile);
 #if !SRC_SHARDED_B
-                        uint32_t l1_write_addr_b = get_write_ptr(cb_id_src_b);
-                        noc_async_read_tile(tile_offset_b + tw, src_b, l1_write_addr_b);
+                        uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+                        noc_async_read_tile(tile_offset_b + th, src_b, l1_write_addr_src_b);
                         noc_async_read_barrier();
 #endif
-                        FILL_TILE_WITH_FIRST_ROW_B(cb_id_src_b);
-#if !SRC_SHARDED_B
+                        FILL_TILE_WITH_FIRST_COLUMN_B(cb_id_src_b);
                         cb_push_back(cb_id_src_b, onetile);
 #endif
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+#if SRC_BCAST_ROW_B
+                            // read a tile from src_b
+                            cb_reserve_back(cb_id_src_b, onetile);
+#if !SRC_SHARDED_B
+                            uint32_t l1_write_addr_b = get_write_ptr(cb_id_src_b);
+                            noc_async_read_tile(tile_offset_b + tw, src_b, l1_write_addr_b);
+                            noc_async_read_barrier();
+#endif
+                            FILL_TILE_WITH_FIRST_ROW_B(cb_id_src_b);
+#if !SRC_SHARDED_B
+                            cb_push_back(cb_id_src_b, onetile);
+#endif
 #else
-                        // read a tile from src
-                        cb_reserve_back(cb_id_src, onetile);
+                            // read a tile from src
+                            cb_reserve_back(cb_id_src, onetile);
 #if !SRC_SHARDED_B
-                        uint32_t l1_write_addr = get_write_ptr(cb_id_src);
-                        noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
-                        noc_async_read_barrier();
+                            uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+                            noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
+                            noc_async_read_barrier();
 #endif
-                        FILL_TILE_WITH_FIRST_ROW(cb_id_src);
+                            FILL_TILE_WITH_FIRST_ROW(cb_id_src);
 #if !SRC_SHARDED_B
-                        cb_push_back(cb_id_src, onetile);
+                            cb_push_back(cb_id_src, onetile);
 #endif
 #endif
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
                     }
-                    if constexpr (!has_sharding) {
-                        // next row of tiles should start at the first column
-                        start_tw = 0;
-                    }
+#if !SRC_SHARDED
+                    // same as following logically
+                    // tile_offset += HtWt;
+                    // tile_offset += next_c_shift;
+                    tile_offset += c_stride;
+#endif
+#if !SRC_SHARDED_B
+                    tile_offset_b += c_stride_b;
+#endif
                 }
 #if !SRC_SHARDED
-                // same as following logically
-                // tile_offset += HtWt;
-                // tile_offset += next_channel_shift;
-                tile_offset += c_stride;
+                tile_offset += next_n_shift;
 #endif
 #if !SRC_SHARDED_B
-                tile_offset_b += c_stride_b;
+                tile_offset_b += next_n_shift_b;
 #endif
             }
 #if !SRC_SHARDED
-            tile_offset += next_batch_shift;
+            tile_offset += next_d_shift;
 #endif
 #if !SRC_SHARDED_B
-            tile_offset_b += next_batch_shift_b;
+            tile_offset_b += next_d_shift_b;
 #endif
         }
 #if !SRC_SHARDED
-        tile_offset += next_depth_shift;
+        tile_offset += next_nd_shift;
 #endif
 #if !SRC_SHARDED_B
-        tile_offset_b += next_depth_shift_b;
+        tile_offset_b += next_nd_shift_b;
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp
@@ -14,18 +14,21 @@ void kernel_main() {
     const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
     const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
     const uint32_t nD_stride = get_arg_val<uint32_t>(5);
-    const uint32_t n_stride = get_arg_val<uint32_t>(6);
-    const uint32_t c_stride = get_arg_val<uint32_t>(7);
-    const uint32_t N = get_arg_val<uint32_t>(8);
-    const uint32_t C = get_arg_val<uint32_t>(9);
-    const uint32_t Ht = get_arg_val<uint32_t>(10);
-    const uint32_t Wt = get_arg_val<uint32_t>(11);
-    const uint32_t cND = get_arg_val<uint32_t>(12);  // collapsed dims > 4
-    const uint32_t src_addr_b = get_arg_val<uint32_t>(13);
-    const uint32_t nD_stride_b = get_arg_val<uint32_t>(14);
-    const uint32_t n_stride_b = get_arg_val<uint32_t>(15);
-    const uint32_t c_stride_b = get_arg_val<uint32_t>(16);
-    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(17);
+    const uint32_t d_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t D = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg_val<uint32_t>(10);
+    const uint32_t C = get_arg_val<uint32_t>(11);
+    const uint32_t Ht = get_arg_val<uint32_t>(12);
+    const uint32_t Wt = get_arg_val<uint32_t>(13);
+    const uint32_t cND = get_arg_val<uint32_t>(14);  // collapsed dims > 5
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(15);
+    const uint32_t nD_stride_b = get_arg_val<uint32_t>(16);
+    const uint32_t d_stride_b = get_arg_val<uint32_t>(17);
+    const uint32_t n_stride_b = get_arg_val<uint32_t>(18);
+    const uint32_t c_stride_b = get_arg_val<uint32_t>(19);
+    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(20);
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
@@ -47,125 +50,138 @@ void kernel_main() {
     constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
     const uint32_t HtWt = Ht * Wt;
 
-    const uint32_t tiles_per_depth = N * C * HtWt;
-    uint32_t start_d = start_tile_id / tiles_per_depth;  // ND index
-    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
-    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
-    uint32_t tiles_per_channel = HtWt;
-    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
-    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
-    uint32_t start_th = start_t / Wt;                          // H index
-    uint32_t start_tw = start_t % Wt;                          // W index
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
     uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride;
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
 #if !SRC_BCAST
     tile_offset += start_th * Wt;
 #endif
-    uint32_t next_channel_shift = c_stride - HtWt;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
-    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
 
-    uint32_t tile_offset_b = start_d * nD_stride_b + start_n * n_stride_b + start_c * c_stride_b;
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b;
 #if !SRC_BCAST_B
     tile_offset_b += start_th * Wt;
 #endif
-    uint32_t next_channel_shift_b = c_stride_b - HtWt;
-    uint32_t next_batch_shift_b = n_stride_b - c_stride_b * C;
-    uint32_t next_depth_shift_b = nD_stride_b - (n_stride_b * N);
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
 
     uint32_t num_tiles_read = 0;
-    for (uint32_t nd = start_d; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_n = 0) {
-        for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
-            for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
 #if SRC_BCAST
-                cb_reserve_back(cb_id_src, onetile);
+                    cb_reserve_back(cb_id_src, onetile);
 #if !SRC_SHARDED
-                uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-                noc_async_read_tile(tile_offset, src, l1_write_addr_src);
-                noc_async_read_barrier();
+                    uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                    noc_async_read_tile(tile_offset, src, l1_write_addr_src);
+                    noc_async_read_barrier();
 #endif
-                FILL_TILE_WITH_FIRST_ELEMENT(cb_id_src);
-                cb_push_back(cb_id_src, onetile);
+                    FILL_TILE_WITH_FIRST_ELEMENT(cb_id_src);
+                    cb_push_back(cb_id_src, onetile);
 #endif
 #if SRC_BCAST_B
-                cb_reserve_back(cb_id_src_b, onetile);
+                    cb_reserve_back(cb_id_src_b, onetile);
 #if !SRC_SHARDED_B
-                uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
-                noc_async_read_tile(tile_offset_b, src_b, l1_write_addr_src_b);
-                noc_async_read_barrier();
+                    uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+                    noc_async_read_tile(tile_offset_b, src_b, l1_write_addr_src_b);
+                    noc_async_read_barrier();
 #endif
-                FILL_TILE_WITH_FIRST_ELEMENT_B(cb_id_src_b);
-                cb_push_back(cb_id_src_b, onetile);
+                    FILL_TILE_WITH_FIRST_ELEMENT_B(cb_id_src_b);
+                    cb_push_back(cb_id_src_b, onetile);
 #endif
-                for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
-                    for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
-                         ++tw, ++num_tiles_read) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
 #if !SRC_BCAST
-                        cb_reserve_back(cb_id_src, onetile);
+                            cb_reserve_back(cb_id_src, onetile);
 #if !SRC_SHARDED
-                        uint32_t l1_write_addr = get_write_ptr(cb_id_src);
-                        noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
-                        noc_async_read_barrier();
+                            uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+                            noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
+                            noc_async_read_barrier();
 #endif
-                        cb_push_back(cb_id_src, onetile);
+                            cb_push_back(cb_id_src, onetile);
 #endif
 #if !SRC_BCAST_B
-                        cb_reserve_back(cb_id_src_b, onetile);
+                            cb_reserve_back(cb_id_src_b, onetile);
 #if !SRC_SHARDED_B
-                        uint32_t l1_write_addr_b = get_write_ptr(cb_id_src_b);
-                        noc_async_read_tile(tile_offset_b + tw, src_b, l1_write_addr_b);
-                        noc_async_read_barrier();
+                            uint32_t l1_write_addr_b = get_write_ptr(cb_id_src_b);
+                            noc_async_read_tile(tile_offset_b + tw, src_b, l1_write_addr_b);
+                            noc_async_read_barrier();
 #endif
 #if !SRC_SHARDED_B
-                        cb_push_back(cb_id_src_b, onetile);
+                            cb_push_back(cb_id_src_b, onetile);
 #endif
 #endif
-                    }
-                    if constexpr (!has_sharding) {
-                        // next row of tiles should start at the first column
-                        start_tw = 0;
-                    }
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
 #if !SRC_BCAST && !SRC_SHARDED
-                    tile_offset += Wt;
+                        tile_offset += Wt;
 #endif
 #if !SRC_BCAST_B && !SRC_SHARDED_B
-                    tile_offset_b += Wt;
+                        tile_offset_b += Wt;
+#endif
+                    }
+#if !SRC_SHARDED
+#if SRC_BCAST
+                    // same as following logically
+                    // tile_offset += HtWt;
+                    // tile_offset += next_c_shift;
+                    tile_offset += c_stride;
+#else
+                    tile_offset += next_c_shift;
+#endif
+#endif
+#if !SRC_SHARDED_B
+#if SRC_BCAST_B
+                    tile_offset_b += c_stride_b;
+#else
+                    tile_offset_b += next_c_shift_b;
+#endif
 #endif
                 }
 #if !SRC_SHARDED
-#if SRC_BCAST
-                // same as following logically
-                // tile_offset += HtWt;
-                // tile_offset += next_channel_shift;
-                tile_offset += c_stride;
-#else
-                tile_offset += next_channel_shift;
-#endif
+                tile_offset += next_n_shift;
 #endif
 #if !SRC_SHARDED_B
-#if SRC_BCAST_B
-                tile_offset_b += c_stride_b;
-#else
-                tile_offset_b += next_channel_shift_b;
-#endif
+                tile_offset_b += next_n_shift_b;
 #endif
             }
 #if !SRC_SHARDED
-            tile_offset += next_batch_shift;
+            tile_offset += next_d_shift;
 #endif
 #if !SRC_SHARDED_B
-            tile_offset_b += next_batch_shift_b;
+            tile_offset_b += next_d_shift_b;
 #endif
         }
 #if !SRC_SHARDED
-        tile_offset += next_depth_shift;
+        tile_offset += next_nd_shift;
 #endif
 #if !SRC_SHARDED_B
-        tile_offset_b += next_depth_shift_b;
+        tile_offset_b += next_nd_shift_b;
 #endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast.cpp
@@ -14,13 +14,15 @@ void kernel_main() {
     const uint32_t dst_num_tiles = get_arg_val<uint32_t>(4);
     const uint32_t dst_shard_width = get_arg_val<uint32_t>(5);
     const uint32_t nD_stride = get_arg_val<uint32_t>(6);
-    const uint32_t n_stride = get_arg_val<uint32_t>(7);
-    const uint32_t c_stride = get_arg_val<uint32_t>(8);
-    const uint32_t N = get_arg_val<uint32_t>(9);
-    const uint32_t C = get_arg_val<uint32_t>(10);
-    const uint32_t Ht = get_arg_val<uint32_t>(11);
-    const uint32_t Wt = get_arg_val<uint32_t>(12);
-    const uint32_t cND = get_arg_val<uint32_t>(13);  // collapsed dims > 4
+    const uint32_t d_stride = get_arg_val<uint32_t>(7);
+    const uint32_t n_stride = get_arg_val<uint32_t>(8);
+    const uint32_t c_stride = get_arg_val<uint32_t>(9);
+    const uint32_t D = get_arg_val<uint32_t>(10);
+    const uint32_t N = get_arg_val<uint32_t>(11);
+    const uint32_t C = get_arg_val<uint32_t>(12);
+    const uint32_t Ht = get_arg_val<uint32_t>(13);
+    const uint32_t Wt = get_arg_val<uint32_t>(14);
+    const uint32_t cND = get_arg_val<uint32_t>(15);  // collapsed dims > 5
 
     constexpr uint32_t onetile = 1;
 
@@ -38,43 +40,47 @@ void kernel_main() {
     constexpr bool has_sharding = get_compile_time_arg_val(2) == 1;
     const uint32_t HtWt = Ht * Wt;
 
-    const uint32_t tiles_per_depth = N * C * HtWt;
-    uint32_t start_d = start_tile_id / tiles_per_depth;  // collapsed ND index
-    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
-    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
-    uint32_t tiles_per_channel = HtWt;
-    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
-    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
-    uint32_t start_th = start_t / Wt;                          // H index
-    uint32_t start_tw = start_t % Wt;                          // W index
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
     uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
 
     uint32_t num_tiles_written = 0;
     uint32_t dst_tile_offset = start_tile_id;
 
-    for (uint32_t nd = start_d; nd < cND && num_tiles_written < dst_num_tiles; ++nd, start_n = 0) {
-        for (uint32_t n = start_n; n < N && num_tiles_written < dst_num_tiles; ++n, start_c = 0) {
-            for (uint32_t c = start_c; c < C && num_tiles_written < dst_num_tiles; ++c, start_th = 0) {
-                for (uint32_t th = start_th; th < Ht && num_tiles_written < dst_num_tiles; ++th) {
-                    for (uint32_t tw = start_tw; tw < end_tw && num_tiles_written < dst_num_tiles;
-                         ++tw, ++num_tiles_written) {
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_written < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_written < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_written < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_written < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_written < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_written < dst_num_tiles;
+                             ++tw, ++num_tiles_written) {
 #if !DST_SHARDED
-                        //  write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
-                        cb_wait_front(cb_id_dst, onetile);
-                        uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
-                        noc_async_write_tile(dst_tile_offset + num_tiles_written, dst, l1_read_addr);
-                        noc_async_write_barrier();
-                        cb_pop_front(cb_id_dst, onetile);
+                            //  write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                            cb_wait_front(cb_id_dst, onetile);
+                            uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
+                            noc_async_write_tile(dst_tile_offset + num_tiles_written, dst, l1_read_addr);
+                            noc_async_write_barrier();
+                            cb_pop_front(cb_id_dst, onetile);
 #endif
-                    }
-                    if constexpr (has_sharding) {
-                        // adjust the output tile offset since we had to skip parts of the row
-                        dst_tile_offset += (Wt - dst_shard_width);
-                    } else {
-                        // otherwise, next row of tiles should start at the first column
-                        start_tw = 0;
+                        }
+                        if constexpr (has_sharding) {
+                            // adjust the output tile offset since we had to skip parts of the row
+                            dst_tile_offset += (Wt - dst_shard_width);
+                        } else {
+                            // otherwise, next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Ticket
#21967 

### Problem description
Broadcasting tensors on dim 5 is desired but not supported. Add support by extending runtime arguments to loop over 5th dim and only fold dims 6 and greater.

### What's changed
Three extra runtime args for reader, two extra runtime args for writer, and extra loop for reading tiles from input.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16126864186) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes