### PR TITLE
Fix pcc check to text demo

### DIFF
--- a/models/demos/llama3_subdevices/tt/generator.py
+++ b/models/demos/llama3_subdevices/tt/generator.py
@@ -485,7 +485,7 @@ class Generator:
         return trace_tok_rm
 
     def read_decode_output(self, tt_logits, unpadded_batch, is_tokens=True):
-        logits = self.model.process_output_decode(tt_logits, B=unpadded_batch, S=1)
+        logits = self.model.process_output_decode(tt_logits)
         return logits
 
     def chat_completion(

--- a/models/demos/llama3_subdevices/tt/llama_model.py
+++ b/models/demos/llama3_subdevices/tt/llama_model.py
@@ -448,7 +448,7 @@ class TtTransformer(LightweightModule):
         )
 
         # sampling
-        tt_logits = self.tt_sampling(tt_logits[0], tt_out_tok=x)
+        tt_toks = self.tt_sampling(tt_logits[0], tt_out_tok=x)
 
         # Save otuput logits to global python object
         if tt_out_logits_saved is not None:
@@ -469,7 +469,7 @@ class TtTransformer(LightweightModule):
             rot_mat_idxs,
             sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
         )
-        return tt_logits
+        return tt_toks
 
     def switch_mode(self, mode):
         if mode == "decode":


### PR DESCRIPTION
### Problem description
PCC check was failing at text demo in TG demo pipeline

### What's changed
Removed unused parameters in `process_output_decode()` and renamed output of sampling to be `tt_toks`, since there is name clash with output of forward pass, overwriting `tt_logits` to be the tokens when PCC check was expecting it to be logits

### Checklist
- TG demo run all passing [here](https://github.com/tenstorrent/tt-metal/actions/runs/15945824188)
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes