### PR TITLE
Fix device hang when opening from forked process

### DIFF
--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -41,6 +41,10 @@ public:
         return *_inst;
     }
 
+    // For fork safety handlers
+    static DevicePool* instance_ptr();
+    static void reset_instance();
+
     static void initialize(
         const std::vector<chip_id_t>& device_ids,
         uint8_t num_hw_cqs,


### PR DESCRIPTION
- Add pthread_atfork handlers to properly reset DevicePool state in child
- Clear singleton instance in child process to force reinitialization
- Register handlers on first DevicePool initialization

This ensures that forked processes can safely open devices without hanging due to inherited mutex and singleton state.


### Ticket
Fixes #16457 

### Problem description
Opening a device in a **forked process** (e.g. via Python `multiprocessing`) hangs indefinitely.  
Root cause: the child inherits the parent’s `DevicePool` singleton and stale mutexes, so the first device call deadlocks.

### What's changed
* **device_pool.cpp**
  * Added `pthread_atfork` pre-/post-fork handlers.
  * Child handler clears the singleton pointer and re-initialises the mutex.
  * Registered handlers during first `DevicePool::initialize()`.
  * Added `instance_ptr()` and `reset_instance()` helpers.
* **device_pool.hpp**
  * Declared the two helper methods.

Impact: children now safely call `ttnn.open_device()` without hanging.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] CLA / DCO check is green
- [ ] clang-format / pre-commit passes