### PR TITLE
Update circular buffer code comments

### DIFF
--- a/tt_metal/include/compute_kernel_api/cb_api.h
+++ b/tt_metal/include/compute_kernel_api/cb_api.h
@@ -57,10 +57,11 @@ ALWI void cb_wait_front(uint32_t cbid, uint32_t ntiles) { UNPACK((llk_wait_tiles
  * the CB
  *
  * Important note: This operation updates the read pointer of the CB, the CB pointer
- * can only be updated from one thread at a time. Example: if compute kernel has cb_pop_front(input_id, 1)
+ * can only be updated from one thread only. Example: if compute kernel has cb_pop_front(input_id, 1)
  * and writer kernel also has cb_pop_front(input_id, 1), these calls will produce non-deterministic behavior because
  * cb pointers are not synchronized across threads. Per circular buffer index, only have one thread pop tiles
- * to update the read pointer
+ * to update the read pointer. For specialized cases multiple circular buffers may point to same memory and
+ * the different buffers can be managed by separate threads.
  *
  * Return value: None
  *
@@ -108,10 +109,11 @@ ALWI void cb_reserve_back(uint32_t cbid, uint32_t ntiles) {
  * valid section of the CB
  *
  * Important note: This operation updates the write pointer of the CB, the CB pointer
- * can only be updated from one thread at a time. Example: if compute kernel has cb_push_back(output_id, 1)
+ * can only be updated from one thread only. Example: if compute kernel has cb_push_back(output_id, 1)
  * and reader kernel also has cb_push_back(output_id, 1), these calls will produce non-deterministic behavior because
  * cb pointers are not synchronized across threads. Per circular buffer index, only have one thread push tiles
- * to update the write pointer
+ * to update the write pointer. For specialized cases multiple circular buffers may point to same memory and
+ * the different buffers can be managed by separate threads.
  *
  * Return value: None
  *


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24343)

### Problem description
The comment specifying how a circular buffer should be used among threads was not clear and users encountered bugs by misunderstanding the usage. 

### What's changed
The comment related to circular buffer is a bit more elaborated. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes