### PR TITLE
#23287: Migrate tests from using `aggregate_as_tensor` to the official TT-NN sharing APIs

### DIFF
--- a/tech_reports/TT-Distributed/TTMeshMigrationGuide.md
+++ b/tech_reports/TT-Distributed/TTMeshMigrationGuide.md
@@ -1,5 +1,7 @@
 # TTNN Device to MeshDevice Migration Guide
 
+April 23, 2025
+
 # Introduction
 
 There is a major change being merged to TT-Metal & TTNN in relation to working with multiple devices. Currently, TTNN manages multi-device tensors and operations by creating a tensor on each of user exposed device and deploying the same OP on each device with a lot of non-trivial multi-threading and synchronization involved.

--- a/tests/nightly/t3000/ccl/test_all_to_all.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all.py
@@ -200,15 +200,20 @@ def run_all_to_all_impl(
 
     for i in range(num_iters if not reuse_inputs else 1):
         output_tensor = torch.rand(logical_shape).bfloat16()
-
         output_tensor_goldens_list.append(torch.chunk(output_tensor, num_devices, out_dim))
-        input_tensors = torch.chunk(output_tensor, num_devices, in_dim)
-        tt_input_tensors = []
-        for i, t in enumerate(input_tensors):
-            tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout))
-            logger.info(f"using device {mesh_device.get_device_ids()[i]}")
-
-        input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(mesh_device, input_mem_config)
+        input_tensor_mesh = ttnn.from_torch(
+            output_tensor,
+            device=mesh_device,
+            layout=layout,
+            dtype=input_dtype,
+            memory_config=input_mem_config,
+            mesh_mapper=ttnn.create_mesh_mapper(
+                mesh_device,
+                ttnn.MeshMapperConfig(
+                    [ttnn.PlacementReplicate(), ttnn.PlacementShard(in_dim)], ttnn.MeshShape(1, num_devices)
+                ),
+            ),
+        )
 
         input_tensor_mesh_list.append(input_tensor_mesh)
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/fabric_edm_packet_header.hpp>
 
 #include "ttnn/common/queue_id.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/ccl/erisc_datamover_builder_helper.hpp"
 #include "ttnn/operations/ccl/common/host/ccl_worker_builder.hpp"
@@ -2117,15 +2118,18 @@ void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_li
     // INPUT TENSOR setup
     log_info(tt::LogTest, "setting up input tensors");
     size_t page_size = tile_size(DataFormat::Float16);
-    std::vector<Tensor> device_input_tensors;
-    for (size_t i = 0; i < num_devices; i++) {
-        auto t = ttnn::experimental::view(ttnn::arange(0, num_elems, 1), input_shape).to_layout(layout);
 
-        device_input_tensors.push_back(t);
-    }
-    // Need to make it a mesh tensor for use with the op
-    const Tensor input_mesh_tensor = ttnn::distributed::aggregate_as_tensor(device_input_tensors, AllGatherTensor{})
-                                         .to_device(test_fixture.mesh_device_.get());
+    // Replicate the tensor across (1, num_devices) submesh.
+    const Tensor input_mesh_tensor = ttnn::distributed::distribute_tensor(
+        ttnn::experimental::view(ttnn::arange(0, num_elems, 1, DataType::BFLOAT16), input_shape).to_layout(layout),
+        *ttnn::distributed::create_mesh_mapper(
+            *test_fixture.mesh_device_,
+            ttnn::distributed::MeshMapperConfig{
+                .placements =
+                    {ttnn::distributed::MeshMapperConfig::Replicate{},
+                     ttnn::distributed::MeshMapperConfig::Replicate{}},
+                .mesh_shape_override = MeshShape{1, num_devices}}),
+        *test_fixture.mesh_device_);
     std::optional<SubdeviceInfo> subdevice_managers = create_worker_subdevices(devices);
 
     log_info(tt::LogTest, "launching op");
@@ -2181,15 +2185,18 @@ void run_ring_all_gather_with_persistent_fabric(
     // INPUT TENSOR setup
     log_info(tt::LogTest, "setting up input tensors");
     size_t page_size = tile_size(DataFormat::Float16);
-    std::vector<Tensor> device_input_tensors;
-    for (size_t i = 0; i < num_devices; i++) {
-        auto t = ttnn::experimental::view(ttnn::arange(0, num_elems, 1), input_shape).to_layout(layout);
 
-        device_input_tensors.push_back(t);
-    }
-    // Need to make it a mesh tensor for use with the op
-    const Tensor input_mesh_tensor = ttnn::distributed::aggregate_as_tensor(device_input_tensors, AllGatherTensor{})
-                                         .to_device(test_fixture.mesh_device_.get());
+    // Replicate the tensor across (1, num_devices) submesh.
+    const Tensor input_mesh_tensor = ttnn::distributed::distribute_tensor(
+        ttnn::experimental::view(ttnn::arange(0, num_elems, 1, DataType::BFLOAT16), input_shape).to_layout(layout),
+        *ttnn::distributed::create_mesh_mapper(
+            *test_fixture.mesh_device_,
+            ttnn::distributed::MeshMapperConfig{
+                .placements =
+                    {ttnn::distributed::MeshMapperConfig::Replicate{},
+                     ttnn::distributed::MeshMapperConfig::Replicate{}},
+                .mesh_shape_override = MeshShape{1, num_devices}}),
+        *test_fixture.mesh_device_);
 
     std::optional<SubdeviceInfo> subdevice_managers = create_worker_subdevices(devices);
     ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
@@ -26,6 +26,7 @@
 #include <tt-metalium/sub_device_types.hpp>
 #include "tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp"
 #include "ttnn/distributed/api.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/global_semaphore.hpp"
 #include "ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"
@@ -70,18 +71,18 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
 
     // INPUT TENSOR setup
     size_t page_size = tile_size(DataFormat::Float16);
-    std::vector<Tensor> device_input_tensors;
-    for (size_t i = 0; i < num_devices; i++) {
-        // host_input_tensors.push_back(ttnn::numpy::random::uniform(bfloat16(-1.0f), bfloat16(1.0f) ,
-        // {input_shape[0],input_shape[1],input_shape[2],input_shape[3]}, layout).to_device(devices[i]));
-        auto t =
-            ttnn::experimental::view(ttnn::arange(0, num_elems, 1, DataType::BFLOAT16), input_shape).to_layout(layout);
-        device_input_tensors.push_back(t);
-    }
-    // Need to make it a mesh tensor for use with the op
-    const Tensor input_mesh_tensor = ttnn::distributed::aggregate_as_tensor(device_input_tensors, AllGatherTensor{})
-                                         .to_device(test_fixture.mesh_device_.get());
 
+    // Replicate the tensor across (1, num_devices) submesh.
+    const Tensor input_mesh_tensor = ttnn::distributed::distribute_tensor(
+        ttnn::experimental::view(ttnn::arange(0, num_elems, 1, DataType::BFLOAT16), input_shape).to_layout(layout),
+        *ttnn::distributed::create_mesh_mapper(
+            *test_fixture.mesh_device_,
+            ttnn::distributed::MeshMapperConfig{
+                .placements =
+                    {ttnn::distributed::MeshMapperConfig::Replicate{},
+                     ttnn::distributed::MeshMapperConfig::Replicate{}},
+                .mesh_shape_override = MeshShape{1, num_devices}}),
+        *test_fixture.mesh_device_);
     std::optional<SubdeviceInfo> subdevice_managers = create_worker_subdevices(devices);
 
     GlobalSemaphore from_remote_multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore(

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 
 #include "ttnn/distributed/api.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/distributed/distributed_tensor_config.hpp"
 #include "ttnn/mesh_device_operation_adapter.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
@@ -28,18 +29,19 @@ using ::ttnn::device_operation::mesh_device_operation_utils::all_tensors_have_un
 using ::ttnn::device_operation::mesh_device_operation_utils::extract_tensor_coordinates;
 using ::ttnn::device_operation::mesh_device_operation_utils::filter_tensor_shards;
 
-// Returns device tensor with `num_device_shards` populated.
-Tensor make_tensor_with_num_shards(const TensorSpec& tensor_spec, int num_device_shards, MeshDevice* mesh_device) {
+// Returns a dummy device tensor with `num_device_shards` populated.
+Tensor make_tensor_with_num_shards(int num_device_shards, MeshDevice* mesh_device) {
     TT_FATAL(num_device_shards > 0 && num_device_shards <= mesh_device->num_devices(), "Invalid number of shards");
 
-    auto host_tensor = Tensor::from_vector(std::vector<float>(tensor_spec.logical_shape().volume()), tensor_spec);
-    std::vector<Tensor> host_tensors;
-    host_tensors.reserve(num_device_shards);
-    for (int i = 0; i < num_device_shards; ++i) {
-        host_tensors.push_back(host_tensor);
-    }
-
-    return distributed::aggregate_as_tensor(host_tensors, tt::tt_metal::AllGatherTensor{}).to_device(mesh_device);
+    const auto global_shape = ttnn::Shape{num_device_shards, 1, 32, 32};
+    auto buffer = std::make_shared<std::vector<float>>(global_shape.volume());
+    return distributed::create_distributed_tensor(
+        tt::stl::make_span(*buffer),
+        global_shape,
+        tt::tt_metal::MemoryPin{buffer},
+        tt::tt_metal::TensorLayout(DataType::FLOAT32, Layout::TILE, MemoryConfig{}),
+        *distributed::shard_tensor_to_mesh_mapper(*mesh_device, /*dim=*/0),
+        *mesh_device);
 }
 
 struct SharedVariables {};
@@ -173,9 +175,7 @@ TEST_F(LaunchOperationT3000Test, UniformTensor) {
 }
 
 TEST_F(LaunchOperationT3000Test, UnevenTensor) {
-    const TensorSpec tensor_spec = TensorSpec(
-        ttnn::Shape{1, 1, 32, 32}, tt::tt_metal::TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
-    auto uneven_tensor = make_tensor_with_num_shards(tensor_spec, 2, mesh_device_.get());
+    auto uneven_tensor = make_tensor_with_num_shards(2, mesh_device_.get());
 
     EXPECT_THAT(uneven_tensor.device_storage().coords, SizeIs(2));
 
@@ -245,9 +245,7 @@ TEST_F(LaunchOperationT3000Test, FilterTensorShards) {
 }
 
 TEST_F(LaunchOperationT3000Test, LaunchOpFilterTensorShards) {
-    const TensorSpec tensor_spec = TensorSpec(
-        ttnn::Shape{1, 1, 32, 32}, tt::tt_metal::TensorLayout(DataType::FLOAT32, Layout::TILE, MemoryConfig{}));
-    auto full_tensor = make_tensor_with_num_shards(tensor_spec, 8, mesh_device_.get());
+    auto full_tensor = make_tensor_with_num_shards(8, mesh_device_.get());
     auto sum = ttnn::add(full_tensor, full_tensor);
 
     EXPECT_TRUE(all_tensors_have_uniform_storage(sum));
@@ -263,7 +261,7 @@ TEST_F(LaunchOperationT3000Test, LaunchOpFilterTensorShards) {
             ttnn::MeshCoordinate{1, 2},
             ttnn::MeshCoordinate{1, 3}));
 
-    auto uneven_tensor = make_tensor_with_num_shards(tensor_spec, 2, mesh_device_.get());
+    auto uneven_tensor = make_tensor_with_num_shards(2, mesh_device_.get());
     auto sum_uneven = ttnn::add(uneven_tensor, uneven_tensor);
 
     EXPECT_FALSE(all_tensors_have_uniform_storage(sum_uneven));
@@ -277,9 +275,7 @@ TEST_F(LaunchOperationT3000Test, LaunchOpFilterTensorShards) {
 TEST_F(LaunchOperationT3000Test, CachingHeterogeneousDispatch) {
     EXPECT_EQ(mesh_device_->get_program_cache().num_entries(), 0);
 
-    const TensorSpec tensor_spec = TensorSpec(
-        ttnn::Shape{1, 1, 32, 32}, tt::tt_metal::TensorLayout(DataType::FLOAT32, Layout::TILE, MemoryConfig{}));
-    auto full_tensor = make_tensor_with_num_shards(tensor_spec, 8, mesh_device_.get());
+    auto full_tensor = make_tensor_with_num_shards(8, mesh_device_.get());
     auto sum = ttnn::add(full_tensor, full_tensor);
 
     EXPECT_EQ(mesh_device_->get_program_cache().num_entries(), 1);
@@ -287,7 +283,7 @@ TEST_F(LaunchOperationT3000Test, CachingHeterogeneousDispatch) {
     auto sum2 = ttnn::add(full_tensor, full_tensor);
     EXPECT_EQ(mesh_device_->get_program_cache().num_entries(), 1);
 
-    auto uneven_tensor = make_tensor_with_num_shards(tensor_spec, 2, mesh_device_.get());
+    auto uneven_tensor = make_tensor_with_num_shards(2, mesh_device_.get());
     auto sum_uneven = ttnn::add(uneven_tensor, uneven_tensor);
 
     EXPECT_EQ(mesh_device_->get_program_cache().num_entries(), 2);

--- a/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/concat_fuse_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/concat_fuse_test.py
@@ -201,13 +201,20 @@ def run_concat_fuse_impl(
     for i in range(num_iters):
         output_tensor = torch.rand(output_shape).bfloat16()
         output_tensor_goldens_list.append(output_tensor)
-        input_tensors = torch.chunk(output_tensor, num_devices, dim)
-        tt_input_tensors = []
-        for i, t in enumerate(input_tensors):
-            tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout))
-            logger.info(f"using device {mesh_device.get_device_ids()[i]}")
 
-        input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(mesh_device, input_mem_config)
+        input_tensor_mesh = ttnn.from_torch(
+            output_tensor,
+            device=mesh_device,
+            layout=layout,
+            dtype=input_dtype,
+            memory_config=input_mem_config,
+            mesh_mapper=ttnn.create_mesh_mapper(
+                mesh_device,
+                ttnn.MeshMapperConfig(
+                    [ttnn.PlacementReplicate(), ttnn.PlacementShard(0)], ttnn.MeshShape(1, num_devices)
+                ),
+            ),
+        )
 
         input_tensor_mesh_list.append(input_tensor_mesh)
 
@@ -243,13 +250,16 @@ def run_concat_fuse_impl(
             ),
         )
 
-        zeros_tensor = torch.zeros(output_shape).bfloat16()
-        tt_intermediate_tensors = []
-        for i in range(4):
-            tt_intermediate_tensor = ttnn.Tensor(zeros_tensor, input_dtype).to(layout)
-            tt_intermediate_tensors.append(tt_intermediate_tensor)
-        intermediate_tensor_mesh = ttnn.aggregate_as_tensor(tt_intermediate_tensors).to(
-            mesh_device, intermediate_mem_config
+        intermediate_tensor_mesh = ttnn.from_torch(
+            torch.zeros(output_shape).bfloat16(),
+            device=mesh_device,
+            layout=layout,
+            dtype=input_dtype,
+            memory_config=intermediate_mem_config,
+            mesh_mapper=ttnn.create_mesh_mapper(
+                mesh_device,
+                ttnn.MeshMapperConfig([ttnn.PlacementReplicate(), ttnn.PlacementReplicate()], ttnn.MeshShape(1, 4)),
+            ),
         )
         intermediate_tensors_list.append(intermediate_tensor_mesh)
     tt_out_tensor_list = []

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_matmul.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_matmul.py
@@ -56,11 +56,20 @@ def run_all_gather_matmul_on_t3000_impl(
     ##### Create input tensor for the all gather #####
     _, _, _, hidden_dim = ag_output_shape
     input_tensor = torch.randn(ag_output_shape).float()
-    input_tensors = torch.chunk(input_tensor, num_devices, dim)
-    tt_input_tensors = []
-    for i, t in enumerate(input_tensors):
-        tt_input_tensors.append(ttnn.Tensor(tensor=t, data_type=ag_input_dtype, tile=ttnn.Tile(tile)).to(layout))
-    input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(t3k_mesh_device, mem_config_input)
+    input_tensor_mesh = ttnn.from_torch(
+        input_tensor,
+        device=t3k_mesh_device,
+        layout=layout,
+        dtype=ag_input_dtype,
+        memory_config=mem_config_input,
+        mesh_mapper=ttnn.create_mesh_mapper(
+            t3k_mesh_device,
+            ttnn.MeshMapperConfig(
+                [ttnn.PlacementReplicate(), ttnn.PlacementShard(dim)], ttnn.MeshShape(1, num_devices)
+            ),
+        ),
+        tile=ttnn.Tile(tile),
+    )
 
     ##### Create the weight matrix for the matmul #####
     if use_bias:

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_async.py
@@ -52,7 +52,7 @@ def run_all_reduce_test(
     logger.info(f"Per chip output shape: {per_chip_output_shape}, devices: {num_devices}")
     # Generate input tensors
 
-    tt_input_tensors = []
+    canonical_input_tensors = []
     input_tensors = []
 
     numel = math.prod(per_chip_output_shape)
@@ -60,15 +60,24 @@ def run_all_reduce_test(
         input_tensors[-1] = torch.arange(numel).reshape(per_chip_output_shape).bfloat16()
     for i in range(num_devices):
         input_tensor = torch.rand(per_chip_output_shape).bfloat16()
-        t = ttnn.from_torch(input_tensor, input_dtype, layout=layout)
-        tt_input_tensors.append(t)
+        canonical_input_tensors.append(input_tensor)
         input_tensor = input_tensor.view(1, -1, input_tensor.shape[2], input_tensor.shape[3])
         input_tensors.append(input_tensor)
 
     unchunked_input_tensor = torch.cat(input_tensors)
 
-    assert len(tt_input_tensors) == num_devices
-    input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(mesh_device, mem_config)
+    assert len(canonical_input_tensors) == num_devices
+    input_tensor_mesh = ttnn.from_torch(
+        torch.cat(canonical_input_tensors),
+        dtype=input_dtype,
+        layout=layout,
+        device=mesh_device,
+        memory_config=mem_config,
+        mesh_mapper=ttnn.create_mesh_mapper(
+            mesh_device,
+            ttnn.MeshMapperConfig([ttnn.PlacementReplicate(), ttnn.PlacementShard(0)], ttnn.MeshShape(1, num_devices)),
+        ),
+    )
     # Run the op
     for i in range(num_iters):
         output_tensor_mesh = ttnn.experimental.all_reduce_async(

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_t3000_frequent.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_t3000_frequent.py
@@ -99,7 +99,7 @@ def run_all_reduce_test(
     logger.info(f"Per chip output shape: {per_chip_output_shape}, devices: {num_devices}")
     # Generate input tensors
 
-    tt_input_tensors = []
+    canonical_input_tensors = []
     input_tensors = []
 
     numel = math.prod(per_chip_output_shape)
@@ -107,16 +107,25 @@ def run_all_reduce_test(
         input_tensors[-1] = torch.arange(numel).reshape(per_chip_output_shape).bfloat16()
     for i in range(num_devices):
         input_tensor = torch.rand(per_chip_output_shape).bfloat16()
-        t = ttnn.from_torch(input_tensor, input_dtype, layout=layout)
-        tt_input_tensors.append(t)
+        canonical_input_tensors.append(input_tensor)
         input_tensor = input_tensor.view(1, -1, input_tensor.shape[2], input_tensor.shape[3])
         input_tensors.append(input_tensor)
 
     unchunked_input_tensor = torch.cat(input_tensors)
 
-    assert len(tt_input_tensors) == num_devices
+    assert len(canonical_input_tensors) == num_devices
+    input_tensor_mesh = ttnn.from_torch(
+        torch.cat(canonical_input_tensors),
+        dtype=input_dtype,
+        layout=layout,
+        device=mesh_device,
+        memory_config=mem_config,
+        mesh_mapper=ttnn.create_mesh_mapper(
+            mesh_device,
+            ttnn.MeshMapperConfig([ttnn.PlacementReplicate(), ttnn.PlacementShard(0)], ttnn.MeshShape(1, num_devices)),
+        ),
+    )
 
-    input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(mesh_device, mem_config)
     # Run the op
     for i in range(num_iters):
         output_tensor_mesh = ttnn.experimental.all_reduce(

--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_prefill_ccl_ops.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_prefill_ccl_ops.py
@@ -132,11 +132,14 @@ def run_all_gather_impl(
     for i in range(num_iters):
         ag_output_tensor = torch.randn(ag_output_shape).bfloat16()
         ag_output_tensor_goldens_list.append(ag_output_tensor)
-        input_tensors = torch.chunk(ag_output_tensor, num_devices, dim)
-        tt_input_tensors = []
-        for i, t in enumerate(input_tensors):
-            tt_input_tensors.append(ttnn.Tensor(t, ag_input_dtype).to(layout))
-        input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(t3k_mesh_device, mem_config)
+        input_tensor_mesh = ttnn.from_torch(
+            ag_output_tensor,
+            device=t3k_mesh_device,
+            layout=layout,
+            dtype=ag_input_dtype,
+            memory_config=mem_config,
+            mesh_mapper=ttnn.ShardTensorToMesh(t3k_mesh_device, dim=dim),
+        )
 
         input_tensor_mesh_list.append(input_tensor_mesh)
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -218,13 +218,20 @@ def run_all_gather_impl(
                             tile_id += 1
 
         output_tensor_goldens_list.append(output_tensor)
-        input_tensors = torch.chunk(output_tensor, num_devices, dim)
-        tt_input_tensors = []
-        for i, t in enumerate(input_tensors):
-            tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout))
-            logger.info(f"using device {mesh_device.get_device_ids()[i]}")
 
-        input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(mesh_device, input_mem_config)
+        input_tensor_mesh = ttnn.from_torch(
+            output_tensor,
+            device=mesh_device,
+            layout=layout,
+            dtype=input_dtype,
+            memory_config=input_mem_config,
+            mesh_mapper=ttnn.create_mesh_mapper(
+                mesh_device,
+                ttnn.MeshMapperConfig(
+                    [ttnn.PlacementReplicate(), ttnn.PlacementShard(dim)], ttnn.MeshShape(1, num_devices)
+                ),
+            ),
+        )
 
         input_tensor_mesh_list.append(input_tensor_mesh)
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather_matmul.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather_matmul.py
@@ -110,12 +110,14 @@ def run_all_gather_impl(
         ag_output_tensor = torch.rand(ag_output_shape).bfloat16()
         ag_output_tensor_goldens_list.append(ag_output_tensor)
 
-        input_tensors = torch.chunk(ag_output_tensor, num_devices, dim)
-
-        tt_input_tensors = []
-        for i, t in enumerate(input_tensors):
-            tt_input_tensors.append(ttnn.Tensor(t, ag_input_dtype).to(layout))
-        input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(t3k_mesh_device, mem_config_input)
+        input_tensor_mesh = ttnn.from_torch(
+            ag_output_tensor,
+            device=t3k_mesh_device,
+            layout=layout,
+            dtype=ag_input_dtype,
+            memory_config=mem_config_input,
+            mesh_mapper=ttnn.ShardTensorToMesh(t3k_mesh_device, dim=dim),
+        )
 
         input_tensor_mesh_list.append(input_tensor_mesh)
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_matmul_reduce_scatter.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_matmul_reduce_scatter.py
@@ -166,10 +166,20 @@ def run_reduce_scatter_impl(
         mm_input_tensor = torch.rand(mm_input_shape).bfloat16()
         input_tensors = torch.chunk(mm_input_tensor, num_devices, 3)
         torch_input_tensor_list.append(input_tensors)
-        tt_input_tensors = []
-        for j, t in enumerate(input_tensors):
-            tt_input_tensors.append(ttnn.Tensor(t, rs_input_dtype).to(layout))
-        input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(t3k_mesh_device, mem_config_input)
+
+        input_tensor_mesh = ttnn.from_torch(
+            mm_input_tensor,
+            device=t3k_mesh_device,
+            layout=layout,
+            dtype=rs_input_dtype,
+            memory_config=mem_config_input,
+            mesh_mapper=ttnn.create_mesh_mapper(
+                t3k_mesh_device,
+                ttnn.MeshMapperConfig(
+                    [ttnn.PlacementReplicate(), ttnn.PlacementShard(3)], ttnn.MeshShape(1, num_devices)
+                ),
+            ),
+        )
 
         tt_input_tensor_mesh_list.append(input_tensor_mesh)
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
@@ -167,8 +167,6 @@ def run_reduce_scatter_test(
     canonical_input_shape = per_chip_output_shape.copy()
     canonical_input_shape[dim] *= num_devices
 
-    tt_input_tensors = []
-
     numel = canonical_input_shape[0] * canonical_input_shape[1] * canonical_input_shape[2] * canonical_input_shape[3]
     input_tensors = [
         torch.rand(canonical_input_shape).bfloat16() if not debug else torch.ones(canonical_input_shape).bfloat16()
@@ -184,13 +182,18 @@ def run_reduce_scatter_test(
                             for xx in range(32):
                                 input_tensors[-1][w, z, y + yy, x + xx] = tile_id
                         tile_id += 1
-    for i, canonical_input_tensor in enumerate(input_tensors):
-        logger.info(f"Creating input tensor on device {mesh_device.get_device_ids()[i]}")
-        tt_input_tensors.append(ttnn.Tensor(canonical_input_tensor, input_dtype).to(layout))
 
-    assert len(tt_input_tensors) == num_devices
-
-    input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(mesh_device, input_mem_config)
+    input_tensor_mesh = ttnn.from_torch(
+        torch.cat(input_tensors),
+        dtype=input_dtype,
+        layout=layout,
+        device=mesh_device,
+        memory_config=input_mem_config,
+        mesh_mapper=ttnn.create_mesh_mapper(
+            mesh_device,
+            ttnn.MeshMapperConfig([ttnn.PlacementReplicate(), ttnn.PlacementShard(0)], ttnn.MeshShape(1, num_devices)),
+        ),
+    )
 
     # Run the op
     if trace_mode:

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_post_commit.py
@@ -436,16 +436,23 @@ def run_reduce_scatter_sharded_test(
 
     numel = canonical_input_shape[0] * canonical_input_shape[1] * canonical_input_shape[2] * canonical_input_shape[3]
     input_tensors = [
-        # torch.rand(canonical_input_shape).bfloat16() if not debug else torch.arange(numel).reshape(canonical_input_shape).bfloat16()
         torch.rand(canonical_input_shape).bfloat16() if not debug else torch.ones(canonical_input_shape).bfloat16()
         for _ in range(num_devices)
     ]
     if debug:
         input_tensors[-1] = torch.arange(numel).reshape(canonical_input_shape).bfloat16()
-    for i, canonical_input_tensor in enumerate(input_tensors):
-        tt_input_tensors.append(ttnn.Tensor(canonical_input_tensor, input_dtype).to(tensor_layout))
 
-    input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors).to(t3k_mesh_device, input_mem_config)
+    input_tensor_mesh = ttnn.from_torch(
+        torch.cat(input_tensors, dim=0),
+        device=t3k_mesh_device,
+        layout=tensor_layout,
+        dtype=input_dtype,
+        memory_config=input_mem_config,
+        mesh_mapper=ttnn.create_mesh_mapper(
+            t3k_mesh_device,
+            ttnn.MeshMapperConfig([ttnn.PlacementReplicate(), ttnn.PlacementShard(0)], ttnn.MeshShape(1, num_devices)),
+        ),
+    )
 
     # Run the op
     if trace_mode:


### PR DESCRIPTION
### Ticket
#23287

### Problem description
`aggregate_as_tensor` provides an ad hoc way to stitch together host tensors for later upload to device.

This doesn't support multi-host, uses the legacy `DistributedTensorConfig`, and overall only used for one-off testing. No models use this path.

### What's changed
Migrate `aggregate_as_tensor` to the official sharing APIs. In all of the cases, tests used `torch.chunk` to split a tensor across devices, then manually created multi device tensor via `aggregate_as_tensor` API.

Using proper sharding APIs provides a more principled approach to creating multi-device tensors, which is expressive, efficient and supports multi-host natively. There is no reason for an additional `aggregate_as_tensor` only used for these tests.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15961205725)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15961209935)
- [x] [TG tests](https://github.com/tenstorrent/tt-metal/actions/runs/15961212484)
- [x] New/Existing tests provide coverage for changes