### PR TITLE
#24347: Skip non-det failing permute specific case test for int32

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -109,7 +109,9 @@ def test_permute_on_less_than_4D(device, perm, dtype):
 @pytest.mark.parametrize("s", [8])
 @pytest.mark.parametrize("h", [1500])
 @pytest.mark.parametrize("w", [64])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+# @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+# #24347: Looks like we have a non-det issue on N150 + N300
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 def test_permute_for_specific_case(device, b, s, h, w, dtype):
     torch.manual_seed(2005)
     shape = (b, s, h, w)


### PR DESCRIPTION
### Ticket

#24347

### Problem description

We're seeing this fail non-det

### What's changed

Disable for now and let people know

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes