### PR TITLE
Remove e flag and add fail var for run_performance.sh

### DIFF
--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+# add comment
 set -o pipefail
 
 if [[ -z "$TT_METAL_HOME" ]]; then

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -10,7 +10,7 @@ fi
 run_perf_models_other() {
     local tt_arch=$1
     local test_marker=$2
-    fail=0
+    local fail=0
 
     if [ "$tt_arch" == "grayskull" ]; then
         env pytest models/demos/grayskull/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker; ((fail+=$?));

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -13,71 +13,71 @@ run_perf_models_other() {
     fail=0
 
     if [ "$tt_arch" == "grayskull" ]; then
-        env pytest models/demos/grayskull/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker; fail+=$?;
+        env pytest models/demos/grayskull/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker; ((fail+=$?));
     fi
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/sentence_bert/tests -m $test_marker; fail+=$?;
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/sentence_bert/tests -m $test_marker; ((fail+=$?));
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker; fail+=$?;
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker; ((fail+=$?));
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/bert_tiny/tests/test_performance.py -m $test_marker; fail+=$?;
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/bert_tiny/tests/test_performance.py -m $test_marker; ((fail+=$?));
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/yolov4/tests/perf -m $test_marker; fail+=$?;
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/yolov4/tests/perf -m $test_marker; ((fail+=$?));
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov7/tests/ -m $test_marker; fail+=$?;
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov7/tests/ -m $test_marker; ((fail+=$?));
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/distilbert/tests/test_perf_distilbert.py -m $test_marker; fail+=$?;
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/distilbert/tests/test_perf_distilbert.py -m $test_marker; ((fail+=$?));
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/perf/test_perf_segformer.py -m $test_marker; fail+=$?;
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/perf/test_perf_segformer.py -m $test_marker; ((fail+=$?));
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py -m $test_marker; fail+=$?;
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py -m $test_marker; ((fail+=$?));
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/perf/test_perf_segformer_trace_2cq.py -m $test_marker; fail+=$?;
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/perf/test_perf_segformer_trace_2cq.py -m $test_marker; ((fail+=$?));
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/whisper/tests/test_performance.py -m $test_marker; fail+=$?;
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/whisper/tests/test_performance.py -m $test_marker; ((fail+=$?));
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/metal_BERT_large_11/tests -m $test_marker; fail+=$?;
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/metal_BERT_large_11/tests -m $test_marker; ((fail+=$?));
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/vgg_unet/tests -m $test_marker; fail+=$?;
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/vgg_unet/tests -m $test_marker; ((fail+=$?));
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov9c/tests/perf -m $test_marker; fail+=$?;
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov9c/tests/perf -m $test_marker; ((fail+=$?));
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py -m $test_marker; fail+=$?;
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py -m $test_marker; ((fail+=$?));
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s_world/tests -m $test_marker; fail+=$?;
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/mobilenetv2/tests -m $test_marker; fail+=$?;
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s_world/tests -m $test_marker; ((fail+=$?));
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/mobilenetv2/tests -m $test_marker; ((fail+=$?));
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/ufld_v2/tests -m $test_marker; fail+=$?;
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/ufld_v2/tests -m $test_marker; ((fail+=$?));
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8x/tests -m $test_marker; fail+=$?;
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8x/tests -m $test_marker; ((fail+=$?));
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s/tests -m $test_marker; fail+=$?;
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s/tests -m $test_marker; ((fail+=$?));
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/yolov10/tests -m $test_marker; fail+=$?;
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/yolov10/tests -m $test_marker; ((fail+=$?));
 
     fi
 
-    env pytest -n auto tests/ttnn/integration_tests/bert/test_performance.py -m $test_marker; fail+=$?;
+    env pytest -n auto tests/ttnn/integration_tests/bert/test_performance.py -m $test_marker; ((fail+=$?));
 
-    env pytest -n auto models/demos/ttnn_falcon7b/tests -m $test_marker; fail+=$?;
+    env pytest -n auto models/demos/ttnn_falcon7b/tests -m $test_marker; ((fail+=$?));
 
-    env pytest models/demos/distilbert/tests/test_perf_distilbert.py -m $test_marker; fail+=$?;
+    env pytest models/demos/distilbert/tests/test_perf_distilbert.py -m $test_marker; ((fail+=$?));
 
-    # env pytest -n auto models/demos/vgg/tests/test_perf_vgg.py -m $test_marker; fail+=$?;
+    # env pytest -n auto models/demos/vgg/tests/test_perf_vgg.py -m $test_marker; ((fail+=$?));
 
-    env pytest -n auto models/demos/convnet_mnist/tests -m $test_marker; fail+=$?;
+    env pytest -n auto models/demos/convnet_mnist/tests -m $test_marker; ((fail+=$?));
 
-    env pytest -n auto models/demos/bert_tiny/tests/test_performance.py -m $test_marker; fail+=$?;
+    env pytest -n auto models/demos/bert_tiny/tests/test_performance.py -m $test_marker; ((fail+=$?));
 
-    # env pytest -n auto models/demos/mnist/tests -m $test_marker; fail+=$?;
+    # env pytest -n auto models/demos/mnist/tests -m $test_marker; ((fail+=$?));
 
-    env pytest -n auto models/demos/squeezebert/tests/test_performance.py -m $test_marker; fail+=$?;
+    env pytest -n auto models/demos/squeezebert/tests/test_performance.py -m $test_marker; ((fail+=$?));
 
-    env pytest -n auto models/demos/roberta/tests/test_performance.py -m $test_marker; fail+=$?;
+    env pytest -n auto models/demos/roberta/tests/test_performance.py -m $test_marker; ((fail+=$?));
 
     ## Merge all the generated reports
-    env python3 models/perf/merge_perf_results.py; fail+=$?;
+    env python3 models/perf/merge_perf_results.py; ((fail+=$?));
 
     if [[ $fail -ne 0 ]]; then
         exit 1
@@ -93,15 +93,15 @@ run_perf_models_llm_javelin() {
         export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
     fi
 
-    env pytest -n auto models/demos/falcon7b_common/tests -m $test_marker; fail+=$?;
+    env pytest -n auto models/demos/falcon7b_common/tests -m $test_marker; ((fail+=$?));
 
-    env QWEN_DIR=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2-7B-Instruct FAKE_DEVICE=N150 pytest -n auto models/demos/qwen/tests -m $test_marker; fail+=$?;
+    env QWEN_DIR=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2-7B-Instruct FAKE_DEVICE=N150 pytest -n auto models/demos/qwen/tests -m $test_marker; ((fail+=$?));
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
-        env pytest -n auto models/demos/wormhole/mamba/tests -m $test_marker; fail+=$?;
+        env pytest -n auto models/demos/wormhole/mamba/tests -m $test_marker; ((fail+=$?));
     fi
     ## Merge all the generated reports
-    env python3 models/perf/merge_perf_results.py; fail+=$?;
+    env python3 models/perf/merge_perf_results.py; ((fail+=$?));
 
     if [[ $fail -ne 0 ]]; then
         exit 1
@@ -114,11 +114,11 @@ run_perf_models_cnn_javelin() {
     fail=0
 
     # Run tests
-    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests -m $test_marker; fail+=$?;
-    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/stable_diffusion/tests -m $test_marker --timeout=480; fail+=$?;
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests -m $test_marker; ((fail+=$?));
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/stable_diffusion/tests -m $test_marker --timeout=480; ((fail+=$?));
 
     ## Merge all the generated reports
-    env python3 models/perf/merge_perf_results.py; fail+=$?;
+    env python3 models/perf/merge_perf_results.py; ((fail+=$?));
 
     if [[ $fail -ne 0 ]]; then
         exit 1

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -87,7 +87,7 @@ run_perf_models_other() {
 run_perf_models_llm_javelin() {
     local tt_arch=$1
     local test_marker=$2
-    fail=0
+    local fail=0
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
         export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eo pipefail
+set -o pipefail
 
 if [[ -z "$TT_METAL_HOME" ]]; then
   echo "Must provide TT_METAL_HOME in environment" 1>&2
@@ -10,104 +10,120 @@ fi
 run_perf_models_other() {
     local tt_arch=$1
     local test_marker=$2
+    fail=0
 
     if [ "$tt_arch" == "grayskull" ]; then
-        env pytest models/demos/grayskull/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker
+        env pytest models/demos/grayskull/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker; fail+=$?;
     fi
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/sentence_bert/tests -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/sentence_bert/tests -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/bert_tiny/tests/test_performance.py -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/bert_tiny/tests/test_performance.py -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/yolov4/tests/perf -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/yolov4/tests/perf -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov7/tests/ -m $test_marker
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/distilbert/tests/test_perf_distilbert.py -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov7/tests/ -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/perf/test_perf_segformer.py -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/distilbert/tests/test_perf_distilbert.py -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/perf/test_perf_segformer.py -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/perf/test_perf_segformer_trace_2cq.py -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/whisper/tests/test_performance.py -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/perf/test_perf_segformer_trace_2cq.py -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/metal_BERT_large_11/tests -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/whisper/tests/test_performance.py -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/vgg_unet/tests -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/metal_BERT_large_11/tests -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov9c/tests/perf -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/vgg_unet/tests -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov9c/tests/perf -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s_world/tests -m $test_marker
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/mobilenetv2/tests -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/ufld_v2/tests -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s_world/tests -m $test_marker; fail+=$?;
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/mobilenetv2/tests -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8x/tests -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/ufld_v2/tests -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s/tests -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8x/tests -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/yolov10/tests -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s/tests -m $test_marker; fail+=$?;
+
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/yolov10/tests -m $test_marker; fail+=$?;
 
     fi
 
-    env pytest -n auto tests/ttnn/integration_tests/bert/test_performance.py -m $test_marker
+    env pytest -n auto tests/ttnn/integration_tests/bert/test_performance.py -m $test_marker; fail+=$?;
 
-    env pytest -n auto models/demos/ttnn_falcon7b/tests -m $test_marker
+    env pytest -n auto models/demos/ttnn_falcon7b/tests -m $test_marker; fail+=$?;
 
-    env pytest models/demos/distilbert/tests/test_perf_distilbert.py -m $test_marker
+    env pytest models/demos/distilbert/tests/test_perf_distilbert.py -m $test_marker; fail+=$?;
 
-    # env pytest -n auto models/demos/vgg/tests/test_perf_vgg.py -m $test_marker
+    # env pytest -n auto models/demos/vgg/tests/test_perf_vgg.py -m $test_marker; fail+=$?;
 
-    env pytest -n auto models/demos/convnet_mnist/tests -m $test_marker
+    env pytest -n auto models/demos/convnet_mnist/tests -m $test_marker; fail+=$?;
 
-    env pytest -n auto models/demos/bert_tiny/tests/test_performance.py -m $test_marker
+    env pytest -n auto models/demos/bert_tiny/tests/test_performance.py -m $test_marker; fail+=$?;
 
-    # env pytest -n auto models/demos/mnist/tests -m $test_marker
+    # env pytest -n auto models/demos/mnist/tests -m $test_marker; fail+=$?;
 
-    env pytest -n auto models/demos/squeezebert/tests/test_performance.py -m $test_marker
+    env pytest -n auto models/demos/squeezebert/tests/test_performance.py -m $test_marker; fail+=$?;
 
-    env pytest -n auto models/demos/roberta/tests/test_performance.py -m $test_marker
+    env pytest -n auto models/demos/roberta/tests/test_performance.py -m $test_marker; fail+=$?;
 
     ## Merge all the generated reports
-    env python3 models/perf/merge_perf_results.py
+    env python3 models/perf/merge_perf_results.py; fail+=$?;
+
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 run_perf_models_llm_javelin() {
     local tt_arch=$1
     local test_marker=$2
+    fail=0
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
         export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
     fi
 
-    env pytest -n auto models/demos/falcon7b_common/tests -m $test_marker
+    env pytest -n auto models/demos/falcon7b_common/tests -m $test_marker; fail+=$?;
 
-    env QWEN_DIR=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2-7B-Instruct FAKE_DEVICE=N150 pytest -n auto models/demos/qwen/tests -m $test_marker
+    env QWEN_DIR=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2-7B-Instruct FAKE_DEVICE=N150 pytest -n auto models/demos/qwen/tests -m $test_marker; fail+=$?;
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
-        env pytest -n auto models/demos/wormhole/mamba/tests -m $test_marker
+        env pytest -n auto models/demos/wormhole/mamba/tests -m $test_marker; fail+=$?;
     fi
     ## Merge all the generated reports
-    env python3 models/perf/merge_perf_results.py
+    env python3 models/perf/merge_perf_results.py; fail+=$?;
+
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 run_perf_models_cnn_javelin() {
     local tt_arch=$1
     local test_marker=$2
+    fail=0
 
     # Run tests
-    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests -m $test_marker
-    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/stable_diffusion/tests -m $test_marker --timeout=480
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests -m $test_marker; fail+=$?;
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/stable_diffusion/tests -m $test_marker --timeout=480; fail+=$?;
 
     ## Merge all the generated reports
-    env python3 models/perf/merge_perf_results.py
+    env python3 models/perf/merge_perf_results.py; fail+=$?;
+
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 main() {

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eo pipefail
+set -o pipefail
 
 if [[ -z "$TT_METAL_HOME" ]]; then
   echo "Must provide TT_METAL_HOME in environment" 1>&2
@@ -10,104 +10,119 @@ fi
 run_perf_models_other() {
     local tt_arch=$1
     local test_marker=$2
+    fail=0
 
     if [ "$tt_arch" == "grayskull" ]; then
-        env pytest models/demos/grayskull/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker
+        env pytest models/demos/grayskull/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker; fail+=$?;
     fi
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/sentence_bert/tests -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/sentence_bert/tests -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/bert_tiny/tests/test_performance.py -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/bert_tiny/tests/test_performance.py -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/yolov4/tests/perf -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/yolov4/tests/perf -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/yolov7/tests/ -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/yolov7/tests/ -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/distilbert/tests/test_perf_distilbert.py -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/distilbert/tests/test_perf_distilbert.py -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/perf/test_perf_segformer.py -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/perf/test_perf_segformer.py -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/perf/test_perf_segformer_trace_2cq.py -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/perf/test_perf_segformer_trace_2cq.py -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/whisper/tests/test_performance.py -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/whisper/tests/test_performance.py -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/metal_BERT_large_11/tests -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/metal_BERT_large_11/tests -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/vgg_unet/tests -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/vgg_unet/tests -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov9c/tests/perf -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov9c/tests/perf -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s_world/tests -m $test_marker
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/mobilenetv2/tests -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s_world/tests -m $test_marker; fail+=$?;
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/mobilenetv2/tests -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/ufld_v2/tests -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/ufld_v2/tests -m $test_marker; fail+=$?;
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8x/tests -m $test_marker
+        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8x/tests -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s/tests -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s/tests -m $test_marker; fail+=$?;
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/yolov10/tests -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/yolov10/tests -m $test_marker; fail+=$?;
 
     fi
 
-    env pytest -n auto tests/ttnn/integration_tests/bert/test_performance.py -m $test_marker
+    env pytest -n auto tests/ttnn/integration_tests/bert/test_performance.py -m $test_marker; fail+=$?;
 
-    env pytest -n auto models/demos/ttnn_falcon7b/tests -m $test_marker
+    env pytest -n auto models/demos/ttnn_falcon7b/tests -m $test_marker; fail+=$?;
 
-    env pytest models/demos/distilbert/tests/test_perf_distilbert.py -m $test_marker
+    env pytest models/demos/distilbert/tests/test_perf_distilbert.py -m $test_marker; fail+=$?;
 
-    # env pytest -n auto models/demos/vgg/tests/test_perf_vgg.py -m $test_marker
+    # env pytest -n auto models/demos/vgg/tests/test_perf_vgg.py -m $test_marker; fail+=$?;
 
-    env pytest -n auto models/demos/convnet_mnist/tests -m $test_marker
+    env pytest -n auto models/demos/convnet_mnist/tests -m $test_marker; fail+=$?;
 
-    env pytest -n auto models/demos/bert_tiny/tests/test_performance.py -m $test_marker
+    env pytest -n auto models/demos/bert_tiny/tests/test_performance.py -m $test_marker; fail+=$?;
 
-    # env pytest -n auto models/demos/mnist/tests -m $test_marker
+    # env pytest -n auto models/demos/mnist/tests -m $test_marker; fail+=$?;
 
-    env pytest -n auto models/demos/squeezebert/tests/test_performance.py -m $test_marker
+    env pytest -n auto models/demos/squeezebert/tests/test_performance.py -m $test_marker; fail+=$?;
 
-    env pytest -n auto models/demos/roberta/tests/test_performance.py -m $test_marker
+    env pytest -n auto models/demos/roberta/tests/test_performance.py -m $test_marker; fail+=$?;
 
     ## Merge all the generated reports
-    env python3 models/perf/merge_perf_results.py
+    env python3 models/perf/merge_perf_results.py; fail+=$?;
+
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 run_perf_models_llm_javelin() {
     local tt_arch=$1
     local test_marker=$2
+    fail=0
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
         export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
     fi
 
-    env pytest -n auto models/demos/falcon7b_common/tests -m $test_marker
+    env pytest -n auto models/demos/falcon7b_common/tests -m $test_marker; fail+=$?;
 
-    env QWEN_DIR=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2-7B-Instruct FAKE_DEVICE=N150 pytest -n auto models/demos/qwen/tests -m $test_marker
+    env QWEN_DIR=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2-7B-Instruct FAKE_DEVICE=N150 pytest -n auto models/demos/qwen/tests -m $test_marker; fail+=$?;
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
-        env pytest -n auto models/demos/wormhole/mamba/tests -m $test_marker
+        env pytest -n auto models/demos/wormhole/mamba/tests -m $test_marker; fail+=$?;
     fi
     ## Merge all the generated reports
-    env python3 models/perf/merge_perf_results.py
+    env python3 models/perf/merge_perf_results.py; fail+=$?;
+
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 run_perf_models_cnn_javelin() {
     local tt_arch=$1
     local test_marker=$2
+    fail=0
 
     # Run tests
-    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests -m $test_marker
-    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/stable_diffusion/tests -m $test_marker --timeout=480
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests -m $test_marker; fail+=$?;
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/stable_diffusion/tests -m $test_marker --timeout=480; fail+=$?;
 
     ## Merge all the generated reports
-    env python3 models/perf/merge_perf_results.py
+    env python3 models/perf/merge_perf_results.py; fail+=$?;
+
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 main() {

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -111,7 +111,7 @@ run_perf_models_llm_javelin() {
 run_perf_models_cnn_javelin() {
     local tt_arch=$1
     local test_marker=$2
-    fail=0
+    local fail=0
 
     # Run tests
     env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests -m $test_marker; ((fail+=$?));


### PR DESCRIPTION
### Problem description
Currently, if a model test fails in single-card model perf, the remaining tests don't run.

### What's changed
Remove the e flag and add fail variable to capture exit code so that all tests can run

### Checklist
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/15976035528) CI passes