### PR TITLE
Fix model perf test with enabling `device_kernel_first_to_last_start` analysis types with longer timeout 

### DIFF
--- a/models/demos/llama3_subdevices/tests/decoder_perf_targets_4u.json
+++ b/models/demos/llama3_subdevices/tests/decoder_perf_targets_4u.json
@@ -70,7 +70,7 @@
             "op_name": "ReduceScatter_FF3",
             "kernel_duration": 9456.963068181818,
             "op_to_op": 911.3131313131312,
-            "first_to_last_start": 626.7323232323232,
+            "first_to_last_start": 370.0,
             "non-overlapped-dispatch-time": 7952.344444444445,
             "kernel_duration_relative_margin": 0.05,
             "op_to_op_duration_relative_margin": 0.2,
@@ -80,7 +80,7 @@
         "Matmul_0": {
             "op_name": "QKV_MM",
             "kernel_duration": 8795.294507575758,
-            "op_to_op": 734.2121212121211,
+            "op_to_op": 889.2222222222222,
             "first_to_last_start": 2196.5,
             "non-overlapped-dispatch-time": 5763.372222222222,
             "kernel_duration_relative_margin": 0.05,

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -37,7 +37,7 @@ MIN_TYPE = "min"
 MAX_TYPE = "max"
 
 
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(900)
 @pytest.mark.parametrize(
     "weights, layers, input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stress_test, start_pos",
     [

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -785,6 +785,7 @@ def test_llama_TG_perf_device(
     assert all_passing
 
 
+@pytest.mark.timeout(900)
 @pytest.mark.models_device_performance_bare_metal
 # To update:
 # Run FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_KERNELS_EARLY_RETURN=1  pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -37,7 +37,7 @@ MIN_TYPE = "min"
 MAX_TYPE = "max"
 
 
-@pytest.mark.timeout(900)
+@pytest.mark.timeout(600)
 @pytest.mark.parametrize(
     "weights, layers, input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stress_test, start_pos",
     [
@@ -379,6 +379,7 @@ def load_perf_targets(galaxy_type):
     return perf_targets
 
 
+@pytest.mark.timeout(900)
 @pytest.mark.models_device_performance_bare_metal
 # To update:
 # Run FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -405,7 +405,10 @@ def test_llama_TG_perf_device(
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
     profiler.start("run")
     profiler.start(step_name)
-    post_processed_results = run_device_perf(command, subdir, num_iterations, cols, batch_size)
+    device_analysis_types = ["device_kernel_duration", "device_kernel_first_to_last_start"]
+    post_processed_results = run_device_perf(
+        command, subdir, num_iterations, cols, batch_size, device_analysis_types=device_analysis_types
+    )
     profiler.end(step_name)
     profiler.end("run")
 

--- a/models/perf/device_perf_utils.py
+++ b/models/perf/device_perf_utils.py
@@ -19,7 +19,16 @@ from tt_metal.tools.profiler.process_model_log import (
 )
 
 
-def run_device_perf(command, subdir, num_iterations, cols, batch_size, op_name="", has_signposts=False):
+def run_device_perf(
+    command,
+    subdir,
+    num_iterations,
+    cols,
+    batch_size,
+    op_name="",
+    has_signposts=False,
+    device_analysis_types=["device_kernel_duration"],
+):
     duration_cols = [col + " DURATION [ns]" for col in cols]
     samples_cols = [col + " SAMPLES/S" for col in cols]
 
@@ -32,7 +41,7 @@ def run_device_perf(command, subdir, num_iterations, cols, batch_size, op_name="
         results[f"MAX {d_col}"] = -float("inf")
 
     for _ in range(num_iterations):
-        run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+        run_device_profiler(command, subdir, device_analysis_types)
         r = post_process_ops_log(subdir, duration_cols, op_name=op_name, has_signposts=has_signposts)
         for d_col in duration_cols:
             results[f"AVG {d_col}"] += r[d_col]


### PR DESCRIPTION
### Problem description
Model perf tests were failing due to incorrect pydantic parsing (root cause was that these metrics `device_kernel_first_to_last_start ` were not generated by default due to PR [here](https://github.com/tenstorrent/tt-metal/pull/23448) that defaults to generate only the `device_kernel_duration` metrics. We enable them for this tests. (status: waiting runtime to determine if `device_kernel_first_to_last_start ` metrics are important and kept in model perf tests)

### What's changed
- Added the option to add analysis types through run_device_profiler
- Extended timeout as generating the statistics takes longer time

### Checklist
- [ ] TG model perf tests passing run [here](https://github.com/tenstorrent/tt-metal/actions/runs/15949343375)
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes