### PR TITLE
[produce data] [skip ci] Manually paginate the job results when --paginate fails due to ghapi returning HTTP Error 502

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -119,10 +119,15 @@ jobs:
           gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }} > workflow.json
           echo "[Info] Workflow run attempt jobs"
           # Try the original --paginate approach first, fall back to manual pagination if it fails
-          if gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}/jobs --paginate | jq -s '{total_count: .[0].total_count, jobs: map(.jobs) | add}' > workflow_jobs.json; then
+          paginated_output=$(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}/jobs --paginate 2>&1)
+          paginate_exit_code=$?
+
+          if [ $paginate_exit_code -eq 0 ]; then
             echo "Successfully fetched jobs using --paginate"
+            echo "$paginated_output" | jq -s '{total_count: .[0].total_count, jobs: map(.jobs) | add}' > workflow_jobs.json
           else
-            echo "--paginate failed, falling back to manual pagination"
+            echo "--paginate failed (exit code: $paginate_exit_code), falling back to manual pagination"
+            echo "Error output: $paginated_output"
             # Manual pagination to avoid 502 errors with --paginate
             # Get first page to determine total count
             first_page=$(gh api "/repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}/jobs?per_page=50&page=1")

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -118,9 +118,37 @@ jobs:
           gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}
           gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }} > workflow.json
           echo "[Info] Workflow run attempt jobs"
-          gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}/jobs --paginate
-          # GitHub chunks the jobs array into multiple objects side-by-side if there are more than 100 jobs, so we need to slurp them into one giant object for later Python processing
-          gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}/jobs --paginate | jq -s '{total_count: .[0].total_count, jobs: map(.jobs) | add}' > workflow_jobs.json
+          # Try the original --paginate approach first, fall back to manual pagination if it fails
+          if gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}/jobs --paginate | jq -s '{total_count: .[0].total_count, jobs: map(.jobs) | add}' > workflow_jobs.json; then
+            echo "Successfully fetched jobs using --paginate"
+          else
+            echo "--paginate failed, falling back to manual pagination"
+            # Manual pagination to avoid 502 errors with --paginate
+            # Get first page to determine total count
+            first_page=$(gh api "/repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}/jobs?per_page=50&page=1")
+            total_count=$(echo "$first_page" | jq -r '.total_count')
+            echo "Total jobs: $total_count"
+
+            # Calculate total pages needed
+            per_page=50
+            total_pages=$(( (total_count + per_page - 1) / per_page ))
+            echo "Total pages: $total_pages"
+
+            # Initialize with first page
+            all_jobs=$(echo "$first_page" | jq -r '.jobs')
+
+            # Fetch remaining pages if any
+            for page in $(seq 2 $total_pages); do
+              echo "Fetching page $page of $total_pages"
+              page_data=$(gh api "/repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}/jobs?per_page=50&page=$page")
+              page_jobs=$(echo "$page_data" | jq -r '.jobs')
+              all_jobs=$(jq -s '.[0] + .[1]' <(echo "$all_jobs") <(echo "$page_jobs"))
+              sleep 5
+            done
+
+            # Create final JSON with total_count and combined jobs
+            echo "$all_jobs" | jq -s '{total_count: '$total_count', jobs: .[0]}' > workflow_jobs.json
+          fi
       - name: Collect workflow artifact and job logs
         shell: bash
         env:

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -119,8 +119,10 @@ jobs:
           gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }} > workflow.json
           echo "[Info] Workflow run attempt jobs"
           # Try the original --paginate approach first, fall back to manual pagination if it fails
+          set +e  # Disable exit on error
           paginated_output=$(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}/jobs --paginate 2>&1)
           paginate_exit_code=$?
+          set -e  # Re-enable exit on error
 
           if [ $paginate_exit_code -eq 0 ]; then
             echo "Successfully fetched jobs using --paginate"

--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -26,13 +26,65 @@ download_artifacts() {
     fi
 }
 
+# Function to get jobs with pagination fallback
+get_jobs_with_pagination_fallback() {
+    local repo=$1
+    local workflow_run_id=$2
+    local attempt_number=$3
+
+    # Try the original --paginate approach first, fall back to manual pagination if it fails
+    set +e  # Disable exit on error
+    paginated_output=$(gh api /repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/jobs --paginate 2>&1)
+    paginate_exit_code=$?
+    set -e  # Re-enable exit on error
+
+    if [ $paginate_exit_code -eq 0 ]; then
+        echo "Successfully fetched jobs using --paginate"
+        echo "$paginated_output"
+    else
+        echo "--paginate failed (exit code: $paginate_exit_code), falling back to manual pagination"
+        echo "Error output: $paginated_output"
+
+        # Manual pagination to avoid 502 errors with --paginate
+        # Get first page to determine total count
+        first_page=$(gh api "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/jobs?per_page=50&page=1")
+        total_count=$(echo "$first_page" | jq -r '.total_count')
+        echo "Total jobs: $total_count"
+
+        # Calculate total pages needed
+        per_page=50
+        total_pages=$(( (total_count + per_page - 1) / per_page ))
+        echo "Total pages: $total_pages"
+
+        # Initialize with first page
+        all_jobs=$(echo "$first_page" | jq -r '.jobs')
+
+        # Fetch remaining pages if any
+        for page in $(seq 2 $total_pages); do
+            echo "Fetching page $page of $total_pages"
+            page_data=$(gh api "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/jobs?per_page=50&page=$page")
+            page_jobs=$(echo "$page_data" | jq -r '.jobs')
+            all_jobs=$(jq -s '.[0] + .[1]' <(echo "$all_jobs") <(echo "$page_jobs"))
+            sleep 5
+        done
+
+        # Return the combined jobs in the expected format
+        echo "$all_jobs" | jq -s '{total_count: '$total_count', jobs: .[0]}'
+    fi
+}
+
 download_logs_for_all_jobs() {
     local repo=$1
     local workflow_run_id=$2
     local attempt_number=$3
 
     echo "[info] Downloading logs for workflow with id $workflow_run_id for attempt $attempt_number"
-    gh api /repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/jobs --paginate | jq -c '.jobs[] | {id: .id, conclusion: .conclusion}' | while read -r job; do
+
+    # Get jobs using the pagination fallback function
+    jobs_data=$(get_jobs_with_pagination_fallback "$repo" "$workflow_run_id" "$attempt_number")
+
+    # Process the jobs data
+    echo "$jobs_data" | jq -c '.jobs[] | {id: .id, conclusion: .conclusion}' | while read -r job; do
         job_id=$(echo "$job" | jq -r '.id')
         job_conclusion=$(echo "$job" | jq -r '.conclusion')
         echo "[info] download logs for job with id $job_id, attempt number $attempt_number"
@@ -47,7 +99,6 @@ download_logs_for_all_jobs() {
             gh api /repos/$repo/check-runs/$job_id/annotations > generated/cicd/$workflow_run_id/logs/${job_id}_annotations.json
         fi
     done
-
 }
 
 main() {

--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -39,29 +39,29 @@ get_jobs_with_pagination_fallback() {
     set -e  # Re-enable exit on error
 
     if [ $paginate_exit_code -eq 0 ]; then
-        echo "Successfully fetched jobs using --paginate"
+        echo "Successfully fetched jobs using --paginate" >&2
         echo "$paginated_output"
     else
-        echo "--paginate failed (exit code: $paginate_exit_code), falling back to manual pagination"
-        echo "Error output: $paginated_output"
+        echo "--paginate failed (exit code: $paginate_exit_code), falling back to manual pagination" >&2
+        echo "Error output: $paginated_output" >&2
 
         # Manual pagination to avoid 502 errors with --paginate
         # Get first page to determine total count
         first_page=$(gh api "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/jobs?per_page=50&page=1")
         total_count=$(echo "$first_page" | jq -r '.total_count')
-        echo "Total jobs: $total_count"
+        echo "Total jobs: $total_count" >&2
 
         # Calculate total pages needed
         per_page=50
         total_pages=$(( (total_count + per_page - 1) / per_page ))
-        echo "Total pages: $total_pages"
+        echo "Total pages: $total_pages" >&2
 
         # Initialize with first page
         all_jobs=$(echo "$first_page" | jq -r '.jobs')
 
         # Fetch remaining pages if any
         for page in $(seq 2 $total_pages); do
-            echo "Fetching page $page of $total_pages"
+            echo "Fetching page $page of $total_pages" >&2
             page_data=$(gh api "/repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/jobs?per_page=50&page=$page")
             page_jobs=$(echo "$page_data" | jq -r '.jobs')
             all_jobs=$(jq -s '.[0] + .[1]' <(echo "$all_jobs") <(echo "$page_jobs"))


### PR DESCRIPTION
### Ticket
None

### Problem description
`gh api` is more flaky recently, I noticed  when getting all job data with `--paginate` the api will sometimes return http error 502 and confirmed it by running the api calls locally. When grabbing the workflow data per page with a per-page job count >=100 the same also may occur.

### What's changed
If `--paginate` fails, fall back to manual pagination of the workflow per-job data (50 jobs per page)

### Checklist
- [x] Passing run of produce_data branch: https://github.com/tenstorrent/tt-metal/actions/runs/16054854378/job/45306560023