### PR TITLE
enable resnet50 perf test and run only trace+2cq mode

### DIFF
--- a/models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py
@@ -9,7 +9,6 @@ from models.utility_functions import run_for_wormhole_b0
 
 
 @run_for_wormhole_b0()
-@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",
@@ -35,7 +34,6 @@ def test_perf(
 
 
 @run_for_wormhole_b0()
-@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 1500000}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",
@@ -60,7 +58,6 @@ def test_perf_trace(
     )
 
 
-@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_command_queues": 2}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -18,7 +18,7 @@ run_perf_models_other() {
     if [ "$tt_arch" == "wormhole_b0" ]; then
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/sentence_bert/tests -m $test_marker
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker
 
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/bert_tiny/tests/test_performance.py -m $test_marker
 


### PR DESCRIPTION
### Ticket
#24363
#24360

### What's changed
- resnet50 test was enabled on single-card model perf pipeline
- instead of 4 tests, we now run only the most performant one - with trace and 2cqs

### Checklist

- [x] https://github.com/tenstorrent/tt-metal/actions/runs/15978503955