### PR TITLE
#24339: Migrate tt-train mesh mappers to TT-NN APIs

### DIFF
--- a/tt-train/sources/examples/linear_regression_ddp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_ddp/main.cpp
@@ -5,6 +5,7 @@
 #include <fmt/format.h>
 
 #include <core/ttnn_all_includes.hpp>
+#include <ttnn/distributed/distributed_tensor.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
@@ -58,14 +59,11 @@ int main() {
                 std::move(target.begin(), target.end(), std::back_inserter(targets));
             }
 
-            xt::xarray<float> data_xtensor = xt::adapt(data, std::vector<size_t>{batch_size, 1, 1, num_features});
-            xt::xarray<float> targets_xtensor = xt::adapt(targets, std::vector<size_t>{batch_size, 1, 1, num_targets});
-
-            auto mesh_shape = device->shape();
-            ttml::core::XTensorToMeshVariant<float> composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 0);
-            auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_xtensor(data_xtensor, device, composer));
-            auto targets_tensor =
-                ttml::autograd::create_tensor(ttml::core::from_xtensor(targets_xtensor, device, composer));
+            const auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 0);
+            auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
+                data, ttnn::Shape{batch_size, 1, 1, num_features}, device, ttnn::Layout::TILE, mapper.get()));
+            auto targets_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
+                targets, ttnn::Shape{batch_size, 1, 1, num_targets}, device, ttnn::Layout::TILE, mapper.get()));
 
             return std::make_pair(data_tensor, targets_tensor);
         };

--- a/tt-train/sources/examples/linear_regression_ddp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_ddp/main.cpp
@@ -5,7 +5,6 @@
 #include <fmt/format.h>
 
 #include <core/ttnn_all_includes.hpp>
-#include <ttnn/distributed/distributed_tensor.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"

--- a/tt-train/sources/ttml/core/distributed_mapping.hpp
+++ b/tt-train/sources/ttml/core/distributed_mapping.hpp
@@ -18,28 +18,6 @@ std::vector<xt::xarray<T>> chunk(const xt::xarray<T>& tensor, int num_chunks, in
 }
 
 template <class Derived, typename T>
-class XTensorToMesh {
-public:
-    XTensorToMesh(tt::tt_metal::distributed::MeshShape mesh_shape) : m_mesh_shape(std::move(mesh_shape)) {
-    }
-
-    std::vector<xt::xarray<T>> map(const xt::xarray<T>& tensor) const {
-        return static_cast<Derived const*>(this)->map_impl(tensor);
-    }
-
-    std::unordered_map<std::string, std::string> config() const {
-        return static_cast<Derived const*>(this)->config_impl();
-    }
-
-protected:
-    tt::tt_metal::distributed::MeshShape m_mesh_shape;
-
-    size_t get_num_devices() const {
-        return m_mesh_shape.mesh_size();
-    }
-};
-
-template <class Derived, typename T>
 class MeshToXTensor {
 public:
     MeshToXTensor(tt::tt_metal::distributed::MeshShape mesh_shape) : m_mesh_shape(std::move(mesh_shape)) {
@@ -51,100 +29,6 @@ public:
 
 protected:
     tt::tt_metal::distributed::MeshShape m_mesh_shape;
-};
-
-template <typename T>
-class ShardXTensorToMesh : public XTensorToMesh<ShardXTensorToMesh<T>, T> {
-public:
-    using Base = XTensorToMesh<ShardXTensorToMesh<T>, T>;
-    ShardXTensorToMesh(tt::tt_metal::distributed::MeshShape mesh_shape, int dim) :
-        Base(std::move(mesh_shape)), m_shard_dim(dim) {
-    }
-
-    std::vector<xt::xarray<T>> map_impl(const xt::xarray<T>& tensor) const {
-        int num_devices = Base::get_num_devices();
-        auto sliced_tensors = chunk(tensor, num_devices, m_shard_dim);
-        return sliced_tensors;
-    }
-
-    std::unordered_map<std::string, std::string> config_impl() const {
-        return {{"strategy", "shard"}, {"shard_dim", std::to_string(m_shard_dim)}};
-    }
-
-private:
-    int m_shard_dim = 0;
-};
-
-template <typename T>
-class ShardTensor2dMesh : public XTensorToMesh<ShardTensor2dMesh<T>, T> {
-public:
-    using Base = XTensorToMesh<ShardTensor2dMesh<T>, T>;
-    ShardTensor2dMesh(
-        tt::tt_metal::distributed::MeshShape mesh_shape,
-        const std::pair<std::optional<int>, std::optional<int>>& dims) :
-        Base(std::move(mesh_shape)), m_dims(dims) {
-        // We trust the provided mesh shape and do not validate against a MeshDevice.
-    }
-
-    std::vector<xt::xarray<T>> map_impl(const xt::xarray<T>& tensor) const {
-        if (!m_dims.first.has_value() && !m_dims.second.has_value()) {
-            throw std::invalid_argument("ShardTensor2dMesh requires at least one dimension to shard");
-        }
-
-        int rows = Base::m_mesh_shape[0];
-        int cols = Base::m_mesh_shape[1];
-        auto row_dim = m_dims.first;
-        auto col_dim = m_dims.second;
-
-        std::vector<xt::xarray<T>> row_tensors;
-
-        // Shard along rows
-        if (!row_dim.has_value()) {
-            row_tensors.reserve(rows);
-            for (int i = 0; i < rows; ++i) {
-                row_tensors.push_back(tensor);
-            }
-        } else {
-            row_tensors = chunk(tensor, rows, row_dim.value());
-        }
-
-        std::vector<xt::xarray<T>> tensor_shards;
-        tensor_shards.reserve(static_cast<size_t>(rows * cols));
-        // Shard along columns
-        if (!col_dim.has_value()) {
-            for (const auto& t : row_tensors) {
-                for (int i = 0; i < cols; ++i) {
-                    tensor_shards.push_back(t);
-                }
-            }
-        } else {
-            for (const auto& t : row_tensors) {
-                auto col_chunks = chunk(t, cols, col_dim.value());
-                tensor_shards.insert(tensor_shards.end(), col_chunks.begin(), col_chunks.end());
-            }
-        }
-
-        if (static_cast<int>(tensor_shards.size()) != rows * cols) {
-            throw std::runtime_error(fmt::format(
-                "ShardTensor2dMesh: Sharding failed. Number of shards should match the product of the mesh "
-                "dimensions. Size: {}, rows: {}, cols: {}",
-                tensor_shards.size(),
-                rows,
-                cols));
-        }
-
-        return tensor_shards;
-    }
-
-    std::unordered_map<std::string, std::string> config_impl() const {
-        return {
-            {"strategy", "shard_2d"},
-            {"mesh_shape_y", std::to_string(Base::m_mesh_shape[0])},
-            {"mesh_shape_x", std::to_string(Base::m_mesh_shape[1])}};
-    }
-
-private:
-    std::pair<std::optional<int>, std::optional<int>> m_dims;
 };
 
 template <typename T>
@@ -186,29 +70,6 @@ private:
 };
 
 template <typename T>
-class ReplicateXTensorToMesh : public XTensorToMesh<ReplicateXTensorToMesh<T>, T> {
-public:
-    using Base = XTensorToMesh<ReplicateXTensorToMesh<T>, T>;
-    ReplicateXTensorToMesh(tt::tt_metal::distributed::MeshShape mesh_shape) : Base(std::move(mesh_shape)) {
-    }
-
-    std::vector<xt::xarray<T>> map_impl(const xt::xarray<T>& tensor) const {
-        int num_devices = Base::get_num_devices();
-        std::vector<xt::xarray<T>> tensors;
-        tensors.reserve(static_cast<size_t>(num_devices));
-        for (int i = 0; i < num_devices; ++i) {
-            tensors.push_back(tensor);  // Note: this copies the tensor
-        }
-        return tensors;
-    }
-
-    std::unordered_map<std::string, std::string> config_impl() const {
-        int num_devices = Base::get_num_devices();
-        return {{"strategy", "replicate"}, {"replication_factor", std::to_string(num_devices)}};
-    }
-};
-
-template <typename T>
 class ConcatMeshToXTensor : public MeshToXTensor<ConcatMeshToXTensor<T>, T> {
 public:
     using Base = MeshToXTensor<ConcatMeshToXTensor<T>, T>;
@@ -234,9 +95,6 @@ public:
         return tensors;
     }
 };
-
-template <typename T>
-using XTensorToMeshVariant = std::variant<ShardXTensorToMesh<T>, ShardTensor2dMesh<T>, ReplicateXTensorToMesh<T>>;
 
 template <typename T>
 using MeshToXTensorVariant = std::variant<ConcatMeshToXTensor<T>, ConcatMesh2dToTensor<T>, VectorMeshToXTensor<T>>;

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -13,6 +13,8 @@
 #include <functional>
 #include <optional>
 #include <stdexcept>
+#include <ttnn/distributed/distributed_tensor.hpp>
+#include <ttnn/tensor/types.hpp>
 
 #include "core/xtensor_utils.hpp"
 
@@ -51,35 +53,6 @@ void print_tensor_stats_(const tt::tt_metal::Tensor& tensor, const std::string& 
         median,
         mean,
         variance);
-}
-
-// copypaste from deprecated tensor pybinds ttnn
-tt::tt_metal::HostBuffer create_owned_buffer_from_vector_of_floats(
-    const std::vector<float>& data, ttnn::DataType data_type) {
-    switch (data_type) {
-        case ttnn::DataType::BFLOAT8_B: {
-            auto uint32_vector = pack_fp32_vec_as_bfp8_tiles(data, /*row_major_input=*/false, /*is_exp_a=*/false);
-            return tt::tt_metal::HostBuffer(std::move(uint32_vector));
-        }
-        case ttnn::DataType::BFLOAT4_B: {
-            auto uint32_vector = pack_fp32_vec_as_bfp4_tiles(data, /*row_major_input=*/false, /*is_exp_a=*/false);
-            return tt::tt_metal::HostBuffer(std::move(uint32_vector));
-        }
-        case ttnn::DataType::FLOAT32: {
-            auto data_copy = data;
-            return tt::tt_metal::HostBuffer(std::move(data_copy));
-        }
-        case ttnn::DataType::BFLOAT16: {
-            std::vector<bfloat16> bfloat16_data(data.size());
-            std::transform(std::begin(data), std::end(data), std::begin(bfloat16_data), [](float value) {
-                return bfloat16(value);
-            });
-            return tt::tt_metal::HostBuffer(std::move(bfloat16_data));
-        }
-        default: {
-            throw std::runtime_error("Cannot create a host buffer!");
-        }
-    }
 }
 
 template <typename T>
@@ -137,58 +110,13 @@ tt::tt_metal::Tensor ones(const ttnn::Shape& shape, ttnn::distributed::MeshDevic
     return core::full(shape, 1.F, device, dtype);
 }
 
-template <class T, ttnn::DataType TensorType>
-[[nodiscard]] tt::tt_metal::Tensor from_xtensors_to_host(
-    const std::vector<xt::xarray<T>>& buffers, const std::unordered_map<std::string, std::string>& config) {
-    std::vector<tt::tt_metal::HostBuffer> host_owned_buffers;
-    host_owned_buffers.reserve(buffers.size());
-    if (buffers.empty()) {
-        throw std::runtime_error("Cannot create a host buffer from an empty vector of xtensors!");
-    }
-
-    auto first_shape = buffers.front().shape();
-    for (int i = 0; i < buffers.size(); ++i) {
-        if (buffers[i].shape() != first_shape) {
-            throw std::runtime_error(fmt::format(
-                "Cannot create a host buffer from xtensors with different shapes: {} vs {}!",
-                ttnn::experimental::xtensor::get_shape_from_xarray(buffers[0]),
-                ttnn::experimental::xtensor::get_shape_from_xarray(buffers[i])));
-        }
-    }
-    auto tensor_spec = ttnn::TensorSpec(
-        ttnn::experimental::xtensor::get_shape_from_xarray(buffers.front()),
-        ttnn::TensorLayout(TensorType, ttnn::PageConfig(ttnn::Layout::ROW_MAJOR), ttnn::MemoryConfig{}));
-
-    for (const auto& buffer : buffers) {
-        if constexpr (std::is_same_v<T, float>) {
-            auto owned_buffer =
-                create_owned_buffer_from_vector_of_floats(std::vector<T>(buffer.begin(), buffer.end()), TensorType);
-            host_owned_buffers.push_back(std::move(owned_buffer));
-        } else {
-            auto owned_buffer = tt::tt_metal::HostBuffer(std::vector<T>(buffer.begin(), buffer.end()));
-            host_owned_buffers.push_back(std::move(owned_buffer));
-        }
-    }
-
-    return ttnn::Tensor(
-        tt::tt_metal::MultiDeviceHostStorage(std::move(host_owned_buffers)),
-        tensor_spec,
-        tt::tt_metal::get_distributed_tensor_config(config));
-}
-
-template tt::tt_metal::Tensor from_xtensors_to_host<float, ttnn::DataType::BFLOAT16>(
-    const std::vector<xt::xarray<float>>& buffers, const std::unordered_map<std::string, std::string>& config);
-template tt::tt_metal::Tensor from_xtensors_to_host<uint32_t, ttnn::DataType::UINT32>(
-    const std::vector<xt::xarray<uint32_t>>& buffers, const std::unordered_map<std::string, std::string>& config);
-template tt::tt_metal::Tensor from_xtensors_to_host<int32_t, tt::tt_metal::DataType::INT32>(
-    const std::vector<xt::xarray<int32_t>>& buffers, const std::unordered_map<std::string, std::string>& config);
-
 template <>
 tt::tt_metal::Tensor from_vector<float, ttnn::DataType::BFLOAT16>(
     const std::vector<float>& buffer,
     const ttnn::Shape& shape,
     ttnn::distributed::MeshDevice* device,
-    ttnn::Layout layout) {
+    ttnn::Layout layout,
+    const ttnn::distributed::TensorToMesh* mesh_mapper) {
     assert(device != nullptr);
     const ttnn::DataType data_type = ttnn::DataType::BFLOAT16;
     ttnn::MemoryConfig output_mem_config{};
@@ -197,9 +125,12 @@ tt::tt_metal::Tensor from_vector<float, ttnn::DataType::BFLOAT16>(
         throw std::logic_error(
             fmt::format("Current buffer size is {} different from shape volume {}", buffer.size(), volume));
     }
-    auto owned_buffer = create_owned_buffer_from_vector_of_floats(buffer, data_type);
-    // remove possible paddings from the shape (it conflicts with ROW MAJOR)
-    auto output = tt::tt_metal::Tensor(std::move(owned_buffer), shape, data_type, ttnn::Layout::ROW_MAJOR);
+
+    const auto tensor_layout =
+        ttnn::TensorLayout(data_type, ttnn::PageConfig(ttnn::Layout::ROW_MAJOR), tt::tt_metal::MemoryConfig{});
+    auto output = (mesh_mapper != nullptr) ? ttnn::distributed::create_distributed_tensor(
+                                                 ttsl::make_const_span(buffer), shape, tensor_layout, *mesh_mapper)
+                                           : ttnn::Tensor::from_vector(buffer, ttnn::TensorSpec(shape, tensor_layout));
 
     const size_t MAX_TILE_DIMENSION = 16384;
     // Temporary workaround for the issue with tilize for large size
@@ -224,8 +155,9 @@ tt::tt_metal::Tensor from_vector<float, ttnn::DataType::FLOAT32>(
     const std::vector<float>& buffer,
     const ttnn::Shape& shape,
     ttnn::distributed::MeshDevice* device,
-    ttnn::Layout layout) {
-    auto tensor = from_vector<float, ttnn::DataType::BFLOAT16>(buffer, shape, device, layout);
+    ttnn::Layout layout,
+    const ttnn::distributed::TensorToMesh* mesh_mapper) {
+    auto tensor = from_vector<float, ttnn::DataType::BFLOAT16>(buffer, shape, device, layout, mesh_mapper);
     return ttnn::typecast(tensor, ttnn::DataType::FLOAT32);
 }
 
@@ -237,7 +169,8 @@ tt::tt_metal::Tensor from_vector<uint32_t, ttnn::DataType::UINT32>(
     const std::vector<uint32_t>& buffer,
     const ttnn::Shape& shape,
     ttnn::distributed::MeshDevice* device,
-    ttnn::Layout layout) {
+    ttnn::Layout layout,
+    const ttnn::distributed::TensorToMesh* mesh_mapper) {
     ttnn::MemoryConfig output_mem_config{};
     auto volume = shape.volume();
     if (buffer.size() != volume) {
@@ -245,10 +178,12 @@ tt::tt_metal::Tensor from_vector<uint32_t, ttnn::DataType::UINT32>(
             fmt::format("Current buffer size is {} different from shape volume {}", buffer.size(), volume));
     }
 
-    // remove possible paddings from the shape (it conflicts with ROW MAJOR)
-    std::vector<uint32_t> buffer_copy = buffer;
-    auto output =
-        ttml_create_owned_tensor(std::move(buffer_copy), shape, ttnn::DataType::UINT32, ttnn::Layout::ROW_MAJOR);
+    const auto tensor_layout =
+        ttnn::TensorLayout(ttnn::DataType::UINT32, ttnn::PageConfig(ttnn::Layout::ROW_MAJOR), output_mem_config);
+    auto output = (mesh_mapper != nullptr) ? ttnn::distributed::create_distributed_tensor(
+                                                 ttsl::make_const_span(buffer), shape, tensor_layout, *mesh_mapper)
+                                           : ttnn::Tensor::from_vector(buffer, ttnn::TensorSpec(shape, tensor_layout));
+
     if (device != nullptr) {
         if (layout != ttnn::Layout::ROW_MAJOR) {
             output = ttnn::to_layout(output, layout, std::nullopt, output_mem_config);
@@ -267,7 +202,8 @@ tt::tt_metal::Tensor from_vector<int32_t, ttnn::DataType::INT32>(
     const std::vector<int32_t>& buffer,
     const ttnn::Shape& shape,
     ttnn::distributed::MeshDevice* device,
-    ttnn::Layout layout) {
+    ttnn::Layout layout,
+    const ttnn::distributed::TensorToMesh* mesh_mapper) {
     ttnn::MemoryConfig output_mem_config{};
     auto volume = shape.volume();
     if (buffer.size() != volume) {
@@ -275,10 +211,12 @@ tt::tt_metal::Tensor from_vector<int32_t, ttnn::DataType::INT32>(
             fmt::format("Current buffer size is {} different from shape volume {}", buffer.size(), volume));
     }
 
-    // remove possible paddings from the shape (it conflicts with ROW MAJOR)
-    std::vector<int32_t> buffer_copy = buffer;
-    auto output =
-        ttml_create_owned_tensor(std::move(buffer_copy), shape, ttnn::DataType::INT32, ttnn::Layout::ROW_MAJOR);
+    const auto tensor_layout =
+        ttnn::TensorLayout(ttnn::DataType::INT32, ttnn::PageConfig(ttnn::Layout::ROW_MAJOR), output_mem_config);
+    auto output = (mesh_mapper != nullptr) ? ttnn::distributed::create_distributed_tensor(
+                                                 ttsl::make_const_span(buffer), shape, tensor_layout, *mesh_mapper)
+                                           : ttnn::Tensor::from_vector(buffer, ttnn::TensorSpec(shape, tensor_layout));
+
     if (device != nullptr) {
         if (layout != ttnn::Layout::ROW_MAJOR) {
             output = ttnn::to_layout(output, layout, std::nullopt, output_mem_config);
@@ -304,49 +242,6 @@ void print_tensor_stats(const tt::tt_metal::Tensor& tensor, const std::string& n
         print_tensor_stats_<uint32_t>(tensor, name);
     }
 }
-
-template <class T, ttnn::DataType TensorType>
-tt::tt_metal::Tensor from_xtensor(
-    const xt::xarray<T>& tensor,
-    ttnn::distributed::MeshDevice* device,
-    const XTensorToMeshVariant<T>& composer,
-    ttnn::Layout layout) {
-    auto sharded_tensors = std::visit([&tensor](auto&& arg) { return arg.map(tensor); }, composer);
-    auto config = std::visit([](auto&& arg) { return arg.config(); }, composer);
-    auto output = from_xtensors_to_host<T, TensorType>(sharded_tensors, config);
-    ttnn::MemoryConfig output_mem_config{};
-
-    if constexpr (std::is_same_v<T, int32_t> || std::is_same_v<T, uint32_t>) {
-        if (layout != ttnn::Layout::ROW_MAJOR) {
-            output = ttnn::to_layout(output, layout, std::nullopt, output_mem_config);
-        }
-        output = ttnn::to_device(output, device, output_mem_config);
-    } else {
-        output = ttnn::to_device(output, device, output_mem_config);
-        if (layout == ttnn::Layout::TILE) {
-            output = ttnn::tilize_with_zero_padding(output, output_mem_config, std::nullopt, /* multicore */ true);
-        }
-    }
-    return output;
-}
-
-template tt::tt_metal::Tensor from_xtensor<float, ttnn::DataType::BFLOAT16>(
-    const xt::xarray<float>& tensor,
-    ttnn::distributed::MeshDevice* device,
-    const XTensorToMeshVariant<float>& composer,
-    ttnn::Layout layout);
-
-template tt::tt_metal::Tensor from_xtensor<int32_t, ttnn::DataType::INT32>(
-    const xt::xarray<int32_t>& tensor,
-    ttnn::distributed::MeshDevice* device,
-    const XTensorToMeshVariant<int32_t>& composer,
-    ttnn::Layout layout);
-
-template tt::tt_metal::Tensor from_xtensor<uint32_t, ttnn::DataType::UINT32>(
-    const xt::xarray<uint32_t>& tensor,
-    ttnn::distributed::MeshDevice* device,
-    const XTensorToMeshVariant<uint32_t>& composer,
-    ttnn::Layout layout);
 
 std::vector<std::span<std::byte>> get_bytes_from_cpu_tensor(ttnn::Tensor& tensor) {
     std::vector<std::span<std::byte>> res;

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -13,7 +13,6 @@
 #include <functional>
 #include <optional>
 #include <stdexcept>
-#include <ttnn/distributed/distributed_tensor.hpp>
 #include <ttnn/tensor/types.hpp>
 
 #include "core/xtensor_utils.hpp"

--- a/tt-train/sources/ttml/core/tt_tensor_utils.hpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.hpp
@@ -6,6 +6,7 @@
 
 #include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
+#include <ttnn/distributed/distributed_tensor.hpp>
 #include <vector>
 
 #include "core/distributed_mapping.hpp"
@@ -35,11 +36,8 @@ template <class VectorType = float, ttnn::DataType TensorType = ttnn::DataType::
     const std::vector<VectorType>& buffer,
     const ttnn::Shape& shape,
     ttnn::distributed::MeshDevice* device,
-    ttnn::Layout layout = ttnn::Layout::TILE);
-
-template <class VectorType = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
-[[nodiscard]] tt::tt_metal::Tensor from_xtensors_to_host(
-    const std::vector<xt::xarray<VectorType>>& buffers, const std::unordered_map<std::string, std::string>& config);
+    ttnn::Layout layout = ttnn::Layout::TILE,
+    const ttnn::distributed::TensorToMesh* mesh_mapper = nullptr);
 
 template <class T = float>
 [[nodiscard]] std::vector<T> to_vector(const tt::tt_metal::Tensor& tensor) {
@@ -52,10 +50,14 @@ template <class T = float>
 
 template <class T = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
 [[nodiscard]] tt::tt_metal::Tensor from_xtensor(
-    const xt::xarray<T>& buffer, ttnn::distributed::MeshDevice* device, ttnn::Layout layout = ttnn::Layout::TILE) {
+    const xt::xarray<T>& buffer,
+    ttnn::distributed::MeshDevice* device,
+    ttnn::Layout layout = ttnn::Layout::TILE,
+    const ttnn::distributed::TensorToMesh* mesh_mapper = nullptr) {
     auto shape = ttnn::experimental::xtensor::get_shape_from_xarray(buffer);
     auto buffer_view = xtensor_to_span(buffer);
-    return from_vector<T, TensorType>(std::vector<T>(buffer_view.begin(), buffer_view.end()), shape, device, layout);
+    return from_vector<T, TensorType>(
+        std::vector<T>(buffer_view.begin(), buffer_view.end()), shape, device, layout, mesh_mapper);
 }
 
 template <class T = float>
@@ -79,13 +81,6 @@ auto to_xtensor(const tt::tt_metal::Tensor& tensor, const MeshToXTensorVariant<T
     }
     return std::visit([&res](auto&& arg) { return arg.compose(res); }, composer);
 }
-
-template <class T = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
-tt::tt_metal::Tensor from_xtensor(
-    const xt::xarray<T>& tensor,
-    ttnn::distributed::MeshDevice* device,
-    const XTensorToMeshVariant<T>& composer,
-    ttnn::Layout layout = ttnn::Layout::TILE);
 
 std::vector<std::span<std::byte>> get_bytes_from_cpu_tensor(ttnn::Tensor& cpu_tensor);
 

--- a/tt-train/sources/ttml/core/ttnn_all_includes.hpp
+++ b/tt-train/sources/ttml/core/ttnn_all_includes.hpp
@@ -24,6 +24,7 @@
 #include <ttnn/core.hpp>                                                                           // NOLINT
 #include <ttnn/device.hpp>                                                                         // NOLINT
 #include <ttnn/distributed/api.hpp>                                                                // NOLINT
+#include <ttnn/distributed/distributed_tensor.hpp>                                                 // NOLINT
 #include <ttnn/distributed/types.hpp>                                                              // NOLINT
 #include <ttnn/operations/ccl/all_gather/all_gather.hpp>                                           // NOLINT
 #include <ttnn/operations/copy/typecast/typecast.hpp>                                              // NOLINT

--- a/tt-train/sources/ttml/models/distributed/llama.cpp
+++ b/tt-train/sources/ttml/models/distributed/llama.cpp
@@ -27,10 +27,10 @@ void initialize_weights(DistributedLlama& model) {
             auto* device = &autograd::ctx().get_device();
             auto num_devices = static_cast<uint32_t>(device->num_devices());
             tensor_shape[0] *= num_devices;
-            core::XTensorToMeshVariant<float> shard_composer = core::ShardXTensorToMesh<float>(device->shape(), 0);
             auto weight_xtensor = init::normal_init(tensor_shape, {0.F, 0.02F});
-            tensor_ptr->set_value(
-                core::from_xtensor<float, ttnn::DataType::BFLOAT16>(weight_xtensor, device, shard_composer));
+            const auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 0);
+            tensor_ptr->set_value(ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(
+                weight_xtensor, device, ttnn::Layout::TILE, mapper.get()));
         } else if (name.find("bias") != std::string::npos) {
             init::constant_init(tensor_ptr, tensor.logical_shape(), 0.F);
         }

--- a/tt-train/sources/ttml/modules/distributed/linear.cpp
+++ b/tt-train/sources/ttml/modules/distributed/linear.cpp
@@ -59,11 +59,10 @@ void RowParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out_fe
     auto mesh_shape = device->shape();
     const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
 
-    ttml::core::XTensorToMeshVariant<float> shard_composer =
-        ttml::core::ShardXTensorToMesh<float>(mesh_shape, rank - 1U);
     auto weight = init::uniform_init(weight_shape, init::UniformRange{-init_k, init_k});
+    const auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 0);
     m_weight = autograd::create_tensor(
-        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(weight, device, shard_composer));
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(weight, device, ttnn::Layout::TILE, mapper.get()));
 
     if (has_bias) {
         auto bias_shape = core::create_shape({1, 1, 1, out_features});
@@ -110,19 +109,16 @@ void ColumnParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out
     auto mesh_shape = device->shape();
     const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
 
-    ttml::core::XTensorToMeshVariant<float> shard_composer =
-        ttml::core::ShardXTensorToMesh<float>(mesh_shape, rank - 2U);
     auto weight = init::uniform_init(weight_shape, init::UniformRange{-init_k, init_k});
+    const auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 0);
     m_weight = autograd::create_tensor(
-        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(weight, device, shard_composer));
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(weight, device, ttnn::Layout::TILE, mapper.get()));
 
     if (has_bias) {
         auto bias_shape = core::create_shape({1, 1, 1, out_features});
         auto bias = init::uniform_init(bias_shape, init::UniformRange{-init_k, init_k});
-        ttml::core::XTensorToMeshVariant<float> shard_composer =
-            ttml::core::ShardXTensorToMesh<float>(mesh_shape, rank - 1U);
         m_bias = autograd::create_tensor(
-            ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(bias, device, shard_composer));
+            ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(bias, device, ttnn::Layout::TILE, mapper.get()));
     }
 }
 

--- a/tt-train/tests/core/distributed_test.cpp
+++ b/tt-train/tests/core/distributed_test.cpp
@@ -23,56 +23,6 @@ protected:
 using TestTypes = ::testing::Types<uint32_t, float>;
 TYPED_TEST_SUITE(MeshOpsTest, TestTypes);
 
-TYPED_TEST(MeshOpsTest, ShardXTensorToMeshBasicShard) {
-    MetalMeshShape mesh_shape{1, 4};
-
-    // A simple 1D tensor to shard across 4 devices
-    auto tensor = xt::arange<TypeParam>(8);  // [0,...,7]
-
-    ttml::core::ShardXTensorToMesh<TypeParam> sharder(mesh_shape, 0);
-    auto shards = sharder.map(tensor);
-
-    // With 4 shards, each shard should have size 2
-    ASSERT_THAT(shards, SizeIs(4));
-    for (auto& s : shards) {
-        EXPECT_EQ(s.size(), 2u);
-    }
-}
-
-TYPED_TEST(MeshOpsTest, ShardTensor2dMeshTwoDimSharding) {
-    // Mesh shape: 2x2, total 4 devices
-    MetalMeshShape mesh_shape{2, 2};
-
-    // Create a 2D tensor shape: (4,4)
-    auto tensor = xt::arange<TypeParam>(16).reshape({4, 4});
-
-    // Shard along row_dim=0 and col_dim=1
-    ttml::core::ShardTensor2dMesh<TypeParam> sharder(mesh_shape, {0, 1});
-    auto shards = sharder.map(tensor);
-
-    ASSERT_THAT(shards, SizeIs(4));
-    // Check shapes of shards
-    for (auto& shard : shards) {
-        EXPECT_EQ(shard.shape()[0], 2u);
-        EXPECT_EQ(shard.shape()[1], 2u);
-    }
-}
-
-TYPED_TEST(MeshOpsTest, ReplicateXTensorToMeshReplication) {
-    MetalMeshShape mesh_shape{2, 2};
-    int num_devices = mesh_shape.mesh_size();  // 4
-
-    auto tensor = xt::arange<TypeParam>(4);  // [0,1,2,3]
-
-    ttml::core::ReplicateXTensorToMesh<TypeParam> replicator(mesh_shape);
-    auto replicas = replicator.map(tensor);
-
-    ASSERT_THAT(replicas, SizeIs(num_devices));
-    for (const auto& t : replicas) {
-        EXPECT_TRUE(xt::allclose(t, tensor));
-    }
-}
-
 TYPED_TEST(MeshOpsTest, ConcatMesh2dToTensorRecomposition) {
     MetalMeshShape mesh_shape{2, 2};
 

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -7,6 +7,7 @@
 
 #include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
+#include <ttnn/distributed/distributed_tensor.hpp>
 #include <xtensor-blas/xlinalg.hpp>
 
 #include "autograd/auto_context.hpp"
@@ -39,9 +40,9 @@ TEST_F(N300UtilsTest, TestXTensorReplicateInt32) {
     auto mesh_shape = device->shape();
     xt::xarray<int32_t> test_data = {30, 20, 2};
     xt::xarray<int32_t> xtensor = test_data.reshape({1, 1, 1, 3});
-    ttml::core::XTensorToMeshVariant<int32_t> replicate_composer =
-        ttml::core::ReplicateXTensorToMesh<int32_t>(mesh_shape);
-    auto tensor = ttml::core::from_xtensor<int32_t, ttnn::DataType::INT32>(xtensor, device, replicate_composer);
+    const auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tensor =
+        ttml::core::from_xtensor<int32_t, ttnn::DataType::INT32>(xtensor, device, ttnn::Layout::TILE, mapper.get());
     ttml::core::MeshToXTensorVariant<int32_t> identity_composer = ttml::core::VectorMeshToXTensor<int32_t>(mesh_shape);
     auto xtensors_back = ttml::core::to_xtensor<int32_t>(tensor, identity_composer);
 
@@ -54,9 +55,9 @@ TEST_F(N300UtilsTest, TestXTensorReplicateUInt32) {
     auto mesh_shape = device->shape();
     xt::xarray<uint32_t> test_data = {30U, 20U, 2U};
     xt::xarray<uint32_t> xtensor = test_data.reshape({1, 1, 1, 3});
-    ttml::core::XTensorToMeshVariant<uint32_t> replicate_composer =
-        ttml::core::ReplicateXTensorToMesh<uint32_t>(mesh_shape);
-    auto tensor = ttml::core::from_xtensor<uint32_t, ttnn::DataType::UINT32>(xtensor, device, replicate_composer);
+    const auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tensor =
+        ttml::core::from_xtensor<uint32_t, ttnn::DataType::UINT32>(xtensor, device, ttnn::Layout::TILE, mapper.get());
     ttml::core::MeshToXTensorVariant<uint32_t> identity_composer =
         ttml::core::VectorMeshToXTensor<uint32_t>(mesh_shape);
     auto xtensors_back = ttml::core::to_xtensor<uint32_t>(tensor, identity_composer);
@@ -69,8 +70,8 @@ TEST_F(N300UtilsTest, TestXTensorReplicate) {
     auto mesh_shape = device->shape();
     xt::xarray<float> test_data = {30.F, 20.F, 2.F};
     xt::xarray<float> xtensor = test_data.reshape({1, 1, 1, 3});
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tensor = ttml::core::from_xtensor(xtensor, device, replicate_composer);
+    const auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tensor = ttml::core::from_xtensor(xtensor, device, ttnn::Layout::TILE, mapper.get());
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
     auto xtensors_back = ttml::core::to_xtensor(tensor, identity_composer);
 
@@ -85,8 +86,8 @@ TEST_F(N300UtilsTest, TestXTensorShardAxis3) {
     xt::xarray<float> test_data = xt::arange(8);
     xt::xarray<float> xtensor = test_data.reshape({1, 1, 2, 4});
 
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
-    auto tensor = ttml::core::from_xtensor(xtensor, device, replicate_composer);
+    const auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 3);
+    auto tensor = ttml::core::from_xtensor(xtensor, device, ttnn::Layout::TILE, mapper.get());
 
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
     auto xtensors_back = ttml::core::to_xtensor(tensor, identity_composer);
@@ -105,8 +106,8 @@ TEST_F(N300UtilsTest, TestXTensorShardAxis2) {
     xt::xarray<float> test_data = xt::arange(8);
     xt::xarray<float> xtensor = test_data.reshape({1, 1, 2, 4});
 
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 2);
-    auto tensor = ttml::core::from_xtensor(xtensor, device, replicate_composer);
+    const auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 2);
+    auto tensor = ttml::core::from_xtensor(xtensor, device, ttnn::Layout::TILE, mapper.get());
 
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
     auto xtensors_back = ttml::core::to_xtensor(tensor, identity_composer);
@@ -124,8 +125,8 @@ TEST_F(N300UtilsTest, TestXTensorReplicateAllReduce) {
 
     xt::xarray<float> xtensor = xt::random::rand({32 * 32}, -0.05, 0.05).reshape({1, 1, 32, 32});
 
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tensor = ttml::core::from_xtensor(xtensor, device, replicate_composer);
+    const auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tensor = ttml::core::from_xtensor(xtensor, device, ttnn::Layout::TILE, mapper.get());
 
     auto sum_tensor = ttnn::experimental::all_reduce(
         tensor, ttnn::operations::reduction::ReduceType::Sum, 1, std::nullopt, ttnn::ccl::Topology::Ring);
@@ -147,8 +148,8 @@ TEST_F(N300UtilsTest, TestXTensorReplicateAllReduceBadTiles) {
 
     xt::xarray<float> xtensor = xt::random::rand({32}, -1.F, 1.F).reshape({1, 1, 4, 8});
 
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tensor = ttml::core::from_xtensor(xtensor, device, replicate_composer);
+    const auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tensor = ttml::core::from_xtensor(xtensor, device, ttnn::Layout::TILE, mapper.get());
 
     auto sum_tensor = ttnn::experimental::all_reduce(
         tensor, ttnn::operations::reduction::ReduceType::Sum, 1, std::nullopt, ttnn::ccl::Topology::Ring);
@@ -168,8 +169,8 @@ TEST_F(N300UtilsTest, TestXTensorShardAxis2AddScalar) {
     xt::xarray<float> test_data = xt::arange(8);
     xt::xarray<float> xtensor = test_data.reshape({1, 1, 2, 4});
 
-    ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 2);
-    auto tensor = ttml::core::from_xtensor(xtensor, device, shard_composer);
+    const auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 2);
+    auto tensor = ttml::core::from_xtensor(xtensor, device, ttnn::Layout::TILE, mapper.get());
     auto out_tensor = ttnn::add(tensor, scalar);
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
     auto xtensors_back = ttml::core::to_xtensor(out_tensor, identity_composer);
@@ -189,10 +190,9 @@ TEST_F(N300UtilsTest, TestXTensorShardAxis3Matmul) {
     xt::xarray<float> xtensor_a = xt::random::rand({128 * 64}, -0.005, 0.005).reshape({1, 1, 128, 64});
     xt::xarray<float> xtensor_b = xt::random::rand({256 * 64}, -0.005, 0.005).reshape({1, 1, 64, 256});
 
-    ttml::core::XTensorToMeshVariant<float> replicate_composer2 = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 2);
-    ttml::core::XTensorToMeshVariant<float> replicate_composer3 = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
-    auto tensor_a = ttml::core::from_xtensor(xtensor_a, device, replicate_composer3);
-    auto tensor_b = ttml::core::from_xtensor(xtensor_b, device, replicate_composer3);
+    const auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 3);
+    auto tensor_a = ttml::core::from_xtensor(xtensor_a, device, ttnn::Layout::TILE, mapper.get());
+    auto tensor_b = ttml::core::from_xtensor(xtensor_b, device, ttnn::Layout::TILE, mapper.get());
 
     auto gathered_ta =
         ttnn::all_gather(tensor_a, 3 /*, {0, 4}, 1 ,std::nullopt, std::nullopt, std::nullopt, std::nullopt*/);
@@ -228,9 +228,8 @@ TEST_F(N300UtilsTest, DropoutDifferentSeed) {
     for (auto& shape : shapes) {
         fmt::println("Testing shape: {}", shape);
         xt::xarray<float> xtensor = xt::ones<float>(shape);
-        ttml::core::XTensorToMeshVariant<float> replicate_composer =
-            ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-        auto xtensor_tensor = ttml::core::from_xtensor(xtensor, device, replicate_composer);
+        const auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+        auto xtensor_tensor = ttml::core::from_xtensor(xtensor, device, ttnn::Layout::TILE, mapper.get());
         auto out_tensor = ttnn::experimental::dropout(xtensor_tensor, prob, scale, dropout_seed1);
         ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
         auto xtensors_back = ttml::core::to_xtensor(out_tensor, identity_composer);
@@ -243,8 +242,8 @@ TEST_F(N300UtilsTest, MorehClipGradNorm) {
     auto mesh_shape = device->shape();
     xt::xarray<float> xtensor = xt::ones<float>({4, 1, 20, 5});
 
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tensor = ttml::core::from_xtensor(xtensor, device, replicate_composer, ttnn::Layout::TILE);
+    const auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tensor = ttml::core::from_xtensor(xtensor, device, ttnn::Layout::TILE, mapper.get());
     auto do_it = [&tensor]() {
         ttnn::moreh_clip_grad_norm(
             std::vector<tt::tt_metal::Tensor>{tensor},

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -7,7 +7,6 @@
 
 #include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
-#include <ttnn/distributed/distributed_tensor.hpp>
 #include <xtensor-blas/xlinalg.hpp>
 
 #include "autograd/auto_context.hpp"

--- a/tt-train/tests/model/linear_regression_ddp_test.cpp
+++ b/tt-train/tests/model/linear_regression_ddp_test.cpp
@@ -82,14 +82,20 @@ TEST_F(LinearRegressionDDPTest, Full) {
                 std::move(target.begin(), target.end(), std::back_inserter(targets));
             }
 
-            xt::xarray<float> data_xtensor = xt::adapt(data, std::vector<size_t>{batch_size, 1, 1, num_features});
-            xt::xarray<float> targets_xtensor = xt::adapt(targets, std::vector<size_t>{batch_size, 1, 1, num_targets});
-
-            auto mesh_shape = device->shape();
-            ttml::core::XTensorToMeshVariant<float> composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-            auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_xtensor(data_xtensor, device, composer));
+            const auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+            auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(
+                data,
+                ttml::core::create_shape({batch_size, 1, 1, num_features}),
+                device,
+                ttnn::Layout::TILE,
+                mapper.get()));
             auto targets_tensor =
-                ttml::autograd::create_tensor(ttml::core::from_xtensor(targets_xtensor, device, composer));
+                ttml::autograd::create_tensor(ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(
+                    targets,
+                    ttml::core::create_shape({batch_size, 1, 1, num_targets}),
+                    device,
+                    ttnn::Layout::TILE,
+                    mapper.get()));
 
             return std::make_pair(data_tensor, targets_tensor);
         };

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -64,8 +64,9 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNotInputParallel) {
     auto mesh_shape = device->shape();
 
     xt::xarray<float> test_data = xt::random::rand({in_features}, 0.F, 1.F).reshape({1U, 1U, 1U, in_features});
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, replicate_composer);
+    auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto output = layer(tensor);
 
@@ -106,8 +107,9 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasNotInputParallel) {
     auto mesh_shape = device->shape();
 
     xt::xarray<float> test_data = xt::random::rand({in_features}, 0.F, 1.F).reshape({1U, 1U, 1U, in_features});
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, replicate_composer);
+    auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto output = layer(tensor);
 
@@ -144,8 +146,9 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasInputParallel) {
     auto mesh_shape = device->shape();
 
     xt::xarray<float> test_data = xt::random::rand({in_features}, 0.F, 1.F).reshape({1U, 1U, 1U, in_features});
-    ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, shard_composer);
+    auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 3);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto output = layer(tensor);
 
@@ -182,8 +185,9 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasInputParallel) {
     auto mesh_shape = device->shape();
 
     xt::xarray<float> test_data = xt::random::rand({in_features}, 0.F, 1.F).reshape({1U, 1U, 1U, in_features});
-    ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, shard_composer);
+    auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 3);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto output = layer(tensor);
 
@@ -217,8 +221,9 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasAllGather) {
     auto mesh_shape = device->shape();
 
     xt::xarray<float> test_data = xt::random::rand({in_features}, 0.F, 1.F).reshape({1U, 1U, 1U, in_features});
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, replicate_composer);
+    auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto output = layer(tensor);
 
@@ -257,8 +262,9 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasAllGather) {
     auto mesh_shape = device->shape();
 
     xt::xarray<float> test_data = xt::random::rand({in_features}, 0.F, 1.F).reshape({1U, 1U, 1U, in_features});
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, replicate_composer);
+    auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto output = layer(tensor);
 
@@ -293,8 +299,9 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasNoAllGather) {
     auto mesh_shape = device->shape();
 
     xt::xarray<float> test_data = xt::random::rand({in_features}, 0.F, 1.F).reshape({1U, 1U, 1U, in_features});
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, replicate_composer);
+    auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto output = layer(tensor);
 
@@ -341,8 +348,9 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasNoAllGather) {
     auto mesh_shape = device->shape();
 
     xt::xarray<float> test_data = xt::random::rand({in_features}, 0.F, 1.F).reshape({1U, 1U, 1U, in_features});
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, replicate_composer);
+    auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto output = layer(tensor);
 
@@ -390,8 +398,9 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNanoGPT) {
 
     xt::xarray<float> test_data = xt::random::rand({in_features * batch_size * sequence_length}, -1.F, 1.F)
                                       .reshape({batch_size, 1U, sequence_length, in_features});
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, replicate_composer);
+    auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto output = layer(tensor);
     output->backward();
@@ -457,8 +466,9 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasNanoGPT) {
 
     xt::xarray<float> test_data = xt::random::rand({in_features * batch_size * sequence_length}, -1.F, 1.F)
                                       .reshape({batch_size, 1U, sequence_length, in_features});
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, replicate_composer);
+    auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto output = layer(tensor);
     output->backward();
@@ -524,8 +534,9 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasNanoGPT) {
 
     xt::xarray<float> test_data = xt::random::rand({in_features * batch_size * sequence_length}, -1.F, 1.F)
                                       .reshape({batch_size, 1U, sequence_length, in_features});
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, replicate_composer);
+    auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(test_data, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto output = layer(tensor);
     output->backward();

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -46,8 +46,9 @@ TEST_F(N300CommOpsTest, TestAllReduceNotFullyTiled) {
     std::iota(test_data_vec.begin(), test_data_vec.end(), 0.0F);
     xt::xarray<float> test_data = xt::adapt(test_data_vec);
     xt::xarray<float> xtensor = test_data.reshape({1U, 1U, 1U, size});
-    ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, shard_composer);
+    auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 3);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto all_reduce_tensor = ttml::ops::distributed::all_reduce(tensor);
 
@@ -62,9 +63,9 @@ TEST_F(N300CommOpsTest, TestAllReduceNotFullyTiled) {
     EXPECT_TRUE(xt::allclose(all_reduce_expected, all_reduce_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-3));
 
     xt::xarray<float> grad_data = xt::random::rand(all_reduce_expected.shape(), 0.F, 1.F);
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
+    mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
     auto tt_grad_tensor =
-        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(grad_data, device, replicate_composer);
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(grad_data, device, ttnn::Layout::TILE, mapper.get());
     all_reduce_tensor->set_grad(tt_grad_tensor);
     all_reduce_tensor->backward();
 
@@ -100,8 +101,9 @@ TEST_F(N300CommOpsTest, TestAllReduceNanoGPT) {
     ttml::init::uniform_init(test_data_vec, {-1.F, 1.F});
     xt::xarray<float> test_data = xt::adapt(test_data_vec);
     xt::xarray<float> xtensor = test_data.reshape({batch, 1U, height, size});
-    ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, shard_composer);
+    auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 3);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto all_reduce_tensor = ttml::ops::distributed::all_reduce(tensor);
 
@@ -116,9 +118,9 @@ TEST_F(N300CommOpsTest, TestAllReduceNanoGPT) {
     EXPECT_TRUE(xt::allclose(all_reduce_expected, all_reduce_xtensor[1], /* rtol */ 1e-3, /* atol */ 2e-2));
 
     xt::xarray<float> grad_data = xt::random::rand(all_reduce_expected.shape(), 0.F, 1.F);
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
+    mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
     auto tt_grad_tensor =
-        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(grad_data, device, replicate_composer);
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(grad_data, device, ttnn::Layout::TILE, mapper.get());
     all_reduce_tensor->set_grad(tt_grad_tensor);
     all_reduce_tensor->backward();
 
@@ -149,8 +151,9 @@ TEST_F(N300CommOpsTest, TestAllReduceFullyTiled) {
     ttml::init::uniform_init(test_data_vec, {0.F, 0.001F});
     xt::xarray<float> test_data = xt::adapt(test_data_vec);
     xt::xarray<float> xtensor = test_data.reshape({1U, 1U, height, size});
-    ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, shard_composer);
+    auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 3);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto all_reduce_tensor = ttml::ops::distributed::all_reduce(tensor);
 
@@ -165,9 +168,9 @@ TEST_F(N300CommOpsTest, TestAllReduceFullyTiled) {
     EXPECT_TRUE(xt::allclose(all_reduce_expected, all_reduce_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
 
     xt::xarray<float> grad_data = xt::random::rand(all_reduce_expected.shape(), 0.F, 1.F);
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
+    mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
     auto tt_grad_tensor =
-        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(grad_data, device, replicate_composer);
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(grad_data, device, ttnn::Layout::TILE, mapper.get());
     all_reduce_tensor->set_grad(tt_grad_tensor);
     all_reduce_tensor->backward();
 
@@ -197,8 +200,9 @@ TEST_F(N300CommOpsTest, TestAllGatherNotFullyTiled) {
     std::iota(test_data_vec.begin(), test_data_vec.end(), 0.0F);
     xt::xarray<float> test_data = xt::adapt(test_data_vec);
     xt::xarray<float> xtensor = test_data.reshape({1U, 1U, 1U, size});
-    ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, shard_composer);
+    auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 3);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto gathered_tensor = ttml::ops::distributed::all_gather(tensor, 3);
 
@@ -208,9 +212,9 @@ TEST_F(N300CommOpsTest, TestAllGatherNotFullyTiled) {
     EXPECT_TRUE(xt::allclose(xtensor, gathered_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
 
     xt::xarray<float> grad_data = xt::random::rand(xtensor.shape(), 0.F, 1.F);
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
+    mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
     auto tt_grad_tensor =
-        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(grad_data, device, replicate_composer);
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(grad_data, device, ttnn::Layout::TILE, mapper.get());
     gathered_tensor->set_grad(tt_grad_tensor);
     gathered_tensor->backward();
 
@@ -242,8 +246,9 @@ TEST_F(N300CommOpsTest, TestAllGatherFullyTiled) {
     ttml::init::uniform_init(test_data_vec, {-1.F, 1.F});
     xt::xarray<float> test_data = xt::adapt(test_data_vec);
     xt::xarray<float> xtensor = test_data.reshape({batch, 1U, height, size});
-    ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, shard_composer);
+    auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 3);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto gathered_tensor = ttml::ops::distributed::all_gather(tensor, 3);
 
@@ -253,9 +258,9 @@ TEST_F(N300CommOpsTest, TestAllGatherFullyTiled) {
     EXPECT_TRUE(xt::allclose(xtensor, gathered_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
 
     xt::xarray<float> grad_data = xt::random::rand(xtensor.shape(), 0.F, 1.F);
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
+    mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
     auto tt_grad_tensor =
-        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(grad_data, device, replicate_composer);
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(grad_data, device, ttnn::Layout::TILE, mapper.get());
     gathered_tensor->set_grad(tt_grad_tensor);
     gathered_tensor->backward();
 
@@ -285,8 +290,9 @@ TEST_F(N300CommOpsTest, TestScatterNotFullyTiled) {
     std::iota(test_data_vec.begin(), test_data_vec.end(), 0.0F);
     xt::xarray<float> test_data = xt::adapt(test_data_vec);
     xt::xarray<float> xtensor = test_data.reshape({1U, 1U, 1U, size});
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, replicate_composer);
+    auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, ttnn::Layout::TILE, mapper.get());
     auto tensor = ttml::autograd::create_tensor(tt_tensor);
     auto scattered_tensor = ttml::ops::distributed::scatter(tensor, 3);
 
@@ -300,8 +306,9 @@ TEST_F(N300CommOpsTest, TestScatterNotFullyTiled) {
 
     // check backward
     xt::xarray<float> grad_data = xt::random::rand(xtensor.shape(), 0.F, 1.F);
-    ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
-    auto tt_grad_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(grad_data, device, shard_composer);
+    mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 3);
+    auto tt_grad_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(grad_data, device, ttnn::Layout::TILE, mapper.get());
     scattered_tensor->set_grad(tt_grad_tensor);
     scattered_tensor->backward();
 
@@ -330,8 +337,9 @@ TEST_F(N300CommOpsTest, TestScatterFullyTiled) {
     xt::xarray<float> xtensor = test_data.reshape({batch, 1U, height, size});
 
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
-    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
-    auto tt_tensor = ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, replicate_composer);
+    auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
+    auto tt_tensor =
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, ttnn::Layout::TILE, mapper.get());
 
     auto xtensor_after_replication = ttml::core::to_xtensor<float>(tt_tensor, identity_composer);
     EXPECT_TRUE(xt::allclose(xtensor, xtensor_after_replication[0], /* rtol */ 1e-3, /* atol */ 1e-2));
@@ -355,8 +363,8 @@ TEST_F(N300CommOpsTest, TestScatterFullyTiled) {
 
     // check backward
     xt::xarray<float> grad_data = xt::random::rand(xtensor.shape(), -1.F, 1.F);
-    ttml::core::XTensorToMeshVariant<float> shard_composer = ttml::core::ShardXTensorToMesh<float>(mesh_shape, 3);
-    auto tt_grad_tensor = ttml::core::from_xtensor(grad_data, device, shard_composer);
+    mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 3);
+    auto tt_grad_tensor = ttml::core::from_xtensor(grad_data, device, ttnn::Layout::TILE, mapper.get());
     scattered_tensor->set_grad(tt_grad_tensor);
     scattered_tensor->backward();
 

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -9,6 +9,7 @@
 #include <tt_stl/small_vector.hpp>
 #include <tt-metalium/memory_pin.hpp>
 
+#include "tt_stl/span.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/distributed/types.hpp"
 
@@ -176,6 +177,17 @@ Tensor create_distributed_tensor(
     tt::stl::Span<T> buffer,
     const ttnn::Shape& global_shape,
     const tt::tt_metal::MemoryPin& buffer_pin,
+    const tt::tt_metal::TensorLayout& shard_layout,
+    const TensorToMesh& mapper,
+    std::optional<std::reference_wrapper<MeshDevice>> mesh_device = std::nullopt,
+    ttnn::QueueId cq_id = ttnn::DefaultQueueId,
+    T pad_value = 0);
+
+// Overload for unowned spans of data.
+template <typename T>
+Tensor create_distributed_tensor(
+    tt::stl::Span<const T> buffer,
+    const ttnn::Shape& global_shape,
     const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device = std::nullopt,

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -63,6 +63,28 @@ TensorSpec compute_tensor_spec_for_shards(
     return TensorSpec(*shard_shape, global_layout);
 }
 
+// Creates a host buffer from a span, with the following optimizations:
+// - If the span is mutable and the physical data matches the logical data, the span is used directly.
+// - Otherwise, a copy of the data is created.
+template <typename T>
+tt::tt_metal::HostBuffer create_host_buffer_from_span(
+    tt::stl::Span<T> span, const tt::tt_metal::MemoryPin& buffer_pin, const TensorSpec& tensor_spec, T pad_value) {
+    if constexpr (!std::is_const_v<T>) {
+        if (tensor_spec.layout() == tt::tt_metal::Layout::ROW_MAJOR &&
+            tensor_spec.physical_shape() == tensor_spec.logical_2d_shape() &&
+            tensor_spec.data_type() == tt::tt_metal::convert_to_data_type<T>()) {
+            return tt::tt_metal::HostBuffer(span, buffer_pin);
+        }
+    }
+
+    return tt::tt_metal::host_buffer::get_host_buffer(Tensor::from_span(
+        tt::stl::make_const_span(span),
+        tensor_spec,
+        /*device=*/nullptr,
+        ttnn::DefaultQueueId,
+        pad_value));
+}
+
 }  // namespace
 
 std::ostream& operator<<(std::ostream& os, const MeshMapperConfig::Placement& placement) {
@@ -209,15 +231,8 @@ public:
         // Optimize a fully replicated path, which can use the same buffer for all shards.
         if (shard_dims.empty()) {
             const TensorSpec tensor_spec(shape, layout);
-            tt::tt_metal::HostBuffer replicated_buffer;
-            if (tensor_spec.layout() == tt::tt_metal::Layout::ROW_MAJOR &&
-                tensor_spec.physical_shape() == tensor_spec.logical_2d_shape() &&
-                tensor_spec.data_type() == tt::tt_metal::convert_to_data_type<T>()) {
-                replicated_buffer = tt::tt_metal::HostBuffer(span, buffer_pin);
-            } else {
-                replicated_buffer = tt::tt_metal::host_buffer::get_host_buffer(Tensor::from_span(
-                    tt::stl::make_const_span(span), tensor_spec, /*device=*/nullptr, ttnn::DefaultQueueId, pad_value));
-            }
+            auto replicated_buffer = create_host_buffer_from_span<T>(span, buffer_pin, tensor_spec, pad_value);
+
             auto distributed_buffer =
                 tt::tt_metal::DistributedHostBuffer::create(global_shape_, local_shape_, local_offset_);
             auto remap_fn = get_remap_fn(distribution_mode_, &global_range_);
@@ -314,7 +329,8 @@ private:
                         if (it != converted_buffers.end()) {
                             return it->second;
                         }
-                        std::vector<T> data_vec(xtensor_view->get().begin(), xtensor_view->get().end());
+                        std::vector<std::remove_const_t<T>> data_vec(
+                            xtensor_view->get().begin(), xtensor_view->get().end());
                         Tensor shard_tensor = Tensor::from_vector(
                             std::move(data_vec),
                             shard_spec,
@@ -402,7 +418,7 @@ Tensor TensorToMesh::operator()(
     const tt::tt_metal::MemoryPin& buffer_pin,
     const tt::tt_metal::TensorLayout& layout,
     T pad_value) const {
-    return (*impl_)(buffer, shape, buffer_pin, layout, pad_value);
+    return (*impl_).template operator()<T>(buffer, shape, buffer_pin, layout, pad_value);
 }
 
 tt::tt_metal::DistributedTensorConfig TensorToMesh::config() const { return impl_->config(); }
@@ -545,61 +561,50 @@ Tensor create_distributed_tensor(
     return output;
 }
 
-// Explicit instantiation of `create_distributed_tensor` for supported data types.
-template Tensor create_distributed_tensor<bfloat16>(
-    tt::stl::Span<bfloat16> buffer,
+template <typename T>
+Tensor create_distributed_tensor(
+    tt::stl::Span<const T> buffer,
     const ttnn::Shape& global_shape,
-    const tt::tt_metal::MemoryPin& buffer_pin,
     const tt::tt_metal::TensorLayout& shard_layout,
     const TensorToMesh& mapper,
     std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
     ttnn::QueueId cq_id,
-    bfloat16 pad_value);
-template Tensor create_distributed_tensor<float>(
-    tt::stl::Span<float> buffer,
-    const ttnn::Shape& global_shape,
-    const tt::tt_metal::MemoryPin& buffer_pin,
-    const tt::tt_metal::TensorLayout& shard_layout,
-    const TensorToMesh& mapper,
-    std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
-    ttnn::QueueId cq_id,
-    float pad_value);
-template Tensor create_distributed_tensor<int32_t>(
-    tt::stl::Span<int32_t> buffer,
-    const ttnn::Shape& global_shape,
-    const tt::tt_metal::MemoryPin& buffer_pin,
-    const tt::tt_metal::TensorLayout& shard_layout,
-    const TensorToMesh& mapper,
-    std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
-    ttnn::QueueId cq_id,
-    int32_t pad_value);
-template Tensor create_distributed_tensor<uint8_t>(
-    tt::stl::Span<uint8_t> buffer,
-    const ttnn::Shape& global_shape,
-    const tt::tt_metal::MemoryPin& buffer_pin,
-    const tt::tt_metal::TensorLayout& shard_layout,
-    const TensorToMesh& mapper,
-    std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
-    ttnn::QueueId cq_id,
-    uint8_t pad_value);
-template Tensor create_distributed_tensor<uint16_t>(
-    tt::stl::Span<uint16_t> buffer,
-    const ttnn::Shape& global_shape,
-    const tt::tt_metal::MemoryPin& buffer_pin,
-    const tt::tt_metal::TensorLayout& shard_layout,
-    const TensorToMesh& mapper,
-    std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
-    ttnn::QueueId cq_id,
-    uint16_t pad_value);
-template Tensor create_distributed_tensor<uint32_t>(
-    tt::stl::Span<uint32_t> buffer,
-    const ttnn::Shape& global_shape,
-    const tt::tt_metal::MemoryPin& buffer_pin,
-    const tt::tt_metal::TensorLayout& shard_layout,
-    const TensorToMesh& mapper,
-    std::optional<std::reference_wrapper<MeshDevice>> mesh_device,
-    ttnn::QueueId cq_id,
-    uint32_t pad_value);
+    T pad_value) {
+    Tensor output =
+        mapper.template operator()<const T>(buffer, global_shape, tt::tt_metal::MemoryPin(), shard_layout, pad_value);
+    if (mesh_device.has_value()) {
+        return output.to_device(&(mesh_device->get()), output.memory_config(), cq_id);
+    }
+    return output;
+}
+
+#define INSTANTIATE_CREATE_DISTRIBUTED_TENSOR(TYPE)                    \
+    template Tensor create_distributed_tensor<TYPE>(                   \
+        tt::stl::Span<TYPE> buffer,                                    \
+        const ttnn::Shape& global_shape,                               \
+        const tt::tt_metal::MemoryPin& buffer_pin,                     \
+        const tt::tt_metal::TensorLayout& shard_layout,                \
+        const TensorToMesh& mapper,                                    \
+        std::optional<std::reference_wrapper<MeshDevice>> mesh_device, \
+        ttnn::QueueId cq_id,                                           \
+        TYPE pad_value);                                               \
+    template Tensor create_distributed_tensor<TYPE>(                   \
+        tt::stl::Span<const TYPE> buffer,                              \
+        const ttnn::Shape& global_shape,                               \
+        const tt::tt_metal::TensorLayout& shard_layout,                \
+        const TensorToMesh& mapper,                                    \
+        std::optional<std::reference_wrapper<MeshDevice>> mesh_device, \
+        ttnn::QueueId cq_id,                                           \
+        TYPE pad_value);
+
+INSTANTIATE_CREATE_DISTRIBUTED_TENSOR(bfloat16)
+INSTANTIATE_CREATE_DISTRIBUTED_TENSOR(float)
+INSTANTIATE_CREATE_DISTRIBUTED_TENSOR(int32_t)
+INSTANTIATE_CREATE_DISTRIBUTED_TENSOR(uint8_t)
+INSTANTIATE_CREATE_DISTRIBUTED_TENSOR(uint16_t)
+INSTANTIATE_CREATE_DISTRIBUTED_TENSOR(uint32_t)
+
+#undef INSTANTIATE_CREATE_DISTRIBUTED_TENSOR
 
 Tensor aggregate_tensor(const Tensor& tensor, const MeshToTensor& composer) {
     return composer.compose(get_device_tensors(tensor.cpu()));


### PR DESCRIPTION
### Ticket
#24339

### Problem description
Need to migrate ad-hoc APIs to TT-NN.

### What's changed
Migrate the APIs, remove the old code.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15979273312)
- [x] New/Existing tests provide coverage for changes