### PR TITLE
[Fabric/BH] Update BH LLM-box tests

### DIFF
--- a/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {name: fabric 1D unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*" },
+          {name: fabric 1D unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*" },
           {name: fabric 2D fixture unit tests, cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*" },
           {name: fabric system health tests, cmd: ./build/test/tt_metal/tt_fabric/test_system_health },
           {name: cpp unit tests eth, cmd: ./build/test/tt_metal/unit_tests_eth },

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -63,7 +63,7 @@ test_suite_bh_single_pcie_llama_demo_tests() {
 test_suite_bh_llmbox_metal_unit_tests() {
     echo "[upstream-tests] Running BH LLMBox metal unit tests"
 
-    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*"
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
     ./build/test/tt_metal/tt_fabric/test_system_health
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Recently the mux fixtures were re-named. This caused the BH LLM box pipeline to pick up the test that is known to be not working for BH yet. 

### What's changed
Update the gtest filters to pick the correct tests and skip the 1D Mux tests for now (especially `TestFabricMuxStressOpenClose`)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x]  [BH LLM box unit tests] (https://github.com/tenstorrent/tt-metal/actions/runs/15980586186)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes