### PR TITLE
[skip ci] Update mixtral8x7b/README

### DIFF
--- a/models/demos/t3000/mixtral8x7b/README.md
+++ b/models/demos/t3000/mixtral8x7b/README.md
@@ -48,7 +48,7 @@ Note that the cached weights folder structure will contain the general and instr
 4. Cache the weights (first-time setup):
 ```bash
 # Build a full 32 layer model to cache the weights. This will take some time.
-pytest -svv models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py::test_mixtral_model_inference[wormhole_b0-True-1-32-output]
+pytest -svv models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py::test_mixtral_model_inference[wormhole_b0-True-32]
 ```
 
 ### Run the demo


### PR DESCRIPTION
### Ticket
[Invalid arguments in Mixtral README.md #23855](https://github.com/tenstorrent/tt-metal/issues/23855)

### Problem description
The instructions for caching the weights had mismatching arguments.

### What's changed
- Updated arguments to match what is expected by the function.
- Validated by running it on a T3K
 
### Checklist
- [x] New/Existing tests provide coverage for changes