### PR TITLE
[TT-train] Fix deprecated ns

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     - id: check-added-large-files
 # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 25.1.0
+  rev: 23.10.1
   hooks:
     - id: black
       language_version: python3
@@ -28,11 +28,11 @@ repos:
       files: ^models/
       exclude: ^models/(demos/llama3_subdevices|experimental)/
 - repo: https://github.com/BlankSpruce/gersemi
-  rev: 0.19.3
+  rev: 0.16.2
   hooks:
   - id: gersemi
 - repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.37.1
+  rev: v1.35.1
   hooks:
     - id: yamllint
 - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     - id: check-added-large-files
 # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 23.10.1
+  rev: 25.1.0
   hooks:
     - id: black
       language_version: python3
@@ -28,11 +28,11 @@ repos:
       files: ^models/
       exclude: ^models/(demos/llama3_subdevices|experimental)/
 - repo: https://github.com/BlankSpruce/gersemi
-  rev: 0.16.2
+  rev: 0.19.3
   hooks:
   - id: gersemi
 - repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.35.1
+  rev: v1.37.1
   hooks:
     - id: yamllint
 - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -113,6 +113,7 @@ if(NOT TARGET Metalium::Metal)
     # Try to find the library
     find_library(TT_METAL_LIBRARY NAMES "tt_metal" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
     find_library(TTNN_LIBRARY NAMES "_ttnn.so" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
+    find_library(TTNNCPP_LIBRARY NAMES "_ttnncpp.so" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
     find_library(DEVICE_LIBRARY NAMES "device" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
 
     if(TT_METAL_LIBRARY)
@@ -149,6 +150,20 @@ if(NOT TARGET Metalium::Metal)
     else()
         message(FATAL_ERROR "_ttnn.so not found in ${METALIUM_LIB_PATH}")
     endif()
+    if(TTNNCPP_LIBRARY)
+        add_library(Metalium::TTNNCPP SHARED IMPORTED)
+        set_target_properties(
+            Metalium::TTNNCPP
+            PROPERTIES
+                IMPORTED_LOCATION
+                    "${TTNNCPP_LIBRARY}"
+                INTERFACE_INCLUDE_DIRECTORIES
+                    "${METALIUM_INCLUDE_DIRS}"
+        )
+        message(STATUS "Successfully found _ttnncpp.so at ${TTNNCPP_LIBRARY}")
+    else()
+        message(FATAL_ERROR "_ttnncpp.so not found in ${METALIUM_LIB_PATH}")
+    endif()
 else()
     message(STATUS "Metalium targets already exists")
 endif()
@@ -172,6 +187,7 @@ target_link_libraries(
         atomic
         Metalium::Metal
         Metalium::TTNN
+        Metalium::TTNNCPP
         Python3::Python
         fmt::fmt-header-only
         magic_enum::magic_enum

--- a/tt-train/sources/ttml/autograd/auto_context.cpp
+++ b/tt-train/sources/ttml/autograd/auto_context.cpp
@@ -26,7 +26,7 @@ uint32_t AutoContext::get_seed() const {
 }
 
 AutoContext& AutoContext::get_instance() {
-    static tt::stl::Indestructible<AutoContext> instance{};
+    static ttsl::Indestructible<AutoContext> instance{};
     return instance.get();
 }
 std::optional<NodeId> AutoContext::add_backward_node(GradFunction&& grad_function, std::span<NodeId> links) {

--- a/tt-train/sources/ttml/autograd/auto_context.hpp
+++ b/tt-train/sources/ttml/autograd/auto_context.hpp
@@ -71,7 +71,7 @@ private:
 
     std::shared_ptr<DistributedContext> m_distributed_context;
 
-    friend class tt::stl::Indestructible<AutoContext>;
+    friend class ttsl::Indestructible<AutoContext>;
 };
 
 inline auto& ctx() {

--- a/tt-train/sources/ttml/autograd/tensor.cpp
+++ b/tt-train/sources/ttml/autograd/tensor.cpp
@@ -53,7 +53,7 @@ void Tensor::add_grad(const tt::tt_metal::Tensor& grad) {
 
     // It is important to not use inline addition here
     // m_grad might share memory with other tensors
-    constexpr tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> none{};
+    constexpr ttsl::Span<const ttnn::operations::unary::UnaryWithParam> none{};
     m_grad = ttnn::add(m_grad, grad, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
 }
 

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.cpp
@@ -100,7 +100,7 @@ CrossEntropyBackwardDeviceOperation::tensor_return_value_t CrossEntropyBackwardD
     return output_tensor;
 }
 
-tt::stl::hash::hash_t CrossEntropyBackwardDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t CrossEntropyBackwardDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     const auto& input_logical_shape = input_tensor.logical_shape();

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.hpp
@@ -29,7 +29,7 @@ struct CrossEntropyBackwardDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const ttnn::Tensor& input_tensor,

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.cpp
@@ -101,7 +101,7 @@ CrossEntropyForwardDeviceOperation::tensor_return_value_t CrossEntropyForwardDev
     return output_tensor;
 }
 
-tt::stl::hash::hash_t CrossEntropyForwardDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t CrossEntropyForwardDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     const auto& input_logical_shape = input_tensor.logical_shape();

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.hpp
@@ -29,7 +29,7 @@ struct CrossEntropyForwardDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const ttnn::Tensor& input_tensor,

--- a/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_device_operation.cpp
@@ -98,7 +98,7 @@ ProfilerNoopOperation::tensor_return_value_t ProfilerNoopOperation::create_outpu
     return output_tensor;
 }
 
-tt::stl::hash::hash_t ProfilerNoopOperation::compute_program_hash(
+ttsl::hash::hash_t ProfilerNoopOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     const auto& input_logical_shape = input_tensor.logical_shape();

--- a/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_device_operation.hpp
@@ -29,7 +29,7 @@ struct ProfilerNoopOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const ttnn::Tensor& input_tensor, const std::optional<ttnn::Tensor>& preallocated_output = std::nullopt);

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.cpp
@@ -127,7 +127,7 @@ tensor_return_value_t RMSNormForwardDeviceOperation::create_output_tensors(
     return output_tensors;
 }
 
-tt::stl::hash::hash_t RMSNormForwardDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t RMSNormForwardDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     const auto& input_logical_shape = input_tensor.logical_shape();

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.hpp
@@ -29,7 +29,7 @@ struct RMSNormForwardDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const ttnn::Tensor& input_tensor,

--- a/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation.cpp
@@ -111,7 +111,7 @@ SoftmaxDeviceOperation::tensor_return_value_t SoftmaxDeviceOperation::create_out
     return output_tensor;
 }
 
-tt::stl::hash::hash_t SoftmaxDeviceOperation::compute_program_hash(
+ttsl::hash::hash_t SoftmaxDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     const auto& input_logical_shape = input_tensor.logical_shape();

--- a/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation.hpp
@@ -29,7 +29,7 @@ struct SoftmaxDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const ttnn::Tensor& input_tensor,

--- a/tt-train/sources/ttml/ops/binary_ops.cpp
+++ b/tt-train/sources/ttml/ops/binary_ops.cpp
@@ -66,7 +66,7 @@ autograd::TensorPtr operator+(const autograd::TensorPtr& a, const autograd::Auto
 autograd::TensorPtr operator+(const autograd::TensorPtr& a, const autograd::TensorPtr& b) {
     auto out = autograd::create_tensor();
 
-    constexpr tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> none{};
+    constexpr ttsl::Span<const ttnn::operations::unary::UnaryWithParam> none{};
     out->set_value(
         ttnn::add(a->get_value(), b->get_value(), std::nullopt, std::nullopt, std::nullopt, none, none, none, false));
     autograd::GradFunction grad = [a, b, out]() {

--- a/tt-train/sources/ttml/ops/rmsnorm_op.cpp
+++ b/tt-train/sources/ttml/ops/rmsnorm_op.cpp
@@ -54,7 +54,7 @@ autograd::TensorPtr rmsnorm(const autograd::TensorPtr &tensor, const autograd::T
 
         auto dL_dout = out->get_grad();  // Grad w.r.t normalized arctivations, hence [B,1,S,C]
 
-        constexpr auto none = tt::stl::Span<const ttnn::operations::unary::UnaryWithParam>{};
+        constexpr auto none = ttsl::Span<const ttnn::operations::unary::UnaryWithParam>{};
 
         auto scaled_gain = ttnn::divide(
             g,
@@ -166,7 +166,7 @@ autograd::TensorPtr rmsnorm_composite(
 
     ttnn::Tensor seq_means_of_squares = ttnn::mean(squares, /*dim_arg=*/-1, /*keep_dim=*/true);  // [B,1,S,1]
 
-    constexpr auto none = tt::stl::Span<const ttnn::operations::unary::UnaryWithParam>{};
+    constexpr auto none = ttsl::Span<const ttnn::operations::unary::UnaryWithParam>{};
 
     ttnn::Tensor seq_means_of_squares_plus_epsilon = ttnn::add(
         seq_means_of_squares,
@@ -216,7 +216,7 @@ autograd::TensorPtr rmsnorm_composite(
 
         auto dL_dout = out->get_grad();  // Grad w.r.t normalized arctivations, hence [B,1,S,C]
 
-        constexpr auto none = tt::stl::Span<const ttnn::operations::unary::UnaryWithParam>{};
+        constexpr auto none = ttsl::Span<const ttnn::operations::unary::UnaryWithParam>{};
 
         auto scaled_gain = ttnn::divide(
             g,

--- a/tt-train/sources/ttml/ops/scaled_dot_product_attention.cpp
+++ b/tt-train/sources/ttml/ops/scaled_dot_product_attention.cpp
@@ -147,7 +147,7 @@ autograd::TensorPtr scaled_dot_product_attention(
     auto groups = value->get_value().logical_shape().to_array_4D()[1];
 
     const float scale = 1.0F / std::sqrt(static_cast<float>(embedding_dim));
-    constexpr auto none = tt::stl::Span<const ttnn::operations::unary::UnaryWithParam>{};
+    constexpr auto none = ttsl::Span<const ttnn::operations::unary::UnaryWithParam>{};
     auto q_scaled =
         ttnn::multiply(query->get_value(), scale, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
     auto key_tensor = key->get_value();
@@ -189,7 +189,7 @@ autograd::TensorPtr scaled_dot_product_attention(
 
     ttml::autograd::GradFunction grad =
         [scale, query, key, value, attention_weights, out, mask, batch_num, heads, seq_len, embedding_dim, groups]() {
-            constexpr auto none = tt::stl::Span<const ttnn::operations::unary::UnaryWithParam>{};
+            constexpr auto none = ttsl::Span<const ttnn::operations::unary::UnaryWithParam>{};
             auto dL_dout = out->get_grad();  // (B, H, S, embedding_dim)
             // dL_d(softmax(σQK+mask)) = dL_dout @ value^T
             ttnn::Tensor dL_dattention_weights =


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/24179

### Problem description
tt::stl was deprecated
ttnncpp.so was introduced
### What's changed
* Updated namespace to the ttsl
* Added ttnncpp dependency to the cmake

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes