### PR TITLE
#0: Fixes/improvements for multi host sockets

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp
@@ -17,7 +17,7 @@ void fabric_write_any_len(
         data_packet_header_addr->to_noc_unicast_write(NocUnicastCommandHeader{dst_addr}, FABRIC_MAX_PACKET_SIZE);
         fabric_connection.wait_for_empty_write_slot();
         fabric_connection.send_payload_without_header_non_blocking_from_address(src_addr, FABRIC_MAX_PACKET_SIZE);
-        fabric_connection.send_payload_blocking_from_address(
+        fabric_connection.send_payload_flush_blocking_from_address(
             (uint32_t)data_packet_header_addr, sizeof(PACKET_HEADER_TYPE));
         dst_addr += FABRIC_MAX_PACKET_SIZE;
         src_addr += FABRIC_MAX_PACKET_SIZE;
@@ -26,7 +26,8 @@ void fabric_write_any_len(
     data_packet_header_addr->to_noc_unicast_write(NocUnicastCommandHeader{dst_addr}, xfer_size);
     fabric_connection.wait_for_empty_write_slot();
     fabric_connection.send_payload_without_header_non_blocking_from_address(src_addr, xfer_size);
-    fabric_connection.send_payload_blocking_from_address((uint32_t)data_packet_header_addr, sizeof(PACKET_HEADER_TYPE));
+    fabric_connection.send_payload_flush_blocking_from_address(
+        (uint32_t)data_packet_header_addr, sizeof(PACKET_HEADER_TYPE));
 }
 
 void kernel_main() {

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -60,6 +60,11 @@ void append_fabric_connection_rt_args(
     std::vector<uint32_t>& worker_args,
     CoreType core_type = CoreType::WORKER);
 
+// returns which links on a given src chip are available for forwarding the data to a dst chip
+// these link indices can then be used to establish connection with the fabric routers
+std::vector<uint32_t> get_forwarding_link_indices(
+    const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id);
+
 FabricNodeId get_fabric_node_id_from_physical_chip_id(chip_id_t physical_chip_id);
 
 namespace experimental {

--- a/tt_metal/api/tt-metalium/mesh_socket.hpp
+++ b/tt_metal/api/tt-metalium/mesh_socket.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <magic_enum/magic_enum.hpp>
 #include <tt-metalium/distributed_context.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/routing_table_generator.hpp>
@@ -78,7 +79,7 @@ public:
     // Access the socket endpoint type (SENDER or RECEIVER).
     SocketEndpoint get_socket_endpoint_type() const { return socket_endpoint_type_; }
 
-    const tt::tt_fabric::FabricNodeId& get_fabric_node_id(SocketEndpoint endpoint, MeshCoordinate coord) const;
+    tt::tt_fabric::FabricNodeId get_fabric_node_id(SocketEndpoint endpoint, const MeshCoordinate& coord) const;
 
 private:
     MeshSocket(
@@ -96,7 +97,9 @@ private:
     std::shared_ptr<MeshBuffer> config_buffer_;
     SocketConfig config_;
     SocketEndpoint socket_endpoint_type_;
-    std::array<std::unordered_map<MeshCoordinate, tt::tt_fabric::FabricNodeId>, 2> fabric_node_id_map_;
+    std::
+        array<std::unordered_map<MeshCoordinate, tt::tt_fabric::FabricNodeId>, magic_enum::enum_count<SocketEndpoint>()>
+            fabric_node_id_map_;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/mesh_socket.hpp
+++ b/tt_metal/api/tt-metalium/mesh_socket.hpp
@@ -6,6 +6,7 @@
 
 #include <tt-metalium/distributed_context.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/routing_table_generator.hpp>
 
 namespace tt::tt_metal::distributed {
 
@@ -77,6 +78,8 @@ public:
     // Access the socket endpoint type (SENDER or RECEIVER).
     SocketEndpoint get_socket_endpoint_type() const { return socket_endpoint_type_; }
 
+    const tt::tt_fabric::FabricNodeId& get_fabric_node_id(SocketEndpoint endpoint, MeshCoordinate coord) const;
+
 private:
     MeshSocket(
         std::shared_ptr<MeshBuffer> data_buffer,
@@ -93,6 +96,7 @@ private:
     std::shared_ptr<MeshBuffer> config_buffer_;
     SocketConfig config_;
     SocketEndpoint socket_endpoint_type_;
+    std::array<std::unordered_map<MeshCoordinate, tt::tt_fabric::FabricNodeId>, 2> fabric_node_id_map_;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_socket.cpp
+++ b/tt_metal/distributed/mesh_socket.cpp
@@ -94,7 +94,7 @@ std::shared_ptr<MeshBuffer> MeshSocket::get_config_buffer() const { return confi
 
 const SocketConfig& MeshSocket::get_config() const { return config_; }
 
-const tt::tt_fabric::FabricNodeId& MeshSocket::get_fabric_node_id(SocketEndpoint endpoint, MeshCoordinate coord) const {
+tt::tt_fabric::FabricNodeId MeshSocket::get_fabric_node_id(SocketEndpoint endpoint, const MeshCoordinate& coord) const {
     return fabric_node_id_map_[static_cast<std::underlying_type_t<SocketEndpoint>>(endpoint)].at(coord);
 }
 

--- a/tt_metal/distributed/mesh_socket.cpp
+++ b/tt_metal/distributed/mesh_socket.cpp
@@ -46,10 +46,12 @@ void MeshSocket::connect_with_peer(std::shared_ptr<multihost::DistributedContext
         forward_descriptor_to_peer(local_endpoint_desc, socket_endpoint_type_, context);
         remote_endpoint_desc =
             receive_and_verify_descriptor_from_peer(local_endpoint_desc, socket_endpoint_type_, context);
+        fabric_node_id_map_ = generate_fabric_node_id_map(config_, local_endpoint_desc, remote_endpoint_desc);
     } else {
         remote_endpoint_desc =
             receive_and_verify_descriptor_from_peer(local_endpoint_desc, socket_endpoint_type_, context);
         forward_descriptor_to_peer(local_endpoint_desc, socket_endpoint_type_, context);
+        fabric_node_id_map_ = generate_fabric_node_id_map(config_, remote_endpoint_desc, local_endpoint_desc);
     }
     write_socket_configs(config_buffer_, local_endpoint_desc, remote_endpoint_desc, socket_endpoint_type_);
 }
@@ -75,6 +77,11 @@ std::pair<MeshSocket, MeshSocket> MeshSocket::create_socket_pair(
     write_socket_configs(sender_config_buffer, send_peer_descriptor, recv_peer_descriptor, SocketEndpoint::SENDER);
     write_socket_configs(recv_config_buffer, recv_peer_descriptor, send_peer_descriptor, SocketEndpoint::RECEIVER);
 
+    auto fabric_node_id_map = generate_fabric_node_id_map(config, send_peer_descriptor, recv_peer_descriptor);
+
+    sender_socket.fabric_node_id_map_ = fabric_node_id_map;
+    receiver_socket.fabric_node_id_map_ = fabric_node_id_map;
+
     return {sender_socket, receiver_socket};
 }
 
@@ -86,5 +93,9 @@ std::shared_ptr<MeshBuffer> MeshSocket::get_data_buffer() const {
 std::shared_ptr<MeshBuffer> MeshSocket::get_config_buffer() const { return config_buffer_; }
 
 const SocketConfig& MeshSocket::get_config() const { return config_; }
+
+const tt::tt_fabric::FabricNodeId& MeshSocket::get_fabric_node_id(SocketEndpoint endpoint, MeshCoordinate coord) const {
+    return fabric_node_id_map_[static_cast<std::underlying_type_t<SocketEndpoint>>(endpoint)].at(coord);
+}
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -47,6 +47,8 @@ void validate_fabric_config_for_sockets(
     TT_FATAL(fabric_config_supported, "Unsupported Fabric Config for Sockets specified {}", fabric_config);
 }
 
+// This does not return a FabricNodeId because for 1D fabric, we return a distance between the sender and receiver
+// instead of a chip id (FabricNodeId also stores its chip_id as uint32_t)
 std::pair<tt_fabric::MeshId, uint32_t> get_sender_receiver_chip_fabric_encoding(
     tt_fabric::FabricNodeId sender_node_id,
     tt_fabric::FabricNodeId recv_node_id,

--- a/tt_metal/distributed/mesh_socket_utils.hpp
+++ b/tt_metal/distributed/mesh_socket_utils.hpp
@@ -55,9 +55,4 @@ SocketPeerDescriptor receive_and_verify_descriptor_from_peer(
     SocketEndpoint socket_endpoint_type,
     const std::shared_ptr<const multihost::DistributedContext>& context);
 
-//  =============== Additional utility functions  ===============
-
-// Given a MeshDevice and a logical device coordinate, determine the device's physical mesh id
-uint32_t get_physical_mesh_id(const MeshDevice* mesh_device, const MeshCoordinate& coord);
-
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_socket_utils.hpp
+++ b/tt_metal/distributed/mesh_socket_utils.hpp
@@ -55,4 +55,9 @@ SocketPeerDescriptor receive_and_verify_descriptor_from_peer(
     SocketEndpoint socket_endpoint_type,
     const std::shared_ptr<const multihost::DistributedContext>& context);
 
+std::array<std::unordered_map<MeshCoordinate, tt::tt_fabric::FabricNodeId>, 2> generate_fabric_node_id_map(
+    const SocketConfig& config,
+    const SocketPeerDescriptor& sender_descriptor,
+    const SocketPeerDescriptor& receiver_descriptor);
+
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -195,6 +195,20 @@ void append_fabric_connection_rt_args(
         worker_args);
 }
 
+std::vector<uint32_t> get_forwarding_link_indices(
+    const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    // find the forwarding direction b/w src and dest chip
+    const auto& forwarding_direction = control_plane.get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
+    if (!forwarding_direction.has_value()) {
+        return {};
+    }
+
+    return get_forwarding_link_indices_in_direction(
+        src_fabric_node_id, dst_fabric_node_id, forwarding_direction.value());
+}
+
 namespace experimental {
 
 size_t get_number_of_available_routing_planes(

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -100,20 +100,6 @@ std::vector<uint32_t> get_forwarding_link_indices_in_direction(
     return link_indices;
 }
 
-std::vector<uint32_t> get_forwarding_link_indices(
-    const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id) {
-    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-
-    // find the forwarding direction b/w src and dest chip
-    const auto& forwarding_direction = control_plane.get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
-    if (!forwarding_direction.has_value()) {
-        return {};
-    }
-
-    return get_forwarding_link_indices_in_direction(
-        src_fabric_node_id, dst_fabric_node_id, forwarding_direction.value());
-}
-
 void set_routing_mode(uint16_t routing_mode) {
     // override for forced routing mode
     if (routing_mode == ROUTING_MODE_UNDEFINED) {

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -31,11 +31,6 @@ FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::Cluster
 std::vector<uint32_t> get_forwarding_link_indices_in_direction(
     const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id, RoutingDirection direction);
 
-// returns which links on a given src chip are available for forwarding the data to a dst chip
-// these link indices can then be used to establish connection with the fabric routers
-std::vector<uint32_t> get_forwarding_link_indices(
-    const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id);
-
 void get_optimal_noc_for_edm(
     FabricEriscDatamoverBuilder& edm_builder1,
     FabricEriscDatamoverBuilder& edm_builder2,

--- a/tt_metal/hw/inc/socket_api.h
+++ b/tt_metal/hw/inc/socket_api.h
@@ -138,7 +138,8 @@ void fabric_socket_notify_receiver(
     fabric_header_addr->to_noc_unicast_inline_write(
         NocUnicastInlineWriteCommandHeader{downstream_bytes_sent_noc_addr, socket.bytes_sent});
     fabric_connection.wait_for_empty_write_slot();
-    fabric_connection.send_payload_blocking_from_address((uint32_t)fabric_header_addr, sizeof(PACKET_HEADER_TYPE));
+    fabric_connection.send_payload_flush_blocking_from_address(
+        (uint32_t)fabric_header_addr, sizeof(PACKET_HEADER_TYPE));
 }
 #endif
 
@@ -265,7 +266,8 @@ void fabric_socket_notify_sender(
     fabric_header_addr->to_noc_unicast_inline_write(
         NocUnicastInlineWriteCommandHeader{upstream_bytes_acked_noc_addr, socket.bytes_acked});
     fabric_connection.wait_for_empty_write_slot();
-    fabric_connection.send_payload_blocking_from_address((uint32_t)fabric_header_addr, sizeof(PACKET_HEADER_TYPE));
+    fabric_connection.send_payload_flush_blocking_from_address(
+        (uint32_t)fabric_header_addr, sizeof(PACKET_HEADER_TYPE));
 }
 #endif
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Some functional/performance changes needed for multi host sockets.

### What's changed
Switch to flushes instead of full barriers in the socket kernel apis for improved perf.

Move `get_forwarding_link_indices` from fabric_utils to fabric api as this is needed when using fabric (ex `append_fabric_connection_rt_args` expects us to pass the link index).

Update mesh socket host internals to pass the FabricNodeId instead of the physical device ids when exchanging sender receiver data. This is needed since the physical device ids can't be used to look up anything on a different host. Store the sender/receiver MeshCoordinate to FabricNodeId to enable lookup from host for setting up fabric using `get_fabric_node_id`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16034727433
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes
T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/16029547098