### PR TITLE
#23273: SDXL: Update model configs for k,v matmuls.

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_attention.py
@@ -67,7 +67,7 @@ def test_attention(
         dtype=ttnn.bfloat16,
         device=device,
         layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.L1_MEMORY_CONFIG,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     ttnn_encoder_tensor = (
         ttnn.from_torch(
@@ -75,7 +75,7 @@ def test_attention(
             dtype=ttnn.bfloat16,
             device=device,
             layout=ttnn.TILE_LAYOUT,
-            memory_config=ttnn.L1_MEMORY_CONFIG,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
         if encoder_shape is not None
         else None

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
@@ -26,7 +26,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
             20,
             1280,
             0,
-            0.965,
+            0.966,
         ),
         (
             (1, 1280, 64, 64),

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
@@ -139,7 +139,7 @@ def run_unet_model(
 
     ttnn.DumpDeviceProfiler(device)
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.995)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.994)
     logger.info(f"PCC of first iteration is: {pcc_message}")
 
     for _ in range(iterations - 1):

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -43,7 +43,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 262_568_458
+    expected_device_perf_cycles_per_iteration = 259_207_833
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
@@ -111,9 +111,6 @@ class TtAttention(nn.Module):
                     use_height_and_width_as_shard_shape=True,
                 )
 
-            seq_len = hidden_states.shape[-2]
-            print(f"QKV matmul, seq_len: {seq_len}")
-
             qkv_fused = ttnn.matmul(
                 hidden_states,
                 self.tt_qkv_weights,
@@ -133,7 +130,6 @@ class TtAttention(nn.Module):
             )
             ttnn.deallocate(qkv_fused)
         else:
-            print(f"Q matmul, seq_len: {hidden_states.shape[-2]}")
             q_heads = ttnn.matmul(
                 hidden_states,
                 self.tt_q_weights,
@@ -141,7 +137,6 @@ class TtAttention(nn.Module):
                 compute_kernel_config=self.q_compute_kernel_config,
                 memory_config=ttnn.L1_MEMORY_CONFIG,
             )
-            print(f"K matmul, seq_len: {encoder_hidden_states.shape[-2]}")
             k_heads = ttnn.matmul(
                 encoder_hidden_states,
                 self.tt_k_weights,
@@ -149,7 +144,6 @@ class TtAttention(nn.Module):
                 compute_kernel_config=self.default_compute_kernel_config,
                 program_config=self.k_program_config,
             )
-            print(f"V matmul, seq_len: {encoder_hidden_states.shape[-2]}")
             v_heads = ttnn.matmul(
                 encoder_hidden_states,
                 self.tt_v_weights,
@@ -193,7 +187,6 @@ class TtAttention(nn.Module):
         )
         hidden_states = ttnn.experimental.nlp_concat_heads(hidden_states, memory_config=ttnn.L1_MEMORY_CONFIG)
 
-        print(f"DO matmul, seq_len: {hidden_states.shape[-2]}")
         hidden_states = ttnn.linear(
             hidden_states,
             self.tt_out_weights,


### PR DESCRIPTION
### Ticket
#23273 

### Problem description
k,v matmuls were unoptimised

### What's changed
Add configs for k,v matmuls.
Update device perf
### Checklist
- [] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15993203803/job/45111017250) Did not reach SDXL, ran localy and upated targets
- [x] [Frequent model tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) SDXL tests pass, other failures