### PR TITLE
Migrate addalpha, subalpha to device

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -161,48 +161,6 @@ def test_binary_logical_xor_ttnn(input_shapes, device):
     assert comp_pass
 
 
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
-@pytest.mark.parametrize("alpha", [1.0, 5.0, 10.0])
-def test_binary_addalpha_ttnn(input_shapes, alpha, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
-
-    output_tensor = ttnn.addalpha(input_tensor1, input_tensor2, alpha)
-    golden_function = ttnn.get_golden_function(ttnn.addalpha)
-    golden_tensor = golden_function(in_data1, in_data2, alpha)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
-@pytest.mark.parametrize("alpha", [1.0, 5.0, 10.0])
-def test_binary_subalpha_ttnn(input_shapes, alpha, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
-
-    output_tensor = ttnn.subalpha(input_tensor1, input_tensor2, alpha)
-    golden_function = ttnn.get_golden_function(ttnn.subalpha)
-    golden_tensor = golden_function(in_data1, in_data2, alpha)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
 @pytest.mark.parametrize("accurate_mode", [False, True])
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py
@@ -61,6 +61,8 @@ import ttnn
         ttnn.logaddexp2,
         ttnn.squared_difference,
         ttnn.bias_gelu,
+        ttnn.addalpha,
+        ttnn.subalpha,
     ],
 )
 def test_ND_subtile_bcast(device, shapes, ttnn_fn):
@@ -73,9 +75,6 @@ def test_ND_subtile_bcast(device, shapes, ttnn_fn):
     else:
         torch_input_tensor_b = torch.rand(shapes[1], dtype=torch.bfloat16) * 100 - 50
 
-    golden_fn = ttnn.get_golden_function(ttnn_fn)
-    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
-
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )
@@ -83,7 +82,16 @@ def test_ND_subtile_bcast(device, shapes, ttnn_fn):
         torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )
 
-    output_tensor = ttnn_fn(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
+    golden_fn = ttnn.get_golden_function(ttnn_fn)
+    
+    if ttnn_fn in (ttnn.addalpha, ttnn.subalpha):
+        alpha = random.uniform(-10.0, 10.0)
+        torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b, alpha)
+        output_tensor = ttnn_fn(input_tensor_a, input_tensor_b, alpha, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    else:
+        torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
+        output_tensor = ttnn_fn(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG, use_legacy=None)
+
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py
@@ -83,7 +83,7 @@ def test_ND_subtile_bcast(device, shapes, ttnn_fn):
     )
 
     golden_fn = ttnn.get_golden_function(ttnn_fn)
-    
+
     if ttnn_fn in (ttnn.addalpha, ttnn.subalpha):
         alpha = random.uniform(-10.0, 10.0)
         torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b, alpha)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_math_binary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_math_binary.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 import ttnn
-
+import random
 from math import pi
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
@@ -99,3 +99,55 @@ def test_squared_difference(device, h, w):
 @pytest.mark.parametrize("w", [128])
 def test_hypot(device, h, w):
     run_math_binary_test_range(device, h, w, ttnn.hypot, 0, 100)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        (torch.Size([100])),
+        (torch.Size([32, 32])),
+        (torch.Size([3, 128, 32])),
+        (torch.Size([1, 3, 320, 384])),
+        (torch.Size([1, 1, 32, 320, 12])),
+    ],
+)
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype",
+    [
+        (torch.float32, ttnn.float32),
+        (torch.bfloat16, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize(
+    "ttnn_op",
+    [
+        ttnn.addalpha,
+        ttnn.subalpha,
+    ],
+)
+def test_addalpha_subalpha(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, device):
+    torch_input_tensor_a = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
+    torch_input_tensor_b = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-150, 150)
+    alpha = random.uniform(-100.0, 100.0)
+
+    golden_function = ttnn.get_golden_function(ttnn_op)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, alpha, device=device)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn_dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn_dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    output_tensor = ttnn_op(input_tensor_a, input_tensor_b, alpha)
+    assert_with_pcc(ttnn.to_torch(output_tensor), torch_output_tensor)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_math_binary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_math_binary.py
@@ -126,6 +126,7 @@ def test_hypot(device, h, w):
     ],
 )
 def test_addalpha_subalpha(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, device):
+    random.seed(0)
     torch_input_tensor_a = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     torch_input_tensor_b = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-150, 150)
     alpha = random.uniform(-100.0, 100.0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_math_binary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_math_binary.py
@@ -9,7 +9,7 @@ import torch
 import ttnn
 import random
 from math import pi
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
 from models.utility_functions import torch_random
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -731,6 +731,32 @@ Tensor BinaryOperationSfpu<binary_op_type>::invoke(
         use_legacy);
 }
 
+template <BinaryOpType binary_op_type>
+Tensor BinaryOperationAddalpha<binary_op_type>::invoke(
+    QueueId queue_id,
+    const Tensor& lhs,
+    const Tensor& rhs,
+    float alpha,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output) {
+    SmallVector<unary::UnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    return BinaryOperation<operations::binary::BinaryOpType::ADD>::invoke(
+        queue_id, lhs, rhs, std::nullopt, memory_config, output, {}, {}, rhs_activations, false);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor BinaryOperationSubalpha<binary_op_type>::invoke(
+    QueueId queue_id,
+    const Tensor& lhs,
+    const Tensor& rhs,
+    float alpha,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output) {
+    SmallVector<unary::UnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    return BinaryOperation<operations::binary::BinaryOpType::SUB>::invoke(
+        queue_id, lhs, rhs, std::nullopt, memory_config, output, {}, {}, rhs_activations, false);
+}
+
 template struct BinaryOperation<BinaryOpType::ADD>;
 template struct InplaceBinaryOperation<BinaryOpType::ADD>;
 template struct BinaryOperation<BinaryOpType::SUB>;
@@ -788,5 +814,8 @@ template struct BinaryOperationSfpu<BinaryOpType::MAXIMUM>;
 template struct BinaryOperationSfpu<BinaryOpType::MINIMUM>;
 template struct BinaryOperationSfpu<BinaryOpType::GCD>;
 template struct BinaryOperationSfpu<BinaryOpType::LCM>;
+
+template struct BinaryOperationAddalpha<BinaryOpType::ADDALPHA>;
+template struct BinaryOperationSubalpha<BinaryOpType::SUBALPHA>;
 
 }  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -157,6 +157,28 @@ struct BinaryOperationSfpu {
         std::optional<bool> use_legacy = std::nullopt);
 };
 
+template <BinaryOpType binary_op_type>
+struct BinaryOperationAddalpha {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& lhs,
+        const Tensor& rhs,
+        float alpha,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& output = std::nullopt);
+};
+
+template <BinaryOpType binary_op_type>
+struct BinaryOperationSubalpha {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& lhs,
+        const Tensor& rhs,
+        float alpha,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& output = std::nullopt);
+};
+
 }  // namespace binary
 }  // namespace operations
 
@@ -257,6 +279,12 @@ constexpr auto rsub_ = ttnn::register_operation<
 constexpr auto bias_gelu_ = ttnn::register_operation<
     "ttnn::bias_gelu_",
     operations::binary::InplaceBinaryOperation<operations::binary::BinaryOpType::BIAS_GELU>>();
+constexpr auto addalpha = ttnn::register_operation<
+    "ttnn::addalpha",
+    operations::binary::BinaryOperationAddalpha<operations::binary::BinaryOpType::ADDALPHA>>();
+constexpr auto subalpha = ttnn::register_operation<
+    "ttnn::subalpha",
+    operations::binary::BinaryOperationSubalpha<operations::binary::BinaryOpType::SUBALPHA>>();
 
 template <typename InputBType>
 ttnn::Tensor operator+(const ttnn::Tensor& lhs, InputBType rhs) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -78,17 +78,6 @@ struct ExecuteBinaryCompositeOps {
 };
 
 template <BinaryCompositeOpType binary_comp_op_type>
-struct ExecuteBinaryCompositeOpsFloat {
-    static Tensor invoke(
-        const Tensor& input_tensor_a,
-        const Tensor& input_tensor_b,
-        float alpha,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt) {
-        return OpHandler<binary_comp_op_type>::handle(input_tensor_a, input_tensor_b, alpha, memory_config);
-    }
-};
-
-template <BinaryCompositeOpType binary_comp_op_type>
 struct ExecuteBinaryCompositeOpsIsClose {
     static Tensor invoke(
         const Tensor& input_tensor_a,
@@ -285,6 +274,36 @@ struct ExecuteGCD {
         QueueId queue_id,
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
+        const std::optional<const DataType>& output_dtype = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        std::optional<bool> use_legacy = std::nullopt);
+};
+
+struct ExecuteAddalpha {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        float alpha,
+        const std::optional<const DataType>& output_dtype = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        std::optional<bool> use_legacy = std::nullopt);
+};
+
+struct ExecuteSubalpha {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        float alpha,
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
@@ -518,18 +537,14 @@ constexpr auto xlogy = ttnn::register_operation<
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::XLOGY>>();
 constexpr auto minimum = ttnn::register_operation<"ttnn::minimum", operations::binary::ExecuteMinimum>();
 constexpr auto maximum = ttnn::register_operation<"ttnn::maximum", operations::binary::ExecuteMaximum>();
+constexpr auto addalpha = ttnn::register_operation<"ttnn::addalpha", operations::binary::ExecuteAddalpha>();
+constexpr auto subalpha = ttnn::register_operation<"ttnn::subalpha", operations::binary::ExecuteSubalpha>();
 constexpr auto atan2 = ttnn::register_operation<
     "ttnn::atan2",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::ATAN2>>();
 constexpr auto nextafter = ttnn::register_operation<
     "ttnn::nextafter",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::NEXTAFTER>>();
-constexpr auto addalpha = ttnn::register_operation<
-    "ttnn::addalpha",
-    operations::binary::ExecuteBinaryCompositeOpsFloat<operations::binary::BinaryCompositeOpType::ADDALPHA>>();
-constexpr auto subalpha = ttnn::register_operation<
-    "ttnn::subalpha",
-    operations::binary::ExecuteBinaryCompositeOpsFloat<operations::binary::BinaryCompositeOpType::SUBALPHA>>();
 constexpr auto isclose = ttnn::register_operation<
     "ttnn::isclose",
     operations::binary::ExecuteBinaryCompositeOpsIsClose<operations::binary::BinaryCompositeOpType::ISCLOSE>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -289,13 +289,8 @@ struct ExecuteAddalpha {
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         float alpha,
-        const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
-        std::optional<bool> use_legacy = std::nullopt);
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
 struct ExecuteSubalpha {
@@ -304,13 +299,8 @@ struct ExecuteSubalpha {
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         float alpha,
-        const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
-        std::optional<bool> use_legacy = std::nullopt);
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
 struct ExecuteMaximum {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -283,26 +283,6 @@ struct ExecuteGCD {
         std::optional<bool> use_legacy = std::nullopt);
 };
 
-struct ExecuteAddalpha {
-    static Tensor invoke(
-        QueueId queue_id,
-        const Tensor& input_tensor_a,
-        const Tensor& input_tensor_b,
-        float alpha,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
-};
-
-struct ExecuteSubalpha {
-    static Tensor invoke(
-        QueueId queue_id,
-        const Tensor& input_tensor_a,
-        const Tensor& input_tensor_b,
-        float alpha,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
-};
-
 struct ExecuteMaximum {
     static Tensor invoke(
         QueueId queue_id,
@@ -527,8 +507,6 @@ constexpr auto xlogy = ttnn::register_operation<
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::XLOGY>>();
 constexpr auto minimum = ttnn::register_operation<"ttnn::minimum", operations::binary::ExecuteMinimum>();
 constexpr auto maximum = ttnn::register_operation<"ttnn::maximum", operations::binary::ExecuteMaximum>();
-constexpr auto addalpha = ttnn::register_operation<"ttnn::addalpha", operations::binary::ExecuteAddalpha>();
-constexpr auto subalpha = ttnn::register_operation<"ttnn::subalpha", operations::binary::ExecuteSubalpha>();
 constexpr auto atan2 = ttnn::register_operation<
     "ttnn::atan2",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::ATAN2>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -596,6 +596,110 @@ void bind_binary_unary_operation(
 }
 
 template <typename binary_operation_t>
+void bind_binary_with_float_param(
+    py::module& module,
+    const binary_operation_t& operation,
+    const std::string& description,
+    const std::string& math,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = "") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor): the input tensor.
+            alpha (float): the value to be multiplied.
+
+        Keyword args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            dtype (ttnn.DataType, optional): data type for the output tensor. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            activations (List[str], optional): list of activation functions to apply to the output tensor. Defaults to `None`.
+            queue_id (int, optional): command queue id. Defaults to `0`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Supports broadcasting.
+
+        Note:
+            Supported dtypes, layouts, and ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+                 - Ranks
+               * - {4}
+                 - TILE
+                 - 2, 3, 4
+
+            {5}
+
+        Example:
+            >>> tensor1 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> tensor2 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> alpha = 1.0
+            >>> output = {1}(tensor1, tensor2, alpha)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description,
+        math,
+        supported_dtype,
+        note);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               const Tensor& input_tensor_b,
+               float alpha,
+               const std::optional<const DataType>& dtype,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor,
+               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const std::optional<bool>& use_legacy,
+               QueueId queue_id) -> ttnn::Tensor {
+                return self(
+                    queue_id,
+                    input_tensor_a,
+                    input_tensor_b,
+                    alpha,
+                    dtype,
+                    memory_config,
+                    output_tensor,
+                    activations,
+                    input_tensor_a_activations,
+                    input_tensor_b_activations,
+                    use_legacy);
+            },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::arg("alpha") = 1.0f,
+            py::kw_only(),
+            py::arg("dtype") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("use_legacy") = std::nullopt,
+            py::arg("queue_id") = DefaultQueueId});
+}
+
+template <typename binary_operation_t>
 void bind_bitwise_binary_ops_operation(
     py::module& module,
     const binary_operation_t& operation,
@@ -799,79 +903,6 @@ void bind_binary_composite(
             },
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt});
-}
-
-template <typename binary_operation_t>
-void bind_binary_composite_with_alpha(
-    py::module& module,
-    const binary_operation_t& operation,
-    const std::string& description,
-    const std::string& math,
-    const std::string& supported_dtype = "BFLOAT16",
-    const std::string& note = "") {
-    auto doc = fmt::format(
-        R"doc(
-        {2}
-
-        .. math::
-            {3}
-
-        Args:
-            input_tensor_a (ttnn.Tensor): the input tensor.
-            input_tensor_b (ttnn.Tensor): the input tensor.
-            alpha (float): the value to be multiplied.
-
-        Keyword Args:
-            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
-
-        Returns:
-            ttnn.Tensor: the output tensor.
-
-        Note:
-            Supported dtypes, layouts, and ranks:
-
-            .. list-table::
-               :header-rows: 1
-
-               * - Dtypes
-                 - Layouts
-                 - Ranks
-               * - {4}
-                 - TILE
-                 - 2, 3, 4
-
-            {5}
-
-        Example:
-            >>> tensor1 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
-            >>> tensor2 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
-            >>> alpha = 1.0
-            >>> output = {1}(tensor1, tensor2, alpha)
-        )doc",
-        operation.base_name(),
-        operation.python_fully_qualified_name(),
-        description,
-        math,
-        supported_dtype,
-        note);
-
-    bind_registered_operation(
-        module,
-        operation,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const binary_operation_t& self,
-               const Tensor& input_tensor_a,
-               const Tensor& input_tensor_b,
-               float alpha,
-               const std::optional<MemoryConfig>& memory_config) {
-                return self(input_tensor_a, input_tensor_b, alpha, memory_config);
-            },
-            py::arg("input_tensor_a"),
-            py::arg("input_tensor_b"),
-            py::arg("alpha") = 1.0f,
             py::kw_only(),
             py::arg("memory_config") = std::nullopt});
 }
@@ -2166,14 +2197,14 @@ void py_module(py::module& module) {
         R"doc(ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device))doc",
         R"doc(ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device))doc");
 
-    detail::bind_binary_composite_with_alpha(
+    detail::bind_binary_with_float_param(
         module,
         ttnn::addalpha,
-        R"doc(Computes addalpha for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`.)doc",
+        R"doc(Computes addalpha for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
         R"doc(\mathrm{{output\_tensor}} = \mathrm{{input\_tensor\_a\ + input\_tensor\_b\ * \alpha}})doc",
         R"doc(BFLOAT16, BFLOAT8_B)doc");
 
-    detail::bind_binary_composite_with_alpha(
+    detail::bind_binary_with_float_param(
         module,
         ttnn::subalpha,
         R"doc(Computes subalpha for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -617,9 +617,7 @@ void bind_binary_with_float_param(
 
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
-            dtype (ttnn.DataType, optional): data type for the output tensor. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            activations (List[str], optional): list of activation functions to apply to the output tensor. Defaults to `None`.
             queue_id (int, optional): command queue id. Defaults to `0`.
 
         Returns:
@@ -664,38 +662,17 @@ void bind_binary_with_float_param(
                const Tensor& input_tensor_a,
                const Tensor& input_tensor_b,
                float alpha,
-               const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
-                return self(
-                    queue_id,
-                    input_tensor_a,
-                    input_tensor_b,
-                    alpha,
-                    dtype,
-                    memory_config,
-                    output_tensor,
-                    activations,
-                    input_tensor_a_activations,
-                    input_tensor_b_activations,
-                    use_legacy);
+                return self(queue_id, input_tensor_a, input_tensor_b, alpha, memory_config, output_tensor);
             },
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
             py::arg("alpha") = 1.0f,
             py::kw_only(),
-            py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
@@ -39,6 +39,8 @@ enum class BinaryOpType {
     MINIMUM,
     GCD,
     LCM,
+    ADDALPHA,
+    SUBALPHA,
 };
 
 }  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -53,14 +53,9 @@ Tensor ExecuteAddalpha::invoke(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     float alpha,
-    const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
-    std::optional<bool> use_legacy) {
-    SmallVector<unary::UnaryWithParam> modified_rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    const std::optional<Tensor>& optional_output_tensor) {
+    SmallVector<unary::UnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
     return BinaryOperation<operations::binary::BinaryOpType::ADD>::invoke(
         queue_id,
         input_tensor_a,
@@ -68,9 +63,9 @@ Tensor ExecuteAddalpha::invoke(
         std::nullopt,
         memory_config,
         optional_output_tensor,
-        post_activations,
-        lhs_activations,
-        modified_rhs_activations,
+        {},
+        {},
+        rhs_activations,
         false);
 }
 
@@ -80,14 +75,9 @@ Tensor ExecuteSubalpha::invoke(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     float alpha,
-    const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
-    std::optional<bool> use_legacy) {
-    SmallVector<unary::UnaryWithParam> modified_rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    const std::optional<Tensor>& optional_output_tensor) {
+    SmallVector<unary::UnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
     return BinaryOperation<operations::binary::BinaryOpType::SUB>::invoke(
         queue_id,
         input_tensor_a,
@@ -95,9 +85,9 @@ Tensor ExecuteSubalpha::invoke(
         std::nullopt,
         memory_config,
         optional_output_tensor,
-        post_activations,
-        lhs_activations,
-        modified_rhs_activations,
+        {},
+        {},
+        rhs_activations,
         false);
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -47,50 +47,6 @@ Tensor _xlogy(const Tensor& input_a, const Tensor& input_b, const std::optional<
     return result;
 }
 
-// addalpha(input, other, alpha) = input + (alpha * other)
-Tensor ExecuteAddalpha::invoke(
-    QueueId queue_id,
-    const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
-    float alpha,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor) {
-    SmallVector<unary::UnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
-    return BinaryOperation<operations::binary::BinaryOpType::ADD>::invoke(
-        queue_id,
-        input_tensor_a,
-        input_tensor_b,
-        std::nullopt,
-        memory_config,
-        optional_output_tensor,
-        {},
-        {},
-        rhs_activations,
-        false);
-}
-
-// subalpha(input, other, alpha) = input - (alpha * other)
-Tensor ExecuteSubalpha::invoke(
-    QueueId queue_id,
-    const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
-    float alpha,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor) {
-    SmallVector<unary::UnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
-    return BinaryOperation<operations::binary::BinaryOpType::SUB>::invoke(
-        queue_id,
-        input_tensor_a,
-        input_tensor_b,
-        std::nullopt,
-        memory_config,
-        optional_output_tensor,
-        {},
-        {},
-        rhs_activations,
-        false);
-}
-
 // nextafter
 Tensor _nextafter(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     const float eps = tt::tt_metal::hal::get_eps();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -16,7 +16,6 @@ namespace ttnn::operations::binary {
 enum class BinaryCompositeOpType {
     HYPOT,
     XLOGY,
-    ADDALPHA,
     SUBALPHA,
     NEXTAFTER,
     ISCLOSE,
@@ -32,7 +31,6 @@ Tensor _hypot(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _xlogy(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _atan2(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _nextafter(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
-Tensor _addalpha(const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _subalpha(const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _isclose(const Tensor&, const Tensor&, float, float, bool, const std::optional<MemoryConfig>&);
 Tensor _div_no_nan(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
@@ -72,13 +70,6 @@ template <>
 struct OpHandler<BinaryCompositeOpType::ATAN2> {
     static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
         return _atan2(t1, t2, mem_cfg);
-    }
-};
-
-template <>
-struct OpHandler<BinaryCompositeOpType::ADDALPHA> {
-    static Tensor handle(const Tensor& t1, const Tensor& t2, float alpha, const std::optional<MemoryConfig>& mem_cfg) {
-        return _addalpha(t1, t2, alpha, mem_cfg);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -16,7 +16,6 @@ namespace ttnn::operations::binary {
 enum class BinaryCompositeOpType {
     HYPOT,
     XLOGY,
-    SUBALPHA,
     NEXTAFTER,
     ISCLOSE,
     ATAN2,
@@ -31,7 +30,6 @@ Tensor _hypot(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _xlogy(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _atan2(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _nextafter(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
-Tensor _subalpha(const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _isclose(const Tensor&, const Tensor&, float, float, bool, const std::optional<MemoryConfig>&);
 Tensor _div_no_nan(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _div_no_nan_overload(const Tensor&, float, const std::optional<MemoryConfig>&);
@@ -70,13 +68,6 @@ template <>
 struct OpHandler<BinaryCompositeOpType::ATAN2> {
     static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
         return _atan2(t1, t2, mem_cfg);
-    }
-};
-
-template <>
-struct OpHandler<BinaryCompositeOpType::SUBALPHA> {
-    static Tensor handle(const Tensor& t1, const Tensor& t2, float alpha, const std::optional<MemoryConfig>& mem_cfg) {
-        return _subalpha(t1, t2, alpha, mem_cfg);
     }
 };
 


### PR DESCRIPTION
### Ticket
#23100 
#23101 

### Problem description
TTNN addalpha and subalpha have been implemented as composite ops.

### What's changed
Migrated addalpha and subalpha as device ops.

### Performance Results
**Addalpha:**
<img width="393" alt="Screenshot 2025-07-04 at 11 55 43" src="https://github.com/user-attachments/assets/539e22fe-d30d-4032-8032-c3ea712fc491" />


Device version is **44.06%** faster than the composite version of addalpha.

**Subalpha:**
<img width="391" alt="Screenshot 2025-07-04 at 11 55 54" src="https://github.com/user-attachments/assets/a2abac8d-7a08-4dfe-8b94-21921e8ba705" />


Device version is **61.25%** faster than the composite version of subalpha.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16148406263) - PASSED
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16003409186) - PASSED
- [x] [Blackhole Nightly Tests](https://github.com/tenstorrent/tt-metal/actions/runs/16141634680) - PASSED
- [x] New/Existing tests provide coverage for changes