### PR TITLE
#22262: Enforce presence of MeshDevice when loading multi-device storage

### DIFF
--- a/models/demos/metal_BERT_large_11/tt/tensor_utils.py
+++ b/models/demos/metal_BERT_large_11/tt/tensor_utils.py
@@ -34,7 +34,7 @@ def load_or_compute_and_cache(
     tensor = None
     if cache_path:
         try:
-            tensor = ttnn.load_tensor(cache_path)
+            tensor = ttnn.load_tensor(cache_path, device=device)
             logger.info(f"Loaded tensor from cache: {cache_path}")
         except Exception as e:
             logger.warning(f"Failed to load tensor from cache: {cache_path}. Error: {e}")

--- a/tests/ttnn/unit_tests/test_dump_and_load.py
+++ b/tests/ttnn/unit_tests/test_dump_and_load.py
@@ -45,20 +45,3 @@ def test_dump_from_device_and_load_to_device(tmp_path, device, height, width, la
 
     loaded_torch_tensor = ttnn.to_torch(loaded_tensor)
     assert torch.allclose(torch_tensor, loaded_torch_tensor)
-
-
-@pytest.mark.parametrize("height", [1024])
-@pytest.mark.parametrize("width", [1024])
-@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
-@pytest.mark.parametrize("memory_config", [None, ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
-def test_dump_from_device_and_load_to_host(tmp_path, device, height, width, layout, memory_config):
-    file_name = tmp_path / pathlib.Path("tensor.bin")
-
-    torch_tensor = torch.rand((height, width), dtype=torch.bfloat16)
-    tensor = ttnn.from_torch(torch_tensor, layout=layout, device=device, memory_config=memory_config)
-    ttnn.dump_tensor(file_name, tensor)
-
-    loaded_tensor = ttnn.load_tensor(file_name)
-
-    loaded_torch_tensor = ttnn.to_torch(loaded_tensor)
-    assert torch.allclose(torch_tensor, loaded_torch_tensor)

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -269,7 +269,9 @@ DistributedStorage load_multi_device_host_storage(
 DistributedStorage load_storage(
     FILE* input_file, DataType data_type, Layout layout, StorageType storage_type, MeshDevice* device) {
     if (storage_type == StorageType::MULTI_DEVICE_HOST or storage_type == StorageType::DEVICE) {
-        TT_FATAL(device != nullptr, "Device is required for multi-device host storage");
+        // TODO: #22262 - Migrate to the new serialization format that embeds the required information into the tensor
+        // file.
+        TT_FATAL(device != nullptr, "MeshDevice is required for loading multi-device host storage");
         return load_multi_device_host_storage(input_file, data_type, layout, *device);
     }
     return DistributedStorage{load_host_storage(input_file, data_type), ReplicateTensor{}};

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -22,6 +22,7 @@
 
 #include "distributed/distributed_tensor_config.hpp"
 #include "tensor/tensor_spec.hpp"
+#include "tt-metalium/distributed_host_buffer.hpp"
 #include "tt-metalium/mesh_coord.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/storage.hpp"
@@ -167,7 +168,7 @@ struct DistributedStorage {
 
 template <typename T>
 DistributedStorage load_multi_device_host_storage(
-    FILE* input_file, DataType data_type, Layout layout, MeshDevice* mesh_device) {
+    FILE* input_file, DataType data_type, Layout layout, const MeshDevice& mesh_device) {
     uint64_t num_buffers = 0;
     DistributedTensorConfig strategy;
     safe_fread(&num_buffers, sizeof(num_buffers), 1, input_file);
@@ -186,11 +187,9 @@ DistributedStorage load_multi_device_host_storage(
         buffers.push_back(std::move(buffer));
         ignore_spec(load_tensor_spec(input_file));
 
-        auto num_devices = mesh_device ? mesh_device->num_devices() : 1;
-        for (std::size_t i = 1; i < num_devices; ++i) {
+        for (std::size_t i = 1; i < mesh_device.num_devices(); ++i) {
             buffers.push_back(buffers[0]);
         }
-
     } else {
         for (std::size_t i = 0; i < num_buffers; ++i) {
             uint64_t size = 0;
@@ -205,7 +204,23 @@ DistributedStorage load_multi_device_host_storage(
         }
     }
 
-    return {MultiDeviceHostStorage{std::move(buffers)}, strategy};
+    // Create a distributed host buffer with the same shape as the mesh device.
+    auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device.shape());
+    const auto dst_range = [&mesh_device, &strategy]() {
+        if (auto* shard2d_strategy = std::get_if<ShardTensor2D>(&strategy)) {
+            distributed::MeshShape distribution_shape(shard2d_strategy->shard_mesh.y, shard2d_strategy->shard_mesh.x);
+            return distributed::MeshCoordinateRange(distribution_shape);
+        } else {
+            return distributed::MeshCoordinateRange(mesh_device.shape());
+        }
+    }();
+
+    auto dst_coord_it = dst_range.begin();
+    for (int i = 0; i < buffers.size(); ++i, ++dst_coord_it) {
+        distributed_host_buffer.emplace_shard(*dst_coord_it, [b = buffers[i]]() { return b; });
+    }
+
+    return {MultiDeviceHostStorage{std::move(distributed_host_buffer)}, strategy};
 }
 
 HostStorage load_host_storage(FILE* input_file, DataType data_type) {
@@ -233,7 +248,7 @@ HostStorage load_host_storage(FILE* input_file, DataType data_type) {
 }
 
 DistributedStorage load_multi_device_host_storage(
-    FILE* input_file, DataType data_type, Layout layout, MeshDevice* mesh_device) {
+    FILE* input_file, DataType data_type, Layout layout, const MeshDevice& mesh_device) {
     if (data_type == DataType::UINT32 or data_type == DataType::BFLOAT8_B or data_type == DataType::BFLOAT4_B) {
         using T = std::uint32_t;
         return load_multi_device_host_storage<T>(input_file, data_type, layout, mesh_device);
@@ -254,7 +269,8 @@ DistributedStorage load_multi_device_host_storage(
 DistributedStorage load_storage(
     FILE* input_file, DataType data_type, Layout layout, StorageType storage_type, MeshDevice* device) {
     if (storage_type == StorageType::MULTI_DEVICE_HOST or storage_type == StorageType::DEVICE) {
-        return load_multi_device_host_storage(input_file, data_type, layout, device);
+        TT_FATAL(device != nullptr, "Device is required for multi-device host storage");
+        return load_multi_device_host_storage(input_file, data_type, layout, *device);
     }
     return DistributedStorage{load_host_storage(input_file, data_type), ReplicateTensor{}};
 }


### PR DESCRIPTION
### Ticket
#22262

### Problem description
In TT-NN, we would like to avoid representing "host" storage without any notion of distribution shape. Serialization lib violates that, as it relies on a linear list of device shards, which get mapped to specific devices upon writing to storage.

### What's changed
1. Check that `MeshDevice*` is non null on the load path for multi-device storage.
2. Use the device to create a distributed host buffer with shape, then distribute the deserialized data onto the shape before creating a host tensor.

This path will be migrated to using a new serialization scheme that relaxes the requirement.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16014280521) - known failure in `test_tosa_scatter_normal`
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/16003380930)
- [X] [Single device pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/16031192263)
- [x] New/Existing tests provide coverage for changes