### PR TITLE
Clear info before initializing dynamic routing plane

### DIFF
--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1450,11 +1450,9 @@ std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_routing_planes_in_dir
             this->router_port_directions_to_num_routing_planes_map_.at(fabric_node_id).at(routing_direction);
         TT_FATAL(
             eth_chans.size() >= num_routing_planes,
-            "Not enough active fabric eth channels in direction {} for (chip_id: {}, mesh_id: {}, num_routing_planes: "
-            "{}, eth_chans.size(): {})",
+            "Not enough active fabric eth channels for node {} in direction {}. Requested {} routing planes but only have {} eth channels",
+            fabric_node_id,
             routing_direction,
-            fabric_node_id.chip_id,
-            fabric_node_id.mesh_id,
             num_routing_planes,
             eth_chans.size());
         eth_chans.resize(num_routing_planes);

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -138,6 +138,9 @@ void ControlPlane::initialize_dynamic_routing_plane_counts(
     if (fabric_config == tt_metal::FabricConfig::CUSTOM || fabric_config == tt_metal::FabricConfig::DISABLED) {
         return;
     }
+
+    this->router_port_directions_to_num_routing_planes_map_.clear();
+
     auto topology = FabricContext::get_topology_from_config(fabric_config);
     size_t min_routing_planes = std::numeric_limits<size_t>::max();
 
@@ -1445,7 +1448,15 @@ std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_routing_planes_in_dir
         this->router_port_directions_to_num_routing_planes_map_.at(fabric_node_id).contains(routing_direction)) {
         num_routing_planes =
             this->router_port_directions_to_num_routing_planes_map_.at(fabric_node_id).at(routing_direction);
-        TT_FATAL(eth_chans.size() >= num_routing_planes, "Not enough active fabric eth channels in direction");
+        TT_FATAL(
+            eth_chans.size() >= num_routing_planes,
+            "Not enough active fabric eth channels in direction {} for (chip_id: {}, mesh_id: {}, num_routing_planes: "
+            "{}, eth_chans.size(): {})",
+            routing_direction,
+            fabric_node_id.chip_id,
+            fabric_node_id.mesh_id,
+            num_routing_planes,
+            eth_chans.size());
         eth_chans.resize(num_routing_planes);
     }
     return eth_chans;

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -90,11 +90,9 @@ void append_fabric_connection_rt_args(
     CoreType core_type) {
     TT_FATAL(
         src_fabric_node_id != dst_fabric_node_id,
-        "Expected different src and dst chip ids but got same, src:  (M {} D {}), dst:  (M {} D {})",
-        src_fabric_node_id.mesh_id,
-        src_fabric_node_id.chip_id,
-        dst_fabric_node_id.mesh_id,
-        dst_fabric_node_id.chip_id);
+        "Expected different src and dst chip ids but got same, Src: {}, Dst: {}",
+        src_fabric_node_id,
+        dst_fabric_node_id);
 
     const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
 
@@ -107,9 +105,9 @@ void append_fabric_connection_rt_args(
     if (!is_2d_fabric && !is_TG_gateway_connection(src_fabric_node_id, dst_fabric_node_id)) {
         TT_FATAL(
             src_fabric_node_id.mesh_id == dst_fabric_node_id.mesh_id,
-            "Currently only the chips on the same mesh are supported for 1D fabric. Src mesh id: {}, Dst mesh id: {}",
-            src_fabric_node_id.mesh_id,
-            dst_fabric_node_id.mesh_id);
+            "Currently only the chips on the same mesh are supported for 1D fabric. Src: {}, Dst: {}",
+            src_fabric_node_id,
+            dst_fabric_node_id);
     }
 
     // get the direction in which the data will be forwarded from the src_fabric_node_id
@@ -138,7 +136,7 @@ void append_fabric_connection_rt_args(
     }
     TT_FATAL(
         forwarding_direction.has_value(),
-        "Could not find any forwarding direction from source {} to destination {}",
+        "Could not find any forwarding direction from src {} to dst {}",
         src_fabric_node_id,
         dst_fabric_node_id);
 
@@ -146,7 +144,7 @@ void append_fabric_connection_rt_args(
         control_plane.get_active_fabric_eth_channels_in_direction(src_fabric_node_id, forwarding_direction.value());
     TT_FATAL(
         link_idx < candidate_eth_chans.size(),
-        "Requested link index {} is out of bounds. {} ethernet channels available to forward b/w source {} and destination {}",
+        "Requested link index {} is out of bounds. {} ethernet channels available to forward b/w src {} and dst {}",
         link_idx,
         candidate_eth_chans.size(),
         src_fabric_node_id,
@@ -156,7 +154,7 @@ void append_fabric_connection_rt_args(
         get_forwarding_link_indices_in_direction(src_fabric_node_id, dst_fabric_node_id, forwarding_direction.value());
     TT_FATAL(
         std::find(forwarding_links.begin(), forwarding_links.end(), link_idx) != forwarding_links.end(),
-        "Requested link index {} cannot be used for forwarding b/w source {} and destination {}. Valid forwarding links are {}",
+        "Requested link index {} cannot be used for forwarding b/w src {} and dst {}. Valid forwarding links are {}",
         link_idx,
         src_fabric_node_id,
         dst_fabric_node_id,

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -148,15 +148,20 @@ void append_fabric_connection_rt_args(
         control_plane.get_active_fabric_eth_channels_in_direction(src_fabric_node_id, forwarding_direction.value());
     TT_FATAL(
         link_idx < candidate_eth_chans.size(),
-        "requested link idx {}, out of bounds, max available {}",
+        "requested link idx {}, out of bounds, max available {}, cannot be used for forwarding b/w src (M {} D {}) and "
+        "dst (M {} D {})",
         link_idx,
-        candidate_eth_chans.size());
+        candidate_eth_chans.size(),
+        src_fabric_node_id.mesh_id,
+        src_fabric_node_id.chip_id,
+        dst_fabric_node_id.mesh_id,
+        dst_fabric_node_id.chip_id);
 
     const auto forwarding_links =
         get_forwarding_link_indices_in_direction(src_fabric_node_id, dst_fabric_node_id, forwarding_direction.value());
     TT_FATAL(
         std::find(forwarding_links.begin(), forwarding_links.end(), link_idx) != forwarding_links.end(),
-        "requested link idx {}, cannot be used for forwarding b/w src (M {} D {}) and dst  (M {} D {})",
+        "requested link idx {}, cannot be used for forwarding b/w src (M {} D {}) and dst (M {} D {})",
         link_idx,
         src_fabric_node_id.mesh_id,
         src_fabric_node_id.chip_id,

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -138,35 +138,29 @@ void append_fabric_connection_rt_args(
     }
     TT_FATAL(
         forwarding_direction.has_value(),
-        "Could not find any forwarding direction from src  (M {} D {}) to dst  (M {} D {})",
-        src_fabric_node_id.mesh_id,
-        src_fabric_node_id.chip_id,
-        dst_fabric_node_id.mesh_id,
-        dst_fabric_node_id.chip_id);
+        "Could not find any forwarding direction from source {} to destination {}",
+        src_fabric_node_id,
+        dst_fabric_node_id);
 
     const auto candidate_eth_chans =
         control_plane.get_active_fabric_eth_channels_in_direction(src_fabric_node_id, forwarding_direction.value());
     TT_FATAL(
         link_idx < candidate_eth_chans.size(),
-        "requested link idx {}, out of bounds, max available {}, cannot be used for forwarding b/w src (M {} D {}) and "
-        "dst (M {} D {})",
+        "Requested link index {} is out of bounds. {} ethernet channels available to forward b/w source {} and destination {}",
         link_idx,
         candidate_eth_chans.size(),
-        src_fabric_node_id.mesh_id,
-        src_fabric_node_id.chip_id,
-        dst_fabric_node_id.mesh_id,
-        dst_fabric_node_id.chip_id);
+        src_fabric_node_id,
+        dst_fabric_node_id);
 
     const auto forwarding_links =
         get_forwarding_link_indices_in_direction(src_fabric_node_id, dst_fabric_node_id, forwarding_direction.value());
     TT_FATAL(
         std::find(forwarding_links.begin(), forwarding_links.end(), link_idx) != forwarding_links.end(),
-        "requested link idx {}, cannot be used for forwarding b/w src (M {} D {}) and dst (M {} D {})",
+        "Requested link index {} cannot be used for forwarding b/w source {} and destination {}. Valid forwarding links are {}",
         link_idx,
-        src_fabric_node_id.mesh_id,
-        src_fabric_node_id.chip_id,
-        dst_fabric_node_id.mesh_id,
-        dst_fabric_node_id.chip_id);
+        src_fabric_node_id,
+        dst_fabric_node_id,
+        forwarding_links);
 
     const auto fabric_router_channel = candidate_eth_chans[link_idx];
     const auto router_direction = control_plane.routing_direction_to_eth_direction(forwarding_direction.value());


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/18726)

### Problem description
- Need to clear the ports and directions map before running initialize dynamic routing planes otherwise old data from previous test runs will be there

### What's changed
- Clear the map before initializing
- Add more info to error messages to know which chip and direction has a problem

### Checklist
TG Quick
https://github.com/tenstorrent/tt-metal/actions/runs/16004548724
T3K Fast
https://github.com/tenstorrent/tt-metal/actions/runs/16004545605
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/16004547035
APC
https://github.com/tenstorrent/tt-metal/actions/runs/16004549500