### PR TITLE
Fix for test_perf_vanilla_unet

### DIFF
--- a/models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py
+++ b/models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py
@@ -129,8 +129,6 @@ def get_expected_times(name):
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True, ids=["0"])
 def test_vanilla_unet(device, reset_seeds):
     torch.manual_seed(0)
-    # https://github.com/tenstorrent/tt-metal/issues/23281
-    device.disable_and_clear_program_cache()
 
     weights_path = "models/experimental/functional_vanilla_unet/unet.pt"
     if not os.path.exists(weights_path):

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -42,7 +42,7 @@ run_perf_models_other() {
 
         # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov9c/tests/perf -m $test_marker
 
-        # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py -m $test_marker
 
         # env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s_world/tests -m $test_marker
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/mobilenetv2/tests -m $test_marker


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24428)

### Problem description
We disabled the device cache for this test because it was failing when we originally did the change

### What's changed
Reenabling the cache, seems it seems to be working now

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes