### PR TITLE
Enable and start dev-hugepages\x2d1G.mount during configure_hugepages…

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -415,7 +415,8 @@ configure_hugepages() {
     TEMP_DIR=$(mktemp -d)
     wget -P $TEMP_DIR $TT_TOOLS_LINK
     apt-get install -y --no-install-recommends $TEMP_DIR/$TT_TOOLS_NAME
-    systemctl enable --now tenstorrent-hugepages.service
+    sudo systemctl enable --now 'dev-hugepages\x2d1G.mount'
+    sudo systemctl enable --now tenstorrent-hugepages.service
     rm -rf "$TEMP_DIR"
 }
 


### PR DESCRIPTION
… in install_dependencies.sh

### Ticket
N/A

### Problem description
The install_dependencies.sh script does not automatically start the dev-hugepages\x2d1G.mount service setup by tenstorrent-tools, leading to the following exception:

```
unknown file: Failure
C++ exception with description "TT_ASSERT @ /home/ubuntu/tt-metal/tt_metal/third_party/umd/device/cluster.cpp:123: hugepages_initialized
info:
Hugepages must be successfully initialized if workload contains remote chips!
```

### What's changed
Fixes the issue by enabling and starting the dev-hugepages mount service.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes