### PR TITLE
Convert an optional TensorSpec to an optional Tensor

### DIFF
--- a/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
@@ -82,6 +82,8 @@ auto query_op_constraints(Op op, IDevice* device, Args&&... args) {
         auto transform_arg = [device](auto&& arg) {
             if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, TensorSpec>) {
                 return create_device_tensor(arg, device);
+            } else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, std::optional<TensorSpec>>) {
+                return arg ? std::optional<Tensor>(create_device_tensor(*arg, device)) : std::nullopt;
             } else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, std::vector<TensorSpec>>) {
                 std::vector<Tensor> result(arg.size());
                 std::transform(arg.begin(), arg.end(), result.begin(), [device](auto&& item) {

--- a/ttnn/api/ttnn/graph/graph_query_op_runtime.hpp
+++ b/ttnn/api/ttnn/graph/graph_query_op_runtime.hpp
@@ -43,6 +43,8 @@ auto capture_op_trace(Op op, MeshDevice* device, Args&&... args) {
     auto transform_arg = [device](auto&& arg) {
         if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, TensorSpec>) {
             return create_device_tensor(arg, device);
+        } else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, std::optional<TensorSpec>>) {
+            return arg ? std::optional<Tensor>(create_device_tensor(*arg, device)) : std::nullopt;
         } else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, std::vector<TensorSpec>>) {
             std::vector<Tensor> result(arg.size());
             std::transform(arg.begin(), arg.end(), result.begin(), [device](auto&& arg) {


### PR DESCRIPTION
### Ticket
Needed by the constraint API for `PrepareConvBias` Op (https://github.com/tenstorrent/tt-mlir/pull/3943)

### Problem description
A contraint/runtime query may contain an optional TensorSpecs which need to be converted into an optional Tensors for the op to consume.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes