### PR TITLE
Llama70b - Set Ring fabric impl by default on 6U

### DIFF
--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -28,9 +28,9 @@ jobs:
       matrix:
         test-group: [
           { name: "Galaxy Llama3 demo tests", arch: wormhole_b0, model: llama3, timeout: 30, owner_id: U053W15B6JF}, # Djordje Ivanovic
-          { name: "Galaxy Llama3 8B data-parallel demo tests", arch: wormhole_b0, model: llama3_8b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
-          { name: "Galaxy Llama3 70B data-parallel demo tests", arch: wormhole_b0, model: llama3_70b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
-          { name: "Galaxy Falcon7b demo tests", arch: wormhole_b0, model: falcon7b, timeout: 30, owner_id: U05RWH3QUPM}, # Salar Hosseini
+          # { name: "Galaxy Llama3 8B data-parallel demo tests", arch: wormhole_b0, model: llama3_8b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
+          # { name: "Galaxy Llama3 70B data-parallel demo tests", arch: wormhole_b0, model: llama3_70b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
+          # { name: "Galaxy Falcon7b demo tests", arch: wormhole_b0, model: falcon7b, timeout: 30, owner_id: U05RWH3QUPM}, # Salar Hosseini
         ]
     runs-on:
       - arch-wormhole_b0

--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -28,9 +28,9 @@ jobs:
       matrix:
         test-group: [
           { name: "Galaxy Llama3 demo tests", arch: wormhole_b0, model: llama3, timeout: 30, owner_id: U053W15B6JF}, # Djordje Ivanovic
-          # { name: "Galaxy Llama3 8B data-parallel demo tests", arch: wormhole_b0, model: llama3_8b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
-          # { name: "Galaxy Llama3 70B data-parallel demo tests", arch: wormhole_b0, model: llama3_70b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
-          # { name: "Galaxy Falcon7b demo tests", arch: wormhole_b0, model: falcon7b, timeout: 30, owner_id: U05RWH3QUPM}, # Salar Hosseini
+          { name: "Galaxy Llama3 8B data-parallel demo tests", arch: wormhole_b0, model: llama3_8b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
+          { name: "Galaxy Llama3 70B data-parallel demo tests", arch: wormhole_b0, model: llama3_70b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
+          { name: "Galaxy Falcon7b demo tests", arch: wormhole_b0, model: falcon7b, timeout: 30, owner_id: U05RWH3QUPM}, # Salar Hosseini
         ]
     runs-on:
       - arch-wormhole_b0

--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -27,13 +27,13 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {
-            name: "Galaxy CNN model perf tests",
-            model-type: "CNN",
-            arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
-            cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode ""'
-          },  # Pavle Josipovic
+          # {
+          #   name: "Galaxy CNN model perf tests",
+          #   model-type: "CNN",
+          #   arch: wormhole_b0,
+          #   runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+          #   cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode ""'
+          # },  # Pavle Josipovic
           {
             name: "Galaxy Llama 70B model perf tests",
             model-type: "Llama-70B",
@@ -51,24 +51,24 @@ jobs:
             runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
             owner_id: U071CKL4AFK # Ammar Vora
           },
-          {
-            name: "Galaxy Llama 70B prefill perf tests [128]",
-            arch: wormhole_b0,
-            cmd: "FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_prefill_device_perf.py::test_llama_TG_perf_device[128]",
-            timeout: 100,
-            tracy: true,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
-            owner_id: U03PUAKE719 # Miguel Tairum
-          },
-          {
-            name: "Galaxy Llama 70B prefill perf tests [4096]",
-            arch: wormhole_b0,
-            cmd: "FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_prefill_device_perf.py::test_llama_TG_perf_device[4096]",
-            timeout: 100,
-            tracy: true,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
-            owner_id: U03PUAKE719 # Miguel Tairum
-          },
+          # {
+          #   name: "Galaxy Llama 70B prefill perf tests [128]",
+          #   arch: wormhole_b0,
+          #   cmd: "FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_prefill_device_perf.py::test_llama_TG_perf_device[128]",
+          #   timeout: 100,
+          #   tracy: true,
+          #   runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+          #   owner_id: U03PUAKE719 # Miguel Tairum
+          # },
+          # {
+          #   name: "Galaxy Llama 70B prefill perf tests [4096]",
+          #   arch: wormhole_b0,
+          #   cmd: "FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_prefill_device_perf.py::test_llama_TG_perf_device[4096]",
+          #   timeout: 100,
+          #   tracy: true,
+          #   runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+          #   owner_id: U03PUAKE719 # Miguel Tairum
+          # },
 
         ]
     name: ${{ matrix.test-group.name }}

--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -27,13 +27,13 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          # {
-          #   name: "Galaxy CNN model perf tests",
-          #   model-type: "CNN",
-          #   arch: wormhole_b0,
-          #   runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
-          #   cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode ""'
-          # },  # Pavle Josipovic
+          {
+            name: "Galaxy CNN model perf tests",
+            model-type: "CNN",
+            arch: wormhole_b0,
+            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+            cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode ""'
+          },  # Pavle Josipovic
           {
             name: "Galaxy Llama 70B model perf tests",
             model-type: "Llama-70B",
@@ -51,24 +51,24 @@ jobs:
             runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
             owner_id: U071CKL4AFK # Ammar Vora
           },
-          # {
-          #   name: "Galaxy Llama 70B prefill perf tests [128]",
-          #   arch: wormhole_b0,
-          #   cmd: "FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_prefill_device_perf.py::test_llama_TG_perf_device[128]",
-          #   timeout: 100,
-          #   tracy: true,
-          #   runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
-          #   owner_id: U03PUAKE719 # Miguel Tairum
-          # },
-          # {
-          #   name: "Galaxy Llama 70B prefill perf tests [4096]",
-          #   arch: wormhole_b0,
-          #   cmd: "FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_prefill_device_perf.py::test_llama_TG_perf_device[4096]",
-          #   timeout: 100,
-          #   tracy: true,
-          #   runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
-          #   owner_id: U03PUAKE719 # Miguel Tairum
-          # },
+          {
+            name: "Galaxy Llama 70B prefill perf tests [128]",
+            arch: wormhole_b0,
+            cmd: "FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_prefill_device_perf.py::test_llama_TG_perf_device[128]",
+            timeout: 100,
+            tracy: true,
+            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+            owner_id: U03PUAKE719 # Miguel Tairum
+          },
+          {
+            name: "Galaxy Llama 70B prefill perf tests [4096]",
+            arch: wormhole_b0,
+            cmd: "FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_prefill_device_perf.py::test_llama_TG_perf_device[4096]",
+            timeout: 100,
+            tracy: true,
+            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+            owner_id: U03PUAKE719 # Miguel Tairum
+          },
 
         ]
     name: ${{ matrix.test-group.name }}

--- a/models/demos/llama3_subdevices/conftest.py
+++ b/models/demos/llama3_subdevices/conftest.py
@@ -21,7 +21,7 @@ def device_params(request, galaxy_type):
     # Get param dict passed in from test parametrize (or default to empty dict)
     params = getattr(request, "param", {}).copy()
 
-    if "fabric_config" in params:
+    if "fabric_config" in params and params["fabric_config"] == True:
         params["fabric_config"] = (
             ttnn.FabricConfig.FABRIC_1D_RING if galaxy_type == "6U" else ttnn.FabricConfig.FABRIC_1D
         )

--- a/models/demos/llama3_subdevices/conftest.py
+++ b/models/demos/llama3_subdevices/conftest.py
@@ -21,8 +21,9 @@ def device_params(request, galaxy_type):
     # Get param dict passed in from test parametrize (or default to empty dict)
     params = getattr(request, "param", {}).copy()
 
-    # Inject or modify key depending on galaxy_type
-    params["fabric_config"] = ttnn.FabricConfig.FABRIC_1D_RING if galaxy_type == "6U" else ttnn.FabricConfig.FABRIC_1D
-    print(f"Using device_params: {params}")
+    if "fabric_config" in params:
+        params["fabric_config"] = (
+            ttnn.FabricConfig.FABRIC_1D_RING if galaxy_type == "6U" else ttnn.FabricConfig.FABRIC_1D
+        )
 
     return params

--- a/models/demos/llama3_subdevices/conftest.py
+++ b/models/demos/llama3_subdevices/conftest.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 import gc
+import ttnn
 
 
 @pytest.fixture(autouse=True)
@@ -13,3 +14,15 @@ def ensure_gc():
 @pytest.fixture(autouse=True)
 def ensure_devices(ensure_devices_tg):
     pass
+
+
+@pytest.fixture
+def device_params(request, galaxy_type):
+    # Get param dict passed in from test parametrize (or default to empty dict)
+    params = getattr(request, "param", {}).copy()
+
+    # Inject or modify key depending on galaxy_type
+    params["fabric_config"] = ttnn.FabricConfig.FABRIC_1D_RING if galaxy_type != "6U" else ttnn.FabricConfig.FABRIC_1D
+    print(f"Using device_params: {params}")
+
+    return params

--- a/models/demos/llama3_subdevices/conftest.py
+++ b/models/demos/llama3_subdevices/conftest.py
@@ -22,7 +22,7 @@ def device_params(request, galaxy_type):
     params = getattr(request, "param", {}).copy()
 
     # Inject or modify key depending on galaxy_type
-    params["fabric_config"] = ttnn.FabricConfig.FABRIC_1D_RING if galaxy_type != "6U" else ttnn.FabricConfig.FABRIC_1D
+    params["fabric_config"] = ttnn.FabricConfig.FABRIC_1D_RING if galaxy_type == "6U" else ttnn.FabricConfig.FABRIC_1D
     print(f"Using device_params: {params}")
 
     return params

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -727,7 +727,7 @@ def run_llama3_demo(
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 23887872,
             "worker_l1_size": 1344544,
-            # fabric_config is configured in local conftest.py
+            "fabric_config": True,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -14,7 +14,6 @@ import requests
 from pathlib import Path
 import hashlib
 
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
 
 from models.demos.llama3_subdevices.tt.llama_common import (
     PagedAttentionConfig,
@@ -131,7 +130,6 @@ def run_llama3_demo(
     output_filename = f"{output_directory}/demo_user_output_{timestamp}.txt"
 
     dtype = ttnn.bfloat8_b
-    num_links = 4 if is_RING_6U else 2
     assert batch_size <= 32, "Max batch size currently supported is 32"
     assert max_seq_len <= 128 * 1024, "Max sequence length must be less than 128k tokens"
 

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -729,7 +729,7 @@ def run_llama3_demo(
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 23887872,
             "worker_l1_size": 1344544,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D,
+            # fabric_config is configured in local conftest.py
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/demo/demo_performance.py
+++ b/models/demos/llama3_subdevices/demo/demo_performance.py
@@ -436,6 +436,7 @@ def run_llama3_decode_performance(
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 23887872,
+            "fabric_config": True,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/demo/demo_performance.py
+++ b/models/demos/llama3_subdevices/demo/demo_performance.py
@@ -10,8 +10,6 @@ import os
 import ttnn
 import pytest
 
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
-
 from models.demos.llama3_subdevices.tt.llama_common import (
     PagedAttentionConfig,
 )
@@ -438,7 +436,6 @@ def run_llama3_decode_performance(
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 23887872,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -301,6 +301,7 @@ def create_tt_model(
             "num_command_queues": 1,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "worker_l1_size": 1344544,
+            "fabric_config": True,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -12,8 +12,6 @@ import pytest
 import os
 import ttnn
 
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
-
 from models.demos.llama3_subdevices.tt.generator import Generator, SamplingParams
 from models.demos.llama3_subdevices.tt.model_config import LlamaOptimizations
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
@@ -303,7 +301,6 @@ def create_tt_model(
             "num_command_queues": 1,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "worker_l1_size": 1344544,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -21,7 +21,6 @@ from tt_metal.tools.profiler.process_model_log import (
 from models.demos.llama3_subdevices.demo.demo_decode import run_llama3_demo
 from models.demos.llama3_subdevices.demo.demo_decode import LlamaOptimizations
 
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
 
 DECODER_OP_START_INDEX = 4
 DECODER_OP_END_INDEX = -23
@@ -81,7 +80,6 @@ MAX_TYPE = "max"
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 23887872,
             "worker_l1_size": 1344544,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -80,6 +80,7 @@ MAX_TYPE = "max"
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 23887872,
             "worker_l1_size": 1344544,
+            "fabric_config": True,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
@@ -16,8 +16,6 @@ from models.demos.llama3_subdevices.tt.model_config import TtModelArgs, LlamaOpt
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
 from tqdm import tqdm
 
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
-
 
 @torch.no_grad()
 @pytest.mark.parametrize(
@@ -80,7 +78,6 @@ is_RING_6U = os.environ.get("RING_6U", "0") == "1"
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 23887872,
             "worker_l1_size": 1344544,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
@@ -78,6 +78,7 @@ from tqdm import tqdm
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 23887872,
             "worker_l1_size": 1344544,
+            "fabric_config": True,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder.py
@@ -22,8 +22,6 @@ from models.utility_functions import skip_for_grayskull
 from models.demos.llama3_subdevices.tt.prefetcher_common import TtLlamaPrefetcherSetup
 from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
-
 
 @torch.no_grad()
 @skip_for_grayskull("Requires wormhole_b0 to run")
@@ -65,7 +63,6 @@ is_RING_6U = os.environ.get("RING_6U", "0") == "1"
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 165136000,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder.py
@@ -63,6 +63,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 165136000,
+            "fabric_config": True,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
@@ -39,6 +39,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 165136000,
+            "fabric_config": True,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
@@ -13,8 +13,6 @@ from models.utility_functions import skip_for_grayskull
 from models.demos.llama3_subdevices.tt.prefetcher_common import TtLlamaPrefetcherSetup
 from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
-
 
 @torch.no_grad()
 @skip_for_grayskull("Requires wormhole_b0 to run")
@@ -41,7 +39,6 @@ is_RING_6U = os.environ.get("RING_6U", "0") == "1"
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 165136000,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_embedding.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_embedding.py
@@ -16,8 +16,6 @@ from models.utility_functions import (
 from models.utility_functions import skip_for_grayskull
 from models.demos.llama3_subdevices.tt.llama_common import HostEmbedding
 
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
-
 
 @torch.no_grad()
 @skip_for_grayskull("Requires wormhole_b0 to run")
@@ -40,7 +38,7 @@ is_RING_6U = os.environ.get("RING_6U", "0") == "1"
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D}],
+    [{}],
     indirect=True,
 )
 def test_llama_embedding(max_seq_len, batch_size, mesh_device, reset_seeds, ensure_gc):

--- a/models/demos/llama3_subdevices/tests/test_llama_embedding.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_embedding.py
@@ -38,7 +38,11 @@ from models.demos.llama3_subdevices.tt.llama_common import HostEmbedding
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{}],
+    [
+        {
+            "fabric_config": True,
+        }
+    ],
     indirect=True,
 )
 def test_llama_embedding(max_seq_len, batch_size, mesh_device, reset_seeds, ensure_gc):

--- a/models/demos/llama3_subdevices/tests/test_llama_model.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_model.py
@@ -5,7 +5,6 @@ import torch
 import pytest
 from loguru import logger
 import ttnn
-import os
 from models.demos.llama3_subdevices.tt.llama_common import (
     sample_host,
     HostEmbedding,
@@ -21,8 +20,6 @@ from models.utility_functions import (
     comp_allclose,
 )
 from models.utility_functions import skip_for_grayskull
-
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
 
 
 @torch.no_grad()
@@ -86,7 +83,6 @@ is_RING_6U = os.environ.get("RING_6U", "0") == "1"
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "worker_l1_size": 1344544,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_model.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_model.py
@@ -83,6 +83,7 @@ from models.utility_functions import skip_for_grayskull
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "worker_l1_size": 1344544,
+            "fabric_config": True,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_model_nd.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_model_nd.py
@@ -73,6 +73,7 @@ from models.utility_functions import skip_for_blackhole
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "worker_l1_size": 1344544,
+            "fabric_config": True,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_model_nd.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_model_nd.py
@@ -5,7 +5,6 @@ import torch
 import pytest
 from loguru import logger
 import ttnn
-import os
 from models.demos.llama3_subdevices.tt.llama_common import (
     HostEmbedding,
     PagedAttentionConfig,
@@ -15,8 +14,6 @@ from models.demos.llama3_subdevices.tt.llama_model import TtTransformer
 from models.demos.llama3_subdevices.tt.sampling import TTSampling
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
 from models.utility_functions import skip_for_blackhole
-
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
 
 
 @torch.no_grad()
@@ -76,7 +73,6 @@ is_RING_6U = os.environ.get("RING_6U", "0") == "1"
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "worker_l1_size": 1344544,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_lm_head.py
+++ b/models/demos/llama3_subdevices/tests/test_lm_head.py
@@ -43,6 +43,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": True,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_lm_head.py
+++ b/models/demos/llama3_subdevices/tests/test_lm_head.py
@@ -18,8 +18,6 @@ from models.utility_functions import skip_for_grayskull
 from models.demos.llama3_subdevices.tt.prefetcher_common import TtLlamaPrefetcherSetup
 from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
-
 
 @torch.no_grad()
 @skip_for_grayskull("Requires wormhole_b0 to run")
@@ -45,7 +43,6 @@ is_RING_6U = os.environ.get("RING_6U", "0") == "1"
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_sampling.py
+++ b/models/demos/llama3_subdevices/tests/test_sampling.py
@@ -210,6 +210,7 @@ def reference_sampling(input_tensor, sampling_params, num_devices, padded_vocab_
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 31744,
             "worker_l1_size": 1344544,
+            "fabric_config": True,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_sampling.py
+++ b/models/demos/llama3_subdevices/tests/test_sampling.py
@@ -22,8 +22,6 @@ from scipy.stats import entropy
 import numpy as np
 from collections import Counter
 
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
-
 
 def counts_to_vector(*samples, return_prob=True, dtype=float):
     """
@@ -212,14 +210,13 @@ def reference_sampling(input_tensor, sampling_params, num_devices, padded_vocab_
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "trace_region_size": 31744,
             "worker_l1_size": 1344544,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D,
         }
     ],
     indirect=True,
 )
 def test_llama_sampling_inference(dtype, sampling_params, batch_size, mesh_device, reset_seeds):
     use_tracing = False
-    load_cached_outputs = True
+    load_cached_outputs = False
     num_samples = 10
     num_compile_steps = 1
     model_args = TtModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=32, dummy_weights=True)

--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
@@ -4,12 +4,10 @@
 
 import pytest
 from loguru import logger
-import os
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from models.perf.device_perf_utils import run_device_perf_detailed
 
 THRESHOLD = 0.4
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
 
 
 @pytest.mark.parametrize(
@@ -23,13 +21,14 @@ def test_ag_tg_llama_perf(
     ag_type,
     warmup_iters,
     perf_target_us,
+    galaxy_type,
 ):
     profiler = BenchmarkProfiler()
     benchmark_data = BenchmarkData()
     step_name = f"all_gather_{ag_type}"
 
     subdir = "llama_ccl_perf"
-    if is_RING_6U:
+    if galaxy_type == "6U":
         command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py::test_all_gather_6u_llama -k {ag_type}"
     else:
         command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py::test_all_gather_tg_llama -k {ag_type}"
@@ -59,7 +58,7 @@ def test_ag_tg_llama_perf(
     benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-{ag_type}-std", measured_std)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"tg_llama_ops",
+        run_type=f"tg_llama_ops" if galaxy_type != "6U" else "tg_llama_ops_6U",
         ml_model_name="llama70b-tg",
     )
 
@@ -79,13 +78,14 @@ def test_ar_tg_llama_perf(
     ar_type,
     warmup_iters,
     perf_target_us,
+    galaxy_type,
 ):
     profiler = BenchmarkProfiler()
     benchmark_data = BenchmarkData()
     step_name = f"all_reduce_{ar_type}"
 
     subdir = "llama_ccl_perf"
-    if is_RING_6U:
+    if galaxy_type == "6U":
         command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py::test_all_reduce_6U_llama -k {ar_type}"
     else:
         command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py::test_all_reduce_tg_llama -k {ar_type}"
@@ -115,7 +115,7 @@ def test_ar_tg_llama_perf(
     benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-{ar_type}-std", measured_std)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"tg_llama_ops",
+        run_type=f"tg_llama_ops" if galaxy_type != "6U" else "tg_llama_ops_6U",
         ml_model_name="llama70b-tg",
     )
 
@@ -135,13 +135,14 @@ def test_matmul_rs(
     ar_type,
     warmup_iters,
     perf_target_us,
+    galaxy_type,
 ):
     profiler = BenchmarkProfiler()
     benchmark_data = BenchmarkData()
     step_name = f"matmul_rs_test"
 
     subdir = "llama_ccl_perf"
-    if is_RING_6U:
+    if galaxy_type == "6U":
         command = f"pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_rs_matmul_1d_gather_in0.py::test_6U_matmul_1d_ring_llama_with_rs_perf"
     else:
         command = f"pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_rs_matmul_1d_gather_in0.py::test_tg_matmul_1d_ring_llama_with_rs_perf"
@@ -171,7 +172,7 @@ def test_matmul_rs(
     benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-std", measured_std)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"tg_llama_ops",
+        run_type=f"tg_llama_ops" if galaxy_type != "6U" else "tg_llama_ops_6U",
         ml_model_name="llama70b-tg",
     )
 
@@ -189,13 +190,14 @@ def test_rms_perf(
     ar_type,
     warmup_iters,
     perf_target_us,
+    galaxy_type,
 ):
     profiler = BenchmarkProfiler()
     benchmark_data = BenchmarkData()
     step_name = f"rms_test"
 
     subdir = "llama_ccl_perf"
-    if is_RING_6U:
+    if galaxy_type == "6U":
         command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_minimals.py::test_6u_trace_rms_fuse"
     else:
         command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_minimals.py::test_tg_trace_rms_fuse"
@@ -225,7 +227,7 @@ def test_rms_perf(
     benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-std", measured_std)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"tg_llama_ops",
+        run_type=f"tg_llama_ops" if galaxy_type != "6U" else "tg_llama_ops_6U",
         ml_model_name="llama70b-tg",
     )
 
@@ -242,13 +244,14 @@ def test_rms_perf(
 def test_fused_all_gather_concat_perf(
     warmup_iters,
     perf_target_us,
+    galaxy_type,
 ):
     profiler = BenchmarkProfiler()
     benchmark_data = BenchmarkData()
     step_name = f"all_gather_concat_heads"
 
     subdir = "llama_ccl_perf"
-    if is_RING_6U:
+    if galaxy_type == "6U":
         command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_minimals.py::test_concat_fuse_6u"
     else:
         command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_minimals.py::test_concat_fuse"
@@ -278,7 +281,7 @@ def test_fused_all_gather_concat_perf(
     benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-std", measured_std)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"tg_llama_ops",
+        run_type=f"tg_llama_ops" if galaxy_type != "6U" else "tg_llama_ops_6U",
         ml_model_name="llama70b-tg",
     )
 
@@ -295,13 +298,14 @@ def test_fused_all_gather_concat_perf(
 def test_fused_all_reduce_create_heads_perf(
     warmup_iters,
     perf_target_us,
+    galaxy_type,
 ):
     profiler = BenchmarkProfiler()
     benchmark_data = BenchmarkData()
     step_name = f"all_reduce_create_heads"
 
     subdir = "llama_ccl_perf"
-    if is_RING_6U:
+    if galaxy_type == "6U":
         command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_qkv_all_reduce_minimal.py::test_all_reduce_qkv_heads_fuse_perf_6U"
     else:
         command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_qkv_all_reduce_minimal.py::test_all_reduce_qkv_heads_fuse_perf"
@@ -331,7 +335,7 @@ def test_fused_all_reduce_create_heads_perf(
     benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-std", measured_std)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"tg_llama_ops",
+        run_type=f"tg_llama_ops" if galaxy_type != "6U" else "tg_llama_ops_6U",
         ml_model_name="llama70b-tg",
     )
 
@@ -348,13 +352,14 @@ def test_fused_all_reduce_create_heads_perf(
 def test_reduce_scatter_perf(
     warmup_iters,
     perf_target_us,
+    galaxy_type,
 ):
     profiler = BenchmarkProfiler()
     benchmark_data = BenchmarkData()
     step_name = f"reduce_scatter_perf"
 
     subdir = "llama_ccl_perf"
-    if is_RING_6U:
+    if galaxy_type == "6U":
         command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_6U.py::test_fabric_reduce_scatter_tg_trace_6u"
     else:
         command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py::test_fabric_reduce_scatter_tg_trace"
@@ -383,7 +388,7 @@ def test_reduce_scatter_perf(
     benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-std", measured_std)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"tg_llama_ops",
+        run_type=f"tg_llama_ops" if galaxy_type != "6U" else "tg_llama_ops_6U",
         ml_model_name="llama70b-tg",
     )
 
@@ -400,13 +405,14 @@ def test_reduce_scatter_perf(
 def test_rs_create_heads_perf(
     warmup_iters,
     perf_target_us,
+    galaxy_type,
 ):
     profiler = BenchmarkProfiler()
     benchmark_data = BenchmarkData()
     step_name = f"rs_create_heads_perf"
 
     subdir = "llama_ccl_perf"
-    if is_RING_6U:
+    if galaxy_type == "6U":
         command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_create_heads_async_TG.py::test_rs_create_heads_6u_trace"
     else:
         command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_create_heads_async_TG.py::test_rs_create_heads_tg_trace"
@@ -435,7 +441,7 @@ def test_rs_create_heads_perf(
     benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-std", measured_std)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"tg_llama_ops",
+        run_type=f"tg_llama_ops" if galaxy_type != "6U" else "tg_llama_ops_6U",
         ml_model_name="llama70b-tg",
     )
 

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
@@ -30,6 +30,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": True,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
@@ -22,8 +22,6 @@ from models.utility_functions import skip_for_grayskull
 from models.demos.llama3_subdevices.tt.prefetcher_common import TtLlamaPrefetcherSetup
 from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
-
 
 @torch.no_grad()
 @skip_for_grayskull("Requires wormhole_b0 to run")
@@ -32,7 +30,6 @@ is_RING_6U = os.environ.get("RING_6U", "0") == "1"
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
@@ -43,6 +43,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": True,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
@@ -18,8 +18,6 @@ from models.utility_functions import skip_for_grayskull
 from models.demos.llama3_subdevices.tt.prefetcher_common import TtLlamaPrefetcherSetup
 from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
-
 
 @torch.no_grad()
 @skip_for_grayskull("Requires wormhole_b0 to run")
@@ -45,7 +43,6 @@ is_RING_6U = os.environ.get("RING_6U", "0") == "1"
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D,
         }
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_rms_norm.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_rms_norm.py
@@ -18,8 +18,6 @@ from models.demos.llama3_subdevices.tt.distributed_norm import DistributedNorm
 from models.demos.llama3_subdevices.tt.prefetcher_common import TtLlamaPrefetcherSetup
 from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
-
 
 @torch.no_grad()
 @skip_for_grayskull("Requires wormhole_b0 to run")
@@ -51,7 +49,6 @@ is_RING_6U = os.environ.get("RING_6U", "0") == "1"
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING if is_RING_6U else ttnn.FabricConfig.FABRIC_1D,
         }
     ],
     indirect=True,
@@ -90,7 +87,9 @@ def test_llama_rms_norm_inference(
     )
 
     # Wrap it in DistributedNorm
-    tt_model = DistributedNorm(tt_inner_norm, model_args, TG=model_args.is_galaxy, tt_ccl=tt_ccl)
+    tt_model = DistributedNorm(
+        tt_inner_norm, model_args, TG=model_args.is_galaxy, tt_ccl=tt_ccl, ccl_topology=model_args["CCL_TOPOLOGY"]
+    )
 
     # Create reference model (unchanged)
     partial_state_dict = {

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_rms_norm.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_rms_norm.py
@@ -49,6 +49,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": True,
         }
     ],
     indirect=True,
@@ -88,7 +89,11 @@ def test_llama_rms_norm_inference(
 
     # Wrap it in DistributedNorm
     tt_model = DistributedNorm(
-        tt_inner_norm, model_args, TG=model_args.is_galaxy, tt_ccl=tt_ccl, ccl_topology=model_args["CCL_TOPOLOGY"]
+        tt_inner_norm,
+        model_args,
+        TG=model_args.is_galaxy,
+        tt_ccl=tt_ccl,
+        ccl_topology=model_args.model_config["CCL_TOPOLOGY"],
     )
 
     # Create reference model (unchanged)

--- a/models/demos/llama3_subdevices/tt/distributed_norm.py
+++ b/models/demos/llama3_subdevices/tt/distributed_norm.py
@@ -8,10 +8,11 @@ from models.demos.llama3_subdevices.tt.llama_ccl import tt_sharded_distributed_r
 
 
 class DistributedNorm(LightweightModule):
-    def __init__(self, norm, args, TG=False, tt_ccl=None):
+    def __init__(self, norm, args, TG=False, tt_ccl=None, ccl_topology=None):
         self.norm = norm
         self.args = args
         self.tt_ccl = tt_ccl
+        self.ccl_topology = ccl_topology
 
         if TG:
             core_grid_ln, grid_offset = (8, 2), ttnn.CoreCoord(1, 0)
@@ -66,6 +67,7 @@ class DistributedNorm(LightweightModule):
                     ln_sharded_stats_memcfg=self.ln_sharded_stats_memcfg,
                     tt_ccl=self.tt_ccl,
                     output_mem_config=self.norm.output_mem_config,
+                    ccl_topology=self.ccl_topology,
                 )
             else:
                 return tt_distributed_rmsnorm(

--- a/models/demos/llama3_subdevices/tt/llama_attention.py
+++ b/models/demos/llama3_subdevices/tt/llama_attention.py
@@ -6,9 +6,6 @@ import torch
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
-import os
-
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
 
 
 class TtLlamaAttention(LightweightModule):
@@ -288,7 +285,7 @@ class TtLlamaAttention(LightweightModule):
         ) = self.tt_ccl.llama_rs_create_heads(
             xqkv_fused_sharded,
             cluster_axis=1,
-            num_links=4 if is_RING_6U else 3,
+            num_links=self.model_config["GALAXY_NUM_LINKS"],
             dim=3,
             qkv_memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
         )
@@ -362,7 +359,7 @@ class TtLlamaAttention(LightweightModule):
             attn_output_1G4D_sharded,
             dim=1,
             cluster_axis=1,
-            num_links=4 if is_RING_6U else 3,
+            num_links=self.model_config["GALAXY_NUM_LINKS"],
             memory_config=self.model_config["SHARDED_ATTN_WO_INPUT_RING_MEMCFG"],
             num_heads=self.n_local_heads,
         )
@@ -385,7 +382,7 @@ class TtLlamaAttention(LightweightModule):
         dense_out_reduced = self.tt_ccl.line_all_reduce(
             dense_out_ttnn,
             cluster_axis=0,
-            num_links=4 if is_RING_6U else 3,
+            num_links=self.model_config["GALAXY_NUM_LINKS"],
             memory_config=self.model_config["DECODE_RESIDUAL_MEMCFG"],
         )
         ttnn.deallocate(dense_out_ttnn)

--- a/models/demos/llama3_subdevices/tt/llama_ccl.py
+++ b/models/demos/llama3_subdevices/tt/llama_ccl.py
@@ -4,9 +4,6 @@
 
 import ttnn
 import torch
-import os
-
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
 
 
 class TT_CCL:
@@ -475,7 +472,7 @@ class TT_CCL:
                 num_links=num_links,
                 memory_config=memory_config,
                 dtype=dtype,
-                topology=ttnn.Topology.Ring if is_RING_6U else ttnn.Topology.Linear,
+                topology=self.model_config["CCL_TOPOLOGY"],
                 subdevice_id=self.worker_sub_device_id,
                 use_noc1_only=use_noc1_only,
             )
@@ -552,7 +549,7 @@ class TT_CCL:
             multi_device_global_semaphore=self.gather_semaphore_handles[cluster_axis][self.gather_idx[cluster_axis]],
             num_heads=num_heads,
             memory_config=memory_config,
-            topology=ttnn.Topology.Ring if is_RING_6U else ttnn.Topology.Linear,
+            topology=self.model_config["CCL_TOPOLOGY"],
             num_links=num_links,
             subdevice_id=self.worker_sub_device_id,
             num_kv_heads=num_kv_heads,
@@ -608,7 +605,7 @@ class TT_CCL:
             program_config=program_config,
             memory_config_mm=memory_config,
             global_cb=global_cb,
-            topology=ttnn.Topology.Ring if is_RING_6U else ttnn.Topology.Linear,
+            topology=self.model_config["CCL_TOPOLOGY"],
             use_noc1_only=use_noc1_only,
         )
         self.gather_idx[cluster_axis] = (self.gather_idx[cluster_axis] + 1) % self.num_cbs
@@ -638,7 +635,7 @@ class TT_CCL:
             subdevice_id=self.worker_sub_device_id,
             cluster_axis=1,
             mesh_device=self.mesh_device,
-            topology=ttnn.Topology.Ring if is_RING_6U else ttnn.Topology.Linear,
+            topology=self.model_config["CCL_TOPOLOGY"],
             num_links=num_links,
             num_heads=8,
             num_kv_heads=1,
@@ -709,7 +706,7 @@ class TT_CCL:
                 mesh_device=self.mesh_device,
                 num_links=num_links,
                 memory_config=memory_config,
-                topology=ttnn.Topology.Ring if is_RING_6U else ttnn.Topology.Linear,
+                topology=self.model_config["CCL_TOPOLOGY"],
                 use_noc1_only=use_noc1_only,
             )
             self.gather_idx[cluster_axis] = (self.gather_idx[cluster_axis] + 1) % self.num_cbs
@@ -737,7 +734,7 @@ class TT_CCL:
                     else self.all_gather_buffers[seqlen].get(buffer_key, None)
                 )
         else:
-            topology = ttnn.Topology.Ring if is_RING_6U else ttnn.Topology.Linear
+            topology = self.model_config["CCL_TOPOLOGY"]
             assert buffer_key is not None, "buffer_key is None"
             persistent_buffer = self.all_gather_buffers.get(buffer_key, None)
         # ttnn.synchronize_device(self.mesh_device, sub_device_ids=[self.worker_sub_device_id])
@@ -770,7 +767,7 @@ class TT_CCL:
             dim,
             cluster_axis=cluster_axis,
             mesh_device=self.mesh_device,
-            topology=ttnn.Topology.Ring if is_RING_6U else ttnn.Topology.Linear,
+            topology=self.model_config["CCL_TOPOLOGY"],
             multi_device_global_semaphore=self.gather_semaphore_handles[cluster_axis][self.gather_idx[cluster_axis]],
             num_links=num_links,
             num_heads=num_heads,
@@ -907,7 +904,7 @@ def tt_sharded_distributed_rmsnorm(
         cluster_axis,
         tt_ccl.mesh_device,
         semaphore,
-        topology=ttnn.Topology.Ring if is_RING_6U else ttnn.Topology.Linear,
+        topology=self.model_config["CCL_TOPOLOGY"],
         residual_input_tensor=res,
         num_links=1,
         epsilon=epsilon,

--- a/models/demos/llama3_subdevices/tt/llama_ccl.py
+++ b/models/demos/llama3_subdevices/tt/llama_ccl.py
@@ -891,6 +891,7 @@ def tt_sharded_distributed_rmsnorm(
     tt_ccl=None,
     output_mem_config=None,
     use_noc1_only=False,
+    ccl_topology=None,
 ):
     # inp = ttnn.to_memory_config(inp, memory_config=ln_sharded_input_memcfg)
 
@@ -904,7 +905,7 @@ def tt_sharded_distributed_rmsnorm(
         cluster_axis,
         tt_ccl.mesh_device,
         semaphore,
-        topology=self.model_config["CCL_TOPOLOGY"],
+        topology=ccl_topology,
         residual_input_tensor=res,
         num_links=1,
         epsilon=epsilon,

--- a/models/demos/llama3_subdevices/tt/llama_decoder.py
+++ b/models/demos/llama3_subdevices/tt/llama_decoder.py
@@ -89,6 +89,7 @@ class TtTransformerBlock(LightweightModule):
             args,
             TG=args.is_galaxy,
             tt_ccl=tt_ccl,
+            ccl_topology=self.model_config["CCL_TOPOLOGY"],
         )
         self.ff_norm = DistributedNorm(
             RMSNorm(
@@ -107,6 +108,7 @@ class TtTransformerBlock(LightweightModule):
             args,
             TG=args.is_galaxy,
             tt_ccl=tt_ccl,
+            ccl_topology=self.model_config["CCL_TOPOLOGY"],
         )
 
     def prefetch(self, prefetcher_setup, tt_ccl):

--- a/models/demos/llama3_subdevices/tt/llama_mlp.py
+++ b/models/demos/llama3_subdevices/tt/llama_mlp.py
@@ -6,9 +6,6 @@ import torch
 import ttnn
 from models.common.lightweightmodule import LightweightModule
 import torch.nn.functional as F
-import os
-
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
 
 
 def pad_to_next_multiple(tensor):
@@ -141,7 +138,7 @@ class TtLlamaMLP(LightweightModule):
             self.w3,
             w1_out,
             cluster_axis=1,
-            num_links=4 if is_RING_6U else 3,
+            num_links=self.model_config["GALAXY_NUM_LINKS"],
             RS_memory_config=self.model_config["REDUCE_SCATTER_OUT_MEMCFG"],
             compute_kernel_config=self.args.compute_kernel_config_lofi
             if self.four_bit_mlp
@@ -158,7 +155,7 @@ class TtLlamaMLP(LightweightModule):
             w3_out_reduced = self.tt_ccl.line_reduce_scatter(
                 w3_out,
                 cluster_axis=1,
-                num_links=4 if is_RING_6U else 3,
+                num_links=self.model_config["GALAXY_NUM_LINKS"],
                 memory_config=self.model_config["REDUCE_SCATTER_OUT_MEMCFG"],
                 use_noc1_only=False,
             )
@@ -183,7 +180,7 @@ class TtLlamaMLP(LightweightModule):
             ff1ff3,
             dim=3,
             cluster_axis=1,
-            num_links=4 if is_RING_6U else 3,
+            num_links=self.model_config["GALAXY_NUM_LINKS"],
             memory_config=self.model_config["FF2_IN_RING_MEMCFG"],
             buffer_key="BINARY_MUL",
         )
@@ -204,7 +201,7 @@ class TtLlamaMLP(LightweightModule):
         w2_out_reduced = self.tt_ccl.line_all_reduce(
             w2_out,
             cluster_axis=0,
-            num_links=4 if is_RING_6U else 3,
+            num_links=self.model_config["GALAXY_NUM_LINKS"],
             memory_config=self.model_config["DECODE_RESIDUAL_MEMCFG"],
         )
 

--- a/models/demos/llama3_subdevices/tt/llama_model.py
+++ b/models/demos/llama3_subdevices/tt/llama_model.py
@@ -112,6 +112,7 @@ class TtTransformer(LightweightModule):
             args,
             args.is_galaxy,
             tt_ccl=self.tt_ccl,
+            ccl_topology=self.model_config["CCL_TOPOLOGY"],
         )
 
         self.lm_head = LMHead(

--- a/models/demos/llama3_subdevices/tt/lm_head.py
+++ b/models/demos/llama3_subdevices/tt/lm_head.py
@@ -6,9 +6,6 @@ import math
 import torch
 import ttnn
 from models.common.lightweightmodule import LightweightModule
-import os
-
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
 
 
 class LMHead(LightweightModule):
@@ -191,7 +188,7 @@ class LMHead(LightweightModule):
         outputs = []
         num_links = 3
         if mode == "decode":
-            num_links = 4 if is_RING_6U else 3
+            num_links = self.args.model_config["GALAXY_NUM_LINKS"]
             for weight, pc in zip(self.output_weights_decode, self.program_configs):
                 x = ttnn.to_memory_config(x, self.args.model_config["SHARDED_LM_HEAD_INPUT_32_RING_MEMCFG"])
                 output = ttnn.linear(

--- a/models/demos/llama3_subdevices/tt/model_config.py
+++ b/models/demos/llama3_subdevices/tt/model_config.py
@@ -603,6 +603,16 @@ class TtModelArgs:
         device = mesh_device if mesh_device is not None else None
         self.cluster_shape = list(mesh_device.shape)
         self.is_galaxy = self.num_devices == 32
+        self.galaxy_type = None
+
+        if self.is_galaxy:
+            self.galaxy_type = "6U" if ttnn.GetNumPCIeDevices() == 32 else "4U"
+        else:
+            raise ValueError(
+                f"Unsupported number of devices: {self.num_devices}. Only 32 devices (Galaxy) are supported."
+            )
+        self.model_config["GALAXY_NUM_LINKS"] = {"6U": 4, "4U": 3}.get(self.galaxy_type)
+        self.model_config["CCL_TOPOLOGY"] = {"6U": ttnn.Topology.Ring, "4U": ttnn.Topology.Linear}.get(self.galaxy_type)
         if device is not None:  # Avoid issue with test_llama_torch.py not having a device
             self.n_local_heads = self.n_heads // self.cluster_shape[1]
 

--- a/models/demos/llama3_subdevices/tt/sampling.py
+++ b/models/demos/llama3_subdevices/tt/sampling.py
@@ -4,10 +4,7 @@
 
 import torch
 import ttnn
-import os
 from models.common.lightweightmodule import LightweightModule
-
-is_RING_6U = os.environ.get("RING_6U", "0") == "1"
 
 
 class TTSampling(LightweightModule):
@@ -29,7 +26,7 @@ class TTSampling(LightweightModule):
         self.max_top_k = args.max_top_k
         self.temperature = temperature
 
-        max_num_gather_links = 4 if is_RING_6U else 3
+        max_num_gather_links = args.model_config["GALAXY_NUM_LINKS"]
         self.num_gather_links = (
             self.max_top_k // 32 if self.max_top_k // 32 <= max_num_gather_links else max_num_gather_links
         )


### PR DESCRIPTION
### Problem description
We are currently using 6U_RING flag to use ring fabric and all ring optimizations.
### What's changed
- RING_6U is removed from all files.
- Galaxy type is determined in device_params fixture
- Model now determines 4U vs 6U based on galaxy_type fixture instead of manual flag used
### Checklist
- [ ] [TG pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/16008419919)
- [ ] [6U quick and stress](https://github.com/tenstorrent/tt-metal/actions/runs/16008426291)
- [ ] [6U demo](https://github.com/tenstorrent/tt-metal/actions/runs/16008348855)
- [ ] [6U frequent](https://github.com/tenstorrent/tt-metal/actions/runs/16008462540)
- [ ] [6U model perf](https://github.com/tenstorrent/tt-metal/actions/runs/16008468982)