### PR TITLE
Workaround to allow DPRINT in noc_nonblocking_api.h

### DIFF
--- a/tt_metal/hw/inc/risc_common.h
+++ b/tt_metal/hw/inc/risc_common.h
@@ -145,6 +145,17 @@ inline uint32_t special_mult(uint32_t a, uint32_t special_b) {
     return 0;
 }
 
+// Invalidates Blackhole's entire L1 cache
+// Blackhole L1 cache is a small write-through cache (4x16B L1 lines). The cache covers all of L1 (no
+// MMU or range registers).
+//  Writing an address on one proc and reading it from another proc only requires the reader to invalidate.
+//  Need to invalidate any address written by noc that may have been previously read by riscv
+inline __attribute__((always_inline)) void invalidate_l1_cache() {
+#if defined(ARCH_BLACKHOLE) && !defined(DISABLE_L1_DATA_CACHE)
+    asm("fence");
+#endif
+}
+
 // risc_init function isn't required for TRISCS
 #if !defined(COMPILE_FOR_TRISC)  // BRISC, NCRISC, ERISC, IERISC
 #include "noc_nonblocking_api.h"
@@ -173,17 +184,6 @@ inline void riscv_wait(uint32_t cycles) {
 #endif
         wall_clock = clock_lo[0] | ((uint64_t)clock_hi[0] << 32);
     } while (wall_clock < (wall_clock_timestamp + cycles));
-}
-
-// Invalidates Blackhole's entire L1 cache
-// Blackhole L1 cache is a small write-through cache (4x16B L1 lines). The cache covers all of L1 (no
-// MMU or range registers).
-//  Writing an address on one proc and reading it from another proc only requires the reader to invalidate.
-//  Need to invalidate any address written by noc that may have been previously read by riscv
-inline __attribute__((always_inline)) void invalidate_l1_cache() {
-#if defined(ARCH_BLACKHOLE) && !defined(DISABLE_L1_DATA_CACHE)
-    asm("fence");
-#endif
 }
 
 // Flush i$ on ethernet riscs


### PR DESCRIPTION
### Problem description
There is a circular dependency risc_common.h -> noc_nonblocking_api.h -> dprint.h if DPRINT is needed in noc_nonblocking_api.h and it won't compile because the definition of invalidate_l1_cache is not visible to dprint.h.

### What's changed
The workaround is to move the definition up a bit.  Some header file spilt may be required to properly solve the circular dependency.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16032120128) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes