### PR TITLE
Run all tests in single-card model perf in separate steps of the workflow

### DIFF
--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -48,7 +48,7 @@ jobs:
           name: ${{ inputs.wheel-artifact-name }}
       - name: Enable Performance mode
         run: sudo cpupower frequency-set -g performance
-      - name: Run sentence_bert tests
+      - name: Run falcon7b_common tests
         if: ${{ matrix.model-type == 'llm_javelin' && !cancelled() }}
         timeout-minutes: 70
         uses: ./.github/actions/docker-run
@@ -66,7 +66,50 @@ jobs:
             -e GITHUB_ACTIONS=true
           install_wheel: true
           run_args: |
-            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/sentence_bert/tests -m models_performance_bare_metal
+            export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+            env pytest -n auto models/demos/falcon7b_common/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run qwen tests
+        if: ${{ matrix.model-type == 'llm_javelin' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+            env QWEN_DIR=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2-7B-Instruct FAKE_DEVICE=N150 pytest -n auto models/demos/qwen/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run mamba tests
+        if: ${{ matrix.model-type == 'llm_javelin' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+            env pytest -n auto models/demos/wormhole/mamba/tests -m models_performance_bare_metal
             env python3 models/perf/merge_perf_results.py
       # TODO: Fix the pipeline before enabling notifications.
       #- uses: tenstorrent/tt-metal/.github/actions/slack-report@main

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -151,6 +151,526 @@ jobs:
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/stable_diffusion/tests -m models_performance_bare_metal --timeout=480
             env python3 models/perf/merge_perf_results.py
+      - name: Run sentence_bert tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/sentence_bert/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run resnet50 tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run bert_tiny tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/bert_tiny/tests/test_performance.py -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run yolov4 tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/yolov4/tests/perf -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run yolov7 tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov7/tests/ -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run distilbert tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/distilbert/tests/test_perf_distilbert.py -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run segformer tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/test_e2e_performant.py -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run vit tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run whisper tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/whisper/tests/test_performance.py -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run metal_BERT_large_11 tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/metal_BERT_large_11/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run vgg_unet tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/vgg_unet/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run yolov9c tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov9c/tests/perf -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run functional_vanilla_unet tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run yolov8s_world tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s_world/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run mobilenetv2 tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/mobilenetv2/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run ufld_v2 tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/ufld_v2/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run yolov8x tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8x/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run yolov8s tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run yolov10 tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/yolov10/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run bert tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env pytest -n auto tests/ttnn/integration_tests/bert/test_performance.py -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run ttnn_falcon7b tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env pytest -n auto models/demos/ttnn_falcon7b/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run vgg tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env pytest -n auto models/demos/vgg/tests/test_perf_vgg.py -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run convnet_mnist tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env pytest -n auto models/demos/convnet_mnist/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run mnist tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env pytest -n auto models/demos/mnist/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run squeezebert tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env pytest -n auto models/demos/squeezebert/tests/test_performance.py -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run roberta tests
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env pytest -n auto models/demos/roberta/tests/test_performance.py -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
       # TODO: Fix the pipeline before enabling notifications.
       #- uses: tenstorrent/tt-metal/.github/actions/slack-report@main
       #  if: ${{ failure() }}

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -23,7 +23,7 @@ jobs:
         test-info: [
           {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "perf-no-reset-grayskull"], machine-type: "bare_metal"},
         ]
-        model-type: [llm_javelin, cnn_javelin, other]
+        model-type: [cnn_javelin]
     name: "${{ matrix.model-type }} ${{ matrix.test-info.name }}"
     defaults:
       run:
@@ -130,7 +130,6 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
       - name: Run stable_diffusion tests
         if: ${{ matrix.model-type == 'cnn_javelin' && !cancelled() }}
         timeout-minutes: 70
@@ -150,7 +149,6 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/stable_diffusion/tests -m models_performance_bare_metal --timeout=480
-            env python3 models/perf/merge_perf_results.py
       - name: Run sentence_bert tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -670,6 +668,25 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto models/demos/roberta/tests/test_performance.py -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Merge Perf Results
+        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
             env python3 models/perf/merge_perf_results.py
       # TODO: Fix the pipeline before enabling notifications.
       #- uses: tenstorrent/tt-metal/.github/actions/slack-report@main

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal"},
+          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "perf-no-reset-grayskull"], machine-type: "bare_metal"},
         ]
         model-type: [llm_javelin, cnn_javelin, other]
     name: "${{ matrix.model-type }} ${{ matrix.test-info.name }}"

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -23,7 +23,7 @@ jobs:
         test-info: [
           {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "perf-no-reset-grayskull"], machine-type: "bare_metal"},
         ]
-        model-type: [llm_javelin, cnn_javelin, other]
+        model-type: [other2]
     name: "${{ matrix.model-type }} ${{ matrix.test-info.name }}"
     defaults:
       run:
@@ -391,7 +391,7 @@ jobs:
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov9c/tests/perf -m models_performance_bare_metal
             
       - name: Run functional_vanilla_unet tests
-        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        if: ${{ matrix.model-type == 'other2' && !cancelled() }}
         timeout-minutes: 70
         uses: ./.github/actions/docker-run
         env:
@@ -408,10 +408,10 @@ jobs:
             -e GITHUB_ACTIONS=true
           install_wheel: true
           run_args: |
-            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py -m models_performance_bare_metal
-            
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py -m models_performance_bare_metal | tee output.txt
+            test ${PIPESTATUS[0]} -eq 0
       - name: Run yolov8s_world tests
-        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        if: ${{ matrix.model-type == 'other2' && !cancelled() }}
         timeout-minutes: 70
         uses: ./.github/actions/docker-run
         env:
@@ -428,10 +428,10 @@ jobs:
             -e GITHUB_ACTIONS=true
           install_wheel: true
           run_args: |
-            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s_world/tests -m models_performance_bare_metal
-            
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s_world/tests -m models_performance_bare_metal | tee output.txt
+            test ${PIPESTATUS[0]} -eq 0
       - name: Run mobilenetv2 tests
-        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        if: ${{ matrix.model-type == 'other2' && !cancelled() }}
         timeout-minutes: 70
         uses: ./.github/actions/docker-run
         env:
@@ -448,8 +448,8 @@ jobs:
             -e GITHUB_ACTIONS=true
           install_wheel: true
           run_args: |
-            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/mobilenetv2/tests -m models_performance_bare_metal
-            
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/mobilenetv2/tests -m models_performance_bare_metal | tee output.txt
+            test ${PIPESTATUS[0]} -eq 0
       - name: Run ufld_v2 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Enable Performance mode
         run: sudo cpupower frequency-set -g performance
       - name: Run sentence_bert tests
-        if: ${{ matrix.model-type == 'llm_javelin' && !cancelled()}}
+        if: ${{ matrix.model-type == 'llm_javelin' && !cancelled() }}
         timeout-minutes: 70
         uses: ./.github/actions/docker-run
         env:

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -672,7 +672,7 @@ jobs:
             env pytest -n auto models/demos/roberta/tests/test_performance.py -m models_performance_bare_metal
             env python3 models/perf/merge_perf_results.py
       - name: Merge Perf Results
-        if: ${{ matrix.model-type == 'other' && !cancelled() }}
+        if: ${{ !cancelled() }}
         timeout-minutes: 70
         uses: ./.github/actions/docker-run
         env:

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -23,7 +23,7 @@ jobs:
         test-info: [
           {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "perf-no-reset-grayskull"], machine-type: "bare_metal"},
         ]
-        model-type: [cnn_javelin]
+        model-type: [llm_javelin, cnn_javelin, other]
     name: "${{ matrix.model-type }} ${{ matrix.test-info.name }}"
     defaults:
       run:
@@ -68,7 +68,7 @@ jobs:
           run_args: |
             export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
             env pytest -n auto models/demos/falcon7b_common/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run qwen tests
         if: ${{ matrix.model-type == 'llm_javelin' && !cancelled() }}
         timeout-minutes: 70
@@ -89,7 +89,7 @@ jobs:
           run_args: |
             export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
             env QWEN_DIR=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2-7B-Instruct FAKE_DEVICE=N150 pytest -n auto models/demos/qwen/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run mamba tests
         if: ${{ matrix.model-type == 'llm_javelin' && !cancelled() }}
         timeout-minutes: 70
@@ -110,7 +110,7 @@ jobs:
           run_args: |
             export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
             env pytest -n auto models/demos/wormhole/mamba/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run functional_unet tests
         if: ${{ matrix.model-type == 'cnn_javelin' && !cancelled() }}
         timeout-minutes: 70
@@ -170,7 +170,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/sentence_bert/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run resnet50 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -190,7 +190,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run bert_tiny tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -210,7 +210,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/bert_tiny/tests/test_performance.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run yolov4 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -230,7 +230,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/yolov4/tests/perf -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run yolov7 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -250,7 +250,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov7/tests/ -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run distilbert tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -270,7 +270,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/distilbert/tests/test_perf_distilbert.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run segformer tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -290,7 +290,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/test_e2e_performant.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run vit tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -310,7 +310,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run whisper tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -330,7 +330,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/whisper/tests/test_performance.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run metal_BERT_large_11 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -350,7 +350,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/metal_BERT_large_11/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run vgg_unet tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -370,7 +370,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/vgg_unet/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run yolov9c tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -390,7 +390,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov9c/tests/perf -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run functional_vanilla_unet tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -410,7 +410,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run yolov8s_world tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -430,7 +430,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s_world/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run mobilenetv2 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -450,7 +450,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/mobilenetv2/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run ufld_v2 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -470,7 +470,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/ufld_v2/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run yolov8x tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -490,7 +490,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8x/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run yolov8s tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -510,7 +510,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run yolov10 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -530,7 +530,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/yolov10/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run bert tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -550,7 +550,7 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto tests/ttnn/integration_tests/bert/test_performance.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run ttnn_falcon7b tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -570,7 +570,7 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto models/demos/ttnn_falcon7b/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run vgg tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -590,7 +590,7 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto models/demos/vgg/tests/test_perf_vgg.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run convnet_mnist tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -610,7 +610,7 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto models/demos/convnet_mnist/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run mnist tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -630,7 +630,7 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto models/demos/mnist/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run squeezebert tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -650,7 +650,7 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto models/demos/squeezebert/tests/test_performance.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run roberta tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -670,7 +670,7 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto models/demos/roberta/tests/test_performance.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Merge Perf Results
         if: ${{ !cancelled() }}
         timeout-minutes: 70

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -48,7 +48,8 @@ jobs:
           name: ${{ inputs.wheel-artifact-name }}
       - name: Enable Performance mode
         run: sudo cpupower frequency-set -g performance
-      - name: Run performance regressions
+      - name: Run sentence_bert tests
+        if: ${{ matrix.model-type == 'llm_javelin' && !cancelled()}}
         timeout-minutes: 70
         uses: ./.github/actions/docker-run
         env:
@@ -64,7 +65,9 @@ jobs:
             -e GTEST_OUTPUT=xml:generated/test_reports/
             -e GITHUB_ACTIONS=true
           install_wheel: true
-          run_args: ./tests/scripts/run_tests.sh --tt-arch ${{ matrix.test-info.arch }} --pipeline-type ${{ matrix.model-type }}_models_performance_${{ matrix.test-info.machine-type }}
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/sentence_bert/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
       # TODO: Fix the pipeline before enabling notifications.
       #- uses: tenstorrent/tt-metal/.github/actions/slack-report@main
       #  if: ${{ failure() }}

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -68,7 +68,6 @@ jobs:
           run_args: |
             export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
             env pytest -n auto models/demos/falcon7b_common/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run qwen tests
         if: ${{ matrix.model-type == 'llm_javelin' && !cancelled() }}
         timeout-minutes: 70
@@ -89,7 +88,7 @@ jobs:
           run_args: |
             export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
             env QWEN_DIR=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2-7B-Instruct FAKE_DEVICE=N150 pytest -n auto models/demos/qwen/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run mamba tests
         if: ${{ matrix.model-type == 'llm_javelin' && !cancelled() }}
         timeout-minutes: 70
@@ -110,7 +109,7 @@ jobs:
           run_args: |
             export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
             env pytest -n auto models/demos/wormhole/mamba/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run functional_unet tests
         if: ${{ matrix.model-type == 'cnn_javelin' && !cancelled() }}
         timeout-minutes: 70
@@ -130,7 +129,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run stable_diffusion tests
         if: ${{ matrix.model-type == 'cnn_javelin' && !cancelled() }}
         timeout-minutes: 70
@@ -150,7 +149,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/stable_diffusion/tests -m models_performance_bare_metal --timeout=480
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run sentence_bert tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -170,7 +169,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/sentence_bert/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run resnet50 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -190,7 +189,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run bert_tiny tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -210,7 +209,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/bert_tiny/tests/test_performance.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run yolov4 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -230,7 +229,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/yolov4/tests/perf -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run yolov7 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -250,7 +249,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov7/tests/ -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run distilbert tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -270,7 +269,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/distilbert/tests/test_perf_distilbert.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run segformer tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -290,7 +289,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/segformer/tests/test_e2e_performant.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run vit tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -310,7 +309,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run whisper tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -330,7 +329,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/whisper/tests/test_performance.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run metal_BERT_large_11 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -350,7 +349,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/metal_BERT_large_11/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run vgg_unet tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -370,7 +369,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/vgg_unet/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run yolov9c tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -390,7 +389,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov9c/tests/perf -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run functional_vanilla_unet tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -410,7 +409,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_vanilla_unet/test/test_perf_vanilla_unet.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run yolov8s_world tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -430,7 +429,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s_world/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run mobilenetv2 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -450,7 +449,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/mobilenetv2/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run ufld_v2 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -470,7 +469,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/ufld_v2/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run yolov8x tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -490,7 +489,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8x/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run yolov8s tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -510,7 +509,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/yolov8s/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run yolov10 tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -530,7 +529,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/yolov10/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run bert tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -550,7 +549,7 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto tests/ttnn/integration_tests/bert/test_performance.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run ttnn_falcon7b tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -570,7 +569,7 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto models/demos/ttnn_falcon7b/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run vgg tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -590,7 +589,7 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto models/demos/vgg/tests/test_perf_vgg.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run convnet_mnist tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -610,7 +609,7 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto models/demos/convnet_mnist/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run mnist tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -630,7 +629,7 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto models/demos/mnist/tests -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run squeezebert tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -650,7 +649,7 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto models/demos/squeezebert/tests/test_performance.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Run roberta tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70
@@ -670,7 +669,7 @@ jobs:
           install_wheel: true
           run_args: |
             env pytest -n auto models/demos/roberta/tests/test_performance.py -m models_performance_bare_metal
-            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
+            
       - name: Merge Perf Results
         if: ${{ !cancelled() }}
         timeout-minutes: 70

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -130,6 +130,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run stable_diffusion tests
         if: ${{ matrix.model-type == 'cnn_javelin' && !cancelled() }}
         timeout-minutes: 70
@@ -149,6 +150,7 @@ jobs:
           install_wheel: true
           run_args: |
             env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/stable_diffusion/tests -m models_performance_bare_metal --timeout=480
+            env python3 models/perf/merge_perf_results.py >> output.txt 2>&1
       - name: Run sentence_bert tests
         if: ${{ matrix.model-type == 'other' && !cancelled() }}
         timeout-minutes: 70

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -111,6 +111,46 @@ jobs:
             export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
             env pytest -n auto models/demos/wormhole/mamba/tests -m models_performance_bare_metal
             env python3 models/perf/merge_perf_results.py
+      - name: Run functional_unet tests
+        if: ${{ matrix.model-type == 'cnn_javelin' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests -m models_performance_bare_metal
+            env python3 models/perf/merge_perf_results.py
+      - name: Run stable_diffusion tests
+        if: ${{ matrix.model-type == 'cnn_javelin' && !cancelled() }}
+        timeout-minutes: 70
+        uses: ./.github/actions/docker-run
+        env:
+          LOGURU_LEVEL: INFO
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ matrix.test-info.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/
+            -e GITHUB_ACTIONS=true
+          install_wheel: true
+          run_args: |
+            env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/stable_diffusion/tests -m models_performance_bare_metal --timeout=480
+            env python3 models/perf/merge_perf_results.py
       # TODO: Fix the pipeline before enabling notifications.
       #- uses: tenstorrent/tt-metal/.github/actions/slack-report@main
       #  if: ${{ failure() }}


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-metal/issues/24145

### Problem description
Allow all tests to run even if another test fails

### What's changed
Each test output will be displayed in separate steps of the job

### Checklist
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/16010217916)
* CI doesn't pass but will allow model owners to view the log for their failing test to fix the issue but this workflow runs as expected