### PR TITLE
Use condition variable to wait for binary instead of busy loop

### DIFF
--- a/tt_metal/detail/kernel_cache.hpp
+++ b/tt_metal/detail/kernel_cache.hpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <stdint.h>
 #include <unordered_set>
+#include <condition_variable>
 
 namespace tt::tt_metal::detail {
 struct HashLookup {
@@ -29,24 +30,31 @@ struct HashLookup {
         return ret;
     }
 
-    bool is_bin_generated(size_t khash) {
+    void wait_for_bin_generated(size_t khash) {
         std::unique_lock<std::mutex> lock(mutex_);
-        return generated_bins_.find(khash) != generated_bins_.end();
+        bin_ready_cv_.wait(lock, [this, khash]() { return generated_bins_.find(khash) != generated_bins_.end(); });
     }
 
     void add_generated_bin(size_t khash) {
-        std::unique_lock<std::mutex> lock(mutex_);
-        generated_bins_.insert(khash);
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            generated_bins_.insert(khash);
+        }
+        // Notify all waiting threads that a new binary is generated
+        bin_ready_cv_.notify_all();
     }
 
     void clear() {
         std::unique_lock<std::mutex> lock(mutex_);
         hashes_.clear();
         generated_bins_.clear();
+        // Notify waiting threads that cache has been cleared
+        bin_ready_cv_.notify_all();
     }
 
 private:
     std::mutex mutex_;
+    std::condition_variable bin_ready_cv_;
     std::unordered_set<size_t> hashes_;
     std::unordered_set<size_t> generated_bins_;
 };

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1468,8 +1468,7 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                         GenerateBinaries(device, build_options, kernel);
                         detail::HashLookup::inst().add_generated_bin(kernel_hash);
                     }
-                    while (not detail::HashLookup::inst().is_bin_generated(kernel_hash)) {
-                    }
+                    detail::HashLookup::inst().wait_for_bin_generated(kernel_hash);
 
                     Inspector::program_kernel_compile_finished(this, device, kernel, build_options);
                 },


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22634

### Problem description
Kernel compile uses busy loop and mutex lock to wait for binary built by other thread which consume much CPU time.

### What's changed
Use condition variable to wait for the binary.
CPU time is now efficiently shared by other process/thread

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes