### PR TITLE
Data parallel test for sentence_bert

### DIFF
--- a/models/demos/t3000/sentence_bert/README.md
+++ b/models/demos/t3000/sentence_bert/README.md
@@ -1,0 +1,61 @@
+# SentenceBERT T3000
+
+### Platforms:
+
+T3000
+
+**Note:** This demo is specifically designed for T3000 devices and uses optimized device parameters for maximum performance.
+
+To obtain the perf reports through profiler, please build with following command:
+```
+./build_metal.sh -p
+```
+
+### Introduction
+
+**bert-base-turkish-cased-mean-nli-stsb-tr** is a SentenceBERT-based model fine-tuned for semantic textual similarity and natural language inference tasks in Turkish. Built on a cased BERT architecture, it leverages mean pooling to generate dense sentence embeddings, enabling efficient and accurate sentence-level understanding. Optimized for performance in real-world NLP applications such as semantic search, clustering, and question answering.
+
+Resource link - [source](https://huggingface.co/emrecan/bert-base-turkish-cased-mean-nli-stsb-tr)
+
+### Details
+
+- The entry point to the SentenceBERT model is located at: `models/demos/sentence_bert/ttnn/ttnn_sentence_bert.py`
+- Batch size: 8 (configurable via device_batch_size parameter)
+- Sequence Length: 384
+- Data Types: bfloat16 (activation), bfloat8_b (weights)
+- Device Parameters: Optimized for T3000 with L1 small size: 79104, trace region size: 23887872, num command queues: 2
+
+### How to Run:
+
+Use the following command to run the end-to-end performant model with Trace+2CQs (without mean-pooling):
+
+```
+pytest --disable-warnings models/demos/t3000/sentence_bert/tests/test_sentence_bert_e2e_performant.py::test_e2e_performant_sentencebert_data_parallel
+```
+
+### Performant Model with Trace+2CQ
+
+> **Note:** SentenceBERT uses BERT-base as its backbone model.
+- End-to-end performance without mean-pooling post-processing is **3073 sentences per second**
+- Uses data parallel execution across multiple devices when available
+- Optimized for T3000 architecture with specific device parameters
+
+### Test Features
+
+- **Data Parallel Execution**: Automatically scales batch size based on number of available devices
+- **Trace Optimization**: Uses TTNN trace capture and execution for optimal performance
+- **Memory Optimization**: Configured with T3000-specific memory parameters for optimal resource utilization
+
+### Device Configuration
+
+The test uses the following optimized device parameters for T3000:
+- L1 small size: 79104
+- Trace region size: 23887872
+- Number of command queues: 2
+
+### Performance Metrics
+
+The test outputs detailed performance information including:
+- Batch size (scaled by number of devices)
+- Average inference time per iteration
+- Sentences processed per second

--- a/models/demos/t3000/sentence_bert/tests/test_sentence_bert_e2e_performant.py
+++ b/models/demos/t3000/sentence_bert/tests/test_sentence_bert_e2e_performant.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+
+import pytest
+from loguru import logger
+
+import ttnn
+from models.demos.sentence_bert.runner.performant_runner import SentenceBERTPerformantRunner
+from models.utility_functions import run_for_wormhole_b0
+
+
+@run_for_wormhole_b0()
+@pytest.mark.model_perf_t3000
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 79104, "trace_region_size": 23887872, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "act_dtype, weight_dtype",
+    ((ttnn.bfloat16, ttnn.bfloat8_b),),
+)
+@pytest.mark.parametrize("device_batch_size, sequence_length", [(8, 384)])
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
+def test_e2e_performant_sentencebert_data_parallel(
+    mesh_device, device_batch_size, sequence_length, act_dtype, weight_dtype
+):
+    batch_size = device_batch_size * mesh_device.get_num_devices()
+    performant_runner = SentenceBERTPerformantRunner(
+        device=mesh_device,
+        device_batch_size=device_batch_size,
+        sequence_length=sequence_length,
+        act_dtype=act_dtype,
+        weight_dtype=weight_dtype,
+    )
+    performant_runner._capture_sentencebert_trace_2cqs()
+    inference_times = []
+    for _ in range(10):
+        t0 = time.time()
+        _ = performant_runner.run()
+        t1 = time.time()
+        inference_times.append(t1 - t0)
+
+    performant_runner.release()
+
+    inference_time_avg = round(sum(inference_times) / len(inference_times), 6)
+    logger.info(
+        f"ttnn_sentencebert_batch_size: {batch_size}, One inference iteration time (sec): {inference_time_avg}, Sentence per sec: {round(batch_size/inference_time_avg)}"
+    )


### PR DESCRIPTION
### Problem description
Added data parallel implementation for sentence_bert

### What's changed
Added a new file under /t3000 directory for data parallel test
Changed performant_runner_infra file of sentence_bert to implement mesh mapper code

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes