### PR TITLE
#19340: Add Eval script for swin_v2

### DIFF
--- a/models/experimental/classification_eval/README.md
+++ b/models/experimental/classification_eval/README.md
@@ -9,6 +9,7 @@
 | ViT          | (224, 224) | 8          | 512     | 81.25%               | 82.23%                 |
 | ResNet50     | (224, 224) | 16         | 512     | 78.52%                 | 75.59%                |
 | MobileNetV2  | (224, 224) | 8          | 512     | 68.36%                 | 65.62%                 |
+| SwinV2       | (512, 512) | 1          | 512     | 75.59%                 | 81.05%                 |
 
 ***Note:*** The accuracy is for the selected random samples from the validation dataset.
 
@@ -36,6 +37,12 @@ Where,
  pytest models/experimental/classification_eval/classification_eval.py::test_mobilenetv2_image_classification_eval[8-224-tt_model-device_params0]
  ```
 
+ **SwinV2:** <br>
+**_For 512x512,_**<br>
+ ```sh
+ pytest models/experimental/classification_eval/classification_eval.py::test_swin_v2_image_classification_eval[1-512-tt_model-device_params0]
+ ```
+
 ## To run the test of torch vs ground truth, please follow the following commands:
 
 **Vit:** <br>
@@ -54,4 +61,10 @@ Where,
 **_For 224x224,_**<br>
  ```sh
  pytest models/experimental/classification_eval/classification_eval.py::test_mobilenetv2_image_classification_eval[8-224-torch_model-device_params0]
+ ```
+
+ **SwinV2:** <br>
+**_For 512x512,_**<br>
+ ```sh
+ pytest models/experimental/classification_eval/classification_eval.py::test_swin_v2_image_classification_eval[1-512-torch_model-device_params0]
  ```


### PR DESCRIPTION
### Ticket
[#19340](https://github.com/tenstorrent/tt-metal/issues/19340)

### Problem description
Add evaluation pipeline for swin_v2 model

### What's changed
Integrated the swin_v2 model into the [classification_eval](https://github.com/tenstorrent/tt-metal/blob/main/models/experimental/classification_eval/classification_eval.py) script

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes