### PR TITLE
Topk indices model integration

### DIFF
--- a/models/demos/llama3_subdevices/tests/decoder_perf_targets_4u.json
+++ b/models/demos/llama3_subdevices/tests/decoder_perf_targets_4u.json
@@ -353,7 +353,7 @@
         },
         "TopK_0": {
             "op_name": "TopK_0",
-            "kernel_duration": 615934.5340909091,
+            "kernel_duration": 325436,
             "op_to_op": 733.0,
             "non-overlapped-dispatch-time": 5187.35,
             "kernel_duration_relative_margin": 0.2,

--- a/models/demos/llama3_subdevices/tests/decoder_perf_targets_6u.json
+++ b/models/demos/llama3_subdevices/tests/decoder_perf_targets_6u.json
@@ -281,7 +281,7 @@
         },
         "TopK_0": {
             "op_name": "TopK_0",
-            "kernel_duration": 553289.8125,
+            "kernel_duration": 293601,
             "op_to_op": 668.0,
             "non-overlapped-dispatch-time": 4645.0,
             "kernel_duration_relative_margin": 0.2,

--- a/models/demos/llama3_subdevices/tt/sampling.py
+++ b/models/demos/llama3_subdevices/tt/sampling.py
@@ -76,6 +76,18 @@ class TTSampling(LightweightModule):
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
+        indices_tensor_torch = torch.zeros(1, 1, self.max_batch_size, self.args.padded_vocab_size, dtype=torch.int32)
+        for i in range(indices_tensor_torch.shape[3]):
+            indices_tensor_torch[:, :, :, i] = i
+        self.tt_indices_tensor = ttnn.from_torch(
+            indices_tensor_torch,
+            dtype=ttnn.uint16,
+            layout=ttnn.Layout.TILE,
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=(3, None), mesh_shape=self.args.cluster_shape),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
     def forward(
         self,
         x: ttnn.Tensor,
@@ -102,7 +114,11 @@ class TTSampling(LightweightModule):
 
         # Local top k
         topk_values, topk_indices = ttnn.topk(
-            x_bf16, k=self.max_top_k, dim=-1, sub_core_grids=self.args.sub_core_grid_topk
+            x_bf16,
+            k=self.max_top_k,
+            dim=-1,
+            sub_core_grids=self.args.sub_core_grid_topk,
+            indices_tensor=self.tt_indices_tensor,
         )
 
         # Gather values

--- a/tests/scripts/tg/run_tg_demo_tests.sh
+++ b/tests/scripts/tg/run_tg_demo_tests.sh
@@ -11,11 +11,11 @@ run_tg_llama3_tests() {
   llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
 
   for llama_dir in "$llama70b"; do
-    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/demo_decode.py -k "full" --timeout 1000; fail+=$?;
-    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/text_demo.py -k "repeat" --timeout 1000; fail+=$?;
-    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/text_demo.py -k "long-context-batch32" --timeout 1000; fail+=$?;
-    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/text_demo.py -k "long-context-32k" --timeout 1000; fail+=$?;
-    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/text_demo.py -k "pcc-80L" --timeout 1000; fail+=$?;
+    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG RING_6U=1 pytest -n auto models/demos/llama3_subdevices/demo/demo_decode.py -k "full" --timeout 1000; fail+=$?;
+    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG RING_6U=1 pytest -n auto models/demos/llama3_subdevices/demo/text_demo.py -k "repeat" --timeout 1000; fail+=$?;
+    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG RING_6U=1 pytest -n auto models/demos/llama3_subdevices/demo/text_demo.py -k "long-context-batch32" --timeout 1000; fail+=$?;
+    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG RING_6U=1 pytest -n auto models/demos/llama3_subdevices/demo/text_demo.py -k "long-context-32k" --timeout 1000; fail+=$?;
+    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG RING_6U=1 pytest -n auto models/demos/llama3_subdevices/demo/text_demo.py -k "pcc-80L" --timeout 1000; fail+=$?;
 
     echo "LOG_METAL: Llama3 tests for $llama_dir completed"
   done

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -22,10 +22,10 @@ run_tg_llama_70b_model_perf_tests() {
   echo "LOG_METAL: Running run_tg_llama_70b_model_perf_tests"
 
   # Run non-overlapped dispatch perf test
-  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch --timeout=600 ; fail+=$?
+  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG  RING_6U=1 LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch --timeout=600 ; fail+=$?
 
   # Run kernel and op to op latency test
-  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device --timeout=600 ; fail+=$?
+  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG  RING_6U=1 LLAMA_DIR=$llama70b pytest -n auto models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device --timeout=600 ; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     echo "LOG_METAL: run_tg_llama_70b_model_perf_tests failed"

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -8,7 +8,7 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids=None):
+def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids=None, pass_indices_tensor=False):
     torch.manual_seed(2005)
     shape = [N, C, H, W]
     torch_dtype = torch.bfloat16
@@ -16,9 +16,26 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
     pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=dim, largest=largest, sorted=True)
     ttnn_input = ttnn.from_torch(input, dtype, layout=ttnn.Layout.TILE, device=device)
 
-    ttnn_topk_values, ttnn_topk_indices = ttnn.topk(
-        ttnn_input, k, dim=dim, largest=largest, sorted=sorted, sub_core_grids=sub_core_grids
-    )
+    if pass_indices_tensor:
+        indices_tensor_torch = torch.zeros(shape, dtype=torch.int32)
+        for i in range(W):
+            indices_tensor_torch[:, :, :, i] = i
+        indices_tensor = ttnn.from_torch(indices_tensor_torch, ttnn.uint16, layout=ttnn.Layout.TILE, device=device)
+    else:
+        indices_tensor = None
+
+    try:
+        ttnn_topk_values, ttnn_topk_indices = ttnn.topk(
+            ttnn_input,
+            k,
+            dim=dim,
+            largest=largest,
+            sorted=sorted,
+            sub_core_grids=sub_core_grids,
+            indices_tensor=indices_tensor,
+        )
+    except Exception as e:
+        raise e
 
     desired_shape = [N, C, H, W]
     desired_shape[dim] = k
@@ -129,6 +146,13 @@ def test_topk(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids
     ],
 )
 @pytest.mark.parametrize(
+    "pass_indices_tensor",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
     "sub_core_grids",
     [
         ttnn.CoreRangeSet(
@@ -138,11 +162,11 @@ def test_topk(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids
         ),
     ],
 )
-def test_topk_sub_core_grids(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids):
+def test_topk_sub_core_grids(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids, pass_indices_tensor):
     if dim == 0 or dim == 1:
         # As of now, when we try to get top-k for dim = 0 or 1, we get following error from transpose_op.cpp's validate():
         # input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32
         # this is because, transpose.cpp always typecasts bf8 to bf16
         # and when dim = 0 or 1, transpose converts it into TransposeOpDim::HC & this dim doesnt support bf16 or fp32
         pytest.skip()
-    run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids)
+    run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids, pass_indices_tensor)

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -157,7 +157,9 @@ def test_topk(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids
     [
         ttnn.CoreRangeSet(
             [
-                ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 7)),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)
+                ),  # Note: for TG llama we use 1,0 to 3,9 but this requires TGs (non-harvested) and "dispatch_core_axis": ttnn.DispatchCoreAxis.COL device_param
             ]
         ),
     ],

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_read_index_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_read_index_local_topk.cpp
@@ -28,30 +28,27 @@ void kernel_main() {
     constexpr uint32_t tile_bytes_indices = get_tile_size(cb_id_in1);
     constexpr DataFormat data_format_indices = get_dataformat(cb_id_in1);
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
+    const InterleavedAddrGenFast<src_is_dram> s_input = {
         .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
 
     const InterleavedAddrGenFast<src_indices_is_dram> s_indices = {
         .bank_base_address = src_indices_addr, .page_size = tile_bytes_indices, .data_format = data_format_indices};
 
-    // Stream in input tensor and generate the relevant index tensor tiles
+    // Stream in input tensor and index tensor
     // The input buffer has four tiles as we double-buffer for the two tiles needed for topk_local_sort to start
     // We could load in an entire row of tiles at a time but that would require substantially more memory (we would be
     // double buffering four Wt_local sized CBs)
     for (uint32_t i = start_ht; i < Ht; ++i) {
         for (uint32_t j = start_wt; j < start_wt + Wt_local; ++j) {
-            // Read input tensor
+            // Read input tensor and indices tensor
             cb_reserve_back(cb_id_in0, onetile);
-            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-            noc_async_read_tile(i * Wt + j, s, l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in0, onetile);
-
-            // Read indices tensor for same tile
             cb_reserve_back(cb_id_in1, onetile);
+            uint32_t l1_write_addr_input = get_write_ptr(cb_id_in0);
             uint32_t l1_write_addr_indices = get_write_ptr(cb_id_in1);
+            noc_async_read_tile(i * Wt + j, s_input, l1_write_addr_input);
             noc_async_read_tile(i * Wt + j, s_indices, l1_write_addr_indices);
             noc_async_read_barrier();
+            cb_push_back(cb_id_in0, onetile);
             cb_push_back(cb_id_in1, onetile);
         }
     }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_read_index_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_read_index_local_topk.cpp
@@ -4,43 +4,17 @@
 
 #include <stdint.h>
 #include "dataflow_api.h"
-/**
- * add a cb full of indices for the tile
- * each row is identical in the index tensor, so we just need to add an offset based on which row tile it is
- * first 32 elements are {0,..31}, then next 32 are {32,..64}
- * wt is which tile it is along the row [0, Wt) so j + 32*wt is the value in the tile at each element
- */
-FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
-    // TODO: investigate moving to compile time (binary size is at risk)
-    cb_reserve_back(cb_id, 1);
-    uint32_t write_addr = get_write_ptr(cb_id);
-    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr);
-    uint16_t wt_offset = wt << 5;
-
-    uint32_t count = 0;
-    for (uint32_t i = 0; i < 2; ++i) {
-        for (uint32_t j = 0; j < 2; ++j) {
-            for (uint32_t k = 0; k < 16; ++k) {
-                for (uint32_t l = 0; l < 16; l += 2) {
-                    uint16_t value = l + 16 * j + wt_offset;
-                    ptr[count] = (value + 1) << 16 | value;
-                    count++;
-                }
-            }
-        }
-    }
-    cb_push_back(cb_id, 1);
-}
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_ht = get_arg_val<uint32_t>(1);
-    uint32_t start_wt = get_arg_val<uint32_t>(2);
+    uint32_t src_indices_addr = get_arg_val<uint32_t>(1);
+    uint32_t start_ht = get_arg_val<uint32_t>(2);
+    uint32_t start_wt = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
     constexpr bool src_is_dram = (bool)get_compile_time_arg_val(2);
-    // not using indices tensor arg get_compile_time_arg_val(3)
+    constexpr bool src_indices_is_dram = (bool)get_compile_time_arg_val(3);
 
     constexpr uint32_t Ht = get_compile_time_arg_val(4);
     constexpr uint32_t Wt_local = get_compile_time_arg_val(5);
@@ -51,8 +25,14 @@ void kernel_main() {
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
     constexpr DataFormat data_format = get_dataformat(cb_id_in0);
 
+    constexpr uint32_t tile_bytes_indices = get_tile_size(cb_id_in1);
+    constexpr DataFormat data_format_indices = get_dataformat(cb_id_in1);
+
     const InterleavedAddrGenFast<src_is_dram> s = {
         .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+
+    const InterleavedAddrGenFast<src_indices_is_dram> s_indices = {
+        .bank_base_address = src_indices_addr, .page_size = tile_bytes_indices, .data_format = data_format_indices};
 
     // Stream in input tensor and generate the relevant index tensor tiles
     // The input buffer has four tiles as we double-buffer for the two tiles needed for topk_local_sort to start
@@ -60,12 +40,19 @@ void kernel_main() {
     // double buffering four Wt_local sized CBs)
     for (uint32_t i = start_ht; i < Ht; ++i) {
         for (uint32_t j = start_wt; j < start_wt + Wt_local; ++j) {
+            // Read input tensor
             cb_reserve_back(cb_id_in0, onetile);
             uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
             noc_async_read_tile(i * Wt + j, s, l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(cb_id_in0, onetile);
-            generate_index_tile(cb_id_in1, j);  // index tensor tile at width chunk j
+
+            // Read indices tensor for same tile
+            cb_reserve_back(cb_id_in1, onetile);
+            uint32_t l1_write_addr_indices = get_write_ptr(cb_id_in1);
+            noc_async_read_tile(i * Wt + j, s_indices, l1_write_addr_indices);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in1, onetile);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -76,7 +76,9 @@ constexpr uint32_t min_dim_per_core = 64;
 namespace ttnn::operations::reduction {
 
 void TopK::validate_with_output_tensors(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    const std::vector<Tensor>& input_tensors,
+    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+    const std::vector<std::optional<Tensor>>& output_tensors) const {
     auto input_shape = input_tensors.at(0).padded_shape();
     TT_FATAL(input_shape.rank() == 4, "Input shape must be 4D, got {}", input_shape.rank());
 
@@ -151,8 +153,11 @@ std::vector<Tensor> TopK::create_output_tensors(
 }
 
 operation::ProgramWithCallbacks TopK::create_program(
-    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+    const std::vector<Tensor>& input_tensors,
+    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+    std::vector<Tensor>& output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
+    const auto& indices_tensor = optional_input_tensors.at(0);
     bool multicore_supported = true;
     multicore_supported &= (input_tensor.padded_shape()[dim] >= topk_utils::multi_core_min_width);
 
@@ -181,6 +186,7 @@ operation::ProgramWithCallbacks TopK::create_program(
     if (multicore_supported) {
         return detail::topk_multicore_interleaved(
             input_tensor,
+            indices_tensor,
             this->k,
             this->dim,
             this->largest,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.hpp
@@ -20,13 +20,17 @@ struct TopK {
     const CoreRangeSet sub_core_grids;
 
     void validate_with_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        const std::vector<std::optional<Tensor>>& output_tensors) const;
     std::vector<TensorSpec> compute_output_specs(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     std::vector<Tensor> create_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        std::vector<Tensor>& output_tensors) const;
 };
 
 }  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
@@ -261,6 +261,7 @@ static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
  */
 operation::ProgramWithCallbacks topk_multicore_interleaved(
     const Tensor& input_tensor,
+    const std::optional<Tensor>& input_indices_tensor,
     const uint32_t k,
     const int8_t dim,
     const bool largest,
@@ -285,10 +286,14 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     auto input_buffer = input_tensor.buffer();
     auto values_buffer = value_tensor.buffer();
     auto index_buffer = index_tensor.buffer();
+    auto input_indices_buffer = input_indices_tensor.has_value() ? input_indices_tensor->buffer() : nullptr;
 
     bool input_is_dram = input_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     bool values_is_dram = values_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
     bool index_is_dram = index_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool input_indices_is_dram = input_indices_tensor.has_value()
+                                     ? input_indices_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                     : false;
 
     uint32_t num_input_tiles = input_tensor.physical_volume() / TILE_HW;
     uint32_t num_value_tiles = value_tensor.physical_volume() / TILE_HW;
@@ -409,13 +414,20 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
         input_cb_index,
         index_cb_index,
         (uint32_t)input_is_dram,
+        (uint32_t)input_indices_is_dram,
         Ht,
         Wt_local,
         input_shape[-1] / TILE_WIDTH,  // Wt
     };
+    std::string reader_kernel_path =
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_local_topk.cpp";
+    if (input_indices_tensor.has_value()) {
+        reader_kernel_path =
+            "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_read_index_local_topk.cpp";
+    }
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
-        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_local_topk.cpp",
+        reader_kernel_path,
         local_cores_range_set,
         tt::tt_metal::ReaderDataMovementConfig(reader_local_compile_time_args));
 
@@ -512,15 +524,28 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     int core_w = 0;
     bool ascending = !largest;
     for (auto core : local_cores) {
-        SetRuntimeArgs(
-            program,
-            unary_reader_kernel_id,
-            core,
-            {
-                input_buffer->address(),
-                0,  // no height parallelism for now
-                core_w * Wt_local,
-            });
+        if (input_indices_tensor.has_value()) {
+            SetRuntimeArgs(
+                program,
+                unary_reader_kernel_id,
+                core,
+                {
+                    input_buffer->address(),
+                    input_indices_buffer->address(),
+                    0,  // no height parallelism for now
+                    core_w * Wt_local,
+                });
+        } else {
+            SetRuntimeArgs(
+                program,
+                unary_reader_kernel_id,
+                core,
+                {
+                    input_buffer->address(),
+                    0,  // no height parallelism for now
+                    core_w * Wt_local,
+                });
+        }
 
         SetRuntimeArgs(
             program,
@@ -554,15 +579,20 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
             const void* operation,
             const Program& program,
             const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>&,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<Tensor>& output_tensors) {
             auto input_buffer = input_tensors.at(0).buffer();
             auto values_buffer = output_tensors.at(0).buffer();
             auto index_buffer = output_tensors.at(1).buffer();
+            auto input_indices_buffer =
+                optional_input_tensors.at(0).has_value() ? optional_input_tensors.at(0).value().buffer() : nullptr;
 
             for (auto core : local_cores) {
                 auto& reader_runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
                 reader_runtime_args[0] = input_buffer->address();
+                if (optional_input_tensors.at(0).has_value()) {
+                    reader_runtime_args[1] = input_indices_buffer->address();
+                }
             }
 
             auto& writer_runtime_args = GetRuntimeArgs(program, binary_writer_final_kernel_id, final_core);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -18,6 +18,7 @@ tt::tt_metal::operation::ProgramWithCallbacks topk_single_core_interleaved(
 
 tt::tt_metal::operation::ProgramWithCallbacks topk_multicore_interleaved(
     const Tensor& input_tensor,
+    const std::optional<Tensor>& indices_tensor,
     uint32_t k,
     int8_t dim,
     bool largest,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -37,7 +37,8 @@ std::vector<Tensor> post_topk_transform_tensor(
     const uint32_t adjusted_k,
     const Shape& original_lshape,
     const MemoryConfig& input_memory_config,
-    const CoreRangeSet& sub_core_grids) {
+    const CoreRangeSet& sub_core_grids,
+    const std::optional<Tensor>& indices_tensor = std::nullopt) {
     const auto& input_shape = input_tensor.padded_shape();
     const auto orig_rank = input_shape.rank();
 
@@ -108,6 +109,7 @@ std::vector<Tensor> ExecuteTopK::invoke(
     const bool sorted,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<Tensor>& indices_tensor,
     std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors) {
     const ttnn::Shape& original_lshape = input_tensor.logical_shape();
 
@@ -132,10 +134,10 @@ std::vector<Tensor> ExecuteTopK::invoke(
     auto output_tensor_vec = tt::tt_metal::operation::run(
         TopK{adjusted_k, -1, largest, sorted, input_memory_config, used_sub_core_grids},
         {padded_tensor},
-        {},
+        {indices_tensor},
         optional_output_tensors.has_value()
             ? reduction_common::tuple_to_vector_optional(optional_output_tensors.value())
-            : std::vector<std::optional<Tensor>>{},
+            : std::vector<std::optional<Tensor>>{std::nullopt, std::nullopt},
         queue_id);
 
     return CMAKE_UNIQUE_NAMESPACE::post_topk_transform_tensor(
@@ -147,7 +149,8 @@ std::vector<Tensor> ExecuteTopK::invoke(
         adjusted_k,
         original_lshape,
         input_memory_config,
-        used_sub_core_grids);
+        used_sub_core_grids,
+        indices_tensor);
 }
 
 }  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
@@ -23,6 +23,7 @@ struct ExecuteTopK {
         bool sorted,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<CoreRangeSet>& sub_core_grids,
+        const std::optional<Tensor>& indices_tensor,
         std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -43,6 +43,8 @@ void bind_reduction_topk_operation(py::module& module) {
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
                 queue_id (int, optional): command queue id. Defaults to `0`.
+                sub_core_grids (ttnn.CoreRangeSet, optional): Core range set to run the operation on. Defaults to `None`.
+                indices_tensor (ttnn.Tensor, optional): Preallocated indices tensor. Defaults to `None`.
 
             Returns:
                 List of ttnn.Tensor: the output tensor.
@@ -64,6 +66,7 @@ void bind_reduction_topk_operation(py::module& module) {
                std::optional<std::tuple<ttnn::Tensor, ttnn::Tensor>> optional_output_tensors,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::CoreRangeSet>& sub_core_grids,
+               const std::optional<ttnn::Tensor>& indices_tensor,
                QueueId queue_id) {
                 return self(
                     queue_id,
@@ -74,6 +77,7 @@ void bind_reduction_topk_operation(py::module& module) {
                     sorted,
                     memory_config,
                     sub_core_grids,
+                    indices_tensor,
                     optional_output_tensors);
             },
             py::arg("input_tensor").noconvert(),
@@ -85,6 +89,7 @@ void bind_reduction_topk_operation(py::module& module) {
             py::arg("out") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("sub_core_grids") = std::nullopt,
+            py::arg("indices_tensor") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
 


### PR DESCRIPTION
### What's changed
Added topk optimisation where we pass in the indices as an optional input tensor to the op. Improves topk for sampling by 300 us (620 us before, 322 us after the change).

Depends on this [PR](https://github.com/tenstorrent/tt-metal/pull/24434 ) for topk optimisation.

### Checklist
- [ ] [TG llama pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/16021507443) CI running
- [ ] [6U](https://github.com/tenstorrent/tt-metal/actions/runs/16023166698) CI running