### PR TITLE
Transformers 4.53.0 rearrange nested models

### DIFF
--- a/models/tt_transformers/requirements.txt
+++ b/models/tt_transformers/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/tenstorrent/llama-models.git@tt_metal_tag
-transformers == 4.51.3
-protobuf == 3.20.0
+transformers>=4.52.0
+protobuf==3.20.0

--- a/models/tt_transformers/requirements.txt
+++ b/models/tt_transformers/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/tenstorrent/llama-models.git@tt_metal_tag
-transformers>=4.52.0
+transformers==4.53.0
 protobuf==3.20.0

--- a/models/tt_transformers/tt/load_checkpoints.py
+++ b/models/tt_transformers/tt/load_checkpoints.py
@@ -12,13 +12,15 @@ from safetensors.torch import load_file as safetensors_load_file
 from tqdm import tqdm
 
 
-def _get_known_prefixes():
-    return [
-        "text_model.",  # Llama Vision
-        "vision_model.",
-        "language_model.",  # Gemma3
-        "vision_tower.",
-    ]
+def _get_known_prefixes_mapping():
+    return {
+        # Llama Vision
+        "text_model.": "",
+        "vision_model.": "",
+        # Gemma3
+        "model.language_model.": "model.",
+        "model.vision_tower.": "model.",
+    }
 
 
 # TODO Update function for large models: For 1 layer tests we only want to load 1 checkpoint file, instead of all.
@@ -55,9 +57,9 @@ def standardize_hf_keys(state_dict):
     key_hf = "model.embed_tokens.weight"
 
     # Check if the key_meta exists with any known prefix
-    if not any(f"{prefix}{key_meta}" in state_dict for prefix in _get_known_prefixes()):
+    if not any(f"{prefix}{key_meta}" in state_dict for prefix in _get_known_prefixes_mapping().keys()):
         # Assume tied to the embeddings if not present
-        for prefix in _get_known_prefixes():
+        for prefix in _get_known_prefixes_mapping().keys():
             if f"{prefix}{key_hf}" in state_dict:
                 state_dict[f"{prefix}{key_meta}"] = state_dict[f"{prefix}{key_hf}"]
                 break
@@ -129,19 +131,19 @@ def map_hf_to_meta_keys(loaded_weights):
     meta_state_dict = {}
     for key, tensor in loaded_weights.items():
         # Remove known prefix if present
-        prefix = next((p for p in _get_known_prefixes() if key.startswith(p)), "")
-        key = key[len(prefix) :]
+        prefix = next((p for p in _get_known_prefixes_mapping().keys() if key.startswith(p)), "")
+        key = key.replace(prefix, _get_known_prefixes_mapping().get(prefix, ""), 1)
 
         if key in hf_to_meta:
             # Direct match for top-level keys
-            meta_state_dict[prefix + hf_to_meta[key]] = tensor
+            meta_state_dict[hf_to_meta[key]] = tensor
         elif "model.layers." in key:
             # Extract layer number and form a template key
             parts = key.split(".")
             layer_num = parts[2]  # e.g. "0" in "model.layers.0.input_layernorm.weight"
             template_key = "model.layers.{layer}." + ".".join(parts[3:])
             if template_key in hf_to_meta:
-                meta_state_dict[prefix + hf_to_meta[template_key].format(layer=layer_num)] = tensor
+                meta_state_dict[hf_to_meta[template_key].format(layer=layer_num)] = tensor
 
     return meta_state_dict
 

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1356,9 +1356,7 @@ class ModelArgs:
         return xs_1BSH
 
     def _get_text_prefix(self):
-        if "gemma-3" in self.model_name.lower():
-            return "language_model."
-        elif self.is_vision():
+        if self.is_vision():
             return "text_model."
         else:
             return ""
@@ -2018,7 +2016,8 @@ class ModelArgs:
                     model = self.cached_hf_model
                 # HACK: Assume that we want the language model layers only
                 if hasattr(model, "language_model"):
-                    model = model.language_model
+                    model.model = model.language_model
+                    # We keep language_model because transformers don't let us change or delete it
                 model.model.layers = model.model.layers[: self.n_layers]
             if wrap:
                 wrapper = HfModelWrapper(model, self.head_dim)


### PR DESCRIPTION
### Ticket
[24432](https://github.com/tenstorrent/tt-metal/issues/24432)

### Problem description
- With 17742bd in transformers library the nested models are rearranged
- The change is obvious for Gemma3 and language_model attribute and we cannot load the model anymore

### What's changed
Updated handling of nested weights

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16002631663)
- [ ] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16002635564) - Failures same as main
- [ ] [(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16002640963) - Qwen2.5 is faster than the target, Qwen3 fails because of timm dependency ([#24338](https://github.com/tenstorrent/tt-metal/issues/24338))