### PR TITLE
Reenable cache for functional vanilla unet

### DIFF
--- a/models/experimental/functional_vanilla_unet/demo/demo.py
+++ b/models/experimental/functional_vanilla_unet/demo/demo.py
@@ -121,9 +121,6 @@ def create_custom_preprocessor(device):
 @pytest.mark.parametrize("use_torch_model", [False])
 @run_for_wormhole_b0()
 def test_unet_demo_single_image(device, reset_seeds, model_location_generator, use_torch_model):
-    # https://github.com/tenstorrent/tt-metal/issues/23269
-    device.disable_and_clear_program_cache()
-
     weights_path = "models/experimental/functional_vanilla_unet/unet.pt"
     if not os.path.exists(weights_path):
         os.system("bash models/experimental/functional_vanilla_unet/weights_download.sh")


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/23269)

### Problem description
Cache was disabled for this specific model because it was failing the tests

### What's changed
Reenabled cache since other fixes already solved this problem

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes