### PR TITLE
Add layout argument for arange operation

### DIFF
--- a/tests/ttnn/python_api_testing/non_working_unit_tests/grayskull/test_arange.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/grayskull/test_arange.py
@@ -34,7 +34,7 @@ def run_arange_tests(
 
         x = ttnn_ops.setup_ttnn_tensor(x, device, dlayout[0], in_mem_config[0], dtype[0])
 
-        tt_result = ttnn.arange(start, end, step, device)
+        tt_result = ttnn.arange(start, end, step, device=device)
 
         tt_result = ttnn_ops.ttnn_tensor_to_torch(tt_result, output_mem_config)
         if divup((end - start), step) % 2 != 0:

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
+import math
 import torch
 import torch.nn as nn
 import ttnn
@@ -264,6 +264,57 @@ def test_full_multi_device(mesh_device, input_shape, fill_value, layout):
         assert torch.allclose(torch_tensor, output_tensor)
 
 
+def test_arange_defaults():
+    start = 0
+    end = 10
+    step = 3
+    width_dim = int(((abs(end - start) + abs(step) - 1) // abs(step)))
+
+    output_tensor = ttnn.arange(start, end, step)
+    assert output_tensor.shape == [width_dim]
+    assert output_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
+    assert output_tensor.dtype == ttnn.bfloat16
+    assert output_tensor.memory_config() == ttnn.DRAM_MEMORY_CONFIG
+
+    output_tensor = ttnn.arange(end)
+    assert output_tensor.shape == [end]
+    assert output_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
+    assert output_tensor.dtype == ttnn.bfloat16
+    assert output_tensor.memory_config() == ttnn.DRAM_MEMORY_CONFIG
+
+
+@pytest.mark.parametrize(
+    "end",
+    [100, 103, 226, 300, 3, 1, 0],
+)
+@pytest.mark.parametrize(
+    "step",
+    [1, 2, 3, 5, 0, -1, -3, -4],
+)
+@pytest.mark.parametrize(
+    "start",
+    [4, 8, 16, 0, 201, 135, 98],
+)
+def test_arange_tile_layout(device, start, end, step):
+    if (start > end and step > 0) or (start < end and step < 0) or (step == 0):
+        pytest.skip(f"Skipping invalid case: start={start}, end={end}, step={step}")
+
+    golden_arange = ttnn.get_golden_function(ttnn.arange)
+    torch_output_tensor = golden_arange(start, end, step)
+
+    output_tensor = ttnn.arange(start, end, step, device=device, layout=ttnn.TILE_LAYOUT)
+    width_dim = int(((abs(end - start) + abs(step) - 1) // abs(step)))
+
+    assert output_tensor.layout == ttnn.TILE_LAYOUT
+    assert output_tensor.padded_shape == [ttnn.TILE_SIZE, math.ceil(width_dim / ttnn.TILE_SIZE) * ttnn.TILE_SIZE]
+    assert output_tensor.shape == [width_dim]
+
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+
+
 @pytest.mark.parametrize(
     "start",
     [4, 8, 16, 0, 201, 135, 98],
@@ -282,8 +333,8 @@ def test_arange(device, start, end, step):
 
     torch_output_tensor = torch.arange(start, end, step)
 
-    output_tensor = ttnn.arange(start, end, step, ttnn.bfloat16, device)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.arange(start, end, step, dtype=ttnn.bfloat16, device=device)
+    assert output_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -311,10 +362,11 @@ def test_arange_multi_device(mesh_device, start, end, step):
         start,
         end,
         step,
-        ttnn.bfloat16,
-        mesh_device,
+        dtype=ttnn.bfloat16,
+        device=mesh_device,
     )
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    assert output_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
+
     output_tensor = ttnn.from_device(output_tensor)
     output_tensors = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(output_tensor.cpu())]
     for output_tensor in output_tensors:

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -309,6 +309,7 @@ def test_arange_tile_layout(device, start, end, step):
     assert output_tensor.layout == ttnn.TILE_LAYOUT
     assert output_tensor.padded_shape == [ttnn.TILE_SIZE, math.ceil(width_dim / ttnn.TILE_SIZE) * ttnn.TILE_SIZE]
     assert output_tensor.shape == [width_dim]
+    assert output_tensor.storage_type() == ttnn.DEVICE_STORAGE_TYPE
 
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -272,12 +272,13 @@ def test_arange_defaults():
 
     output_tensor = ttnn.arange(start, end, step)
     assert output_tensor.shape == [width_dim]
-    assert output_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
-    assert output_tensor.dtype == ttnn.bfloat16
-    assert output_tensor.memory_config() == ttnn.DRAM_MEMORY_CONFIG
 
     output_tensor = ttnn.arange(end)
     assert output_tensor.shape == [end]
+
+    output_tensor = ttnn.arange(start, end)
+    assert output_tensor.shape == [end - start]
+
     assert output_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
     assert output_tensor.dtype == ttnn.bfloat16
     assert output_tensor.memory_config() == ttnn.DRAM_MEMORY_CONFIG

--- a/ttnn/cpp/ttnn-pybind/operations/creation.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/creation.cpp
@@ -16,6 +16,7 @@
 #include "ttnn-pybind/decorators.hpp"
 #include "ttnn-pybind/types.hpp"
 #include "ttnn/operations/creation.hpp"
+#include "ttnn/tensor/enum_types.hpp"
 
 namespace ttnn::operations::creation {
 namespace {
@@ -269,7 +270,7 @@ template <typename creation_operation_t>
 void bind_arange_operation(py::module& module, const creation_operation_t& operation) {
     auto doc = fmt::format(
         R"doc(
-        Creates a tensor with values ranging from `start` (inclusive) to `end` (exclusive) with a specified `step` size. The data type, device, and memory configuration of the resulting tensor can be specified.
+        Creates a tensor with values ranging from `start` (inclusive) to `end` (exclusive) with a specified `step` size. The data type, device, layout and memory configuration of the resulting tensor can be specified.
 
         Args:
             start (int, optional): The start of the range. Defaults to 0.
@@ -278,6 +279,7 @@ void bind_arange_operation(py::module& module, const creation_operation_t& opera
             dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to `ttnn.bfloat16`.
             device (ttnn.Device, optional): The device where the tensor will be allocated. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): The memory configuration for the tensor. Defaults to `ttnn.DRAM_MEMORY_CONFIG`.
+            layout (ttnn.Layout, optional): The tensor layout. Defaults to `ttnn.ROW_MAJOR`.
 
         Returns:
             ttnn.Tensor: A tensor containing evenly spaced values within the specified range.
@@ -300,15 +302,31 @@ void bind_arange_operation(py::module& module, const creation_operation_t& opera
                const int64_t step,
                const DataType dtype,
                const std::optional<std::reference_wrapper<MeshDevice>> device,
-               const MemoryConfig& memory_config) -> ttnn::Tensor {
-                return self(start, end, step, dtype, device, memory_config);
+               const MemoryConfig& memory_config,
+               const Layout layout) -> ttnn::Tensor {
+                return self(start, end, step, dtype, device, memory_config, layout);
             },
             py::arg("start") = 0,
             py::arg("end"),
             py::arg("step") = 1,
+            py::kw_only(),
             py::arg("dtype") = DataType::BFLOAT16,
             py::arg("device") = std::nullopt,
-            py::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG});
+            py::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG,
+            py::arg("layout") = Layout::ROW_MAJOR},
+        ttnn::pybind_overload_t{
+            [](const creation_operation_t& self,
+               const int64_t end,
+               const DataType dtype,
+               const std::optional<std::reference_wrapper<MeshDevice>> device,
+               const MemoryConfig& memory_config,
+               const Layout layout) -> ttnn::Tensor { return self(end, dtype, device, memory_config, layout); },
+            py::arg("end"),
+            py::kw_only(),
+            py::arg("dtype") = DataType::BFLOAT16,
+            py::arg("device") = std::nullopt,
+            py::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG,
+            py::arg("layout") = Layout::ROW_MAJOR});
 }
 
 template <typename creation_operation_t>

--- a/ttnn/cpp/ttnn-pybind/operations/creation.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/creation.cpp
@@ -306,7 +306,7 @@ void bind_arange_operation(py::module& module, const creation_operation_t& opera
                const Layout layout) -> ttnn::Tensor {
                 return self(start, end, step, dtype, device, memory_config, layout);
             },
-            py::arg("start") = 0,
+            py::arg("start"),
             py::arg("end"),
             py::arg("step") = 1,
             py::kw_only(),

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -67,8 +67,7 @@ Tensor arange_impl(
     TensorSpec spec{
         ttnn::Shape{static_cast<uint32_t>(size)}, TensorLayout{data_type, PageConfig{layout}, output_mem_config}};
 
-    auto output = Tensor::from_vector(
-        owned_buffer, spec, device.has_value() ? std::addressof(device->get()) : nullptr);  // do we need to pass cq_id
+    auto output = Tensor::from_vector(owned_buffer, spec, device.has_value() ? std::addressof(device->get()) : nullptr);
 
     return output;
 }

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -44,6 +44,7 @@ Tensor arange_impl(
     const Layout layout = Layout::ROW_MAJOR,
     std::optional<std::reference_wrapper<MeshDevice>> device = std::nullopt,
     const MemoryConfig& output_mem_config = ttnn::DRAM_MEMORY_CONFIG) {
+    using namespace tt::tt_metal;
     constexpr DataType data_type = tt::tt_metal::convert_to_data_type<T>();
 
     TT_FATAL(step != 0, "Step must be nonzero");
@@ -62,14 +63,11 @@ Tensor arange_impl(
             owned_buffer[index++] = static_cast<T>(value);
         }
     }
-    using namespace tt::tt_metal;
 
     TensorSpec spec{
         ttnn::Shape{static_cast<uint32_t>(size)}, TensorLayout{data_type, PageConfig{layout}, output_mem_config}};
 
-    auto output = Tensor::from_vector(owned_buffer, spec, device.has_value() ? std::addressof(device->get()) : nullptr);
-
-    return output;
+    return Tensor::from_vector(owned_buffer, spec, device.has_value() ? std::addressof(device->get()) : nullptr);
 }
 
 template <typename T>

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -67,7 +67,7 @@ Tensor arange_impl(
     TensorSpec spec{
         ttnn::Shape{static_cast<uint32_t>(size)}, TensorLayout{data_type, PageConfig{layout}, output_mem_config}};
 
-    return Tensor::from_vector(owned_buffer, spec, device.has_value() ? std::addressof(device->get()) : nullptr);
+    return Tensor::from_vector(std::move(owned_buffer), spec, device.has_value() ? std::addressof(device->get()) : nullptr);
 }
 
 template <typename T>


### PR DESCRIPTION
### Ticket
[Arange op API for output layout argument](https://github.com/tenstorrent/tt-metal/issues/20251)

### Problem description
The created tensor uses a hardcoded row-major layout.

### What's changed
- Introduced a layout argument in the Python binding and updated the C++ implementation to use this argument instead of the previously hardcoded row-major layout
- Added unit tests to validate tensor creation with TILE layout
- Corrected argument handling to allow calling the operation with default values for the end and step arguments, as described, and added a unit test to validate this.
- Updated the operation description to reflect these changes

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes. [Results](https://github.com/tenstorrent/tt-metal/actions/runs/16032282111)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes