### PR TITLE
Enable 32bit index tensor in TopK sorting algorithm

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -208,7 +208,13 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
 
 
 @pytest.mark.parametrize("dim1", [1])
-@pytest.mark.parametrize("dim2", [50257])
+# This test picks the maximum dim2 that will pick the singlecore implementation.
+# TopK multicore uses 8 cores in blackhole, so we need to add support for bitonic sort with 8 cores
+# and non power of 2 dims as compared to wormhole. Issue #23465.
+@pytest.mark.parametrize(
+    "dim2",
+    [8192 - 64, pytest.param(50257, marks=pytest.mark.xfail(condition=is_blackhole(), reason="Issue #23465"))],
+)
 @pytest.mark.parametrize("dim", [1])
 @pytest.mark.parametrize("k", [50, 3200])
 @pytest.mark.parametrize("largest", [True])

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -208,18 +208,62 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
 
 
 @pytest.mark.parametrize("dim1", [1])
-# This test picks the maximum dim2 that will pick the singlecore implementation.
-# TopK multicore uses 8 cores in blackhole, so we need to add support for bitonic sort with 8 cores
-# and non power of 2 dims as compared to wormhole. Issue #23465.
-@pytest.mark.parametrize(
-    "dim2",
-    [8192 - 64, pytest.param(50257, marks=pytest.mark.xfail(condition=is_blackhole(), reason="Issue #23465"))],
-)  # Need to resolve issue #20294 to verify 128256 for OXMIQ <- will need topk_local_sort to handle uint32_t
+@pytest.mark.parametrize("dim2", [50257])
 @pytest.mark.parametrize("dim", [1])
 @pytest.mark.parametrize("k", [50, 3200])
 @pytest.mark.parametrize("largest", [True])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
+    torch.manual_seed(2005)
+    shape = [dim1, dim2]
+    torch_dtype = torch.bfloat16
+
+    input = torch.randn(shape, dtype=torch_dtype) * 0.9
+
+    pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=dim, largest=largest, sorted=True)
+
+    ttnn_input = ttnn.from_torch(input, dtype, layout=ttnn.Layout.TILE, device=device)
+    ttnn_topk_values, ttnn_topk_indices = ttnn.topk(ttnn_input, k, dim=dim, largest=largest, sorted=True)
+
+    desired_shape = [dim1, dim2]
+    desired_shape[dim] = k
+
+    assert list(ttnn_topk_values.shape) == desired_shape
+    assert list(ttnn_topk_indices.shape) == desired_shape
+
+    ttnn_torch_values = ttnn.to_torch(ttnn_topk_values)
+    ttnn_torch_indices = ttnn.to_torch(ttnn_topk_indices)
+
+    # Add 2^16 to negative values
+    ttnn_torch_indices = ttnn_torch_indices.to(dtype=torch.int32)
+    ttnn_torch_indices = torch.where(ttnn_torch_indices < 0, ttnn_torch_indices + 65536, ttnn_torch_indices)
+
+    if dtype == ttnn.bfloat8_b:
+        pcc_values = 0.99
+    else:
+        pcc_values = 1.0
+
+    # Convert to int64 only for torch.gather which requires signed indices
+    ttnn_torch_gather_from_indices = torch.gather(
+        input, dim, ttnn_torch_indices.to(torch.int64)  # Convert to signed only for PyTorch API compatibility
+    )
+
+    cosine = torch.nn.CosineSimilarity(dim=dim)
+    ttnn_torch_cosine = torch.mean(cosine(pyt_topk_values, ttnn_torch_gather_from_indices))
+    assert (
+        ttnn_torch_cosine > 0.99
+    ), f"Cosine similarity between topk values and gather from indices is {ttnn_torch_cosine} which is less than 0.99"
+    assert_with_pcc(pyt_topk_values, ttnn_torch_values, pcc_values)
+
+
+@skip_for_blackhole("Bad CosineSimilarity on BH. Issue #21881")
+@pytest.mark.parametrize("dim1", [1])
+@pytest.mark.parametrize("dim2", [128256, 151936])
+@pytest.mark.parametrize("dim", [1])
+@pytest.mark.parametrize("k", [50])
+@pytest.mark.parametrize("largest", [True])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_large_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
     torch.manual_seed(2005)
     shape = [dim1, dim2]
     torch_dtype = torch.bfloat16

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -262,7 +262,6 @@ def test_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
     assert_with_pcc(pyt_topk_values, ttnn_torch_values, pcc_values)
 
 
-@skip_for_blackhole("Bad CosineSimilarity on BH. Issue #21881")
 @pytest.mark.parametrize("dim1", [1])
 @pytest.mark.parametrize("dim2", [128256, 151936])
 @pytest.mark.parametrize("dim", [1])

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -83,7 +83,6 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
         (1, 1, 32, 8192, 3, 50),  # passed
         (1, 1, 64, 64, 2, 32),  # passed
         (1, 1, 64, 64, 2, 64),  # passed
-        (1, 1, 32, 8192, 3, 50),  # passed
         (1, 2048, 1, 64, 1, 32),  # skipped
         (1, 1, 32, 64, 3, 2),  # passed
         (1, 1, 32, 64, 3, 4),  # passed
@@ -172,3 +171,43 @@ def test_topk_sub_core_grids(N, C, H, W, dim, k, dtype, sorted, largest, device,
         # and when dim = 0 or 1, transpose converts it into TransposeOpDim::HC & this dim doesnt support bf16 or fp32
         pytest.skip()
     run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids, pass_indices_tensor)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    (ttnn.bfloat16,),
+    ids=[
+        "BFLOAT16_B",
+    ],
+)
+@pytest.mark.parametrize(
+    "N, C, H, W, dim, k",
+    (
+        (1, 1, 32, 151936, 3, 50),  # passed  - customer shape 2
+        (1, 1, 32, 128256, 3, 50),  # passed  - customer shape 1
+    ),
+)
+@pytest.mark.parametrize(
+    "sorted",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "largest",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "sub_core_grids",
+    [
+        None,
+    ],
+)
+def test_topk_large_2d_shapes(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids):
+    if dim == 0 or dim == 1:
+        pytest.skip()
+    run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_transpose_dest_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_transpose_dest_api.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_transpose_dest_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_transpose_dest_api.h
@@ -9,7 +9,7 @@
 
 template <bool transpose_of_faces = true, bool is_32bit = false>
 inline void llk_math_transpose_dest(uint dst_index) {
-    _llk_math_transpose_dest_<transpose_of_faces, is_32bit>(dst_index);
+    _llk_math_transpose_dest_<DST_ACCUM_MODE, transpose_of_faces, is_32bit>(dst_index);
 }
 
 template <bool transpose_of_faces = true, bool is_32bit = false>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
@@ -13,21 +13,21 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void calculate_bitonic_topk_phases_steps(
     uint idir, uint i_end_phase, uint i_start_phase, uint i_end_step, uint i_start_step) {
-    _bitonic_topk_phases_steps<APPROXIMATION_MODE, ITERATIONS>(
+    _bitonic_topk_phases_steps<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(
         idir, i_end_phase, i_start_phase, i_end_step, i_start_step);
 }
 
-template <bool APPROXIMATION_MODE, bool idir = false, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, bool idir = false, int ITERATIONS = 8>
 inline void calculate_bitonic_topk_merge(uint m_iter, uint k) {
-    _bitonic_topk_merge<APPROXIMATION_MODE, idir, ITERATIONS>(m_iter, k);
+    _bitonic_topk_merge<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir, ITERATIONS>(m_iter, k);
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void calculate_bitonic_topk_rebuild(uint idir, uint m_iter, uint k, uint logk, uint skip_second) {
-    _bitonic_topk_rebuild<APPROXIMATION_MODE, ITERATIONS>(idir, m_iter, k, logk, skip_second);
+    _bitonic_topk_rebuild<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(idir, m_iter, k, logk, skip_second);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
@@ -13,19 +13,19 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_bitonic_topk_phases_steps(
     uint idir, uint i_end_phase, uint i_start_phase, uint i_end_step, uint i_start_step) {
     _bitonic_topk_phases_steps<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(
         idir, i_end_phase, i_start_phase, i_end_step, i_start_step);
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, bool idir = false, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool idir = false, int ITERATIONS = 8>
 inline void calculate_bitonic_topk_merge(uint m_iter, uint k) {
     _bitonic_topk_merge<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir, ITERATIONS>(m_iter, k);
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_bitonic_topk_rebuild(uint idir, uint m_iter, uint k, uint logk, uint skip_second) {
     _bitonic_topk_rebuild<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(idir, m_iter, k, logk, skip_second);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::topk_local_sort, APPROXIMATE>(sfpu::topk_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     uint dst_index,
     int idir,
@@ -28,7 +28,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     int i_start_step,
     int vector_mode = (int)VectorMode::RC_custom) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE>,
+        ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index,
         vector_mode,
         idir,
@@ -38,14 +38,18 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
         i_start_step);
 }
 
-template <bool APPROXIMATE, bool idir = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, bool idir = false>
 inline void llk_math_eltwise_unary_sfpu_topk_merge(
     uint dst_index, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, idir>, dst_index, vector_mode, m_iter, k);
+        ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir>,
+        dst_index,
+        vector_mode,
+        m_iter,
+        k);
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     uint dst_index,
     bool idir,
@@ -55,7 +59,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     int skip_second,
     int vector_mode = (int)VectorMode::RC_custom) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE>,
+        ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index,
         vector_mode,
         idir,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::topk_local_sort, APPROXIMATE>(sfpu::topk_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     uint dst_index,
     int idir,
@@ -38,7 +38,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
         i_start_step);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, bool idir = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false>
 inline void llk_math_eltwise_unary_sfpu_topk_merge(
     uint dst_index, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
@@ -49,7 +49,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_merge(
         k);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     uint dst_index,
     bool idir,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_transpose_dest_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_transpose_dest_api.h
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_transpose_dest_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_transpose_dest_api.h
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
@@ -13,21 +13,21 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void calculate_bitonic_topk_phases_steps(
     uint idir, uint i_end_phase, uint i_start_phase, uint i_end_step, uint i_start_step) {
-    _bitonic_topk_phases_steps<APPROXIMATION_MODE, ITERATIONS>(
+    _bitonic_topk_phases_steps<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(
         idir, i_end_phase, i_start_phase, i_end_step, i_start_step);
 }
 
-template <bool APPROXIMATION_MODE, bool idir = false, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, bool idir = false, int ITERATIONS = 8>
 inline void calculate_bitonic_topk_merge(uint m_iter, uint k) {
-    _bitonic_topk_merge<APPROXIMATION_MODE, idir, ITERATIONS>(m_iter, k);
+    _bitonic_topk_merge<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir, ITERATIONS>(m_iter, k);
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void calculate_bitonic_topk_rebuild(uint idir, uint m_iter, uint k, uint logk, uint skip_second) {
-    _bitonic_topk_rebuild<APPROXIMATION_MODE, ITERATIONS>(idir, m_iter, k, logk, skip_second);
+    _bitonic_topk_rebuild<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(idir, m_iter, k, logk, skip_second);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
@@ -13,19 +13,19 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_bitonic_topk_phases_steps(
     uint idir, uint i_end_phase, uint i_start_phase, uint i_end_step, uint i_start_step) {
     _bitonic_topk_phases_steps<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(
         idir, i_end_phase, i_start_phase, i_end_step, i_start_step);
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, bool idir = false, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool idir = false, int ITERATIONS = 8>
 inline void calculate_bitonic_topk_merge(uint m_iter, uint k) {
     _bitonic_topk_merge<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir, ITERATIONS>(m_iter, k);
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_bitonic_topk_rebuild(uint idir, uint m_iter, uint k, uint logk, uint skip_second) {
     _bitonic_topk_rebuild<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(idir, m_iter, k, logk, skip_second);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::topk_local_sort, APPROXIMATE>(sfpu::topk_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     uint dst_index,
     int idir,
@@ -28,7 +28,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     int i_start_step,
     int vector_mode = (int)VectorMode::RC_custom) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE>,
+        ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index,
         vector_mode,
         idir,
@@ -38,14 +38,18 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
         i_start_step);
 }
 
-template <bool APPROXIMATE, bool idir = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, bool idir = false>
 inline void llk_math_eltwise_unary_sfpu_topk_merge(
     uint dst_index, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, idir>, dst_index, vector_mode, m_iter, k);
+        ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir>,
+        dst_index,
+        vector_mode,
+        m_iter,
+        k);
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     uint dst_index,
     bool idir,
@@ -55,7 +59,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     int skip_second,
     int vector_mode = (int)VectorMode::RC_custom) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE>,
+        ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en>,
         dst_index,
         vector_mode,
         idir,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::topk_local_sort, APPROXIMATE>(sfpu::topk_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     uint dst_index,
     int idir,
@@ -38,7 +38,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
         i_start_step);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, bool idir = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false>
 inline void llk_math_eltwise_unary_sfpu_topk_merge(
     uint dst_index, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
@@ -49,7 +49,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_merge(
         k);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     uint dst_index,
     bool idir,

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -863,7 +863,7 @@ ALWI void silu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_silu_init<APPROX>
 // clang-format on
 ALWI void topk_local_sort(
     uint32_t idst, int idir, int i_end_phase, int i_start_phase = 0, int i_end_step = 0, int i_start_step = 0) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_local_sort<true>(
+    MATH((llk_math_eltwise_unary_sfpu_topk_local_sort<true, DST_ACCUM_MODE>(
         idst, idir, i_end_phase, i_start_phase, i_end_step, i_start_step)));
 }
 
@@ -899,7 +899,7 @@ ALWI void topk_local_sort(
 // clang-format on
 template <bool idir = false>
 ALWI void topk_merge(uint32_t idst, int m_iter, int k) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_merge<true, idir>(idst, m_iter, k)));
+    MATH((llk_math_eltwise_unary_sfpu_topk_merge<true, DST_ACCUM_MODE, idir>(idst, m_iter, k)));
 }
 
 // topK rebuild
@@ -935,7 +935,7 @@ ALWI void topk_merge(uint32_t idst, int m_iter, int k) {
  */
 // clang-format on
 ALWI void topk_rebuild(uint32_t idst, bool idir, int m_iter, int k, int logk, int skip_second) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_rebuild<true>(idst, idir, m_iter, k, logk, skip_second)));
+    MATH((llk_math_eltwise_unary_sfpu_topk_rebuild<true, DST_ACCUM_MODE>(idst, idir, m_iter, k, logk, skip_second)));
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -1,10 +1,11 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
 #include "compute_kernel_api/common.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/transpose_wh_dest.h"
 #ifdef TRISC_MATH
 #include "llk_math_common_api.h"
 #include "llk_math_unary_datacopy_api.h"

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -33,12 +33,13 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
 
     if (is_int32) {
         UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, true>(icb, false)));
-        UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(true, false)));
+        UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
+            true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(true, false, icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {
         UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, false>(icb, true)));
-        UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true)));
+        UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(true, true, icb)));
     }
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
@@ -60,11 +61,12 @@ ALWI void transpose_wh_init_short(uint32_t icb) {
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
 
     if (is_int32) {
-        UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(true, false)));
+        UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
+            true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(true, false, icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {
-        UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true)));
+        UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(true, true, icb)));
     }
 
@@ -97,11 +99,11 @@ ALWI void transpose_wh_tile(uint32_t icb, uint32_t itile, uint32_t idst) {
     if (is_int32) {
         UNPACK((llk_unpack_A<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(icb, itile, true)));
         UNPACK((llk_unpack_set_srcb_dummy_valid()));
-        MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(idst)));
+        MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(idst, icb)));
         MATH((llk_math_transpose_dest<false, true>(idst)));
     } else {
         UNPACK((llk_unpack_A<BroadcastType::NONE, false>(icb, itile, true)));
-        MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(idst)));
+        MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(idst, icb)));
     }
 #endif
 }

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -4,8 +4,6 @@
 #pragma once
 
 #include "compute_kernel_api/common.h"
-#include "compute_kernel_api/tile_move_copy.h"
-#include "compute_kernel_api/transpose_wh_dest.h"
 #ifdef TRISC_MATH
 #include "llk_math_common_api.h"
 #include "llk_math_unary_datacopy_api.h"

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+//
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/tt_metal/include/compute_kernel_api/transpose_wh_dest.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh_dest.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+//
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transpose_op.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+//
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transpose_op.hpp"

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
@@ -11,21 +10,39 @@
  * first 32 elements are {0,..31}, then next 32 are {32,..64}
  * wt is which tile it is along the row [0, Wt) so j + 32*wt is the value in the tile at each element
  */
-FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
+FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt, const uint32_t uint16_output) {
     // TODO: investigate moving to compile time (binary size is at risk)
     cb_reserve_back(cb_id, 1);
     uint32_t write_addr = get_write_ptr(cb_id);
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr);
-    uint16_t wt_offset = wt << 5;
 
-    uint32_t count = 0;
-    for (uint32_t i = 0; i < 2; ++i) {
-        for (uint32_t j = 0; j < 2; ++j) {
-            for (uint32_t k = 0; k < 16; ++k) {
-                for (uint32_t l = 0; l < 16; l += 2) {
-                    uint16_t value = l + 16 * j + wt_offset;
-                    ptr[count] = (value + 1) << 16 | value;
-                    count++;
+    if (uint16_output) {
+        uint16_t wt_offset = wt << 5;
+
+        uint32_t count = 0;
+        for (uint32_t i = 0; i < 2; ++i) {
+            for (uint32_t j = 0; j < 2; ++j) {
+                for (uint32_t k = 0; k < 16; ++k) {
+                    for (uint32_t l = 0; l < 16; l += 2) {
+                        uint16_t value = l + 16 * j + wt_offset;
+                        ptr[count] = (value + 1) << 16 | value;
+                        count++;
+                    }
+                }
+            }
+        }
+    } else {
+        uint32_t wt_offset = wt << 5;
+
+        uint32_t count = 0;
+        for (uint32_t i = 0; i < 2; ++i) {
+            for (uint32_t j = 0; j < 2; ++j) {
+                for (uint32_t k = 0; k < 16; ++k) {
+                    for (uint32_t l = 0; l < 16; l++) {
+                        uint32_t value = l + 16 * j + wt_offset;
+                        ptr[count] = value;
+                        count++;
+                    }
                 }
             }
         }
@@ -42,6 +59,7 @@ void kernel_main() {
 
     constexpr uint32_t Ht = get_compile_time_arg_val(3);
     constexpr uint32_t Wt = get_compile_time_arg_val(4);
+    constexpr uint32_t uint16_output = get_compile_time_arg_val(5);
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
@@ -61,7 +79,7 @@ void kernel_main() {
             noc_async_read_tile(i * Wt + j, s, l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(cb_id_in0, onetile);
-            generate_index_tile(cb_intermed_index, j);
+            generate_index_tile(cb_intermed_index, j, uint16_output);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
@@ -11,7 +11,7 @@
  * first 32 elements are {0,..31}, then next 32 are {32,..64}
  * wt is which tile it is along the row [0, Wt) so j + 32*wt is the value in the tile at each element
  */
-FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt, const uint32_t uint16_output) {
+FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt, const bool uint16_output) {
     // TODO: investigate moving to compile time (binary size is at risk)
     cb_reserve_back(cb_id, 1);
     uint32_t write_addr = get_write_ptr(cb_id);
@@ -60,7 +60,7 @@ void kernel_main() {
 
     constexpr uint32_t Ht = get_compile_time_arg_val(3);
     constexpr uint32_t Wt = get_compile_time_arg_val(4);
-    constexpr uint32_t uint16_output = get_compile_time_arg_val(5);
+    constexpr bool uint16_output = get_compile_time_arg_val(5) == 1;
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #include "topk_op.hpp"
@@ -47,7 +46,7 @@ static inline bool verify_multi_core_cost(
     return false;
 }
 
-static inline bool verify_single_core_cost(const std::vector<Tensor>& input_tensors, uint32_t k) {
+static inline bool verify_single_core_cost(const std::vector<Tensor>& input_tensors, uint32_t k, bool uint16_output) {
     uint32_t num_cb_unit = 2;
     uint32_t cb_in_units = 2 * num_cb_unit;
     uint32_t Ktiles = tt::div_up(k, tt::constants::TILE_WIDTH);
@@ -57,8 +56,10 @@ static inline bool verify_single_core_cost(const std::vector<Tensor>& input_tens
     uint32_t output_cb_tile_count = Ktiles;
 
     auto device = input_tensors.at(0).device();
-    tt::DataFormat value_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensors.at(0).dtype());
-    tt::DataFormat index_cb_data_format = tt::DataFormat::UInt16;
+    tt::DataFormat value_cb_data_format =
+        tt::tt_metal::datatype_to_dataformat_converter(input_tensors.at(0).get_dtype());
+
+    tt::DataFormat index_cb_data_format = uint16_output ? tt::DataFormat::UInt16 : tt::DataFormat::UInt32;
 
     uint32_t value_tile_size = tile_size(value_cb_data_format);
     uint32_t index_tile_size = tile_size(index_cb_data_format);
@@ -96,6 +97,7 @@ void TopK::validate_with_output_tensors(
 
     bool can_run = false;
 
+    bool uint16_output = (input_shape[this->dim] < 65536);
     if (input_shape[dim] >= topk_utils::multi_core_min_width) {  // multicore implementation
         can_run = topk_utils::verify_multi_core_cost(
             input_tensors,
@@ -111,10 +113,10 @@ void TopK::validate_with_output_tensors(
             this->sub_core_grids.ranges().size());
 
         if (!can_run) {  // can we default to new topk implementation on single core
-            can_run = topk_utils::verify_single_core_cost(input_tensors, this->k);
+            can_run = topk_utils::verify_single_core_cost(input_tensors, this->k, uint16_output);
         }
     } else {
-        can_run = topk_utils::verify_single_core_cost(input_tensors, this->k);
+        can_run = topk_utils::verify_single_core_cost(input_tensors, this->k, uint16_output);
     }
     TT_FATAL(can_run, "Not enough cores or cache size available to run topk operation");
 }
@@ -129,11 +131,15 @@ std::vector<TensorSpec> TopK::compute_output_specs(
     const auto& input_tensor = input_tensors.at(0);
     auto output_shape = input_tensors.at(0).logical_shape();
     output_shape[-1] = this->k;
+    ttnn::Shape input_shape = input_tensors.at(0).get_padded_shape();
+    bool uint16_output = (input_shape[this->dim] < 65536);
 
     auto values_spec =
-        TensorSpec(output_shape, TensorLayout(input_tensor.dtype(), PageConfig(Layout::TILE), output_mem_config));
-    auto index_spec =
-        TensorSpec(output_shape, TensorLayout(DataType::UINT16, PageConfig(Layout::TILE), output_mem_config));
+        TensorSpec(output_shape, TensorLayout(input_tensor.get_dtype(), PageConfig(Layout::TILE), output_mem_config));
+    DataType index_dtype = uint16_output ? DataType::UINT16 : DataType::UINT32;
+    TensorSpec index_spec =
+        TensorSpec(output_shape, TensorLayout(index_dtype, PageConfig(Layout::TILE), output_mem_config));
+
     return {values_spec, index_spec};
 }
 
@@ -161,29 +167,34 @@ operation::ProgramWithCallbacks TopK::create_program(
     bool multicore_supported = true;
     multicore_supported &= (input_tensor.padded_shape()[dim] >= topk_utils::multi_core_min_width);
 
-    auto input_shape = input_tensors.at(0).padded_shape();
-    auto device = input_tensors.at(0).device();
+    ttnn::Shape input_shape = input_tensors.at(0).get_padded_shape();
 
-    tt::DataFormat value_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensors.at(0).dtype());
-    tt::DataFormat index_cb_data_format = tt::DataFormat::UInt16;
-    uint32_t value_tile_size = tile_size(value_cb_data_format);
-    uint32_t index_tile_size = tile_size(index_cb_data_format);
-
-    // There is a L1 cache issue for multicore implementation (previous version) because footprint depends on input
-    // tensor size. New implementation takes up less L1 cache size because footprint is based on K size, and not input
-    // tensor size, so it can handle larger input tensor sizes.
-    // TODO: implement new topk implementation for multicore
-    multicore_supported &= topk_utils::verify_multi_core_cost(
-        input_tensors,
-        input_shape[this->dim],
-        topk_utils::min_dim_per_core,
-        input_shape[this->dim] / 2,
-        this->k,
-        this->sub_core_grids);
-
-    multicore_supported &= (this->k <= 64);  // old implementation cannot handle k>64
-
-    if (multicore_supported) {
+    multicore_supported &= (input_tensor.get_padded_shape()[dim] >= topk_utils::multi_core_min_width);
+    bool uint16_output = (input_shape[this->dim] < 65536);
+    multicore_supported &= uint16_output;    // for now multicore does not support uint32 output, so if uint16 is not
+                                             // supported, we default to single core
+    multicore_supported &= (this->k <= 64);  // multicore implementation only supports k <= 64
+    if (multicore_supported) {               // don't bother with longer check if already false
+        multicore_supported &= topk_utils::verify_multi_core_cost(
+            input_tensors,
+            input_shape[this->dim],
+            topk_utils::min_dim_per_core,
+            input_shape[this->dim] / 2,
+            this->k,
+            this->sub_core_grids);
+    }
+    if (!multicore_supported) {
+        return detail::topk_single_core_interleaved(
+            input_tensor,
+            this->k,
+            this->dim,
+            this->largest,
+            this->sorted,
+            uint16_output,
+            this->sub_core_grids,
+            output_tensors.at(0),
+            output_tensors.at(1));
+    } else {
         return detail::topk_multicore_interleaved(
             input_tensor,
             indices_tensor,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -96,7 +96,7 @@ void TopK::validate_with_output_tensors(
 
     bool can_run = false;
 
-    bool uint16_output = (input_shape[this->dim] < 65536);
+    bool uint16_output = (input_shape[this->dim] <= std::numeric_limits<uint16_t>::max());
     if (input_shape[dim] >= topk_utils::multi_core_min_width) {  // multicore implementation
         can_run = topk_utils::verify_multi_core_cost(
             input_tensors,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
 // SPDX-License-Identifier: Apache-2.0
 
 #include "topk_op.hpp"

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/host_api.hpp>
@@ -20,6 +19,7 @@ operation::ProgramWithCallbacks topk_single_core_interleaved(
     const int8_t dim,
     const bool largest,
     const bool sorted,
+    const bool uint16_output,
     const CoreRangeSet& sub_core_grids,
     Tensor& value_tensor,
     Tensor& index_tensor) {
@@ -128,7 +128,8 @@ operation::ProgramWithCallbacks topk_single_core_interleaved(
             .set_page_size(output_ind_cb_index, index_tile_size);
     auto cb_output_ind_tensor = tt::tt_metal::CreateCircularBuffer(program, core, output_ind_cb_config);
 
-    std::vector<uint32_t> reader_compile_time_args = {input_cb_index, index_cb_index, (uint32_t)input_is_dram, Ht, Wt};
+    std::vector<uint32_t> reader_compile_time_args = {
+        input_cb_index, index_cb_index, (uint32_t)input_is_dram, Ht, Wt, (uint32_t)uint16_output};
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp",
@@ -184,7 +185,7 @@ operation::ProgramWithCallbacks topk_single_core_interleaved(
         program,
         "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp",
         core,
-        tt::tt_metal::ComputeConfig{.compile_args = compute_args});
+        tt::tt_metal::ComputeConfig{.fp32_dest_acc_en = !uint16_output, .compile_args = compute_args});
 
     auto override_runtime_args_callback = [unary_reader_kernel_id, binary_writer_kernel_id, core](
                                               const void* operation,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/host_api.hpp>

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/run_operation.hpp"
@@ -8,10 +7,11 @@ namespace ttnn::operations::reduction::detail {
 
 tt::tt_metal::operation::ProgramWithCallbacks topk_single_core_interleaved(
     const Tensor& input_tensor,
-    uint32_t k,
-    int8_t dim,
-    bool largest,
-    bool sorted,
+    const uint32_t k,
+    const int8_t dim,
+    const bool largest,
+    const bool sorted,
+    const bool uint16_output,
     const CoreRangeSet& sub_core_grids,
     Tensor& value_tensor,
     Tensor& index_tensor);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/run_operation.hpp"

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -8,11 +8,11 @@ namespace ttnn::operations::reduction::detail {
 
 tt::tt_metal::operation::ProgramWithCallbacks topk_single_core_interleaved(
     const Tensor& input_tensor,
-    const uint32_t k,
-    const int8_t dim,
-    const bool largest,
-    const bool sorted,
-    const bool uint16_output,
+    uint32_t k,
+    int8_t dim,
+    bool largest,
+    bool sorted,
+    bool uint16_output,
     const CoreRangeSet& sub_core_grids,
     Tensor& value_tensor,
     Tensor& index_tensor);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/20294)

### Problem description
Index tensor limit of uint16 limits the size of array that can be sorted by the algorithm. Extending to uint32 enables a few key workloads to be run.

### What's changed
Depending on Dest mode (32bit vs 16bit) the LLK can load either uint16 or uint32 index values. This also requires a transpose wh LLK API, which was added recently.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16034058666) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16034060157) CI with demo tests passes (if applicable)
- [x] New/Existing tests provide coverage for changes