### PR TITLE
Add fabric test infra high-level patterns

### DIFF
--- a/tests/scripts/run_cpp_fabric_tests.sh
+++ b/tests/scripts/run_cpp_fabric_tests.sh
@@ -33,4 +33,4 @@ echo "Running fabric unit tests now...";
 #############################################
 echo "Running fabric sanity tests now...";
 
-./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity.yaml
+./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -60,7 +60,8 @@ run_t3000_ttfabric_tests() {
 
   ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=T3k*MeshGraphFabric2DDynamicTests*
 
-  TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity.yaml
+  TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+  TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_t3k.yaml
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity.yaml
@@ -70,6 +70,19 @@ Tests:
     patterns:
       - type: all_to_all_multicast
 
+  - name: "UnidirectionalMulticastLinear"
+    fabric_setup:
+      topology: Linear
+
+    defaults:
+      ftype: mcast
+      ntype: unicast_write
+      size: 1024
+      num_packets: 100
+
+    patterns:
+      - type: unidirectional_linear_multicast
+
   - name: "FullDevicePairingLinear"
     fabric_setup:
       topology: Linear

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity.yaml
@@ -83,6 +83,19 @@ Tests:
     patterns:
       - type: unidirectional_linear_multicast
 
+  - name: "HalfRingMulticast"
+    fabric_setup:
+      topology: Ring
+
+    defaults:
+      ftype: mcast
+      ntype: unicast_write
+      size: 1024
+      num_packets: 100
+
+    patterns:
+      - type: full_ring_multicast
+
   - name: "FullDevicePairingLinear"
     fabric_setup:
       topology: Linear

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity.yaml
@@ -83,7 +83,7 @@ Tests:
     patterns:
       - type: unidirectional_linear_multicast
 
-  - name: "HalfRingMulticast"
+  - name: "FullRingMulticast"
     fabric_setup:
       topology: Ring
 
@@ -95,6 +95,19 @@ Tests:
 
     patterns:
       - type: full_ring_multicast
+
+  - name: "HalfRingMulticast"
+    fabric_setup:
+      topology: Ring
+
+    defaults:
+      ftype: mcast
+      ntype: unicast_write
+      size: 1024
+      num_packets: 100
+
+    patterns:
+      - type: half_ring_multicast
 
   - name: "FullDevicePairingLinear"
     fabric_setup:

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
@@ -83,32 +83,6 @@ Tests:
     patterns:
       - type: unidirectional_linear_multicast
 
-  - name: "FullRingMulticast"
-    fabric_setup:
-      topology: Ring
-
-    defaults:
-      ftype: mcast
-      ntype: unicast_write
-      size: 1024
-      num_packets: 100
-
-    patterns:
-      - type: full_ring_multicast
-
-  - name: "HalfRingMulticast"
-    fabric_setup:
-      topology: Ring
-
-    defaults:
-      ftype: mcast
-      ntype: unicast_write
-      size: 1024
-      num_packets: 100
-
-    patterns:
-      - type: half_ring_multicast
-
   - name: "FullDevicePairingLinear"
     fabric_setup:
       topology: Linear

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_t3k.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_t3k.yaml
@@ -1,0 +1,26 @@
+Tests:
+  - name: "FullRingMulticast"
+    fabric_setup:
+      topology: Ring
+
+    defaults:
+      ftype: mcast
+      ntype: unicast_write
+      size: 1024
+      num_packets: 100
+
+    patterns:
+      - type: full_ring_multicast
+
+  - name: "HalfRingMulticast"
+    fabric_setup:
+      topology: Ring
+
+    defaults:
+      ftype: mcast
+      ntype: unicast_write
+      size: 1024
+      num_packets: 100
+
+    patterns:
+      - type: half_ring_multicast

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -311,7 +311,7 @@ public:
     // ======================================================================================
     // IRouteManager methods
     // ======================================================================================
-    uint32_t get_num_mesh_dims() const override { return NUM_MESH_DIMS; }
+    uint32_t get_num_mesh_dims() const override { return mesh_shape_.dims(); }
 
     // TODO: instead of parsing ChipSendType, this should only care about unicast/mcast
     // or capturing every device in the path or not

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -343,6 +343,34 @@ public:
         return hops;
     }
 
+    std::unordered_map<RoutingDirection, uint32_t> get_unidirectional_linear_mcast_hops(
+        const FabricNodeId& src_node_id, uint32_t dim) const override {
+        std::unordered_map<RoutingDirection, uint32_t> hops;
+        for (const auto& direction : FabricContext::routing_directions) {
+            hops[direction] = 0;
+        }
+
+        const auto src_coord = get_device_coord(src_node_id);
+
+        if (dim == NS_DIM) {
+            if (src_coord[NS_DIM] < mesh_shape_[NS_DIM] / 2) {
+                hops[RoutingDirection::S] = mesh_shape_[NS_DIM] - src_coord[NS_DIM] - 1;
+            } else {
+                hops[RoutingDirection::N] = src_coord[NS_DIM];
+            }
+        } else if (dim == EW_DIM) {
+            if (src_coord[EW_DIM] < mesh_shape_[EW_DIM] / 2) {
+                hops[RoutingDirection::E] = mesh_shape_[EW_DIM] - src_coord[EW_DIM] - 1;
+            } else {
+                hops[RoutingDirection::W] = src_coord[EW_DIM];
+            }
+        } else {
+            TT_THROW("input mesh dim is not supported: {}", dim);
+        }
+
+        return hops;
+    }
+
     std::vector<std::unordered_map<RoutingDirection, uint32_t>> split_multicast_hops(
         const std::unordered_map<RoutingDirection, uint32_t>& hops) const override {
         std::vector<std::unordered_map<RoutingDirection, uint32_t>> split_hops;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -666,7 +666,7 @@ public:
         return possible_dsts[0];
     }
 
-    MeshShape get_mesh_shape() const { return mesh_shape_; }
+    MeshShape get_mesh_shape() const override { return mesh_shape_; }
 
     RoutingDirection get_forwarding_direction(
         const FabricNodeId& src_node_id, const FabricNodeId& dst_node_id) const override {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -51,6 +51,15 @@ enum class RoutingType {
     Dynamic,
 };
 
+enum class HighLevelTrafficPattern {
+    AllToAllUnicast,
+    FullDeviceRandomPairing,
+    AllToAllMulticast,
+    UnidirectionalLinearMulticast,
+    FullRingMulticast,
+    HalfRingMulticast,
+};
+
 struct TestFabricSetup {
     tt::tt_fabric::Topology topology;
     std::optional<RoutingType> routing_type;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -1029,6 +1029,11 @@ private:
         for (const auto& src_node : devices) {
             // instantiate N/S E/W traffic on seperate senders to avoid bottlnecking on sender.
             for (uint32_t dim = 0; dim < this->route_manager_.get_num_mesh_dims(); ++dim) {
+                // Skip dimensions with only one device
+                if (this->route_manager_.get_mesh_shape()[dim] < 2) {
+                    continue;
+                }
+
                 auto hops = this->route_manager_.get_unidirectional_linear_mcast_hops(src_node, dim);
 
                 TrafficPatternConfig specific_pattern;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -6,6 +6,7 @@
 
 #include <vector>
 #include <unordered_map>
+#include <optional>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_graph.hpp>
 #include <tt-metalium/fabric_edm_packet_header.hpp>
@@ -21,6 +22,8 @@ namespace tt::tt_fabric {
 namespace fabric_tests {
 
 using MeshCoordinate = tt::tt_metal::distributed::MeshCoordinate;
+
+enum class HighLevelTrafficPattern;  // Forward declaration
 
 class IDeviceInfoProvider {
 public:
@@ -61,13 +64,13 @@ public:
         const FabricNodeId& src_node_id) const = 0;
     virtual std::unordered_map<RoutingDirection, uint32_t> get_unidirectional_linear_mcast_hops(
         const FabricNodeId& src_node_id, uint32_t dim) const = 0;
-    virtual std::pair<FabricNodeId, FabricNodeId> get_wrap_around_mesh_ring_neighbors(
+    virtual std::optional<std::pair<FabricNodeId, FabricNodeId>> get_wrap_around_mesh_ring_neighbors(
         const FabricNodeId& src_node, const std::vector<FabricNodeId>& devices) const = 0;
     virtual std::unordered_map<RoutingDirection, uint32_t> get_full_or_half_ring_mcast_hops(
         const FabricNodeId& src_node_id,
         const FabricNodeId& dst_node_forward_id,
         const FabricNodeId& dst_node_backward_id,
-        const std::string& patter_type) const = 0;
+        HighLevelTrafficPattern pattern_type) const = 0;
     virtual std::vector<std::unordered_map<RoutingDirection, uint32_t>> split_multicast_hops(
         const std::unordered_map<RoutingDirection, uint32_t>& hops) const = 0;
     virtual FabricNodeId get_random_unicast_destination(FabricNodeId src_node_id, std::mt19937& gen) const = 0;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -46,8 +46,6 @@ public:
 
 class IRouteManager {
 public:
-    static constexpr uint32_t NUM_MESH_DIMS = 2;
-
     virtual ~IRouteManager() = default;
     virtual uint32_t get_num_mesh_dims() const = 0;
     virtual std::vector<FabricNodeId> get_dst_node_ids_from_hops(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -46,6 +46,7 @@ public:
     static constexpr uint32_t NUM_MESH_DIMS = 2;
 
     virtual ~IRouteManager() = default;
+    virtual uint32_t get_num_mesh_dims() const = 0;
     virtual std::vector<FabricNodeId> get_dst_node_ids_from_hops(
         FabricNodeId src_node_id,
         std::unordered_map<RoutingDirection, uint32_t>& hops,
@@ -60,6 +61,8 @@ public:
         const FabricNodeId& src_node_id) const = 0;
     virtual std::unordered_map<RoutingDirection, uint32_t> get_unidirectional_linear_mcast_hops(
         const FabricNodeId& src_node_id, uint32_t dim) const = 0;
+    virtual std::pair<FabricNodeId, FabricNodeId> get_wrap_around_mesh_ring_neighbors(
+        const FabricNodeId& src_node, const std::vector<FabricNodeId>& devices) const = 0;
     virtual std::unordered_map<RoutingDirection, uint32_t> get_full_or_half_ring_mcast_hops(
         const FabricNodeId& src_node_id,
         const FabricNodeId& dst_node_forward_id,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -60,10 +60,11 @@ public:
         const FabricNodeId& src_node_id) const = 0;
     virtual std::unordered_map<RoutingDirection, uint32_t> get_unidirectional_linear_mcast_hops(
         const FabricNodeId& src_node_id, uint32_t dim) const = 0;
-    virtual std::unordered_map<RoutingDirection, uint32_t> get_full_ring_mcast_hops(
+    virtual std::unordered_map<RoutingDirection, uint32_t> get_full_or_half_ring_mcast_hops(
         const FabricNodeId& src_node_id,
         const FabricNodeId& dst_node_forward_id,
-        const FabricNodeId& dst_node_backward_id) const = 0;
+        const FabricNodeId& dst_node_backward_id,
+        const std::string& patter_type) const = 0;
     virtual std::vector<std::unordered_map<RoutingDirection, uint32_t>> split_multicast_hops(
         const std::unordered_map<RoutingDirection, uint32_t>& hops) const = 0;
     virtual FabricNodeId get_random_unicast_destination(FabricNodeId src_node_id, std::mt19937& gen) const = 0;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -43,6 +43,8 @@ public:
 
 class IRouteManager {
 public:
+    static constexpr uint32_t NUM_MESH_DIMS = 2;
+
     virtual ~IRouteManager() = default;
     virtual std::vector<FabricNodeId> get_dst_node_ids_from_hops(
         FabricNodeId src_node_id,
@@ -56,6 +58,8 @@ public:
         std::mt19937& gen) const = 0;
     virtual std::unordered_map<RoutingDirection, uint32_t> get_full_mcast_hops(
         const FabricNodeId& src_node_id) const = 0;
+    virtual std::unordered_map<RoutingDirection, uint32_t> get_unidirectional_linear_mcast_hops(
+        const FabricNodeId& src_node_id, uint32_t dim) const = 0;
     virtual std::vector<std::unordered_map<RoutingDirection, uint32_t>> split_multicast_hops(
         const std::unordered_map<RoutingDirection, uint32_t>& hops) const = 0;
     virtual FabricNodeId get_random_unicast_destination(FabricNodeId src_node_id, std::mt19937& gen) const = 0;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -47,6 +47,7 @@ public:
 class IRouteManager {
 public:
     virtual ~IRouteManager() = default;
+    virtual MeshShape get_mesh_shape() const = 0;
     virtual uint32_t get_num_mesh_dims() const = 0;
     virtual std::vector<FabricNodeId> get_dst_node_ids_from_hops(
         FabricNodeId src_node_id,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -60,6 +60,10 @@ public:
         const FabricNodeId& src_node_id) const = 0;
     virtual std::unordered_map<RoutingDirection, uint32_t> get_unidirectional_linear_mcast_hops(
         const FabricNodeId& src_node_id, uint32_t dim) const = 0;
+    virtual std::unordered_map<RoutingDirection, uint32_t> get_full_ring_mcast_hops(
+        const FabricNodeId& src_node_id,
+        const FabricNodeId& dst_node_forward_id,
+        const FabricNodeId& dst_node_backward_id) const = 0;
     virtual std::vector<std::unordered_map<RoutingDirection, uint32_t>> split_multicast_hops(
         const std::unordered_map<RoutingDirection, uint32_t>& hops) const = 0;
     virtual FabricNodeId get_random_unicast_destination(FabricNodeId src_node_id, std::mt19937& gen) const = 0;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24251)

### Problem description
currently fabric test infra doesn't have some 1d fabric test patterns (uni-dir linear, full/half ring), adding these.

Only tested on T3K as on 6U there're rt arg excess maximum err.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16058392903
- [ ] ubenchmark