### PR TITLE
Rename FD on Fabric fixtures

### DIFF
--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -242,7 +242,7 @@ class CommandQueueMultiDeviceProgramFixture : public CommandQueueMultiDeviceFixt
 
 class CommandQueueMultiDeviceBufferFixture : public CommandQueueMultiDeviceFixture {};
 
-class CommandQueueOnFabricMultiDeviceFixture : public CommandQueueMultiDeviceFixture,
+class CommandQueueMultiDeviceOnFabricFixture : public CommandQueueMultiDeviceFixture,
                                                public ::testing::WithParamInterface<tt::tt_metal::FabricConfig> {
 protected:
     void SetUp() override {

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <umd/device/types/arch.h>
+#include "fabric_types.hpp"
 #include "gtest/gtest.h"
 #include "dispatch_fixture.hpp"
 #include "hostdevcommon/common_values.hpp"
@@ -248,6 +249,15 @@ protected:
     void SetUp() override {
         if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
             GTEST_SKIP() << "Dispatch on Fabric tests only applicable on Wormhole B0";
+        }
+        // Skip unsupported FabricConfigs on TG
+        if (tt::tt_metal::IsGalaxyCluster()) {
+            switch (GetParam()) {
+                case tt::tt_metal::FabricConfig::FABRIC_1D:
+                case tt::tt_metal::FabricConfig::FABRIC_2D:
+                case tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC: break;
+                default: GTEST_SKIP() << "Unsupported FabricConfig for this test";
+            }
         }
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(true);
         // This will force dispatch init to inherit the FabricConfig param

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <umd/device/types/arch.h>
+#include <cstdint>
 #include "fabric_types.hpp"
 #include "gtest/gtest.h"
 #include "dispatch_fixture.hpp"
@@ -250,14 +251,9 @@ protected:
         if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
             GTEST_SKIP() << "Dispatch on Fabric tests only applicable on Wormhole B0";
         }
-        // Skip unsupported FabricConfigs on TG
+        // Skip for TG as it's still being implemented
         if (tt::tt_metal::IsGalaxyCluster()) {
-            switch (GetParam()) {
-                case tt::tt_metal::FabricConfig::FABRIC_1D:
-                case tt::tt_metal::FabricConfig::FABRIC_2D:
-                case tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC: break;
-                default: GTEST_SKIP() << "Unsupported FabricConfig for this test";
-            }
+            GTEST_SKIP();
         }
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(true);
         // This will force dispatch init to inherit the FabricConfig param

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1339,18 +1339,17 @@ auto CommandQueueFabricConfigsToTest = ::testing::Values(
     tt::tt_metal::FabricConfig::FABRIC_2D,
     tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC);
 
-INSTANTIATE_TEST_SUITE_P(CommandQueue, CommandQueueOnFabricMultiDeviceFixture, CommandQueueFabricConfigsToTest);
+INSTANTIATE_TEST_SUITE_P(CommandQueue, CommandQueueMultiDeviceOnFabricFixture, CommandQueueFabricConfigsToTest);
 
-INSTANTIATE_TEST_SUITE_P(
-    MultiCommandQueue, MultiCommandQueueOnFabricMultiDeviceFixture, CommandQueueFabricConfigsToTest);
+INSTANTIATE_TEST_SUITE_P(MultiCommandQueue, MultiCommandQueueOnFabricFixture, CommandQueueFabricConfigsToTest);
 
-TEST_P(CommandQueueOnFabricMultiDeviceFixture, TensixTestBasicDispatchFunctions) {
+TEST_P(CommandQueueMultiDeviceOnFabricFixture, TensixTestBasicDispatchFunctions) {
     for (IDevice* device : devices_) {
         local_test_functions::test_basic_dispatch_functions(device, 0);
     }
 }
 
-TEST_P(MultiCommandQueueOnFabricMultiDeviceFixture, TensixTestBasicDispatchFunctions) {
+TEST_P(MultiCommandQueueOnFabricFixture, TensixTestBasicDispatchFunctions) {
     for (IDevice* device : devices_) {
         for (int cq_id = 0; cq_id < device->num_hw_cqs(); ++cq_id) {
             local_test_functions::test_basic_dispatch_functions(device, cq_id);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1339,10 +1339,11 @@ auto CommandQueueFabricConfigsToTest = ::testing::Values(
     tt::tt_metal::FabricConfig::FABRIC_2D,
     tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC);
 
-INSTANTIATE_TEST_SUITE_P(CommandQueue, CommandQueueMultiDeviceOnFabricFixture, CommandQueueFabricConfigsToTest);
+INSTANTIATE_TEST_SUITE_P(
+    CommandQueueMultiDevice, CommandQueueMultiDeviceOnFabricFixture, CommandQueueFabricConfigsToTest);
 
 INSTANTIATE_TEST_SUITE_P(
-    MultiCommandQueue, MultiCommandQueueMultiDeviceOnFabricFixture, CommandQueueFabricConfigsToTest);
+    MultiCommandQueueMultiDevice, MultiCommandQueueMultiDeviceOnFabricFixture, CommandQueueFabricConfigsToTest);
 
 TEST_P(CommandQueueMultiDeviceOnFabricFixture, TensixTestBasicDispatchFunctions) {
     for (IDevice* device : devices_) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1341,7 +1341,8 @@ auto CommandQueueFabricConfigsToTest = ::testing::Values(
 
 INSTANTIATE_TEST_SUITE_P(CommandQueue, CommandQueueMultiDeviceOnFabricFixture, CommandQueueFabricConfigsToTest);
 
-INSTANTIATE_TEST_SUITE_P(MultiCommandQueue, MultiCommandQueueOnFabricFixture, CommandQueueFabricConfigsToTest);
+INSTANTIATE_TEST_SUITE_P(
+    MultiCommandQueue, MultiCommandQueueMultiDeviceOnFabricFixture, CommandQueueFabricConfigsToTest);
 
 TEST_P(CommandQueueMultiDeviceOnFabricFixture, TensixTestBasicDispatchFunctions) {
     for (IDevice* device : devices_) {
@@ -1349,7 +1350,7 @@ TEST_P(CommandQueueMultiDeviceOnFabricFixture, TensixTestBasicDispatchFunctions)
     }
 }
 
-TEST_P(MultiCommandQueueOnFabricFixture, TensixTestBasicDispatchFunctions) {
+TEST_P(MultiCommandQueueMultiDeviceOnFabricFixture, TensixTestBasicDispatchFunctions) {
     for (IDevice* device : devices_) {
         for (int cq_id = 0; cq_id < device->num_hw_cqs(); ++cq_id) {
             local_test_functions::test_basic_dispatch_functions(device, cq_id);

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -173,13 +173,9 @@ protected:
         if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
             GTEST_SKIP() << "Dispatch on Fabric tests only applicable on Wormhole B0";
         }
+        // Skip for TG as it's still being implemented
         if (tt::tt_metal::IsGalaxyCluster()) {
-            switch (GetParam()) {
-                case tt::tt_metal::FabricConfig::FABRIC_1D:
-                case tt::tt_metal::FabricConfig::FABRIC_2D:
-                case tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC: break;
-                default: GTEST_SKIP() << "Unsupported FabricConfig for this test";
-            }
+            GTEST_SKIP();
         }
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(true);
         // This will force dispatch init to inherit the FabricConfig param

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -166,8 +166,8 @@ class MultiCommandQueueMultiDeviceBufferFixture : public MultiCommandQueueMultiD
 
 class MultiCommandQueueMultiDeviceEventFixture : public MultiCommandQueueMultiDeviceFixture {};
 
-class MultiCommandQueueOnFabricMultiDeviceFixture : public MultiCommandQueueMultiDeviceFixture,
-                                                    public ::testing::WithParamInterface<tt::tt_metal::FabricConfig> {
+class MultiCommandQueueOnFabricFixture : public MultiCommandQueueMultiDeviceFixture,
+                                         public ::testing::WithParamInterface<tt::tt_metal::FabricConfig> {
 protected:
     void SetUp() override {
         if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -166,8 +166,8 @@ class MultiCommandQueueMultiDeviceBufferFixture : public MultiCommandQueueMultiD
 
 class MultiCommandQueueMultiDeviceEventFixture : public MultiCommandQueueMultiDeviceFixture {};
 
-class MultiCommandQueueOnFabricFixture : public MultiCommandQueueMultiDeviceFixture,
-                                         public ::testing::WithParamInterface<tt::tt_metal::FabricConfig> {
+class MultiCommandQueueMultiDeviceOnFabricFixture : public MultiCommandQueueMultiDeviceFixture,
+                                                    public ::testing::WithParamInterface<tt::tt_metal::FabricConfig> {
 protected:
     void SetUp() override {
         if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -173,6 +173,14 @@ protected:
         if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
             GTEST_SKIP() << "Dispatch on Fabric tests only applicable on Wormhole B0";
         }
+        if (tt::tt_metal::IsGalaxyCluster()) {
+            switch (GetParam()) {
+                case tt::tt_metal::FabricConfig::FABRIC_1D:
+                case tt::tt_metal::FabricConfig::FABRIC_2D:
+                case tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC: break;
+                default: GTEST_SKIP() << "Unsupported FabricConfig for this test";
+            }
+        }
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(true);
         // This will force dispatch init to inherit the FabricConfig param
         tt::tt_metal::detail::SetFabricConfig(GetParam(), FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Was not running on T3K

### What's changed
- Rename it so the gtest filter in run_t3000_unit_tests.sh run_ttmetal_tests will pick it up

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/16041360808
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/16042696985
TG
https://github.com/tenstorrent/tt-metal/actions/runs/16042700374