### PR TITLE
feat: Convert is_dest_accum_en boolean template parameter to enum class

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_api.h
@@ -45,7 +45,7 @@ inline void llk_math_eltwise_binary_init_with_operands(
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     int NUM_FIDELITY_PHASES = 0,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_acc = true) {
@@ -55,7 +55,7 @@ inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_ac
         eltwise_binary_type,
         src_b_bcast_type,
         DST_SYNC_MODE,
-        is_fp32_dest_acc_en,
+        fp32_dest_accumulation,
         NUM_FIDELITY_PHASES,
         binary_reuse_dest>(num_faces, dst_index, clear_fp32_dst_acc);
 }
@@ -63,7 +63,7 @@ inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_ac
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     int NUM_FIDELITY_PHASES = 0,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(
@@ -78,7 +78,7 @@ inline void llk_math_eltwise_binary(
         eltwise_binary_type,
         src_b_bcast_type,
         DST_SYNC_MODE,
-        is_fp32_dest_acc_en,
+        fp32_dest_accumulation,
         NUM_FIDELITY_PHASES,
         binary_reuse_dest>(num_faces, dst_index, clear_fp32_dst_acc);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -35,14 +35,14 @@ inline void llk_math_wait_for_dest_available() {
     WAYPOINT("MWDD");
 }
 
-template <bool is_fp32_dest_acc_en>
+template <DestAccumulation fp32_dest_accumulation>
 inline void llk_math_dest_section_done() {
-    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
+    _llk_math_dest_section_done_<DST_SYNC_MODE, fp32_dest_accumulation>();
 }
 
-template <bool is_fp32_dest_acc_en>
+template <DestAccumulation fp32_dest_accumulation>
 inline void llk_math_pack_sync_init() {
-    _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
+    _llk_math_pack_sync_init_<DST_SYNC_MODE, fp32_dest_accumulation>();
 }
 
 template <bool mail2math = true, bool mail2pack = true>
@@ -59,28 +59,28 @@ inline void llk_math_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _
 
 inline void llk_math_debug_dump_seek(std::uint8_t offset) { _llk_math_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
-    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srca_operand_id]);
+    _llk_math_reconfig_data_format_srca_<fp32_dest_accumulation, to_from_int8>(unpack_dst_format[new_srca_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
-    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srcb_operand_id]);
+    _llk_math_reconfig_data_format_srcb_<fp32_dest_accumulation, to_from_int8>(unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format(const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
-    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_math_reconfig_data_format_<fp32_dest_accumulation, to_from_int8>(
         unpack_dst_format[new_srca_operand_id], unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
@@ -93,33 +93,33 @@ inline void llk_math_reconfig_data_format(
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id]) &&
         (unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand, srcb_new_operand);
+        llk_math_reconfig_data_format<fp32_dest_accumulation, to_from_int8>(srca_new_operand, srcb_new_operand);
     } else if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<fp32_dest_accumulation, to_from_int8>(srca_new_operand);
     } else if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<fp32_dest_accumulation, to_from_int8>(srcb_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<fp32_dest_accumulation, to_from_int8>(srca_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<fp32_dest_accumulation, to_from_int8>(srcb_new_operand);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
@@ -13,24 +13,24 @@
 template <
     PoolType type,
     ReduceDim dim,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     int num_fidelity_phases = 0,
     bool is_int_fpu_en = false>
 inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en>(dst_index, false, num_faces);
+    _llk_math_reduce_<type, dim, fp32_dest_accumulation, num_fidelity_phases, is_int_fpu_en>(dst_index, false, num_faces);
 }
 
 template <
     PoolType type,
     ReduceDim dim,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     int num_fidelity_phases = 0,
     bool is_int_fpu_en = false>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     const std::uint32_t operand_id = get_operand_id(operandA);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en>(dst_index, false, num_faces);
+    _llk_math_reduce_<type, dim, fp32_dest_accumulation, num_fidelity_phases, is_int_fpu_en>(dst_index, false, num_faces);
 }
 
 template <PoolType type, ReduceDim dim, int num_fidelity_phases = 0>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -13,32 +13,32 @@
 
 template <
     DataCopyType type,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
 inline void llk_math_eltwise_unary_datacopy(uint dst_index, uint operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
+    _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, fp32_dest_accumulation, src_b_bcast_type, unpack_to_dest>(
         dst_index, unpack_src_format[operand_id], unpack_dst_format[operand_id]);
 }
 
 template <
     DataCopyType type,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
 inline void llk_math_eltwise_unary_datacopy_block(uint start_dst_index, uint ntiles, uint operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
 
     for (uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
-        _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
+        _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, fp32_dest_accumulation, src_b_bcast_type, unpack_to_dest>(
             dst_index, unpack_src_format[operand_id], unpack_dst_format[operand_id]);
     }
 }
 
 template <
     DataCopyType type,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool is_int_fpu_en = false,
     bool tilize = false>
@@ -50,6 +50,6 @@ inline void llk_math_eltwise_unary_datacopy_init(
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t dst_format = get_operand_dst_format(operand_id);
-    _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, tilize, is_int_fpu_en>(
+    _llk_math_eltwise_unary_datacopy_init_<type, fp32_dest_accumulation, src_b_bcast_type, tilize, is_int_fpu_en>(
         transpose_of_faces, within_face_16x16_transpose, num_faces, dst_format);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -35,7 +35,7 @@ inline void llk_pack_mop_config(const uint32_t output) {
         pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile);
 }
 
-template <bool is_fp32_dest_acc_en, bool untilize = false, bool tilize = false>
+template <DestAccumulation fp32_dest_accumulation, bool untilize = false, bool tilize = false>
 inline void llk_pack_hw_configure(const llk_pack_params_t* pack_params) {
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
@@ -46,7 +46,7 @@ inline void llk_pack_hw_configure(const llk_pack_params_t* pack_params) {
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize, tilize>(
+    _llk_pack_hw_configure_<fp32_dest_accumulation, untilize, tilize>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
@@ -59,7 +59,7 @@ inline void llk_pack_hw_configure(const llk_pack_params_t* pack_params) {
 }
 
 template <
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     bool untilize = false,
     ReluType relu_type = ReluType::NO_RELU,
     std::uint32_t relu_threshold = 0,
@@ -72,10 +72,10 @@ inline void llk_pack_hw_configure_disaggregated(std::uint32_t pack_output) {
                 .ApplyRelu = (std::uint32_t)relu_type,
                 .Threshold = relu_threshold,
             }}};
-    llk_pack_hw_configure<is_fp32_dest_acc_en, untilize, tilize>(&llk_pack_params);
+    llk_pack_hw_configure<fp32_dest_accumulation, untilize, tilize>(&llk_pack_params);
 }
 
-template <bool is_fp32_dest_acc_en, bool untilize = false, bool tilize = false>
+template <DestAccumulation fp32_dest_accumulation, bool untilize = false, bool tilize = false>
 inline void llk_pack_untilize_hw_configure(
     const llk_pack_params_t* pack_params, const std::uint32_t face_r_dim, const std::uint32_t num_faces) {
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
@@ -85,7 +85,7 @@ inline void llk_pack_untilize_hw_configure(
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize, tilize>(
+    _llk_pack_hw_configure_<fp32_dest_accumulation, untilize, tilize>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
@@ -98,7 +98,7 @@ inline void llk_pack_untilize_hw_configure(
 }
 
 template <
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     bool untilize = false,
     ReluType relu_type = ReluType::NO_RELU,
     std::uint32_t relu_threshold = 0,
@@ -112,10 +112,10 @@ inline void llk_pack_untilize_hw_configure_disaggregated(
                 .ApplyRelu = (std::uint32_t)relu_type,
                 .Threshold = relu_threshold,
             }}};
-    llk_pack_untilize_hw_configure<is_fp32_dest_acc_en, untilize, tilize>(&llk_pack_params, face_r_dim, num_faces);
+    llk_pack_untilize_hw_configure<fp32_dest_accumulation, untilize, tilize>(&llk_pack_params, face_r_dim, num_faces);
 }
 
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, bool untilize = false>
+template <PoolType type, ReduceDim dim, DestAccumulation fp32_dest_accumulation, bool untilize = false>
 inline void llk_pack_reduce_hw_configure(const llk_pack_params_t* pack_params) {
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
@@ -126,7 +126,7 @@ inline void llk_pack_reduce_hw_configure(const llk_pack_params_t* pack_params) {
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
-    _llk_pack_reduce_hw_configure_<type, dim, is_fp32_dest_acc_en, untilize>(
+    _llk_pack_reduce_hw_configure_<type, dim, fp32_dest_accumulation, untilize>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
@@ -141,7 +141,7 @@ inline void llk_pack_reduce_hw_configure(const llk_pack_params_t* pack_params) {
 template <
     PoolType type,
     ReduceDim dim,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     bool untilize = false,
     ReluType relu_type = ReluType::NO_RELU,
     std::uint32_t relu_threshold = 0>
@@ -149,7 +149,7 @@ inline void llk_pack_reduce_hw_configure_disaggregated(std::uint32_t pack_output
     llk_pack_params_t llk_pack_params = {
         .pack_output = pack_output,
         .relu_config = {.f = {.ApplyRelu = (std::uint32_t)relu_type, .Threshold = relu_threshold}}};
-    llk_pack_reduce_hw_configure<type, dim, is_fp32_dest_acc_en, untilize>(&llk_pack_params);
+    llk_pack_reduce_hw_configure<type, dim, fp32_dest_accumulation, untilize>(&llk_pack_params);
 }
 
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
@@ -189,7 +189,7 @@ inline std::uint32_t get_output_tile_address(std::uint8_t output_id, std::uint32
     return pack_tile_addr;
 }
 
-template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, bool untilize = false>
+template <DestAccumulation fp32_dest_accumulation, bool out_of_order_output = false, bool untilize = false>
 inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32_t output_tile_index = 0) {
     std::uint8_t output_id = get_output_id(output);
 
@@ -197,7 +197,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
 
     std::uint32_t pack_tile_addr = get_output_tile_address<out_of_order_output, untilize>(output_id, output_tile_index);
 
-    _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(tile_index, pack_tile_addr);
+    _llk_pack_<DST_SYNC_MODE, fp32_dest_accumulation, untilize>(tile_index, pack_tile_addr);
 }
 
 /*************************************************************************
@@ -268,7 +268,7 @@ inline void llk_pack_untilize(
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, bool untilize = false>
+template <DestAccumulation fp32_dest_accumulation, bool out_of_order_output = false, bool untilize = false>
 inline void llk_matmul_pack(
     std::uint32_t start_tile_index, std::uint32_t output, uint32_t ntiles, std::uint32_t output_tile_index = 0) {
     std::uint8_t output_id = get_output_id(output);
@@ -279,7 +279,7 @@ inline void llk_matmul_pack(
         std::uint32_t pack_tile_addr =
             get_output_tile_address<out_of_order_output, untilize>(output_id, output_tile_index);
 
-        _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(tile_index, pack_tile_addr);
+        _llk_pack_<DST_SYNC_MODE, fp32_dest_accumulation, untilize>(tile_index, pack_tile_addr);
     }
 }
 
@@ -294,9 +294,9 @@ inline void llk_packer_set_math_semaphore() {
     _llk_packer_set_math_semaphore_<WaitRes>();
 }
 
-template <bool is_fp32_dest_acc_en>
+template <DestAccumulation fp32_dest_accumulation>
 inline void llk_pack_dest_section_done() {
-    _llk_pack_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
+    _llk_pack_dest_section_done_<DST_SYNC_MODE, fp32_dest_accumulation>();
 }
 
 template <bool untilize = false, bool diagonal = false>
@@ -308,13 +308,13 @@ inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_outpu
     _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE, DstTileFaceLayout::RowMajor>(face_r_dim, narrow_tile);
 }
 
-template <bool is_fp32_dest_acc_en, bool untilize = false>
+template <DestAccumulation fp32_dest_accumulation, bool untilize = false>
 inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
     const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor>(face_r_dim, narrow_tile);
+    _llk_pack_dest_init_<DST_SYNC_MODE, fp32_dest_accumulation, DstTileFaceLayout::RowMajor>(face_r_dim, narrow_tile);
 }
 
 template <bool mail2math = true, bool mail2pack = true>
@@ -330,7 +330,7 @@ inline void llk_pack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _
 
 inline void llk_pack_debug_dump_seek(std::uint8_t offset) { _llk_pack_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool is_tile_dim_reconfig_en = false>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t output_id = get_output_id(new_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
@@ -339,7 +339,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en, is_tile_dim_reconfig_en, DstTileFaceLayout::RowMajor, false>(
+    _llk_pack_reconfig_data_format_<fp32_dest_accumulation, is_tile_dim_reconfig_en, DstTileFaceLayout::RowMajor, false>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         get_local_cb_interface(output_id).fifo_page_size,
@@ -350,7 +350,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
         narrow_tile);
 }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool is_tile_dim_reconfig_en = false>
 inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const std::uint32_t new_output) {
     std::uint32_t old_output_id = get_output_id(old_output);
     std::uint32_t new_output_id = get_output_id(new_output);
@@ -358,7 +358,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const 
     if ((pack_dst_format[old_output_id] != pack_dst_format[new_output_id]) &&
         (pack_dst_format[old_output_id] != (uint)DataFormat::Invalid) &&
         (pack_dst_format[new_output_id] != (uint)DataFormat::Invalid)) {
-        llk_pack_reconfig_data_format<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(new_output);
+        llk_pack_reconfig_data_format<fp32_dest_accumulation, is_tile_dim_reconfig_en>(new_output);
     } else if constexpr (is_tile_dim_reconfig_en) {
         // Same format but different tile dims
         llk_pack_mop_config<false, false>(new_output);
@@ -377,7 +377,7 @@ inline void llk_pack_reduce_mask_config() {
 inline void llk_pack_reduce_mask_clear() { _llk_pack_reduce_mask_clear_(); }
 
 // FIXME-WH-UPLIFT
-template <ReduceDim dim, bool is_fp32_dest_acc_en, bool at_kernel_start = false, bool revert = false>
+template <ReduceDim dim, DestAccumulation fp32_dest_accumulation, bool at_kernel_start = false, bool revert = false>
 inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
     const bool untilize = false;
     if constexpr (at_kernel_start) {
@@ -394,7 +394,7 @@ inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
                 .Threshold = 0,
             }};
 
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
+        _llk_pack_hw_configure_<fp32_dest_accumulation, untilize>(
             pack_src_format[output_id],
             pack_dst_format[output_id],
             tile_size,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_param_structs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_param_structs.h
@@ -6,6 +6,16 @@
 
 #include <cstdint>
 
+// Enum class for destination accumulation control - replaces boolean template parameter is_fp32_dest_acc_en
+enum class DestAccumulation {
+    Disable = 0,
+    Enable = 1
+};
+
+// Convenience constants for backward compatibility and readability
+constexpr DestAccumulation DestAccumulation_Disable = DestAccumulation::Disable;
+constexpr DestAccumulation DestAccumulation_Enable = DestAccumulation::Enable;
+
 //***
 //  Unpack LLK param structs
 //***

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -17,9 +17,9 @@ sfpi_inline vFloat sfpu_reciprocal(const vFloat in) {
     return _sfpu_reciprocal_<max_iter>(in);
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, DestAccumulation fp32_dest_accumulation, int ITERATIONS = 8>
 inline void calculate_reciprocal() {
-    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(ITERATIONS);
+    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_accumulation>(ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_recip.h
@@ -12,10 +12,10 @@ namespace ckernel {
 
 // New LLK SFPU APIs
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+template <bool APPROXIMATE, DestAccumulation fp32_dest_accumulation>
 inline void llk_math_eltwise_unary_sfpu_reciprocal(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_reciprocal<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_reciprocal<APPROXIMATE, fp32_dest_accumulation, 8>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -10,7 +10,7 @@
  * LLK UNPACK AB
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
+template <DestAccumulation fp32_dest_accumulation, StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_AB_hw_configure(
     const llk_unpack_AB_params_t* unpack_AB_params, const int within_face_16x16_transpose = 0) {
     // In0 -> unpA
@@ -23,7 +23,7 @@ inline void llk_unpack_AB_hw_configure(
     const uint32_t num_faces = get_operand_num_faces(unpA_operand_id);    // num faces in unpA and unpB are the same
     const uint32_t face_r_dim = get_operand_face_r_dim(unpA_operand_id);  // face r dim in unpA and unpB are the same
 
-    _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_AB_hw_configure_<fp32_dest_accumulation, stoch_rnd_mode>(
         unpack_src_format[unpA_operand_id],
         unpack_src_format[unpB_operand_id],
         unpack_dst_format[unpA_operand_id],
@@ -33,12 +33,12 @@ inline void llk_unpack_AB_hw_configure(
         num_faces);
 }
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
+template <DestAccumulation fp32_dest_accumulation, StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_AB_hw_configure_disaggregated(
     const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const int within_face_16x16_transpose = 0) {
     const llk_unpack_AB_params_t unpack_AB_params = {.unpA_operand = unpA_operand, .unpB_operand = unpB_operand};
 
-    llk_unpack_AB_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_AB_params, within_face_16x16_transpose);
+    llk_unpack_AB_hw_configure<fp32_dest_accumulation, stoch_rnd_mode>(&unpack_AB_params, within_face_16x16_transpose);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -10,7 +10,7 @@
  * LLK UNPACK AB MATMUL
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
+template <DestAccumulation fp32_dest_accumulation, StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_AB_matmul_hw_configure(const llk_unpack_AB_matmul_params_t* unpack_AB_params) {
     const bool transpose_xy_srca = unpack_AB_params->transpose_xy_srca;
 
@@ -27,7 +27,7 @@ inline void llk_unpack_AB_matmul_hw_configure(const llk_unpack_AB_matmul_params_
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
     const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
 
-    _llk_unpack_AB_matmul_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_AB_matmul_hw_configure_<fp32_dest_accumulation, stoch_rnd_mode>(
         unpack_src_format[unpA_operand_id],
         unpack_src_format[unpB_operand_id],
         unpack_dst_format[unpA_operand_id],
@@ -41,12 +41,12 @@ inline void llk_unpack_AB_matmul_hw_configure(const llk_unpack_AB_matmul_params_
         get_local_cb_interface(unpB_operand_id).fifo_page_size);
 }
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
+template <DestAccumulation fp32_dest_accumulation, StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_AB_matmul_hw_configure_disaggregated(
     const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const std::uint32_t transpose_xy_srca = 0) {
     const llk_unpack_AB_matmul_params_t unpack_AB_matmul_params = {
         .unpA_operand = unpA_operand, .unpB_operand = unpB_operand, .transpose_xy_srca = transpose_xy_srca};
-    llk_unpack_AB_matmul_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_AB_matmul_params);
+    llk_unpack_AB_matmul_hw_configure<fp32_dest_accumulation, stoch_rnd_mode>(&unpack_AB_matmul_params);
 }
 
 inline void llk_unpack_AB_matmul_mop_config(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -11,7 +11,7 @@
  *************************************************************************/
 
 template <
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     StochRndType stoch_rnd_mode = StochRndType::None,
     bool disable_src_zero_flag = false>
 inline void llk_unpack_A_hw_configure(
@@ -20,7 +20,7 @@ inline void llk_unpack_A_hw_configure(
     const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
 
-    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
+    _llk_unpack_A_hw_configure_<fp32_dest_accumulation, stoch_rnd_mode, disable_src_zero_flag>(
         unpack_src_format[unpA_operand_id],
         unpack_dst_format[unpA_operand_id],
         unpA_face_r_dim,
@@ -29,13 +29,13 @@ inline void llk_unpack_A_hw_configure(
 }
 
 template <
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     StochRndType stoch_rnd_mode = StochRndType::None,
     bool disable_src_zero_flag = false>
 inline void llk_unpack_A_hw_configure_disaggregated(
     const std::uint32_t unpA_operand, const int within_face_16x16_transpose = 0) {
     const llk_unpack_A_params_t unpack_A_params = {.unpA_operand = unpA_operand};
-    llk_unpack_A_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
+    llk_unpack_A_hw_configure<fp32_dest_accumulation, stoch_rnd_mode, disable_src_zero_flag>(
         &unpack_A_params, within_face_16x16_transpose);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -53,74 +53,74 @@ inline void llk_unpack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) {
 
 inline void llk_unpack_debug_dump_seek(std::uint8_t offset) { _llk_unpack_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
-    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srca_impl_<fp32_dest_accumulation, to_from_int8>(
         unpack_src_format[srca_operand_id],
         unpack_dst_format[srca_operand_id],
         get_local_cb_interface(srca_operand_id).fifo_page_size);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
-    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srcb_impl_<fp32_dest_accumulation, to_from_int8>(
         unpack_src_format[srcb_operand_id],
         unpack_dst_format[srcb_operand_id],
         get_local_cb_interface(srcb_operand_id).fifo_page_size);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if (should_reconfigure_cbs(srca_old_operand, srca_new_operand)) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+        llk_unpack_reconfig_data_format_srca<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(
             srca_new_operand);
     } else if constexpr (is_tile_dim_reconfig_en) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+        llk_unpack_reconfig_data_format_srca<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(
             srca_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if (should_reconfigure_cbs(srcb_old_operand, srcb_new_operand)) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+        llk_unpack_reconfig_data_format_srcb<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(
             srcb_new_operand);
     } else if constexpr (is_tile_dim_reconfig_en) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+        llk_unpack_reconfig_data_format_srcb<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(
             srcb_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(srcb_new_operand);
+    llk_unpack_reconfig_data_format_srca<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(srca_new_operand);
+    llk_unpack_reconfig_data_format_srcb<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(srcb_new_operand);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
     const std::uint32_t srcb_old_operand,
     const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+    llk_unpack_reconfig_data_format_srca<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(
         srca_old_operand, srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+    llk_unpack_reconfig_data_format_srcb<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(
         srcb_old_operand, srcb_new_operand);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
@@ -10,7 +10,7 @@
  * LLK UNPACK REDUCE
  *************************************************************************/
 
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
+template <PoolType type, ReduceDim dim, DestAccumulation fp32_dest_accumulation, StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_reduce_hw_configure(
     const llk_unpack_reduce_params_t* unpack_reduce_params, const float const_mult) {
     constexpr bool within_face_16x16_transpose = (ReduceDim::REDUCE_ROW == dim);
@@ -27,7 +27,7 @@ inline void llk_unpack_reduce_hw_configure(
             ((((std::uint32_t)unpack_dst_format[unpA_operand_id] >> 2) & 0x1) ? (std::uint32_t)DataFormat::Float16_b
                                                                               : (std::uint32_t)DataFormat::Float16);
 
-    _llk_unpack_reduce_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_reduce_hw_configure_<fp32_dest_accumulation, stoch_rnd_mode>(
         unpack_src_format[unpA_operand_id],
         unpB_src_format,
         unpack_dst_format[unpA_operand_id],
@@ -39,10 +39,10 @@ inline void llk_unpack_reduce_hw_configure(
         unpA_num_faces);
 }
 
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
+template <PoolType type, ReduceDim dim, DestAccumulation fp32_dest_accumulation, StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_reduce_hw_configure_disaggregated(const std::uint32_t unpA_operand, const float mult) {
     const llk_unpack_reduce_params_t unpack_reduce_params = {.unpA_operand = unpA_operand};
-    llk_unpack_reduce_hw_configure<type, dim, is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_reduce_params, mult);
+    llk_unpack_reduce_hw_configure<type, dim, fp32_dest_accumulation, stoch_rnd_mode>(&unpack_reduce_params, mult);
 }
 
 template <PoolType type, ReduceDim dim>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -11,7 +11,7 @@
  * LLK UNPACK TILIZE
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en>
+template <DestAccumulation fp32_dest_accumulation>
 inline void llk_unpack_tilize_hw_configure(const llk_unpack_A_params_t *unpack_tilize_params) {
     constexpr bool within_face_16x16_transpose = false;
     constexpr StochRndType stoch_rnd_mode = StochRndType::None;
@@ -20,7 +20,7 @@ inline void llk_unpack_tilize_hw_configure(const llk_unpack_A_params_t *unpack_t
     const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
 
-    _llk_unpack_tilize_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_tilize_hw_configure_<fp32_dest_accumulation, stoch_rnd_mode>(
         unpack_src_format[unpA_operand_id],
         unpack_dst_format[unpA_operand_id],
         unpA_face_r_dim,
@@ -28,10 +28,10 @@ inline void llk_unpack_tilize_hw_configure(const llk_unpack_A_params_t *unpack_t
         unpA_num_faces);
 }
 
-template <bool is_fp32_dest_acc_en>
+template <DestAccumulation fp32_dest_accumulation>
 inline void llk_unpack_tilize_hw_configure_disaggregated(const std::uint32_t unpA_operand) {
     const llk_unpack_A_params_t unpack_tilize_params = {.unpA_operand = unpA_operand};
-    llk_unpack_tilize_hw_configure<is_fp32_dest_acc_en>(&unpack_tilize_params);
+    llk_unpack_tilize_hw_configure<fp32_dest_accumulation>(&unpack_tilize_params);
 }
 
 inline void llk_unpack_tilize_mop_config(const std::uint32_t operand) {
@@ -100,7 +100,7 @@ inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c
  * LLK UNPACK TILIZE SRC A, UNPACK SRC B
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
+template <DestAccumulation fp32_dest_accumulation, StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_tilizeA_B_hw_configure(
     const llk_unpack_AB_params_t *unpack_tilizeA_B_params, const int within_face_16x16_transpose = 0) {
     // In0 -> unpA
@@ -116,7 +116,7 @@ inline void llk_unpack_tilizeA_B_hw_configure(
     // unpB -> srcB
     const uint32_t num_faces_b = get_operand_num_faces(unpB_operand_id);
     const uint32_t face_r_dim_b = get_operand_face_r_dim(unpB_operand_id);
-    configure_unpack_AB<is_fp32_dest_acc_en, false, false, false>(
+    configure_unpack_AB<fp32_dest_accumulation, false, false, false>(
         unpack_src_format[unpA_operand_id],
         unpack_src_format[unpB_operand_id],
         unpack_dst_format[unpA_operand_id],
@@ -128,11 +128,11 @@ inline void llk_unpack_tilizeA_B_hw_configure(
         num_faces_b);
 }
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
+template <DestAccumulation fp32_dest_accumulation, StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_tilizeA_B_hw_configure_disaggregated(
     const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const int within_face_16x16_transpose = 0) {
     const llk_unpack_AB_params_t unpack_tilizeA_B_params = {.unpA_operand = unpA_operand, .unpB_operand = unpB_operand};
-    llk_unpack_tilizeA_B_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    llk_unpack_tilizeA_B_hw_configure<fp32_dest_accumulation, stoch_rnd_mode>(
         &unpack_tilizeA_B_params, within_face_16x16_transpose);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
@@ -9,7 +9,7 @@
 /*************************************************************************
  * LLK UNPACK UNTILIZE
  *************************************************************************/
-template <bool is_fp32_dest_acc_en>
+template <DestAccumulation fp32_dest_accumulation>
 inline void llk_unpack_untilize_hw_configure(const llk_unpack_A_params_t* unpack_untilize_params) {
     constexpr bool is_row_pool = false;
     constexpr bool within_face_16x16_transpose = false;
@@ -19,7 +19,7 @@ inline void llk_unpack_untilize_hw_configure(const llk_unpack_A_params_t* unpack
     const uint32_t unpA_num_faces = 4;
     const uint32_t unpA_face_r_dim = FACE_R_DIM;
 
-    _llk_unpack_untilize_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_untilize_hw_configure_<fp32_dest_accumulation, stoch_rnd_mode>(
         unpack_src_format[unpA_operand_id],
         unpack_dst_format[unpA_operand_id],
         unpA_face_r_dim,
@@ -27,12 +27,12 @@ inline void llk_unpack_untilize_hw_configure(const llk_unpack_A_params_t* unpack
         unpA_num_faces);
 }
 
-template <bool is_fp32_dest_acc_en>
+template <DestAccumulation fp32_dest_accumulation>
 inline void llk_unpack_untilize_hw_configure_disaggregated(const std::uint32_t unpA_operand) {
     const llk_unpack_A_params_t unpack_untilize_params = {
         .unpA_operand = unpA_operand,
     };
-    llk_unpack_untilize_hw_configure<is_fp32_dest_acc_en>(&unpack_untilize_params);
+    llk_unpack_untilize_hw_configure<fp32_dest_accumulation>(&unpack_untilize_params);
 }
 
 inline void llk_unpack_untilize_mop_config() { _llk_unpack_untilize_mop_config_(); }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_api.h
@@ -45,7 +45,7 @@ inline void llk_math_eltwise_binary_init_with_operands(
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     int NUM_FIDELITY_PHASES = 0,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_acc = true) {
@@ -55,7 +55,7 @@ inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_ac
         eltwise_binary_type,
         src_b_bcast_type,
         DST_SYNC_MODE,
-        is_fp32_dest_acc_en,
+        fp32_dest_accumulation,
         NUM_FIDELITY_PHASES,
         binary_reuse_dest>(num_faces, dst_index, clear_fp32_dst_acc);
 }
@@ -63,7 +63,7 @@ inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_ac
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     int NUM_FIDELITY_PHASES = 0,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(
@@ -78,7 +78,7 @@ inline void llk_math_eltwise_binary(
         eltwise_binary_type,
         src_b_bcast_type,
         DST_SYNC_MODE,
-        is_fp32_dest_acc_en,
+        fp32_dest_accumulation,
         NUM_FIDELITY_PHASES,
         binary_reuse_dest>(num_faces, dst_index, clear_fp32_dst_acc);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -36,14 +36,14 @@ inline void llk_math_wait_for_dest_available() {
     WAYPOINT("MWDD");
 }
 
-template <bool is_fp32_dest_acc_en>
+template <DestAccumulation fp32_dest_accumulation>
 inline void llk_math_dest_section_done() {
-    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
+    _llk_math_dest_section_done_<DST_SYNC_MODE, fp32_dest_accumulation>();
 }
 
-template <bool is_fp32_dest_acc_en>
+template <DestAccumulation fp32_dest_accumulation>
 inline void llk_math_pack_sync_init() {
-    _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
+    _llk_math_pack_sync_init_<DST_SYNC_MODE, fp32_dest_accumulation>();
 }
 
 template <bool mail2math = true, bool mail2pack = true>
@@ -60,28 +60,28 @@ inline void llk_math_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _
 
 inline void llk_math_debug_dump_seek(std::uint8_t offset) { _llk_math_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
-    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srca_operand_id]);
+    _llk_math_reconfig_data_format_srca_<fp32_dest_accumulation, to_from_int8>(unpack_dst_format[new_srca_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
-    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srcb_operand_id]);
+    _llk_math_reconfig_data_format_srcb_<fp32_dest_accumulation, to_from_int8>(unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format(const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
-    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_math_reconfig_data_format_<fp32_dest_accumulation, to_from_int8>(
         unpack_dst_format[new_srca_operand_id], unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
@@ -94,33 +94,33 @@ inline void llk_math_reconfig_data_format(
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id]) &&
         (unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand, srcb_new_operand);
+        llk_math_reconfig_data_format<fp32_dest_accumulation, to_from_int8>(srca_new_operand, srcb_new_operand);
     } else if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<fp32_dest_accumulation, to_from_int8>(srca_new_operand);
     } else if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<fp32_dest_accumulation, to_from_int8>(srcb_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<fp32_dest_accumulation, to_from_int8>(srca_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<fp32_dest_accumulation, to_from_int8>(srcb_new_operand);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
@@ -13,23 +13,23 @@
 template <
     PoolType type,
     ReduceDim dim,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     int num_fidelity_phases = 0,
     bool is_int_fpu_en = false>
 inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en>(dst_index, false, num_faces);
+    _llk_math_reduce_<type, dim, fp32_dest_accumulation, num_fidelity_phases, is_int_fpu_en>(dst_index, false, num_faces);
 }
 
 template <
     PoolType type,
     ReduceDim dim,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     int num_fidelity_phases = 0,
     bool is_int_fpu_en = false>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     const std::uint32_t operand_id = get_operand_id(operandA);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en>(dst_index, false, num_faces);
+    _llk_math_reduce_<type, dim, fp32_dest_accumulation, num_fidelity_phases, is_int_fpu_en>(dst_index, false, num_faces);
 }
 
 template <PoolType type, ReduceDim dim, int num_fidelity_phases = 0>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -13,32 +13,32 @@
 
 template <
     DataCopyType type,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
 inline void llk_math_eltwise_unary_datacopy(uint dst_index, uint operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
+    _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, fp32_dest_accumulation, src_b_bcast_type, unpack_to_dest>(
         dst_index, unpack_src_format[operand_id], unpack_dst_format[operand_id]);
 }
 
 template <
     DataCopyType type,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
 inline void llk_math_eltwise_unary_datacopy_block(uint start_dst_index, uint ntiles, uint operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
 
     for (uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
-        _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
+        _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, fp32_dest_accumulation, src_b_bcast_type, unpack_to_dest>(
             dst_index, unpack_src_format[operand_id], unpack_dst_format[operand_id]);
     }
 }
 
 template <
     DataCopyType type,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool is_int_fpu_en = false,
     bool tilize = false /*unused*/>
@@ -50,6 +50,6 @@ inline void llk_math_eltwise_unary_datacopy_init(
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t dst_format = get_operand_dst_format(operand_id);
-    _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en>(
+    _llk_math_eltwise_unary_datacopy_init_<type, fp32_dest_accumulation, src_b_bcast_type, is_int_fpu_en>(
         transpose_of_faces, within_face_16x16_transpose, num_faces, dst_format);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -35,7 +35,7 @@ inline void llk_pack_mop_config(const uint32_t output) {
         pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
 }
 
-template <bool is_fp32_dest_acc_en, bool untilize = false>
+template <DestAccumulation fp32_dest_accumulation, bool untilize = false>
 inline void llk_pack_hw_configure(const llk_pack_params_t* pack_params) {
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
@@ -45,7 +45,7 @@ inline void llk_pack_hw_configure(const llk_pack_params_t* pack_params) {
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
+    _llk_pack_hw_configure_<fp32_dest_accumulation, untilize>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
@@ -57,7 +57,7 @@ inline void llk_pack_hw_configure(const llk_pack_params_t* pack_params) {
 }
 
 template <
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     bool untilize = false,
     ReluType relu_type = ReluType::NO_RELU,
     std::uint32_t relu_threshold = 0,
@@ -70,10 +70,10 @@ inline void llk_pack_hw_configure_disaggregated(std::uint32_t pack_output) {
                 .ApplyRelu = (std::uint32_t)relu_type,
                 .Threshold = relu_threshold,
             }}};
-    llk_pack_hw_configure<is_fp32_dest_acc_en, untilize>(&llk_pack_params);
+    llk_pack_hw_configure<fp32_dest_accumulation, untilize>(&llk_pack_params);
 }
 
-template <bool is_fp32_dest_acc_en, bool untilize = false>
+template <DestAccumulation fp32_dest_accumulation, bool untilize = false>
 inline void llk_pack_untilize_hw_configure(
     const llk_pack_params_t* pack_params, const std::uint32_t face_r_dim, const std::uint32_t num_faces) {
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
@@ -82,7 +82,7 @@ inline void llk_pack_untilize_hw_configure(
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
+    _llk_pack_hw_configure_<fp32_dest_accumulation, untilize>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
@@ -94,7 +94,7 @@ inline void llk_pack_untilize_hw_configure(
 }
 
 template <
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     bool untilize = false,
     ReluType relu_type = ReluType::NO_RELU,
     std::uint32_t relu_threshold = 0,
@@ -108,10 +108,10 @@ inline void llk_pack_untilize_hw_configure_disaggregated(
                 .ApplyRelu = (std::uint32_t)relu_type,
                 .Threshold = relu_threshold,
             }}};
-    llk_pack_untilize_hw_configure<is_fp32_dest_acc_en, untilize>(&llk_pack_params, face_r_dim, num_faces);
+    llk_pack_untilize_hw_configure<fp32_dest_accumulation, untilize>(&llk_pack_params, face_r_dim, num_faces);
 }
 
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, bool untilize = false>
+template <PoolType type, ReduceDim dim, DestAccumulation fp32_dest_accumulation, bool untilize = false>
 inline void llk_pack_reduce_hw_configure(const llk_pack_params_t* pack_params) {
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
@@ -121,7 +121,7 @@ inline void llk_pack_reduce_hw_configure(const llk_pack_params_t* pack_params) {
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
-    _llk_pack_reduce_hw_configure_<type, dim, is_fp32_dest_acc_en, untilize>(
+    _llk_pack_reduce_hw_configure_<type, dim, fp32_dest_accumulation, untilize>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
@@ -135,7 +135,7 @@ inline void llk_pack_reduce_hw_configure(const llk_pack_params_t* pack_params) {
 template <
     PoolType type,
     ReduceDim dim,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     bool untilize = false,
     ReluType relu_type = ReluType::NO_RELU,
     std::uint32_t relu_threshold = 0>
@@ -143,7 +143,7 @@ inline void llk_pack_reduce_hw_configure_disaggregated(std::uint32_t pack_output
     llk_pack_params_t llk_pack_params = {
         .pack_output = pack_output,
         .relu_config = {.f = {.ApplyRelu = (std::uint32_t)relu_type, .Threshold = relu_threshold}}};
-    llk_pack_reduce_hw_configure<type, dim, is_fp32_dest_acc_en, untilize>(&llk_pack_params);
+    llk_pack_reduce_hw_configure<type, dim, fp32_dest_accumulation, untilize>(&llk_pack_params);
 }
 
 template <bool untilize = false, bool zero_output = false, bool tilize = false /*unused*/>
@@ -202,7 +202,7 @@ inline std::uint32_t get_output_tile_address(std::uint8_t output_id, std::uint32
     return pack_tile_addr;
 }
 
-template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, bool untilize = false>
+template <DestAccumulation fp32_dest_accumulation, bool out_of_order_output = false, bool untilize = false>
 inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32_t output_tile_index = 0) {
     std::uint8_t output_id = get_output_id(output);
 
@@ -210,7 +210,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
 
     std::uint32_t pack_tile_addr = get_output_tile_address<out_of_order_output, untilize>(output_id, output_tile_index);
 
-    _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(tile_index, pack_tile_addr);
+    _llk_pack_<DST_SYNC_MODE, fp32_dest_accumulation, untilize>(tile_index, pack_tile_addr);
 }
 
 /*************************************************************************
@@ -268,7 +268,7 @@ inline void llk_pack_untilize(
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, bool untilize = false>
+template <DestAccumulation fp32_dest_accumulation, bool out_of_order_output = false, bool untilize = false>
 inline void llk_matmul_pack(
     std::uint32_t start_tile_index, std::uint32_t output, uint32_t ntiles, std::uint32_t output_tile_index = 0) {
     std::uint8_t output_id = get_output_id(output);
@@ -279,7 +279,7 @@ inline void llk_matmul_pack(
         std::uint32_t pack_tile_addr =
             get_output_tile_address<out_of_order_output, untilize>(output_id, output_tile_index);
 
-        _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(tile_index, pack_tile_addr);
+        _llk_pack_<DST_SYNC_MODE, fp32_dest_accumulation, untilize>(tile_index, pack_tile_addr);
     }
 }
 
@@ -294,9 +294,9 @@ inline void llk_packer_set_math_semaphore() {
     _llk_packer_set_math_semaphore_<WaitRes>();
 }
 
-template <bool is_fp32_dest_acc_en>
+template <DestAccumulation fp32_dest_accumulation>
 inline void llk_pack_dest_section_done() {
-    _llk_pack_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
+    _llk_pack_dest_section_done_<DST_SYNC_MODE, fp32_dest_accumulation>();
 }
 
 template <bool untilize = false, bool diagonal = false>
@@ -309,13 +309,13 @@ inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_outpu
         face_r_dim, narrow_tile);
 }
 
-template <bool is_fp32_dest_acc_en, bool untilize = false>
+template <DestAccumulation fp32_dest_accumulation, bool untilize = false>
 inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
     const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor, untilize>(
+    _llk_pack_dest_init_<DST_SYNC_MODE, fp32_dest_accumulation, DstTileFaceLayout::RowMajor, untilize>(
         face_r_dim, narrow_tile);
 }
 
@@ -333,7 +333,7 @@ inline void llk_pack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _
 
 inline void llk_pack_debug_dump_seek(std::uint8_t offset) { _llk_pack_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool is_tile_dim_reconfig_en = false>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t output_id = get_output_id(new_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
@@ -341,7 +341,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en, is_tile_dim_reconfig_en, DstTileFaceLayout::RowMajor>(
+    _llk_pack_reconfig_data_format_<fp32_dest_accumulation, is_tile_dim_reconfig_en, DstTileFaceLayout::RowMajor>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         get_local_cb_interface(output_id).fifo_page_size,
@@ -351,7 +351,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
         narrow_tile);
 }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool is_tile_dim_reconfig_en = false>
 inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const std::uint32_t new_output) {
     std::uint32_t old_output_id = get_output_id(old_output);
     std::uint32_t new_output_id = get_output_id(new_output);
@@ -359,7 +359,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const 
     if ((pack_dst_format[old_output_id] != pack_dst_format[new_output_id]) &&
         (pack_dst_format[old_output_id] != (uint)DataFormat::Invalid) &&
         (pack_dst_format[new_output_id] != (uint)DataFormat::Invalid)) {
-        llk_pack_reconfig_data_format<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(new_output);
+        llk_pack_reconfig_data_format<fp32_dest_accumulation, is_tile_dim_reconfig_en>(new_output);
     } else if constexpr (is_tile_dim_reconfig_en) {
         // Same format but different tile dims
         llk_pack_mop_config<false, false>(new_output);
@@ -378,7 +378,7 @@ inline void llk_pack_reduce_mask_config() {
 inline void llk_pack_reduce_mask_clear() { _llk_pack_reduce_mask_clear_(); }
 
 // FIXME-WH-UPLIFT
-template <ReduceDim dim, bool is_fp32_dest_acc_en, bool at_kernel_start = false, bool revert = false>
+template <ReduceDim dim, DestAccumulation fp32_dest_accumulation, bool at_kernel_start = false, bool revert = false>
 inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
     const bool untilize = false;
     if constexpr (at_kernel_start) {
@@ -394,7 +394,7 @@ inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
                 .Threshold = 0,
             }};
 
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
+        _llk_pack_hw_configure_<fp32_dest_accumulation, untilize>(
             pack_src_format[output_id],
             pack_dst_format[output_id],
             tile_size,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_param_structs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_param_structs.h
@@ -6,6 +6,16 @@
 
 #include <cstdint>
 
+// Enum class for destination accumulation control - replaces boolean template parameter is_fp32_dest_acc_en
+enum class DestAccumulation {
+    Disable = 0,
+    Enable = 1
+};
+
+// Convenience constants for backward compatibility and readability
+constexpr DestAccumulation DestAccumulation_Disable = DestAccumulation::Disable;
+constexpr DestAccumulation DestAccumulation_Enable = DestAccumulation::Enable;
+
 //***
 //  Unpack LLK param structs
 //***

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -20,9 +20,9 @@ sfpi_inline vFloat sfpu_reciprocal(const vFloat in) {
     return _sfpu_reciprocal_<max_iter>(in);
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, DestAccumulation fp32_dest_accumulation, int ITERATIONS = 8>
 inline void calculate_reciprocal() {
-    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(ITERATIONS);
+    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_accumulation>(ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_recip.h
@@ -12,10 +12,10 @@ namespace ckernel {
 
 // New LLK SFPU APIs
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+template <bool APPROXIMATE, DestAccumulation fp32_dest_accumulation>
 inline void llk_math_eltwise_unary_sfpu_reciprocal(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_reciprocal<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_reciprocal<APPROXIMATE, fp32_dest_accumulation, 8>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -10,7 +10,7 @@
  * LLK UNPACK AB
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
+template <DestAccumulation fp32_dest_accumulation, StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_AB_hw_configure(
     const llk_unpack_AB_params_t* unpack_AB_params, const int within_face_16x16_transpose = 0) {
     // In0 -> unpA
@@ -23,7 +23,7 @@ inline void llk_unpack_AB_hw_configure(
     const uint32_t num_faces = get_operand_num_faces(unpA_operand_id);    // num faces in unpA and unpB are the same
     const uint32_t face_r_dim = get_operand_face_r_dim(unpA_operand_id);  // face r dim in unpA and unpB are the same
 
-    _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_AB_hw_configure_<fp32_dest_accumulation, stoch_rnd_mode>(
         unpack_src_format[unpA_operand_id],
         unpack_src_format[unpB_operand_id],
         unpack_dst_format[unpA_operand_id],
@@ -33,12 +33,12 @@ inline void llk_unpack_AB_hw_configure(
         num_faces);
 }
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
+template <DestAccumulation fp32_dest_accumulation, StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_AB_hw_configure_disaggregated(
     const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const int within_face_16x16_transpose = 0) {
     const llk_unpack_AB_params_t unpack_AB_params = {.unpA_operand = unpA_operand, .unpB_operand = unpB_operand};
 
-    llk_unpack_AB_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_AB_params, within_face_16x16_transpose);
+    llk_unpack_AB_hw_configure<fp32_dest_accumulation, stoch_rnd_mode>(&unpack_AB_params, within_face_16x16_transpose);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -10,7 +10,7 @@
  * LLK UNPACK AB MATMUL
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
+template <DestAccumulation fp32_dest_accumulation, StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_AB_matmul_hw_configure(const llk_unpack_AB_matmul_params_t* unpack_AB_params) {
     const bool transpose_xy_srca = unpack_AB_params->transpose_xy_srca;
 
@@ -27,7 +27,7 @@ inline void llk_unpack_AB_matmul_hw_configure(const llk_unpack_AB_matmul_params_
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
     const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
 
-    _llk_unpack_AB_matmul_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_AB_matmul_hw_configure_<fp32_dest_accumulation, stoch_rnd_mode>(
         unpack_src_format[unpA_operand_id],
         unpack_src_format[unpB_operand_id],
         unpack_dst_format[unpA_operand_id],
@@ -41,12 +41,12 @@ inline void llk_unpack_AB_matmul_hw_configure(const llk_unpack_AB_matmul_params_
         get_local_cb_interface(unpB_operand_id).fifo_page_size);
 }
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
+template <DestAccumulation fp32_dest_accumulation, StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_AB_matmul_hw_configure_disaggregated(
     const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const std::uint32_t transpose_xy_srca = 0) {
     const llk_unpack_AB_matmul_params_t unpack_AB_matmul_params = {
         .unpA_operand = unpA_operand, .unpB_operand = unpB_operand, .transpose_xy_srca = transpose_xy_srca};
-    llk_unpack_AB_matmul_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_AB_matmul_params);
+    llk_unpack_AB_matmul_hw_configure<fp32_dest_accumulation, stoch_rnd_mode>(&unpack_AB_matmul_params);
 }
 
 inline void llk_unpack_AB_matmul_mop_config(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -11,7 +11,7 @@
  *************************************************************************/
 
 template <
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     StochRndType stoch_rnd_mode = StochRndType::None,
     bool disable_src_zero_flag = false>
 inline void llk_unpack_A_hw_configure(
@@ -20,7 +20,7 @@ inline void llk_unpack_A_hw_configure(
     const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
 
-    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
+    _llk_unpack_A_hw_configure_<fp32_dest_accumulation, stoch_rnd_mode, disable_src_zero_flag>(
         unpack_src_format[unpA_operand_id],
         unpack_dst_format[unpA_operand_id],
         unpA_face_r_dim,
@@ -29,13 +29,13 @@ inline void llk_unpack_A_hw_configure(
 }
 
 template <
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     StochRndType stoch_rnd_mode = StochRndType::None,
     bool disable_src_zero_flag = false>
 inline void llk_unpack_A_hw_configure_disaggregated(
     const std::uint32_t unpA_operand, const int within_face_16x16_transpose = 0) {
     const llk_unpack_A_params_t unpack_A_params = {.unpA_operand = unpA_operand};
-    llk_unpack_A_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
+    llk_unpack_A_hw_configure<fp32_dest_accumulation, stoch_rnd_mode, disable_src_zero_flag>(
         &unpack_A_params, within_face_16x16_transpose);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -53,74 +53,74 @@ inline void llk_unpack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) {
 
 inline void llk_unpack_debug_dump_seek(std::uint8_t offset) { _llk_unpack_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
-    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srca_impl_<fp32_dest_accumulation, to_from_int8>(
         unpack_src_format[srca_operand_id],
         unpack_dst_format[srca_operand_id],
         get_local_cb_interface(srca_operand_id).fifo_page_size);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
-    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srcb_impl_<fp32_dest_accumulation, to_from_int8>(
         unpack_src_format[srcb_operand_id],
         unpack_dst_format[srcb_operand_id],
         get_local_cb_interface(srcb_operand_id).fifo_page_size);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if (should_reconfigure_cbs(srca_old_operand, srca_new_operand)) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+        llk_unpack_reconfig_data_format_srca<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(
             srca_new_operand);
     } else if constexpr (is_tile_dim_reconfig_en) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+        llk_unpack_reconfig_data_format_srca<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(
             srca_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if (should_reconfigure_cbs(srcb_old_operand, srcb_new_operand)) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+        llk_unpack_reconfig_data_format_srcb<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(
             srcb_new_operand);
     } else if constexpr (is_tile_dim_reconfig_en) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+        llk_unpack_reconfig_data_format_srcb<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(
             srcb_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(srcb_new_operand);
+    llk_unpack_reconfig_data_format_srca<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(srca_new_operand);
+    llk_unpack_reconfig_data_format_srcb<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(srcb_new_operand);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <DestAccumulation fp32_dest_accumulation, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
     const std::uint32_t srcb_old_operand,
     const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+    llk_unpack_reconfig_data_format_srca<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(
         srca_old_operand, srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
+    llk_unpack_reconfig_data_format_srcb<fp32_dest_accumulation, to_from_int8, is_tile_dim_reconfig_en>(
         srcb_old_operand, srcb_new_operand);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
@@ -13,7 +13,7 @@
 template <
     PoolType type,
     ReduceDim dim,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_reduce_hw_configure(
     const llk_unpack_reduce_params_t* unpack_reduce_params, const float const_mult) {
@@ -31,7 +31,7 @@ inline void llk_unpack_reduce_hw_configure(
             ((((std::uint32_t)unpack_dst_format[unpA_operand_id] >> 2) & 0x1) ? (std::uint32_t)DataFormat::Float16_b
                                                                               : (std::uint32_t)DataFormat::Float16);
 
-    _llk_unpack_reduce_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_reduce_hw_configure_<fp32_dest_accumulation, stoch_rnd_mode>(
         unpack_src_format[unpA_operand_id],
         unpB_src_format,
         unpack_dst_format[unpA_operand_id],
@@ -46,11 +46,11 @@ inline void llk_unpack_reduce_hw_configure(
 template <
     PoolType type,
     ReduceDim dim,
-    bool is_fp32_dest_acc_en,
+    DestAccumulation fp32_dest_accumulation,
     StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_reduce_hw_configure_disaggregated(const std::uint32_t unpA_operand, const float mult) {
     const llk_unpack_reduce_params_t unpack_reduce_params = {.unpA_operand = unpA_operand};
-    llk_unpack_reduce_hw_configure<type, dim, is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_reduce_params, mult);
+    llk_unpack_reduce_hw_configure<type, dim, fp32_dest_accumulation, stoch_rnd_mode>(&unpack_reduce_params, mult);
 }
 
 template <PoolType type, ReduceDim dim>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -11,7 +11,7 @@
  * LLK UNPACK TILIZE
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en>
+template <DestAccumulation fp32_dest_accumulation>
 inline void llk_unpack_tilize_hw_configure(const llk_unpack_A_params_t* unpack_tilize_params) {
     constexpr bool within_face_16x16_transpose = false;
     constexpr StochRndType stoch_rnd_mode = StochRndType::None;
@@ -20,7 +20,7 @@ inline void llk_unpack_tilize_hw_configure(const llk_unpack_A_params_t* unpack_t
     const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
 
-    _llk_unpack_tilize_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_tilize_hw_configure_<fp32_dest_accumulation, stoch_rnd_mode>(
         unpack_src_format[unpA_operand_id],
         unpack_dst_format[unpA_operand_id],
         unpA_face_r_dim,
@@ -28,10 +28,10 @@ inline void llk_unpack_tilize_hw_configure(const llk_unpack_A_params_t* unpack_t
         unpA_num_faces);
 }
 
-template <bool is_fp32_dest_acc_en>
+template <DestAccumulation fp32_dest_accumulation>
 inline void llk_unpack_tilize_hw_configure_disaggregated(const std::uint32_t unpA_operand) {
     const llk_unpack_A_params_t unpack_tilize_params = {.unpA_operand = unpA_operand};
-    llk_unpack_tilize_hw_configure<is_fp32_dest_acc_en>(&unpack_tilize_params);
+    llk_unpack_tilize_hw_configure<fp32_dest_accumulation>(&unpack_tilize_params);
 }
 
 inline void llk_unpack_tilize_mop_config(const std::uint32_t operand) {
@@ -102,7 +102,7 @@ inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c
  * LLK UNPACK TILIZE SRC A, UNPACK SRC B
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
+template <DestAccumulation fp32_dest_accumulation, StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_tilizeA_B_hw_configure(
     const llk_unpack_AB_params_t* unpack_tilizeA_B_params, const int within_face_16x16_transpose = 0) {
     // In0 -> unpA
@@ -116,7 +116,7 @@ inline void llk_unpack_tilizeA_B_hw_configure(
 
     const uint32_t face_r_dim = get_operand_face_r_dim(unpA_operand_id);  // face r dim in unpA and unpB are the same
 
-    _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_AB_hw_configure_<fp32_dest_accumulation, stoch_rnd_mode>(
         unpack_src_format[unpA_operand_id],
         unpack_src_format[unpB_operand_id],
         unpack_dst_format[unpA_operand_id],
@@ -126,11 +126,11 @@ inline void llk_unpack_tilizeA_B_hw_configure(
         num_faces);
 }
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
+template <DestAccumulation fp32_dest_accumulation, StochRndType stoch_rnd_mode = StochRndType::None>
 inline void llk_unpack_tilizeA_B_hw_configure_disaggregated(
     const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const int within_face_16x16_transpose = 0) {
     const llk_unpack_AB_params_t unpack_tilizeA_B_params = {.unpA_operand = unpA_operand, .unpB_operand = unpB_operand};
-    llk_unpack_tilizeA_B_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    llk_unpack_tilizeA_B_hw_configure<fp32_dest_accumulation, stoch_rnd_mode>(
         &unpack_tilizeA_B_params, within_face_16x16_transpose);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
@@ -9,7 +9,7 @@
 /*************************************************************************
  * LLK UNPACK UNTILIZE
  *************************************************************************/
-template <bool is_fp32_dest_acc_en>
+template <DestAccumulation fp32_dest_accumulation>
 inline void llk_unpack_untilize_hw_configure(const llk_unpack_A_params_t* unpack_untilize_params) {
     constexpr bool is_row_pool = false;
     constexpr bool within_face_16x16_transpose = false;
@@ -19,7 +19,7 @@ inline void llk_unpack_untilize_hw_configure(const llk_unpack_A_params_t* unpack
     const uint32_t unpA_num_faces = 4;
     const uint32_t unpA_face_r_dim = FACE_R_DIM;
 
-    _llk_unpack_untilize_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_untilize_hw_configure_<fp32_dest_accumulation, stoch_rnd_mode>(
         unpack_src_format[unpA_operand_id],
         unpack_dst_format[unpA_operand_id],
         unpA_face_r_dim,
@@ -27,12 +27,12 @@ inline void llk_unpack_untilize_hw_configure(const llk_unpack_A_params_t* unpack
         unpA_num_faces);
 }
 
-template <bool is_fp32_dest_acc_en>
+template <DestAccumulation fp32_dest_accumulation>
 inline void llk_unpack_untilize_hw_configure_disaggregated(const std::uint32_t unpA_operand) {
     const llk_unpack_A_params_t unpack_untilize_params = {
         .unpA_operand = unpA_operand,
     };
-    llk_unpack_untilize_hw_configure<is_fp32_dest_acc_en>(&unpack_untilize_params);
+    llk_unpack_untilize_hw_configure<fp32_dest_accumulation>(&unpack_untilize_params);
 }
 
 inline void llk_unpack_untilize_mop_config() { _llk_unpack_untilize_mop_config_(); }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -397,12 +397,22 @@ static void generate_dst_accum_mode_descriptor(JitBuildOptions& options) {
     ofstream file_stream;
 
     file_stream.open(dst_accum_format_descriptor);
+    
+    file_stream << "#pragma once" << endl;
+    file_stream << "#include \"llk_param_structs.h\"" << endl << endl;
 
+    file_stream << "#ifndef DST_ACCUM_MODE" << endl;
     if (options.fp32_dest_acc_en == 0) {
-        file_stream << "constexpr bool DST_ACCUM_MODE = false;" << endl;
+        file_stream << "constexpr DestAccumulation DST_ACCUM_MODE = DestAccumulation::Disable;" << endl;
     } else {
-        file_stream << "constexpr bool DST_ACCUM_MODE = true;" << endl;
+        file_stream << "constexpr DestAccumulation DST_ACCUM_MODE = DestAccumulation::Enable;" << endl;
     }
+    file_stream << "#else" << endl;
+    file_stream << "// DST_ACCUM_MODE is already defined as a macro, create enum value from it" << endl;
+    file_stream << "constexpr DestAccumulation DST_ACCUM_MODE_ENUM = (DST_ACCUM_MODE) ? DestAccumulation::Enable : DestAccumulation::Disable;" << endl;
+    file_stream << "#undef DST_ACCUM_MODE" << endl;
+    file_stream << "#define DST_ACCUM_MODE DST_ACCUM_MODE_ENUM" << endl;
+    file_stream << "#endif" << endl;
 
     file_stream.close();
 }


### PR DESCRIPTION
### Ticket
#24109 

### Problem description
Convert is_dest_accum_en boolean template parameter to enum classg

### What's changed
Updated `tt_metal/jit_build/genfiles.cpp` to generate `constexpr DestAccumulation DST_ACCUM_MODE = DestAccumulation::Enable/Disable` instead of boolean values, completing the boolean-to-enum conversion for destination accumulation template parameters across the entire codebase.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes