### PR TITLE
IOMMU tests

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -66,8 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: n150-viommu },
-          { arch: wormhole_b0, runner-label: N300 },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
         ]
     uses: ./.github/workflows/build-and-unit-tests.yaml
     with:
@@ -84,31 +83,13 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: n150-viommu },
-          { arch: wormhole_b0, runner-label: N300 },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
         ]
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # Fabric Unit Tests
-  fabric-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # TTNN FD Unit tests
   ttnn-unit-tests:
@@ -118,8 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: n150-viommu },
-          { arch: wormhole_b0, runner-label: N300 },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
         ]
     uses: ./.github/workflows/ttnn-post-commit.yaml
     with:
@@ -136,8 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: n150-viommu },
-          { arch: wormhole_b0, runner-label: N300 },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
         ]
     uses: ./.github/workflows/models-post-commit.yaml
     with:
@@ -153,8 +132,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: n150-viommu },
-          { arch: wormhole_b0, runner-label: N300 },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
         ]
     uses: ./.github/workflows/cpp-post-commit.yaml
     with:
@@ -170,8 +148,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: n150-viommu },
-          { arch: wormhole_b0, runner-label: N300 },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
         ]
     uses: ./.github/workflows/tt-train-post-commit.yaml
     with:
@@ -185,8 +162,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: n150-viommu },
-          { arch: wormhole_b0, runner-label: N300 },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
         ]
     uses: ./.github/workflows/run-profiler-regression.yaml
     secrets: inherit

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -118,8 +118,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n300-viommu-large-stable },
         ]
     uses: ./.github/workflows/ttnn-post-commit.yaml
     with:
@@ -136,8 +136,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n300-viommu-large-stable },
         ]
     uses: ./.github/workflows/models-post-commit.yaml
     with:
@@ -153,8 +153,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n300-viommu-large-stable },
         ]
     uses: ./.github/workflows/cpp-post-commit.yaml
     with:
@@ -170,8 +170,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n300-viommu-large-stable },
         ]
     uses: ./.github/workflows/tt-train-post-commit.yaml
     with:

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: n150-viommu },
+          { arch: wormhole_b0, runner-label: N150 },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/build-and-unit-tests.yaml
@@ -84,7 +84,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: n150-viommu },
+          { arch: wormhole_b0, runner-label: N150 },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -118,7 +118,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: n150-viommu },
+          { arch: wormhole_b0, runner-label: N150 },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/ttnn-post-commit.yaml
@@ -136,7 +136,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: n150-viommu },
+          { arch: wormhole_b0, runner-label: N150 },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/models-post-commit.yaml
@@ -153,7 +153,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: n150-viommu },
+          { arch: wormhole_b0, runner-label: N150 },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/cpp-post-commit.yaml
@@ -170,7 +170,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: n150-viommu },
+          { arch: wormhole_b0, runner-label: N150 },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/tt-train-post-commit.yaml
@@ -185,7 +185,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: n150-viommu },
+          { arch: wormhole_b0, runner-label: N150 },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/run-profiler-regression.yaml

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -66,7 +66,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
+          { arch: wormhole_b0, runner-label: n150-viommu },
+          { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/build-and-unit-tests.yaml
     with:
@@ -83,13 +84,31 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
+          { arch: wormhole_b0, runner-label: n150-viommu },
+          { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # Fabric Unit Tests
+  fabric-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # TTNN FD Unit tests
   ttnn-unit-tests:
@@ -99,7 +118,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
+          { arch: wormhole_b0, runner-label: n150-viommu },
+          { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/ttnn-post-commit.yaml
     with:
@@ -116,7 +136,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
+          { arch: wormhole_b0, runner-label: n150-viommu },
+          { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/models-post-commit.yaml
     with:
@@ -132,7 +153,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
+          { arch: wormhole_b0, runner-label: n150-viommu },
+          { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/cpp-post-commit.yaml
     with:
@@ -148,7 +170,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
+          { arch: wormhole_b0, runner-label: n150-viommu },
+          { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/tt-train-post-commit.yaml
     with:
@@ -162,7 +185,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n150-viommu-large-stable },
+          { arch: wormhole_b0, runner-label: n150-viommu },
+          { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/run-profiler-regression.yaml
     secrets: inherit

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: n150-viommu },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/build-and-unit-tests.yaml
@@ -84,7 +84,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: n150-viommu },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -118,7 +118,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: n150-viommu },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/ttnn-post-commit.yaml
@@ -136,7 +136,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: n150-viommu },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/models-post-commit.yaml
@@ -153,7 +153,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: n150-viommu },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/cpp-post-commit.yaml
@@ -170,7 +170,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: n150-viommu },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/tt-train-post-commit.yaml
@@ -185,7 +185,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: n150-viommu },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/run-profiler-regression.yaml

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   metalium-basic:
-    runs-on: ${{ format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner) }}
+    runs-on: ${{ format('tt-beta-ubuntu-2204-{0}-viommu-large-stable', inputs.runner) }}
     container:
       image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -31,7 +31,6 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -44,7 +44,7 @@ jobs:
           }
         ]
     name: ${{ matrix.test-group.name }}
-    runs-on: ["in-service", "${{ inputs.runner-label }}", "pipeline-perf"]
+    runs-on: ${{ inputs.runner-label }}
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
@@ -31,7 +31,7 @@ jobs:
           }
         ]
     name: ${{ matrix.test-group.name }}
-    runs-on: ["in-service", "${{ inputs.runner-label }}", "pipeline-perf"]
+    runs-on: ${{ inputs.runner-label }}
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
@@ -53,7 +53,6 @@ jobs:
         GTEST_OUTPUT: xml:/work/generated/test_reports/
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -45,7 +45,6 @@ jobs:
         LOGURU_LEVEL: INFO
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -7,7 +7,7 @@ on:
           description: 'Optional: BH'
           required: false
           type: string
-          default: 'BH'
+          default: 'tt-beta-ubuntu-2204-p150b-viommu-large-stable'
       enable-ttnn-unit-tests:
           description: 'Enable ttnn unit tests'
           default: false
@@ -26,7 +26,7 @@ on:
           description: 'Optional: BH'
           required: true
           type: string
-          default: 'BH'
+          default: 'tt-beta-ubuntu-2204-p150b-viommu-large-stable'
       build-type:
         description: 'Build type for the workflow'
         required: false
@@ -111,7 +111,7 @@ jobs:
     secrets: inherit
     with:
       arch: "blackhole"
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
@@ -122,7 +122,7 @@ jobs:
     uses: ./.github/workflows/umd-unit-tests.yaml
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   sd-unit-tests:
@@ -131,7 +131,7 @@ jobs:
     secrets: inherit
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -143,7 +143,7 @@ jobs:
     with:
       timeout: 40
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
@@ -154,7 +154,7 @@ jobs:
     uses: ./.github/workflows/cpp-post-commit.yaml
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       timeout: 20
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
@@ -180,7 +180,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
     with:
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -192,7 +192,7 @@ jobs:
     uses: ./.github/workflows/ttnn-post-commit.yaml
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -244,7 +244,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
     with:
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -257,7 +257,7 @@ jobs:
     uses: ./.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -81,7 +81,7 @@ jobs:
             fi
             matrix='["BH-LLMBox"]'
           else
-            matrix='["P100", "P150"]'
+            matrix='["P100", "tt-beta-ubuntu-2204-p150b-viommu-large-stable"]'
           fi
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
@@ -111,7 +111,7 @@ jobs:
     secrets: inherit
     with:
       arch: "blackhole"
-      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
+      runner-label: ${{ 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
@@ -122,7 +122,7 @@ jobs:
     uses: ./.github/workflows/umd-unit-tests.yaml
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
+      runner-label: ${{ 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   sd-unit-tests:
@@ -131,7 +131,7 @@ jobs:
     secrets: inherit
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
+      runner-label: ${{ 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -143,7 +143,7 @@ jobs:
     with:
       timeout: 40
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
+      runner-label: ${{ 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
@@ -180,7 +180,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
     with:
-      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
+      runner-label: ${{ 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -192,7 +192,7 @@ jobs:
     uses: ./.github/workflows/ttnn-post-commit.yaml
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
+      runner-label: ${{ 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -244,7 +244,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
     with:
-      runner-label: ${{ inputs.runner-label || 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
+      runner-label: ${{ 'tt-beta-ubuntu-2204-p150b-viommu-large-stable' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -51,8 +51,8 @@ jobs:
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
-        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
+        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-viommu-large-stable', inputs.runner-label))
+        || fromJSON(format('["{0}"]', inputs.runner-label))
       }}
     container:
       image: ${{ (inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && 'harbor.ci.tenstorrent.net/' || '' }}${{ inputs.docker-image || 'docker-image-unresolved!' }}

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -66,7 +66,6 @@ jobs:
         TT_METAL_HOME: /work
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/conda-post-commit.yaml
+++ b/.github/workflows/conda-post-commit.yaml
@@ -100,7 +100,6 @@ jobs:
         PYTHONPATH: /work
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -75,8 +75,8 @@ jobs:
     runs-on: >-
       ${{
         (startsWith(inputs.runner-label, 'tt-beta-ubuntu') && fromJSON(format('["{0}"]', inputs.runner-label)))
-        || github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
-        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
+        || github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-viommu-large-stable', inputs.runner-label)
+        || fromJSON(format('["{0}"]', inputs.runner-label))
       }}
     steps:
       - name: ⬇️  Setup Job

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -66,7 +66,6 @@ jobs:
         TT_METAL_HOME: /work
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/didt-tests.yaml
+++ b/.github/workflows/didt-tests.yaml
@@ -34,7 +34,6 @@ jobs:
         PYTHONPATH: /work
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/fabric-build-and-unit-tests-wrapper.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests-wrapper.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n300-large-stable },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n300-viommu-large-stable },
         ]
     uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
     with:

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -36,9 +36,9 @@ jobs:
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
-        || github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
-        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
+        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-viommu-large-stable', inputs.runner-label))
+        || github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-viommu-large-stable', inputs.runner-label)
+        || fromJSON(format('["{0}"]', inputs.runner-label))
       }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved' }}

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -51,7 +51,6 @@ jobs:
         GTEST_OUTPUT: xml:/work/generated/test_reports/
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -44,8 +44,8 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
-        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
+        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-viommu-large-stable', inputs.runner-label))
+        || fromJSON(format('["{0}"]', inputs.runner-label))
       }}
     container:
       image: ${{ (inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && 'harbor.ci.tenstorrent.net/' || '' }}${{ inputs.docker-image || 'docker-image-unresolved!' }}

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -55,7 +55,6 @@ jobs:
         PYTHONPATH: /work
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -95,7 +95,6 @@ jobs:
         TT_METAL_DEVICE_PROFILER: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -37,8 +37,8 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
-        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
+        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-viommu-large-stable', inputs.runner-label)
+        || fromJSON(format('["{0}"]', inputs.runner-label))
       }}
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -48,7 +48,6 @@ jobs:
         PYTHONPATH: /work
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:
@@ -87,8 +86,6 @@ jobs:
     name: models slow dispatch
     runs-on:
       - ${{ inputs.runner-label }}
-      - in-service
-      - cloud-virtual-machine
     container:
       image: ${{ inputs.docker-image }}
       env:
@@ -98,7 +95,6 @@ jobs:
         SLOW_RUNTIME_MODE: true
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -25,8 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          {name: "N300 WH B0 not yet ported", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal", civ2-compatible: false, timeout: 120},
-          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["tt-beta-ubuntu-2204-n300-large-stable"], machine-type: "CIv2", civ2-compatible: true, timeout: 120},
+          {name: "N300 WH B0 not yet ported", arch: wormhole_b0, runs-on: ["tt-beta-ubuntu-2204-n300-viommu-large-stable"], machine-type: "bare_metal", civ2-compatible: false, timeout: 120},
+          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["tt-beta-ubuntu-2204-n300-viommu-large-stable"], machine-type: "CIv2", civ2-compatible: true, timeout: 120},
         ]
     name: "${{ matrix.test-info.name }} device perf"
     runs-on: ${{ matrix.test-info.runs-on }}
@@ -41,7 +41,6 @@ jobs:
         GITHUB_ACTIONS: true
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal"},
+          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["tt-beta-ubuntu-2204-n300-viommu-large-stable"], machine-type: "bare_metal"},
         ]
         model-type: [llm_javelin, cnn_javelin, other]
     name: "${{ matrix.model-type }} ${{ matrix.test-info.name }}"

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -90,7 +90,6 @@ jobs:
         PYTHONPATH: /work
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -67,8 +67,8 @@ jobs:
       fail-fast: false
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
-        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
+        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-viommu-large-stable', inputs.runner-label))
+        || fromJSON(format('["{0}"]', inputs.runner-label))
       }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -88,7 +88,6 @@ jobs:
         TRACY_NO_INVARIANT_CHECK: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent -e TT_GH_CI_INFRA"
     defaults:

--- a/.github/workflows/sdk-examples.yaml
+++ b/.github/workflows/sdk-examples.yaml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   sdk-examples:
-    runs-on: ${{ format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner) }}
+    runs-on: ${{ format('tt-beta-ubuntu-2204-{0}-viommu-large-stable', inputs.runner) }}
     container:
       image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!'}}
       volumes:

--- a/.github/workflows/sdk-examples.yaml
+++ b/.github/workflows/sdk-examples.yaml
@@ -23,7 +23,6 @@ jobs:
       image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!'}}
       volumes:
         - /work
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -24,8 +24,8 @@ jobs:
   smoke:
     runs-on: >-
       ${{
-        ((inputs.runner == 'N150' || inputs.runner == 'N300' || inputs.runner == 'N300-llmbox' || inputs.runner == 'P150b-viommu') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner))
-        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner))
+        ((inputs.runner == 'N150' || inputs.runner == 'N300' || inputs.runner == 'N300-llmbox' || inputs.runner == 'P150b-viommu') && format('tt-beta-ubuntu-2204-{0}-viommu-large-stable', inputs.runner))
+        || fromJSON(format('["{0}"]', inputs.runner))
       }}
     container:
       image: ${{ (inputs.runner == 'N150' || inputs.runner == 'N300' || inputs.runner == 'N300-llmbox' || inputs.runner == 'P150b-viommu') && 'harbor.ci.tenstorrent.net/' || '' }}${{ inputs.docker-image || 'docker-image-unresolved!' }}

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -35,7 +35,6 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -44,10 +44,7 @@ jobs:
     env:
        ARCH_NAME: ${{ matrix.test-group.arch }}
     runs-on:
-      - arch-wormhole_b0
-      - config-t3000
-      - pipeline-perf
-      - ${{ inputs.extra-tag }}
+      - tt-beta-ubuntu-2204-n300-llmbox-viommu-stable
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -35,7 +35,6 @@ jobs:
         GTEST_OUTPUT: xml:/work/generated/test_reports/
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -56,7 +56,6 @@ jobs:
         LOGURU_LEVEL: INFO
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/t3000-model-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-model-perf-tests-impl.yaml
@@ -39,10 +39,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     runs-on:
-      - arch-wormhole_b0
-      - config-t3000
-      - pipeline-perf
-      - ${{ inputs.extra-tag }}
+      - tt-beta-ubuntu-2204-n300-llmbox-viommu-stable
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/t3000-nightly-tests-impl.yaml
+++ b/.github/workflows/t3000-nightly-tests-impl.yaml
@@ -43,7 +43,6 @@ jobs:
         LOGURU_LEVEL: INFO
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/t3000-perplexity-tests-impl.yaml
+++ b/.github/workflows/t3000-perplexity-tests-impl.yaml
@@ -49,7 +49,6 @@ jobs:
         LOGURU_LEVEL: INFO
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/t3000-profiler-tests-impl.yaml
+++ b/.github/workflows/t3000-profiler-tests-impl.yaml
@@ -42,7 +42,6 @@ jobs:
         DONT_USE_VIRTUAL_ENVIRONMENT: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -41,10 +41,7 @@ jobs:
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:
-      - arch-wormhole_b0
-      - config-t3000
-      - pipeline-functional
-      - ${{ inputs.extra-tag }}
+      - tt-beta-ubuntu-2204-n300-llmbox-viommu-stable
     container:
       image: ${{ inputs.docker-image }}
       env:

--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -53,7 +53,6 @@ jobs:
         GTEST_OUTPUT: xml:/work/generated/test_reports/
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -48,7 +48,6 @@ jobs:
         ARCH_NAME: ${{ matrix.test-group.arch }}
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/tg-frequent-tests-impl.yaml
+++ b/.github/workflows/tg-frequent-tests-impl.yaml
@@ -48,7 +48,6 @@ jobs:
         GITHUB_ACTIONS: true
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -59,7 +59,6 @@ jobs:
         ARCH_NAME: ${{ matrix.test-group.arch }}
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -44,7 +44,6 @@ jobs:
         GTEST_OUTPUT: xml:/work/generated/test_reports/
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: --device /dev/tenstorrent
     defaults:
@@ -96,7 +95,6 @@ jobs:
         TT_METAL_ENABLE_ERISC_IRAM: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: --device /dev/tenstorrent
     defaults:
@@ -149,7 +147,6 @@ jobs:
         GTEST_OUTPUT: xml:/work/generated/test_reports/
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: --device /dev/tenstorrent
     defaults:

--- a/.github/workflows/tg-stress.yaml
+++ b/.github/workflows/tg-stress.yaml
@@ -45,7 +45,6 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /work
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: --device /dev/tenstorrent
     defaults:
@@ -92,7 +91,6 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /work
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: --device /dev/tenstorrent
     defaults:

--- a/.github/workflows/tg-unit-tests-impl.yaml
+++ b/.github/workflows/tg-unit-tests-impl.yaml
@@ -43,7 +43,6 @@ jobs:
         TT_METAL_HOME: /work
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:
@@ -102,7 +101,6 @@ jobs:
         GTEST_OUTPUT: xml:/work/generated/test_reports/
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - ${{ matrix.test-group.mlperf && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -47,7 +47,6 @@ jobs:
         LOGURU_LEVEL: INFO
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -33,8 +33,8 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
-        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
+        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-viommu-large-stable', inputs.runner-label)
+        || fromJSON(format('["{0}"]', inputs.runner-label))
       }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -45,7 +45,6 @@ jobs:
         ENABLE_CI_ONLY_TT_TRAIN_TESTS: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -101,8 +101,8 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
-        || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
+        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-viommu-large-stable', inputs.runner-label)
+        || fromJSON(format('["{0}"]', inputs.runner-label))
       }}
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -112,7 +112,6 @@ jobs:
         PYTHONPATH: /work
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -635,7 +635,6 @@ jobs:
         TT_SMI_RESET_COMMAND: ${{ matrix.test-group.tt-smi-cmd }}
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -40,7 +40,6 @@ jobs:
         PYTHONPATH: /work
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -25,8 +25,6 @@ jobs:
     name: UMD tests ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on:
       - ${{ inputs.runner-label }}
-      - cloud-virtual-machine
-      - in-service
     container:
       image: ${{ inputs.docker-image }}
       env:
@@ -36,7 +34,6 @@ jobs:
         PYTHONPATH: /work
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -81,7 +81,6 @@ jobs:
         FILE_BENCHMARK_LOG: "./output/vllm_benchmark.log"
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
All runs on brosko/iommu :
- [ ] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/16056029140
- [ ] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/16056032087
- [ ] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/16056034644
- [ ] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/16056037276
- [ ] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/16056039453
- [ ] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/16056041251

main branch for comparison:
All runs on brosko/iommutest_base :
- [ ] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/16056099127
- [ ] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/16056101954
- [ ] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/16056105482
- [ ] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/16056106886
- [ ] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/16056108702
- [ ] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/16056110857

All runs on brosko/iommu_base_bh :
- [ ] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/16119427218

(same as previous but reverted hugepage setup) All runs on brosko/iommu_base_bh_only :
- [ ] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/16124134249

(same as previous but fixed tags) All runs on brosko/iommu_base_bh_only :
- [ ] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/16137354076

(KMD2.0 starts mapping iatu on its own):
All runs on brosko/iommu_test_noc_buf :
- [ ] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/16119996423