### PR TITLE
Revert "fixing unused variables in ttnn v2"

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_command_stream_builders.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_command_stream_builders.cpp
@@ -40,6 +40,7 @@ std::vector<std::pair<size_t, size_t>> compute_evenly_split_sizes(size_t size, s
 
     auto compute_slice_offset = [num_larger_slices_total, larger_slice_size, smaller_slice_size](int64_t slice_index) {
         int64_t num_larger_slices = std::min(slice_index, num_larger_slices_total);
+        int64_t num_smaller_slices = std::min(slice_index - num_larger_slices, 0L);
         return num_larger_slices * larger_slice_size + (slice_index - num_larger_slices) * smaller_slice_size;
     };
 

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
@@ -264,15 +264,19 @@ size_t generate_ccl_tensor_slice_command_args(
     std::size_t num_command_args_added = 0;
     auto const args_index_old = args_out.size();
     if (!last_tensor_slice.has_value()) {
+        const std::size_t args_index_old = args_out.size();
         // push back Command Header
         // push back arg 0 header
         log_trace(tt::LogOp, "Generating full tensor spec command args");
         add_ccl_command_arg_to_runtime_args<ttnn::ccl::cmd::CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES>(
             current_tensor_slice, args_out);
+        const size_t args_index_new = args_out.size();
         // We can reused cached values for the first slice
         num_command_args_added++;
     } else {
         auto const& last_slice = last_tensor_slice.value();
+        const std::size_t args_index_old = args_out.size();
+        auto header_index = args_out.size();
 
         // tensor shape
         if (last_slice.tensor_shape != current_tensor_slice.tensor_shape) {
@@ -847,6 +851,7 @@ tt::tt_metal::KernelHandle generate_multi_command_stream_kernel_ct_args(
         num_packet_headers_storable * packet_header_size_bytes,
         packet_header_size_bytes,
         worker_core_range);
+    auto reserved_packet_header_CB_handle = CreateCircularBuffer(program, worker_core_range, cb_config);
 
     {  // CT ARGS
         std::vector<uint32_t> ct_args = {my_chip_id.value_or(0xFFFF), reserved_packet_header_CB_index};
@@ -1536,6 +1541,7 @@ std::vector<uint32_t> CCLWorkerArgBuilder::generate_sender_reader_kernel_rt_args
     const std::size_t num_commands_expected = this->input_tensor_partition.partition_size;
 
     auto const& tensor_shape = worker_slice.tensor_shape;
+    auto const& tensor_slice_shape = worker_slice.tensor_slice_shape;
 
     auto num_slices = input_tensor_partition.partition_size;
     auto start_slice_index = input_tensor_partition.partition_index;
@@ -1582,7 +1588,7 @@ std::vector<uint32_t> CCLWorkerArgBuilder::generate_sender_reader_kernel_rt_args
 
     auto const& addr_gen_rt_args = ttnn::ccl::legacy_emit_address_generator_runtime_args(this->device, input_tensor);
     std::ranges::copy(addr_gen_rt_args, std::back_inserter(args));
-    for ([[maybe_unused]] auto const& arg : addr_gen_rt_args) {
+    for (auto const& arg : addr_gen_rt_args) {
         log_trace(tt::LogOp, "ccl_send_reader arg[{}]: addr_gen_rt_args[] {}", logged_arg_idx, args[logged_arg_idx]);
         logged_arg_idx++;
     }
@@ -1614,6 +1620,7 @@ std::vector<uint32_t> CCLWorkerArgBuilder::generate_sender_writer_kernel_rt_args
     const std::size_t num_commands_expected = this->output_tensor_partition.partition_size - 1;
 
     auto const& tensor_shape = worker_slice.tensor_shape;
+    auto const& tensor_slice_shape = worker_slice.tensor_slice_shape;
 
     auto num_slices = output_tensor_partition.partition_size;
     auto start_slice_index = output_tensor_partition.partition_index;
@@ -1742,7 +1749,7 @@ std::vector<uint32_t> CCLWorkerArgBuilder::generate_sender_writer_kernel_rt_args
 
     auto const& addr_gen_rt_args = ttnn::ccl::legacy_emit_address_generator_runtime_args(this->device, output_tensor);
     std::ranges::copy(addr_gen_rt_args, std::back_inserter(args));
-    for ([[maybe_unused]] auto const& arg : addr_gen_rt_args) {
+    for (auto const& arg : addr_gen_rt_args) {
         log_trace(tt::LogOp, "ccl_send_writer arg[{}]: addr_gen_rt_args[] {}", logged_arg_idx, args[logged_arg_idx]);
         logged_arg_idx++;
     }

--- a/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
@@ -223,6 +223,7 @@ inline size_t flattened_index (const ttnn::ccl::Shape4D<uint32_t>& shape, const 
         uint32_t curr_num_wrap_around = (flattened_offset_worker_slice + offset_into_worker_slice) / tensor_slice_shape.x;
         uint32_t num_wrap_around = curr_num_wrap_around - prev_num_wrap_around;
 
+        bool end_of_worker_slice_row = offset_into_worker_slice == worker_slice_volume;
         // Check for wrap around
         if (num_wrap_around > 0) { // wrap around wrt to global tensor
             curr_page_idx += num_wrap_around * (tensor_shape.x - tensor_slice_shape.x) + stride;

--- a/ttnn/cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp
@@ -257,6 +257,7 @@ struct WidthShardedAddressGenerator {
         std::uint32_t worker_x_offset = (!tensor_shard_spec.transposed_grid * shard_grid_inner_dim_index) + (tensor_shard_spec.transposed_grid * shard_grid_outer_dim_index);
 
         std::uint32_t page_in_shard_x = page_global_inner_dim - (global_shard_index * tensor_shard_spec.get_pages_per_shard_x());
+        std::uint32_t page_in_shard_y = page_global_outer_dim;
         std::uint32_t page_offset_in_shard = (page_global_outer_dim * tensor_shard_spec.get_pages_per_shard_x()) + page_in_shard_x;
 
         std::uint32_t worker_x_logical = tensor_shard_spec.shard_grid_start_x_logical + worker_x_offset;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
@@ -112,6 +112,7 @@ static_assert(
     static_cast<size_t>(LineDirection::BACKWARD) ==
     static_cast<size_t>(ttnn::ccl::LineDirection::BACKWARD));
 
+constexpr LineDirection relay_to_final_output_dir = LineDirection::FORWARD;
 // TODO: promote to header
 
 struct ReduceScatterCircularBuffers {
@@ -434,6 +435,7 @@ static WorkerCoreBundle select_worker_cores_for_line_topology(size_t num_links, 
 
     static constexpr std::size_t num_directions_per_line = 2;
     WorkerCoreBundle worker_cores;
+    size_t current_chunk = 0;
 
     constexpr size_t num_final_reducers_per_link = 1;
     constexpr size_t per_link_num_workers_needed = num_directions_per_line + num_final_reducers_per_link;
@@ -699,6 +701,7 @@ static void generate_final_reducer_reader_worker_command_streams(
     using namespace ttnn::ccl::cmd::uops;
     using namespace ttnn::ccl::cmd::builder;
 
+    auto const& all_tensors = builder_config.all_tensors.get();
     auto const& reader_cbs = builder_config.all_cbs.get().final_reducer_reader;
     size_t num_partial_reducer_workers =
         builder_config.worker_cores.get().partial_reducers[LineDirection::FORWARD].size();
@@ -749,6 +752,7 @@ static void generate_final_reducer_writer_worker_command_streams(
     auto const tensor_slice = generate_tensor_slices(1, *output_tensor_sync_bundle.tensor, 0).at(0);
     auto worker_slices = split_tensor_slices_across_workers_page_aligned(num_workers, {tensor_slice});
 
+    auto const& sync = output_tensor_sync_bundle.sync_spec;
     TT_FATAL(
         worker_slices.size() == num_workers,
         "Internal error. Expected number of worker slices to match number of workers");
@@ -795,6 +799,7 @@ static void generate_partial_reducer_reader_worker_command_streams(
     log_trace(
         tt::LogOp, "generate_partial_reducer_reader_worker_command_streams. topologyu: {}", topology_config.topology());
 
+    bool in0_async_mode_specified = in0_tensor_sync.has_value();
     bool in1_async_mode_specified = in1_tensor_sync.has_value();
     TT_FATAL(in1_async_mode_specified, "Internal error. Expected input tensor sync to be populated");
     auto const& from_remote_input_tensor_sync = in1_tensor_sync;
@@ -941,6 +946,7 @@ static void generate_partial_reducer_writer_worker_command_streams(
     auto internal_command_stream_sync_sem_id = CreateSemaphore(builder_config.program.get(), worker_cores, 0);
     for (size_t w = 0; w < num_workers; w++) {
         {  // Command stream 0
+            const size_t operand_index = 0;
             auto& worker_command_stream0 = worker_command_streams.writer_cmds0[worker_cores_vec[w]];
             for (size_t i = 0; i < remote_out_worker_tensor_slices[w].size(); i++) {
                 auto const& s = remote_out_worker_tensor_slices[w][i];
@@ -994,6 +1000,7 @@ static void generate_partial_reducer_writer_worker_command_streams(
             worker_command_stream0.push_back(local_core_semaphore_inc(internal_command_stream_sync_sem_id, 1));
         }
         {  // Command stream 1
+            const size_t operand_index = 1;
             auto& worker_command_stream1 = worker_command_streams.writer_cmds1[worker_cores_vec[w]];
 
             TT_FATAL(
@@ -1043,6 +1050,7 @@ static void create_non_end_of_line_final_reducer_worker_commands(
     std::unordered_map<CoreCoord, size_t>& math_page_counts_out) {
     auto const& final_reducer_worker_cores = builder_config.worker_cores.get().final_reducers_vec;
     auto const& all_program_tensors = builder_config.all_tensors.get();
+    auto const& all_cbs = builder_config.all_cbs.get();
     log_trace(tt::LogOp, "--------------------------------------");
     log_trace(tt::LogOp, "CREATE WORKER (final reducer - not end. Device={})", builder_config.device->id());
 
@@ -1083,6 +1091,9 @@ static void populate_partial_reduce_worker_commands(
     std::unordered_map<CoreCoord, size_t>& math_page_counts_out) {
     auto const& partial_reducer_worker_cores = builder_config.worker_cores.get().partial_reducers_vec;
     auto const& all_tensors = builder_config.all_tensors.get();
+    auto const& all_cbs = builder_config.all_cbs.get();
+    auto const& topology_config = builder_config.topology_config.get();
+    auto const& kernel_ids = builder_config.kernel_ids.get();
     log_trace(tt::LogOp, "--------------------------------------");
     log_trace(tt::LogOp, "CREATE WORKER (partial reducer - not end. Device={})", builder_config.device->id());
 
@@ -1201,12 +1212,14 @@ static void populate_partial_reduce_rt_args(
 
     auto const& all_tensors = builder_config.all_tensors.get();
     auto const& kernel_ids = builder_config.kernel_ids.get();
+    auto device = builder_config.device;
 
     auto const& partial_reducer_worker_cores = builder_config.worker_cores.get().partial_reducers_vec;
     std::array<std::vector<CoreCoord>, 2> partial_reducer_worker_cores_vec = {
         partial_reducer_worker_cores[LineDirection::FORWARD], partial_reducer_worker_cores[LineDirection::BACKWARD]};
 
     for (auto line_direction : {LineDirection::FORWARD, LineDirection::BACKWARD}) {
+        bool is_forward_direction = line_direction == LineDirection::FORWARD;
         uint32_t link = 0;
         for (size_t i = 0; i < partial_reducer_worker_cores_vec[line_direction].size(); i++) {
             auto const& w_logical = partial_reducer_worker_cores_vec[line_direction][i];
@@ -1400,6 +1413,7 @@ static void create_end_of_line_worker_commands(
         remote_writer_worker_sliced_fwd, remote_writer_worker_sliced_bwd};
 
     std::array<std::vector<CoreCoord>, 2> const reader_worker_cores_per_direction = worker_cores.partial_reducers_vec;
+    std::array<std::vector<CoreCoord>, 2> const& writer_worker_cores_per_direction = reader_worker_cores_per_direction;
 
     auto const local_partial_output_tensor_slice = convert_to_whole_tensor_slice(*all_tensors.local_final_output_tensor);
     auto writer_end_of_line_output_worker_slices =
@@ -1412,6 +1426,7 @@ static void create_end_of_line_worker_commands(
         num_workers);
 
     for (auto direction : {LineDirection::FORWARD, LineDirection::BACKWARD}) {
+        bool is_forward_direction = direction == LineDirection::FORWARD;
         bool is_start_of_line = topology_config.is_first_device_in_line(direction);
 
         auto const& reader_worker_cores = reader_worker_cores_per_direction[direction];
@@ -1517,12 +1532,14 @@ static void create_end_of_line_worker_runtime_args(
     WorkerCoreBundle const& worker_cores = builder_config.worker_cores.get();
 
     std::array<std::vector<CoreCoord>, 2> const reader_worker_cores_per_direction = worker_cores.partial_reducers_vec;
+    std::array<std::vector<CoreCoord>, 2> const& writer_worker_cores_per_direction = reader_worker_cores_per_direction;
     auto num_workers = worker_cores.partial_reducers_vec[LineDirection::FORWARD].size();
 
     // Generate the kernels themselves
     for (auto direction : {LineDirection::FORWARD, LineDirection::BACKWARD}) {
         bool is_start_of_line = builder_config.topology_config.get().is_first_device_in_line(direction);
         auto const& reader_worker_cores = reader_worker_cores_per_direction[direction];
+        bool is_forward_direction = direction == LineDirection::FORWARD;
 
 
         Tensor* output_tensor_ptr = nullptr;
@@ -1784,6 +1801,7 @@ static void initialize_op_internal_tensor_syncs(
     WorkerCoreBundle const& worker_cores,
     GlobalSemaphore const& from_remote_sem,
     GlobalSemaphore const& to_remote_sem) {
+    auto core_coord_lt = [](CoreCoord const& a, CoreCoord const& b) { return a.y < b.y || (a.y == b.y && a.x < b.x); };
 
     TT_FATAL(
         worker_cores.partial_reducers_vec[LineDirection::BACKWARD].size() > 0,
@@ -1794,6 +1812,7 @@ static void initialize_op_internal_tensor_syncs(
     auto all_partial_reducer_cores = worker_cores.partial_reducers[LineDirection::FORWARD];
     all_partial_reducer_cores = all_partial_reducer_cores.merge(worker_cores.partial_reducers[LineDirection::BACKWARD]);
 
+    auto partial_reducers_in1_sem_id = CreateSemaphore(program, all_partial_reducer_cores, 0, CoreType::WORKER);
     for (auto direction : {LineDirection::FORWARD, LineDirection::BACKWARD}) {
         all_tensors.input_tensor_from_remote_sync[direction] = TensorSyncSpec{};
         for (auto const& worker_core : partial_reducer_cores[direction]) {
@@ -2067,6 +2086,7 @@ void lower_command_streams_to_noc_commands(
         bool is_start_of_line = builder_config.topology_config.get().is_last_device_in_line(direction);
 
         auto const& partial_reducers = builder_config.worker_cores.get().partial_reducers_vec[direction];
+        auto const& final_reducers = builder_config.worker_cores.get().final_reducers_vec;
 
         lower_command_streams(
             partial_reducers, command_streams.reader_cmds0, *builder_config.all_tensors.get().input_tensor);
@@ -2128,6 +2148,7 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
     const GlobalSemaphore& to_remote_sem,
     const std::optional<SubDeviceId>& sub_device_id) {
     using namespace ttnn::ccl::worker_detail;
+    bool do_dynamic_fabric_bringup_and_teardown = fabric_mode == fabric_lifetime_mode::TRANSIENT;
 
     // Constants/ "Globals"
     constexpr auto math_in0_cb = tt::CBIndex::c_0;
@@ -2255,6 +2276,7 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
         page_size,
         pages_per_cb_packet,
         dim};
+    bool is_end_of_line = topology_config.is_at_end_of_line();
 
     log_trace(tt::LogOp, "Pages per CB packet: {}", pages_per_cb_packet);
     WorkerCommandStreams command_streams;


### PR DESCRIPTION
PR breaks couple of Llama pipelines:
Galaxy quick - [it started on this PR ](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml)
Galaxy unit tests - https://github.com/tenstorrent/tt-metal/actions/runs/16042781105

Passing with revert here: https://github.com/tenstorrent/tt-metal/actions/runs/16045784028