### PR TITLE
Topk: parallel over more cores in sub range

### DIFF
--- a/models/demos/llama3_70b_galaxy/demo/text_demo_targets.json
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo_targets.json
@@ -4,7 +4,7 @@
             "prefill_pcc": 0.9174011812353029,
             "decode_pcc": 0.9558788865391203,
             "throughput": 59.87,
-            "absolute_margin": 2.0,
+            "absolute_margin": 1.0,
             "token_pos": 127
         }
     },

--- a/models/demos/llama3_70b_galaxy/tests/decoder_perf_targets_4u.json
+++ b/models/demos/llama3_70b_galaxy/tests/decoder_perf_targets_4u.json
@@ -333,7 +333,7 @@
         },
         "TopK_0": {
             "op_name": "TopK_0",
-            "kernel_duration": 325436,
+            "kernel_duration": 199802.71875,
             "op_to_op": 733.0,
             "non-overlapped-dispatch-time": 5187.35,
             "kernel_duration_relative_margin": 0.2,

--- a/models/demos/llama3_70b_galaxy/tests/decoder_perf_targets_6u.json
+++ b/models/demos/llama3_70b_galaxy/tests/decoder_perf_targets_6u.json
@@ -271,7 +271,7 @@
     },
     "TopK_0": {
       "op_name": "TopK_0",
-      "kernel_duration": 288709.40625,
+      "kernel_duration": 179979.625,
       "op_to_op": 671.0,
       "non-overlapped-dispatch-time": 4614.0,
       "kernel_duration_relative_margin": 0.2,

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -220,8 +220,22 @@ std::vector<CoreCoord> grid_to_cores_with_noop(
 std::vector<CoreCoord> corerange_to_cores(
     const CoreRangeSet& crs, std::optional<uint32_t> max_cores = std::nullopt, bool row_wise = false);
 
-CoreRangeSet select_from_corerange(
+// Select a CoreRangeSet of cores from a CoreRangeSet.
+// The method will traverse the given CoreRangeSet in row-wise order and return a subset of cores based on start_index
+// and end_index (inclusive), where each core is represented by it's own CoreRange in the returned CoreRangeSet. Example
+// usage: CoreRangeSet crs = {{0, 0, 2, 2}, {4, 0, 5, 2}}; CoreRangeSet selected_cores = select_from_corerangeset(crs,
+// 0, 3); selected_cores = {{0,0}, {1,0}, {2,0}, {4,0}}
+CoreRangeSet select_from_corerangeset(
     const CoreRangeSet& crs, uint32_t start_index, uint32_t end_index, bool row_wise = false);
+
+// Select a contiguous CoreRange of cores from a CoreRangeSet.
+// The method will select an x by y contiguous CoreRange of cores from the given CoreRangeSet. If multiple CoreRanges of
+// size x by y are found, the method will return the lower leftmost subset of cores in the first available CoreRange.
+// Example usage:
+// CoreRangeSet crs = {{0, 0, 2, 2}, {4, 0, 5, 2}};
+// CoreRange selected_core_range = select_contiguous_range_from_corerangeset(crs, 3, 1);
+// selected_core_range = {{0,0}, {2,1}}
+std::optional<CoreRange> select_contiguous_range_from_corerangeset(const CoreRangeSet& crs, uint32_t x, uint32_t y);
 
 bool operator!=(const CoreRangeSet& a, const CoreRangeSet& b);
 

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -635,13 +635,26 @@ std::vector<CoreCoord> corerange_to_cores(const CoreRangeSet& crs, std::optional
     return all_cores;
 }
 
-CoreRangeSet select_from_corerange(const CoreRangeSet& crs, uint32_t start_index, uint32_t end_index, bool row_wise) {
+CoreRangeSet select_from_corerangeset(
+    const CoreRangeSet& crs, uint32_t start_index, uint32_t end_index, bool row_wise) {
     auto all_cores = corerange_to_cores(crs, end_index + 1, row_wise);
     std::vector<CoreRange> selected_cores;
     for (uint32_t i = start_index; i <= end_index; i++) {
         selected_cores.push_back(CoreRange(all_cores[i], all_cores[i]));
     }
     return CoreRangeSet(selected_cores);
+}
+std::optional<CoreRange> select_contiguous_range_from_corerangeset(const CoreRangeSet& crs, uint32_t x, uint32_t y) {
+    for (const auto& core_range : crs.ranges()) {
+        const auto& start_coord = core_range.start_coord;
+        const auto& end_coord = core_range.end_coord;
+        if (start_coord.x + x > end_coord.x || start_coord.y + y > end_coord.y) {
+            continue;
+        }
+        CoreCoord new_end_coord = {start_coord.x + x, start_coord.y + y};
+        return CoreRange(start_coord, new_end_coord);
+    }
+    return std::nullopt;
 }
 
 bool operator!=(const CoreRangeSet& a, const CoreRangeSet& b) { return !(a == b); }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -5,73 +5,9 @@
 #include "topk_op.hpp"
 #include "topk_program_factory.hpp"
 #include "topk_constants.hpp"
+#include "topk_utils.hpp"
 
 using namespace tt::tt_metal;
-
-namespace topk_utils {
-
-static inline uint32_t largest_power_of_two(std::uint32_t x) { return x == 0 ? 0 : (1 << (31 - __builtin_clz(x))); }
-
-static inline bool verify_multi_core_cost(
-    const std::vector<Tensor>& input_tensors,
-    uint32_t width,
-    uint32_t min_dim,
-    uint32_t max_dim,
-    uint32_t k,
-    const CoreRangeSet& core_range_set) {
-    auto device = input_tensors.at(0).device();
-    tt::DataFormat value_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensors.at(0).dtype());
-    tt::DataFormat index_cb_data_format = tt::DataFormat::UInt16;
-
-    uint32_t value_tile_size = tile_size(value_cb_data_format);
-    uint32_t index_tile_size = tile_size(index_cb_data_format);
-
-    const auto core_range = core_range_set.ranges().at(0);
-    const auto max_cores = core_range.end_coord.y - core_range.start_coord.y - 1;
-    uint32_t start_split_size = width / largest_power_of_two(max_cores);
-    for (uint32_t split_size = start_split_size; split_size <= max_dim; split_size *= 2) {
-        uint32_t rem = width % split_size;
-        uint32_t num_cores = width / split_size + (rem > 0);
-        uint32_t memory_cost_gather =
-            2 * num_cores * (value_tile_size + index_tile_size);  // gathering one index and one value tile from each
-                                                                  // local core, allocating two CBs for each
-        uint32_t memory_cost_local =
-            (split_size / tt::constants::TILE_WIDTH) *
-            (value_tile_size + index_tile_size);  // we divide the width into split_size chunks and each chunk, as well
-                                                  // as a matching set of indices, is processed by a core
-        if (num_cores <= max_cores &&
-            (memory_cost_gather + (memory_cost_local * num_cores)) < (device->l1_size_per_core() * num_cores) &&
-            num_cores > 1 && split_size >= min_dim) {
-            return true;
-        }
-    }
-    return false;
-}
-
-static inline bool verify_single_core_cost(const std::vector<Tensor>& input_tensors, uint32_t k, bool uint16_output) {
-    uint32_t num_cb_unit = 2;
-    uint32_t cb_in_units = 2 * num_cb_unit;
-    uint32_t Ktiles = tt::div_up(k, tt::constants::TILE_WIDTH);
-    uint32_t input_cb_tile_count = cb_in_units;
-    uint32_t transposed_cb_tile_count = 4;
-    uint32_t result_prep_cb_tile_count = 2 * Ktiles;  // intermediate output
-    uint32_t output_cb_tile_count = Ktiles;
-
-    auto device = input_tensors.at(0).device();
-    tt::DataFormat value_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensors.at(0).dtype());
-    tt::DataFormat index_cb_data_format = uint16_output ? tt::DataFormat::UInt16 : tt::DataFormat::UInt32;
-
-    uint32_t value_tile_size = tile_size(value_cb_data_format);
-    uint32_t index_tile_size = tile_size(index_cb_data_format);
-
-    uint32_t memory_cost_local =
-        (input_cb_tile_count + transposed_cb_tile_count + result_prep_cb_tile_count + output_cb_tile_count) *
-        (value_tile_size + index_tile_size);  // we divide the width into split_size chunks and each chunk, as well
-                                              // as a matching set of indices, is processed by a core
-    return memory_cost_local < device->l1_size_per_core();
-}
-
-}  // namespace topk_utils
 
 namespace ttnn::operations::reduction {
 
@@ -99,13 +35,26 @@ void TopK::validate_with_output_tensors(
 
     bool uint16_output = (input_shape[this->dim] <= std::numeric_limits<uint16_t>::max());
     if (input_shape[dim] >= topk::constants::multi_core_min_width) {  // multicore implementation
+        auto device = input_tensors.at(0).device();
+        tt::DataFormat value_cb_data_format =
+            tt::tt_metal::datatype_to_dataformat_converter(input_tensors.at(0).dtype());
+        tt::DataFormat index_cb_data_format = tt::DataFormat::UInt16;
+
+        uint32_t value_tile_size = tile_size(value_cb_data_format);
+        uint32_t index_tile_size = tile_size(index_cb_data_format);
+
+        const auto core_range = this->sub_core_grids.ranges().at(0);
+
         can_run = topk_utils::verify_multi_core_cost(
             input_tensors,
             input_shape[this->dim],
             topk::constants::min_dim_per_core,
             input_shape[this->dim] / 2,
             this->k,
-            this->sub_core_grids);
+            core_range,
+            device->l1_size_per_core(),
+            value_tile_size,
+            index_tile_size);
 
         TT_FATAL(
             this->sub_core_grids.ranges().size() == 1,
@@ -172,13 +121,25 @@ operation::ProgramWithCallbacks TopK::create_program(
                                              // supported, we default to single core
     multicore_supported &= (this->k <= 64);  // multicore implementation only supports k <= 64
     if (multicore_supported) {               // don't bother with longer check if already false
+        auto device = input_tensors.at(0).device();
+        tt::DataFormat value_cb_data_format =
+            tt::tt_metal::datatype_to_dataformat_converter(input_tensors.at(0).dtype());
+        tt::DataFormat index_cb_data_format = tt::DataFormat::UInt16;
+
+        uint32_t value_tile_size = tile_size(value_cb_data_format);
+        uint32_t index_tile_size = tile_size(index_cb_data_format);
+
+        const auto core_range = this->sub_core_grids.ranges().at(0);
         multicore_supported &= topk_utils::verify_multi_core_cost(
             input_tensors,
             input_shape[this->dim],
             topk::constants::min_dim_per_core,
             input_shape[this->dim] / 2,
             this->k,
-            this->sub_core_grids);
+            core_range,
+            device->l1_size_per_core(),
+            value_tile_size,
+            index_tile_size);
     }
 
     if (multicore_supported) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -6,6 +6,7 @@
 #include "topk_program_factory.hpp"
 #include "topk_constants.hpp"
 #include "topk_utils.hpp"
+#include "tt-metalium/allocator.hpp"
 
 using namespace tt::tt_metal;
 
@@ -52,7 +53,7 @@ void TopK::validate_with_output_tensors(
             input_shape[this->dim] / 2,
             this->k,
             core_range,
-            device->l1_size_per_core(),
+            device->allocator()->get_statistics(tt::tt_metal::BufferType::L1).largest_free_block_bytes,
             value_tile_size,
             index_tile_size);
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
@@ -6,6 +6,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include "ttnn/operation.hpp"
+#include "topk_utils.hpp"
 
 #include <iostream>
 #include <cmath>
@@ -209,8 +210,6 @@ operation::ProgramWithCallbacks topk_single_core_interleaved(
     return {std::move(program), override_runtime_args_callback};
 }
 
-static inline uint32_t largest_power_of_two(std::uint32_t x) { return x == 0 ? 0 : (1 << (31 - __builtin_clz(x))); }
-
 /**
  * Split the work along the width such that the width is divisible by min_dim and the number of cores used is less than
  * or equal to max_cores. Each core must have a minimum of two tiles - min_dim = 64 as that's the minimum size for the
@@ -220,37 +219,31 @@ static inline uint32_t largest_power_of_two(std::uint32_t x) { return x == 0 ? 0
  * for the gather, we only need 3 cores per row. Then take cores_per_row = 3 and try to split the height such that the
  * number of cores used is less than or equal to max_cores.
  */
-static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
-    uint16_t width,
-    uint16_t min_dim,
-    uint16_t max_dim,
-    CoreRange core_range,
+static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
+    uint32_t width,
+    uint32_t min_dim,
+    uint32_t max_dim,
     uint32_t k,
+    const CoreRange core_range,
     const uint32_t l1_size,
     const uint32_t value_tile_size,
     const uint32_t index_tile_size) {
-    const auto max_cores = core_range.end_coord.y - core_range.start_coord.y - 1;
-    uint16_t start_split_size = width / largest_power_of_two(max_cores);
-    for (uint16_t split_size = start_split_size; split_size <= max_dim; split_size *= 2) {
-        uint16_t rem = width % split_size;
-        uint16_t num_cores = width / split_size + (rem > 0);
-        uint32_t memory_cost_gather =
-            2 * num_cores * (value_tile_size + index_tile_size);  // gathering one index and one value tile from each
-                                                                  // local core, allocating two CBs for each
-        uint32_t memory_cost_local =
-            (split_size / tt::constants::TILE_WIDTH) *
-            (value_tile_size + index_tile_size);  // we divide the width into split_size chunks and each chunk, as well
-                                                  // as a matching set of indices, is processed by a core
-        if (num_cores <= max_cores && (memory_cost_gather + memory_cost_local * num_cores) < (l1_size * num_cores) &&
-            num_cores > 1 && split_size >= min_dim) {
-            return {
-                num_cores + 1,
-                split_size,
-                rem,
-                num_cores * std::max(static_cast<uint32_t>(k), static_cast<uint32_t>(tt::constants::TILE_WIDTH))};
-        }
+    auto config_opt = ttnn::operations::reduction::topk_utils::find_topk_core_config(
+        width, min_dim, max_dim, k, core_range, l1_size, value_tile_size, index_tile_size);
+    if (config_opt.has_value()) {
+        auto config = config_opt.value();
+        return {
+            config.num_cores + 1,
+            config.split_size,
+            config.rem,
+            config.final_input_size,
+            config.selected_x,
+            config.selected_y};
+    } else {
+        const auto max_cores = (core_range.end_coord.y - core_range.start_coord.y - 1) *
+                               (core_range.end_coord.x - core_range.start_coord.x);
+        return {max_cores + 1, width, 0, width * k, 0, 0};
     }
-    return {max_cores + 1, width, 0, width * k};
 }
 
 /**
@@ -298,23 +291,30 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
 
     auto input_shape = input_tensor.padded_shape();
     uint32_t Ht = (input_shape[0] * input_shape[1] * input_shape[2]) / TILE_HEIGHT;
-    const auto& [num_cores, local_topk_input_size, rem, final_topk_input_size] = cores_utilized(
+    const auto& [num_cores, local_topk_input_size, rem, final_topk_input_size, selected_x, selected_y] = cores_utilized(
         input_shape[dim],
         64,
         input_shape[dim] / 2,
-        first_core_range,
         k,
+        first_core_range,
         device->l1_size_per_core(),
         value_tile_size,
         index_tile_size);
 
-    auto all_cores_range_set = select_from_corerange(first_core_range_set, 0, num_cores - 1u, false);
+    constexpr bool select_cores_row_wise = false;
 
-    auto local_cores_range_set = select_from_corerange(first_core_range_set, 0, num_cores - 2u, false);
-    auto local_cores = corerange_to_cores(local_cores_range_set, num_cores - 1u, false);
+    auto local_cores_range =
+        select_contiguous_range_from_corerangeset(first_core_range_set, selected_x - 1, selected_y - 1);
+    auto local_cores_range_set = CoreRangeSet(local_cores_range.value());
+    auto local_cores =
+        corerange_to_cores(local_cores_range_set, local_cores_range_set.num_cores(), select_cores_row_wise);
 
-    auto final_cores_range_set = select_from_corerange(first_core_range_set, num_cores - 1u, num_cores - 1u, false);
-    auto final_core = corerange_to_cores(final_cores_range_set, 1u, false).at(0);
+    auto final_cores_range_set =
+        select_from_corerangeset(first_core_range_set, selected_y, selected_y, select_cores_row_wise);
+    auto final_core = corerange_to_cores(final_cores_range_set, 1u, select_cores_row_wise).at(0);
+
+    auto all_cores_range_set = local_cores_range_set;
+    all_cores_range_set = all_cores_range_set.merge(final_cores_range_set);
 
     uint32_t Wt_local = local_topk_input_size / TILE_WIDTH;
     uint32_t Wt_final = final_topk_input_size / TILE_WIDTH;

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.hpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+
+namespace ttnn {
+namespace operations {
+namespace reduction {
+namespace topk_utils {
+
+uint32_t largest_power_of_two(uint32_t x) { return x == 0 ? 0 : (1U << (31 - __builtin_clz(x))); }
+
+struct TopKCoreConfig {
+    uint16_t num_cores = 0;
+    uint16_t split_size = 0;
+    uint16_t rem = 0;
+    uint16_t final_input_size = 0;
+    uint16_t selected_x = 0;
+    uint16_t selected_y = 0;
+};
+
+std::optional<TopKCoreConfig> find_topk_core_config(
+    uint32_t width,
+    uint32_t min_dim,
+    uint32_t max_dim,
+    uint32_t k,
+    const tt::tt_metal::CoreRange& core_range,
+    uint32_t l1_size,
+    uint32_t value_tile_size,
+    uint32_t index_tile_size) {
+    const auto max_cores =
+        (core_range.end_coord.y - core_range.start_coord.y - 1) * (core_range.end_coord.x - core_range.start_coord.x);
+    uint32_t start_split_size =
+        static_cast<uint32_t>(width / tt::constants::TILE_WIDTH / largest_power_of_two(max_cores)) *
+        tt::constants::TILE_WIDTH;
+    for (uint32_t split_size = start_split_size; split_size <= max_dim; split_size *= 2) {
+        uint32_t rem = width % split_size;
+        uint32_t num_cores = width / split_size + (rem > 0);
+        uint32_t memory_cost_gather = 2 * num_cores * (value_tile_size + index_tile_size);
+        uint32_t memory_cost_local = (split_size / tt::constants::TILE_WIDTH) * (value_tile_size + index_tile_size);
+        uint32_t max_x = core_range.end_coord.x - core_range.start_coord.x;
+        uint32_t max_y = core_range.end_coord.y - core_range.start_coord.y - 1;
+        uint32_t max_cores_available = max_x * max_y;
+        if (num_cores > max_cores_available) {
+            continue;
+        }
+        bool contiguous_cores_available = false;
+        uint32_t selected_x = 0;
+        uint32_t selected_y = 0;
+        for (uint32_t y = max_y; y > 0; y--) {
+            for (uint32_t x = max_x; x > 0; x--) {
+                if (x * y == num_cores) {
+                    selected_x = x;
+                    selected_y = y;
+                    contiguous_cores_available = true;
+                    break;
+                }
+            }
+        }
+        if (num_cores <= max_cores && memory_cost_gather + (memory_cost_local * num_cores) < (l1_size * num_cores) &&
+            num_cores > 1 && split_size >= min_dim && contiguous_cores_available && rem == 0) {
+            TopKCoreConfig config;
+            config.num_cores = static_cast<uint16_t>(num_cores);
+            config.split_size = static_cast<uint16_t>(split_size);
+            config.rem = static_cast<uint16_t>(rem);
+            config.final_input_size =
+                static_cast<uint16_t>(num_cores * std::max(k, static_cast<uint32_t>(tt::constants::TILE_WIDTH)));
+            config.selected_x = static_cast<uint16_t>(selected_x);
+            config.selected_y = static_cast<uint16_t>(selected_y);
+            return std::make_optional(config);
+        }
+    }
+    return std::nullopt;
+}
+
+bool verify_multi_core_cost(
+    const std::vector<ttnn::Tensor>& input_tensors,
+    uint32_t width,
+    uint32_t min_dim,
+    uint32_t max_dim,
+    uint32_t k,
+    const tt::tt_metal::CoreRange& core_range,
+    uint32_t l1_size,
+    uint32_t value_tile_size,
+    uint32_t index_tile_size) {
+    auto config =
+        find_topk_core_config(width, min_dim, max_dim, k, core_range, l1_size, value_tile_size, index_tile_size);
+    return config.has_value();
+}
+
+bool verify_single_core_cost(const std::vector<ttnn::Tensor>& input_tensors, uint32_t k, bool uint16_output) {
+    uint32_t num_cb_unit = 2;
+    uint32_t cb_in_units = 2 * num_cb_unit;
+    uint32_t Ktiles = tt::div_up(k, tt::constants::TILE_WIDTH);
+    uint32_t input_cb_tile_count = cb_in_units;
+    uint32_t transposed_cb_tile_count = 4;
+    uint32_t result_prep_cb_tile_count = 2 * Ktiles;  // intermediate output
+    uint32_t output_cb_tile_count = Ktiles;
+    auto device = input_tensors.at(0).device();
+    tt::DataFormat value_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensors.at(0).dtype());
+    tt::DataFormat index_cb_data_format = uint16_output ? tt::DataFormat::UInt16 : tt::DataFormat::UInt32;
+    uint32_t value_tile_size = tt::tile_size(value_cb_data_format);
+    uint32_t index_tile_size = tt::tile_size(index_cb_data_format);
+    uint32_t memory_cost_local =
+        (input_cb_tile_count + transposed_cb_tile_count + result_prep_cb_tile_count + output_cb_tile_count) *
+        (value_tile_size + index_tile_size);
+    return memory_cost_local < device->l1_size_per_core();
+}
+
+}  // namespace topk_utils
+}  // namespace reduction
+}  // namespace operations
+}  // namespace ttnn


### PR DESCRIPTION
### Problem description
Topk perf is not optimised. Currently it only uses one column of the core range set passed into the op, it could parallelise computation over more cores.

### What's changed
Added support to use more cores. A sub range of the core range set is used. For TG llama this means we can now use 17 cores instead of 9.
Perf improvement: 122 us (based on shape [1,1,32,16k]
Old perf: 322 us (with passing in indices tensors)
New perf: 200 us (with passing in indices tensors)

TG llama e2e perf:
72.17 t/s/u -> 71.58 t/s/u

### Checklist
- [ ] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/16696546928) passing
- [ ] [4U pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/16696561334/job/47261799437) passing
- [ ] [6U pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/16696566286) passing; unrelated device perf failures (after rebase)