### PR TITLE
#0: Re-add `concat` function in terms of Tensor

### DIFF
--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -55,4 +55,8 @@ XtensorAdapter<typename Expression::value_type> concat_ndim(
     const tt::stl::SmallVector<int>& num_chunks,
     const tt::stl::SmallVector<int>& dims);
 
+// Overload in terms of `Tensor`.
+[[deprecated("Use high-level APIs defined in distributed_tensor.hpp")]] tt::tt_metal::Tensor concat(
+    const std::vector<tt::tt_metal::Tensor>& tensors, int dim = 0);
+
 }  // namespace ttnn::experimental::xtensor

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -56,7 +56,7 @@ XtensorAdapter<typename Expression::value_type> concat_ndim(
     const tt::stl::SmallVector<int>& dims);
 
 // Overload in terms of `Tensor`.
-[[deprecated("Use high-level APIs defined in distributed_tensor.hpp")]] tt::tt_metal::Tensor concat(
-    const std::vector<tt::tt_metal::Tensor>& tensors, int dim = 0);
+// Deprecated: Use high-level APIs defined in distributed_tensor.hpp
+tt::tt_metal::Tensor concat(const std::vector<tt::tt_metal::Tensor>& tensors, int dim = 0);
 
 }  // namespace ttnn::experimental::xtensor


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`const std::vector<tt::tt_metal::Tensor>& tensors, int dim = 0);` is relied upon by tt-mlir. Re-adding it temporarily, to allow the client to migrate smoothly.

### What's changed
Re-introduce the function deleted in [f8f9322](https://github.com/tenstorrent/tt-metal/commit/f8f93226e86efa6a8e02b253dfaeacfe470d7b12#diff-9373a1c5668c813f4d731e664ee61c65c01882b0b5bd9c9c0ce5b21e8008a1bcL218).

### Checklist
- [X] New/Existing tests provide coverage for changes