### PR TITLE
24276: Migrate exp related ops implementation to llk repo

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -173,7 +173,9 @@ target_sources(
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_converter.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cumsum.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_dropout.h
+            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_elu.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp.h
+            third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_exp2.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_fill.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_gelu.h
             third_party/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_hardtanh.h
@@ -256,7 +258,9 @@ target_sources(
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_converter.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cumsum.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_dropout.h
+            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_elu.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp.h
+            third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_exp2.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_fill.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_gelu.h
             third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_hardtanh.h

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -5,9 +5,7 @@
 #pragma once
 
 #include "ckernel.h"
-#include "ckernel_defs.h"
-#include "sfpu/ckernel_sfpu_converter.h"
-#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_elu.h"
 #include "sfpi.h"
 
 using namespace sfpi;
@@ -17,36 +15,12 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_elu(uint slope) {
-    const bool FAST_APPROX = false;          // Elu does not use fast approximation.
-    const bool SCALE_EN = false;             // Elu does not use scale.
-    const bool SKIP_POSITIVE_CHECK = false;  // Elu does not skip positive check.
-    // SFPU microcode
-    vFloat s = Converter::as_float(slope);
-#pragma GCC unroll 0
-    for (int d = 0; d < 8; d++) {
-        vFloat v = dst_reg[0];
-
-        v_if(v < 0.0f) {
-            vFloat v_exp = _calculate_exponential_body_improved_<
-                APPROXIMATION_MODE,
-                SCALE_EN,
-                ITERATIONS,
-                FAST_APPROX,
-                SKIP_POSITIVE_CHECK>(v);
-            v = s * (v_exp - 1.0f);
-        }
-        v_endif;
-
-        dst_reg[0] = v;
-
-        dst_reg++;
-    }
+    _calculate_elu_<APPROXIMATION_MODE, ITERATIONS>(slope);
 }
 
 template <bool APPROXIMATION_MODE>
 void elu_init() {
-    const bool FAST_APPROX = false;  // Elu does not use fast approximation.
-    exp_init<APPROXIMATION_MODE, FAST_APPROX>();
+    _init_elu_<APPROXIMATION_MODE>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -15,17 +15,24 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_elu(uint slope) {
+    const bool FAST_APPROX = false;          // Elu does not use fast approximation.
+    const bool SCALE_EN = false;             // Elu does not use scale.
+    const bool SKIP_POSITIVE_CHECK = false;  // Elu does not skip positive check.
     // SFPU microcode
     vFloat s = Converter::as_float(slope);
-
 #pragma GCC unroll 0
     for (int d = 0; d < 8; d++) {
         vFloat v = dst_reg[0];
 
         v_if(v < 0.0f) {
-            vFloat v_exp = calculate_exponential_body_improved<APPROXIMATION_MODE>(v);
+            vFloat v_exp = _calculate_exponential_body_improved_<
+                APPROXIMATION_MODE,
+                SCALE_EN,
+                ITERATIONS,
+                FAST_APPROX,
+                SKIP_POSITIVE_CHECK>(v);
             v = s * (v_exp - 1.0f);
         }
         v_endif;
@@ -38,15 +45,8 @@ inline void calculate_elu(uint slope) {
 
 template <bool APPROXIMATION_MODE>
 void elu_init() {
-    if constexpr (APPROXIMATION_MODE) {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = s2vFloat16b(p_exp::C23_73);
-        vConstFloatPrgm2 = s2vFloat16b(p_exp::ADJ_EXP);
-    } else {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = 2.0f;
-        vConstFloatPrgm2 = 0.863281f;
-    }
+    const bool FAST_APPROX = false;  // Elu does not use fast approximation.
+    exp_init<APPROXIMATION_MODE, FAST_APPROX>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -4,11 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
 #include "ckernel_sfpu_elu.h"
-#include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -4,13 +4,9 @@
 
 #pragma once
 
-#include <limits>
-
 #include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_recip.h"
-#include "sfpi.h"
 #include "sfpu/ckernel_sfpu_exp.h"
+#include "sfpi.h"
 
 using namespace sfpi;
 
@@ -25,9 +21,9 @@ template <
     bool SCALE_EN = false,
     int ITERATIONS = 8,
     bool SKIP_POSITIVE_CHECK = false>
-void calculate_exponential(const uint iterations = ITERATIONS, const uint exp_base_scale_factor = 0x3F80) {
+void calculate_exponential(const uint exp_base_scale_factor = 0x3F80) {
     _calculate_exponential_<APPROXIMATION_MODE, SCALE_EN, ITERATIONS, FAST_APPROX, SKIP_POSITIVE_CHECK>(
-        iterations, exp_base_scale_factor);
+        exp_base_scale_factor);
 }
 
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, uint32_t scale = 0x3F800000>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -30,58 +30,6 @@ void calculate_exponential(const uint iterations = ITERATIONS, const uint exp_ba
         iterations, exp_base_scale_factor);
 }
 
-template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat calculate_exponential_body(vFloat in) {
-    vFloat out;
-
-    if constexpr (APPROXIMATION_MODE) {
-        v_if(in >= 89) {
-            vFloat val_inf = std::numeric_limits<float>::infinity();
-            out = val_inf;
-        }
-        v_elseif(in < -42) { out = 0.0f; }
-        v_else { out = _calculate_exponential_body_<APPROXIMATION_MODE>(in); }
-        v_endif;
-    } else {
-        out = _calculate_exponential_body_<APPROXIMATION_MODE>(in);
-    }
-
-    return out;
-}
-
-template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat calculate_exponential_body_improved(vFloat val) {
-    vFloat out;
-    if constexpr (APPROXIMATION_MODE) {
-        v_if(val >= 89) {
-            vFloat val_inf = std::numeric_limits<float>::infinity();
-            out = val_inf;
-        }
-        v_elseif(val < -42) { out = 0.0f; }
-        v_else {
-            // * by 1/ln2 and add convert to 7.3 FxP format
-            vFloat vConstLn2Recip = vConstFloatPrgm0;
-            vFloat c23_73 = vConstFloatPrgm1;
-            vInt adj_exp = vConstIntPrgm2;
-            val = val * vConstLn2Recip + c23_73;
-
-            // Remove Exponent of 7 and bias the Mantissa to 127.
-            vInt val_short = adj_exp + reinterpret<vInt>(val);
-
-            // SHL to move integer bits to exponent
-            val_short <<= 10 - p_exp::FRAC_BITS;
-            out = reinterpret<vFloat>(val_short);
-        }
-        v_endif;
-    } else {
-        // Force sign to 0 (make number positive)
-        out = sfpu_exp(setsgn(val, 0));
-        v_if(val < 0) { out = sfpu_reciprocal(out); }
-        v_endif;
-    }
-    return out;
-}
-
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, uint32_t scale = 0x3F800000>
 void exp_init() {
     _init_exponential_<APPROXIMATION_MODE, FAST_APPROX, scale>();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -8,12 +8,10 @@
 #include "sfpu/ckernel_sfpu_exp.h"
 #include "sfpi.h"
 
-using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
 
-sfpi_inline vFloat sfpu_exp(vFloat val) { return _sfpu_exp_(val); }
+sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
 
 template <
     bool APPROXIMATION_MODE,
@@ -21,7 +19,7 @@ template <
     bool SCALE_EN = false,
     int ITERATIONS = 8,
     bool SKIP_POSITIVE_CHECK = false>
-void calculate_exponential(const uint exp_base_scale_factor = 0x3F80) {
+void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
     _calculate_exponential_<APPROXIMATION_MODE, SCALE_EN, ITERATIONS, FAST_APPROX, SKIP_POSITIVE_CHECK>(
         exp_base_scale_factor);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -5,8 +5,7 @@
 #pragma once
 
 #include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_exp.h"
+#include "sfpu/ckernel_sfpu_exp2.h"
 
 using namespace sfpi;
 
@@ -15,30 +14,12 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_exp2() {
-    const bool FAST_APPROX = false;          // Exp2 does not use fast approximation.
-    const bool SCALE_EN = false;             // Exp2 does not use scale.
-    const bool SKIP_POSITIVE_CHECK = false;  // Exp2 does not skip positive check.
-    // SFPU microcode
-    for (int d = 0; d < ITERATIONS; d++) {
-        vFloat v = dst_reg[0];
-        // log(2) = 0.6931471805;
-        v = v * 0.6931471805f;
-        // exp = e^(v)
-        vFloat exp = _calculate_exponential_body_improved_<
-            APPROXIMATION_MODE,
-            SCALE_EN,
-            ITERATIONS,
-            FAST_APPROX,
-            SKIP_POSITIVE_CHECK>(v);
-        dst_reg[0] = exp;
-        dst_reg++;
-    }
+    _calculate_exp2_<APPROXIMATION_MODE, ITERATIONS>();
 }
 
 template <bool APPROXIMATION_MODE>
 inline void exp2_init() {
-    const bool FAST_APPROX = false;  // Exp2 does not use fast approximation.
-    exp_init<APPROXIMATION_MODE, FAST_APPROX>();
+    _init_exp2_<APPROXIMATION_MODE>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -15,13 +15,21 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_exp2() {
+    const bool FAST_APPROX = false;          // Exp2 does not use fast approximation.
+    const bool SCALE_EN = false;             // Exp2 does not use scale.
+    const bool SKIP_POSITIVE_CHECK = false;  // Exp2 does not skip positive check.
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
         // log(2) = 0.6931471805;
         v = v * 0.6931471805f;
         // exp = e^(v)
-        vFloat exp = calculate_exponential_body_improved<APPROXIMATION_MODE>(v);
+        vFloat exp = _calculate_exponential_body_improved_<
+            APPROXIMATION_MODE,
+            SCALE_EN,
+            ITERATIONS,
+            FAST_APPROX,
+            SKIP_POSITIVE_CHECK>(v);
         dst_reg[0] = exp;
         dst_reg++;
     }
@@ -29,15 +37,8 @@ inline void calculate_exp2() {
 
 template <bool APPROXIMATION_MODE>
 inline void exp2_init() {
-    if constexpr (APPROXIMATION_MODE) {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = s2vFloat16b(p_exp::C23_73);
-        vConstFloatPrgm2 = s2vFloat16b(p_exp::ADJ_EXP);
-    } else {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = 2.0f;
-        vConstFloatPrgm2 = 0.863281f;
-    }
+    const bool FAST_APPROX = false;  // Exp2 does not use fast approximation.
+    exp_init<APPROXIMATION_MODE, FAST_APPROX>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -4,10 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
 #include "sfpu/ckernel_sfpu_exp2.h"
-
-using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -5,8 +5,7 @@
 #pragma once
 
 #include "ckernel.h"
-#include "ckernel_defs.h"
-#include "ckernel_sfpu_exp.h"
+#include "sfpu/ckernel_sfpu_expm1.h"
 
 using namespace sfpi;
 
@@ -15,27 +14,12 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_expm1() {
-    const bool FAST_APPROX = false;          // Expm1 does not use fast approximation.
-    const bool SCALE_EN = false;             // Expm1 does not use scale.
-    const bool SKIP_POSITIVE_CHECK = false;  // Expm1 does not skip positive check.
-    // SFPU microcode
-    for (int d = 0; d < ITERATIONS; d++) {
-        vFloat v = dst_reg[0];
-        v = _calculate_exponential_body_improved_<
-            APPROXIMATION_MODE,
-            SCALE_EN,
-            ITERATIONS,
-            FAST_APPROX,
-            SKIP_POSITIVE_CHECK>(v);
-        dst_reg[0] = v - 1.0f;
-        dst_reg++;
-    }
+    _calculate_expm1_<APPROXIMATION_MODE, ITERATIONS>();
 }
 
 template <bool APPROXIMATION_MODE>
 void expm1_init() {
-    const bool FAST_APPROX = false;  // Expm1 does not use fast approximation.
-    exp_init<APPROXIMATION_MODE, FAST_APPROX>();
+    _init_expm1_<APPROXIMATION_MODE>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -15,10 +15,18 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_expm1() {
+    const bool FAST_APPROX = false;          // Expm1 does not use fast approximation.
+    const bool SCALE_EN = false;             // Expm1 does not use scale.
+    const bool SKIP_POSITIVE_CHECK = false;  // Expm1 does not skip positive check.
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
-        v = calculate_exponential_body_improved<APPROXIMATION_MODE>(v);
+        v = _calculate_exponential_body_improved_<
+            APPROXIMATION_MODE,
+            SCALE_EN,
+            ITERATIONS,
+            FAST_APPROX,
+            SKIP_POSITIVE_CHECK>(v);
         dst_reg[0] = v - 1.0f;
         dst_reg++;
     }
@@ -26,15 +34,8 @@ inline void calculate_expm1() {
 
 template <bool APPROXIMATION_MODE>
 void expm1_init() {
-    if constexpr (APPROXIMATION_MODE) {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = s2vFloat16b(p_exp::C23_73);
-        vConstFloatPrgm2 = s2vFloat16b(p_exp::ADJ_EXP);
-    } else {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = 2.0f;
-        vConstFloatPrgm2 = 0.863281f;
-    }
+    const bool FAST_APPROX = false;  // Expm1 does not use fast approximation.
+    exp_init<APPROXIMATION_MODE, FAST_APPROX>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -4,22 +4,31 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "sfpu/ckernel_sfpu_expm1.h"
-
-using namespace sfpi;
+#include "sfpu/ckernel_sfpu_exp.h"
 
 namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_expm1() {
-    _calculate_expm1_<APPROXIMATION_MODE, ITERATIONS>();
+    const bool SCALE_EN = false;             // Expm1 does not use scale.
+    const bool SKIP_POSITIVE_CHECK = false;  // Expm1 does not skip positive check.
+    const uint16_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B;
+
+    // SFPU microcode
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        v = _calculate_exponential_piecewise_<APPROXIMATION_MODE, SCALE_EN, SKIP_POSITIVE_CHECK>(
+            v, exp_base_scale_factor);
+        sfpi::dst_reg[0] = v - 1.0f;
+        sfpi::dst_reg++;
+    }
 }
 
 template <bool APPROXIMATION_MODE>
 void expm1_init() {
-    _init_expm1_<APPROXIMATION_MODE>();
+    const uint32_t EXP_BASE_SCALE_FACTOR = 0x3F800000;
+    _init_exponential_<APPROXIMATION_MODE, false /*fast_mode*/, EXP_BASE_SCALE_FACTOR>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_elu.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_elu_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::elu, APPROXIMATE>(sfpu::elu_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_elu(uint dst_index, uint param0) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_elu<APPROXIMATE>, dst_index, (int)VectorMode::RC, param0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp.h
@@ -19,15 +19,17 @@ template <
     bool SKIP_POSITIVE_CHECK = false,
     int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_exponential(
-    uint dst_index, int vector_mode = (int)VectorMode::RC, int param0 = 0x3F80) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+    uint dst_index,
+    int vector_mode = (int)VectorMode::RC,
+    int param0 = p_sfpu::kCONST_1_FP16B /* exp_base_scale_factor*/) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_exponential<APPROXIMATE, FAST_APPROX, SCALE_EN, ITERATIONS, SKIP_POSITIVE_CHECK>,
         dst_index,
         vector_mode,
         param0);
 }
 
-template <bool APPROXIMATE, bool FAST_APPROX, uint32_t scale = 0x3F800000>
+template <bool APPROXIMATE, bool FAST_APPROX, uint32_t scale = p_sfpu::kCONST_1_FP16B>
 inline void llk_math_eltwise_unary_sfpu_exponential_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::exponential, APPROXIMATE>(
         sfpu::exp_init<APPROXIMATE, FAST_APPROX, scale>);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp.h
@@ -19,13 +19,12 @@ template <
     bool SKIP_POSITIVE_CHECK = false,
     int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_exponential(
-    uint dst_index, int vector_mode = (int)VectorMode::RC, int param0 = ITERATIONS, int param1 = 0x3F80) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    uint dst_index, int vector_mode = (int)VectorMode::RC, int param0 = 0x3F80) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_exponential<APPROXIMATE, FAST_APPROX, SCALE_EN, ITERATIONS, SKIP_POSITIVE_CHECK>,
         dst_index,
         vector_mode,
-        param0,
-        param1);
+        param0);
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX, uint32_t scale = 0x3F800000>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_exp2_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::exp2, APPROXIMATE>(sfpu::exp2_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_exp2(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_exp2<APPROXIMATE>, dst_index, vector_mode);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_expm1_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::expm1, APPROXIMATE>(sfpu::expm1_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_expm1<APPROXIMATE>, dst_index, vector_mode);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -5,12 +5,8 @@
 #pragma once
 
 #include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
-
+#include "ckernel_sfpu_elu.h"
 #include "sfpi.h"
-#include "ckernel_sfpu_exp.h"
-#include "sfpu/ckernel_sfpu_converter.h"
 
 using namespace sfpi;
 
@@ -19,37 +15,12 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_elu(uint slope) {
-    const bool FAST_APPROX = false;          // Elu does not use fast approximation.
-    const bool SCALE_EN = false;             // Elu does not use scale.
-    const bool SKIP_POSITIVE_CHECK = false;  // Elu does not skip positive check.
-    // SFPU microcode
-    vFloat s = Converter::as_float(slope);
-
-#pragma GCC unroll 0
-    for (int d = 0; d < 8; d++) {
-        vFloat v = dst_reg[0];
-
-        v_if(v < 0.0f) {
-            vFloat v_exp = _calculate_exponential_body_improved_<
-                APPROXIMATION_MODE,
-                SCALE_EN,
-                ITERATIONS,
-                FAST_APPROX,
-                SKIP_POSITIVE_CHECK>(v);
-            v = s * (v_exp - 1.0f);
-        }
-        v_endif;
-
-        dst_reg[0] = v;
-
-        dst_reg++;
-    }
+    _calculate_elu_<APPROXIMATION_MODE, ITERATIONS>(slope);
 }
 
 template <bool APPROXIMATION_MODE>
 void elu_init() {
-    const bool FAST_APPROX = false;  // Elu does not use fast approximation.
-    exp_init<APPROXIMATION_MODE, FAST_APPROX>();
+    _init_elu_<APPROXIMATION_MODE>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -17,8 +17,11 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_elu(uint slope) {
+    const bool FAST_APPROX = false;          // Elu does not use fast approximation.
+    const bool SCALE_EN = false;             // Elu does not use scale.
+    const bool SKIP_POSITIVE_CHECK = false;  // Elu does not skip positive check.
     // SFPU microcode
     vFloat s = Converter::as_float(slope);
 
@@ -27,7 +30,12 @@ inline void calculate_elu(uint slope) {
         vFloat v = dst_reg[0];
 
         v_if(v < 0.0f) {
-            vFloat v_exp = calculate_exponential_body_improved<APPROXIMATION_MODE>(v);
+            vFloat v_exp = _calculate_exponential_body_improved_<
+                APPROXIMATION_MODE,
+                SCALE_EN,
+                ITERATIONS,
+                FAST_APPROX,
+                SKIP_POSITIVE_CHECK>(v);
             v = s * (v_exp - 1.0f);
         }
         v_endif;
@@ -40,15 +48,8 @@ inline void calculate_elu(uint slope) {
 
 template <bool APPROXIMATION_MODE>
 void elu_init() {
-    if constexpr (APPROXIMATION_MODE) {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = s2vFloat16b(p_exp::C23_73);
-        vConstFloatPrgm2 = s2vFloat16b(p_exp::ADJ_EXP);
-    } else {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = 2.0f;
-        vConstFloatPrgm2 = 0.863281f;
-    }
+    const bool FAST_APPROX = false;  // Elu does not use fast approximation.
+    exp_init<APPROXIMATION_MODE, FAST_APPROX>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -4,11 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
 #include "ckernel_sfpu_elu.h"
-#include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -31,58 +31,6 @@ void calculate_exponential(const uint iterations = ITERATIONS, const uint exp_ba
         iterations, exp_base_scale_factor);
 }
 
-template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat calculate_exponential_body(vFloat in) {
-    vFloat out;
-
-    if constexpr (APPROXIMATION_MODE) {
-        v_if(in >= 89) {
-            vFloat val_inf = std::numeric_limits<float>::infinity();
-            out = val_inf;
-        }
-        v_elseif(in < -42) { out = 0.0f; }
-        v_else { out = _calculate_exponential_body_<APPROXIMATION_MODE>(in); }
-        v_endif;
-    } else {
-        out = _calculate_exponential_body_<APPROXIMATION_MODE>(in);
-    }
-
-    return out;
-}
-
-template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat calculate_exponential_body_improved(vFloat val) {
-    vFloat out;
-    if constexpr (APPROXIMATION_MODE) {
-        v_if(val >= 89) {
-            vFloat val_inf = std::numeric_limits<float>::infinity();
-            out = val_inf;
-        }
-        v_elseif(val < -42) { out = 0.0f; }
-        v_else {
-            // * by 1/ln2 and add convert to 7.3 FxP format
-            vFloat vConstLn2Recip = vConstFloatPrgm0;
-            vFloat c23_73 = vConstFloatPrgm1;
-            vInt adj_exp = vConstIntPrgm2;
-            val = val * vConstLn2Recip + c23_73;
-
-            // Remove Exponent of 7 and bias the Mantissa to 127.
-            vInt val_short = adj_exp + reinterpret<vInt>(val);
-
-            // SHL to move integer bits to exponent
-            val_short <<= 10 - p_exp::FRAC_BITS;
-            out = reinterpret<vFloat>(val_short);
-        }
-        v_endif;
-    } else {
-        // Force sign to 0 (make number positive)
-        out = sfpu_exp(setsgn(val, 0));
-        v_if(val < 0) { out = sfpu_reciprocal(out); }
-        v_endif;
-    }
-    return out;
-}
-
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, uint32_t scale = 0x3F800000>
 void exp_init() {
     _init_exponential_<APPROXIMATION_MODE, FAST_APPROX, scale>();

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -4,13 +4,8 @@
 
 #pragma once
 
-#include "ckernel_defs.h"
 #include "ckernel.h"
-#include "noc_nonblocking_api.h"
 #include "sfpu/ckernel_sfpu_exp.h"
-#include "ckernel_sfpu_recip.h"
-#include <limits>
-
 #include "sfpi.h"
 
 using namespace sfpi;
@@ -26,9 +21,9 @@ template <
     bool SCALE_EN = false,
     int ITERATIONS = 8,
     bool SKIP_POSITIVE_CHECK = false>
-void calculate_exponential(const uint iterations = ITERATIONS, const uint exp_base_scale_factor = 0x3F80) {
+void calculate_exponential(const uint exp_base_scale_factor = 0x3F80) {
     _calculate_exponential_<APPROXIMATION_MODE, SCALE_EN, ITERATIONS, FAST_APPROX, SKIP_POSITIVE_CHECK>(
-        iterations, exp_base_scale_factor);
+        exp_base_scale_factor);
 }
 
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, uint32_t scale = 0x3F800000>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -8,12 +8,10 @@
 #include "sfpu/ckernel_sfpu_exp.h"
 #include "sfpi.h"
 
-using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
 
-sfpi_inline vFloat sfpu_exp(vFloat val) { return _sfpu_exp_(val); }
+sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
 
 template <
     bool APPROXIMATION_MODE,
@@ -21,7 +19,7 @@ template <
     bool SCALE_EN = false,
     int ITERATIONS = 8,
     bool SKIP_POSITIVE_CHECK = false>
-void calculate_exponential(const uint exp_base_scale_factor = 0x3F80) {
+void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
     _calculate_exponential_<APPROXIMATION_MODE, SCALE_EN, ITERATIONS, FAST_APPROX, SKIP_POSITIVE_CHECK>(
         exp_base_scale_factor);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -5,9 +5,7 @@
 #pragma once
 
 #include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
-#include "ckernel_sfpu_exp.h"
+#include "sfpu/ckernel_sfpu_exp2.h"
 
 using namespace sfpi;
 
@@ -16,30 +14,12 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_exp2() {
-    const bool FAST_APPROX = false;          // Exp2 does not use fast approximation.
-    const bool SCALE_EN = false;             // Exp2 does not use scale.
-    const bool SKIP_POSITIVE_CHECK = false;  // Exp2 does not skip positive check.
-    // SFPU microcode
-    for (int d = 0; d < ITERATIONS; d++) {
-        vFloat v = dst_reg[0];
-        // log(2) = 0.6931471805;
-        v = v * 0.6931471805f;
-        // exp = e^(v)
-        vFloat exp = _calculate_exponential_body_improved_<
-            APPROXIMATION_MODE,
-            SCALE_EN,
-            ITERATIONS,
-            FAST_APPROX,
-            SKIP_POSITIVE_CHECK>(v);
-        dst_reg[0] = exp;
-        dst_reg++;
-    }
+    _calculate_exp2_<APPROXIMATION_MODE, ITERATIONS>();
 }
 
 template <bool APPROXIMATION_MODE>
 inline void exp2_init() {
-    const bool FAST_APPROX = false;  // Exp2 does not use fast approximation.
-    exp_init<APPROXIMATION_MODE, FAST_APPROX>();
+    _init_exp2_<APPROXIMATION_MODE>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -16,13 +16,21 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_exp2() {
+    const bool FAST_APPROX = false;          // Exp2 does not use fast approximation.
+    const bool SCALE_EN = false;             // Exp2 does not use scale.
+    const bool SKIP_POSITIVE_CHECK = false;  // Exp2 does not skip positive check.
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
         // log(2) = 0.6931471805;
         v = v * 0.6931471805f;
         // exp = e^(v)
-        vFloat exp = calculate_exponential_body_improved<APPROXIMATION_MODE>(v);
+        vFloat exp = _calculate_exponential_body_improved_<
+            APPROXIMATION_MODE,
+            SCALE_EN,
+            ITERATIONS,
+            FAST_APPROX,
+            SKIP_POSITIVE_CHECK>(v);
         dst_reg[0] = exp;
         dst_reg++;
     }
@@ -30,15 +38,8 @@ inline void calculate_exp2() {
 
 template <bool APPROXIMATION_MODE>
 inline void exp2_init() {
-    if constexpr (APPROXIMATION_MODE) {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = s2vFloat16b(p_exp::C23_73);
-        vConstFloatPrgm2 = s2vFloat16b(p_exp::ADJ_EXP);
-    } else {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = 2.0f;
-        vConstFloatPrgm2 = 0.863281f;
-    }
+    const bool FAST_APPROX = false;  // Exp2 does not use fast approximation.
+    exp_init<APPROXIMATION_MODE, FAST_APPROX>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -4,10 +4,7 @@
 
 #pragma once
 
-#include "ckernel.h"
 #include "sfpu/ckernel_sfpu_exp2.h"
-
-using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -16,10 +16,18 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_expm1() {
+    const bool FAST_APPROX = false;          // Expm1 does not use fast approximation.
+    const bool SCALE_EN = false;             // Expm1 does not use scale.
+    const bool SKIP_POSITIVE_CHECK = false;  // Expm1 does not skip positive check.
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
-        v = calculate_exponential_body_improved<APPROXIMATION_MODE>(v);
+        v = _calculate_exponential_body_improved_<
+            APPROXIMATION_MODE,
+            SCALE_EN,
+            ITERATIONS,
+            FAST_APPROX,
+            SKIP_POSITIVE_CHECK>(v);
         dst_reg[0] = v - 1.0f;
         dst_reg++;
     }
@@ -27,15 +35,8 @@ inline void calculate_expm1() {
 
 template <bool APPROXIMATION_MODE>
 void expm1_init() {
-    if constexpr (APPROXIMATION_MODE) {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = s2vFloat16b(p_exp::C23_73);
-        vConstFloatPrgm2 = s2vFloat16b(p_exp::ADJ_EXP);
-    } else {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = 2.0f;
-        vConstFloatPrgm2 = 0.863281f;
-    }
+    const bool FAST_APPROX = false;  // Expm1 does not use fast approximation.
+    exp_init<APPROXIMATION_MODE, FAST_APPROX>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -5,9 +5,7 @@
 #pragma once
 
 #include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
-#include "ckernel_sfpu_exp.h"
+#include "sfpu/ckernel_sfpu_expm1.h"
 
 using namespace sfpi;
 
@@ -16,27 +14,12 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_expm1() {
-    const bool FAST_APPROX = false;          // Expm1 does not use fast approximation.
-    const bool SCALE_EN = false;             // Expm1 does not use scale.
-    const bool SKIP_POSITIVE_CHECK = false;  // Expm1 does not skip positive check.
-    // SFPU microcode
-    for (int d = 0; d < ITERATIONS; d++) {
-        vFloat v = dst_reg[0];
-        v = _calculate_exponential_body_improved_<
-            APPROXIMATION_MODE,
-            SCALE_EN,
-            ITERATIONS,
-            FAST_APPROX,
-            SKIP_POSITIVE_CHECK>(v);
-        dst_reg[0] = v - 1.0f;
-        dst_reg++;
-    }
+    _calculate_expm1_<APPROXIMATION_MODE, ITERATIONS>();
 }
 
 template <bool APPROXIMATION_MODE>
 void expm1_init() {
-    const bool FAST_APPROX = false;  // Expm1 does not use fast approximation.
-    exp_init<APPROXIMATION_MODE, FAST_APPROX>();
+    _init_expm1_<APPROXIMATION_MODE>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -4,22 +4,31 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "sfpu/ckernel_sfpu_expm1.h"
-
-using namespace sfpi;
+#include "sfpu/ckernel_sfpu_exp.h"
 
 namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_expm1() {
-    _calculate_expm1_<APPROXIMATION_MODE, ITERATIONS>();
+    const bool SCALE_EN = false;             // Expm1 does not use scale.
+    const bool SKIP_POSITIVE_CHECK = false;  // Expm1 does not skip positive check.
+    const uint16_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B;
+
+    // SFPU microcode
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        v = _calculate_exponential_piecewise_<APPROXIMATION_MODE, SCALE_EN, SKIP_POSITIVE_CHECK>(
+            v, exp_base_scale_factor);
+        sfpi::dst_reg[0] = v - 1.0f;
+        sfpi::dst_reg++;
+    }
 }
 
 template <bool APPROXIMATION_MODE>
 void expm1_init() {
-    _init_expm1_<APPROXIMATION_MODE>();
+    const uint32_t EXP_BASE_SCALE_FACTOR = 0x3F800000;
+    _init_exponential_<APPROXIMATION_MODE, false /*fast_mode*/, EXP_BASE_SCALE_FACTOR>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_elu.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_elu_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::elu, APPROXIMATE>(sfpu::elu_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_elu(uint dst_index, uint param0) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_elu<APPROXIMATE>, dst_index, (int)VectorMode::RC, param0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp.h
@@ -19,15 +19,17 @@ template <
     bool SKIP_POSITIVE_CHECK = false,
     int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_exponential(
-    uint dst_index, int vector_mode = (int)VectorMode::RC, int param0 = 0x3F80) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+    uint dst_index,
+    int vector_mode = (int)VectorMode::RC,
+    int param0 = p_sfpu::kCONST_1_FP16B /* exp_base_scale_factor*/) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_exponential<APPROXIMATE, FAST_APPROX, SCALE_EN, ITERATIONS, SKIP_POSITIVE_CHECK>,
         dst_index,
         vector_mode,
         param0);
 }
 
-template <bool APPROXIMATE, bool FAST_APPROX, uint32_t scale = 0x3F800000>
+template <bool APPROXIMATE, bool FAST_APPROX, uint32_t scale = p_sfpu::kCONST_1_FP16B>
 inline void llk_math_eltwise_unary_sfpu_exponential_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::exponential, APPROXIMATE>(
         sfpu::exp_init<APPROXIMATE, FAST_APPROX, scale>);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp.h
@@ -19,13 +19,12 @@ template <
     bool SKIP_POSITIVE_CHECK = false,
     int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_exponential(
-    uint dst_index, int vector_mode = (int)VectorMode::RC, int param0 = ITERATIONS, int param1 = 0x3F80) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+    uint dst_index, int vector_mode = (int)VectorMode::RC, int param0 = 0x3F80) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_exponential<APPROXIMATE, FAST_APPROX, SCALE_EN, ITERATIONS, SKIP_POSITIVE_CHECK>,
         dst_index,
         vector_mode,
-        param0,
-        param1);
+        param0);
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX, uint32_t scale = 0x3F800000>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_exp2_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::exp2, APPROXIMATE>(sfpu::exp2_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_exp2(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_exp2<APPROXIMATE>, dst_index, vector_mode);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -17,7 +17,7 @@ inline void llk_math_eltwise_unary_sfpu_expm1_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::expm1, APPROXIMATE>(sfpu::expm1_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_expm1<APPROXIMATE>, dst_index, vector_mode);

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/exp.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/exp.h
@@ -59,7 +59,7 @@ template <
     int iterations = 8>
 ALWI void exp_tile(uint32_t idst, int vector_mode = (int)VectorMode::RC, uint16_t scale = 0x3F80) {
     MATH((llk_math_eltwise_unary_sfpu_exponential<approx, fast_and_approx, scale_en, skip_positive_check, iterations>(
-        idst, vector_mode, iterations, scale)));
+        idst, vector_mode, scale)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/exp.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/exp.h
@@ -57,7 +57,7 @@ template <
     bool scale_en = false,
     bool skip_positive_check = false,
     int iterations = 8>
-ALWI void exp_tile(uint32_t idst, int vector_mode = (int)VectorMode::RC, uint16_t scale = 0x3F80) {
+ALWI void exp_tile(uint32_t idst, int vector_mode = (int)VectorMode::RC, uint16_t scale = p_sfpu::kCONST_1_FP16B) {
     MATH((llk_math_eltwise_unary_sfpu_exponential<approx, fast_and_approx, scale_en, skip_positive_check, iterations>(
         idst, vector_mode, scale)));
 }


### PR DESCRIPTION
### Ticket
#24276 

### Problem description
Migrate exp related ops implementation from tt-metal to tt-llk. This includes following ops:-

- exp
- exp2
- <del>expm1</del> (due to accuracy issues in approx_mode = True)
- elu

TT-LLK [PR](https://github.com/tenstorrent/tt-llk/pull/469)

### What's changed
- Modified tt-metal apis and migrated implementation to tt-llk.
- Tests: Integrated exp related ops tests in tt-llk (as part of eltwise unary sfpu test infra)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16288024157) CI passes
- [x] [Blackhole Post commit nightly](https://github.com/tenstorrent/tt-metal/actions/runs/16168813896)  (conv2d tests are failing in latest main as well)
- [x]  [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16288033046) CI with demo tests passes (if applicable)
- [x]  [T3K tests pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/16259925014) CI with demo tests passes (if applicable)
- [x]  [Single card tests pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/16287994398) (same tests failing as in main branch)