### PR TITLE
Reenabled cache for test_reallocate.py

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_reallocate.py
+++ b/tests/ttnn/unit_tests/operations/test_reallocate.py
@@ -20,9 +20,6 @@ def test_reallocate_interleaved(device, mem_config, num_allocs):
     depth = 2
     batch = 2
 
-    # https://github.com/tenstorrent/tt-metal/issues/23236
-    device.disable_and_clear_program_cache()
-
     if num_allocs == 2 and mem_config == ttnn.DRAM_MEMORY_CONFIG:
         pytest.xfail("#7732: dram tensor corruption after move")
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/23236)

### Problem description
During the initial activation of the cache, this test was failing

### What's changed
This test is behaving the same way with or without cache now, probably was never a real issue and the pipelines were just missbehaving

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes