### PR TITLE
Fix TT-NN Visualizer report gen pybyindings

### DIFF
--- a/ttnn/cpp/ttnn-pybind/reports.cpp
+++ b/ttnn/cpp/ttnn-pybind/reports.cpp
@@ -5,6 +5,7 @@
 #include "reports.hpp"
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "ttnn/reports.hpp"
 #include <tt-metalium/allocator.hpp>


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Generating TT-NN Visualizer reports erroring out:
```
TypeError: get_buffers(): incompatible function arguments. The following argument types are supported:
    1. (devices: std::vector<tt::tt_metal::distributed::MeshDevice*, std::allocator<tt::tt_metal::distributed::MeshDevice*> >) -> std::vector<ttnn::reports::BufferInfo, std::allocator<ttnn::reports::BufferInfo> >
    2. (device: ttnn._ttnn.multi_device.MeshDevice) -> std::vector<ttnn::reports::BufferInfo, std::allocator<ttnn::reports::BufferInfo> >

Invoked with: [MeshDevice(1x1 grid, 1 devices)]
```

Python list isn't being marshalled to std::vector.

### What's changed
Included pybind STL header to fix issue.

Fix was locally tested.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes