### PR TITLE
#20005: remove GS/BH skips for profiler tests

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -23,8 +23,6 @@ from tt_metal.tools.profiler.common import (
     clear_profiler_runtime_artifacts,
 )
 
-from models.utility_functions import skip_for_grayskull, skip_for_blackhole
-
 PROG_EXMP_DIR = "programming_examples/profiler"
 TRACY_TESTS_DIR = "./tests/ttnn/tracy"
 
@@ -109,7 +107,6 @@ def get_function_name():
     return frame.f_code.co_name
 
 
-@skip_for_grayskull()
 def test_multi_op():
     OP_COUNT = 1000
     RUN_COUNT = 2
@@ -216,7 +213,6 @@ def test_full_buffer():
         assert stats[statName]["stats"]["Count"] in REF_COUNT_DICT[ENV_VAR_ARCH_NAME], "Wrong Marker Repeat count"
 
 
-@skip_for_blackhole()
 def test_dispatch_cores():
     OP_COUNT = 1
     RISC_COUNT = 1
@@ -289,8 +285,6 @@ def test_dispatch_cores():
 
 
 # Eth dispatch will be deprecated
-@skip_for_blackhole()
-@skip_for_grayskull()
 def test_ethernet_dispatch_cores():
     REF_COUNT_DICT = {
         "Ethernet CQ Dispatch": [322, 541, 1400, 1900, 2100],
@@ -337,7 +331,6 @@ def test_ethernet_dispatch_cores():
                 ), f"Wrong ethernet dispatch zone count, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
 
 
-@skip_for_grayskull()
 def test_profiler_host_device_sync():
     TOLERANCE = 0.1
 
@@ -471,7 +464,6 @@ def test_noc_event_profiler():
         assert len(noc_trace_data) == 8
 
 
-@skip_for_blackhole()
 def test_fabric_event_profiler_unicast():
     ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
     assert ENV_VAR_ARCH_NAME in ["wormhole_b0", "blackhole"]
@@ -529,7 +521,6 @@ def test_fabric_event_profiler_unicast():
     ), f"Incorrect number of fabric events found in noc trace: {fabric_event_count}, expected {EXPECTED_FABRIC_EVENT_COUNT}"
 
 
-@skip_for_blackhole()
 def test_fabric_event_profiler_1d_multicast():
     ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
     assert ENV_VAR_ARCH_NAME in ["wormhole_b0", "blackhole"]


### PR DESCRIPTION
### Ticket
Link to Github Issue #20005

### Problem description
Some tests were failing on BH. The underlying issue was fixed. But the tests were still skipped.

### What's changed
- Remove the skips
- Remove GS skips since those are no longer needed

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). N/A
- [ ] New/Existing tests provide coverage for changes