### PR TITLE
Fix included CPP files for wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -274,6 +274,7 @@ class CMakeBuild(build_ext):
         ttnn_cpp_patterns = [
             "ttnn/deprecated/**/kernels/**/*",
             "ttnn/operations/**/kernels/**/*",
+            "ttnn/operations/**/kernels_ng/**/*",
             "ttnn/operations/ccl/**/*",
             "ttnn/operations/data_movement/**/*",
             "ttnn/operations/moreh/**/*",

--- a/setup.py
+++ b/setup.py
@@ -275,6 +275,7 @@ class CMakeBuild(build_ext):
             "ttnn/deprecated/**/kernels/**/*",
             "ttnn/operations/**/kernels/**/*",
             "ttnn/operations/**/kernels_ng/**/*",
+            "ttnn/operations/kernel_helper_functions/*",
             "ttnn/operations/ccl/**/*",
             "ttnn/operations/data_movement/**/*",
             "ttnn/operations/moreh/**/*",


### PR DESCRIPTION
Since 0.59.0rc51 (and later), the released wheel file has been broken. Specifically, it looks like there were commits that added new file paths that were not being included in the wheel.

This PR fixes the issue by adding the new file paths. This fix has been verified against the lowering tests in pytorch2.0_ttnn.

Note that the public release 0.60.0 currently has this issue. I am not sure how to update the public release, but it may be worth doing so.