### PR TITLE
Add some tests to run with dispatch on fabric

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -81,6 +81,7 @@ run_t3000_ttnn_tests() {
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./build/test/ttnn/unit_tests_ttnn
   ./build/test/ttnn/unit_tests_ttnn_ccl
   ./build/test/ttnn/unit_tests_ttnn_ccl_multi_tensor
+  TT_METAL_FD_FABRIC=true ./build/test/ttnn/unit_tests_ttnn_ccl_multi_tensor
   ./build/test/ttnn/unit_tests_ttnn_ccl_ops
   ./build/test/ttnn/test_ccl_multi_cq_multi_device
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -588,10 +588,8 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
     FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (tt_fabric::is_tt_fabric_config(fabric_config)) {
         for (int i = 0; i < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices(); i++) {
-            if (not _inst->is_device_active(i)) {
-                // Fabric currently requires all devices to be active
-                TT_THROW("Fabric is being used but Device {} is not active", i);
-            }
+            // Fabric currently requires all devices to be active
+            TT_FATAL(_inst->is_device_active(i), "Fabric is being used but Device {} is not active", i);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -202,6 +202,14 @@ RingTopology::RingTopology(
         if (!is_linear || ring_index != ring_size - 1) {
             uint32_t receiver_device = receiver_device_id.value();
             auto const& sockets = device->get_ethernet_sockets(receiver_device);
+            if (sender_socket_idx >= sockets.size()) {
+                TT_THROW(
+                    "Sender socket index out of bounds. Device {} has {} ethernet cores but tried to access core at "
+                    "index {}",
+                    device->id(),
+                    sockets.size(),
+                    sender_socket_idx);
+            }
             auto eth_sender_core = sockets.at(sender_socket_idx);
             eth_sender_cores.push_back(eth_sender_core);
             log_trace(tt::LogOp, "\teth_sender_core on link {}: (x={},y={})", l, eth_sender_core.x, eth_sender_core.y);
@@ -209,6 +217,14 @@ RingTopology::RingTopology(
         if (!is_linear || ring_index != 0) {
             uint32_t sender_device = sender_device_id.value();
             auto const& sockets = device->get_ethernet_sockets(sender_device);
+            if (receiver_socket_idx >= sockets.size()) {
+                TT_THROW(
+                    "Receiver socket index out of bounds. Device {} has {} ethernet cores but tried to access core at "
+                    "index {}",
+                    device->id(),
+                    sockets.size(),
+                    receiver_socket_idx);
+            }
             auto eth_receiver_core = sockets.at(receiver_socket_idx);
             eth_receiver_cores.push_back(eth_receiver_core);
             log_trace(

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -202,14 +202,13 @@ RingTopology::RingTopology(
         if (!is_linear || ring_index != ring_size - 1) {
             uint32_t receiver_device = receiver_device_id.value();
             auto const& sockets = device->get_ethernet_sockets(receiver_device);
-            if (sender_socket_idx >= sockets.size()) {
-                TT_THROW(
-                    "Sender socket index out of bounds. Device {} has {} ethernet cores but tried to access core at "
-                    "index {}",
-                    device->id(),
-                    sockets.size(),
-                    sender_socket_idx);
-            }
+            TT_FATAL(
+                sender_socket_idx < sockets.size(),
+                "Sender socket index out of bounds. Device {} has {} ethernet cores but tried to access core at "
+                "index {}",
+                device->id(),
+                sockets.size(),
+                sender_socket_idx);
             auto eth_sender_core = sockets.at(sender_socket_idx);
             eth_sender_cores.push_back(eth_sender_core);
             log_trace(tt::LogOp, "\teth_sender_core on link {}: (x={},y={})", l, eth_sender_core.x, eth_sender_core.y);
@@ -217,14 +216,13 @@ RingTopology::RingTopology(
         if (!is_linear || ring_index != 0) {
             uint32_t sender_device = sender_device_id.value();
             auto const& sockets = device->get_ethernet_sockets(sender_device);
-            if (receiver_socket_idx >= sockets.size()) {
-                TT_THROW(
-                    "Receiver socket index out of bounds. Device {} has {} ethernet cores but tried to access core at "
-                    "index {}",
-                    device->id(),
-                    sockets.size(),
-                    receiver_socket_idx);
-            }
+            TT_FATAL(
+                receiver_socket_idx < sockets.size(),
+                "Receiver socket index out of bounds. Device {} has {} ethernet cores but tried to access core at "
+                "index {}",
+                device->id(),
+                sockets.size(),
+                receiver_socket_idx);
             auto eth_receiver_core = sockets.at(receiver_socket_idx);
             eth_receiver_cores.push_back(eth_receiver_core);
             log_trace(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18726

### Problem description
- Ensure legacy and new CCLs are working with dispatch on fabric

### What's changed
- Add `unit_tests_ttnn_ccl_multi_tensor` which contains legacy and async CCLs to run on T3K Unit Tests pipeline to ensure things don't break before FD on Dispatch is enabled by default
- Workaround in the cluster to ensure we only allocate the dispatch fabric routers in the tunnel
- Ethernet core index checking in `ccl_common.cpp`
- Remove redundant logic in DevicePool initialize

### Checklist
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/16056710126
TG
https://github.com/tenstorrent/tt-metal/actions/runs/16056724008
APC
https://github.com/tenstorrent/tt-metal/actions/runs/16056708172