### PR TITLE
Keep multi device fixtures open

### DIFF
--- a/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
@@ -18,6 +18,10 @@ namespace fabric_router_tests {
 
 class InterMeshRoutingFabric2DFixture : public BaseFabricFixture {
 public:
+    // This test fixture closes/opens devices on each test
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
         if (not system_supported()) {
             GTEST_SKIP() << "Skipping since this is not a supported system.";
@@ -43,12 +47,12 @@ public:
         TT_FATAL(
             *(tt::tt_metal::MetalContext::instance().get_distributed_context().size()) > 1,
             "Multi-Host Routing tests require multiple hosts in the system");
-        this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC);
+        this->DoSetUpTestSuite(tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC);
     }
 
     void TearDown() override {
         if (system_supported()) {
-            BaseFabricFixture::TearDown();
+            BaseFabricFixture::DoTearDownTestSuite();
         }
     }
 

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -603,7 +603,7 @@ def test_sub_device_profiler():
     ARCH_NAME = os.getenv("ARCH_NAME")
     run_gtest_profiler_test(
         "./build/test/tt_metal/unit_tests_dispatch",
-        "CommandQueueSingleCardFixture.TensixTestSubDeviceBasicPrograms",
+        "CommandQueueSingleCardSubDeviceFixture.TensixTestSubDeviceBasicPrograms",
     )
     run_gtest_profiler_test(
         "./build/test/tt_metal/unit_tests_dispatch",

--- a/tests/tt_metal/tt_metal/api/test_dram_to_l1_multicast.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_to_l1_multicast.cpp
@@ -152,6 +152,8 @@ TEST_F(DispatchFixture, TensixDRAMtoL1Multicast) {
         .dest_buffer_addr = 200 * 1024,
         .target_grid_offset = 1,
         .kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_multicast.cpp",
+        .exclude_start = {0, 0},
+        .exclude_direction = {0, 0},
     };
     for (unsigned int id = 0; id < devices_.size(); id++) {
         ASSERT_TRUE(unit_tests_common::dram::test_dram_to_l1_multicast::dram_to_l1_multicast(
@@ -163,6 +165,8 @@ TEST_F(DispatchFixture, TensixDRAMtoL1MulticastLoopbackSrc) {
         .dest_buffer_addr = 500 * 1024,
         .target_grid_offset = 0,
         .kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_multicast_include_src.cpp",
+        .exclude_start = {0, 0},
+        .exclude_direction = {0, 0},
     };
     for (unsigned int id = 0; id < devices_.size(); id++) {
         ASSERT_TRUE(unit_tests_common::dram::test_dram_to_l1_multicast::dram_to_l1_multicast(

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -26,6 +26,11 @@ namespace tt::tt_metal {
 class CommandQueueFixture : public DispatchFixture {
 protected:
     tt::tt_metal::IDevice* device_;
+
+    // This test fixture closes/opens devices on each test
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
         if (!this->validate_dispatch_mode()) {
             GTEST_SKIP();
@@ -80,6 +85,9 @@ protected:
 
 class UnitMeshCommandQueueFixture : public DispatchFixture {
 protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
         if (!this->validate_dispatch_mode()) {
             GTEST_SKIP();
@@ -131,6 +139,9 @@ protected:
 
 class CommandQueueSingleCardFixture : virtual public DispatchFixture {
 protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
         if (!this->validate_dispatch_mode()) {
             GTEST_SKIP();
@@ -190,6 +201,9 @@ class CommandQueueSingleCardBufferFixture : public CommandQueueSingleCardFixture
 
 class CommandQueueSingleCardTraceFixture : virtual public CommandQueueSingleCardFixture {
 protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
         if (!this->validate_dispatch_mode()) {
             GTEST_SKIP();
@@ -201,22 +215,35 @@ protected:
 
 class CommandQueueSingleCardProgramFixture : virtual public CommandQueueSingleCardFixture {};
 
+// Multi device command queue fixture. This fixture keeps the device open between test cases.
+// If the device should open closed/reopned for each test case then override the SetUpTestSuite and TearDownTestSuite
+// methods
 class CommandQueueMultiDeviceFixture : public DispatchFixture {
+private:
+    inline static std::vector<tt::tt_metal::IDevice*> devices_internal;
+    inline static std::map<chip_id_t, tt::tt_metal::IDevice*> reserved_devices_internal;
+    inline static size_t num_devices_internal;
+
 protected:
-    void SetUp() override {
-        this->slow_dispatch_ = false;
-        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        if (slow_dispatch) {
-            log_info(tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
-            this->slow_dispatch_ = true;
-            GTEST_SKIP();
+    static bool ShouldSkip() {
+        if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
+            return true;
+        }
+        if (tt::tt_metal::GetNumAvailableDevices() < 2) {
+            return true;
         }
 
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        return false;
+    }
 
-        num_devices_ = tt::tt_metal::GetNumAvailableDevices();
-        if (num_devices_ < 2) {
-            GTEST_SKIP();
+    static std::string_view GetSkipMessage() { return "Requires fast dispatch and at least 2 devices"; }
+
+    static void DoSetUpTestSuite(
+        uint32_t num_cqs = 1,
+        uint32_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
+        uint32_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
+        if (ShouldSkip()) {
+            return;
         }
 
         std::vector<chip_id_t> chip_ids;
@@ -224,30 +251,105 @@ protected:
             chip_ids.push_back(id);
         }
 
-        const auto& dispatch_core_config =
-            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
-        reserved_devices_ = tt::tt_metal::detail::CreateDevices(
-            chip_ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
-        for (const auto& [id, device] : reserved_devices_) {
-            devices_.push_back(device);
+        auto dispatch_core_config = tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
+        const tt::ARCH arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+
+        if (num_cqs > 1 && arch == tt::ARCH::WORMHOLE_B0 && tt::tt_metal::GetNumAvailableDevices() != 1) {
+            if (!tt::tt_metal::IsGalaxyCluster()) {
+                log_warning(
+                    tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
+                dispatch_core_config = DispatchCoreType::ETH;
+            }
+        }
+
+        reserved_devices_internal = tt::tt_metal::detail::CreateDevices(
+            chip_ids, num_cqs, l1_small_size, trace_region_size, dispatch_core_config);
+        for (const auto& [id, device] : reserved_devices_internal) {
+            devices_internal.push_back(device);
         }
     }
 
-    void TearDown() override { tt::tt_metal::detail::CloseDevices(reserved_devices_); }
+    static void DoTearDownTestSuite() {
+        if (ShouldSkip()) {
+            return;
+        }
+        tt::tt_metal::detail::CloseDevices(reserved_devices_internal);
+    }
+
+    static void SetUpTestSuite() { CommandQueueMultiDeviceFixture::DoSetUpTestSuite(); }
+
+    static void TearDownTestSuite() { CommandQueueMultiDeviceFixture::DoTearDownTestSuite(); }
+
+    void SetUp() override {
+        if (ShouldSkip()) {
+            GTEST_SKIP() << GetSkipMessage();
+        }
+
+        slow_dispatch_ = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        num_devices_ = devices_internal.size();
+        devices_ = devices_internal;
+        reserved_devices_ = reserved_devices_internal;
+    }
+
+    void TearDown() override {
+        slow_dispatch_ = false;
+        devices_.clear();
+        reserved_devices_.clear();
+        num_devices_ = 0;
+        arch_ = tt::ARCH::Invalid;
+    }
 
     std::vector<tt::tt_metal::IDevice*> devices_;
     std::map<chip_id_t, tt::tt_metal::IDevice*> reserved_devices_;
     size_t num_devices_;
 };
 
-class CommandQueueMultiDeviceProgramFixture : public CommandQueueMultiDeviceFixture {};
+class CommandQueueMultiDeviceProgramFixture : public CommandQueueMultiDeviceFixture {
+public:
+    static void SetUpTestSuite() {
+        if (ShouldSkip()) {
+            return;
+        }
+        CommandQueueMultiDeviceFixture::DoSetUpTestSuite();
+    }
 
-class CommandQueueMultiDeviceBufferFixture : public CommandQueueMultiDeviceFixture {};
+    static void TearDownTestSuite() {
+        if (ShouldSkip()) {
+            return;
+        }
+        CommandQueueMultiDeviceFixture::DoTearDownTestSuite();
+    }
+};
+
+class CommandQueueMultiDeviceBufferFixture : public CommandQueueMultiDeviceFixture {
+public:
+    static void SetUpTestSuite() {
+        if (ShouldSkip()) {
+            return;
+        }
+        CommandQueueMultiDeviceFixture::DoSetUpTestSuite();
+    }
+
+    static void TearDownTestSuite() {
+        if (ShouldSkip()) {
+            return;
+        }
+        CommandQueueMultiDeviceFixture::DoTearDownTestSuite();
+    }
+};
 
 class CommandQueueMultiDeviceOnFabricFixture : public CommandQueueMultiDeviceFixture,
                                                public ::testing::WithParamInterface<tt::tt_metal::FabricConfig> {
 protected:
+    // Multiple fabric configs so need to reset the devices for each test
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
+        if (CommandQueueMultiDeviceFixture::ShouldSkip()) {
+            GTEST_SKIP() << CommandQueueMultiDeviceFixture::GetSkipMessage();
+        }
         if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
             GTEST_SKIP() << "Dispatch on Fabric tests only applicable on Wormhole B0";
         }
@@ -258,6 +360,7 @@ protected:
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(true);
         // This will force dispatch init to inherit the FabricConfig param
         tt::tt_metal::detail::SetFabricConfig(GetParam(), FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
+        CommandQueueMultiDeviceFixture::DoSetUpTestSuite();
         CommandQueueMultiDeviceFixture::SetUp();
 
         if (::testing::Test::IsSkipped()) {
@@ -267,6 +370,7 @@ protected:
 
     void TearDown() override {
         CommandQueueMultiDeviceFixture::TearDown();
+        CommandQueueMultiDeviceFixture::DoTearDownTestSuite();
         tt::tt_metal::detail::SetFabricConfig(FabricConfig::DISABLED);
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(false);
     }

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -21,6 +21,9 @@ private:
     std::map<chip_id_t, tt::tt_metal::IDevice*> id_to_device_;
 
 protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
         // Save time. Don't do any setup if invalid dispatch mode
         if (!this->validate_dispatch_mode()) {
@@ -76,9 +79,6 @@ protected:
         this->num_devices_ = this->devices_.size();
     }
 
-    DeviceFixture(size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) :
-        DispatchFixture(l1_small_size, trace_region_size) {}
-
     size_t num_devices_;
 
 public:
@@ -97,11 +97,25 @@ public:
 
 class DeviceFixtureWithL1Small : public DeviceFixture {
 public:
-    DeviceFixtureWithL1Small() : DeviceFixture(24 * 1024) {}
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
+    void SetUp() override {
+        if (!this->validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
+        DispatchFixture::DoSetUpTestSuite(24 * 1024);
+        num_devices_ = NumDevices();
+    }
+
+    void TearDown() override { DispatchFixture::TearDownTestSuite(); }
 };
 
 class DeviceSingleCardFixture : public DispatchFixture {
 protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
         if (!this->validate_dispatch_mode()) {
             GTEST_SKIP();
@@ -144,6 +158,9 @@ class DeviceSingleCardBufferFixture : public DeviceSingleCardFixture {};
 
 class BlackholeSingleCardFixture : public DeviceSingleCardFixture {
 protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
         if (!this->validate_dispatch_mode()) {
             GTEST_SKIP();

--- a/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
@@ -21,10 +21,19 @@ namespace tt::tt_metal {
 
 // A dispatch-agnostic test fixture
 class DispatchFixture : public ::testing::Test {
-private:
-    std::map<chip_id_t, tt::tt_metal::IDevice*> id_to_device_;
-
 public:
+    inline static std::map<chip_id_t, tt::tt_metal::IDevice*> id_to_device_;
+    inline static size_t l1_small_size_ = DEFAULT_L1_SMALL_SIZE;
+    inline static size_t trace_region_size_ = DEFAULT_TRACE_REGION_SIZE;
+    inline static tt::ARCH arch_;
+    inline static std::vector<tt::tt_metal::IDevice*> devices_;
+    inline static bool slow_dispatch_;
+
+    static bool IsSlowDispatch() {
+        slow_dispatch_ = getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
+        return slow_dispatch_;
+    }
+
     // A function to run a program, according to which dispatch mode is set.
     void RunProgram(tt::tt_metal::IDevice* device, tt::tt_metal::Program& program, const bool skip_finish = false) {
         if (this->slow_dispatch_) {
@@ -64,48 +73,48 @@ public:
         }
     }
     int NumDevices() { return this->devices_.size(); }
-    bool IsSlowDispatch() { return this->slow_dispatch_; }
 
-protected:
-    tt::ARCH arch_;
-    std::vector<tt::tt_metal::IDevice*> devices_;
-    bool slow_dispatch_;
-    const size_t l1_small_size_{DEFAULT_L1_SMALL_SIZE};
-    const size_t trace_region_size_{DEFAULT_TRACE_REGION_SIZE};
+    static void DoSetUpTestSuite(
+        size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
+        slow_dispatch_ = getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
+        l1_small_size_ = l1_small_size;
+        trace_region_size_ = trace_region_size;
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
-    DispatchFixture(
-        size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) :
-        l1_small_size_{l1_small_size}, trace_region_size_{trace_region_size} {};
-
-    void SetUp() override {
-        this->DetectDispatchMode();
-        // Must set up all available devices
-        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         std::vector<chip_id_t> ids;
         for (chip_id_t id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
             ids.push_back(id);
         }
-        const auto& dispatch_core_config =
-            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
-        id_to_device_ = tt::tt_metal::detail::CreateDevices(
-            ids,
-            tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs(),
-            l1_small_size_,
-            DEFAULT_TRACE_REGION_SIZE,
-            dispatch_core_config);
+        auto dispatch_core_config = tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
+        const auto num_cqs = tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs();
+        if (num_cqs > 1) {
+            if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
+                log_warning(
+                    tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
+                dispatch_core_config = DispatchCoreType::ETH;
+            }
+        }
+        id_to_device_ =
+            tt::tt_metal::detail::CreateDevices(ids, num_cqs, l1_small_size_, trace_region_size_, dispatch_core_config);
         devices_.clear();
         for (auto [device_id, device] : id_to_device_) {
             devices_.push_back(device);
         }
     }
 
-    void TearDown() override {
-        // Checking if devices are empty because DPrintFixture.TensixTestPrintFinish already
-        // closed all devices
+    static void SetUpTestSuite() { DoSetUpTestSuite(); }
+
+    static void TearDownTestSuite() {
         if (!id_to_device_.empty()) {
             tt::tt_metal::detail::CloseDevices(id_to_device_);
             id_to_device_.clear();
-            devices_.clear();
+        }
+    }
+
+    void SetUp() override {
+        // In case one of the tests closed everything then recover them here
+        if (id_to_device_.empty()) {
+            DoSetUpTestSuite(l1_small_size_, trace_region_size_);
         }
     }
 
@@ -113,17 +122,6 @@ protected:
         log_info(tt::LogTest, "Running test on device {}.", device->id());
         run_function();
         log_info(tt::LogTest, "Finished running test on device {}.", device->id());
-    }
-
-    void DetectDispatchMode() {
-        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        if (slow_dispatch) {
-            log_info(tt::LogTest, "Running test using Slow Dispatch");
-            this->slow_dispatch_ = true;
-        } else {
-            log_info(tt::LogTest, "Running test using Fast Dispatch");
-            this->slow_dispatch_ = false;
-        }
     }
 };
 

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -11,17 +11,32 @@
 namespace tt::tt_metal {
 
 class DebugToolsFixture : public DispatchFixture {
-   protected:
+protected:
     bool watcher_previous_enabled;
+
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
+    // This fixture closes/reopens the device on each test
+    void SetUp() override {
+        DispatchFixture::SetUpTestSuite();
+        DispatchFixture::SetUp();
+    }
 
     void TearDown() override {
         DispatchFixture::TearDown();
+        DispatchFixture::TearDownTestSuite();
     }
 
     template <typename T>
     void RunTestOnDevice(const std::function<void(T*, IDevice*)>& run_function, IDevice* device) {
         auto run_function_no_args = [=,this]() { run_function(static_cast<T*>(this), device); };
         DispatchFixture::RunTestOnDevice(run_function_no_args, device);
+    }
+
+public:
+    void EarlyTeardown() {
+        DispatchFixture::TearDown();
     }
 };
 

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_before_finish.cpp
@@ -58,7 +58,7 @@ static void RunTest(DPrintFixture* fixture, IDevice* device) {
     }
     fixture->RunProgram(device, program);
     // Close system instantly after running to attempt to cut off prints.
-    fixture->TearDownTestSuite();
+    fixture->EarlyTeardown();
 
     // Check the print log against expected output.
     vector<string> expected_output;

--- a/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <ostream>
+#include <tt-logger/tt-logger.hpp>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -13,6 +14,7 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
+#include "device_pool.hpp"
 #include "galaxy_fixture.hpp"
 #include "impl/context/metal_context.hpp"
 #include "umd/device/types/cluster_descriptor_types.h"
@@ -178,30 +180,41 @@ TEST_F(TGFixture, ValidateNumGalaxyChips) {
 TEST_F(TGFixture, ValidateChipBoardTypes) {
     uint32_t num_n150_chips = 0;
     uint32_t num_galaxy_chips = 0;
+
+    // Validate the gateway (N150) chips
+    // These chips are not provided in the test fixture devices because they cannot be
+    // dispatched to
+    const std::vector<chip_id_t> tg_gateway_chips{0, 1, 2, 3};
+    for (const chip_id_t gateway_chip_id : tg_gateway_chips) {
+        ASSERT_TRUE(tt::tt_metal::DevicePool::instance().is_device_active(gateway_chip_id))
+            << "Gateway chip " << gateway_chip_id << " is not active";
+        ASSERT_TRUE(is_n150_device(gateway_chip_id)) << "Gateway chip " << gateway_chip_id << " is not an N150 chip";
+        num_n150_chips++;
+    }
+
+    // Validate the galaxy chips
     for (IDevice* device : this->devices_) {
         const chip_id_t device_id = device->id();
         if (is_galaxy_device(device_id)) {
             num_galaxy_chips++;
-        } else if (is_n150_device(device_id)) {
-            num_n150_chips++;
         }
     }
     ASSERT_TRUE(num_galaxy_chips == 32) << "Detected " << num_galaxy_chips << " Galaxy chips" << std::endl;
     ASSERT_TRUE(num_n150_chips == 4) << "Detected " << num_n150_chips << " N150 chips" << std::endl;
 }
 
-TEST_F(TGGFixture, ValidateNumMMIOChips) {
+TEST_F(DISABLED_TGGFixture, ValidateNumMMIOChips) {
     const size_t num_mmio_chips = tt::tt_metal::MetalContext::instance().get_cluster().number_of_pci_devices();
     ASSERT_TRUE(num_mmio_chips == 8) << "Detected " << num_mmio_chips << " MMIO chips" << std::endl;
 }
 
-TEST_F(TGGFixture, ValidateNumGalaxyChips) {
+TEST_F(DISABLED_TGGFixture, ValidateNumGalaxyChips) {
     const size_t num_galaxy_chips = tt::tt_metal::MetalContext::instance().get_cluster().number_of_user_devices();
     ASSERT_TRUE(num_galaxy_chips == 64) << "Detected " << num_galaxy_chips << " Galaxy chips" << std::endl;
 }
 
 // Validate that there are 8 N150 chips and 64 Galaxy chips
-TEST_F(TGGFixture, ValidateChipBoardTypes) {
+TEST_F(DISABLED_TGGFixture, ValidateChipBoardTypes) {
     uint32_t num_n150_chips = 0;
     uint32_t num_galaxy_chips = 0;
     for (IDevice* device : this->devices_) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -295,12 +295,14 @@ TEST_F(DispatchFixture, TensixActiveEthTestCBsAcrossDifferentCoreTypes) {
 }
 
 class EarlyReturnFixture : public DispatchFixture {
-    void SetUp() override {
+protected:
+    static void SetUpTestSuite() {
         tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_early_return(true);
-        DispatchFixture::SetUp();
+        DispatchFixture::SetUpTestSuite();
     }
-    void TearDown() override {
-        DispatchFixture::TearDown();
+
+    static void TearDownTestSuite() {
+        DispatchFixture::TearDownTestSuite();
         tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_early_return(false);
     }
 };

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "command_queue_fixture.hpp"
 #include "fabric_types.hpp"
 #include "gtest/gtest.h"
 #include "dispatch_fixture.hpp"
@@ -21,6 +22,9 @@ namespace tt::tt_metal {
 
 class MultiCommandQueueSingleDeviceFixture : public DispatchFixture {
 protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
     void SetUp() override {
         if (!this->validate_dispatch_mode()) {
             GTEST_SKIP();
@@ -112,54 +116,51 @@ protected:
     DispatchCoreType dispatch_core_type_;
 };
 
-class MultiCommandQueueMultiDeviceFixture : public DispatchFixture {
+class MultiCommandQueueMultiDeviceFixture : public CommandQueueMultiDeviceFixture {
 protected:
+    static bool ShouldSkip() {
+        if (CommandQueueMultiDeviceFixture::ShouldSkip()) {
+            return true;
+        }
+
+        if (tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs() != 2) {
+            return true;
+        }
+
+        return false;
+    }
+
+    static std::string GetSkipMessage() {
+        return "Requires fast dispatch, TT_METAL_GTEST_NUM_HW_CQS=2, at least 2 devices";
+    }
+
+    static void SetUpTestSuite() {
+        if (ShouldSkip()) {
+            return;
+        }
+        CommandQueueMultiDeviceFixture::DoSetUpTestSuite(2);
+    }
+
+    static void TearDownTestSuite() {
+        if (ShouldSkip()) {
+            return;
+        }
+        CommandQueueMultiDeviceFixture::DoTearDownTestSuite();
+    }
+
     void SetUp() override {
-        this->slow_dispatch_ = false;
-        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        if (slow_dispatch) {
-            log_info(tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
-            this->slow_dispatch_ = true;
-            GTEST_SKIP();
+        if (ShouldSkip()) {
+            GTEST_SKIP() << GetSkipMessage();
         }
-
-        auto num_cqs = tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs();
-        if (num_cqs != 2) {
-            log_info(tt::LogTest, "This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
-            GTEST_SKIP();
-        }
-
-        const tt::ARCH arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-
-        DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER;
-        if (arch == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() != 1) {
-            if (!tt::tt_metal::IsGalaxyCluster()) {
-                log_warning(
-                    tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
-                dispatch_core_type = DispatchCoreType::ETH;
-            }
-        }
-
-        std::vector<int> devices_to_open;
-        devices_to_open.reserve(tt::tt_metal::GetNumAvailableDevices());
-        for (int i = 0; i < tt::tt_metal::GetNumAvailableDevices(); ++i) {
-            devices_to_open.push_back(i);
-        }
-        reserved_devices_ = tt::tt_metal::detail::CreateDevices(
-            devices_to_open, num_cqs, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-        for (const auto& [id, device] : reserved_devices_) {
-            devices_.push_back(device);
-        }
+        CommandQueueMultiDeviceFixture::SetUp();
     }
 
     void TearDown() override {
-        if (!reserved_devices_.empty()) {
-            tt::tt_metal::detail::CloseDevices(reserved_devices_);
+        if (ShouldSkip()) {
+            return;
         }
+        CommandQueueMultiDeviceFixture::TearDown();
     }
-
-    std::vector<tt::tt_metal::IDevice*> devices_;
-    std::map<chip_id_t, tt::tt_metal::IDevice*> reserved_devices_;
 };
 
 class MultiCommandQueueMultiDeviceBufferFixture : public MultiCommandQueueMultiDeviceFixture {};
@@ -169,17 +170,36 @@ class MultiCommandQueueMultiDeviceEventFixture : public MultiCommandQueueMultiDe
 class MultiCommandQueueMultiDeviceOnFabricFixture : public MultiCommandQueueMultiDeviceFixture,
                                                     public ::testing::WithParamInterface<tt::tt_metal::FabricConfig> {
 protected:
-    void SetUp() override {
+    static bool ShouldSkip() {
+        if (MultiCommandQueueMultiDeviceFixture::ShouldSkip()) {
+            return true;
+        }
         if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
-            GTEST_SKIP() << "Dispatch on Fabric tests only applicable on Wormhole B0";
+            return true;
         }
         // Skip for TG as it's still being implemented
         if (tt::tt_metal::IsGalaxyCluster()) {
-            GTEST_SKIP();
+            return true;
+        }
+        return false;
+    }
+
+    static std::string GetSkipMessage() {
+        return MultiCommandQueueMultiDeviceFixture::GetSkipMessage() + ", Wormhole B0, not Galaxy Cluster";
+    }
+
+    // Multiple fabric configs so need to reset the devices for each test
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
+    void SetUp() override {
+        if (ShouldSkip()) {
+            GTEST_SKIP() << GetSkipMessage();
         }
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(true);
         // This will force dispatch init to inherit the FabricConfig param
         tt::tt_metal::detail::SetFabricConfig(GetParam(), FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
+        MultiCommandQueueMultiDeviceFixture::DoSetUpTestSuite(2);
         MultiCommandQueueMultiDeviceFixture::SetUp();
 
         if (::testing::Test::IsSkipped()) {
@@ -189,7 +209,11 @@ protected:
     }
 
     void TearDown() override {
+        if (ShouldSkip()) {
+            return;
+        }
         MultiCommandQueueMultiDeviceFixture::TearDown();
+        MultiCommandQueueMultiDeviceFixture::DoTearDownTestSuite();
         tt::tt_metal::detail::SetFabricConfig(FabricConfig::DISABLED);
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(false);
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -68,9 +68,7 @@ public:
 
     void TearDown() {
         device_open = false;
-        for (auto [device_id, device_ptr] : devices_) {
-            tt::tt_metal::CloseDevice(device_ptr);
-        }
+        tt::tt_metal::detail::CloseDevices(devices_);
     }
 
     std::map<chip_id_t, tt_metal::IDevice*> devices_;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18726

### Problem description
- With the Dispatch on Fabric changes, test cases are starting to take a while because we always open and close the devices for each test case

### What's changed
- Update FabricFixture to keep devices open for each fabric mode
- Update Dispatch fixtures to keep multi devices open
- Single device fixtures to remain the same
- Follow up issue which is for cleaning up all the fixtures once dispatch on fabric is enabled: https://github.com/tenstorrent/tt-metal/issues/24541

| Test                                         | Before(ms) | After(ms)  |
|----------------------------------------------|--------|--------|
| 2D Fabric Unit Tests                         | 24865  | 23127  |
| 2D Fabric Unit Tests with Dispatch on Fabric | 35290  | 28062  |
| T3K Fast                                     | 352000 | 327000 |

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/16128581327
T3K Fast
https://github.com/tenstorrent/tt-metal/actions/runs/16057677502
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/16128584504
TG
https://github.com/tenstorrent/tt-metal/actions/runs/16107596740
BH
https://github.com/tenstorrent/tt-metal/actions/runs/16128586055