### PR TITLE
Fix device profiler corruption with cached kernels

### DIFF
--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -164,6 +164,9 @@ private:
     // XORe'd 16-bit FNV-1a hashing functions
     uint16_t hash16CT(const std::string& str);
 
+    void populateZoneSrcLocations(
+        const std::string& new_log_name, const std::string& log_name = "", bool push_new = false);
+
     // Iterate through all zone source locations and generate hash
     void generateZoneSourceLocationsHashes();
 

--- a/tt_metal/impl/profiler/profiler_paths.hpp
+++ b/tt_metal/impl/profiler/profiler_paths.hpp
@@ -33,6 +33,7 @@ inline std::string get_profiler_logs_dir() {
 }
 
 inline std::string PROFILER_ZONE_SRC_LOCATIONS_LOG = get_profiler_logs_dir() + "zone_src_locations.log";
+inline std::string NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG = get_profiler_logs_dir() + "new_zone_src_locations.log";
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -802,18 +802,18 @@ void JitBuildState::extract_zone_src_locations(const string& log_file) const {
     // ZoneScoped;
     static std::atomic<bool> new_log = true;
     if (tt::tt_metal::getDeviceProfilerState()) {
-        if (new_log.exchange(false) && std::filesystem::exists(tt::tt_metal::PROFILER_ZONE_SRC_LOCATIONS_LOG)) {
-            std::remove(tt::tt_metal::PROFILER_ZONE_SRC_LOCATIONS_LOG.c_str());
+        if (new_log.exchange(false) && std::filesystem::exists(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG)) {
+            std::remove(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG.c_str());
         }
 
-        if (!std::filesystem::exists(tt::tt_metal::PROFILER_ZONE_SRC_LOCATIONS_LOG)) {
-            tt::utils::create_file(tt::tt_metal::PROFILER_ZONE_SRC_LOCATIONS_LOG);
+        if (!std::filesystem::exists(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG)) {
+            tt::utils::create_file(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG);
         }
 
         // Only interested in log entries with KERNEL_PROFILER inside them as device code
         // tags source location info with it using pragma messages
         string cmd = "cat " + log_file + " | grep KERNEL_PROFILER";
-        tt::utils::run_command(cmd, tt::tt_metal::PROFILER_ZONE_SRC_LOCATIONS_LOG, false);
+        tt::utils::run_command(cmd, tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG, false);
     }
 }
 


### PR DESCRIPTION
### Ticket
#24489 

### Problem description
With cached kernels, zone locations in device profile logs was corrupted.
 
### What's changed
Keep a super set of all unique source locations under the generated folder

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16062910669)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16058370527)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/16058379076)
- [x] [T3K profiler](https://github.com/tenstorrent/tt-metal/actions/runs/16058356188)