### PR TITLE
[skip ci] Run system health tests first during BH llmbox upstream test

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -63,9 +63,9 @@ test_suite_bh_single_pcie_llama_demo_tests() {
 test_suite_bh_llmbox_metal_unit_tests() {
     echo "[upstream-tests] Running BH LLMBox metal unit tests"
 
+    ./build/test/tt_metal/tt_fabric/test_system_health
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*"
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-    ./build/test/tt_metal/tt_fabric/test_system_health
     ./build/test/tt_metal/unit_tests_eth
 }
 


### PR DESCRIPTION
### Ticket
None

### Problem description
system health test prints the eth link state, we should run that first before any fabric tests

### What's changed
Run that test first

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes