### PR TITLE
#23287: Add `from_host_shards` API

### DIFF
--- a/ttnn/api/ttnn/distributed/api.hpp
+++ b/ttnn/api/ttnn/distributed/api.hpp
@@ -28,10 +28,14 @@ void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device);
 std::vector<Tensor> get_device_tensors(const Tensor& tensor);
 
 // Given a list of per-device shards, returns multi-device tensor.
-// IMPORTANT: to combine on-device shards, prefer `combine_device_tensors` instead.
-// For on-host shards, a new API will be added to accommodate multi-host tensor distribution.
-Tensor aggregate_as_tensor(
+// Deprecated: to combine on-device shards, prefer `combine_device_tensors`. For on-host shards, use
+// `from_host_shards` instead.
+[[deprecated("Use from_host_shards / combine_device_tensors instead")]] Tensor aggregate_as_tensor(
     const std::vector<Tensor>& tensor_shards, const tt::tt_metal::DistributedTensorConfig& config);
+
+// Given a list of host shards, returns a multi-device tensor.
+// Tensor specs (including shapes) must match for all shards, and the number of shards must match the mesh size.
+Tensor from_host_shards(const std::vector<Tensor>& tensor_shards, const MeshShape& mesh_shape);
 
 // Combines tensor shards allocated on individual devices into a single multi-device tensor.
 // All tensors shards must be allocated on the same mesh buffer.

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -643,18 +643,22 @@ void py_module(py::module& module) {
                 Tensor: The aggregated tensor.
             )doc");
     module.def(
-        "aggregate_as_tensor",
-        [](const std::vector<Tensor>& tensors) -> Tensor { return aggregate_as_tensor(tensors, AllGatherTensor{}); },
+        "from_host_shards",
+        [](const std::vector<Tensor>& tensors, const MeshShape& mesh_shape) -> Tensor {
+            return from_host_shards(tensors, mesh_shape);
+        },
         py::arg("tensors"),
+        py::arg("mesh_shape"),
         py::kw_only(),
         R"doc(
-            Aggregates a set of shards into one tensor. Device shards will remain on device and be packed into a multidevice storage object.
+            Creates a multi-device host tensor from a set of individual host shards.
 
             Args:
-                tensor (Tensor): The tensor to aggregate.
+                tensors (List[Tensor]): The tensor shards to aggregate.
+                mesh_shape (MeshShape): The shape of the mesh to aggregate the shards over.
 
             Returns:
-                Tensor: The aggregated tensor.
+                Tensor: The multi-device host tensor.
             )doc");
     module.def(
         "combine_device_tensors",

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -102,7 +102,7 @@ from ttnn._ttnn.multi_device import (
     MeshMapperConfig,
     MeshComposerConfig,
     get_device_tensors,
-    aggregate_as_tensor,
+    from_host_shards,
     combine_device_tensors,
     replicate_tensor_to_mesh_mapper,
     shard_tensor_to_mesh_mapper,


### PR DESCRIPTION
### Ticket
#23287

### Problem description
The API will be used in place of `aggregate_as_tensor` in tt-mlir.

### What's changed
New API + tests.

### Checklist (pending)
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16058469940)
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/16058724675)
- [X] New/Existing tests provide coverage for changes