### PR TITLE
Add generic support for ND routing tables

### DIFF
--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -113,9 +113,8 @@ jobs:
       - name: Run health tests
         timeout-minutes: 20
         # NOTE: These tests do not automatically get added to upstream tests. Please refer to dockerfile/upstream_test_images/.
-        # TODO #23350: This should use TORUS_2D topology not MESH since there are tests that depend on ring here.
         run: |
-          ./build/test/tt_metal/tt_fabric/test_system_health --system-topology TORUS_2D
+          ./build/test/tt_metal/tt_fabric/test_system_health --system-topology TORUS_XY
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardFixture.*";
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardProgramFixture.*";
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites";
@@ -167,7 +166,7 @@ jobs:
         timeout-minutes: 20
         # NOTE: These tests do not automatically get added to upstream tests. Please refer to dockerfile/upstream_test_images/.
         run: |
-          ./build/test/tt_metal/tt_fabric/test_system_health --system-topology TORUS_2D
+          ./build/test/tt_metal/tt_fabric/test_system_health --system-topology TORUS_XY
           pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick";
           pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "quick";
           pytest models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py;

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -86,9 +86,9 @@ test_suite_wh_6u_metal_unit_tests() {
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
 }
 
-test_suite_wh_6u_metal_2d_torus_health_check_tests() {
-    echo "[upstream-tests] Checking for 2D Torus topology on WH 6U"
-    ./build/test/tt_metal/tt_fabric/test_system_health --system-topology TORUS_2D
+test_suite_wh_6u_metal_torus_xy_health_check_tests() {
+    echo "[upstream-tests] Checking for XY Torus topology on WH 6U"
+    ./build/test/tt_metal/tt_fabric/test_system_health --system-topology TORUS_XY
 }
 
 test_suite_wh_6u_model_unit_tests() {
@@ -143,7 +143,7 @@ test_suite_bh_llmbox_llama_demo_tests"
 hw_topology_test_suites["wh_6u"]="test_suite_wh_6u_model_unit_tests
 test_suite_wh_6u_llama_demo_tests
 test_suite_wh_6u_metal_unit_tests
-test_suite_wh_6u_metal_2d_torus_health_check_tests"
+test_suite_wh_6u_metal_torus_xy_health_check_tests"
 
 # Function to display help
 show_help() {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -376,4 +376,356 @@ TEST(MeshGraphValidation, TestExplicitShapeValidationNegative) {
     EXPECT_THROW(std::make_unique<tt_fabric::MeshGraph>(invalid_shape_mesh_graph_desc_path.string()), std::exception);
 }
 
+namespace single_galaxy_constants {
+constexpr std::uint32_t mesh_size = 32;  // 8x4 mesh
+constexpr std::uint32_t mesh_row_size = 4;
+constexpr std::uint32_t num_ports_per_side = 4;
+constexpr std::uint32_t nw_fabric_id = 0;
+constexpr std::uint32_t ne_fabric_id = 3;
+constexpr std::uint32_t sw_fabric_id = 28;
+constexpr std::uint32_t se_fabric_id = 31;
+}  // namespace single_galaxy_constants
+
+TEST(MeshGraphValidation, TestSingleGalaxyMesh) {
+    using namespace single_galaxy_constants;
+    const std::filesystem::path mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.yaml";
+    auto mesh_graph = std::make_unique<MeshGraph>(mesh_graph_desc_path.string());
+    const auto& intra_mesh_connectivity = mesh_graph->get_intra_mesh_connectivity();
+
+    EXPECT_EQ(intra_mesh_connectivity.size(), 1);
+
+    EXPECT_EQ(intra_mesh_connectivity[0].size(), mesh_size);
+    for (std::uint32_t i = 0; i < mesh_size; ++i) {
+        int N = i - mesh_row_size;  // North neighbor
+        int E = i + 1;              // East neighbor
+        int S = i + mesh_row_size;  // South neighbor
+        int W = i - 1;              // West neighbor
+
+        auto row = i / mesh_row_size;
+        auto col = i % mesh_row_size;
+        int N_wrap = (i - mesh_row_size + mesh_size) % mesh_size;
+        int E_wrap = row * mesh_row_size + (col + 1) % mesh_row_size;
+        int S_wrap = (i + mesh_row_size) % mesh_size;
+        int W_wrap = row * mesh_row_size + (col - 1 + mesh_row_size) % mesh_row_size;
+
+        // _wrap represents the wrapped neighbor indices
+        // if X == X_wrap, it means that the neighbor is within the mesh and should be connected
+        // if not, the neighbour represents a wrap-around connection and should not be present in a MESH
+        if (N == N_wrap) {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(N_wrap), 1);
+            EXPECT_EQ(intra_mesh_connectivity[0][i].at(N_wrap).port_direction, RoutingDirection::N);
+            EXPECT_EQ(
+                intra_mesh_connectivity[0][i].at(N_wrap).connected_chip_ids,
+                std::vector<chip_id_t>(num_ports_per_side, N_wrap));
+        } else {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(N_wrap), 0);
+        }
+        if (E == E_wrap) {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(E_wrap), 1);
+            EXPECT_EQ(intra_mesh_connectivity[0][i].at(E_wrap).port_direction, RoutingDirection::E);
+            EXPECT_EQ(
+                intra_mesh_connectivity[0][i].at(E_wrap).connected_chip_ids,
+                std::vector<chip_id_t>(num_ports_per_side, E_wrap));
+        } else {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(E_wrap), 0);
+        }
+        if (S == S_wrap) {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(S_wrap), 1);
+            EXPECT_EQ(intra_mesh_connectivity[0][i].at(S_wrap).port_direction, RoutingDirection::S);
+            EXPECT_EQ(
+                intra_mesh_connectivity[0][i].at(S_wrap).connected_chip_ids,
+                std::vector<chip_id_t>(num_ports_per_side, S_wrap));
+        } else {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(S_wrap), 0);
+        }
+        if (W == W_wrap) {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(W_wrap), 1);
+            EXPECT_EQ(intra_mesh_connectivity[0][i].at(W_wrap).port_direction, RoutingDirection::W);
+            EXPECT_EQ(
+                intra_mesh_connectivity[0][i].at(W_wrap).connected_chip_ids,
+                std::vector<chip_id_t>(num_ports_per_side, W_wrap));
+        } else {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(W_wrap), 0);
+        }
+    }
+}
+
+TEST(RoutingTableValidation, TestSingleGalaxyMesh) {
+    using namespace single_galaxy_constants;
+    // Testing XY dimension order routing, if algorithm changes we can remove this test
+    const std::filesystem::path mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.yaml";
+    auto routing_table_generator = std::make_unique<RoutingTableGenerator>(mesh_graph_desc_path.string());
+    const auto& intra_mesh_routing_table = routing_table_generator->get_intra_mesh_table();
+
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][nw_fabric_id], RoutingDirection::C);
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][ne_fabric_id], RoutingDirection::E);
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][sw_fabric_id], RoutingDirection::S);
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][se_fabric_id], RoutingDirection::S);
+
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][nw_fabric_id], RoutingDirection::W);
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][ne_fabric_id], RoutingDirection::C);
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][sw_fabric_id], RoutingDirection::S);
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][se_fabric_id], RoutingDirection::S);
+
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][nw_fabric_id], RoutingDirection::N);
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][ne_fabric_id], RoutingDirection::N);
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][sw_fabric_id], RoutingDirection::C);
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][se_fabric_id], RoutingDirection::E);
+
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][nw_fabric_id], RoutingDirection::N);
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][ne_fabric_id], RoutingDirection::N);
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][sw_fabric_id], RoutingDirection::W);
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][se_fabric_id], RoutingDirection::C);
+}
+
+TEST(MeshGraphValidation, TestSingleGalaxyTorusXY) {
+    using namespace single_galaxy_constants;
+    const std::filesystem::path mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_xy_graph_descriptor.yaml";
+    auto mesh_graph = std::make_unique<MeshGraph>(mesh_graph_desc_path.string());
+    const auto& intra_mesh_connectivity = mesh_graph->get_intra_mesh_connectivity();
+
+    EXPECT_EQ(intra_mesh_connectivity.size(), 1);
+
+    EXPECT_EQ(intra_mesh_connectivity[0].size(), mesh_size);
+    for (std::uint32_t i = 0; i < mesh_size; ++i) {
+        auto row = i / mesh_row_size;
+        auto col = i % mesh_row_size;
+        int N_wrap = (i - mesh_row_size + mesh_size) % mesh_size;
+        int E_wrap = row * mesh_row_size + (col + 1) % mesh_row_size;
+        int S_wrap = (i + mesh_row_size) % mesh_size;
+        int W_wrap = row * mesh_row_size + (col - 1 + mesh_row_size) % mesh_row_size;
+
+        // _wrap represents the wrapped neighbor indices
+        // check all neighbors including wrap-around connections are present in TORUS_XY
+        EXPECT_EQ(intra_mesh_connectivity[0][i].count(N_wrap), 1);
+        EXPECT_EQ(intra_mesh_connectivity[0][i].at(N_wrap).port_direction, RoutingDirection::N);
+        EXPECT_EQ(
+            intra_mesh_connectivity[0][i].at(N_wrap).connected_chip_ids,
+            std::vector<chip_id_t>(num_ports_per_side, N_wrap));
+        EXPECT_EQ(intra_mesh_connectivity[0][i].count(E_wrap), 1);
+        EXPECT_EQ(intra_mesh_connectivity[0][i].at(E_wrap).port_direction, RoutingDirection::E);
+        EXPECT_EQ(
+            intra_mesh_connectivity[0][i].at(E_wrap).connected_chip_ids,
+            std::vector<chip_id_t>(num_ports_per_side, E_wrap));
+        EXPECT_EQ(intra_mesh_connectivity[0][i].count(S_wrap), 1);
+        EXPECT_EQ(intra_mesh_connectivity[0][i].at(S_wrap).port_direction, RoutingDirection::S);
+        EXPECT_EQ(
+            intra_mesh_connectivity[0][i].at(S_wrap).connected_chip_ids,
+            std::vector<chip_id_t>(num_ports_per_side, S_wrap));
+        EXPECT_EQ(intra_mesh_connectivity[0][i].count(W_wrap), 1);
+        EXPECT_EQ(intra_mesh_connectivity[0][i].at(W_wrap).port_direction, RoutingDirection::W);
+        EXPECT_EQ(
+            intra_mesh_connectivity[0][i].at(W_wrap).connected_chip_ids,
+            std::vector<chip_id_t>(num_ports_per_side, W_wrap));
+    }
+}
+
+TEST(RoutingTableValidation, TestSingleGalaxyTorusXY) {
+    using namespace single_galaxy_constants;
+    // Testing XY dimension order routing, if algorithm changes we can remove this test
+    const std::filesystem::path mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_xy_graph_descriptor.yaml";
+    auto routing_table_generator = std::make_unique<RoutingTableGenerator>(mesh_graph_desc_path.string());
+    const auto& intra_mesh_routing_table = routing_table_generator->get_intra_mesh_table();
+
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][nw_fabric_id], RoutingDirection::C);
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][ne_fabric_id], RoutingDirection::W);
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][sw_fabric_id], RoutingDirection::N);
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][se_fabric_id], RoutingDirection::N);
+
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][nw_fabric_id], RoutingDirection::E);
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][ne_fabric_id], RoutingDirection::C);
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][sw_fabric_id], RoutingDirection::N);
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][se_fabric_id], RoutingDirection::N);
+
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][nw_fabric_id], RoutingDirection::S);
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][ne_fabric_id], RoutingDirection::S);
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][sw_fabric_id], RoutingDirection::C);
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][se_fabric_id], RoutingDirection::W);
+
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][nw_fabric_id], RoutingDirection::S);
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][ne_fabric_id], RoutingDirection::S);
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][sw_fabric_id], RoutingDirection::E);
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][se_fabric_id], RoutingDirection::C);
+}
+
+TEST(MeshGraphValidation, TestSingleGalaxyTorusX) {
+    using namespace single_galaxy_constants;
+    const std::filesystem::path mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_x_graph_descriptor.yaml";
+    auto mesh_graph = std::make_unique<MeshGraph>(mesh_graph_desc_path.string());
+    const auto& intra_mesh_connectivity = mesh_graph->get_intra_mesh_connectivity();
+
+    EXPECT_EQ(intra_mesh_connectivity.size(), 1);
+
+    EXPECT_EQ(intra_mesh_connectivity[0].size(), mesh_size);
+    for (std::uint32_t i = 0; i < mesh_size; ++i) {
+        int N = i - mesh_row_size;  // North neighbor
+        int S = i + mesh_row_size;  // South neighbor
+        auto row = i / mesh_row_size;
+        auto col = i % mesh_row_size;
+        int N_wrap = (i - mesh_row_size + mesh_size) % mesh_size;
+        int E_wrap = row * mesh_row_size + (col + 1) % mesh_row_size;
+        int S_wrap = (i + mesh_row_size) % mesh_size;
+        int W_wrap = row * mesh_row_size + (col - 1 + mesh_row_size) % mesh_row_size;
+
+        // _wrap represents the wrapped neighbor indices
+        // if X == X_wrap, it means that the neighbor is within the mesh and should be connected
+        // if not, the neighbour represents a wrap-around connection and should not be present
+        // in a TORUS_X configuration, we expect wrap around for E/W directions
+        EXPECT_EQ(intra_mesh_connectivity[0][i].count(E_wrap), 1);
+        EXPECT_EQ(intra_mesh_connectivity[0][i].at(E_wrap).port_direction, RoutingDirection::E);
+        EXPECT_EQ(
+            intra_mesh_connectivity[0][i].at(E_wrap).connected_chip_ids,
+            std::vector<chip_id_t>(num_ports_per_side, E_wrap));
+        EXPECT_EQ(intra_mesh_connectivity[0][i].count(W_wrap), 1);
+        EXPECT_EQ(intra_mesh_connectivity[0][i].at(W_wrap).port_direction, RoutingDirection::W);
+        EXPECT_EQ(
+            intra_mesh_connectivity[0][i].at(W_wrap).connected_chip_ids,
+            std::vector<chip_id_t>(num_ports_per_side, W_wrap));
+        if (N == N_wrap) {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(N_wrap), 1);
+            EXPECT_EQ(intra_mesh_connectivity[0][i].at(N_wrap).port_direction, RoutingDirection::N);
+            EXPECT_EQ(
+                intra_mesh_connectivity[0][i].at(N_wrap).connected_chip_ids,
+                std::vector<chip_id_t>(num_ports_per_side, N_wrap));
+        } else {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(N_wrap), 0);
+        }
+        if (S == S_wrap) {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(S_wrap), 1);
+            EXPECT_EQ(intra_mesh_connectivity[0][i].at(S_wrap).port_direction, RoutingDirection::S);
+            EXPECT_EQ(
+                intra_mesh_connectivity[0][i].at(S_wrap).connected_chip_ids,
+                std::vector<chip_id_t>(num_ports_per_side, S_wrap));
+        } else {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(S_wrap), 0);
+        }
+    }
+}
+
+TEST(RoutingTableValidation, TestSingleGalaxyTorusX) {
+    using namespace single_galaxy_constants;
+    // Testing XY dimension order routing, if algorithm changes we can remove this test
+    const std::filesystem::path mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_x_graph_descriptor.yaml";
+    auto routing_table_generator = std::make_unique<RoutingTableGenerator>(mesh_graph_desc_path.string());
+    const auto& intra_mesh_routing_table = routing_table_generator->get_intra_mesh_table();
+
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][nw_fabric_id], RoutingDirection::C);
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][ne_fabric_id], RoutingDirection::W);
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][sw_fabric_id], RoutingDirection::S);
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][se_fabric_id], RoutingDirection::S);
+
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][nw_fabric_id], RoutingDirection::E);
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][ne_fabric_id], RoutingDirection::C);
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][sw_fabric_id], RoutingDirection::S);
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][se_fabric_id], RoutingDirection::S);
+
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][nw_fabric_id], RoutingDirection::N);
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][ne_fabric_id], RoutingDirection::N);
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][sw_fabric_id], RoutingDirection::C);
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][se_fabric_id], RoutingDirection::W);
+
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][nw_fabric_id], RoutingDirection::N);
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][ne_fabric_id], RoutingDirection::N);
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][sw_fabric_id], RoutingDirection::E);
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][se_fabric_id], RoutingDirection::C);
+}
+
+TEST(MeshGraphValidation, TestSingleGalaxyTorusY) {
+    using namespace single_galaxy_constants;
+    const std::filesystem::path mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_y_graph_descriptor.yaml";
+    auto mesh_graph = std::make_unique<MeshGraph>(mesh_graph_desc_path.string());
+    const auto& intra_mesh_connectivity = mesh_graph->get_intra_mesh_connectivity();
+
+    EXPECT_EQ(intra_mesh_connectivity.size(), 1);
+
+    EXPECT_EQ(intra_mesh_connectivity[0].size(), mesh_size);
+    for (std::uint32_t i = 0; i < mesh_size; ++i) {
+        int E = i + 1;  // East neighbor
+        int W = i - 1;  // West neighbor
+        auto row = i / mesh_row_size;
+        auto col = i % mesh_row_size;
+        int N_wrap = (i - mesh_row_size + mesh_size) % mesh_size;
+        int E_wrap = row * mesh_row_size + (col + 1) % mesh_row_size;
+        int S_wrap = (i + mesh_row_size) % mesh_size;
+        int W_wrap = row * mesh_row_size + (col - 1 + mesh_row_size) % mesh_row_size;
+
+        // _wrap represents the wrapped neighbor indices
+        // if X == X_wrap, it means that the neighbor is within the mesh and should be connected
+        // if not, the neighbour represents a wrap-around connection and should not be present
+        // in a TORUS_Y configuration, we expect wrap around for N/S directions
+        EXPECT_EQ(intra_mesh_connectivity[0][i].count(N_wrap), 1);
+        EXPECT_EQ(intra_mesh_connectivity[0][i].at(N_wrap).port_direction, RoutingDirection::N);
+        EXPECT_EQ(
+            intra_mesh_connectivity[0][i].at(N_wrap).connected_chip_ids,
+            std::vector<chip_id_t>(num_ports_per_side, N_wrap));
+
+        EXPECT_EQ(intra_mesh_connectivity[0][i].count(S_wrap), 1);
+        EXPECT_EQ(intra_mesh_connectivity[0][i].at(S_wrap).port_direction, RoutingDirection::S);
+        EXPECT_EQ(
+            intra_mesh_connectivity[0][i].at(S_wrap).connected_chip_ids,
+            std::vector<chip_id_t>(num_ports_per_side, S_wrap));
+        if (E == E_wrap) {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(E_wrap), 1);
+            EXPECT_EQ(intra_mesh_connectivity[0][i].at(E_wrap).port_direction, RoutingDirection::E);
+            EXPECT_EQ(
+                intra_mesh_connectivity[0][i].at(E_wrap).connected_chip_ids,
+                std::vector<chip_id_t>(num_ports_per_side, E_wrap));
+        } else {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(E_wrap), 0);
+        }
+        if (W == W_wrap) {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(W_wrap), 1);
+            EXPECT_EQ(intra_mesh_connectivity[0][i].at(W_wrap).port_direction, RoutingDirection::W);
+            EXPECT_EQ(
+                intra_mesh_connectivity[0][i].at(W_wrap).connected_chip_ids,
+                std::vector<chip_id_t>(num_ports_per_side, W_wrap));
+        } else {
+            EXPECT_EQ(intra_mesh_connectivity[0][i].count(W_wrap), 0);
+        }
+    }
+}
+
+TEST(RoutingTableValidation, TestSingleGalaxyTorusY) {
+    using namespace single_galaxy_constants;
+    // Testing XY dimension order routing, if algorithm changes we can remove this test
+    const std::filesystem::path mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_y_graph_descriptor.yaml";
+    auto routing_table_generator = std::make_unique<RoutingTableGenerator>(mesh_graph_desc_path.string());
+    const auto& intra_mesh_routing_table = routing_table_generator->get_intra_mesh_table();
+
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][nw_fabric_id], RoutingDirection::C);
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][ne_fabric_id], RoutingDirection::E);
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][sw_fabric_id], RoutingDirection::N);
+    EXPECT_EQ(intra_mesh_routing_table[0][nw_fabric_id][se_fabric_id], RoutingDirection::N);
+
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][nw_fabric_id], RoutingDirection::W);
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][ne_fabric_id], RoutingDirection::C);
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][sw_fabric_id], RoutingDirection::N);
+    EXPECT_EQ(intra_mesh_routing_table[0][ne_fabric_id][se_fabric_id], RoutingDirection::N);
+
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][nw_fabric_id], RoutingDirection::S);
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][ne_fabric_id], RoutingDirection::S);
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][sw_fabric_id], RoutingDirection::C);
+    EXPECT_EQ(intra_mesh_routing_table[0][sw_fabric_id][se_fabric_id], RoutingDirection::E);
+
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][nw_fabric_id], RoutingDirection::S);
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][ne_fabric_id], RoutingDirection::S);
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][sw_fabric_id], RoutingDirection::W);
+    EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][se_fabric_id], RoutingDirection::C);
+}
 }  // namespace tt::tt_fabric::fabric_router_tests

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -334,8 +334,8 @@ TEST(Cluster, TestMeshFullConnectivity) {
     if (not target_system_topology_str.empty()) {
         target_system_topology =
             magic_enum::enum_cast<FabricType>(target_system_topology_str, magic_enum::case_insensitive);
-        // TORUS_2D is the only topology that is supported for all cluster types
-        if (target_system_topology.has_value() && *target_system_topology != FabricType::TORUS_2D) {
+        // TORUS_XY is the only topology that is supported for all cluster types
+        if (target_system_topology.has_value() && *target_system_topology != FabricType::TORUS_XY) {
             bool supported_topology = false;
             switch (cluster_type) {
                 case tt::ClusterType::GALAXY:
@@ -385,7 +385,7 @@ TEST(Cluster, TestMeshFullConnectivity) {
                     << num_expected_chip_connections << " chips for " << magic_enum::enum_name(*target_system_topology)
                     << " topology";
             };
-            if (*target_system_topology == FabricType::TORUS_2D) {
+            if (*target_system_topology == FabricType::TORUS_XY) {
                 static constexpr std::uint32_t num_expected_chip_connections = 4;
                 validate_num_connections(num_connections_to_chip.size(), num_expected_chip_connections);
             } else {

--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -37,10 +37,15 @@ struct ChipSpec {
 };
 
 enum class FabricType {
-    MESH = 0,
-    TORUS_1D = 1,
-    TORUS_2D = 2,
+    MESH = 1 << 0,
+    TORUS_X = 1 << 1,  // Connections along mesh_coord[1]
+    TORUS_Y = 1 << 2,  // Connections along mesh_coord[0]
+    TORUS_XY = (TORUS_X | TORUS_Y),
 };
+
+FabricType operator|(FabricType lhs, FabricType rhs);
+FabricType operator&(FabricType lhs, FabricType rhs);
+bool has_flag(FabricType flags, FabricType test_flag);
 
 enum class RoutingDirection {
     N = 0,
@@ -110,7 +115,7 @@ public:
 private:
     void validate_mesh_id(MeshId mesh_id) const;
     std::unordered_map<chip_id_t, RouterEdge> get_valid_connections(
-        chip_id_t src_chip_id, std::uint32_t row_size, std::uint32_t num_chips_in_mesh, FabricType fabric_type) const;
+        const MeshCoordinate& src_mesh_coord, const MeshCoordinateRange& mesh_coord_range, FabricType fabric_type) const;
     void initialize_from_yaml(const std::string& mesh_graph_desc_file_path);
 
     void add_to_connectivity(

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -596,7 +596,7 @@ std::map<FabricNodeId, chip_id_t> ControlPlane::get_physical_chip_mapping_from_m
         }
     } else if (
         mesh_graph_desc_filename == "single_galaxy_mesh_graph_descriptor.yaml" ||
-        mesh_graph_desc_filename == "single_galaxy_torus_2d_graph_descriptor.yaml" ||
+        mesh_graph_desc_filename == "single_galaxy_torus_xy_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "dual_galaxy_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "p100_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "p150_mesh_graph_descriptor.yaml" ||

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -54,7 +54,7 @@ uint32_t get_downstream_edm_count(tt::tt_fabric::Topology topology) {
 
 FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::ClusterType cluster_type) {
     if (cluster_type == tt::ClusterType::GALAXY && fabric_config == tt::tt_metal::FabricConfig::FABRIC_1D_RING) {
-        return FabricType::TORUS_2D;
+        return FabricType::TORUS_XY;
     }
     return FabricType::MESH;
 }

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -20,6 +20,15 @@ enum class ARCH;
 }  // namespace tt
 
 namespace tt::tt_fabric {
+FabricType operator|(FabricType lhs, FabricType rhs) {
+    return static_cast<FabricType>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
+}
+
+FabricType operator&(FabricType lhs, FabricType rhs) {
+    return static_cast<FabricType>(static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
+}
+
+bool has_flag(FabricType flags, FabricType test) { return (flags & test) == test; }
 
 MeshGraph::MeshGraph(const std::string& mesh_graph_desc_file_path) {
     this->initialize_from_yaml(mesh_graph_desc_file_path);
@@ -85,80 +94,42 @@ void MeshGraph::add_to_connectivity(
         }
     }
 }
+
 std::unordered_map<chip_id_t, RouterEdge> MeshGraph::get_valid_connections(
-    chip_id_t src_chip_id, std::uint32_t row_size, std::uint32_t num_chips_in_board, FabricType fabric_type) const {
+    const MeshCoordinate& src_mesh_coord, const MeshCoordinateRange& mesh_coord_range, FabricType fabric_type) const {
     std::unordered_map<chip_id_t, RouterEdge> valid_connections;
-    if (fabric_type == FabricType::MESH) {
-        chip_id_t N = src_chip_id - row_size;
-        chip_id_t E = src_chip_id + 1;
-        chip_id_t S = src_chip_id + row_size;
-        chip_id_t W = src_chip_id - 1;
-        if (N >= 0) {
-            valid_connections.insert(
-                {N,
-                 RouterEdge{
-                     .port_direction = RoutingDirection::N,
-                     .connected_chip_ids = std::vector<chip_id_t>(this->chip_spec_.num_eth_ports_per_direction, N),
-                     .weight = 0}});
-        }
-        if (E < num_chips_in_board && (E / row_size == src_chip_id / row_size)) {
-            valid_connections.insert(
-                {E,
-                 RouterEdge{
-                     .port_direction = RoutingDirection::E,
-                     .connected_chip_ids = std::vector<chip_id_t>(this->chip_spec_.num_eth_ports_per_direction, E),
-                     .weight = 0}});
-        }
-        if (S < num_chips_in_board) {
-            valid_connections.insert(
-                {S,
-                 RouterEdge{
-                     .port_direction = RoutingDirection::S,
-                     .connected_chip_ids = std::vector<chip_id_t>(this->chip_spec_.num_eth_ports_per_direction, S),
-                     .weight = 0}});
-        }
-        if (W >= 0 && (W / row_size == src_chip_id / row_size)) {
-            valid_connections.insert(
-                {W,
-                 RouterEdge{
-                     .port_direction = RoutingDirection::W,
-                     .connected_chip_ids = std::vector<chip_id_t>(this->chip_spec_.num_eth_ports_per_direction, W),
-                     .weight = 0}});
-        }
-    } else if (fabric_type == FabricType::TORUS_1D) {
-        // TODO: add support
-    } else if (fabric_type == FabricType::TORUS_2D) {
-        auto row = src_chip_id / row_size;
-        auto col = src_chip_id % row_size;
-        chip_id_t N = (src_chip_id - row_size + num_chips_in_board) % num_chips_in_board;
-        chip_id_t E = row * row_size + (col + 1) % row_size;
-        chip_id_t S = (src_chip_id + row_size) % num_chips_in_board;
-        chip_id_t W = row * row_size + (col - 1 + row_size) % row_size;
-        valid_connections.insert(
-            {N,
-             RouterEdge{
-                 .port_direction = RoutingDirection::N,
-                 .connected_chip_ids = std::vector<chip_id_t>(this->chip_spec_.num_eth_ports_per_direction, N),
-                 .weight = 0}});
-        valid_connections.insert(
-            {E,
-             RouterEdge{
-                 .port_direction = RoutingDirection::E,
-                 .connected_chip_ids = std::vector<chip_id_t>(this->chip_spec_.num_eth_ports_per_direction, E),
-                 .weight = 0}});
-        valid_connections.insert(
-            {S,
-             RouterEdge{
-                 .port_direction = RoutingDirection::S,
-                 .connected_chip_ids = std::vector<chip_id_t>(this->chip_spec_.num_eth_ports_per_direction, S),
-                 .weight = 0}});
-        valid_connections.insert(
-            {W,
-             RouterEdge{
-                 .port_direction = RoutingDirection::W,
-                 .connected_chip_ids = std::vector<chip_id_t>(this->chip_spec_.num_eth_ports_per_direction, W),
-                 .weight = 0}});
+
+    MeshShape mesh_shape = mesh_coord_range.shape();
+    MeshCoordinate N(src_mesh_coord[0] - 1, src_mesh_coord[1]);
+    MeshCoordinate E(src_mesh_coord[0], src_mesh_coord[1] + 1);
+    MeshCoordinate S(src_mesh_coord[0] + 1, src_mesh_coord[1]);
+    MeshCoordinate W(src_mesh_coord[0], src_mesh_coord[1] - 1);
+
+    if (has_flag(fabric_type, FabricType::TORUS_X)) {
+        E = MeshCoordinate(src_mesh_coord[0], (src_mesh_coord[1] + 1) % mesh_shape[1]);
+        W = MeshCoordinate(src_mesh_coord[0], (src_mesh_coord[1] - 1 + mesh_shape[1]) % mesh_shape[1]);
     }
+    if (has_flag(fabric_type, FabricType::TORUS_Y)) {
+        N = MeshCoordinate((src_mesh_coord[0] - 1 + mesh_shape[0]) % mesh_shape[0], src_mesh_coord[1]);
+        S = MeshCoordinate((src_mesh_coord[0] + 1) % mesh_shape[0], src_mesh_coord[1]);
+    }
+    for (auto& [coord, direction] :
+         {std::pair{N, RoutingDirection::N},
+          std::pair{E, RoutingDirection::E},
+          std::pair{S, RoutingDirection::S},
+          std::pair{W, RoutingDirection::W}}) {
+        if (mesh_coord_range.contains(coord)) {
+            chip_id_t fabric_chip_id = coord[0] * mesh_shape[1] + coord[1];
+            valid_connections.insert(
+                {fabric_chip_id,
+                 RouterEdge{
+                     .port_direction = direction,
+                     .connected_chip_ids =
+                         std::vector<chip_id_t>(this->chip_spec_.num_eth_ports_per_direction, fabric_chip_id),
+                     .weight = 0}});
+        }
+    }
+
     return valid_connections;
 }
 
@@ -266,10 +237,10 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
             board_ew_size);
 
         std::uint32_t mesh_size = mesh_ns_size * mesh_ew_size;
+        MeshShape mesh_shape(mesh_ns_size, mesh_ew_size);
         std::vector<chip_id_t> chip_ids(mesh_size);
         std::iota(chip_ids.begin(), chip_ids.end(), 0);
-        this->mesh_to_chip_ids_.emplace(
-            *mesh_id, MeshContainer<chip_id_t>(MeshShape(mesh_ns_size, mesh_ew_size), chip_ids));
+        this->mesh_to_chip_ids_.emplace(*mesh_id, MeshContainer<chip_id_t>(mesh_shape, chip_ids));
 
         // Fill in host ranks for Mesh
         TT_FATAL(
@@ -311,10 +282,14 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
             MeshContainer<HostRankId>(MeshShape(mesh_board_ns_size, mesh_board_ew_size), mesh_host_ranks_values);
 
         // Fill in connectivity for Mesh
+        MeshCoordinateRange mesh_coord_range(mesh_shape);
         this->intra_mesh_connectivity_[*mesh_id].resize(mesh_size);
-        for (std::uint32_t i = 0; i < mesh_size; i++) {
-            this->intra_mesh_connectivity_[*mesh_id][i] =
-                this->get_valid_connections(i, mesh_ew_size, mesh_size, board_name_to_fabric_type[mesh_board]);
+        for (const auto& src_mesh_coord : mesh_coord_range) {
+            // Get the chip id for the current mesh coordinate
+            chip_id_t src_chip_id = src_mesh_coord[0] * mesh_shape[1] + src_mesh_coord[1];
+            // Get the valid connections for the current chip
+            this->intra_mesh_connectivity_[*mesh_id][src_chip_id] =
+                this->get_valid_connections(src_mesh_coord, mesh_coord_range, board_name_to_fabric_type[mesh_board]);
         }
 
         this->inter_mesh_connectivity_[*mesh_id].resize(this->intra_mesh_connectivity_[*mesh_id].size());

--- a/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_x_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_x_graph_descriptor.yaml
@@ -1,0 +1,28 @@
+ChipSpec: {
+  arch: wormhole_b0,
+  ethernet_ports: {
+    N: 4,
+    E: 4,
+    S: 4,
+    W: 4,
+  }
+}
+
+
+Board: [
+  { name: Galaxy,
+    type: TORUS_X,   # Cables along 4 dimension
+    topology: [8, 4]}
+ ]
+
+Mesh: [
+{
+  id: 0,
+  board: Galaxy,
+  device_topology: [8, 4],
+  host_topology: [1, 1],
+  host_ranks: [[0]]}
+]
+
+Graph: [
+]

--- a/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_xy_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_xy_graph_descriptor.yaml
@@ -1,0 +1,28 @@
+ChipSpec: {
+  arch: wormhole_b0,
+  ethernet_ports: {
+    N: 4,
+    E: 4,
+    S: 4,
+    W: 4,
+  }
+}
+
+
+Board: [
+  { name: Galaxy,
+    type: TORUS_XY,
+    topology: [8, 4]}
+ ]
+
+Mesh: [
+{
+  id: 0,
+  board: Galaxy,
+  device_topology: [8, 4],
+  host_topology: [1, 1],
+  host_ranks: [[0]]}
+]
+
+Graph: [
+]

--- a/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_y_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_y_graph_descriptor.yaml
@@ -11,7 +11,7 @@ ChipSpec: {
 
 Board: [
   { name: Galaxy,
-    type: TORUS_2D,
+    type: TORUS_Y,   # Cables along 8 dimension
     topology: [8, 4]}
  ]
 

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -70,43 +70,75 @@ RoutingTableGenerator::RoutingTableGenerator(const std::string& mesh_graph_desc_
 }
 
 void RoutingTableGenerator::generate_intramesh_routing_table(const IntraMeshConnectivity& intra_mesh_connectivity) {
+    const auto get_shorter_direction_on_row_or_col = [&](std::uint32_t mesh_id_val,
+                                                         std::uint32_t src_chip_id,
+                                                         std::uint32_t dst_chip_id,
+                                                         RoutingDirection a,
+                                                         RoutingDirection b) -> RoutingDirection {
+        // Loop through intra_mesh_connectivity starting with a or b direction and return direction that matches
+        // dst_chip_id_first In case of tie, this function is returning a
+        std::uint32_t curr_a = src_chip_id, curr_b = src_chip_id;
+        bool a_valid = true, b_valid = true;
+        while (a_valid or b_valid) {
+            if (intra_mesh_connectivity[mesh_id_val][curr_a].contains(dst_chip_id) and
+                intra_mesh_connectivity[mesh_id_val][curr_a].at(dst_chip_id).port_direction == a) {
+                return a;
+            } else if (
+                intra_mesh_connectivity[mesh_id_val][curr_b].contains(dst_chip_id) and
+                intra_mesh_connectivity[mesh_id_val][curr_b].at(dst_chip_id).port_direction == b) {
+                return b;
+            } else {
+                a_valid = false;
+                b_valid = false;
+                for (const auto& [next_chip_id, edge] : intra_mesh_connectivity[mesh_id_val][curr_a]) {
+                    if (edge.port_direction == a) {
+                        curr_a = next_chip_id;
+                        a_valid = true;
+                        break;
+                    }
+                }
+                for (const auto& [next_chip_id, edge] : intra_mesh_connectivity[mesh_id_val][curr_b]) {
+                    if (edge.port_direction == b) {
+                        curr_b = next_chip_id;
+                        b_valid = true;
+                        break;
+                    }
+                }
+            }
+        }
+        TT_ASSERT(
+            false,
+            "No valid direction found for src_chip_id {} and dst_chip_id {} in mesh_id {}. "
+            "This should not happen, check the intra_mesh_connectivity.",
+            src_chip_id,
+            dst_chip_id,
+            mesh_id_val);
+        return RoutingDirection::NONE;  // This line should never be reached
+    };
     for (std::uint32_t mesh_id_val = 0; mesh_id_val < this->intra_mesh_table_.size(); mesh_id_val++) {
         MeshId mesh_id{mesh_id_val};
         for (chip_id_t src_chip_id = 0; src_chip_id < this->intra_mesh_table_[mesh_id_val].size(); src_chip_id++) {
             for (chip_id_t dst_chip_id = 0; dst_chip_id < this->intra_mesh_table_[mesh_id_val].size(); dst_chip_id++) {
-                int row_size = this->mesh_graph->get_mesh_shape(mesh_id)[1];
-                uint32_t src_x = src_chip_id / row_size;
-                uint32_t src_y = src_chip_id % row_size;
-                uint32_t dst_x = dst_chip_id / row_size;
-                uint32_t dst_y = dst_chip_id % row_size;
-
+                auto src_mesh_coord = this->mesh_graph->chip_to_coordinate(mesh_id, src_chip_id);
+                auto dst_mesh_coord = this->mesh_graph->chip_to_coordinate(mesh_id, dst_chip_id);
                 uint32_t next_chip_id;
                 // X first routing, traverse rows first
-                if (src_x > dst_x) {
-                    // Move North
-                    next_chip_id = src_chip_id - row_size;
-                    this->intra_mesh_table_[*mesh_id][src_chip_id][dst_chip_id] =
-                        intra_mesh_connectivity[*mesh_id][src_chip_id].at(next_chip_id).port_direction;
+                if (src_mesh_coord[0] != dst_mesh_coord[0]) {
+                    // If source and destination are in different rows, we need to move in the X direction first
+                    // Move North or South
+                    MeshCoordinate target_coord_on_column(dst_mesh_coord[0], src_mesh_coord[1]);
+                    auto target_chip_id = this->mesh_graph->coordinate_to_chip(mesh_id, target_coord_on_column);
+                    auto direction = get_shorter_direction_on_row_or_col(
+                        mesh_id_val, src_chip_id, target_chip_id, RoutingDirection::N, RoutingDirection::S);
+                    this->intra_mesh_table_[*mesh_id][src_chip_id][dst_chip_id] = direction;
                     // TODO: today we are not updating the weight of the edge, should we use weight to balance
                     //  routing traffic?
                     //  intra_mesh_connectivity[mesh_id][src_chip_id][next_chip_id].weight += 1;
-                } else if (src_x < dst_x) {
-                    // Move South
-                    next_chip_id = src_chip_id + row_size;
-                    this->intra_mesh_table_[*mesh_id][src_chip_id][dst_chip_id] =
-                        intra_mesh_connectivity[*mesh_id][src_chip_id].at(next_chip_id).port_direction;
-                    // intra_mesh_connectivity[mesh_id][src_chip_id][next_chip_id].weight += 1;
-                } else if (src_y < dst_y) {
-                    // Move East
-                    next_chip_id = src_chip_id + 1;
-                    this->intra_mesh_table_[*mesh_id][src_chip_id][dst_chip_id] =
-                        intra_mesh_connectivity[*mesh_id][src_chip_id].at(next_chip_id).port_direction;
-                    // intra_mesh_connectivity[mesh_id][src_chip_id][next_chip_id].weight += 1;
-                } else if (src_y > dst_y) {
-                    // Move West
-                    next_chip_id = src_chip_id - 1;
-                    this->intra_mesh_table_[*mesh_id][src_chip_id][dst_chip_id] =
-                        intra_mesh_connectivity[*mesh_id][src_chip_id].at(next_chip_id).port_direction;
+                } else if (src_mesh_coord[1] != dst_mesh_coord[1]) {
+                    // Move East or West
+                    auto direction = get_shorter_direction_on_row_or_col(
+                        mesh_id_val, src_chip_id, dst_chip_id, RoutingDirection::E, RoutingDirection::W);
+                    this->intra_mesh_table_[*mesh_id][src_chip_id][dst_chip_id] = direction;
                     // intra_mesh_connectivity[mesh_id][src_chip_id][next_chip_id].weight += 1;
                 } else {
                     // No movement

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -471,8 +471,8 @@ void MetalContext::initialize_control_plane() {
         case tt::ClusterType::T3K: mesh_graph_descriptor = "t3k_mesh_graph_descriptor.yaml"; break;
         case tt::ClusterType::GALAXY:
             if (tt::tt_fabric::get_fabric_type(this->fabric_config_, cluster_type) ==
-                tt::tt_fabric::FabricType::TORUS_2D) {
-                mesh_graph_descriptor = "single_galaxy_torus_2d_graph_descriptor.yaml";
+                tt::tt_fabric::FabricType::TORUS_XY) {
+                mesh_graph_descriptor = "single_galaxy_torus_xy_graph_descriptor.yaml";
             } else {
                 mesh_graph_descriptor = "single_galaxy_mesh_graph_descriptor.yaml";
             }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24548)

### Problem description
Today, routing tables aren't generated with Torus links in mind, even thought the MeshGraph provides the connections for the 2D/XY case.

### What's changed
- Rename TORUS 2D to XY, to avoid confusion with Fabric_2D/1D
- Generalize MeshGraph connectivity to support X, Y, XY etc. Torus options
- Use intramesh connectivity from MeshGraph (which account for torus links) to generate shortest path routing tables

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes