### PR TITLE
[skip ci] Create BH llmbox demo wrapper

### DIFF
--- a/.github/workflows/blackhole-llmbox-demo-tests.yaml
+++ b/.github/workflows/blackhole-llmbox-demo-tests.yaml
@@ -1,0 +1,24 @@
+name: "(Blackhole) LLMBox Demo tests"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      build-wheel: true
+      version: 22.04
+  blackhole-llmbox-demo-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
+    with:
+      runner-label: BH-LLMBox
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Ticket
#24042

### Problem description
BH LLMBox demo tests only run as part of BH nightly

### What's changed
Create a wrapper to expose BH LLMBox demo tests directly so that devs can dispatch directly.

### Checklist
None