### PR TITLE
#22361: Split demo tests into P100 and P150

### DIFF
--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -19,8 +19,12 @@ jobs:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ["P100", "P150"]
     with:
-      runner-label: BH
+      runner-label: ${{ matrix.test-group }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -176,11 +176,15 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
   blackhole-demo-tests:
-    needs: build-artifact
+    needs: [build-artifact, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     with:
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ matrix.test-group }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -472,7 +472,10 @@ def test_demo_for_conditional_generation(input_path, ttnn_model, device, num_inp
     )
     if is_ci_env:
         if is_blackhole():
-            expected_perf_metrics = {"prefill_t/s": 7.67, "decode_t/s/u": 91.0}
+            if device.dram_grid_size().x == 7:  # P100 DRAM grid is 7x1
+                expected_perf_metrics = {"prefill_t/s": 7.67, "decode_t/s/u": 91.0}
+            else:
+                expected_perf_metrics = {"prefill_t/s": 7.67, "decode_t/s/u": 98.0}
         else:  # wormhole_b0
             expected_perf_metrics = {"prefill_t/s": 3.85, "decode_t/s/u": 51.8}
         expected_perf_metrics["decode_t/s"] = expected_perf_metrics["decode_t/s/u"]  # Only supporting batch 1


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/22361)

### Problem description
BH demo perf test only ran on P100 due to lack of P150 baremetals

### What's changed
- Split the BH demo workflow into P100 and P150
- Split whisper perf target into P100 and P150

### Checklist
- [x] BH demos: https://github.com/tenstorrent/tt-metal/actions/runs/16124794216
- [x] Before merging this PR the P150 baremetals need `pipeline-perf` tag applied to them.