### PR TITLE
Generate topology.json file to store routing information from control plane when NoC tracing is enabled

### DIFF
--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -11,6 +11,7 @@
 #include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
 #include <vector>
 #include <umd/device/tt_core_coordinates.h>
+#include <tt-metalium/fabric_types.hpp>
 
 namespace tt {
 namespace tt_metal {
@@ -20,10 +21,12 @@ class Program;
 
 namespace tt::tt_metal::distributed {
 class MeshDevice;
+class MeshShape;
 }  // namespace tt::tt_metal::distributed
 
 namespace tt::tt_fabric {
 class FabricNodeId;
+enum class RoutingDirection;
 size_t get_tt_fabric_channel_buffer_size_bytes();
 size_t get_tt_fabric_packet_header_size_bytes();
 size_t get_tt_fabric_max_payload_size_bytes();
@@ -66,6 +69,11 @@ std::vector<uint32_t> get_forwarding_link_indices(
     const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id);
 
 FabricNodeId get_fabric_node_id_from_physical_chip_id(chip_id_t physical_chip_id);
+
+std::vector<chan_id_t> get_active_fabric_eth_routing_planes_in_direction(
+    FabricNodeId fabric_node_id, RoutingDirection routing_direction);
+
+std::unordered_map<MeshId, tt::tt_metal::distributed::MeshShape> get_physical_mesh_shapes();
 
 namespace experimental {
 size_t get_number_of_available_routing_planes(

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -80,6 +80,21 @@ FabricNodeId get_fabric_node_id_from_physical_chip_id(chip_id_t physical_chip_id
     return control_plane.get_fabric_node_id_from_physical_chip_id(physical_chip_id);
 }
 
+std::vector<chan_id_t> get_active_fabric_eth_routing_planes_in_direction(
+    FabricNodeId fabric_node_id, RoutingDirection routing_direction) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    return control_plane.get_active_fabric_eth_routing_planes_in_direction(fabric_node_id, routing_direction);
+}
+
+std::unordered_map<MeshId, MeshShape> get_physical_mesh_shapes() {
+    std::unordered_map<MeshId, MeshShape> mesh_shapes;
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    for (auto mesh_id : control_plane.get_user_physical_mesh_ids()) {
+        mesh_shapes[mesh_id] = control_plane.get_physical_mesh_shape(mesh_id);
+    }
+    return mesh_shapes;
+}
+
 void append_fabric_connection_rt_args(
     const FabricNodeId& src_fabric_node_id,
     const FabricNodeId& dst_fabric_node_id,

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1484,6 +1484,7 @@ void DeviceProfiler::dumpResults(
     if (state == ProfilerDumpState::NORMAL && rtoptions.get_profiler_noc_events_enabled()) {
         serializeJsonNocTraces(noc_trace_json_log, rpt_path, device_id, routing_lookup);
         dumpClusterCoordinatesAsJson(std::filesystem::path(rpt_path) / "cluster_coordinates.json");
+        dumpRoutingInfo(std::filesystem::path(rpt_path) / "topology.json");
     }
 
     log_file_ofs.close();

--- a/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
@@ -15,6 +15,8 @@
 
 #include "tt_cluster.hpp"
 #include "fabric/fabric_host_utils.hpp"
+#include "fabric/fabric_context.hpp"
+#include "fabric.hpp"
 #include "tt_metal.hpp"
 
 namespace tt {
@@ -90,6 +92,63 @@ inline void dumpClusterCoordinatesAsJson(const std::filesystem::path& filepath) 
     } else {
         log_error(tt::LogMetal, "Failed to open file '{}' for dumping cluster coordinate map", filepath.string());
     }
+}
+
+inline void dumpRoutingInfo(const std::filesystem::path& filepath) {
+    nlohmann::ordered_json topology_json;
+
+    const Cluster& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+
+    topology_json["mesh_shapes"] = nlohmann::ordered_json::array();
+    for (auto [mesh_id, mesh_shape] : tt::tt_fabric::get_physical_mesh_shapes()) {
+        topology_json["mesh_shapes"].push_back({
+            {"mesh_id", mesh_id.get()},
+            {"shape", std::vector(mesh_shape.cbegin(), mesh_shape.cend())},
+        });
+    }
+
+    topology_json["fabric_config"] = magic_enum::enum_name(tt::tt_metal::MetalContext::instance().get_fabric_config());
+    if (tt::tt_metal::MetalContext::instance().get_fabric_config() != FabricConfig::DISABLED) {
+        topology_json["routing_planes"] = nlohmann::ordered_json::array();
+        topology_json["device_id_to_fabric_node_id"] = nlohmann::ordered_json::object();
+        for (auto physical_chip_id : cluster.get_cluster_desc()->get_all_chips()) {
+            auto fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(physical_chip_id);
+            auto device_routing_planes = nlohmann::ordered_json::array();
+            topology_json["device_id_to_fabric_node_id"][std::to_string(physical_chip_id)] = {
+                fabric_node_id.mesh_id.get(), fabric_node_id.chip_id};
+
+            for (const auto& direction : tt::tt_fabric::FabricContext::routing_directions) {
+                auto eth_routing_planes_in_dir =
+                    tt::tt_fabric::get_active_fabric_eth_routing_planes_in_direction(fabric_node_id, direction);
+
+                while (device_routing_planes.size() < eth_routing_planes_in_dir.size()) {
+                    device_routing_planes.push_back(
+                        {{"routing_plane_id", device_routing_planes.size()},
+                         {"ethernet_channels", nlohmann::ordered_json::object()}});
+                }
+
+                for (int j = 0; j < eth_routing_planes_in_dir.size(); j++) {
+                    chip_id_t eth_channel = eth_routing_planes_in_dir[j];
+                    device_routing_planes[j]["ethernet_channels"][magic_enum::enum_name(direction)] = eth_channel;
+                }
+            }
+
+            topology_json["routing_planes"].push_back(
+                {{"device_id", physical_chip_id}, {"device_routing_planes", device_routing_planes}});
+        }
+    }
+
+    topology_json["eth_chan_to_coord"] = nlohmann::ordered_json::object();
+    auto physical_chip_id = *(cluster.get_cluster_desc()->get_all_chips().begin());
+    for (int j = 0; j < cluster.get_soc_desc(physical_chip_id).get_num_eth_channels(); j++) {
+        tt::umd::CoreCoord edm_eth_core =
+            cluster.get_soc_desc(physical_chip_id).get_eth_core_for_channel(j, CoordSystem::PHYSICAL);
+        topology_json["eth_chan_to_coord"][std::to_string(j)] = {edm_eth_core.x, edm_eth_core.y};
+    }
+
+    std::ofstream topology_json_ofs(filepath);
+    TT_FATAL(topology_json_ofs.is_open(), "Failed to open file '{}' for dumping topology", filepath.string());
+    topology_json_ofs << topology_json.dump(2);
 }
 
 // determines the implied unicast/multicast start distance and range in tt_fabric::LowLatencyRoutingFields


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-npe/issues/52

### Problem description
tt-npe needs to be able to determine the entire route taken by fabric packets from information available in noc traces (e.g. src device, sender channel, and number of hops taken in 1D Unicast) which requires additional routing information to be provided.

### What's changed
- New function dumpRoutingInfo used by device profiler to store routing information from control plane when dumping results. The routing information consists of the shapes for each mesh and the ethernet channels associated with each routing plane ((routing plane, device, direction) -> ethernet channel).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes