### PR TITLE
Fix bug in op performance models with newer interface

### DIFF
--- a/ttnn/api/ttnn/old_infra_device_operation.hpp
+++ b/ttnn/api/ttnn/old_infra_device_operation.hpp
@@ -101,7 +101,7 @@ struct OldInfraDeviceOperation {
     static tt::stl::hash::hash_t compute_program_hash(
         const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
 
-    static auto create_op_performance_model(
+    static OpPerformanceModel<OutputTensors> create_op_performance_model(
         const operation_attributes_t& attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value);

--- a/ttnn/api/ttnn/old_infra_device_operation.hpp
+++ b/ttnn/api/ttnn/old_infra_device_operation.hpp
@@ -101,7 +101,7 @@ struct OldInfraDeviceOperation {
     static tt::stl::hash::hash_t compute_program_hash(
         const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
 
-    static OpPerformanceModel<OutputTensors> create_op_performance_model(
+    static OpPerformanceModelGeneral<OutputTensors> create_op_performance_model(
         const operation_attributes_t& attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value);

--- a/ttnn/core/old_infra_device_operation.cpp
+++ b/ttnn/core/old_infra_device_operation.cpp
@@ -125,7 +125,7 @@ tt::stl::hash::hash_t OldInfraDeviceOperation<OutputTensors>::compute_program_ha
 }
 
 template <typename OutputTensors>
-OpPerformanceModel<OutputTensors> OldInfraDeviceOperation<OutputTensors>::create_op_performance_model(
+OpPerformanceModelGeneral<OutputTensors> OldInfraDeviceOperation<OutputTensors>::create_op_performance_model(
     const operation_attributes_t& attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {

--- a/ttnn/core/old_infra_device_operation.cpp
+++ b/ttnn/core/old_infra_device_operation.cpp
@@ -125,7 +125,7 @@ tt::stl::hash::hash_t OldInfraDeviceOperation<OutputTensors>::compute_program_ha
 }
 
 template <typename OutputTensors>
-auto OldInfraDeviceOperation<OutputTensors>::create_op_performance_model(
+OpPerformanceModel<OutputTensors> OldInfraDeviceOperation<OutputTensors>::create_op_performance_model(
     const operation_attributes_t& attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {


### PR DESCRIPTION
### Ticket
#24485 

### Problem description
The instance method create_op_performance_model() was not being called for various ops (matmul and conv2d tested)

### What's changed
There was an auto return type in one of the device operation classes that was interfering with the compiler's ability to call the correct create_op_performance_model() function

More detail:
The problem is the auto return type for OldInfraDeviceOperation::create_op_performance_model(). If I change the return type to OpPerformanceModelGeneral<OutputTensors>, everything works. It appears that this return type deduction was inhibiting the compiler from being able to take the correct path in MeshDeviceOperationAdapter::create_op_performance_model().

I verified that things are working correctly by logging a message in Matmul::create_op_performance_model(), which was never being printed before but now is. Additionally, I ran the profiler (profile_this.py) on both the auto and non-auto cases. For the auto case I see the PM IDEAL [ns] = 1 (expected for the default case of ideal cycles = 1), and for the non-auto case I see PM IDEAL [ns] = 1478 (can't attest if that's correct or not, but it's certainly not using the default).

conv2d was also not working correctly before. I set up a simple test using conv2d, and the experience was the same as matmul: Didn't work until I changed the auto return type.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes