### PR TITLE
Add logical right shift impl

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
@@ -37,4 +37,14 @@ inline void llk_math_eltwise_binary_sfpu_right_shift(
         vector_mode);
 }
 
+template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
+inline void llk_math_eltwise_binary_sfpu_logical_right_shift(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::_calculate_logical_right_shift_<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
+        dst_index0,
+        dst_index1,
+        vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
@@ -37,4 +37,14 @@ inline void llk_math_eltwise_binary_sfpu_right_shift(
         vector_mode);
 }
 
+template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
+inline void llk_math_eltwise_binary_sfpu_logical_right_shift(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::_calculate_logical_right_shift_<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
+        dst_index0,
+        dst_index1,
+        vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/binary_shift.h
+++ b/tt_metal/include/compute_kernel_api/binary_shift.h
@@ -79,6 +79,38 @@ ALWI void binary_right_shift_int32_tile(uint32_t idst0, uint32_t idst1) {
     MATH((llk_math_eltwise_binary_sfpu_right_shift<APPROX, InstrModLoadStore::INT32>(idst0, idst1)));
 }
 
+// clang-format off
+/**
+ * Performs an elementwise logical shift operation to the right on the input at idst0, by input at idst1: y = x0 >> x1
+ * Both inputs must be of Int32 data type only. Output overwrites first operand in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ * A maximum of 4 tiles from each operand can be loaded into DST at once, for a total of 8 tiles,
+ * when using 16 bit formats. This gets reduced to 2 tiles from each operand for 32 bit formats.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void binary_logical_right_shift_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_logical_right_shift<APPROX>(idst0, idst1)));
+}
+
+template <bool sign_magnitude_format = false>
+ALWI void binary_logical_right_shift_uint32_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_logical_right_shift<APPROX, InstrModLoadStore::INT32, sign_magnitude_format>(
+        idst0, idst1)));
+}
+
+ALWI void binary_logical_right_shift_int32_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_logical_right_shift<APPROX, InstrModLoadStore::INT32>(idst0, idst1)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -785,6 +785,7 @@ template struct BinaryOperation<BinaryOpType::BITWISE_OR>;
 template struct BinaryOperation<BinaryOpType::BITWISE_XOR>;
 template struct BinaryOperation<BinaryOpType::LEFT_SHIFT>;
 template struct BinaryOperation<BinaryOpType::RIGHT_SHIFT>;
+template struct BinaryOperation<BinaryOpType::LOGICAL_RIGHT_SHIFT>;
 
 template struct RelationalBinary<BinaryOpType::EQ>;
 template struct RelationalBinary<BinaryOpType::NE>;
@@ -810,6 +811,7 @@ template struct BinaryOperationSfpu<BinaryOpType::BITWISE_XOR>;
 template struct BinaryOperationSfpu<BinaryOpType::BITWISE_OR>;
 template struct BinaryOperationSfpu<BinaryOpType::LEFT_SHIFT>;
 template struct BinaryOperationSfpu<BinaryOpType::RIGHT_SHIFT>;
+template struct BinaryOperationSfpu<BinaryOpType::LOGICAL_RIGHT_SHIFT>;
 template struct BinaryOperationSfpu<BinaryOpType::MAXIMUM>;
 template struct BinaryOperationSfpu<BinaryOpType::MINIMUM>;
 template struct BinaryOperationSfpu<BinaryOpType::GCD>;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -285,6 +285,9 @@ constexpr auto addalpha = ttnn::register_operation<
 constexpr auto subalpha = ttnn::register_operation<
     "ttnn::subalpha",
     operations::binary::BinaryOperationSubalpha<operations::binary::BinaryOpType::SUBALPHA>>();
+constexpr auto logical_right_shift = ttnn::register_operation<
+    "ttnn::logical_right_shift",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::LOGICAL_RIGHT_SHIFT>>();
 
 template <typename InputBType>
 ttnn::Tensor operator+(const ttnn::Tensor& lhs, InputBType rhs) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -874,9 +874,6 @@ void bind_logical_binary_ops_operation(
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
@@ -886,9 +883,9 @@ void bind_logical_binary_ops_operation(
                     dtype,
                     memory_config,
                     output_tensor,
-                    activations,
-                    input_tensor_a_activations,
-                    input_tensor_b_activations,
+                    ttnn::SmallVector<unary::UnaryWithParam>(),
+                    ttnn::SmallVector<unary::UnaryWithParam>(),
+                    ttnn::SmallVector<unary::UnaryWithParam>(),
                     use_legacy);
             },
             py::arg("input_tensor_a"),
@@ -897,9 +894,6 @@ void bind_logical_binary_ops_operation(
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -807,6 +807,104 @@ void bind_bitwise_binary_ops_operation(
 }
 
 template <typename binary_operation_t>
+void bind_logical_binary_ops_operation(
+    py::module& module,
+    const binary_operation_t& operation,
+    const std::string& description,
+    const std::string& math,
+    const std::string& info = ". ",
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = " ") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor or Integer): the input tensor.
+
+        Keyword args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            queue_id (int, optional): command queue id. Defaults to `0`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+
+        Note:
+            Supported dtypes, layouts, and ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+                 - Ranks
+               * - {5}
+                 - TILE
+                 - 2, 3, 4
+
+            {6}
+
+        Example:
+            >>> tensor1 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> tensor2 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> output = {1}(tensor1, tensor2/scalar)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description,
+        math,
+        info,
+        supported_dtype,
+        note);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const ttnn::Tensor& input_tensor_a,
+               const ttnn::Tensor& input_tensor_b,
+               const std::optional<const DataType>& dtype,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor,
+               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const std::optional<bool>& use_legacy,
+               QueueId queue_id) -> ttnn::Tensor {
+                return self(
+                    queue_id,
+                    input_tensor_a,
+                    input_tensor_b,
+                    dtype,
+                    memory_config,
+                    output_tensor,
+                    activations,
+                    input_tensor_a_activations,
+                    input_tensor_b_activations,
+                    use_legacy);
+            },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::kw_only(),
+            py::arg("dtype") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("use_legacy") = std::nullopt,
+            py::arg("queue_id") = DefaultQueueId});
+}
+
+template <typename binary_operation_t>
 void bind_binary_composite(
     py::module& module,
     const binary_operation_t& operation,
@@ -2070,6 +2168,14 @@ void py_module(py::module& module) {
         ttnn::bitwise_right_shift,
         R"doc(Perform bitwise_right_shift operation on :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`. :attr:`input_tensor_b` has shift_bits which are integers within range (0, 31))doc",
         R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_and|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
+        ". ",
+        R"doc(INT32)doc");
+
+    detail::bind_logical_binary_ops_operation(
+        module,
+        ttnn::logical_right_shift,
+        R"doc(Perform logical_right_shift operation on :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`. :attr:`input_tensor_b` has shift_bits which are integers within range (0, 31). Logical right shift fills vacated bits with zeros.)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \verb|logical_right_shift|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
         ". ",
         R"doc(INT32)doc");
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
@@ -32,6 +32,7 @@ enum class BinaryOpType {
     BITWISE_OR,
     LEFT_SHIFT,
     RIGHT_SHIFT,
+    LOGICAL_RIGHT_SHIFT,
     QUANT,
     REQUANT,
     DEQUANT,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -269,6 +269,10 @@ std::map<std::string, std::string> get_defines_fp32(
             new_defines.insert({"SHIFT_INIT", fmt::format("binary_shift_tile_init();")});
             op_name = "binary_right_shift_tile";
             break;
+        case BinaryOpType::LOGICAL_RIGHT_SHIFT:
+            new_defines.insert({"SHIFT_INIT", fmt::format("binary_shift_tile_init();")});
+            op_name = "binary_logical_right_shift_tile";
+            break;
         case BinaryOpType::MAXIMUM:
             new_defines.insert({"BINOP_INIT", fmt::format("binary_max_tile_init();")});
             if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -46,7 +46,8 @@ namespace utils {
         case BinaryOpType::GCD:
         case BinaryOpType::LCM:
         case BinaryOpType::LEFT_SHIFT:
-        case BinaryOpType::RIGHT_SHIFT: return (a == DataType::INT32 && b == DataType::INT32);
+        case BinaryOpType::RIGHT_SHIFT:
+        case BinaryOpType::LOGICAL_RIGHT_SHIFT: return ((a == DataType::INT32 && b == DataType::INT32) || (a == DataType::UINT32 && b == DataType::UINT32));
         case BinaryOpType::BITWISE_XOR:
         case BinaryOpType::BITWISE_OR:
         case BinaryOpType::BITWISE_AND: return ((a == DataType::INT32 && b == DataType::INT32) || (a == DataType::UINT16 && b == DataType::UINT16));

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -38,7 +38,8 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
         case LCM:
         case GCD: return (a == INT32 && b == INT32);
         case LEFT_SHIFT:
-        case RIGHT_SHIFT: return ((a == INT32 || a == UINT32) && (b == INT32 || b == UINT32));
+        case RIGHT_SHIFT:
+        case LOGICAL_RIGHT_SHIFT: return ((a == INT32 || a == UINT32) && (b == INT32 || b == UINT32));
         case BITWISE_XOR:
         case BITWISE_OR:
         case BITWISE_AND: return ((a == INT32 && b == INT32) || (a == UINT16 && b == UINT16));

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -246,6 +246,13 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>) : b
                 TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
             }
             break;
+        case BinaryOpType::LOGICAL_RIGHT_SHIFT:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LOGICAL_RIGHT_SHIFT;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
         case BinaryOpType::POWER:
             if (is_sfpu_op()) {
                 binary_op = SfpuBinaryOp::POWER;
@@ -353,6 +360,14 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
                 return {"binary_shift_tile_init();", "binary_right_shift_int32_tile"};
             } else {
                 return {"binary_shift_tile_init();", "binary_right_shift_tile"};
+            }
+        case LOGICAL_RIGHT_SHIFT:
+            if (dtype == DataType::UINT32) {
+                return {"binary_shift_tile_init();", "binary_logical_right_shift_uint32_tile"};
+            } else if (dtype == DataType::INT32) {
+                return {"binary_shift_tile_init();", "binary_logical_right_shift_int32_tile"};
+            } else {
+                return {"binary_shift_tile_init();", "binary_logical_right_shift_tile"};
             }
         case BITWISE_AND:
             if (dtype == DataType::UINT16) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -60,6 +60,7 @@ struct OpConfig {
         LCM,
         LEFT_SHIFT,
         RIGHT_SHIFT,
+        LOGICAL_RIGHT_SHIFT,
         BITWISE_AND,
         BITWISE_OR,
         BITWISE_XOR,

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -509,4 +509,14 @@ def _golden_function_prelu(input_tensor_a, input_tensor_b, *args, **kwargs):
 ttnn.attach_golden_function(ttnn.prelu, golden_function=_golden_function_prelu)
 
 
+def _golden_function_logical_right_shift(input_tensor_a, shift_amt, *args, **kwargs):
+    import torch
+
+    t1_uint = input_tensor_a.to(torch.int64) & 0xFFFFFFFF
+    result = (t1_uint >> shift_amt).to(torch.int32)
+    return result
+
+
+ttnn.attach_golden_function(ttnn.logical_right_shift, golden_function=_golden_function_logical_right_shift)
+
 __all__ = []


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22862

### Problem description
logical shift implementation not available

### What's changed
Add logical right shift implementation

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/16133828794
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/16134158690
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes