### PR TITLE
#19393: Fix untilize + bias + fp32 + packer_l1 accumulation in Conv2D

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -37,7 +37,7 @@ import torch
 )
 @pytest.mark.parametrize(
     "packer_l1_acc",
-    [True],
+    [True, False],
 )
 @pytest.mark.parametrize(
     "filter, padding",

--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -37,7 +37,7 @@ import torch
 )
 @pytest.mark.parametrize(
     "packer_l1_acc",
-    [False],
+    [True],
 )
 @pytest.mark.parametrize(
     "filter, padding",
@@ -75,9 +75,6 @@ def test_conv_features(
 
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat8_b:
         pytest.skip("Row major layout not compatible with bfloat8_b")
-
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and output_dtype == ttnn.bfloat16 and packer_l1_acc and fp32_accum:
-        pytest.skip("skipping due to pack_untilize_dst issue!")
 
     run_conv(
         device,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -424,7 +424,7 @@ void MAIN {
             }
 #endif
             if constexpr (untilize_out) {
-#if defined PACKER_L1_ACC and not defined FUSE_BIAS
+#if defined PACKER_L1_ACC
                 pack_reconfig_data_format(matmul_partials_cb, out_cb_id);
                 pack_reconfig_l1_acc(0);
 #endif

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -375,7 +375,7 @@ void MAIN {
             // if last block we pack the final result with relu enabled
             PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
 #endif
-            pack_reconfig_data_format(matmul_partials_cb, out_cb_id);
+            pack_reconfig_data_format(matmul_partials_cb, untilize_mode_out_cb_id);
 #ifdef PACKER_L1_ACC
             pack_reconfig_l1_acc(0);
 #endif


### PR DESCRIPTION
### Ticket
#19393

### Problem description
Conv2D had the wrong output when untilize_out, fused bias, packer L1 + FP32 accumulation were all enabled.

### What's changed
In the fused bias addition code, the packer was configured with out_cb_id. However, when untilized_out is enabled the output is actually written to matmul_partials_cb.
With FP32 accumulation, matmul_partials is fp32, but out_cb_id is bfp16. This causes the packer to be incorrectly configured, and it doesn't write the output of fused bias addition correctly.

Fixed by configuring the packer with the correct CB. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16111884500)
- [x] Nightly L2 [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16111895132)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16117813437)
- [x] Frequent Models [same as main](https://github.com/tenstorrent/tt-metal/actions/runs/16111900671)
- [x] New/Existing tests provide coverage for changes