### PR TITLE
[skip ci] Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -240,34 +240,34 @@ models/demos/yolov4 @dvartaniansTT @mbahnasTT @rdraskicTT @mbezuljTT @tenstorren
 models/demos/**/*resnet* @tenstorrent/metalium-developers-convolutions @mradosavljevicTT
 models/experimental/ @sminakov-tt @dgomezTT @jmalone-tt @ayerofieiev-tt @uaydonat
 models/experimental/functional_unet @esmalTT @uaydonat @tenstorrent/metalium-developers-convolutions
-models/demos/ufld_v2 @tenstorrent/cse-developer-ttnn
-models/demos/vgg_unet @tenstorrent/cse-developer-ttnn
+models/demos/ufld_v2 @dvartaniansTT @tenstorrent/cse-developer-ttnn
+models/demos/vgg_unet @dvartaniansTT @tenstorrent/cse-developer-ttnn
 models/experimental/openpdn_mnist @tenstorrent/cse-developer-ttnn
-models/experimental/functional_vanilla_unet @tenstorrent/cse-developer-ttnn
-models/demos/sentence_bert @tenstorrent/cse-developer-ttnn
+models/experimental/functional_vanilla_unet @dvartaniansTT @tenstorrent/cse-developer-ttnn
+models/demos/sentence_bert @arginugaTT @tenstorrent/cse-developer-ttnn
 models/experimental/grok @yieldthought @uaydonat
-models/demos/wormhole/vit @tenstorrent/cse-developer-ttnn @uaydonat
-models/demos/vit  @tenstorrent/cse-developer-ttnn @uaydonat
+models/demos/wormhole/vit @arginugaTT @tenstorrent/cse-developer-ttnn @uaydonat
+models/demos/vit @arginugaTT @tenstorrent/cse-developer-ttnn @uaydonat
 models/experimental/*yolo*/ @tenstorrent/cse-developer-ttnn @uaydonat
 models/experimental/yolo_eval @tenstorrent/cse-developer-ttnn @tenstorrent/metalium-developers-convolutions
-models/demos/segformer @tenstorrent/cse-developer-ttnn @uaydonat @tenstorrent/metalium-developers-convolutions
+models/demos/segformer @arginugaTT @tenstorrent/cse-developer-ttnn @uaydonat @tenstorrent/metalium-developers-convolutions
 models/perf/ @yieldthought @uaydonat
 models/perf/benchmarking_utils.py @skhorasganiTT @williamlyTT @uaydonat
 models/demos/utils/llm_demo_utils.py @skhorasganiTT @mtairum @uaydonat
 models/experimental/stable_diffusion_xl_base @mbezuljTT @pavlepopovic @ipotkonjak-tt @tenstorrent/metalium-developers-convolutions
-models/demos/mobilenetv2 @tenstorrent/cse-developer-ttnn
-models/demos/yolov8s_world @tenstorrent/cse-developer-ttnn
-models/experimental/yolov10 @tenstorrent/cse-developer-ttnn
-models/demos/yolov9c @tenstorrent/cse-developer-ttnn
-models/demos/yolov8x @tenstorrent/cse-developer-ttnn
-models/demos/yolov8s @tenstorrent/cse-developer-ttnn
+models/demos/mobilenetv2 @dvartaniansTT @tenstorrent/cse-developer-ttnn
+models/demos/yolov8s_world @ssinghalTT @tenstorrent/cse-developer-ttnn
+models/experimental/yolov10 @ssinghalTT @tenstorrent/cse-developer-ttnn
+models/demos/yolov9c @ssinghalTT @tenstorrent/cse-developer-ttnn
+models/demos/yolov8x @ssinghalTT @tenstorrent/cse-developer-ttnn
+models/demos/yolov8s @ssinghalTT @tenstorrent/cse-developer-ttnn
 models/experimental/stable_diffusion_35_large/ @jonathansuTT @cglagovichTT @tenstorrent/cse-developer-ttnn
-models/experimental/swin_s @tenstorrent/cse-developer-ttnn
-models/demos/yolov7 @tenstorrent/cse-developer-ttnn
+models/experimental/swin_s @arginugaTT @tenstorrent/cse-developer-ttnn
+models/demos/yolov7 @ssinghalTT @tenstorrent/cse-developer-ttnn
 models/experimental/classification_eval @tenstorrent/cse-developer-ttnn
-models/experimental/yolov11 @tenstorrent/cse-developer-ttnn
+models/experimental/yolov11 @ssinghalTT @tenstorrent/cse-developer-ttnn
 models/experimental/segmentation_evaluation @tenstorrent/cse-developer-ttnn
-models/experimental/yolov6l @tenstorrent/cse-developer-ttnn
+models/experimental/yolov6l @ssinghalTT @tenstorrent/cse-developer-ttnn
 
 # docs
 docs/Makefile @tenstorrent/metalium-developers-infra


### PR DESCRIPTION
This change explicitly specifies the model owner for many models that were missing one.