### PR TITLE
FlashMLA decode

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py
@@ -1,0 +1,368 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import math
+import torch
+import numpy as np
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_allclose,
+    comp_pcc,
+)
+from models.utility_functions import nearest_y
+
+import ttnn
+from loguru import logger
+import pytest
+
+
+def scaled_dot_product_attention_reference(Q, K, V, start_indices, padded_layer_len, scale, is_causal=True):
+    b, nh, _, _ = Q.shape  # b, nh, 1, d
+    _, nkv, _, _ = K.shape
+
+    attn_mask = None
+    if is_causal:
+        attn_mask = torch.zeros((b, nh, 1, padded_layer_len))
+        for i in range(b):
+            start_idx = start_indices[i]
+            attn_mask[i, :, :, start_idx + 1 :] = torch.finfo(torch.float32).min
+    else:
+        assert False, "Non-causal attention is not supported in this function."
+
+    Q_slice = Q[:, :nh, :, :]  # b, nh, 1, d
+    K_slice = K[:, :nkv, :padded_layer_len, :]  # b, nkv, S, d
+    K_slice = torch.cat(
+        [K_slice[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1
+    )  # b, nh, d, S
+    V_slice = V[:, :, :padded_layer_len, :]  # b, nkv, S, d
+    V_slice = torch.cat(
+        [V_slice[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1
+    )  # b, nh, d, S
+    attn_mask_slice = attn_mask[:, :nh, :, :]  # b, nh, 1, S
+    out = torch.nn.functional.scaled_dot_product_attention(
+        Q_slice, K_slice, V_slice, attn_mask_slice, scale=scale, is_causal=False
+    )  # b, nh, 1, d
+
+    return out
+
+
+def flash_mla_decode_tt(
+    query,
+    key,
+    value,
+    nh,
+    nkv,
+    is_causal=True,
+):
+    pass
+
+
+def run_flash_mla_decode_impl(
+    device,
+    batch,
+    seq_len,
+    nh,
+    nkv,
+    kv_lora_rank,
+    d_rope,
+    q_num_cores,
+    q_dtype,
+    dtype,
+):
+    # Log the test parameters
+    logger.info(f"Running FlashMLA Decode with parameters: ")
+    logger.info(f"Batch: {batch}")
+    logger.info(f"Sequence Length: {seq_len}")
+    logger.info(f"Number of Heads (Q): {nh}")
+    logger.info(f"Number of Heads (KV): {nkv}")
+    logger.info(f"KV LoRA Rank: {kv_lora_rank}")
+    logger.info(f"Dimensionality of RoPE: {d_rope}")
+    logger.info(f"Number of Cores for Q Sharding: {q_num_cores}")
+    logger.info(f"Query Data Type: {q_dtype}")
+    logger.info(f"Key-Value Data Type: {dtype}")
+
+    ######################
+    ### Torch Setup
+    ######################
+    q = torch.randn(batch, nh, 1, kv_lora_rank + d_rope).float()  # (B, H, S (1 for decode), D)
+    k = torch.randn(batch, nkv, seq_len, kv_lora_rank + d_rope).float()  # (B, H, S, D)
+    v = k[..., :kv_lora_rank]  # (B, H, S, D)
+
+    ######################
+    ### TT Setup
+    #######################
+
+    q_chunk_size = 0  # Not used in decode
+    k_chunk_size = 128
+
+    scale = (kv_lora_rank + d_rope) ** -0.5
+
+    max_start_idx = seq_len // 2
+    start_indices = np.linspace(0, max_start_idx, batch, dtype=np.int32).tolist() if batch > 1 else [max_start_idx]
+
+    padded_layer_len = nearest_y(max_start_idx + 1, k_chunk_size)
+
+    sdpa_program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+        q_chunk_size=q_chunk_size,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    # Set up input tensors
+    if q_num_cores < 1:  # DRAM
+        q_mem_config = ttnn.DRAM_MEMORY_CONFIG
+        out_mem_config = ttnn.DRAM_MEMORY_CONFIG
+    else:
+        num_cores_x, num_cores_y = device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y
+        if q_num_cores > num_cores_x * num_cores_y:
+            pytest.skip(
+                f"Skipping test with q_num_cores {q_num_cores} > device compute grid size {num_cores_x * num_cores_y}."
+            )
+
+        if nkv == 1:
+            # Batch + nh shard if nkv == 1
+            q_num_cores = min(batch * nh, q_num_cores)  # Limit q_num_cores to batch size
+        else:
+            # Only batch shard if nkv > 1
+            q_num_cores = min(batch, q_num_cores)  # Limit q_num_cores to batch size
+
+        block_height = nearest_y(np.prod(q.shape[:-1]) // q_num_cores, ttnn.TILE_SIZE)
+
+        q_core_grid = ttnn.num_cores_to_corerangeset(
+            q_num_cores, device.compute_with_storage_grid_size(), row_wise=True
+        )
+
+        q_mem_config = ttnn.create_sharded_memory_config(
+            shape=(block_height, q.shape[-1]),
+            core_grid=q_core_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            use_height_and_width_as_shard_shape=True,
+        )
+        out_mem_config = ttnn.create_sharded_memory_config(
+            shape=(block_height, v.shape[-1]),
+            core_grid=q_core_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+    # GQA only supports DRAM memory config for output
+    if nkv > 1:
+        out_mem_config = ttnn.DRAM_MEMORY_CONFIG
+
+    tt_q = ttnn.from_torch(
+        q.permute(2, 0, 1, 3),  # (B, H, S, D) -> (S, B, H, D)
+        device=device,
+        dtype=q_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=q_mem_config,
+    )
+    tt_k = ttnn.from_torch(
+        k,
+        device=device,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    ##########################
+    ### FlashMLA Decode
+    ##########################
+    logger.info(
+        f"Running FlashMLA Decode with TT Q shape: {tt_q.shape}, TT K shape: {tt_k.shape}, head_dim_v: {kv_lora_rank}"
+    )
+    tt_out = ttnn.transformer.flash_multi_latent_attention_decode(
+        tt_q,
+        tt_k,
+        head_dim_v=kv_lora_rank,
+        cur_pos=start_indices,
+        scale=scale,
+        program_config=sdpa_program_config,
+        compute_kernel_config=compute_kernel_config,
+        memory_config=out_mem_config,
+    )
+    tt_out_torch = ttnn.to_torch(tt_out)[..., :nh, :].permute(1, 2, 0, 3)  # (S, B, H, D) -> (B, H, S, D)
+
+    ########################
+    ### Validation
+    ########################
+    out_t = scaled_dot_product_attention_reference(
+        q,
+        k,
+        v,
+        start_indices,
+        padded_layer_len,
+        scale,
+    )
+
+    pcc_threshold = 0.99
+    if dtype == ttnn.bfloat4_b:
+        pcc_threshold = 0.91
+    if dtype == ttnn.bfloat8_b:
+        pcc_threshold = 0.98
+
+    out_pass, out_pcc = comp_pcc(tt_out_torch, out_t, pcc_threshold)
+    logger.info(f"Output PCC: {out_pcc}")
+
+    assert out_pass, f"Output mismatch: PCC {out_pcc} < 0.99"
+
+
+@pytest.mark.parametrize(
+    "batch, seq_len, nh, nkv, kv_lora_rank, d_rope, q_num_cores",
+    # batch, seq_len, num heads q, num heads kv, kv lora rank, dim rope, number of cores to shard q on
+    [
+        (2, 16 * 1024, 128, 1, 512, 64, 8),  # DeepSeek V3 TG full DP
+        (2, 16 * 1024, 128, 1, 256, 64, 16),
+        (2, 16 * 1024, 128, 1, 256, 64, 32),
+        (2, 16 * 1024, 128, 1, 256, 64, 64),
+        (8, 16 * 1024, 128, 1, 256, 64, 64),
+        (8, 16 * 1024, 16, 1, 256, 64, 64),
+        (8, 16 * 1024, 48, 1, 128, 64, 16),
+        (2, 8 * 1024, 8, 1, 128, 64, 0),
+        (2, 8 * 1024, 64, 1, 256, 0, 0),
+        (2, 8 * 1024, 64, 1, 32, 64, 0),
+        (8, 4 * 1024, 8, 1, 128, 32, 0),
+        (16, 8 * 1024, 8, 1, 128, 32, 0),
+    ],
+)
+@pytest.mark.parametrize(
+    "q_dtype, dtype",
+    [
+        (ttnn.bfloat16, ttnn.bfloat8_b),
+        (ttnn.bfloat8_b, ttnn.bfloat8_b),
+        (ttnn.bfloat16, ttnn.bfloat4_b),
+        (ttnn.bfloat8_b, ttnn.bfloat4_b),
+    ],
+)
+def test_flash_mla_decode(
+    device,
+    batch,
+    seq_len,
+    nh,
+    nkv,
+    kv_lora_rank,
+    d_rope,
+    q_num_cores,
+    q_dtype,
+    dtype,
+    function_level_defaults,
+    reset_seeds,
+):
+    run_flash_mla_decode_impl(
+        device,
+        batch,
+        seq_len,
+        nh,
+        nkv,
+        kv_lora_rank,
+        d_rope,
+        q_num_cores,
+        q_dtype,
+        dtype,
+    )
+
+
+@pytest.mark.parametrize(
+    "batch",
+    [
+        1,  # Single batch
+        2,  # Multiple batches
+        8,  # Even larger batch size
+    ],
+)
+@pytest.mark.parametrize(
+    "seq_len",
+    [
+        1 * 1024,  # Long sequence length
+    ],
+)
+@pytest.mark.parametrize(
+    "nh",
+    [
+        16,
+        32,
+        128,
+    ],
+)
+@pytest.mark.parametrize(
+    "nkv",
+    [
+        1,
+        8,
+        16,
+    ],
+)
+@pytest.mark.parametrize(
+    "kv_lora_rank",
+    [
+        64,
+        512,
+    ],
+)
+@pytest.mark.parametrize(
+    "d_rope",
+    [
+        0,
+        32,
+        128,
+    ],
+)
+@pytest.mark.parametrize(
+    "q_num_cores",
+    [
+        0,  # No sharding
+        8,  # Shard across 8 cores
+        64,  # Shard across all cores
+    ],
+)
+@pytest.mark.parametrize(
+    "q_dtype, dtype",
+    [
+        (ttnn.bfloat16, ttnn.bfloat8_b),
+    ],
+)
+def test_flash_mla_decode_stress(
+    device,
+    batch,
+    seq_len,
+    nh,
+    nkv,
+    kv_lora_rank,
+    d_rope,
+    q_num_cores,
+    q_dtype,
+    dtype,
+    function_level_defaults,
+    reset_seeds,
+):
+    # If GQA (nkv > 1), then only batch shard
+    # If nkv == 1, then batch * nh shard, unless q_num_cores is 0 (ie, in DRAM)
+    num_sharding_cores = batch if nkv > 1 else max(batch, q_num_cores)
+    if nh * (kv_lora_rank + d_rope) * nkv / num_sharding_cores >= 8 * 1024:  # found experimentally
+        pytest.skip(
+            f"Skipping test with large values, due to memory constraints. Got {nh=}, {kv_lora_rank=}, {nkv=}, {batch=}, {q_num_cores=}, {d_rope=}"
+        )
+
+    if batch * nh < ttnn.TILE_SIZE and q_num_cores > 0:
+        pytest.skip("Skipping test with small batch and nh with q_num_cores > 0.")
+
+    run_flash_mla_decode_impl(
+        device,
+        batch,
+        seq_len,
+        nh,
+        nkv,
+        kv_lora_rank,
+        d_rope,
+        q_num_cores,
+        q_dtype,
+        dtype,
+    )

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -394,6 +394,7 @@ ALWI void cb_matmul_blocks(
  * Template Parameters:
  * @tparam St - Total sequence length in tiles
  * @tparam DHt - Head dimension in tiles
+ * @tparam vDHt - Head dimension for v in tiles
  * @tparam Sq_chunk_t - Query chunk size in tiles
  * @tparam Sk_chunk_t - Key chunk size in tiles
  * @tparam qk_in0_block_w - QK matmul block width
@@ -441,6 +442,7 @@ template <
     // Compile-time dimension parameters
     uint32_t St,
     uint32_t DHt,
+    uint32_t vDHt,
     uint32_t Sq_chunk_t,
     uint32_t out_chunk_tiles,
     // QK matmul block parameters
@@ -553,7 +555,7 @@ void flash_attention_loop(
             cb_v_in,
             cb_out_im,
             Sq_chunk_t,
-            DHt,
+            vDHt,
             Sk_chunk_t,
             out_num_blocks,
             out_in0_num_subblocks,
@@ -583,7 +585,7 @@ void flash_attention_loop(
             /* cb_out_accumulate_im *= cb_exp_max_diff */
             reconfig_data_format(cb_out_accumulate_im, cb_exp_max_diff);  // DEBUG
             pack_reconfig_data_format(cb_out_accumulate_im);
-            mul_block_bcast_cols_inplace(cb_out_accumulate_im, cb_exp_max_diff, Sq_chunk_t, DHt);
+            mul_block_bcast_cols_inplace(cb_out_accumulate_im, cb_exp_max_diff, Sq_chunk_t, vDHt);
 
             /* cb_cur_sum += cb_prev_sum */
             reconfig_data_format(cb_cur_sum, cb_prev_sum);  // DEBUG

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -28,29 +28,32 @@ namespace NAMESPACE {
 void MAIN {
     constexpr uint32_t St = get_compile_time_arg_val(0);
     constexpr uint32_t DHt = get_compile_time_arg_val(1);
-    constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(2);
-    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(3);
+    constexpr uint32_t vDHt = get_compile_time_arg_val(2);
+    constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(3);
+    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(4);
 
-    constexpr uint32_t qk_in0_block_w = get_compile_time_arg_val(4);
-    constexpr uint32_t qk_subblock_w = get_compile_time_arg_val(5);
-    constexpr uint32_t qk_subblock_h = get_compile_time_arg_val(6);
-    constexpr uint32_t qk_in0_num_subblocks = get_compile_time_arg_val(7);
-    constexpr uint32_t qk_in1_num_subblocks = get_compile_time_arg_val(8);
-    constexpr uint32_t qk_num_blocks = get_compile_time_arg_val(9);
-    constexpr uint32_t out_in0_block_w = get_compile_time_arg_val(10);
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(11);
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(12);
-    constexpr uint32_t out_in0_num_subblocks = get_compile_time_arg_val(13);
-    constexpr uint32_t out_in1_num_subblocks = get_compile_time_arg_val(14);
-    constexpr uint32_t out_num_blocks = get_compile_time_arg_val(15);
-    constexpr uint32_t num_cores_per_head = get_compile_time_arg_val(18);
-    constexpr uint32_t num_heads_per_core = get_compile_time_arg_val(19);
-    constexpr bool is_causal = get_compile_time_arg_val(20) == 1;
-    constexpr bool use_attention_mask = get_compile_time_arg_val(21) == 1;
-    constexpr uint32_t max_dynamic_chunk_size = get_compile_time_arg_val(22);
-    constexpr bool tilize_q = get_compile_time_arg_val(23) == 1;
+    constexpr uint32_t qk_in0_block_w = get_compile_time_arg_val(5);
+    constexpr uint32_t qk_subblock_w = get_compile_time_arg_val(6);
+    constexpr uint32_t qk_subblock_h = get_compile_time_arg_val(7);
+    constexpr uint32_t qk_in0_num_subblocks = get_compile_time_arg_val(8);
+    constexpr uint32_t qk_in1_num_subblocks = get_compile_time_arg_val(9);
+    constexpr uint32_t qk_num_blocks = get_compile_time_arg_val(10);
+    constexpr uint32_t out_in0_block_w = get_compile_time_arg_val(11);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(12);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(13);
+    constexpr uint32_t out_in0_num_subblocks = get_compile_time_arg_val(14);
+    constexpr uint32_t out_in1_num_subblocks = get_compile_time_arg_val(15);
+    constexpr uint32_t out_num_blocks = get_compile_time_arg_val(16);
+    constexpr uint32_t num_cores_per_head = get_compile_time_arg_val(19);
+    constexpr uint32_t num_heads_per_core = get_compile_time_arg_val(20);
+    constexpr bool is_causal = get_compile_time_arg_val(21) == 1;
+    constexpr bool use_attention_mask = get_compile_time_arg_val(22) == 1;
+    constexpr uint32_t max_dynamic_chunk_size = get_compile_time_arg_val(23);
+    constexpr bool tilize_q = get_compile_time_arg_val(24) == 1;
+    constexpr uint32_t q_heads_parallel_factor = get_compile_time_arg_val(25);
+
     constexpr uint32_t q_chunk_tiles = Sq_chunk_t * DHt;
-    constexpr uint32_t out_chunk_tiles = Sq_chunk_t * DHt;
+    constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
     constexpr bool untilize_output = tilize_q;
     constexpr bool use_pack_untilize = out_chunk_tiles <= MAX_PACK_UNTILIZE_WIDTH;
 
@@ -111,7 +114,7 @@ void MAIN {
             cb_wait_front(cb_index_id, 1);
             volatile uint32_t* index_addr_ptr;
             cb_get_tile(cb_index_id, 0, &index_addr_ptr);
-            cur_pos = index_addr_ptr[4 + cur_batch];
+            cur_pos = index_addr_ptr[4 + (cur_batch / q_heads_parallel_factor)];
             cb_release_tile(cb_index_id);
         }
 
@@ -175,6 +178,7 @@ void MAIN {
             // Compile-time dimension parameters
             St,
             DHt,
+            vDHt,
             Sq_chunk_t,
             out_chunk_tiles,
             // QK matmul block parameters
@@ -230,7 +234,7 @@ void MAIN {
                 for (uint32_t i = 0; i < num_cores_to_wait; i++) {
                     // reconfig_data_format(cb_q_in, cb_q_in); // DEBUG
                     // pack_reconfig_data_format(cb_out_accumulate_im_2);
-                    copy_block(cb_out_o, cb_out_accumulate_im_2, q_chunk_tiles);
+                    copy_block(cb_out_o, cb_out_accumulate_im_2, out_chunk_tiles);
                     copy_block(cb_l_in, cb_prev_sum_2, Sq_chunk_t);
                     max_block(cb_m_in, cb_prev_max, cb_cur_max, Sq_chunk_t);  // pushed, pushed, popped
 
@@ -252,12 +256,12 @@ void MAIN {
 
                     // reconfig_data_format(cb_out_accumulate_im, cb_exp_max_diff); // DEBUG
                     // pack_reconfig_data_format(cb_out_accumulate_im);
-                    mul_block_bcast_cols_inplace(cb_out_accumulate_im, cb_exp_max_diff, Sq_chunk_t, DHt);
-                    mul_block_bcast_cols_inplace(cb_out_accumulate_im_2, cb_exp_max_diff_2, Sq_chunk_t, DHt);
+                    mul_block_bcast_cols_inplace(cb_out_accumulate_im, cb_exp_max_diff, Sq_chunk_t, vDHt);
+                    mul_block_bcast_cols_inplace(cb_out_accumulate_im_2, cb_exp_max_diff_2, Sq_chunk_t, vDHt);
 
                     // reconfig_data_format(cb_out_accumulate_im, cb_out_accumulate_im_2);
                     // pack_reconfig_data_format(cb_out_accumulate_im);
-                    add_block_inplace<true>(cb_out_accumulate_im, cb_out_accumulate_im_2, q_chunk_tiles);
+                    add_block_inplace<true>(cb_out_accumulate_im, cb_out_accumulate_im_2, out_chunk_tiles);
 
                     // copy tiles
                     // reconfig_data_format(cb_cur_max, cb_cur_max); // DEBUG
@@ -279,7 +283,7 @@ void MAIN {
             /* cb_out_accumulate_im *= cb_cur_sum */
             reconfig_data_format(cb_out_accumulate_im, cb_cur_sum);  // DEBUG
             pack_reconfig_data_format(cb_out_accumulate_im);
-            mul_block_bcast_cols_inplace(cb_out_accumulate_im, cb_cur_sum, Sq_chunk_t, DHt);
+            mul_block_bcast_cols_inplace(cb_out_accumulate_im, cb_cur_sum, Sq_chunk_t, vDHt);
             pack_reconfig_data_format(cb_out_final);
 
             if constexpr (untilize_output) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -114,7 +114,8 @@ void MAIN {
             cb_wait_front(cb_index_id, 1);
             volatile uint32_t* index_addr_ptr;
             cb_get_tile(cb_index_id, 0, &index_addr_ptr);
-            cur_pos = index_addr_ptr[4 + (cur_batch / q_heads_parallel_factor)];
+            uint32_t cb_get_tile_offset = 4;  // Using cb_get_tile, the first 4 elements do not have the data
+            cur_pos = index_addr_ptr[cb_get_tile_offset + (cur_batch / q_heads_parallel_factor)];
             cb_release_tile(cb_index_id);
         }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -368,13 +368,16 @@ uint32_t write_partial_tiles_to_memory(
 
 template <
     uint32_t DHt,
+    uint32_t vDHt,
     uint32_t barrier_threshold,
     uint32_t mask_tile_bytes,
     uint32_t PNHt,
     bool use_attention_mask,
     uint32_t cb_k_in,
     uint32_t cb_v_in,
-    uint32_t cb_mask_in>
+    uint32_t cb_mask_in,
+    bool reuse_k  // If enabled, read V from K, instead of from DRAM
+    >
 void read_kv_mask_chunks(
     uint32_t k_chunk_start,
     uint32_t k_chunk_end,
@@ -383,6 +386,7 @@ void read_kv_mask_chunks(
     uint32_t mask_start_tile_id,
     uint32_t Sk_chunk_t,
     uint32_t k_chunk_tiles,
+    uint32_t v_chunk_tiles,
     uint32_t mask_chunk_tiles,
     const InterleavedAddrGenFast<true>& k_reader,
     const InterleavedAddrGenFast<true>& v_reader,
@@ -395,6 +399,7 @@ void read_kv_mask_chunks(
         // Read K chunk transposed
         cb_reserve_back(cb_k_in, k_chunk_tiles);
         uint32_t k_write_ptr = get_write_ptr(cb_k_in);
+        uint64_t k_base_read_ptr = get_noc_addr(k_write_ptr);
         barrier_count = 0;
         for (uint32_t col = 0; col < DHt; ++col) {
             uint32_t k_tile_id = k_start_tile_id + col;
@@ -417,24 +422,44 @@ void read_kv_mask_chunks(
                 PSt, Sk_chunk_t, mask_chunk_tiles, mask_start_tile_id, mask_reader);
         }
 
-        // Read V chunk
-        cb_reserve_back(cb_v_in, k_chunk_tiles);
-        uint32_t v_write_ptr = get_write_ptr(cb_v_in);
-        barrier_count = 0;
-        uint32_t v_tile_id = v_start_tile_id;
-        for (uint32_t row = 0; row < Sk_chunk_t; ++row) {
-            for (uint32_t col = 0; col < DHt; ++col) {
-                noc_async_read_tile(v_tile_id, v_reader, v_write_ptr);
-                if (++barrier_count == barrier_threshold) {
-                    noc_async_read_barrier();
-                    barrier_count = 0;
+        // Read V chunk (tranpose of K)
+        if (reuse_k) {
+            cb_reserve_back(cb_v_in, v_chunk_tiles);
+            uint32_t v_write_ptr = get_write_ptr(cb_v_in);
+            uint64_t k_read_ptr = k_base_read_ptr;
+            for (uint32_t row = 0; row < Sk_chunk_t; ++row) {       // Row of V
+                k_read_ptr = k_base_read_ptr + row * k_tile_bytes;  // Increment across K's Col
+
+                for (uint32_t col = 0; col < vDHt; ++col) {  // Col of V
+                    noc_async_read(k_read_ptr, v_write_ptr, v_tile_bytes);
+
+                    v_write_ptr += v_tile_bytes;
+                    k_read_ptr += Sk_chunk_t * k_tile_bytes;  // Strid across K's width
                 }
-                v_tile_id++;
-                v_write_ptr += v_tile_bytes;
             }
+
+            noc_async_read_barrier();
+            cb_push_back(cb_v_in, v_chunk_tiles);
+        } else {
+            cb_reserve_back(cb_v_in, v_chunk_tiles);
+            uint32_t v_write_ptr = get_write_ptr(cb_v_in);
+            barrier_count = 0;
+            uint32_t v_tile_id = v_start_tile_id;
+            for (uint32_t row = 0; row < Sk_chunk_t; ++row) {
+                for (uint32_t col = 0; col < vDHt; ++col) {
+                    noc_async_read_tile(v_tile_id, v_reader, v_write_ptr);
+                    if (++barrier_count == barrier_threshold) {
+                        noc_async_read_barrier();
+                        barrier_count = 0;
+                    }
+                    v_tile_id++;
+                    v_write_ptr += v_tile_bytes;
+                }
+                v_tile_id += (DHt - vDHt);  // Skip the padding!
+            }
+            noc_async_read_barrier();
+            cb_push_back(cb_v_in, v_chunk_tiles);
+            v_start_tile_id += v_chunk_tiles;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_v_in, k_chunk_tiles);
-        v_start_tile_id += k_chunk_tiles;
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -423,7 +423,7 @@ void read_kv_mask_chunks(
         }
 
         // Read V chunk (tranpose of K)
-        if (reuse_k) {
+        if constexpr (reuse_k) {
             cb_reserve_back(cb_v_in, v_chunk_tiles);
             uint32_t v_write_ptr = get_write_ptr(cb_v_in);
             uint64_t k_read_ptr = k_base_read_ptr;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -19,23 +19,26 @@ void kernel_main() {
     constexpr uint32_t PNHt = get_compile_time_arg_val(1);        // padded number of heads in tiles
     constexpr uint32_t St = get_compile_time_arg_val(2);          // full sequence length of kv cache in tiles
     constexpr uint32_t DHt = get_compile_time_arg_val(3);         // head dim
-    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(4);  // number of tiles in seqlen of a k/v/mask chunk
-    constexpr uint32_t num_cores = get_compile_time_arg_val(5);
-    constexpr bool is_q_sharded = get_compile_time_arg_val(6);
-    constexpr uint32_t num_cores_per_batch = get_compile_time_arg_val(7);
-    constexpr uint32_t k_chunk_size = get_compile_time_arg_val(8);
-    constexpr uint32_t index_stick_size_B = get_compile_time_arg_val(9);
-    constexpr bool is_paged_attention = get_compile_time_arg_val(10) == 1;
-    constexpr uint32_t num_kv_heads = get_compile_time_arg_val(11);
-    constexpr uint32_t block_size_t = get_compile_time_arg_val(12);
-    constexpr uint32_t Bkv = get_compile_time_arg_val(13);
-    constexpr uint32_t num_cores_per_head = get_compile_time_arg_val(14);
-    constexpr uint32_t num_heads_per_core = get_compile_time_arg_val(15);
-    constexpr uint32_t num_output_cores = get_compile_time_arg_val(16);
-    constexpr bool is_causal = get_compile_time_arg_val(17) == 1;
-    constexpr bool use_attention_mask = get_compile_time_arg_val(18) == 1;
-    constexpr uint32_t max_dynamic_chunk_size = get_compile_time_arg_val(19);
-    constexpr bool tilize_q = get_compile_time_arg_val(20) == 1;
+    constexpr uint32_t vDHt = get_compile_time_arg_val(4);        // head dim of V
+    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(5);  // number of tiles in seqlen of a k/v/mask chunk
+    constexpr uint32_t num_cores = get_compile_time_arg_val(6);
+    constexpr bool is_q_sharded = get_compile_time_arg_val(7);
+    constexpr uint32_t num_cores_per_batch = get_compile_time_arg_val(8);
+    constexpr uint32_t k_chunk_size = get_compile_time_arg_val(9);
+    constexpr uint32_t index_stick_size_B = get_compile_time_arg_val(10);
+    constexpr bool is_paged_attention = get_compile_time_arg_val(11) == 1;
+    constexpr uint32_t num_kv_heads = get_compile_time_arg_val(12);
+    constexpr uint32_t block_size_t = get_compile_time_arg_val(13);
+    constexpr uint32_t Bkv = get_compile_time_arg_val(14);
+    constexpr uint32_t q_heads_parallel_factor = get_compile_time_arg_val(15);
+    constexpr uint32_t num_cores_per_head = get_compile_time_arg_val(16);
+    constexpr uint32_t num_heads_per_core = get_compile_time_arg_val(17);
+    constexpr uint32_t num_output_cores = get_compile_time_arg_val(18);
+    constexpr bool is_causal = get_compile_time_arg_val(19) == 1;
+    constexpr bool use_attention_mask = get_compile_time_arg_val(20) == 1;
+    constexpr uint32_t max_dynamic_chunk_size = get_compile_time_arg_val(21);
+    constexpr bool tilize_q = get_compile_time_arg_val(22) == 1;
+    constexpr bool reuse_k = get_compile_time_arg_val(23) == 1;
     uint32_t arg_idx = 0;
     const uint32_t q_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t k_addr = get_arg_val<uint32_t>(arg_idx++);
@@ -76,7 +79,7 @@ void kernel_main() {
             noc_async_read_barrier();
             cb_push_back(cb_index_id, 1);
             volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_wr_ptr);
-            cur_pos = index_ptr[cur_batch];
+            cur_pos = index_ptr[cur_batch / q_heads_parallel_factor];
         }
 
         if (cur_pos == UINT32_MAX) {
@@ -105,6 +108,7 @@ void kernel_main() {
 
     constexpr uint32_t q_chunk_tiles = PNHt * DHt;
     uint32_t k_chunk_tiles = Sk_chunk_t_dynamic * DHt;
+    uint32_t v_chunk_tiles = Sk_chunk_t_dynamic * vDHt;
     uint32_t mask_chunk_tiles = PNHt * Sk_chunk_t_dynamic;
 
     constexpr bool is_dram = true;
@@ -209,7 +213,7 @@ void kernel_main() {
     for (uint32_t cur_head = cur_head_group * num_heads_per_core;
          cur_head < cur_head_group * num_heads_per_core + num_heads_per_core;
          ++cur_head) {
-        const uint32_t mask_batch_offset = (cur_batch % Bkv) * PNHt * St;
+        const uint32_t mask_batch_offset = ((cur_batch / q_heads_parallel_factor) % Bkv) * PNHt * St;
         const uint32_t mask_chunk_offset = k_chunk_start * Sk_chunk_t_dynamic;
         uint32_t mask_start_tile_id = mask_batch_offset + mask_chunk_offset;
         if constexpr (is_paged_attention) {
@@ -245,16 +249,17 @@ void kernel_main() {
                 }
 
                 // Read V chunk in row major order, write in row-major order
-                cb_reserve_back(cb_v_in, k_chunk_tiles);
+                // TODO: Add support to reuse_k for paged FlashMLA
+                cb_reserve_back(cb_v_in, v_chunk_tiles);
                 uint32_t v_write_ptr = get_write_ptr(cb_v_in);
                 barrier_count = 0;
 
                 for (uint32_t row = 0; row < Sk_chunk_t_dynamic; ++row) {
                     uint32_t virtual_v_tile_row_num = k_chunk_start_row_num + row;
                     uint32_t physical_v_tile_id =
-                        virtual_seq_tile_id_to_physical_tile_id<num_kv_heads, block_size_t, DHt>(
+                        virtual_seq_tile_id_to_physical_tile_id<num_kv_heads, block_size_t, DHt /* Use K's head dim */>(
                             virtual_v_tile_row_num, cur_head, page_table_ptr);
-                    for (uint32_t col = 0; col < DHt; ++col) {
+                    for (uint32_t col = 0; col < vDHt; ++col) {
                         noc_async_read_tile(physical_v_tile_id, v_reader, v_write_ptr);
                         physical_v_tile_id += 1;
                         v_write_ptr += v_tile_bytes;
@@ -266,14 +271,15 @@ void kernel_main() {
                     }
                 }
                 noc_async_read_barrier();
-                cb_push_back(cb_v_in, k_chunk_tiles);
+                cb_push_back(cb_v_in, v_chunk_tiles);
             }
         } else {
             // Offset for current batch
-            const uint32_t k_batch_offset = (cur_batch % Bkv) * num_kv_heads * St * DHt;
-            const uint32_t v_batch_offset = (cur_batch % Bkv) * num_kv_heads * St * DHt;
+            const uint32_t k_batch_offset = ((cur_batch / q_heads_parallel_factor) % Bkv) * num_kv_heads * St * DHt;
+            const uint32_t v_batch_offset =
+                ((cur_batch / q_heads_parallel_factor) % Bkv) * num_kv_heads * St * DHt;  // Use K's head dim
             const uint32_t k_head_offset = cur_head * St * DHt;
-            const uint32_t v_head_offset = cur_head * St * DHt;
+            const uint32_t v_head_offset = cur_head * St * DHt;  // Use K's head dim
 
             // Then, read K, V, Mask k_chunk_tiles at a time
             const uint32_t k_chunk_offset = k_chunk_start * Sk_chunk_t_dynamic * DHt;
@@ -283,13 +289,15 @@ void kernel_main() {
 
             read_kv_mask_chunks<
                 DHt,
+                vDHt,
                 barrier_threshold,
                 mask_tile_bytes,
                 PNHt,
                 use_attention_mask,
                 cb_k_in,
                 cb_v_in,
-                cb_mask_in>(
+                cb_mask_in,
+                reuse_k>(
                 k_chunk_start,
                 k_chunk_end,
                 k_start_tile_id,
@@ -297,6 +305,7 @@ void kernel_main() {
                 mask_start_tile_id,
                 Sk_chunk_t_dynamic,
                 k_chunk_tiles,
+                v_chunk_tiles,
                 mask_chunk_tiles,
                 k_reader,
                 v_reader,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
@@ -14,7 +14,14 @@ namespace ttnn::operations::transformer {
 void ScaledDotProductAttentionDecode::validate(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
-    TT_FATAL(input_tensors.size() == 3, "Must have 3 input tensors and mask");
+    bool use_mla = this->use_mla.value_or(false);
+
+    if (use_mla) {
+        TT_FATAL(input_tensors.size() == 2, "Must have 2 input tensors and mask");
+        TT_FATAL(this->head_dim_v.has_value(), "Must provide head_dim_v for multi-latent attention decode");
+    } else {
+        TT_FATAL(input_tensors.size() == 3, "Must have 3 input tensors and mask");
+    }
 
     for (auto& input_tensor : input_tensors) {
         TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to SDPA need to be on device!");
@@ -33,7 +40,21 @@ void ScaledDotProductAttentionDecode::validate(
     const auto q_shape = input_tensors.at(0).padded_shape();
     const auto q_shape_unpadded = input_tensors.at(0).logical_shape();
     const auto k_shape = input_tensors.at(1).padded_shape();
-    const auto v_shape = input_tensors.at(2).padded_shape();
+    const auto v_shape = use_mla ? input_tensors.at(1).padded_shape() : input_tensors.at(2).padded_shape();
+
+    if (use_mla) {
+        // Head dim v validation
+        TT_FATAL(
+            this->head_dim_v.value() <= q_shape[3],
+            "Head dimension of V must be less than or equal to head dim of Q, got {} and {}",
+            head_dim_v,
+            q_shape[3]);
+        TT_FATAL(
+            this->head_dim_v.value() <= k_shape[3],
+            "Head dimension of V must be less than or equal to head dim of K, got {} and {}",
+            this->head_dim_v,
+            q_shape[3]);
+    }
 
     // Input 0 must be sharded by height or DRAM interleaved. All other inputs must be in DRAM.
     const auto Q_memcfg = input_tensors.at(0).memory_config();
@@ -219,6 +240,10 @@ std::vector<TensorSpec> ScaledDotProductAttentionDecode::compute_output_specs(
         output_shape[2] = round_up_to_tile(output_shape[2], tt::constants::TILE_HEIGHT);
         output_layout = Layout::ROW_MAJOR;
     }
+    if (this->use_mla.value_or(false)) {
+        // Multi Latent Attention
+        output_shape[3] = this->head_dim_v.value();
+    }
     return {TensorSpec(output_shape, TensorLayout(input.dtype(), PageConfig(output_layout), output_mem_config))};
 }
 
@@ -228,7 +253,7 @@ operation::ProgramWithCallbacks ScaledDotProductAttentionDecode::create_program(
     std::vector<Tensor>& output_tensors) const {
     auto& input_tensor_q = input_tensors.at(0);
     auto& input_tensor_k = input_tensors.at(1);
-    auto& input_tensor_v = input_tensors.at(2);
+    auto& input_tensor_v = this->use_mla.value_or(false) ? input_tensors.at(1) : input_tensors.at(2);
 
     auto& cur_pos_tensor = optional_input_tensors.at(0);
     auto& page_table_tensor = optional_input_tensors.at(1);
@@ -255,7 +280,9 @@ operation::ProgramWithCallbacks ScaledDotProductAttentionDecode::create_program(
         this->compute_kernel_config,
         this->program_config,
         this->k_chunk_size,
-        this->share_cache);
+        this->share_cache,
+        this->use_mla.value_or(false),
+        this->head_dim_v.value_or(0));
 }
 
 operation::Hash ScaledDotProductAttentionDecode::compute_program_hash(
@@ -271,6 +298,8 @@ operation::Hash ScaledDotProductAttentionDecode::compute_program_hash(
         this->k_chunk_size,
         this->paged_attention,
         this->is_causal,
+        this->use_mla,
+        this->head_dim_v,
         has_attn_mask,
         has_cur_pos,
         input_tensors,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.hpp
@@ -24,6 +24,9 @@ struct ScaledDotProductAttentionDecode {
     const bool paged_attention;
     const std::optional<bool> share_cache;
 
+    const std::optional<bool> use_mla;
+    const std::optional<uint32_t> head_dim_v;
+
     void validate(
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -35,7 +35,9 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     DeviceComputeKernelConfig compute_kernel_config,
     std::optional<SDPAProgramConfig> program_config,
     const uint32_t k_chunk_size,
-    std::optional<bool> share_cache) {
+    std::optional<bool> share_cache,
+    bool use_mla,
+    uint32_t head_dim_v) {
     /*
     Q: 1 x B x PNH x DH
     K: B x NKV x S x DH
@@ -62,6 +64,27 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     uint32_t num_q_heads = q_shape_unpadded[2];
     uint32_t page_block_size_t = 0;
 
+    bool is_q_sharded = input_tensor_q.is_sharded();
+    bool is_output_sharded = output_tensor.is_sharded();
+
+    // balance the number of cores to use based on batch
+    uint32_t q_heads_parallel_factor = 1;
+    if (is_q_sharded && use_mla) {
+        uint32_t q_shard_height = input_tensor_q.memory_config().shard_spec()->shape[0];
+        q_heads_parallel_factor = std::max((uint32_t)1, (num_q_heads + q_shard_height - 1) / q_shard_height);
+
+        if (q_heads_parallel_factor > 1) {
+            TT_FATAL(
+                num_kv_heads == 1,
+                "If parallelizing over Q num heads (with parallelization factor q_heads_parallel_factor: {}), then "
+                "num_kv_heads must be 1, but got num_kv_heads: {}",
+                q_heads_parallel_factor,
+                num_kv_heads);
+        }
+
+        B *= q_heads_parallel_factor;  // adjust batch size to account for Q sharding
+    }
+
     if (is_paged_attention) {
         uint32_t block_size = k_shape[2];
         page_block_size_t = block_size / TILE_HEIGHT;
@@ -71,12 +94,11 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     uint32_t Bkv = k_shape[0];
     uint32_t St = S / TILE_HEIGHT;
     uint32_t DHt = DH / TILE_WIDTH;
-    uint32_t PNHt = PNH / TILE_HEIGHT;
+    uint32_t vDHt = use_mla ? head_dim_v / TILE_WIDTH : DHt;
+    uint32_t PNHt = PNH / q_heads_parallel_factor / TILE_HEIGHT;
 
     const uint32_t Sk_chunk_t = k_chunk_size / TILE_HEIGHT;
 
-    bool is_q_sharded = input_tensor_q.is_sharded();
-    bool is_output_sharded = output_tensor.is_sharded();
     if (!share_cache.has_value()) {
         // default share_cache to false
         share_cache = false;
@@ -94,6 +116,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     log_debug(tt::LogOp, "Bkv: {}", Bkv);
     log_debug(tt::LogOp, "St: {}", St);
     log_debug(tt::LogOp, "DHt: {}", DHt);
+    log_debug(tt::LogOp, "vDHt: {}", vDHt);
     log_debug(tt::LogOp, "PNHt: {}", PNHt);
     log_debug(tt::LogOp, "Sk_chunk_t: {}", Sk_chunk_t);
     log_debug(tt::LogOp, "k_chunk_size: {}", k_chunk_size);
@@ -249,10 +272,10 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
 
     uint32_t q_tiles = PNHt * DHt;
     uint32_t k_tiles = Sk_chunk_t_cb_size * DHt * 2;  // double buffer
-    uint32_t v_tiles = Sk_chunk_t_cb_size * DHt * 2;  // double buffer
+    uint32_t v_tiles = Sk_chunk_t_cb_size * vDHt * 2;  // double buffer
     uint32_t qk_tiles = PNHt * Sk_chunk_t_cb_size;
-    uint32_t out_im_tiles = PNHt * DHt;
-    uint32_t out0_t = PNHt * DHt;
+    uint32_t out_im_tiles = PNHt * vDHt;
+    uint32_t out0_t = PNHt * vDHt;
     uint32_t scale_tiles = 1;
     uint32_t statistics_tiles = PNHt;  // Single column of values in each iteration
 
@@ -292,12 +315,12 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         out_num_blocks = Sk_chunk_t / out_in0_block_w;
     }
 
-    const uint32_t out_out_subblock_w = std::min(DHt, dst_size);
+    const uint32_t out_out_subblock_w = std::min(vDHt, dst_size);
     const uint32_t out_out_subblock_h =
-        (out_out_subblock_w == DHt) ? (std::min(PNHt, dst_size / out_out_subblock_w)) : 1;
+        (out_out_subblock_w == vDHt) ? (std::min(PNHt, dst_size / out_out_subblock_w)) : 1;
 
     const uint32_t out_in0_num_subblocks = PNHt / out_out_subblock_h;
-    const uint32_t out_in1_num_subblocks = DHt / out_out_subblock_w;
+    const uint32_t out_in1_num_subblocks = vDHt / out_out_subblock_w;
 
     // log all values
     log_debug(tt::LogOp, "dst_size: {}", dst_size);
@@ -618,6 +641,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         PNHt,
         St,
         DHt,
+        vDHt,
         Sk_chunk_t,
         num_active_cores,
         is_q_sharded,
@@ -628,6 +652,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         num_kv_heads,
         page_block_size_t,
         Bkv,
+        q_heads_parallel_factor,
         num_cores_per_head,
         num_heads_per_core,
         num_output_cores,
@@ -635,6 +660,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         use_attention_mask,
         max_dynamic_chunk_size,
         tilize_q,
+        (uint32_t)use_mla,
     };
 
     std::vector<uint32_t> writer_compile_time_args_common = {
@@ -642,6 +668,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         PNHt,
         St,
         DHt,
+        vDHt,
         Sk_chunk_t,
         packed_identity_scalar,
         scale_union.u,
@@ -660,11 +687,13 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         output_tensor.element_size(),
         is_causal,
         max_dynamic_chunk_size,
+        q_heads_parallel_factor,
     };
 
     std::vector<uint32_t> compute_compile_time_args_common = {
         St,
         DHt,
+        vDHt,
         PNHt,
         Sk_chunk_t,
         qk_in0_block_w,
@@ -687,6 +716,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         use_attention_mask,
         max_dynamic_chunk_size,
         tilize_q,
+        q_heads_parallel_factor,
     };
 
     // Determine granularity for compute loops
@@ -762,7 +792,8 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         uint32_t core_num_in_reduce = i % num_cores_per_head;
         uint32_t core_num_in_output = i % num_cores_per_batch;
 
-        uint32_t cur_pos = (use_cur_pos_tensor || !is_causal) ? -1 : cur_pos_ids.at(cur_batch);
+        uint32_t cur_pos =
+            (use_cur_pos_tensor || !is_causal) ? -1 : cur_pos_ids.at((uint32_t)(cur_batch / q_heads_parallel_factor));
 
         log_debug(tt::LogOp, "---- core_id: {}, coord: {} ----", i, core);
         log_debug(tt::LogOp, "worker_id_for_reduce: {}", worker_id_for_reduce);
@@ -849,10 +880,12 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
          is_output_sharded,
          cb_out4_id,
          B,
+         q_heads_parallel_factor,
          use_cur_pos_tensor,
          use_attention_mask,
          is_paged_attention,
-         is_causal](
+         is_causal,
+         use_mla](
             const void* operation,
             Program& program,
             const std::vector<Tensor>& input_tensors,
@@ -863,7 +896,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
 
             auto q_buffer = input_tensors.at(0).buffer();
             auto k_buffer = input_tensors.at(1).buffer();
-            auto v_buffer = input_tensors.at(2).buffer();
+            auto v_buffer = use_mla ? input_tensors.at(1).buffer() : input_tensors.at(2).buffer();
 
             auto out0_buffer = output_tensors.at(0).buffer();
             uint32_t q_addr = q_buffer->address();
@@ -892,7 +925,9 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
                 uint32_t cur_batch = i / num_cores_per_batch;
                 uint32_t core_num_in_reduce = (num_cores_per_head == 0) ? 0 : i % num_cores_per_head;
                 uint32_t core_num_in_output = i % num_cores_per_batch;
-                uint32_t cur_pos = (use_cur_pos_tensor || !is_causal) ? -1 : cur_pos_ids.at(cur_batch);
+                uint32_t cur_pos = (use_cur_pos_tensor || !is_causal)
+                                       ? -1
+                                       : cur_pos_ids.at((uint32_t)(cur_batch / q_heads_parallel_factor));
 
                 auto& reader_args = reader_args_by_core[core.x][core.y];
                 auto& writer_args = writer_args_by_core[core.x][core.y];

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.hpp
@@ -24,6 +24,8 @@ tt::tt_metal::operation::ProgramWithCallbacks sdpa_decode_multi_core(
     DeviceComputeKernelConfig compute_kernel_config,
     std::optional<SDPAProgramConfig> program_config,
     uint32_t k_chunk_size,
-    std::optional<bool> share_cache);
+    std::optional<bool> share_cache,
+    bool mla = false,
+    uint32_t head_dim_v = 0);
 
 }  // namespace ttnn::operations::transformer::detail

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
@@ -192,4 +192,87 @@ ttnn::Tensor ExecutePagedScaledDotProductAttentionDecode::invoke(
         compute_kernel_config);
 }
 
+ttnn::Tensor ExecuteFlashMultiLatentAttentionDecode::invoke(
+    QueueId queue_id,
+    const ttnn::Tensor& input_tensor_q,
+    const ttnn::Tensor& input_tensor_k,
+    const uint32_t head_dim_v,
+    const bool is_causal,
+    const std::optional<const Tensor>& attn_mask,
+    const std::vector<uint32_t>& cur_pos,
+    const std::optional<const Tensor>& cur_pos_tensor,
+    std::optional<float> scale,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<SDPAProgramConfig> program_config,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    auto arch = input_tensor_q.storage_type() == StorageType::DEVICE
+                    ? input_tensor_q.device()->arch()
+                    : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    uint32_t s = input_tensor_k.logical_shape()[-2];
+    uint32_t k_chunk_size = get_chunk_size(s);
+    if (program_config.has_value() && program_config.value().k_chunk_size > 0) {
+        k_chunk_size = program_config.value().k_chunk_size;
+        // assert chunk size must be power of 2 and multiple of 32
+        TT_FATAL(
+            (k_chunk_size & (k_chunk_size - 1)) == 0,
+            "User provided k_chunk_size must be power of 2, got: {}",
+            k_chunk_size);
+        TT_FATAL(k_chunk_size % 32 == 0, "User provided k_chunk_size must be multiple of 32, got: {}", k_chunk_size);
+    } else {
+        TT_FATAL(
+            k_chunk_size % 32 == 0,
+            "Chunk size must be multiple of 32, but the maximum calculated k_chunk_size is: {}",
+            k_chunk_size);
+    }
+
+    // get chunk size and then pass to sdpa decode as an attribute for prgm cache
+    auto kernel_config_val = init_device_compute_kernel_config(
+        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
+
+    return operation::run(
+               ScaledDotProductAttentionDecode{
+                   .is_causal = is_causal,
+                   .cur_pos = cur_pos,
+                   .scale = scale,
+                   .output_mem_config = memory_config.value_or(operation::DEFAULT_OUTPUT_MEMORY_CONFIG),
+                   .program_config = program_config,
+                   .compute_kernel_config = kernel_config_val,
+                   .k_chunk_size = k_chunk_size,
+                   .paged_attention = false,
+                   .use_mla = true,
+                   .head_dim_v = head_dim_v},
+               {input_tensor_q, input_tensor_k},
+               {cur_pos_tensor, std::nullopt, attn_mask},
+               {},
+               queue_id)
+        .at(0);
+}
+
+ttnn::Tensor ExecuteFlashMultiLatentAttentionDecode::invoke(
+    const ttnn::Tensor& input_tensor_q,
+    const ttnn::Tensor& input_tensor_k,
+    const uint32_t head_dim_v,
+    const bool is_causal,
+    const std::optional<const Tensor>& attn_mask,
+    const std::vector<uint32_t>& cur_pos,
+    const std::optional<const Tensor>& cur_pos_tensor,
+    std::optional<float> scale,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<SDPAProgramConfig> program_config,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    return invoke(
+        DefaultQueueId,
+        input_tensor_q,
+        input_tensor_k,
+        head_dim_v,
+        is_causal,
+        attn_mask,
+        cur_pos,
+        cur_pos_tensor,
+        scale,
+        memory_config,
+        std::move(program_config),
+        compute_kernel_config);
+}
+
 }  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
@@ -69,6 +69,35 @@ struct ExecutePagedScaledDotProductAttentionDecode {
         std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 };
 
+struct ExecuteFlashMultiLatentAttentionDecode {
+    static ttnn::Tensor invoke(
+        QueueId queue_id,
+        const ttnn::Tensor& input_tensor_q,
+        const ttnn::Tensor& input_tensor_k,
+        const uint32_t head_dim_v,
+        bool is_causal = true,
+        const std::optional<const Tensor>& attn_mask = std::nullopt,
+        const std::vector<uint32_t>& cur_pos = std::vector<uint32_t>(),
+        const std::optional<const Tensor>& cur_pos_tensor = std::nullopt,
+        std::optional<float> scale = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<SDPAProgramConfig> program_config = std::nullopt,
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor_q,
+        const ttnn::Tensor& input_tensor_k,
+        const uint32_t head_dim_v,
+        bool is_causal = true,
+        const std::optional<const Tensor>& attn_mask = std::nullopt,
+        const std::vector<uint32_t>& cur_pos = std::vector<uint32_t>(),
+        const std::optional<const Tensor>& cur_pos_tensor = std::nullopt,
+        std::optional<float> scale = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<SDPAProgramConfig> program_config = std::nullopt,
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+};
+
 }  // namespace operations::transformer
 
 namespace transformer {
@@ -80,6 +109,10 @@ constexpr auto scaled_dot_product_attention_decode = ttnn::register_operation<
 constexpr auto paged_scaled_dot_product_attention_decode = ttnn::register_operation<
     "ttnn::transformer::paged_scaled_dot_product_attention_decode",
     ttnn::operations::transformer::ExecutePagedScaledDotProductAttentionDecode>();
+
+constexpr auto flash_multi_latent_attention_decode = ttnn::register_operation<
+    "ttnn::transformer::flash_multi_latent_attention_decode",
+    ttnn::operations::transformer::ExecuteFlashMultiLatentAttentionDecode>();
 
 }  // namespace transformer
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
@@ -74,7 +74,7 @@ struct ExecuteFlashMultiLatentAttentionDecode {
         QueueId queue_id,
         const ttnn::Tensor& input_tensor_q,
         const ttnn::Tensor& input_tensor_k,
-        const uint32_t head_dim_v,
+        uint32_t head_dim_v,
         bool is_causal = true,
         const std::optional<const Tensor>& attn_mask = std::nullopt,
         const std::vector<uint32_t>& cur_pos = std::vector<uint32_t>(),
@@ -87,7 +87,7 @@ struct ExecuteFlashMultiLatentAttentionDecode {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor_q,
         const ttnn::Tensor& input_tensor_k,
-        const uint32_t head_dim_v,
+        uint32_t head_dim_v,
         bool is_causal = true,
         const std::optional<const Tensor>& attn_mask = std::nullopt,
         const std::vector<uint32_t>& cur_pos = std::vector<uint32_t>(),

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_pybind.cpp
@@ -143,5 +143,53 @@ void py_bind_sdpa_decode(py::module& module) {
             py::arg("compute_kernel_config").noconvert() = std::nullopt,
             py::arg("queue_id") = DefaultQueueId,
         });
+
+    using MLAOperationType = decltype(ttnn::transformer::flash_multi_latent_attention_decode);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::transformer::flash_multi_latent_attention_decode,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const MLAOperationType& self,
+               const ttnn::Tensor& input_tensor_q,
+               const ttnn::Tensor& input_tensor_k,
+               const uint32_t head_dim_v,
+               const bool is_causal,
+               const std::optional<const Tensor>& attn_mask,
+               const std::vector<uint32_t>& cur_pos,
+               const std::optional<const Tensor>& cur_pos_tensor,
+               std::optional<float> scale,
+               const std::optional<MemoryConfig>& memory_config,
+               std::optional<SDPAProgramConfig> program_config,
+               std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+               QueueId queue_id) {
+                return self(
+                    queue_id,
+                    input_tensor_q,
+                    input_tensor_k,
+                    head_dim_v,
+                    is_causal,
+                    attn_mask,
+                    cur_pos,
+                    cur_pos_tensor,
+                    scale,
+                    memory_config,
+                    program_config,
+                    compute_kernel_config);
+            },
+            py::arg("input_tensor_q").noconvert(),
+            py::arg("input_tensor_k").noconvert(),
+            py::arg("head_dim_v").noconvert(),
+            py::kw_only(),
+            py::arg("is_causal").noconvert() = true,
+            py::arg("attn_mask").noconvert() = std::nullopt,
+            py::arg("cur_pos").noconvert() = std::vector<uint32_t>(),
+            py::arg("cur_pos_tensor").noconvert() = std::nullopt,
+            py::arg("scale").noconvert() = std::nullopt,
+            py::arg("memory_config").noconvert() = std::nullopt,
+            py::arg("program_config").noconvert() = std::nullopt,
+            py::arg("compute_kernel_config").noconvert() = std::nullopt,
+            py::arg("queue_id") = DefaultQueueId,
+        });
 }
 }  // namespace ttnn::operations::transformer


### PR DESCRIPTION
### Ticket
- #23022

### Problem description
DeepSeek V3 uses a different attention scheme called Multi-Latent Attention. Here, there are new ideas introduced such as sharing the K/V caches, separating out RoPE, as well as using "absorption" to avoid storing kv_heads in the KV cache. Due to this, an extension to the sdpa_decode op is necessary for bring-up.

### What's changed
- **New Op:** `ttnn.transformer.flash_multi_latent_attention_decode`
  - Reused sdpa_decode impl, and added changes on top 
- Testing infra in APC: `tests/tt_eager/python_api_testing/unit_testing/misc/test_flash_multi_latent_attention_decode.py`


### Features
- No V tensor: V is re-routed to use the K Tensor
  - `head_dim_v`: The head_dim for V is <= head_dim for K. As such, we "slice" the K chunks when reading
  - Also, instead of reading V from DRAM, we just read in a transpose fashion from K's buffer in L1
  - Use vDHt instead of DHt in some places
  
<img width="801" alt="image" src="https://github.com/user-attachments/assets/ab7658e8-b3bc-48f2-9c32-5768f7c93a56" />

- Q heads parallelization
  -  The single-device DeepSeek V3 shapes cause an OOM, due to the large head_dim
  - Added support to parallelize over q heads using `q_heads_parallel_factor`
  - Essentially, it "pushes" q heads into the batch dim to reuse the batch parallelization. **However**, `cur_pos` needs to be correctly indexed to use the correct position for each batch.
  - **Note:** This is currently only supported for the case when kv heads = 1



### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16076542841) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16119862558) CI with demo tests passes (if applicable)
- [x] [New/Existing tests provide coverage for changes](https://github.com/tenstorrent/tt-metal/actions/runs/16076542841/job/45373387685#step:5:2713)
