### PR TITLE
#24584: Skip data_movement tests on BH

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -302,6 +302,9 @@ IDEAS:
 /* ======== PACKET SIZES ======== */
 
 TEST_F(DeviceFixture, TensixDataMovementAllFromAllPacketSizes) {
+    if (arch_ == tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "Skipping test on Blackhole, Issue #24584";
+    }
     uint32_t test_case_id = 0;
 
     /* Parameters */
@@ -322,6 +325,9 @@ TEST_F(DeviceFixture, TensixDataMovementAllFromAllPacketSizes) {
 
 /* ======== All from All ======== */
 TEST_F(DeviceFixture, TensixDataMovementAllFromAllDirectedIdeal) {
+    if (arch_ == tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "Skipping test on Blackhole, Issue #24584";
+    }
     uint32_t test_case_id = 1;
 
     /* Parameters */

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -304,6 +304,9 @@ IDEAS:
 /* ======== PACKET SIZES ======== */
 
 TEST_F(DeviceFixture, TensixDataMovementAllToAllPacketSizes) {
+    if (arch_ == tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "Skipping test on Blackhole, Issue #24584";
+    }
     uint32_t test_case_id = 0;
 
     /* Parameters */
@@ -324,6 +327,9 @@ TEST_F(DeviceFixture, TensixDataMovementAllToAllPacketSizes) {
 
 /* ======== All to All ======== */
 TEST_F(DeviceFixture, TensixDataMovementAllToAllDirectedIdeal) {
+    if (arch_ == tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "Skipping test on Blackhole, Issue #24584";
+    }
     uint32_t test_case_id = 1;
 
     /* Parameters */


### PR DESCRIPTION
### Ticket
#24584

### Problem description
BH post commit sd data movement tests failing when run on unharvested P150
```
260 unique+common runtime args targeting kernel sender on (x=0,y=0) are too large. Max allowable is 256
```

### What's changed
Skip the tests on blackhole for now:
- TensixDataMovementAllFromAllPacketSizes
- TensixDataMovementAllFromAllDirectedIdeal
- TensixDataMovementAllToAllPacketSizes
- TensixDataMovementAllToAllDirectedIdeal

### Checklist
- [x] data_movement tests on unharvested P150: https://github.com/tenstorrent/tt-metal/actions/runs/16079264829