### PR TITLE
Uplift umd to get updated get_ethernet_connections_to_remote_devices functionality

### DIFF
--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -181,7 +181,6 @@ TEST(Cluster, ReportSystemHealth) {
     // It is a report of system health
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& eth_connections = cluster.get_ethernet_connections();
-    const auto& eth_connections_to_remote_mmio_devices = cluster.get_ethernet_connections_to_remote_mmio_devices();
 
     auto unique_chip_ids = tt::tt_metal::MetalContext::instance().get_cluster().get_unique_chip_ids();
     std::stringstream ss;

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1695,13 +1695,15 @@ void ControlPlane::initialize_intermesh_eth_links() {
         }
 
         // Remote connections visible to UMD
-        auto ethernet_connections_to_remote_devices = cluster.get_ethernet_connections_to_remote_devices()[chip_id];
-        for (auto [link, _] : ethernet_connections_to_remote_devices) {
-            // Find the CoreCoord for this channel
-            for (const auto& [core_coord, channel] : soc_desc.logical_eth_core_to_chan_map) {
-                if (channel == link) {
-                    intermesh_eth_links.push_back({core_coord, link});
-                    break;
+        auto remote_connections = cluster.get_ethernet_connections_to_remote_devices().find(chip_id);
+        if (remote_connections != cluster.get_ethernet_connections_to_remote_devices().end()) {
+            for (auto [link, _] : remote_connections->second) {
+                // Find the CoreCoord for this channel
+                for (const auto& [core_coord, channel] : soc_desc.logical_eth_core_to_chan_map) {
+                    if (channel == link) {
+                        intermesh_eth_links.push_back({core_coord, link});
+                        break;
+                    }
                 }
             }
         }

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1673,7 +1673,7 @@ void ControlPlane::initialize_intermesh_eth_links() {
             intermesh_eth_links_[chip_id] = {};
             continue;
         }
-
+        // Remote connections not visible to UMD
         // Read multi-mesh configuration from the first available eth core
         auto first_eth_core = soc_desc.logical_eth_core_to_chan_map.begin()->first;
         tt_cxy_pair virtual_eth_core(
@@ -1685,6 +1685,18 @@ void ControlPlane::initialize_intermesh_eth_links() {
         cluster.read_core(config_data, sizeof(uint32_t), virtual_eth_core, multi_mesh_config_addr);
         std::vector<std::pair<CoreCoord, chan_id_t>> intermesh_eth_links;
         for (auto link : extract_intermesh_eth_links(config_data[0], chip_id)) {
+            // Find the CoreCoord for this channel
+            for (const auto& [core_coord, channel] : soc_desc.logical_eth_core_to_chan_map) {
+                if (channel == link) {
+                    intermesh_eth_links.push_back({core_coord, link});
+                    break;
+                }
+            }
+        }
+
+        // Remote connections visible to UMD
+        auto ethernet_connections_to_remote_devices = cluster.get_ethernet_connections_to_remote_devices()[chip_id];
+        for (auto [link, _] : ethernet_connections_to_remote_devices) {
             // Find the CoreCoord for this channel
             for (const auto& [core_coord, channel] : soc_desc.logical_eth_core_to_chan_map) {
                 if (channel == link) {
@@ -1713,6 +1725,12 @@ bool ControlPlane::is_intermesh_enabled() const {
         return false;
     }
 
+    // UMD Visible Intermesh Links
+    if (!cluster.get_ethernet_connections_to_remote_devices().empty()) {
+        return true;
+    }
+
+    // UMD Hidden Intermesh Links
     std::vector<uint32_t> config_data(1, 0);
     auto first_eth_core = soc_desc.logical_eth_core_to_chan_map.begin()->first;
     tt_cxy_pair virtual_eth_core(

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1278,7 +1278,7 @@ std::tuple<uint64_t, CoreCoord> Cluster::get_connected_ethernet_core_to_remote_m
         "Logical eth core {} is not an active eth core on chip {}.",
         std::get<1>(eth_core).str(),
         std::get<0>(eth_core));
-    const auto& ethernet_connections_to_remote_cluster = this->get_ethernet_connections_to_remote_mmio_devices();
+    const auto& ethernet_connections_to_remote_cluster = this->get_ethernet_connections_to_remote_devices();
     const auto& local_chip_id = std::get<0>(eth_core);
     const auto& local_eth_core = std::get<1>(eth_core);
     TT_FATAL(

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -269,8 +269,8 @@ public:
 
     // TODO: unify uint64_t with ChipUID
     std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<uint64_t, ethernet_channel_t>>>
-    get_ethernet_connections_to_remote_mmio_devices() const {
-        return this->cluster_desc_->get_ethernet_connections_to_remote_mmio_devices();
+    get_ethernet_connections_to_remote_devices() const {
+        return this->cluster_desc_->get_ethernet_connections_to_remote_devices();
     }
 
     // Returns MMIO device ID (logical) that controls given `device_id`. If `device_id` is MMIO device it is returned.

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -262,14 +262,16 @@ public:
     void set_internal_routing_info_for_ethernet_cores(
         bool enable_internal_routing, const std::vector<chip_id_t>& target_mmio_devices = {}) const;
 
-    std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>
-    get_ethernet_connections() const {
+    const std::
+        unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>&
+        get_ethernet_connections() const {
         return this->cluster_desc_->get_ethernet_connections();
     }
 
     // TODO: unify uint64_t with ChipUID
-    std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<uint64_t, ethernet_channel_t>>>
-    get_ethernet_connections_to_remote_devices() const {
+    const std::
+        unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<uint64_t, ethernet_channel_t>>>&
+        get_ethernet_connections_to_remote_devices() const {
         return this->cluster_desc_->get_ethernet_connections_to_remote_devices();
     }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
For multiprocess where we split ex a T3K into two 2x2s to run in separate processes, we need to be able to detect and add the eth links connecting these two meshes.

### What's changed
Uplift umd so that `get_ethernet_connections_to_remote_devices` can now return eth links from one mesh that is visible to umd to a remote mesh.
Update control plane to include these umd visible remote connections in the intermesh links.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16083738337
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes
Galaxy Quick: https://github.com/tenstorrent/tt-metal/actions/runs/16145188236