### PR TITLE
Compile command queue kernels in parallel

### DIFF
--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -200,7 +200,6 @@ private:
         size_t worker_l1_unreserved_start,
         tt::stl::Span<const std::uint32_t> l1_bank_remap);
 
-    void compile_command_queue_programs();
     void configure_command_queue_programs();
 
     void mark_allocations_unsafe();

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -450,6 +450,33 @@ void DevicePool::initialize_active_devices() const {
         }
     }
 
+    // Compile command queue programs
+    for (auto dev : active_devices) {
+        // For Galaxy init, we only need to loop over mmio devices
+        const auto& mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev->id());
+        if (mmio_device_id != dev->id()) {
+            continue;
+        }
+
+        create_cq_program(dev);
+        auto tunnels_from_mmio =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
+        if (not this->skip_remote_devices) {
+            for (uint32_t t = 0; t < tunnels_from_mmio.size(); t++) {
+                // Need to create devices from farthest to the closest.
+                for (uint32_t ts = tunnels_from_mmio[t].size() - 1; ts > 0; ts--) {
+                    uint32_t mmio_controlled_device_id = tunnels_from_mmio[t][ts];
+                    auto device = get_device(mmio_controlled_device_id);
+                    create_cq_program(device);
+                }
+            }
+        }
+    }
+
+    // Compile programs
+    compile_cq_programs();
+
     // Init command queue
     for (auto dev : active_devices) {
         // For Galaxy init, we only need to loop over mmio devices

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -450,7 +450,7 @@ void DevicePool::initialize_active_devices() const {
         }
     }
 
-    // Compile command queue programs
+    // Create command queue programs
     for (auto dev : active_devices) {
         // For Galaxy init, we only need to loop over mmio devices
         const auto& mmio_device_id =

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -36,6 +36,8 @@
 #include "kernel_config/fd_kernel.hpp"
 #include "kernel_types.hpp"
 #include "metal_soc_descriptor.h"
+#include "persistent_kernel_cache.hpp"
+#include "program/program_impl.hpp"
 #include "tt-metalium/program.hpp"
 #include <tt_stl/span.hpp>
 #include <tt-metalium/fabric.hpp>
@@ -745,7 +747,7 @@ static const std::vector<DispatchKernelNode> galaxy_nine_chip_arch_2cq = {
 // clang-format on
 
 std::vector<FDKernel*> node_id_to_kernel;
-std::unordered_map<chip_id_t, std::unique_ptr<Program>> command_queue_pgms;
+tt::tt_metal::detail::ProgramCompileGroup command_queue_compile_group;
 std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> dispatch_cores;
 std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> routing_cores;
 std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> empty_cores;
@@ -933,6 +935,7 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
             delete node_id_to_kernel[idx];
         }
         node_id_to_kernel.clear();
+        command_queue_compile_group.clear();
     }
 
     // Read the input table, create configs for each node + track mmio devices and number of cqs.
@@ -1111,18 +1114,17 @@ void populate_cq_static_args(IDevice* device) {
         }
     }
 
-    // Move program into the storage for create_and_compile_cq_program to be called later
-    command_queue_pgms[device->id()] = std::move(cq_program_ptr);
+    // Move program into the storage for later steps
+    command_queue_compile_group.add_program(device, std::move(cq_program_ptr));
 }
 
-std::unique_ptr<Program> create_and_compile_cq_program(IDevice* device) {
-    TT_ASSERT(
-        command_queue_pgms.contains(device->id()),
+void create_cq_program(IDevice* device) {
+    TT_FATAL(
+        command_queue_compile_group.contains(device),
         "Tried to create and compile CQ program on device {} without static args populated (need to run "
         "populate_cq_static_args())",
         device->id());
     empty_cores.clear();
-    std::unique_ptr<Program> cq_program = std::move(command_queue_pgms[device->id()]);
     // Third pass, populate dependent configs and create kernels for each node
     for (auto node_and_kernel : node_id_to_kernel) {
         if (node_and_kernel->GetDeviceId() == device->id()) {
@@ -1169,15 +1171,25 @@ std::unique_ptr<Program> create_and_compile_cq_program(IDevice* device) {
             termination_info[device->id()].insert(info.value());
         }
     }
+}
 
-    // Compile the program and return it so Device can register it
-    detail::CompileProgram(device, *cq_program, /*force_slow_dispatch=*/true);
+void compile_cq_programs() {
+    if (tt_metal::MetalContext::instance().rtoptions().get_skip_loading_fw()) {
+        detail::EnablePersistentKernelCache();
+    }
+
+    command_queue_compile_group.compile_all(/*force_slow_dispatch=*/true);
+
     // Write runtime args to device
-    detail::WriteRuntimeArgsToDevice(device, *cq_program, /*force_slow_dispatch=*/true);
-    // Erase from map. Note: program in map is no longer valid
-    // It is returned from this function and the caller will take ownership of it
-    command_queue_pgms.erase(device->id());
-    return cq_program;
+    command_queue_compile_group.write_runtime_args(/*force_slow_dispatch=*/true);
+
+    if (tt_metal::MetalContext::instance().rtoptions().get_skip_loading_fw()) {
+        detail::DisablePersistentKernelCache();
+    }
+}
+
+std::unique_ptr<tt::tt_metal::Program> get_compiled_cq_program(tt::tt_metal::IDevice* device) {
+    return command_queue_compile_group.remove_program(device);
 }
 
 void configure_dispatch_cores(IDevice* device) {
@@ -1674,7 +1686,7 @@ void reset_topology_state() {
         delete node_id_to_kernel[idx];
     }
     node_id_to_kernel.clear();
-    command_queue_pgms.clear();
+    command_queue_compile_group.clear();
     dispatch_cores.clear();
     routing_cores.clear();
     empty_cores.clear();

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -47,7 +47,13 @@ void populate_cq_static_args(IDevice* device);
 
 // Fill out all settings for FD kernels on the given device, and add them to a Program and return it.
 // Prerequisites: Must call populate_cq_static_args
-std::unique_ptr<tt::tt_metal::Program> create_and_compile_cq_program(tt::tt_metal::IDevice* device);
+void create_cq_program(tt::tt_metal::IDevice* device);
+
+// Compile all command queue programs created by create_and_compile_cq_program()
+void compile_cq_programs();
+
+// Transfers ownership of a compiled command queue program to the caller
+std::unique_ptr<tt::tt_metal::Program> get_compiled_cq_program(tt::tt_metal::IDevice* device);
 
 // Perform additional configuration (writing to specific L1 addresses, etc.) for FD kernels on this device.
 void configure_dispatch_cores(tt::tt_metal::IDevice* device);

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -52,7 +52,7 @@ void create_cq_program(tt::tt_metal::IDevice* device);
 // Compile all command queue programs created by create_and_compile_cq_program()
 void compile_cq_programs();
 
-// Transfers ownership of a compiled command queue program to the caller
+// Get the compiled command queue program for a given device
 std::unique_ptr<tt::tt_metal::Program> get_compiled_cq_program(tt::tt_metal::IDevice* device);
 
 // Perform additional configuration (writing to specific L1 addresses, etc.) for FD kernels on this device.

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -109,6 +109,53 @@ size_t get_ringbuffer_size(IDevice* device, HalProgrammableCoreType programmable
     }
 }
 
+void validate_kernel_placement(IDevice* device, bool force_slow_dispatch, std::shared_ptr<Kernel> kernel) {
+    // Placement rules:
+    //  Slow dispatch:
+    //      - kernels cannot be on storage only cores
+    //  Fast dispatch (tensix):
+    //      - kernels cannot be on storage only cores an
+    //      - tensix kernels cannot be on dispatch cores
+    //  Fast dispatch (ethernet):
+    //      - kernels cannot be on storage only cores
+    //      - eth kernels cannot be on idle eth cores
+    bool slow_dispatch = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
+
+    const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
+    CoreType dispatch_core_type = dispatch_core_config.get_core_type();
+    const std::vector<CoreCoord>& storage_cores =
+        MetalContext::instance().get_dispatch_query_manager().get_logical_storage_cores_on_user_chips();
+    bool on_storage_only_core =
+        std::any_of(storage_cores.begin(), storage_cores.end(), [&kernel](const CoreCoord& storage_core) {
+            return kernel->is_on_logical_core(storage_core);
+        });
+    TT_FATAL(
+        not on_storage_only_core,
+        "Illegal kernel placement for {}. Kernels cannot be placed on storage only cores!",
+        kernel->name());
+
+    // Kernels used to implement fast dispatch can be placed on dispatch cores
+    if (not slow_dispatch and not force_slow_dispatch) {
+        const std::vector<CoreCoord>& dispatch_cores =
+            MetalContext::instance().get_dispatch_query_manager().get_logical_dispatch_cores_on_user_chips();
+        bool on_dispatch_core = std::any_of(
+            dispatch_cores.begin(),
+            dispatch_cores.end(),
+            [&kernel, &dispatch_core_type](const CoreCoord& dispatch_core) {
+                if (kernel->get_kernel_core_type() != dispatch_core_type) {
+                    return false;
+                }
+
+                return kernel->is_on_logical_core(dispatch_core);
+            });
+
+        TT_FATAL(
+            not on_dispatch_core,
+            "Illegal kernel placement for {}, Kernels cannot be placed on dispatch cores!",
+            kernel->name());
+    }
+};
+
 }  // namespace
 
 namespace tt::tt_metal {
@@ -1386,52 +1433,9 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
     bool profile_kernel = getDeviceProfilerState();
     std::vector<std::shared_future<void>> events;
 
-    auto sync_events = [&events] {
-        for (auto& event : events) {
-            event.get();
-        }
-    };
-
-    auto validate_kernel_placement = [&device, &force_slow_dispatch](std::shared_ptr<Kernel> kernel) {
-        // Placement rules:
-        //  Slow dispatch:
-        //      - kernels cannot be on storage only cores
-        //  Fast dispatch (tensix):
-        //      - kernels cannot be on storage only cores an
-        //      - tensix kernels cannot be on dispatch cores
-        //  Fast dispatch (ethernet):
-        //      - kernels cannot be on storage only cores
-        //      - eth kernels cannot be on idle eth cores
-        bool slow_dispatch = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
-
-        const auto& dispatch_core_config =
-            MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-        CoreType dispatch_core_type = dispatch_core_config.get_core_type();
-        const std::vector<CoreCoord>& storage_cores =
-            MetalContext::instance().get_dispatch_query_manager().get_logical_storage_cores_on_user_chips();
-        bool on_storage_only_core =  std::any_of(storage_cores.begin(), storage_cores.end(), [&kernel](const CoreCoord& storage_core) {
-            return kernel->is_on_logical_core(storage_core);
-        });
-        TT_FATAL(not on_storage_only_core, "Illegal kernel placement for {}. Kernels cannot be placed on storage only cores!", kernel->name());
-
-        // Kernels used to implement fast dispatch can be placed on dispatch cores
-        if (not slow_dispatch and not force_slow_dispatch) {
-            const std::vector<CoreCoord>& dispatch_cores =
-                MetalContext::instance().get_dispatch_query_manager().get_logical_dispatch_cores_on_user_chips();
-            bool on_dispatch_core = std::any_of(dispatch_cores.begin(), dispatch_cores.end(), [&kernel, &dispatch_core_type](const CoreCoord &dispatch_core) {
-                if (kernel->get_kernel_core_type() != dispatch_core_type) {
-                    return false;
-                }
-
-                return kernel->is_on_logical_core(dispatch_core);
-            });
-
-            TT_FATAL(not on_dispatch_core, "Illegal kernel placement for {}, Kernels cannot be placed on dispatch cores!", kernel->name());
-        }
-    };
     for (auto & kernels : kernels_) {
         for (auto &[id, kernel] : kernels) {
-            validate_kernel_placement(kernel);
+            validate_kernel_placement(device, force_slow_dispatch, kernel);
             launch_build_step(
                 [kernel, device, this, &build_env] {
                     JitBuildOptions build_options(
@@ -1470,14 +1474,14 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                 events);
         }
     }
-    sync_events();
+    sync_build_steps(events);
 
     for (auto &kernels : kernels_) {
         for (auto &[id, kernel] : kernels) {
             launch_build_step([kernel, device] { KernelImpl::from(*kernel).read_binaries(device); }, events);
         }
     }
-    sync_events();
+    sync_build_steps(events);
     if (detail::MemoryReporter::enabled()) {
         detail::MemoryReporter::inst().flush_program_memory_usage(get_id(), device);
     }

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -141,43 +141,23 @@ private:
 public:
     ProgramCompileGroup() = default;
 
-    ~ProgramCompileGroup() { program_device_map_.clear(); }
+    ~ProgramCompileGroup();
 
     // Add a program to the compile group. Throws if the program already exists in the group.
-    void add_program(IDevice* device, std::unique_ptr<Program> program) {
-        TT_FATAL(!program_device_map_.contains(device), "Program already exists in the compile group.");
-        program_device_map_[device] = std::move(program);
-    }
+    void add_program(IDevice* device, std::unique_ptr<Program> program);
 
     // Compiles all programs in the group
-    void compile_all(bool force_slow_dispatch) {
-        std::vector<std::shared_future<void>> events;
-        for (auto& [device, program] : program_device_map_) {
-            auto pgm = program.get();
-            launch_build_step(
-                [device, pgm, force_slow_dispatch]() { pgm->compile(device, force_slow_dispatch); }, events);
-        }
-        sync_build_steps(events);
-    }
+    void compile_all(bool force_slow_dispatch);
 
     // Write runtime args for all programs in the group
-    void write_runtime_args(bool force_slow_dispatch) {
-        for (auto& [device, program] : program_device_map_) {
-            detail::WriteRuntimeArgsToDevice(device, *program, force_slow_dispatch);
-        }
-    }
+    void write_runtime_args(bool force_slow_dispatch);
 
     // Remove and return a program from the compile group
-    std::unique_ptr<Program> remove_program(IDevice* device) {
-        TT_FATAL(program_device_map_.contains(device), "Program not found in the compile group.");
-        std::unique_ptr<Program> program = std::move(program_device_map_[device]);
-        program_device_map_.erase(device);
-        return program;
-    }
+    std::unique_ptr<Program> remove_program(IDevice* device);
 
-    void clear() { program_device_map_.clear(); }
+    void clear();
 
-    bool contains(IDevice* device) const { return program_device_map_.contains(device); }
+    bool contains(IDevice* device);
 };
 
 // The internal implementation of the Program class. Program is a view of this class that's usable by API clients.

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -170,7 +170,9 @@ public:
     // Remove and return a program from the compile group
     std::unique_ptr<Program> remove_program(IDevice* device) {
         TT_FATAL(program_device_map_.contains(device), "Program not found in the compile group.");
-        return std::move(program_device_map_[device]);
+        std::unique_ptr<Program> program = std::move(program_device_map_[device]);
+        program_device_map_.erase(device);
+        return program;
     }
 
     void clear() { program_device_map_.clear(); }

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -878,4 +878,10 @@ void launch_build_step(const std::function<void()>& build_func, std::vector<std:
     events.emplace_back(detail::async(build_func));
 }
 
+void sync_build_steps(std::vector<std::shared_future<void>>& events) {
+    for (auto& event : events) {
+        event.wait();
+    }
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -189,5 +189,6 @@ void jit_build_set(const JitBuildStateSet& builds, const JitBuildSettings* setti
 void jit_build_subset(const JitBuildStateSubset& builds, const JitBuildSettings* settings);
 
 void launch_build_step(const std::function<void()>& build_func, std::vector<std::shared_future<void>>& events);
+void sync_build_steps(std::vector<std::shared_future<void>>& events);
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18726

### Problem description
- Since program has been updated to use a condition variable to wait for the build we should have more resources available to compile dispatch programs faster
- Dispatch initialization is getting slow when kernels are not cached yet on large systems such as TG due to the increased number of unique compile args / define combos.
- Function calls to Inspector, HashLookup from ProgramImpl::compile already have mutexes in them as we already compile kernels within a program in parallel.

### What's changed
- Add an internal ProgramCompileGroup
- Updated DevicePool to create all command queue programs (1 per device) and then compile them in a batch
- Table below shows init times on various systems (dispatch only. does not include fabric) measured from DevicePool::initialize_active_devices() [generate static args](https://github.com/tenstorrent/tt-metal/blob/main/tt_metal/impl/device/device_pool.cpp#L430) to the end of that function when [dispatch firmware is set to active](https://github.com/tenstorrent/tt-metal/blob/main/tt_metal/impl/device/device_pool.cpp#L476)

| System (1CQ, Dispatch on Fabric enabled) | Before (ms) | After (ms) | Change |
|------------------------------------------|-------------|------------|--------|
| TG                                       |             |            |        |
| N300                                     | 2444        | 1365       | -44%   |
| T3K                                      | 7059        | 3031       | -57%   |

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/16102118579
T3K Fast
https://github.com/tenstorrent/tt-metal/actions/runs/16129946175
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/16137084671
TG Quick
https://github.com/tenstorrent/tt-metal/actions/runs/16129943457
BH
https://github.com/tenstorrent/tt-metal/actions/runs/16130338167