### PR TITLE
RS Minimal Bug Fix

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_new_reduce_scatter.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_reduce_scatter.py
@@ -32,6 +32,7 @@ def run_reduce_scatter_impl(
     rs_topology,
     num_iters=1,
     enable_trace=True,
+    ones_tensor=False,
 ):
     torch.manual_seed(0)
 
@@ -101,7 +102,10 @@ def run_reduce_scatter_impl(
     for i in range(num_iters):
         rs_global_input_shape = rs_input_shape[:]
         rs_global_input_shape[3] *= num_devices
-        rs_input_tensor = torch.rand(rs_global_input_shape).bfloat16()
+        if ones_tensor:
+            rs_input_tensor = torch.ones(rs_global_input_shape).bfloat16()
+        else:
+            rs_input_tensor = torch.rand(rs_global_input_shape).bfloat16()
         input_tensors = torch.chunk(rs_input_tensor, num_devices, dim)
         torch_input_tensor_list.append(input_tensors)
 
@@ -185,7 +189,12 @@ def run_reduce_scatter_impl(
 
         tt_rs_out = ttnn.from_device(tt_rs_out_tensor)
         tt_rs_out = ttnn.to_torch(tt_rs_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
-        eq, output = comp_pcc(tt_rs_out, torch_rs_out)
+
+        if ones_tensor:
+            eq, output = comp_equal(tt_rs_out, torch_rs_out)
+        else:
+            eq, output = comp_pcc(tt_rs_out, torch_rs_out)
+
         logger.info(f"{output}, iteration {i}")
         assert eq, f"{i} FAILED ag: {output}"
 
@@ -209,8 +218,23 @@ def run_reduce_scatter_impl(
         (8, 1, [4, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         (8, 1, [2, 1, 2048, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         (8, 1, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (8, 1, [1, 1, 512, 256], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (8, 1, [1, 1, 512, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (8, 1, [1, 1, 512, 768], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (8, 1, [1, 1, 512, 1024], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (8, 1, [4, 1, 512, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
-    ids=["batch_8", "batch_4", "batch_2", "batch_1"],
+    ids=[
+        "batch_8",
+        "batch_4",
+        "batch_2",
+        "batch_1",
+        "batch_1_slice_wt_1",
+        "batch_1_slice_wt_2",
+        "batch_1_slice_wt_3",
+        "batch_1_slice_wt_4",
+        "batch_4_slice_wt_2",
+    ],
 )
 @pytest.mark.parametrize(
     "mem_config_input, mem_config_rs",
@@ -228,6 +252,13 @@ def run_reduce_scatter_impl(
         (False, 1),
     ],
     ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "ones_tensor",
+    [
+        True,
+        False,
+    ],
 )
 @pytest.mark.parametrize(
     "device_params, rs_topology",
@@ -249,6 +280,7 @@ def test_reduce_scatter_async(
     mem_config_rs,
     enable_trace,
     num_iters,
+    ones_tensor,
     rs_topology,
 ):
     run_reduce_scatter_impl(
@@ -264,4 +296,5 @@ def test_reduce_scatter_async(
         rs_topology=rs_topology,
         enable_trace=enable_trace,
         num_iters=num_iters,
+        ones_tensor=ones_tensor,
     )

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_reduce_scatter.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_reduce_scatter.py
@@ -220,9 +220,6 @@ def run_reduce_scatter_impl(
         (8, 1, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         (8, 1, [1, 1, 512, 256], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         (8, 1, [1, 1, 512, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, 1, [1, 1, 512, 768], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, 1, [1, 1, 512, 1024], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, 1, [4, 1, 512, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
     ids=[
         "batch_8",
@@ -231,9 +228,6 @@ def run_reduce_scatter_impl(
         "batch_1",
         "batch_1_slice_wt_1",
         "batch_1_slice_wt_2",
-        "batch_1_slice_wt_3",
-        "batch_1_slice_wt_4",
-        "batch_4_slice_wt_2",
     ],
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduce_scatter_minimal_async_reader.cpp
@@ -105,12 +105,16 @@ void kernel_main() {
 
             if constexpr (!direction) {
                 uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
-                tiles_read += backwards_offset;
-                pages_read_in_row += backwards_offset;
-                if (pages_read_in_row >= slice_Wt) {
-                    row_offset += stride_Wt;
-                    pages_read_in_row = pages_read_in_row - slice_Wt;
+
+                for (uint32_t k = 0; k < backwards_offset; ++k) {
+                    tiles_read++;
+                    pages_read_in_row++;
+                    if (pages_read_in_row == slice_Wt) {
+                        row_offset += stride_Wt;
+                        pages_read_in_row = pages_read_in_row - slice_Wt;
+                    }
                 }
+
                 intermediate_pages_read_in_row = pages_read_in_row;
                 intermediate_row_offset = row_offset;
             }
@@ -146,7 +150,7 @@ void kernel_main() {
                     tiles_read++;
 
                     pages_read_in_row++;
-                    if (pages_read_in_row >= slice_Wt) {
+                    if (pages_read_in_row == slice_Wt) {
                         row_offset += stride_Wt;
                         pages_read_in_row = 0;
                     }
@@ -164,7 +168,7 @@ void kernel_main() {
                         intermediate_l1_write_addr += input_tensor_page_size;
 
                         intermediate_pages_read_in_row++;
-                        if (intermediate_pages_read_in_row >= slice_Wt) {
+                        if (intermediate_pages_read_in_row == slice_Wt) {
                             intermediate_row_offset += stride_Wt;
                             intermediate_pages_read_in_row = 0;
                         }
@@ -186,12 +190,16 @@ void kernel_main() {
                     } else {
                         tiles_to_read_in_other_direction = std::min(tiles_remaining_to_read, tile_granularity);
                     }
-                    tiles_read += tiles_to_read_in_other_direction;
-                    pages_read_in_row += tiles_to_read_in_other_direction;
-                    if (pages_read_in_row >= slice_Wt) {
-                        row_offset += stride_Wt;
-                        pages_read_in_row = pages_read_in_row - slice_Wt;
+
+                    for (uint32_t k = 0; k < tiles_to_read_in_other_direction; ++k) {
+                        tiles_read++;
+                        pages_read_in_row++;
+                        if (pages_read_in_row == slice_Wt) {
+                            row_offset += stride_Wt;
+                            pages_read_in_row = pages_read_in_row - slice_Wt;
+                        }
                     }
+
                     intermediate_pages_read_in_row = pages_read_in_row;
                     intermediate_row_offset = row_offset;
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduce_scatter_minimal_async_reader.cpp
@@ -105,9 +105,7 @@ void kernel_main() {
 
             if constexpr (!direction) {
                 uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
-
                 for (uint32_t k = 0; k < backwards_offset; ++k) {
-                    tiles_read++;
                     pages_read_in_row++;
                     if (pages_read_in_row == slice_Wt) {
                         row_offset += stride_Wt;
@@ -115,6 +113,7 @@ void kernel_main() {
                     }
                 }
 
+                tiles_read += backwards_offset;
                 intermediate_pages_read_in_row = pages_read_in_row;
                 intermediate_row_offset = row_offset;
             }
@@ -192,7 +191,6 @@ void kernel_main() {
                     }
 
                     for (uint32_t k = 0; k < tiles_to_read_in_other_direction; ++k) {
-                        tiles_read++;
                         pages_read_in_row++;
                         if (pages_read_in_row == slice_Wt) {
                             row_offset += stride_Wt;
@@ -200,6 +198,7 @@ void kernel_main() {
                         }
                     }
 
+                    tiles_read += tiles_to_read_in_other_direction;
                     intermediate_pages_read_in_row = pages_read_in_row;
                     intermediate_row_offset = row_offset;
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduce_scatter_minimal_async_writer.cpp
@@ -118,12 +118,14 @@ void kernel_main() {
                 uint32_t input_tile_id_start = actual_slice_idx * slice_Wt;
                 if constexpr (!direction) {
                     uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
-                    tiles_read += backwards_offset;
-                    pages_read_in_row += backwards_offset;
 
-                    if (pages_read_in_row >= slice_Wt) {
-                        row_offset += stride_Wt;
-                        pages_read_in_row = pages_read_in_row - slice_Wt;
+                    for (uint32_t k = 0; k < backwards_offset; ++k) {
+                        tiles_read++;
+                        pages_read_in_row++;
+                        if (pages_read_in_row == slice_Wt) {
+                            row_offset += stride_Wt;
+                            pages_read_in_row = pages_read_in_row - slice_Wt;
+                        }
                     }
                 }
 
@@ -151,14 +153,14 @@ void kernel_main() {
                             case 2: {
                                 uint32_t tile_one_id = input_tile_id_start + row_offset + pages_read_in_row;
                                 pages_read_in_row++;
-                                if (pages_read_in_row >= slice_Wt) {
+                                if (pages_read_in_row == slice_Wt) {
                                     row_offset += stride_Wt;
                                     pages_read_in_row = 0;
                                 }
 
                                 uint32_t tile_two_id = input_tile_id_start + row_offset + pages_read_in_row;
                                 pages_read_in_row++;
-                                if (pages_read_in_row >= slice_Wt) {
+                                if (pages_read_in_row == slice_Wt) {
                                     row_offset += stride_Wt;
                                     pages_read_in_row = 0;
                                 }
@@ -182,7 +184,7 @@ void kernel_main() {
                             default: {
                                 uint32_t tile_id = input_tile_id_start + row_offset + pages_read_in_row;
                                 pages_read_in_row++;
-                                if (pages_read_in_row >= slice_Wt) {
+                                if (pages_read_in_row == slice_Wt) {
                                     row_offset += stride_Wt;
                                     pages_read_in_row = 0;
                                 }
@@ -214,11 +216,13 @@ void kernel_main() {
                             tiles_to_read_in_other_direction = std::min(tiles_remaining_to_read, tile_granularity);
                         }
 
-                        tiles_read += tiles_to_read_in_other_direction;
-                        pages_read_in_row += tiles_to_read_in_other_direction;
-                        if (pages_read_in_row >= slice_Wt) {
-                            row_offset += stride_Wt;
-                            pages_read_in_row = pages_read_in_row - slice_Wt;
+                        for (uint32_t k = 0; k < tiles_to_read_in_other_direction; ++k) {
+                            tiles_read++;
+                            pages_read_in_row++;
+                            if (pages_read_in_row == slice_Wt) {
+                                row_offset += stride_Wt;
+                                pages_read_in_row = pages_read_in_row - slice_Wt;
+                            }
                         }
                     }
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduce_scatter_minimal_async_writer.cpp
@@ -118,15 +118,14 @@ void kernel_main() {
                 uint32_t input_tile_id_start = actual_slice_idx * slice_Wt;
                 if constexpr (!direction) {
                     uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
-
                     for (uint32_t k = 0; k < backwards_offset; ++k) {
-                        tiles_read++;
                         pages_read_in_row++;
                         if (pages_read_in_row == slice_Wt) {
                             row_offset += stride_Wt;
                             pages_read_in_row = pages_read_in_row - slice_Wt;
                         }
                     }
+                    tiles_read += backwards_offset;
                 }
 
                 while (tiles_read < tiles_to_read) {
@@ -217,13 +216,13 @@ void kernel_main() {
                         }
 
                         for (uint32_t k = 0; k < tiles_to_read_in_other_direction; ++k) {
-                            tiles_read++;
                             pages_read_in_row++;
                             if (pages_read_in_row == slice_Wt) {
                                 row_offset += stride_Wt;
                                 pages_read_in_row = pages_read_in_row - slice_Wt;
                             }
                         }
+                        tiles_read += tiles_to_read_in_other_direction;
                     }
                 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduction.cpp
@@ -48,7 +48,7 @@ void MAIN {
                 cb_wait_front(intermediate_cb, tile_granularity);
                 cb_reserve_back(output_cb, tile_granularity);
                 acquire_dst();
-                for (uint32_t tile_id = 0; tile_id < tile_granularity; tile_id++) {
+                for (uint32_t tile_id = 0; tile_id < num_pages_to_read; tile_id++) {
                     add_tiles(input_cb_id, intermediate_cb, tile_id, tile_id, tile_id);
                     pack_tile(tile_id, output_cb);
                 }


### PR DESCRIPTION
### Problem description
RS minimal was giving bad PCC for tensors with small slice width. Problem was due to incorrectly updating index offsets for forward/backward direction.

### What's changed
- Update logic for incrementing offset indices 
- Add tests for tensors with small slice width (that fail without this fix)
- Add tests that use ones tensors (during debugging I discovered that with ones tensors I would get a PCC of 1 for a bunch of shapes, but the reduced tensors wouldn't actually be 100% correct, i.e. some tiles would have the incorrect value)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16107886851/job/45446600570
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes