### PR TITLE
#0: Do not check compile time anymore for e2e perf models because we couldn't give less of a shit

### DIFF
--- a/models/perf/merge_perf_results.py
+++ b/models/perf/merge_perf_results.py
@@ -19,7 +19,7 @@ expected_cols = [
     "Throughput CPU (Batch*inf/sec)",
 ]
 
-check_cols = ["Inference Time (sec)", "Compile Time (sec)"]
+check_cols = ["Inference Time (sec)"]
 
 if __name__ == "__main__":
     fname = f"Models_Perf_{today}.csv"


### PR DESCRIPTION
### Ticket

N/A

### Problem description

All infra team does is bump thresholds or skip these tests when compile time regress.

And there has been a lack of meaningful intention or action from Model writers.

### What's changed

Let's stop checking something and causing CI churn when there's no need to.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes