### PR TITLE
DRAM loopback example to use standard interleaved mode

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    	?=
+SPHINXOPTS    	?= -W
 SPHINXBUILD   	?= sphinx-build
 SOURCEDIR     	= source/$(REQUESTED_DOCS_PKG)
 BUILDDIR      	= build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    	?= -W
+SPHINXOPTS    	?=
 SPHINXBUILD   	?= sphinx-build
 SOURCEDIR     	= source/$(REQUESTED_DOCS_PKG)
 BUILDDIR      	= build

--- a/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
@@ -60,7 +60,7 @@ The L1 buffer is created with a size equal to the size of a single tile, which w
 
 .. code-block:: cpp
 
-constexpr uint32_t num_tiles = 50;
+  constexpr uint32_t num_tiles = 50;
   constexpr uint32_t tile_size = TILE_WIDTH * TILE_HEIGHT;
   constexpr uint32_t single_tile_size = sizeof(bfloat16) * tile_size;
   constexpr uint32_t dram_buffer_size = single_tile_size * num_tiles;
@@ -169,9 +169,10 @@ The ``InterleavedAddrGenFast`` object handles bank addressing and page size auto
     }
 
 .. note::
-  ``InterleavedAddrGenFast`` is a helper class that simplifies the generation of addresses for interleaved buffers. It is feasable and sometimes needed to calculate addresses manually, espicially for complex data disctibution schemes. Without the use of the ``InterleavedAddrGenFast`` class. The kernel would look like this:
+  ``InterleavedAddrGenFast`` is a helper class that automatically handles address generation for interleaved buffers. For more complex data distribution patterns or when you need manual control over addressing, you can calculate addresses directly. Without using ``InterleavedAddrGenFast``, the kernel would look like this:
 
   .. code-block:: cpp
+
     constexpr std::uint32_t num_dram_banks = 6; // Number of DRAM banks on Wormhole
     for (uin32_t i = 0; i < num_tiles; i++) {
         // Round-robin bank selection

--- a/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
@@ -159,7 +159,7 @@ The ``InterleavedAddrGenFast`` object handles bank addressing and page size auto
             .data_format = DataFormat::Float16_b,
         };
 
-        for(uin32_t i=0;i<num_tiles;i++) {
+        for(uint32_t i=0;i<num_tiles;i++) {
             noc_async_read_tile(i, in0, l1_buffer_addr);
             noc_async_read_barrier();
 

--- a/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
@@ -54,20 +54,22 @@ Note that almost all operations on the Tensix are aligned with tiles. And a tile
 
 There are two types of buffers in the Tensix: L1 and DRAM. L1 is a misnomer as it can be mistaken as similar to L1 cache in a CPU. In fact, the L1 is a SRAM scratchpad on the Tensix. Each generation of Tenstorrent processors has a different amount of L1 memory per Tensix. Grayskull had 1MB and Wormhole/Blackhole has 1.5MB.
 
-Note the ``page_size`` argument in the buffer config and the ``Interleaved`` in the buffer type. Both L1 and DRAM are split into banks. Each bank is a physical memory unit that can be accessed independently. However, managing banks separately is tricky and not scalable. Interleaved buffers simply round-robin the data across all banks every ``page_size`` bytes. This allows the programmer to treat the buffer as a single unit, while taking advantage of the parallelism of the banks for higher bandwidth. Setting page size equal to the buffer size means that the entire buffer will live on a single bank. This is not recommended for performance and in most cases, page size is set to the size of a tile. However, this configuration allows easy illustration of NoC operations. However, these are implementation details and the programmer should not be overly concerned with them.
+Note the ``page_size`` argument in the buffer config and the ``Interleaved`` in the buffer type. Both L1 and DRAM are split into banks. Each bank is a physical memory unit that can be accessed independently. However, managing banks separately is tricky and not scalable. Interleaved buffers simply round-robin the data across all banks every ``page_size`` bytes. This allows the programmer to treat the buffer as a single unit, while taking advantage of the parallelism of the banks for higher bandwidth. Usually the page size is set to the tile size, which is 2048 bytes in this case. This enabels easy programming while still maintaining high performance. Other values are also supported, but the programmer is then responsible for the performance implications and programming complexity.
+
+The L1 buffer is created with a size equal to the size of a single tile, which will act as a buffer for old temporary data. Then be written back to DRAM.
 
 .. code-block:: cpp
 
+constexpr uint32_t num_tiles = 50;
   constexpr uint32_t tile_size = TILE_WIDTH * TILE_HEIGHT;
   constexpr uint32_t single_tile_size = sizeof(bfloat16) * tile_size;
-  constexpr uint32_t num_tiles = 50;
   constexpr uint32_t dram_buffer_size = single_tile_size * num_tiles;
   tt_metal::InterleavedBufferConfig l1_config{
-                                        .device=device,
-                                        .size = dram_buffer_size,
-                                        .page_size = dram_buffer_size,
-                                        .buffer_type = tt_metal::BufferType::L1
-                                        };
+      .device=device,
+      .size = single_tile_size,
+      .page_size = single_tile_size,
+      .buffer_type = tt_metal::BufferType::L1
+  };
 
   Buffer l1_buffer = CreateBuffer(l1_config);
 
@@ -76,20 +78,17 @@ The only difference between the L1 and DRAM buffer is the ``BufferType``. The L1
 .. code-block:: cpp
 
   tt_metal::InterleavedBufferConfig dram_config{
-                                        .device=device,
-                                        .size = dram_buffer_size,
-                                        .page_size = dram_buffer_size,
-                                        .buffer_type = tt_metal::BufferType::DRAM
-                                        };
+      .device=device,
+      .size = dram_buffer_size,
+      .page_size = single_tile_size,
+      .buffer_type = tt_metal::BufferType::DRAM
+  };
 
   Buffer input_dram_buffer = CreateBuffer(dram_config);
   const uint32_t input_dram_buffer_addr = input_dram_buffer.address();
 
   Buffer output_dram_buffer = CreateBuffer(dram_config);
   const uint32_t output_dram_buffer_addr = output_dram_buffer.address();
-
-  const uint32_t input_bank_id = 0;
-  const uint32_t output_bank_id = 0;
 
 Sending real data into DRAM
 ---------------------------
@@ -136,32 +135,45 @@ Create a kernel that will copy data from DRAM to L1 and back. Since we are only 
 
 The kernel itself is simple. It takes the address and bank indices we just created. Copies data from the input DRAM buffer to the L1 buffer and then back out to the output DRAM buffer. You might notice that the kernel is using ``uint32_t`` instead of pointers for addresses. This is intended design as the DRAM is not directly addressable by the kernels. Instead, access requests are sent to the NoC (Network on Chip) and be brought to the L1 before the kernel can access it in a meaningful way. However, letting the RISC-V core directly access the L1 is not the most efficient way to move data around. Thus the L1 address is also an integer.
 
+The ``InterleavedAddrGenFast`` object handles bank addressing and page size automatically, simplifying interleaved buffer access. Data transfers are asynchronous, allowing the kernel to issue multiple requests while transfers are in progress. This improves performance by utilizing on-core resources more efficiently. In this example, we use ``noc_async_read_barrier()`` and ``noc_async_write_barrier()`` after each operation to ensure data integrity before proceeding to the next loop iteration.
+
 .. code-block:: cpp
 
     // tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp
     void kernel_main() {
-        std::uint32_t l1_buffer_addr = get_arg_val<uint32_t>(0);
+        std::uint32_t l1_buffer_addr        = get_arg_val<uint32_t>(0);
         std::uint32_t dram_buffer_src_addr  = get_arg_val<uint32_t>(1);
-        std::uint32_t dram_buffer_src_bank  = get_arg_val<uint32_t>(2);
         std::uint32_t dram_buffer_dst_addr  = get_arg_val<uint32_t>(3);
-        std::uint32_t dram_buffer_dst_bank  = get_arg_val<uint32_t>(4);
-        std::uint32_t dram_buffer_size      = get_arg_val<uint32_t>(5);
+        std::uint32_t num_tiles             = get_arg_val<uint32_t>(3);
 
-        std::uint64_t dram_buffer_src_noc_addr =
-            get_noc_addr_from_bank_id</*dram=*/true>(dram_buffer_src_bank, dram_buffer_src_addr);
-        // Read data into L1 buffer
-        noc_async_read(dram_buffer_src_noc_addr, l1_buffer_addr, dram_buffer_size);
-        noc_async_read_barrier(); // wait for transfer to complete
+        const uint32_t tile_size_bytes = 32 * 32 * 2; // same tile size as in the host code
+        const InterleavedAddrGenFast<true> in0 = {
+            .bank_base_address = dram_buffer_src_addr, // The base address of the buffer
+            .page_size = tile_size_bytes,              // The size of a buffer page
+            .data_format = DataFormat::Float16_b,      // The data format of the buffer
+        };
 
-        std::uint64_t dram_buffer_dst_noc_addr =
-            get_noc_addr_from_bank_id</*dram=*/true>(dram_buffer_dst_bank, dram_buffer_dst_addr);
-        // write data from L1 back into DRAM
-        noc_async_write(l1_buffer_addr, dram_buffer_dst_noc_addr, dram_buffer_size);
-        noc_async_write_barrier(); // wait for transfer to complete
+        const InterleavedAddrGenFast<true> out0 = {
+            .bank_base_address = dram_buffer_dst_addr,
+            .page_size = tile_size_bytes,
+            .data_format = DataFormat::Float16_b,
+        };
+
+        for(uin32_t i=0;i<num_tiles;i++) {
+            noc_async_read_tile(i, in0, l1_buffer_addr);
+            noc_async_read_barrier();
+
+            noc_async_write_tile(i, out0, l1_buffer_addr);
+            noc_async_write_barrier();
+        }
     }
 
 .. note::
-    Accessing DRAM using an address and bank pair is complicated and not scalable. Most kernels uses interleaved buffers and ``InterleavedAddrGenFast`` instead (introduced in the next example). This acts much more like a pointer and is much easier to use. The interleaved buffer is simply a buffer with page size equal to the tile size.
+    ``InterleavedAddrGenFast`` is a helper class that simplifies the generation of addresses for interleaved buffers. It is feasable and sometimes needed to calculate addresses manually, espicially for complex data disctibution schemes. Without the use of the ``InterleavedAddrGenFast`` class. The kernel would look like this:
+
+    .. code-block:: cpp
+
+        // STUB: fill this in
 
 
 Setting runtime arguments for the data movement kernel
@@ -172,10 +184,8 @@ Setting runtime arguments for the data movement kernel
   const std::vector<uint32_t> runtime_args = {
       l1_buffer.address(),
       input_dram_buffer.address(),
-      input_bank_id,
       output_dram_buffer.address(),
-      output_bank_id,
-      l1_buffer.size()
+      num_tiles
   };
 
   SetRuntimeArgs(
@@ -189,11 +199,8 @@ We now set runtime arguments for our data movement kernel. The kernel can then a
 
 * Where the L1 buffer starts (memory address)
 * Where the input DRAM buffer starts (memory address)
-* The channel index of the input DRAM buffer
 * Where the output DRAM buffer starts (memory address)
-* The channel index of the output DRAM buffer
-* The size of the copy
-  * Which happens to be the same as the size of the L1 buffer
+* How many tiles we are copying (this is used to determine how many times to copy data)
 
 Running the program
 -------------------

--- a/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
@@ -174,7 +174,7 @@ The ``InterleavedAddrGenFast`` object handles bank addressing and page size auto
   .. code-block:: cpp
 
     constexpr std::uint32_t num_dram_banks = 6; // Number of DRAM banks on Wormhole
-    for (uin32_t i = 0; i < num_tiles; i++) {
+    for (uint32_t i = 0; i < num_tiles; i++) {
         // Round-robin bank selection
         uint32_t bank_id = i % num_dram_banks;
         // Offset within the bank for the current tile

--- a/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
@@ -169,7 +169,7 @@ The ``InterleavedAddrGenFast`` object handles bank addressing and page size auto
     }
 
 .. note::
-  ``InterleavedAddrGenFast`` is a helper class that automatically handles address generation for interleaved buffers. For more complex data distribution patterns or when you need manual control over addressing, you can calculate addresses directly. Without using ``InterleavedAddrGenFast``, the kernel would look like this:
+  ``InterleavedAddrGenFast`` handles address generation for tiled interleaved buffers automatically. For none tiled layouts or when manual address control is needed, use ``InterleavedAddrGen`` or calculate addresses manually. Without the helper, the kernel implementation would be:
 
   .. code-block:: cpp
 

--- a/docs/source/tt-metalium/tt_metal/examples/eltwise_binary.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/eltwise_binary.rst
@@ -80,7 +80,7 @@ Data preparation and upload is the same as before. For this example, buffer 0 wi
 Circular buffers
 ----------------
 
-Here we introduce a new concept: circular buffers. They are communication channels between the different kernel on a Tensix. Conceptually they act as pipes between different kernels. There are in total 16 circular buffers supported on a Tensix. To utilize them, the host program must allocate the circular buffers and utilize the appropriate circular buffer index in the kernel.
+Here we introduce a new concept: circular buffers. They are communication channels between the different kernel on a Tensix. Conceptually they act as pipes between different kernels. There are in total 32 circular buffers supported on a Tensix. To utilize them, the host program must allocate the circular buffers and utilize the appropriate circular buffer index in the kernel.
 
 
 

--- a/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
+++ b/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
@@ -164,7 +164,7 @@ Program create_simple_datamovement_program(
 
     // Handle Runtime Args
     const std::vector<uint32_t> runtime_args = {
-        l1_buffer.address(), input.address(), input_bank_id, output.address(), output_bank_id, l1_buffer.size()};
+        l1_buffer.address(), input.address(), output.address(), input.num_pages()};
 
     // Very minimal testing/usage of other SetRuntimeArgs API that TTNN uses for ops here, j
     // just to see it go through the light-metal capture + replay flow.
@@ -295,12 +295,13 @@ TEST_F(LightMetalBasicTest, CreateBufferAndDeallocate) {
 }
 
 void SingleRISCDataMovement_test(tt::tt_metal::IDevice* device, bool rt_arg_per_core_vec) {
-    uint32_t size_bytes = 64;  // 16 elements.
+    uint32_t size_bytes = 32 * 32 * 2;
+    uint32_t page_size = 32 * 32 * 2;
 
     // For extra coverage, use Buffer::create (now support for light metal capture/replay)
-    auto input = Buffer::create(device, size_bytes, size_bytes, BufferType::DRAM);
-    auto output = Buffer::create(device, size_bytes, size_bytes, BufferType::DRAM);
-    auto l1_buffer = Buffer::create(device, size_bytes, size_bytes, BufferType::L1);
+    auto input = Buffer::create(device, size_bytes, page_size, BufferType::DRAM);
+    auto output = Buffer::create(device, size_bytes, page_size, BufferType::DRAM);
+    auto l1_buffer = Buffer::create(device, size_bytes, page_size, BufferType::L1);
 
     log_debug(
         tt::LogTest,

--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -124,11 +124,9 @@ int main(int argc, char** argv) {
             const std::array<uint32_t, 8> runtime_args = {
                 l1_buffer->address(),
                 input_dram_buffer->address(),
-                0,
                 output_dram_buffer->address(),
-                0,
-                l1_buffer->size()
-            };
+                l1_buffer->size(),
+                num_tiles};
 
             SetRuntimeArgs(
                 program,

--- a/tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp
+++ b/tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp
@@ -9,25 +9,40 @@ void kernel_main() {
     std::uint32_t l1_buffer_addr = get_arg_val<uint32_t>(0);
 
     // Address and the DRAM bank ID of the source buffer
-    std::uint32_t dram_buffer_src_addr  = get_arg_val<uint32_t>(1);
-    std::uint32_t dram_buffer_src_bank  = get_arg_val<uint32_t>(2);
+    std::uint32_t dram_buffer_src_addr = get_arg_val<uint32_t>(1);
 
     // Address and the DRAM bank ID of the destination buffer
-    std::uint32_t dram_buffer_dst_addr  = get_arg_val<uint32_t>(3);
-    std::uint32_t dram_buffer_dst_bank  = get_arg_val<uint32_t>(4);
+    std::uint32_t dram_buffer_dst_addr = get_arg_val<uint32_t>(2);
 
     // Size of the buffer in bytes
-    std::uint32_t dram_buffer_size      = get_arg_val<uint32_t>(5);
+    std::uint32_t num_tiles = get_arg_val<uint32_t>(3);
 
-    std::uint64_t dram_buffer_src_noc_addr =
-        get_noc_addr_from_bank_id</*dram=*/true>(dram_buffer_src_bank, dram_buffer_src_addr);
-    // Read data into L1 buffer and wait for transfer to complete
-    noc_async_read(dram_buffer_src_noc_addr, l1_buffer_addr, dram_buffer_size);
-    noc_async_read_barrier();
+    // Each tile is 32x32 elements of bfloat16, which is 2 bytes per element.
+    // So the tile size in bytes is 32 * 32 * 2 = 2048 bytes.
+    // Note that this is the same as the tile size used in the host code
+    // when creating the buffers.
+    const uint32_t tile_size_bytes = 32 * 32 * 2;
+    const InterleavedAddrGenFast<true> in0 = {
+        .bank_base_address = dram_buffer_src_addr,  // The base address of the buffer
+        .page_size = tile_size_bytes,               // The size of a buffer page
+        .data_format = DataFormat::Float16_b,       // The data format of the buffer
+    };
 
-    std::uint64_t dram_buffer_dst_noc_addr =
-        get_noc_addr_from_bank_id</*dram=*/true>(dram_buffer_dst_bank, dram_buffer_dst_addr);
-    // Write data from L1 back into DRAM and wait
-    noc_async_write(l1_buffer_addr, dram_buffer_dst_noc_addr, dram_buffer_size);
-    noc_async_write_barrier();
+    const InterleavedAddrGenFast<true> out0 = {
+        .bank_base_address = dram_buffer_dst_addr,
+        .page_size = tile_size_bytes,
+        .data_format = DataFormat::Float16_b,
+    };
+
+    for (uin32_t i = 0; i < num_tiles; i++) {
+        // Issue a read to the NoC and write to the L1 buffer. This operation is asynchronous.
+        // thus a barrier is needed to ensure that the read is complete before the write.
+        noc_async_read_tile(i, in0, l1_buffer_addr);
+        noc_async_read_barrier();
+        // Write back the tile to the destination DRAM buffer.
+        // Again, this is an asynchronous operation, so we need a barrier to ensure the write
+        // is complete before the next iteration.
+        noc_async_write_tile(i, out0, l1_buffer_addr);
+        noc_async_write_barrier();
+    }
 }

--- a/tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp
+++ b/tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp
@@ -34,7 +34,7 @@ void kernel_main() {
         .data_format = DataFormat::Float16_b,
     };
 
-    for (uin32_t i = 0; i < num_tiles; i++) {
+    for (uint32_t i = 0; i < num_tiles; i++) {
         // Issue a read to the NoC and write to the L1 buffer. This operation is asynchronous.
         // thus a barrier is needed to ensure that the read is complete before the write.
         noc_async_read_tile(i, in0, l1_buffer_addr);

--- a/tt_metal/programming_examples/loopback/loopback.cpp
+++ b/tt_metal/programming_examples/loopback/loopback.cpp
@@ -57,35 +57,30 @@ int main() {
             core,
             DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-        // Data on Tensix is (usually) stored in tiles. A tile is a 2D array of 32x32 elements. And the Tensix uses
+        // Data on Tensix is stored in tiles. A tile is a 2D array of (usually) 32x32 values. And the Tensix uses
         // BFloat16 as the most well supported data type. Thus the tile size is 32x32x2 = 2048 bytes.
+        constexpr uint32_t num_tiles = 50;
         constexpr uint32_t elements_per_tile = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
         constexpr uint32_t tile_size_bytes = sizeof(bfloat16) * elements_per_tile;
-        constexpr uint32_t num_tiles = 50;
         constexpr uint32_t dram_buffer_size = tile_size_bytes * num_tiles;
 
         // Configuration for the buffers.
         tt::tt_metal::InterleavedBufferConfig dram_config{
-            .device = device,          // Device which owns the buffer
-            .size = dram_buffer_size,  // Size of the buffer in bytes
-            .page_size =
-                dram_buffer_size,  // Number of bytes when round-robin between banks. Usually this is the same as the
-                                   // tile size for efficiency. But just for demo, we show it can be different.
-            .buffer_type = tt::tt_metal::BufferType::DRAM};  // Type of buffer (DRAM or L1)
+            .device = device,              // Device which owns the buffer
+            .size = dram_buffer_size,      // Size of the buffer in bytes
+            .page_size = tile_size_bytes,  // Number of bytes when round-robin between banks. Usually this is the same
+                                           // as the tile size for efficiency.
+            .buffer_type = tt::tt_metal::BufferType::DRAM};  // Type of buffer (DRAM or L1(SRAM))
         tt::tt_metal::InterleavedBufferConfig l1_config{
             .device = device,
-            .size = dram_buffer_size,
-            .page_size = dram_buffer_size,
+            .size = tile_size_bytes,
+            .page_size = tile_size_bytes,
             .buffer_type = tt::tt_metal::BufferType::L1};  // This time we allocate on L1
 
         // Allocate the buffers
         auto l1_buffer = CreateBuffer(l1_config);
         auto input_dram_buffer = CreateBuffer(dram_config);
         auto output_dram_buffer = CreateBuffer(dram_config);
-
-        // Since all interleaved buffers have size == page_size, they are entirely contained in the first DRAM bank
-        const uint32_t input_bank_id = 0;
-        const uint32_t output_bank_id = 0;
 
         // Initialize the input buffer with random data.
         std::vector<bfloat16> input_vec(elements_per_tile * num_tiles);
@@ -104,12 +99,7 @@ int main() {
 
         // Set the arguments for the kernel.
         const std::vector<uint32_t> runtime_args = {
-            l1_buffer->address(),
-            input_dram_buffer->address(),
-            input_bank_id,
-            output_dram_buffer->address(),
-            output_bank_id,
-            l1_buffer->size()};
+            l1_buffer->address(), input_dram_buffer->address(), output_dram_buffer->address(), num_tiles};
 
         SetRuntimeArgs(program, dram_copy_kernel_id, core, runtime_args);
 


### PR DESCRIPTION
### Ticket
#21816
#24583

### Problem description

DRAM Loopback example is confusing for new comers. Our current example does manual calculation. But most kernels will be using Address Generator or Accessors. We should avoid manual calculation.

Plus the previous patch broke LightMetal

### What's changed


* Updated DRAM loopback example to use standard interleaved scheme. And use address generator in kernel.
* Fixed a typo in another documentation
* Updated tests that depends on the kernel (LightMetal subject to `rm -rf` but let's get stuff merged)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes