### PR TITLE
Updated tests for the single core upsample operation

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_upsample.py
@@ -66,27 +66,31 @@ def get_shard_grid_from_num_cores(device, ncores: Union[int, Tuple[int, int]]) -
         [2, 1280, 8, 8],  # 512x512
         [2, 1280, 16, 16],
         [2, 1280, 16, 16],
+        [1, 256, 28, 28],
+        [1, 512, 14, 14],
     ],
 )
 @pytest.mark.parametrize("scale_h", [2])
 @pytest.mark.parametrize("scale_w", [2])
-def test_upsample_single_core(device, input_shapes, scale_h, scale_w):
+@pytest.mark.parametrize("mode", ["nearest", "bilinear"])
+def test_upsample_single_core(device, input_shapes, mode, scale_h, scale_w):
     batch_size, height, width, num_channels = input_shapes
+    if mode == "bilinear":
+        pytest.skip("Disabled until single core bilinear mode is supported (#18399)")
 
     torch.manual_seed(0)
     input = torch.rand(input_shapes, dtype=torch.bfloat16)
-    tt_input = input.permute(0, 3, 1, 2)
+    tt_input = input.permute(0, 2, 3, 1)
 
     scale_factor = (scale_h, scale_w)
-    m = nn.Upsample(scale_factor=scale_factor, mode="nearest")
-    torch_result = m(tt_input)
-    torch_result = torch_result.permute(0, 2, 3, 1)
+    m = nn.Upsample(scale_factor=scale_factor, mode=mode)
+    torch_result = m(input)
 
-    ## ttnn uses NHWC, so need to set scale_factor_c = 1
     scale_factor = (scale_h, scale_w)
-    input_tensor = ttnn.from_torch(input, device=device)
-    output_tensor = ttnn.upsample(input_tensor, scale_factor)
+    input_tensor = ttnn.from_torch(tt_input, device=device)
+    output_tensor = ttnn.upsample(input_tensor, scale_factor, mode=mode)
     output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = output_tensor.permute(0, 3, 1, 2)
 
     assert_with_pcc(torch_result, output_tensor)
 

--- a/tests/ttnn/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_upsample.py
@@ -83,8 +83,8 @@ def test_upsample_single_core(device, input_shapes, mode, scale_h, scale_w):
     tt_input = input.permute(0, 2, 3, 1)
 
     scale_factor = (scale_h, scale_w)
-    m = nn.Upsample(scale_factor=scale_factor, mode=mode)
-    torch_result = m(input)
+    torch_upsample = nn.Upsample(scale_factor=scale_factor, mode=mode)
+    torch_result = torch_upsample(input)
 
     scale_factor = (scale_h, scale_w)
     input_tensor = ttnn.from_torch(tt_input, device=device)

--- a/tests/ttnn/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_upsample.py
@@ -338,6 +338,8 @@ def test_upsample_multicore_corerange(
         (1, 72, 8, 8, 2, 2),
         (1, 288, 8, 8, 2, 2),
         (1, 1024, 8, 8, 2, 2),
+        (1, 256, 28, 28, 2, 2),
+        (1, 512, 14, 14, 2, 2),
     ),
 )
 @pytest.mark.parametrize("shard_strategy", [ttnn.ShardStrategy.HEIGHT])


### PR DESCRIPTION
### Problem description

There were unnecessary permutations of the input tensor, causing the upsampling to be done on C and H dimensions, instead of H and W. 

### What's changed

Removed the permutations before passing the input to torch as the input tensor was given in the torch prefered NCHW format. Also added parametrization for bilinear mode upsampling for when (#18399) is resolved.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16110583496)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16110594975)