### PR TITLE
[skip ci] Demote some info messages

### DIFF
--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -485,7 +485,7 @@ void MeshDevice::reshape(const MeshShape& new_shape) {
 
 bool MeshDevice::close() {
     ZoneScoped;
-    log_info(tt::LogMetal, "Closing mesh device {}", this->id());
+    log_trace(tt::LogMetal, "Closing mesh device {}", this->id());
 
     // We only dump profile results for mesh devices that don't have any submeshes as they have active mesh command
     // queues, whereas mesh devices with submeshes don't.

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -425,7 +425,11 @@ bool Device::initialize(
     ZoneScoped;
     // Every initialization call should enable program cache
     this->program_cache_.enable();
-    log_info(tt::LogMetal, "Initializing device {}. Program cache is {}enabled", this->id_, this->program_cache_.is_enabled() ? "": "NOT ");
+    log_debug(
+        tt::LogMetal,
+        "Initializing device {}. Program cache is {}enabled",
+        this->id_,
+        this->program_cache_.is_enabled() ? "" : "NOT ");
     log_debug(tt::LogMetal, "Running with {} cqs ", num_hw_cqs);
     TT_FATAL(num_hw_cqs > 0 and num_hw_cqs <= dispatch_core_manager::MAX_NUM_HW_CQS, "num_hw_cqs can be between 1 and {}", dispatch_core_manager::MAX_NUM_HW_CQS);
     this->using_fast_dispatch_ = false;
@@ -465,7 +469,7 @@ bool Device::initialize(
 }
 
 bool Device::close() {
-    log_info(tt::LogMetal, "Closing device {}", this->id_);
+    log_trace(tt::LogMetal, "Closing device {}", this->id_);
     if (not this->initialized_) {
         TT_THROW("Cannot close device {} that has not been initialized!", this->id_);
     }
@@ -780,7 +784,7 @@ void Device::clear_program_cache() {
 }
 
 void Device::disable_and_clear_program_cache() {
-    log_info(tt::LogMetal, "Disabling and clearing program cache on device {}", this->id_);
+    log_trace(tt::LogMetal, "Disabling and clearing program cache on device {}", this->id_);
     if (this->program_cache_.is_enabled()) {
         program_cache_.disable();
     }


### PR DESCRIPTION
### Ticket
NA

### Problem description
These messages are about tracing program execution, or debugging. They are not info messages where clients should be notified. Every test shows these spam messages.

```
2025-07-07 08:57:37.373 | info     |           Metal | Closing mesh device 149 (mesh_device.cpp:488)
2025-07-07 08:57:37.373 | info     |           Metal | Closing mesh device 148 (mesh_device.cpp:488)
2025-07-07 08:57:37.373 | info     |           Metal | Closing device 0 (device.cpp:468)
2025-07-07 08:57:37.373 | info     |           Metal | Disabling and clearing program cache on device 0 (device.cpp:783)
2025-07-07 08:57:37.374 | info     |           Metal | Closing mesh device 149 (mesh_device.cpp:488)
[       OK ] EmptyTensorTestWithShape/EmptyTensorTest.Combinations/60 (14 ms)
[ RUN      ] EmptyTensorTestWithShape/EmptyTensorTest.Combinations/61
2025-07-07 08:57:37.374 | info     |   SiliconDriver | Opened PCI device 0; KMD version: 2.0.0; API: 2; IOMMU: disabled (pci_device.cpp:198)
2025-07-07 08:57:37.375 | info     |   SiliconDriver | Opened PCI device 0; KMD version: 2.0.0; API: 2; IOMMU: disabled (pci_device.cpp:198)
2025-07-07 08:57:37.386 | info     |           Metal | Initializing device 0. Program cache is enabled (device.cpp:428)
2025-07-07 08:57:37.388 | info     |            Test | Running test with shape=Shape([1, 2]), dtype=DataType::BFLOAT8_B, layout=Layout::TILE, memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0) (test_create_tensor.cpp:126)
2025-07-07 08:57:37.388 | info     |           Metal | Closing mesh device 151 (mesh_device.cpp:488)
2025-07-07 08:57:37.388 | info     |           Metal | Closing mesh device 150 (mesh_device.cpp:488)
2025-07-07 08:57:37.388 | info     |           Metal | Closing device 0 (device.cpp:468)
2025-07-07 08:57:37.388 | info     |           Metal | Disabling and clearing program cache on device 0 (device.cpp:783)
2025-07-07 08:57:37.389 | info     |           Metal | Closing mesh device 151 (mesh_device.cpp:488)
```

### What's changed
Demote info messages to either debug or trace

### Checklist
- Running no checks, as this is trivial change.