### PR TITLE
#23287: Disallow "reshaping" of distributed host buffer

### DIFF
--- a/ttnn/api/ttnn/distributed/api.hpp
+++ b/ttnn/api/ttnn/distributed/api.hpp
@@ -27,12 +27,6 @@ void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device);
 // Given a multi-device tensor, returns a list of individual per-device tensors.
 std::vector<Tensor> get_device_tensors(const Tensor& tensor);
 
-// Given a list of per-device shards, returns multi-device tensor.
-// Deprecated: to combine on-device shards, prefer `combine_device_tensors`. For on-host shards, use
-// `from_host_shards` instead.
-[[deprecated("Use from_host_shards / combine_device_tensors instead")]] Tensor aggregate_as_tensor(
-    const std::vector<Tensor>& tensor_shards, const tt::tt_metal::DistributedTensorConfig& config);
-
 // Given a list of host shards, returns a multi-device tensor.
 // Tensor specs (including shapes) must match for all shards, and the number of shards must match the mesh size.
 Tensor from_host_shards(const std::vector<Tensor>& tensor_shards, const MeshShape& mesh_shape);

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -50,11 +50,6 @@ struct DeviceStorage {
 
 class MultiDeviceHostStorage {
 public:
-    // Constructor that creates a linearized distributed host buffer from a vector of host buffers.
-    // The buffer is re-shaped upon a write to device, to fit the actual shape of the device.
-    // TODO: #24115 - Remove this once there are no more usages of this constructor.
-    explicit MultiDeviceHostStorage(std::vector<HostBuffer> buffers);
-
     explicit MultiDeviceHostStorage(DistributedHostBuffer buffer);
 
     const DistributedHostBuffer& distributed_buffer() const;

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -22,35 +22,6 @@
 using namespace tt::tt_metal;
 
 namespace ttnn::distributed {
-namespace {
-
-// Shared implementation for `combine_device_tensors` and `aggregate_as_tensor`.
-// TODO: #23287 - This won't be necessary, once `aggregate_as_tensor` API is removed.
-Tensor combine_device_tensors_impl(const std::vector<Tensor>& tensor_shards, const Tensor& reference_shard) {
-    auto mesh_buffer = std::get<DeviceStorage>(reference_shard.storage()).mesh_buffer;
-    TT_FATAL(
-        mesh_buffer != nullptr,
-        "Error aggregating multichip tensors: tensors shards must be allocated on a mesh buffer.");
-    std::vector<MeshCoordinate> coords;
-    for (const auto& shard : tensor_shards) {
-        const auto& shard_storage = std::get<DeviceStorage>(shard.storage());
-        TT_FATAL(
-            shard_storage.mesh_buffer == mesh_buffer,
-            "Error aggregating multichip tensors: tensor shards must be allocated on the same mesh buffer. "
-            "Consider moving tensors to host, aggregating, and re-uploading on device storage.");
-        for (const auto& coord : shard_storage.coords) {
-            coords.push_back(coord);
-        }
-    }
-    std::sort(coords.begin(), coords.end());
-    auto duplicate =
-        std::adjacent_find(coords.begin(), coords.end(), [](const auto& a, const auto& b) { return a == b; });
-    TT_FATAL(duplicate == coords.end(), "Found a tensor shard at duplicate coordinate {}", *duplicate);
-    return Tensor(
-        DeviceStorage(std::move(mesh_buffer), std::move(coords)), reference_shard.tensor_spec(), AllGatherTensor{});
-}
-
-}  // namespace
 
 std::shared_ptr<MeshDevice> open_mesh_device(
     const MeshShape& mesh_shape,
@@ -99,40 +70,6 @@ std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
     }
 }
 
-Tensor aggregate_as_tensor(
-    const std::vector<Tensor>& tensor_shards, const tt::tt_metal::DistributedTensorConfig& config) {
-    TT_ASSERT(tensor_shards.size() > 0, "At least one tensor shard must be provided");
-    const auto& reference_shard = tensor_shards.at(0);
-    for (const auto& shard : tensor_shards) {
-        TT_FATAL(
-            shard.storage_type() == reference_shard.storage_type(),
-            "All tensor shards must have the same storage type");
-        TT_FATAL(
-            shard.tensor_spec() == reference_shard.tensor_spec(), "All tensor shards must have the same tensor spec");
-    }
-
-    // Based whether the first tensor shard has Host or Device buffer,
-    // we want to use MultiDeviceHostStorage or MultiDeviceStorage
-    StorageType storage_type = reference_shard.storage_type();
-    if (storage_type == StorageType::HOST) {
-        std::vector<HostBuffer> buffers;
-        for (const auto& shard : tensor_shards) {
-            buffers.push_back(std::get<HostStorage>(shard.get_storage()).buffer);
-            TT_FATAL(
-                shard.get_tensor_spec() == reference_shard.get_tensor_spec(),
-                "Error aggregating multichip tensors: Attempting to aggregate tensors with different tensor specs.");
-        }
-        auto storage = MultiDeviceHostStorage{std::move(buffers)};
-        return Tensor(std::move(storage), reference_shard.get_tensor_spec(), config);
-    } else if (storage_type == StorageType::DEVICE) {
-        return combine_device_tensors_impl(tensor_shards, reference_shard);
-    } else {
-        TT_THROW(
-            "Unsupported storage type for multi-device tensor: {}",
-            tt::stl::get_active_type_name_in_variant(reference_shard.storage()));
-    }
-}
-
 Tensor from_host_shards(const std::vector<Tensor>& tensor_shards, const MeshShape& mesh_shape) {
     TT_FATAL(tensor_shards.size() == mesh_shape.mesh_size(), "Number of tensor shards must match mesh size");
     const auto& reference_shard = tensor_shards.at(0);
@@ -165,7 +102,27 @@ Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards) {
             "All tensor shards must have the same tensor spec");
     }
 
-    return combine_device_tensors_impl(tensor_shards, reference_shard);
+    auto mesh_buffer = std::get<DeviceStorage>(reference_shard.storage()).mesh_buffer;
+    TT_FATAL(
+        mesh_buffer != nullptr,
+        "Error aggregating multichip tensors: tensors shards must be allocated on a mesh buffer.");
+    std::vector<MeshCoordinate> coords;
+    for (const auto& shard : tensor_shards) {
+        const auto& shard_storage = std::get<DeviceStorage>(shard.storage());
+        TT_FATAL(
+            shard_storage.mesh_buffer == mesh_buffer,
+            "Error aggregating multichip tensors: tensor shards must be allocated on the same mesh buffer. "
+            "Consider moving tensors to host, aggregating, and re-uploading on device storage.");
+        for (const auto& coord : shard_storage.coords) {
+            coords.push_back(coord);
+        }
+    }
+    std::sort(coords.begin(), coords.end());
+    auto duplicate =
+        std::adjacent_find(coords.begin(), coords.end(), [](const auto& a, const auto& b) { return a == b; });
+    TT_FATAL(duplicate == coords.end(), "Found a tensor shard at duplicate coordinate {}", *duplicate);
+    return Tensor(
+        DeviceStorage(std::move(mesh_buffer), std::move(coords)), reference_shard.tensor_spec(), AllGatherTensor{});
 }
 
 std::vector<int> get_t3k_physical_device_ids_ring() {

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -54,13 +54,6 @@ bool DeviceStorage::is_uniform_storage() const {
 
 const DistributedHostBuffer& MultiDeviceHostStorage::distributed_buffer() const { return distributed_buffer_; }
 
-MultiDeviceHostStorage::MultiDeviceHostStorage(std::vector<HostBuffer> buffers) :
-    distributed_buffer_(DistributedHostBuffer::create(tt::tt_metal::distributed::MeshShape(buffers.size()))) {
-    for (size_t i = 0; i < buffers.size(); ++i) {
-        distributed_buffer_.emplace_shard(
-            tt::tt_metal::distributed::MeshCoordinate(i), [&buffers, i]() { return std::move(buffers[i]); });
-    }
-}
 MultiDeviceHostStorage::MultiDeviceHostStorage(DistributedHostBuffer buffer) : distributed_buffer_(std::move(buffer)) {}
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
#23287

### Problem description
Due to legacy code, we had a workaround of creating a distributed host buffer with no shape, which will be inferred upon writing to device.

This is no longer needed, as the legacy code (`aggregate_as_tensor`, and old serialization) were dealt with.

### What's changed
Remove workaround.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16120827968)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/16120837008)
- [x] New/Existing tests provide coverage for changes