### PR TITLE
Add support for larger head_dim in paged_update_cache

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_paged_update_cache.py
+++ b/tests/ttnn/unit_tests/operations/test_paged_update_cache.py
@@ -473,7 +473,7 @@ def run_test_paged_update_cache_decode(
 
 @skip_for_grayskull("Grayskull does not support paged cache")
 @pytest.mark.parametrize("block_size", [64, 128], ids=["block64", "block128"])
-@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("head_dim", [128, 512])
 @pytest.mark.parametrize("max_seq_len", [2048])
 @pytest.mark.parametrize("num_users", [32])
 @pytest.mark.parametrize("num_heads", [1, 8])

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/update_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/update_cache.cpp
@@ -7,9 +7,22 @@
 #include "compute_kernel_api/common.h"
 #include "compute_kernel_api/pack_untilize.h"
 #include "compute_kernel_api/tilize.h"
-#include "compute_kernel_api/untilize.h"
 
 namespace NAMESPACE {
+
+// Helper constexpr function to compute num_blocks_per_col
+constexpr uint32_t compute_num_blocks_per_col(uint32_t per_core_block_tile_cnt) {
+    const uint32_t max_bct = DST_ACCUM_MODE ? 4 : 8;
+
+    for (uint32_t bct = max_bct; bct >= 1; --bct) {
+        if (per_core_block_tile_cnt % bct == 0) {
+            return per_core_block_tile_cnt / bct;
+        }
+    }
+
+    return 1;
+}
+
 void MAIN {
     constexpr uint32_t cache_cb = get_compile_time_arg_val(0);
     constexpr uint32_t in_cb = get_compile_time_arg_val(1);
@@ -20,54 +33,37 @@ void MAIN {
     constexpr uint32_t Wt = get_compile_time_arg_val(6);
     constexpr uint32_t num_heads = get_compile_time_arg_val(7);
 
-    constexpr uint32_t MAX_PACK_UNTILIZE_WIDTH = 8;
-    constexpr bool use_pack_untilize = Wt <= MAX_PACK_UNTILIZE_WIDTH;
+    constexpr uint32_t num_blocks_per_col = compute_num_blocks_per_col(Wt);
+    constexpr uint32_t block_ct_dim = Wt / num_blocks_per_col;
+    constexpr uint32_t full_ct_dim = Wt;
 
-    if constexpr (use_pack_untilize) {
-        pack_untilize_init<Wt>(in_cb, untilized_in_cb);
-    } else {
-        untilize_init(in_cb, untilized_in_cb);
-    }
+    pack_untilize_init<block_ct_dim, full_ct_dim>(in_cb, untilized_in_cb);
 
-    cb_wait_front(in_cb, Wt);
     cb_reserve_back(untilized_in_cb, Wt);
-
-    if constexpr (use_pack_untilize) {
-        pack_untilize_block<Wt>(in_cb, 1, untilized_in_cb);
-    } else {
-        untilize_block(in_cb, Wt, untilized_in_cb);
+    for (uint32_t b = 0; b < num_blocks_per_col; ++b) {
+        cb_wait_front(in_cb, block_ct_dim);
+        pack_untilize_block<block_ct_dim, full_ct_dim>(in_cb, 1, untilized_in_cb, b);
+        cb_pop_front(in_cb, block_ct_dim);
     }
-
     cb_push_back(untilized_in_cb, Wt);
-    cb_pop_front(in_cb, Wt);
 
     reconfig_data_format_srca(in_cb, cache_cb);
     pack_reconfig_data_format(untilized_in_cb, untilized_cache_cb);
     for (uint32_t cur_head = 0; cur_head < num_heads; ++cur_head) {
-        if constexpr (use_pack_untilize) {
-            pack_untilize_init_short<Wt>(cache_cb, untilized_cache_cb);
-        } else {
-            untilize_init_short(cache_cb);
-        }
+        pack_untilize_init_short<block_ct_dim, full_ct_dim>(cache_cb, untilized_cache_cb);
 
         // Untilize a block from the cache
-        cb_wait_front(cache_cb, Wt);
         cb_reserve_back(untilized_cache_cb, Wt);
 
-        if constexpr (use_pack_untilize) {
-            pack_untilize_block<Wt>(cache_cb, 1, untilized_cache_cb);
-        } else {
-            untilize_block(cache_cb, Wt, untilized_cache_cb);
+        for (uint32_t b = 0; b < num_blocks_per_col; ++b) {
+            cb_wait_front(cache_cb, block_ct_dim);
+            pack_untilize_block<block_ct_dim, full_ct_dim>(cache_cb, 1, untilized_cache_cb, b);
+            cb_pop_front(cache_cb, block_ct_dim);
         }
 
         cb_push_back(untilized_cache_cb, Wt);
-        cb_pop_front(cache_cb, Wt);
 
-        if constexpr (use_pack_untilize) {
-            pack_untilize_uninit(untilized_cache_cb);
-        } else {
-            untilize_uninit(untilized_cache_cb);
-        }
+        pack_untilize_uninit(untilized_cache_cb);
 
         reconfig_data_format_srca(cache_cb, untilized_cache2_cb);
         pack_reconfig_data_format(untilized_cache_cb, out_cb);


### PR DESCRIPTION
### Ticket
- #23022
- #11573

### Problem description
For larger head_dims (>dst size), `paged_update_cache` gives bad PCC.

### What's changed
- For block size > dst size, use `untilize_block` instead of `pack_untilize_block`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16122308783) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16122325543) CI with