### PR TITLE
Fix yolov6l CI failure

### DIFF
--- a/models/experimental/yolov6l/tt/model_preprocessing.py
+++ b/models/experimental/yolov6l/tt/model_preprocessing.py
@@ -2,11 +2,17 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import sys
+
 import torch
 import torch.nn as nn
 import ttnn
+from models.experimental.yolov6l.reference.yolov6l_utils import fuse_model
 from ttnn.model_preprocessing import preprocess_model_parameters, infer_ttnn_module_args
 from models.experimental.yolov6l.reference.yolov6l import Model
+
+sys.path.append("models/experimental/yolov6l/reference/")
 
 
 def generate_anchors(
@@ -165,3 +171,14 @@ def create_yolov6l_model_parameters_sppf(model: Model, torch_input: torch.Tensor
     )
     parameters["model_args"] = model
     return parameters
+
+
+def load_torch_model_yolov6l():
+    weights = "tests/ttnn/integration_tests/yolov6l/yolov6l.pt"
+    if not os.path.exists(weights):
+        os.system("bash models/experimental/yolov6l/weights_download.sh")
+
+    ckpt = torch.load(weights, map_location=torch.device("cpu"), weights_only=False)
+    model = ckpt["ema" if ckpt.get("ema") else "model"].float()
+    model = fuse_model(model).eval()
+    return model

--- a/tests/ttnn/integration_tests/yolov6l/test_bep_c3.py
+++ b/tests/ttnn/integration_tests/yolov6l/test_bep_c3.py
@@ -2,26 +2,19 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
-import ttnn
 import pytest
-import sys
-from models.experimental.yolov6l.reference.yolov6l_utils import fuse_model
-from models.experimental.yolov6l.reference.yolov6l import BepC3
-from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters
+
+import torch
+
+import ttnn
+from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters, load_torch_model_yolov6l
 from models.experimental.yolov6l.tt.ttnn_bepc3 import TtBepC3
 from tests.ttnn.utils_for_testing import assert_with_pcc
-
-sys.path.append("models/experimental/yolov6l/reference/")
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_yolov6l_bepc3(device, reset_seeds):
-    weights = "tests/ttnn/integration_tests/yolov6l/yolov6l.pt"
-    ckpt = torch.load(weights, map_location=torch.device("cpu"), weights_only=False)
-    model = ckpt["ema" if ckpt.get("ema") else "model"].float()
-    model = fuse_model(model).eval()
-    stride = int(model.stride.max())
+    model = load_torch_model_yolov6l()
 
     model = model.backbone.ERBlock_3[1]
 

--- a/tests/ttnn/integration_tests/yolov6l/test_bifusion.py
+++ b/tests/ttnn/integration_tests/yolov6l/test_bifusion.py
@@ -2,26 +2,19 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
-import ttnn
 import pytest
-import sys
-from models.experimental.yolov6l.reference.yolov6l_utils import fuse_model
-from models.experimental.yolov6l.reference.yolov6l import BiFusion
-from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters
+
+import torch
+
+import ttnn
+from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters, load_torch_model_yolov6l
 from models.experimental.yolov6l.tt.ttnn_bifusion import TtBiFusion
 from tests.ttnn.utils_for_testing import assert_with_pcc
-
-sys.path.append("models/experimental/yolov6l/reference/")
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_yolov6l_bifusion(device, reset_seeds):
-    weights = "tests/ttnn/integration_tests/yolov6l/yolov6l.pt"
-    ckpt = torch.load(weights, map_location=torch.device("cpu"), weights_only=False)
-    model = ckpt["ema" if ckpt.get("ema") else "model"].float()
-    model = fuse_model(model).eval()
-    stride = int(model.stride.max())
+    model = load_torch_model_yolov6l()
 
     model = model.neck.Bifusion0
 

--- a/tests/ttnn/integration_tests/yolov6l/test_bottlerep.py
+++ b/tests/ttnn/integration_tests/yolov6l/test_bottlerep.py
@@ -2,26 +2,19 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
-import ttnn
 import pytest
-import sys
-from models.experimental.yolov6l.reference.yolov6l_utils import fuse_model
-from models.experimental.yolov6l.reference.yolov6l import BottleRep
-from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters
+
+import torch
+
+import ttnn
+from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters, load_torch_model_yolov6l
 from models.experimental.yolov6l.tt.ttnn_bottlerep import TtBottleRep
 from tests.ttnn.utils_for_testing import assert_with_pcc
-
-sys.path.append("models/experimental/yolov6l/reference/")
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_yolov6l_bottlerep(device, reset_seeds):
-    weights = "tests/ttnn/integration_tests/yolov6l/yolov6l.pt"
-    ckpt = torch.load(weights, map_location=torch.device("cpu"), weights_only=False)
-    model = ckpt["ema" if ckpt.get("ema") else "model"].float()
-    model = fuse_model(model).eval()
-    stride = int(model.stride.max())
+    model = load_torch_model_yolov6l()
 
     model = model.backbone.ERBlock_2[1].m.conv1
 

--- a/tests/ttnn/integration_tests/yolov6l/test_cspbep_backbone.py
+++ b/tests/ttnn/integration_tests/yolov6l/test_cspbep_backbone.py
@@ -2,26 +2,19 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
-import ttnn
 import pytest
-import sys
-from models.experimental.yolov6l.reference.yolov6l_utils import fuse_model
-from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters
+
+import torch
+
+import ttnn
+from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters, load_torch_model_yolov6l
 from models.experimental.yolov6l.tt.ttnn_cspbep_backbone import TtCSPBepBackbone
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import comp_pcc
-
-sys.path.append("models/experimental/yolov6l/reference/")
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_yolov6l_cspbep_backbone(device, reset_seeds):
-    weights = "tests/ttnn/integration_tests/yolov6l/yolov6l.pt"
-    ckpt = torch.load(weights, map_location=torch.device("cpu"), weights_only=False)
-    model = ckpt["ema" if ckpt.get("ema") else "model"].float()
-    model = fuse_model(model).eval()
-    stride = int(model.stride.max())
+    model = load_torch_model_yolov6l()
 
     model = model.backbone
 

--- a/tests/ttnn/integration_tests/yolov6l/test_csprep_bifpanneck.py
+++ b/tests/ttnn/integration_tests/yolov6l/test_csprep_bifpanneck.py
@@ -2,26 +2,19 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
-import ttnn
 import pytest
-import sys
-from models.experimental.yolov6l.reference.yolov6l_utils import fuse_model
-from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters
+
+import torch
+
+import ttnn
+from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters, load_torch_model_yolov6l
 from models.experimental.yolov6l.tt.ttnn_csprep_bifpanneck import TtCSPRepBiFPANNeck
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import comp_pcc
-
-sys.path.append("models/experimental/yolov6l/reference/")
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_yolov6l_csprep_bifpanneck(device, reset_seeds):
-    weights = "tests/ttnn/integration_tests/yolov6l/yolov6l.pt"
-    ckpt = torch.load(weights, map_location=torch.device("cpu"), weights_only=False)
-    model = ckpt["ema" if ckpt.get("ema") else "model"].float()
-    model = fuse_model(model).eval()
-    stride = int(model.stride.max())
+    model = load_torch_model_yolov6l()
 
     model = model.neck
 

--- a/tests/ttnn/integration_tests/yolov6l/test_detect.py
+++ b/tests/ttnn/integration_tests/yolov6l/test_detect.py
@@ -2,26 +2,22 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
-import ttnn
 import pytest
-import sys
-from models.experimental.yolov6l.reference.yolov6l_utils import fuse_model
-from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters_detect
+
+import torch
+
+import ttnn
+from models.experimental.yolov6l.tt.model_preprocessing import (
+    create_yolov6l_model_parameters_detect,
+    load_torch_model_yolov6l,
+)
 from models.experimental.yolov6l.tt.ttnn_detect import TtDetect
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import comp_pcc
-
-sys.path.append("models/experimental/yolov6l/reference/")
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_detect(device, reset_seeds):
-    weights = "tests/ttnn/integration_tests/yolov6l/yolov6l.pt"
-    ckpt = torch.load(weights, map_location=torch.device("cpu"), weights_only=False)
-    model = ckpt["ema" if ckpt.get("ema") else "model"].float()
-    model = fuse_model(model).eval()
-    stride = int(model.stride.max())
+    model = load_torch_model_yolov6l()
 
     model = model.detect
 

--- a/tests/ttnn/integration_tests/yolov6l/test_repblock.py
+++ b/tests/ttnn/integration_tests/yolov6l/test_repblock.py
@@ -2,26 +2,19 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
-import ttnn
 import pytest
-import sys
-from models.experimental.yolov6l.reference.yolov6l_utils import fuse_model
-from models.experimental.yolov6l.reference.yolov6l import RepBlock
-from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters
+
+import torch
+
+import ttnn
+from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters, load_torch_model_yolov6l
 from models.experimental.yolov6l.tt.ttnn_repblock import TtRepBlock
 from tests.ttnn.utils_for_testing import assert_with_pcc
-
-sys.path.append("models/experimental/yolov6l/reference/")
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_yolov6l_repblock(device, reset_seeds):
-    weights = "tests/ttnn/integration_tests/yolov6l/yolov6l.pt"
-    ckpt = torch.load(weights, map_location=torch.device("cpu"), weights_only=False)
-    model = ckpt["ema" if ckpt.get("ema") else "model"].float()
-    model = fuse_model(model).eval()
-    stride = int(model.stride.max())
+    model = load_torch_model_yolov6l()
 
     model = model.backbone.ERBlock_2[1].m
 

--- a/tests/ttnn/integration_tests/yolov6l/test_sppf.py
+++ b/tests/ttnn/integration_tests/yolov6l/test_sppf.py
@@ -2,26 +2,19 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
-import ttnn
 import pytest
-import sys
-from models.experimental.yolov6l.reference.yolov6l_utils import fuse_model
-from models.experimental.yolov6l.reference.yolov6l import SPPFModule
-from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters
+
+import torch
+
+import ttnn
+from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters, load_torch_model_yolov6l
 from models.experimental.yolov6l.tt.ttnn_sppf import TtSppf
 from tests.ttnn.utils_for_testing import assert_with_pcc
-
-sys.path.append("models/experimental/yolov6l/reference/")
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_yolov6l_sppf(device, reset_seeds):
-    weights = "tests/ttnn/integration_tests/yolov6l/yolov6l.pt"
-    ckpt = torch.load(weights, map_location=torch.device("cpu"), weights_only=False)
-    model = ckpt["ema" if ckpt.get("ema") else "model"].float()
-    model = fuse_model(model).eval()
-    stride = int(model.stride.max())
+    model = load_torch_model_yolov6l()
 
     model = model.backbone.ERBlock_5[2].sppf
 

--- a/tests/ttnn/integration_tests/yolov6l/test_ttnn_yolov6l.py
+++ b/tests/ttnn/integration_tests/yolov6l/test_ttnn_yolov6l.py
@@ -2,31 +2,19 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
-import ttnn
 import pytest
-import os
-from models.experimental.yolov6l.reference.yolov6l_utils import fuse_model
-from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters
+
+import torch
+
+import ttnn
+from models.experimental.yolov6l.tt.model_preprocessing import create_yolov6l_model_parameters, load_torch_model_yolov6l
 from models.experimental.yolov6l.tt.ttnn_yolov6l import TtYolov6l
-
-
-import sys
 from tests.ttnn.utils_for_testing import assert_with_pcc
-
-sys.path.append("models/experimental/yolov6l/reference/")
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_yolov6l(device, reset_seeds):
-    weights = "tests/ttnn/integration_tests/yolov6l/yolov6l.pt"
-    if not os.path.exists(weights):
-        os.system("bash models/experimental/yolov6l/weights_download.sh")
-
-    ckpt = torch.load(weights, map_location=torch.device("cpu"), weights_only=False)
-    model = ckpt["ema" if ckpt.get("ema") else "model"].float()
-    model = fuse_model(model).eval()
-    stride = int(model.stride.max())
+    model = load_torch_model_yolov6l()
 
     torch_input = torch.randn(1, 3, 640, 480)
 


### PR DESCRIPTION
### Problem description
(Single-card) Frequent model and ttnn tests  CI test is failing due to Yolov6l model, https://github.com/tenstorrent/tt-metal/actions/runs/16047427538/job/45295642873#step:8:5137.

### What's changed
Fixed the issues on yolov6l.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes