### PR TITLE
Enabling APC PF tests for BH.

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_prefetcher.py
+++ b/tests/ttnn/unit_tests/operations/test_prefetcher.py
@@ -11,7 +11,6 @@ from models.utility_functions import is_wormhole_b0, is_blackhole, skip_for_blac
 from tests.ttnn.unit_tests.operations.prefetcher_common import run_prefetcher_mm
 
 
-@skip_for_blackhole("Hangs on Blackhole. Issue #21304")
 @pytest.mark.parametrize(
     "num_reader_cores, num_tensors, input_shapes, dtypes, num_layers",
     [


### PR DESCRIPTION
### Ticket
- #21304

### Problem description
Prefetcher test used to hang on BH.

### What's changed
Hang seems to be resolved on latest main (possibly due to #23618), so re-enabling tests.

### Checklist
- [x] [BH Nightly Passes](https://github.com/tenstorrent/tt-metal/actions/runs/16123471372/) CI passes