### PR TITLE
Add simple `tt-run` MPI launcher for distributed applications

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ Documentation = "https://docs.tenstorrent.com/tt-metal/latest/ttnn"
 Repository = "https://github.com/tenstorrent/tt-metal"
 Issues = "https://github.com/tenstorrent/tt-metal/issues"
 
+[project.scripts]
+tt-run = "ttnn.distributed.ttrun:main"
+
 [tool.black]
 line-length = 120
 include = '^.*(ttnn|tests/scripts|tests/ttnn|tests/tt_eager/python_api_testing|tt_eager/tt_lib|tests/scripts|models/demos|infra|.github)/.*\.py$'

--- a/tests/tt_metal/distributed/config/2x4_multihost_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/2x4_multihost_rank_bindings.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Multihost mesh rank binding configuration for testing
+# Basic configuration with 2 hosts on a single mesh
+
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    host_rank_id: 0
+
+  - rank: 1
+    mesh_id: 0
+    host_rank_id: 1
+
+mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.yaml"

--- a/tests/tt_metal/distributed/config/2x4_multihost_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/2x4_multihost_rank_bindings.yaml
@@ -1,9 +1,3 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-# Multihost mesh rank binding configuration for testing
-# Basic configuration with 2 hosts on a single mesh
-
 rank_bindings:
   - rank: 0
     mesh_id: 0

--- a/tests/tt_metal/distributed/config/2x4_multihost_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/2x4_multihost_rank_bindings.yaml
@@ -1,10 +1,8 @@
 rank_bindings:
   - rank: 0
     mesh_id: 0
-    host_rank_id: 0
 
   - rank: 1
     mesh_id: 0
-    host_rank_id: 1
 
 mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.yaml"

--- a/tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Multihost mesh rank binding configuration for testing
+# Basic configuration with 2 processes on a single mesh
+
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    host_rank_id: 0
+    env_overrides:
+      TT_METAL_VISIBLE_DEVICES: "0,1"
+
+  - rank: 1
+    mesh_id: 0
+    host_rank_id: 1
+    env_overrides:
+      TT_METAL_VISIBLE_DEVICES: "2,3"
+
+mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.yaml"

--- a/tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml
@@ -1,9 +1,7 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Multihost mesh rank binding configuration for testing
-# Basic configuration with 2 processes on a single mesh
-
+# Basic configuration with 2 processes on a single loudbox
+# Rank 0: PCIe Devices {0,1}
+# Rank 1: PCIe Devices {2,3}
 rank_bindings:
   - rank: 0
     mesh_id: 0

--- a/tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml
@@ -5,13 +5,11 @@
 rank_bindings:
   - rank: 0
     mesh_id: 0
-    host_rank_id: 0
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "0,1"
 
   - rank: 1
     mesh_id: 0
-    host_rank_id: 1
     env_overrides:
       TT_METAL_VISIBLE_DEVICES: "2,3"
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -658,6 +658,7 @@ std::map<FabricNodeId, chip_id_t> ControlPlane::get_physical_chip_mapping_from_m
             logical_mesh_chip_id_to_physical_chip_id_mapping.insert({FabricNodeId(MeshId{0}, i), physical_chip_ids[i]});
         }
     } else if (mesh_graph_desc_filename == "t3k_dual_host_mesh_graph_descriptor.yaml") {
+        // TODO(#24230): This path will soon be deprecated once we generalize logical mesh_chip_id to physical chip_id mapping
         auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
         auto chip_eth_coords = cluster.get_user_chip_ethernet_coordinates();
         std::vector<eth_coord_t> eth_coords;
@@ -671,6 +672,8 @@ std::map<FabricNodeId, chip_id_t> ControlPlane::get_physical_chip_mapping_from_m
         auto host_rank_id = this->get_local_host_rank_id_binding();
         auto fabric_chip_ids = this->routing_table_generator_->mesh_graph->get_chip_ids(mesh_id, host_rank_id).values();
 
+        TT_FATAL(fabric_chip_ids.size() == eth_coords.size(),
+            "Number of fabric chip ids {} does not match number of eth coords {}", fabric_chip_ids.size(), eth_coords.size());
         for (std::uint32_t idx = 0; idx < fabric_chip_ids.size(); idx++) {
             auto fabric_chip_id = fabric_chip_ids.at(idx);
             auto eth_coord = eth_coords.at(idx);

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -662,6 +662,7 @@ std::map<FabricNodeId, chip_id_t> ControlPlane::get_physical_chip_mapping_from_m
         auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
         auto chip_eth_coords = cluster.get_user_chip_ethernet_coordinates();
         std::vector<eth_coord_t> eth_coords;
+        eth_coords.reserve(chip_eth_coords.size());
         for (const auto& [_, eth_coord] : chip_eth_coords) {
             eth_coords.push_back(eth_coord);
         }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -465,9 +465,10 @@ void MetalContext::initialize_control_plane() {
     const char* custom_mesh_graph_desc = std::getenv("TT_MESH_GRAPH_DESC_PATH");
     if (custom_mesh_graph_desc != nullptr) {
         std::filesystem::path mesh_graph_desc_path = std::filesystem::path(custom_mesh_graph_desc);
-        if (!std::filesystem::exists(mesh_graph_desc_path)) {
-            TT_THROW("Custom mesh graph descriptor file not found: {}", mesh_graph_desc_path.string());
-        }
+        TT_FATAL(
+            std::filesystem::exists(mesh_graph_desc_path),
+            "Custom mesh graph descriptor file not found: {}",
+            mesh_graph_desc_path.string());
 
         log_info(tt::LogDistributed, "Using custom mesh graph descriptor: {}", mesh_graph_desc_path.string());
         global_control_plane_ = std::make_unique<tt::tt_fabric::GlobalControlPlane>(

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -461,6 +461,20 @@ tt_metal::FabricConfig MetalContext::get_fabric_config() const {
 }
 
 void MetalContext::initialize_control_plane() {
+    // Check for environment variable override for custom mesh graph descriptor path
+    const char* custom_mesh_graph_desc = std::getenv("TT_MESH_GRAPH_DESC_PATH");
+    if (custom_mesh_graph_desc != nullptr) {
+        std::filesystem::path mesh_graph_desc_path = std::filesystem::path(custom_mesh_graph_desc);
+        if (!std::filesystem::exists(mesh_graph_desc_path)) {
+            TT_THROW("Custom mesh graph descriptor file not found: {}", mesh_graph_desc_path.string());
+        }
+
+        log_info(tt::LogDistributed, "Using custom mesh graph descriptor: {}", mesh_graph_desc_path.string());
+        global_control_plane_ = std::make_unique<tt::tt_fabric::GlobalControlPlane>(
+            mesh_graph_desc_path.string());
+        return;
+    }
+
     // Default mode, auto select mesh graph descriptor. In future, we can add a way for user to specify custom
     // descriptors
     std::string mesh_graph_descriptor;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -25,6 +25,7 @@
 
 namespace tt::tt_metal {
 
+namespace {
 // Helper function to validate worker_l1_size, also updates it if it's 0.
 void validate_worker_l1_size(size_t& worker_l1_size, Hal& hal) {
     if (worker_l1_size == 0) {
@@ -39,6 +40,14 @@ void validate_worker_l1_size(size_t& worker_l1_size, Hal& hal) {
         worker_l1_size,
         max_worker_l1_size);
 }
+
+// Check for environment variable override for custom mesh graph descriptor path
+const char* get_custom_mesh_graph_desc_path() {
+    const char* custom_mesh_graph_desc_path = std::getenv("TT_MESH_GRAPH_DESC_PATH");
+    return custom_mesh_graph_desc_path;
+}
+
+}  // namespace
 
 void MetalContext::reinitialize() {
     force_reinit_ = true;
@@ -461,10 +470,8 @@ tt_metal::FabricConfig MetalContext::get_fabric_config() const {
 }
 
 void MetalContext::initialize_control_plane() {
-    // Check for environment variable override for custom mesh graph descriptor path
-    const char* custom_mesh_graph_desc = std::getenv("TT_MESH_GRAPH_DESC_PATH");
-    if (custom_mesh_graph_desc != nullptr) {
-        std::filesystem::path mesh_graph_desc_path = std::filesystem::path(custom_mesh_graph_desc);
+    if (auto* custom_mesh_graph_desc_path = get_custom_mesh_graph_desc_path(); custom_mesh_graph_desc_path != nullptr) {
+        std::filesystem::path mesh_graph_desc_path = std::filesystem::path(custom_mesh_graph_desc_path);
         TT_FATAL(
             std::filesystem::exists(mesh_graph_desc_path),
             "Custom mesh graph descriptor file not found: {}",

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -190,7 +190,7 @@ def main(ctx: click.Context, rank_binding: Path, dry_run: bool, verbose: bool, m
     """tt-run - MPI process launcher for TT-Metal and TTNN distributed applications
 
     tt-run is a lightweight wrapper around `mpirun` that simplifies launching
-    TT-Metal and TTNN distributed applications by automatically mapping
+    TT-Metal and TT-NN distributed applications by automatically mapping
     MPI ranks to target MeshId and HostRankId as defined in the mesh graph descriptor.
 
     \b

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -128,7 +128,13 @@ def build_rank_environment_args(binding: RankBinding, config: TTRunConfig) -> Li
 
 def build_mpi_command(config: TTRunConfig, program: List[str], mpi_args: Optional[List[str]] = None) -> List[str]:
     """Build OpenMPI command with per-rank environment variables."""
-    cmd = ["mpirun"]
+    # Find mpirun-ulfm executable, fall back to mpirun if not found
+    mpi_launcher = shutil.which("mpirun-ulfm")
+    if not mpi_launcher:
+        logger.warning(f"{TT_RUN_PREFIX} mpirun-ulfm not found in PATH, falling back to mpirun")
+        mpi_launcher = "mpirun"
+
+    cmd = [mpi_launcher]
 
     if mpi_args:
         cmd.extend(mpi_args)

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -87,8 +87,6 @@ def get_rank_environment(binding: RankBinding, config: TTRunConfig) -> Dict[str,
         Dictionary of environment variables for this rank
     """
     env = {
-        "PYTHONPATH": os.environ.get("PYTHONPATH", os.getcwd()),
-        "TT_METAL_HOME": os.environ.get("TT_METAL_HOME", os.getcwd()),
         "TT_METAL_CACHE": os.environ.get(
             "TT_METAL_CACHE",
             DEFAULT_CACHE_DIR_PATTERN.format(home=str(Path.home()), hostname=os.uname().nodename, rank=binding.rank),

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -91,7 +91,7 @@ def get_rank_environment(binding: RankBinding, config: TTRunConfig) -> Dict[str,
         "TT_METAL_CACHE": os.environ.get(
             "TT_METAL_CACHE",
             DEFAULT_CACHE_DIR_PATTERN.format(home=str(Path.home()), hostname=os.uname().nodename, rank=binding.rank),
-        ),
+        ), # Need to explicitly configure this because kernel cache is not multi-process safe (#21089)
         "TT_MESH_ID": str(binding.mesh_id),
         "TT_HOST_RANK": str(binding.host_rank_id),
         "TT_MESH_GRAPH_DESC_PATH": config.mesh_graph_desc_path,

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""tt-run - MPI process launcher for TT-Metal and TTNN distributed applications."""
+
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import click
+import yaml
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+TT_RUN_PREFIX = "[tt-run]"
+DEFAULT_CACHE_DIR_PATTERN = "{home}/.cache/{hostname}_rank{rank}"
+INTERRUPTED_EXIT_CODE = 130  # 128 + SIGINT
+PRETTY_PRINT_THRESHOLD = 10  # Minimum args to trigger multi-line formatting
+
+
+class RankBinding(BaseModel):
+    """Binding between MPI rank to target MeshId and HostRankId as defined in the mesh graph descriptor."""
+
+    rank: int = Field(..., ge=0, description="MPI rank (must be >= 0)")
+    mesh_id: int = Field(..., ge=0, description="`MeshId` defines the mesh to which the rank belongs")
+    host_rank_id: int = Field(..., ge=0, description="`HostRankId` defines the host rank within the mesh")
+    env_overrides: Dict[str, str] = Field(default_factory=dict, description="Environment variable overrides")
+
+
+class TTRunConfig(BaseModel):
+    """Rank binding YAML specification consumed by `tt-run`."""
+
+    rank_bindings: List[RankBinding] = Field(..., min_length=1, description="Rank to fabric bindings")
+    global_env: Dict[str, str] = Field(default_factory=dict, description="Global environment variables for all ranks")
+    mesh_graph_desc_path: str = Field(..., description="Path to mesh graph descriptor")
+
+    @field_validator("rank_bindings")
+    def validate_ranks(cls, bindings: List[RankBinding]) -> List[RankBinding]:
+        """Ensure ranks are unique and contiguous starting from 0"""
+        ranks = [b.rank for b in bindings]
+
+        if len(ranks) != len(set(ranks)):
+            raise ValueError("Duplicate ranks found in bindings")
+
+        sorted_ranks = sorted(ranks)
+        if sorted_ranks != list(range(len(ranks))):
+            raise ValueError(f"Ranks must be contiguous from 0. Got: {sorted_ranks}")
+
+        return bindings
+
+    @field_validator("mesh_graph_desc_path")
+    def validate_mesh_graph_exists(cls, path: str) -> str:
+        """Ensure mesh graph descriptor file exists"""
+        mesh_path = Path(path).expanduser().resolve()
+        if not mesh_path.exists():
+            raise ValueError(f"Mesh graph descriptor not found: {mesh_path}")
+        return str(mesh_path)
+
+
+def parse_binding_config(yaml_path: Path) -> TTRunConfig:
+    """Parse YAML configuration file with schema validation."""
+    if not yaml_path.exists():
+        raise ValueError(f"Configuration file not found: {yaml_path}")
+
+    with open(yaml_path, "r") as f:
+        data = yaml.safe_load(f)
+
+    try:
+        return TTRunConfig(**data)
+    except ValidationError as e:
+        raise ValueError(f"Invalid configuration: {e}")
+
+
+def get_rank_environment(binding: RankBinding, config: TTRunConfig) -> Dict[str, str]:
+    """Get all environment variables for a specific rank.
+
+    Args:
+        binding: Rank binding configuration
+        config: Global configuration
+
+    Returns:
+        Dictionary of environment variables for this rank
+    """
+    env = {
+        "PYTHONPATH": os.environ.get("PYTHONPATH", os.getcwd()),
+        "TT_METAL_HOME": os.environ.get("TT_METAL_HOME", os.getcwd()),
+        "TT_METAL_CACHE": os.environ.get(
+            "TT_METAL_CACHE",
+            DEFAULT_CACHE_DIR_PATTERN.format(home=str(Path.home()), hostname=os.uname().nodename, rank=binding.rank),
+        ),
+        "TT_MESH_ID": str(binding.mesh_id),
+        "TT_HOST_RANK": str(binding.host_rank_id),
+        "TT_MESH_GRAPH_DESC_PATH": config.mesh_graph_desc_path,
+    }
+
+    # Apply environment variables with expansion and proper precedence
+    # Global environment variables first
+    env.update({k: os.path.expandvars(v) for k, v in config.global_env.items()})
+    # Rank-specific overrides last (higher precedence)
+    env.update({k: os.path.expandvars(v) for k, v in binding.env_overrides.items()})
+
+    return env
+
+
+def build_rank_environment_args(binding: RankBinding, config: TTRunConfig) -> List[str]:
+    """Build environment variable arguments for mpirun.
+
+    Args:
+        binding: Rank binding configuration
+        config: Global configuration
+
+    Returns:
+        List of ["-x", "KEY=value"] arguments for mpirun
+    """
+    env_args = []
+    env = get_rank_environment(binding, config)
+
+    for key, value in env.items():
+        env_args.extend(["-x", f"{key}={value}"])
+
+    return env_args
+
+
+def build_mpi_command(config: TTRunConfig, program: List[str], mpi_args: Optional[List[str]] = None) -> List[str]:
+    """Build OpenMPI command with per-rank environment variables."""
+    cmd = ["mpirun"]
+
+    if mpi_args:
+        cmd.extend(mpi_args)
+
+    # Build per-rank application contexts
+    for i, binding in enumerate(config.rank_bindings):
+        if i > 0:
+            cmd.append(":")
+
+        cmd.extend(["-np", "1"])
+        cmd.extend(build_rank_environment_args(binding, config))
+        cmd.extend(program)
+
+    return cmd
+
+
+def print_command(cmd: List[str], prefix: str = TT_RUN_PREFIX) -> None:
+    """Pretty print a command for readability."""
+    if len(cmd) > PRETTY_PRINT_THRESHOLD:
+        click.echo(f"{prefix} Command:")
+        parts = []
+        current_part = ["mpirun"]
+
+        for arg in cmd[1:]:
+            if arg == ":":
+                parts.append(" ".join(current_part))
+                current_part = [":"]
+            else:
+                current_part.append(arg)
+
+        if current_part:
+            parts.append(" ".join(current_part))
+
+        click.echo(" \\\n    ".join(parts))
+    else:
+        click.echo(f"{prefix} Command: " + " ".join(cmd))
+
+
+@click.command(
+    context_settings=dict(
+        ignore_unknown_options=True,
+        allow_extra_args=True,
+    )
+)
+@click.option(
+    "--rank-binding",
+    type=click.Path(exists=True, path_type=Path),
+    required=True,
+    help="Rank binding configuration file (YAML)",
+)
+@click.option("--dry-run", is_flag=True, help="Print command without executing")
+@click.option("-v", "--verbose", is_flag=True, help="Verbose output")
+@click.option(
+    "--mpi-args",
+    callback=lambda ctx, param, value: shlex.split(value) if value else None,
+    help="Additional MPI arguments (quoted)",
+)
+@click.pass_context
+def main(ctx: click.Context, rank_binding: Path, dry_run: bool, verbose: bool, mpi_args: Optional[List[str]]) -> None:
+    """tt-run - MPI process launcher for TT-Metal and TTNN distributed applications
+
+    tt-run is a lightweight wrapper around `mpirun` that simplifies launching
+    TT-Metal and TTNN distributed applications by automatically mapping
+    MPI ranks to target MeshId and HostRankId as defined in the mesh graph descriptor.
+
+    \b
+    Quick Start:
+        # Launch with rank binding configuration
+        tt-run --rank-binding rank_binding.yaml ./my_app
+
+        # Launch on multiple hosts with rankfile
+        tt-run --rank-binding binding.yaml --mpi-args "--rankfile hosts.txt" ./my_app
+
+    \b
+    Rank Binding YAML Example:
+        rank_bindings:
+          - rank: 0                  # MPI rank
+            mesh_id: 0               # Mesh ID
+            host_rank_id: 0          # Host rank ID within the mesh
+            env_overrides:
+              RANK_0_ENV_VAR: "value"
+          - rank: 1
+            mesh_id: 0
+            host_rank_id: 1
+            env_overrides:
+              RANK_1_ENV_VAR: "value"
+        global_env:                  # Environment variables for all ranks
+          TT_LOGGER_LEVEL: Debug
+          PYTHONPATH: "${HOME}/my_project:${PYTHONPATH}"  # Supports env var expansion
+        mesh_graph_desc_path: "path/to/mesh_graph.yaml"  # Required
+
+    \b
+    Examples:
+        # Single host, multiple processes
+        tt-run --rank-binding rank_binding.yaml ./my_app
+
+        # Multi-host with rankfile
+        tt-run --rank-binding binding.yaml --mpi-args "--rankfile hosts.txt" ./my_app
+
+        # With additional MPI args
+        tt-run --rank-binding binding.yaml --mpi-args "--bind-to core" ./my_app
+
+        # Dry run to see command
+        tt-run --rank-binding binding.yaml --dry-run ./my_app
+
+    \b
+    Environment Variables:
+        The following variables are automatically set for each rank:
+        - TT_MESH_ID: Mesh identifier
+        - TT_HOST_RANK: Host rank within the mesh
+        - TT_METAL_CACHE: Per-rank cache directory
+        - TT_METAL_HOME: TT-Metal installation directory
+        - PYTHONPATH: Python module search path
+        - TT_MESH_GRAPH_DESC_PATH: Path to mesh graph descriptor
+
+    See examples/ttrun/ for example configuration files.
+    """
+    program = ctx.args
+    try:
+        config = parse_binding_config(rank_binding)
+    except (ValueError, ValidationError) as e:
+        raise click.ClickException(f"Configuration error: {e}")
+
+    if not program:
+        raise click.ClickException("No program specified. Please provide a program to run.")
+
+    # Validate program executable exists
+    program_path = Path(program[0])
+    if not program_path.exists() and not shutil.which(program[0]):
+        raise click.ClickException(f"Program not found: {program[0]}")
+
+    # Build MPI command
+    mpi_cmd = build_mpi_command(config, program, mpi_args)
+
+    if verbose or dry_run:
+        print_command(mpi_cmd)
+
+    if dry_run:
+        return
+
+    try:
+        result = subprocess.run(mpi_cmd)
+        sys.exit(result.returncode)
+    except KeyboardInterrupt:
+        # Handle Ctrl+C gracefully with proper exit code (128 + SIGINT)
+        click.echo(f"\n{TT_RUN_PREFIX} Interrupted", err=True)
+        sys.exit(INTERRUPTED_EXIT_CODE)
+    except OSError as e:
+        raise click.ClickException(f"Error launching mpirun: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -56,7 +56,7 @@ class TTRunConfig(BaseModel):
     def validate_mesh_graph_exists(cls, path: str) -> str:
         """Ensure mesh graph descriptor file exists"""
         mesh_path = Path(path).expanduser().resolve()
-        if not mesh_path.exists():
+        if not mesh_path.is_file():
             raise ValueError(f"Mesh graph descriptor not found: {mesh_path}")
         return str(mesh_path)
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
TT-Metal infrastructure is starting to become multi-process/multi-host aware. We have MeshGraphDescriptors that capture  big-mesh and inter-mesh configurations. We need a way to launch these MPI processes that bind to specific targets in the MeshGraphDescriptor. 

The plan is to extend this to capture the functionality of `tt-train/sources/examples/nano_gpt/3tier/run_3tier_demo.sh`

### What's changed
- Add simple MPI process launcher for TT-Metal and TTNN distributed applications
  - Implements MPI rank binding to specific Mesh Graph Descriptor target
- Update pyproject.toml to include tt-run console script entry point

### Example Usage (TT-NN / TT-Metal):

Metal level multi-process or multi-host process launcher:
`tt-run --rank-binding tests/tt_metal/distributed/config/2x4_multihost_rank_bindings.yaml build/test/ttnn/unit_tests_ttnn_multihost --gtest_filter="*TensorReadWriteLoopback*"`
or via TT-NN:
`tt-run --rank-binding tests/tt_metal/distributed/config/2x4_multihost_rank_bindings.yaml --mpi-args "--tag-output" pytest -svv "tests/ttnn/unit_tests/test_multi_device.py::test_multihost_sanity"`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/16129958456
- [x] T3K Unit Tests: https://github.com/tenstorrent/tt-metal/actions/runs/16129959786

Updated Runs:
- https://github.com/tenstorrent/tt-metal/actions/runs/16179707128
- https://github.com/tenstorrent/tt-metal/actions/runs/16179708196