### PR TITLE
Comment out mobilenetv2 test from (Single-card) Device perf

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -91,7 +91,7 @@ jobs:
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/bert_tiny/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov4/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/distilbert/tests -m models_device_performance_bare_metal
-            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/mobilenetv2/tests -m models_device_performance_bare_metal
+            # WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/mobilenetv2/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8x/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8s/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/functional_vanilla_unet/test -m models_device_performance_bare_metal


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-metal/issues/24652

### Problem description
The model test for mobilenetv2 has been failing and causing the (Single-card) Device perf pipeline to fail. 
https://github.com/tenstorrent/tt-metal/actions/runs/16123205547/job/45494322003#step:5:4176

```
FAILED models/demos/mobilenetv2/tests/test_perf_mobilenetv2.py::test_perf_device_bare_metal_mobilenetv2[10-3178] - subprocess.CalledProcessError: Command '['python3 -m tracy -p -r -o /work/generated/profiler/ttnn_mobilenetv2 --check-exit-code  -t 5000 -m pytest tests/ttnn/integration_tests/mobilenetv2/test_mobilenetv2.py::test_mobilenetv2']' returned non-zero exit status 4.
```

### What's changed
Commented the test out to pipeline back to green