### PR TITLE
Add GetFabricConfig() API and refactor releated APIs

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -1644,7 +1644,7 @@ void test_multi_connection_multi_device_data_copy(
 
 std::pair<MeshCoordinate, MeshCoordinate> get_random_mesh_coordinates(const MeshShape& mesh_shape) {
     std::srand(std::time(nullptr));  // Seed the RNG
-    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+    tt_fabric::FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (tt_fabric::is_2d_fabric_config(fabric_config)) {
         auto coord0 = MeshCoordinate(rand() % mesh_shape[0], rand() % mesh_shape[1]);
         auto coord1 = coord0;

--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
@@ -316,7 +316,7 @@ void run_unicast_recv_step(BaseFabricFixture* fixture) {
         target_address,
         0 /* mcast_mode */,
         true,
-        fabric_config == tt_metal::FabricConfig::FABRIC_2D_DYNAMIC};
+        fabric_config == tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC};
 
     std::vector<uint32_t> receiver_runtime_args = {worker_mem_map.packet_payload_size_bytes, num_packets, time_seed};
 

--- a/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
@@ -47,7 +47,7 @@ public:
         TT_FATAL(
             *(tt::tt_metal::MetalContext::instance().get_distributed_context().size()) > 1,
             "Multi-Host Routing tests require multiple hosts in the system");
-        this->DoSetUpTestSuite(tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC);
+        this->DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
     }
 
     void TearDown() override {

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -70,7 +70,7 @@ public:
         for (unsigned int id = 0; id < num_devices; id++) {
             ids.push_back(id);
         }
-        tt::tt_metal::detail::SetFabricConfig(
+        tt::tt_fabric::SetFabricConfig(
             fabric_config, tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, num_routing_planes);
         devices_map_ = tt::tt_metal::detail::CreateDevices(ids);
         for (auto& [id, device] : devices_map_) {
@@ -80,7 +80,7 @@ public:
 
     static void DoTearDownTestSuite() {
         tt::tt_metal::detail::CloseDevices(devices_map_);
-        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
     }
 
     static void SetUpTestSuite() { TT_THROW("SetUpTestSuite not implemented in BaseFabricFixture"); }

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -123,7 +123,7 @@ protected:
 
 class NightlyFabric2DFixture : public BaseFabricFixture {
 protected:
-    static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_metal::FabricConfig::FABRIC_2D); }
+    static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_2D); }
     static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }
 };
 
@@ -135,7 +135,7 @@ protected:
 
 class NightlyFabric2DDynamicFixture : public BaseFabricFixture {
 protected:
-    static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC); }
+    static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC); }
     static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }
 };
 

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -6,6 +6,7 @@
 
 #include "gtest/gtest.h"
 #include <tt-metalium/device_pool.hpp>
+#include <tt-metalium/fabric.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
@@ -29,12 +30,12 @@ class ControlPlaneFixture : public ::testing::Test {
            // reserve max available planes
            uint8_t num_routing_planes = std::numeric_limits<uint8_t>::max();
            tt::tt_metal::MetalContext::instance().get_cluster().configure_ethernet_cores_for_fabric_routers(
-               tt::tt_metal::FabricConfig::FABRIC_2D, num_routing_planes);
+               tt::tt_fabric::FabricConfig::FABRIC_2D, num_routing_planes);
        }
 
        void TearDown() override {
            tt::tt_metal::MetalContext::instance().get_cluster().configure_ethernet_cores_for_fabric_routers(
-               tt::tt_metal::FabricConfig::DISABLED);
+               tt::tt_fabric::FabricConfig::DISABLED);
        }
 };
 
@@ -56,7 +57,7 @@ public:
     }
 
     static void DoSetUpTestSuite(
-        tt_metal::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt) {
+        tt_fabric::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt) {
         slow_dispatch_ = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch_) {
             log_info(tt::LogTest, "Running fabric api tests with slow dispatch");
@@ -71,7 +72,7 @@ public:
             ids.push_back(id);
         }
         tt::tt_fabric::SetFabricConfig(
-            fabric_config, tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, num_routing_planes);
+            fabric_config, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, num_routing_planes);
         devices_map_ = tt::tt_metal::detail::CreateDevices(ids);
         for (auto& [id, device] : devices_map_) {
             devices_.push_back(device);
@@ -80,7 +81,7 @@ public:
 
     static void DoTearDownTestSuite() {
         tt::tt_metal::detail::CloseDevices(devices_map_);
-        tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
     }
 
     static void SetUpTestSuite() { TT_THROW("SetUpTestSuite not implemented in BaseFabricFixture"); }
@@ -110,13 +111,13 @@ public:
 
 class Fabric1DFixture : public BaseFabricFixture {
 protected:
-    static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_metal::FabricConfig::FABRIC_1D); }
+    static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_1D); }
     static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }
 };
 
 class Fabric2DFixture : public BaseFabricFixture {
 protected:
-    static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_metal::FabricConfig::FABRIC_2D); }
+    static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_2D); }
     static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }
 };
 
@@ -128,7 +129,7 @@ protected:
 
 class Fabric2DDynamicFixture : public BaseFabricFixture {
 protected:
-    static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC); }
+    static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC); }
     static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }
 };
 
@@ -148,7 +149,7 @@ public:
         const std::map<FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
         tt::tt_metal::MetalContext::instance().set_custom_control_plane_mesh_graph(
             mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
-        BaseFabricFixture::DoSetUpTestSuite(tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC);
+        BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
     }
 
 private:

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -1194,7 +1194,7 @@ void RunTest2DMCastConnAPI(
         0 /* use_dram_dst */,
         mcast_mode,
         topology == Topology::Mesh,
-        fabric_config == tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
+        fabric_config == tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC,
         1 /* is_chip_multicast */,
         1 /* additional_dir */};
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -447,7 +447,7 @@ void RunTestUnicastRaw(
         worker_mem_map.target_address,
         0 /* use_dram_dst */,
         topology == Topology::Mesh,
-        fabric_config == tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
+        fabric_config == tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC,
         0 /* is_chip_multicast */,
         0 /* additional_dir */};
 
@@ -588,7 +588,7 @@ void run_unicast_test_bw_chips(
         worker_mem_map.target_address,
         use_dram_dst,
         topology == Topology::Mesh,
-        fabric_config == tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
+        fabric_config == tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC,
         0 /* is_chip_multicast */,
         0 /* additional_dir */};
 
@@ -889,7 +889,7 @@ void RunTestMCastConnAPI(
         worker_mem_map.target_address,
         0 /* use_dram_dst */,
         topology == Topology::Mesh,
-        fabric_config == tt_metal::FabricConfig::FABRIC_2D_DYNAMIC,
+        fabric_config == tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC,
         1 /* is_chip_multicast */,
         1 /* additional_dir */};
 
@@ -1347,8 +1347,8 @@ void RunTestChipMCast1D(
     const auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     assert(
         (topology == Topology::Linear || topology == Topology::Ring) &&
-        (fabric_config == tt_metal::FabricConfig::FABRIC_1D ||
-         fabric_config == tt_metal::FabricConfig::FABRIC_1D_RING));
+        (fabric_config == tt_fabric::FabricConfig::FABRIC_1D ||
+         fabric_config == tt_fabric::FabricConfig::FABRIC_1D_RING));
 
     // Find a device num_hops away in specified direction.
     FabricNodeId src_fabric_node_id(MeshId{0}, 0);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -20,8 +20,8 @@
 
 namespace {
 
-constexpr auto k_FabricConfig = tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC;
-constexpr auto k_ReliabilityMode = tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
+constexpr auto k_FabricConfig = tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC;
+constexpr auto k_ReliabilityMode = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
 
 std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(const std::filesystem::path& graph_desc) {
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(graph_desc.string());

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -277,11 +277,11 @@ protected:
         // Enable Fabric Dispatch
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(true);
         // This will force dispatch init to inherit the FabricConfig param
-        tt::tt_metal::detail::SetFabricConfig(GetParam(), FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+        tt::tt_fabric::SetFabricConfig(GetParam(), tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
         CommandQueueMultiDeviceFixture::SetUp();
 
         if (::testing::Test::IsSkipped()) {
-            tt::tt_metal::detail::SetFabricConfig(FabricConfig::DISABLED);
+            tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
         }
     }
 
@@ -290,7 +290,7 @@ protected:
             return;
         }
         CommandQueueMultiDeviceFixture::TearDown();
-        tt::tt_metal::detail::SetFabricConfig(FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(original_fd_fabric_en_);
     }
 };

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -13,6 +13,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/device.hpp>
 #include "umd/device/types/cluster_descriptor_types.h"
+#include <tt-metalium/fabric.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/tt_metal.hpp>
@@ -257,7 +258,7 @@ class CommandQueueMultiDeviceBufferFixture : public CommandQueueMultiDeviceFixtu
 
 class DISABLED_CommandQueueMultiDeviceOnFabricFixture
     : public CommandQueueMultiDeviceFixture,
-      public ::testing::WithParamInterface<tt::tt_metal::FabricConfig> {
+      public ::testing::WithParamInterface<tt::tt_fabric::FabricConfig> {
 private:
     bool original_fd_fabric_en_ = false;
     inline static ARCH arch_ = tt::ARCH::Invalid;

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -130,7 +130,7 @@ protected:
             (config_.num_cqs >= 2 and is_n300_or_t3k_cluster) ? DispatchCoreType::ETH : DispatchCoreType::WORKER;
 
         if (config_.fabric_config != FabricConfig::DISABLED) {
-            tt::tt_metal::detail::SetFabricConfig(config_.fabric_config);
+            tt::tt_fabric::SetFabricConfig(config_.fabric_config);
         }
         mesh_device_ = MeshDevice::create(
             MeshDeviceConfig(get_mesh_shape(*mesh_device_type)),
@@ -149,7 +149,7 @@ protected:
         mesh_device_->close();
         mesh_device_.reset();
         if (config_.fabric_config != FabricConfig::DISABLED) {
-            tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+            tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
         }
     }
 

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -8,6 +8,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include <tt-metalium/device_pool.hpp>
+#include <tt-metalium/fabric.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "llrt.hpp"
 #include "impl/context/metal_context.hpp"
@@ -88,7 +89,7 @@ protected:
         int num_cqs = 1;
         uint32_t trace_region_size = 0;
         uint32_t worker_l1_size = DEFAULT_WORKER_L1_SIZE;
-        FabricConfig fabric_config = FabricConfig::DISABLED;
+        tt_fabric::FabricConfig fabric_config = tt_fabric::FabricConfig::DISABLED;
     };
 
     MeshDeviceFixtureBase(const Config& fixture_config) : config_(fixture_config) {}
@@ -129,8 +130,8 @@ protected:
         auto core_type =
             (config_.num_cqs >= 2 and is_n300_or_t3k_cluster) ? DispatchCoreType::ETH : DispatchCoreType::WORKER;
 
-        if (config_.fabric_config != FabricConfig::DISABLED) {
-            tt::tt_fabric::SetFabricConfig(config_.fabric_config);
+        if (config_.fabric_config != tt_fabric::FabricConfig::DISABLED) {
+            tt_fabric::SetFabricConfig(config_.fabric_config);
         }
         mesh_device_ = MeshDevice::create(
             MeshDeviceConfig(get_mesh_shape(*mesh_device_type)),
@@ -148,8 +149,8 @@ protected:
         }
         mesh_device_->close();
         mesh_device_.reset();
-        if (config_.fabric_config != FabricConfig::DISABLED) {
-            tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+        if (config_.fabric_config != tt_fabric::FabricConfig::DISABLED) {
+            tt_fabric::SetFabricConfig(tt_fabric::FabricConfig::DISABLED);
         }
     }
 
@@ -246,7 +247,7 @@ class T3000MeshDevice1DFabricFixture : public MeshDeviceFixtureBase {
 protected:
     T3000MeshDevice1DFabricFixture() :
         MeshDeviceFixtureBase(Config{
-            .mesh_device_types = {MeshDeviceType::T3000}, .num_cqs = 1, .fabric_config = FabricConfig::FABRIC_1D}) {}
+            .mesh_device_types = {MeshDeviceType::T3000}, .num_cqs = 1, .fabric_config = tt_fabric::FabricConfig::FABRIC_1D}) {}
 };
 
 class T3000MeshDevice2DFabricFixture : public MeshDeviceFixtureBase {
@@ -255,7 +256,7 @@ protected:
         MeshDeviceFixtureBase(Config{
             .mesh_device_types = {MeshDeviceType::T3000},
             .num_cqs = 1,
-            .fabric_config = FabricConfig::FABRIC_2D_DYNAMIC}) {}
+            .fabric_config = tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC}) {}
 };
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1344,10 +1344,10 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestRuntimeArgsCorrectlySentS
 }
 
 auto CommandQueueFabricConfigsToTest = ::testing::Values(
-    tt::tt_metal::FabricConfig::FABRIC_1D,
-    tt::tt_metal::FabricConfig::FABRIC_1D_RING,
-    tt::tt_metal::FabricConfig::FABRIC_2D,
-    tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC);
+    tt::tt_fabric::FabricConfig::FABRIC_1D,
+    tt::tt_fabric::FabricConfig::FABRIC_1D_RING,
+    tt::tt_fabric::FabricConfig::FABRIC_2D,
+    tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
 
 INSTANTIATE_TEST_SUITE_P(
     CommandQueueMultiDevice, DISABLED_CommandQueueMultiDeviceOnFabricFixture, CommandQueueFabricConfigsToTest);

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -168,7 +168,7 @@ class MultiCommandQueueMultiDeviceEventFixture : public MultiCommandQueueMultiDe
 
 class DISABLED_MultiCommandQueueMultiDeviceOnFabricFixture
     : public MultiCommandQueueMultiDeviceFixture,
-      public ::testing::WithParamInterface<tt::tt_metal::FabricConfig> {
+      public ::testing::WithParamInterface<tt::tt_fabric::FabricConfig> {
 private:
     // Save the result to reduce UMD calls
     inline static bool should_skip_ = false;
@@ -186,18 +186,18 @@ protected:
         original_fd_fabric_en_ = tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric();
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(true);
         // This will force dispatch init to inherit the FabricConfig param
-        tt::tt_metal::detail::SetFabricConfig(GetParam(), FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
+        tt::tt_fabric::SetFabricConfig(GetParam(), tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
         MultiCommandQueueMultiDeviceFixture::SetUp();
 
         if (::testing::Test::IsSkipped()) {
-            tt::tt_metal::detail::SetFabricConfig(
-                FabricConfig::DISABLED, FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+            tt::tt_fabric::SetFabricConfig(
+                tt::tt_fabric::FabricConfig::DISABLED, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
         }
     }
 
     void TearDown() override {
         MultiCommandQueueMultiDeviceFixture::TearDown();
-        tt::tt_metal::detail::SetFabricConfig(FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(original_fd_fabric_en_);
     }
 };

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -9,6 +9,7 @@
 #include "dispatch_fixture.hpp"
 #include "hostdevcommon/common_values.hpp"
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/fabric.hpp>
 #include "umd/device/types/cluster_descriptor_types.h"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -42,7 +42,7 @@ using YamlTestConfigSerializer = tt::tt_fabric::fabric_tests::YamlTestConfigSeri
 using ParsedTestConfig = tt::tt_fabric::fabric_tests::ParsedTestConfig;
 
 using Topology = tt::tt_fabric::Topology;
-using FabricConfig = tt::tt_metal::FabricConfig;
+using FabricConfig = tt::tt_fabric::FabricConfig;
 using RoutingType = tt::tt_fabric::fabric_tests::RoutingType;
 
 const std::unordered_map<std::pair<Topology, RoutingType>, FabricConfig, tt::tt_fabric::fabric_tests::pair_hash>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
@@ -345,7 +345,7 @@ int main(int argc, char** argv) {
         sizeof(tt::tt_fabric::PacketHeader) + test_params.packet_payload_size_bytes;
     test_params.buffer_size_bytes_header_only_channel = sizeof(tt::tt_fabric::PacketHeader);
 
-    tt::tt_metal::detail::SetFabricConfig(
+    tt::tt_fabric::SetFabricConfig(
         tt::tt_metal::FabricConfig::FABRIC_1D, tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     std::vector<chip_id_t> all_device_ids;
@@ -493,7 +493,7 @@ int main(int argc, char** argv) {
     tt::tt_metal::Finish(cq);
 
     tt::tt_metal::detail::CloseDevices(devices);
-    tt::tt_metal::detail::SetFabricConfig(
+    tt::tt_fabric::SetFabricConfig(
         tt::tt_metal::FabricConfig::DISABLED, tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
 
     log_info(tt::LogTest, "Collecting results");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
@@ -346,7 +346,7 @@ int main(int argc, char** argv) {
     test_params.buffer_size_bytes_header_only_channel = sizeof(tt::tt_fabric::PacketHeader);
 
     tt::tt_fabric::SetFabricConfig(
-        tt::tt_metal::FabricConfig::FABRIC_1D, tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+        tt::tt_fabric::FabricConfig::FABRIC_1D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     std::vector<chip_id_t> all_device_ids;
     for (unsigned int id = 0; id < num_devices; id++) {
@@ -494,7 +494,7 @@ int main(int argc, char** argv) {
 
     tt::tt_metal::detail::CloseDevices(devices);
     tt::tt_fabric::SetFabricConfig(
-        tt::tt_metal::FabricConfig::DISABLED, tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+        tt::tt_fabric::FabricConfig::DISABLED, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
 
     log_info(tt::LogTest, "Collecting results");
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -167,7 +167,7 @@ struct test_board_t {
             throw std::runtime_error("Odd number of chips detected, not supported currently");
         }
 
-        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::CUSTOM);
+        tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::CUSTOM);
 
         device_handle_map = tt::tt_metal::detail::CreateDevices(available_chip_ids);
         control_plane = &tt::tt_metal::MetalContext::instance().get_control_plane();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -9,6 +9,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/control_plane.hpp>
 #include <tt-metalium/device_pool.hpp>
+#include <tt-metalium/fabric.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_graph.hpp>
 #include <tt-metalium/tt_metal.hpp>
@@ -167,7 +168,7 @@ struct test_board_t {
             throw std::runtime_error("Odd number of chips detected, not supported currently");
         }
 
-        tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::CUSTOM);
+        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::CUSTOM);
 
         device_handle_map = tt::tt_metal::detail::CreateDevices(available_chip_ids);
         control_plane = &tt::tt_metal::MetalContext::instance().get_control_plane();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -133,7 +133,7 @@ public:
 
     void close_devices() {
         mesh_device_->close();
-        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
 
         mesh_coordinate_to_node_id_.clear();
         node_id_to_mesh_coordinate_.clear();
@@ -847,7 +847,7 @@ private:
     bool are_devices_open_ = false;
 
     void open_devices_internal(tt::tt_metal::FabricConfig fabric_config) {
-        tt::tt_metal::detail::SetFabricConfig(fabric_config);
+        tt::tt_fabric::SetFabricConfig(fabric_config);
         mesh_device_ = MeshDevice::create(mesh_shape_);
 
         TT_FATAL(mesh_device_ != nullptr, "Failed to create MeshDevice with shape {}", mesh_shape_);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/mesh_graph.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/device_pool.hpp>
+#include <tt-metalium/fabric.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/hal.hpp>
@@ -62,7 +63,7 @@ class TestFixture : public IDeviceInfoProvider, public IRouteManager {
     static constexpr uint32_t EW_DIM = 1;
     static constexpr uint32_t NS_DIM = 0;
 
-    static const std::unordered_map<std::pair<Topology, RoutingType>, tt::tt_metal::FabricConfig, pair_hash>
+    static const std::unordered_map<std::pair<Topology, RoutingType>, tt::tt_fabric::FabricConfig, pair_hash>
         topology_to_fabric_config_map;
 
 public:
@@ -88,7 +89,7 @@ public:
             available_node_ids_.emplace_back(FabricNodeId(mesh_id, i));
         }
 
-        current_fabric_config_ = tt::tt_metal::FabricConfig::DISABLED;
+        current_fabric_config_ = tt::tt_fabric::FabricConfig::DISABLED;
     }
 
     std::vector<MeshCoordinate> get_available_device_coordinates() const { return this->available_device_coordinates_; }
@@ -133,11 +134,11 @@ public:
 
     void close_devices() {
         mesh_device_->close();
-        tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
 
         mesh_coordinate_to_node_id_.clear();
         node_id_to_mesh_coordinate_.clear();
-        current_fabric_config_ = tt::tt_metal::FabricConfig::DISABLED;
+        current_fabric_config_ = tt::tt_fabric::FabricConfig::DISABLED;
         are_devices_open_ = false;
     }
 
@@ -837,7 +838,7 @@ private:
     RoutingType routing_type_;
     MeshShape mesh_shape_;
     std::set<MeshId> available_mesh_ids_;
-    tt::tt_metal::FabricConfig current_fabric_config_;
+    tt::tt_fabric::FabricConfig current_fabric_config_;
     std::vector<MeshCoordinate> available_device_coordinates_;
     std::vector<FabricNodeId> available_node_ids_;
     std::shared_ptr<MeshDevice> mesh_device_;
@@ -846,7 +847,7 @@ private:
     std::shared_ptr<MeshWorkload> mesh_workload_;
     bool are_devices_open_ = false;
 
-    void open_devices_internal(tt::tt_metal::FabricConfig fabric_config) {
+    void open_devices_internal(tt::tt_fabric::FabricConfig fabric_config) {
         tt::tt_fabric::SetFabricConfig(fabric_config);
         mesh_device_ = MeshDevice::create(mesh_shape_);
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -110,14 +110,14 @@ public:
     BaseFabricFixture() : device_open(false) {}
 
     BaseFabricFixture(
-        tt::tt_metal::FabricConfig fabric_config,
-        tt::tt_metal::FabricReliabilityMode reliability_mode =
-            tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) :
+        tt::tt_fabric::FabricConfig fabric_config,
+        tt::tt_fabric::FabricReliabilityMode reliability_mode =
+            tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) :
         device_open(false) {
         tt::tt_fabric::SetFabricConfig(fabric_config, reliability_mode);
     }
 
-    virtual ~BaseFabricFixture() { tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED); }
+    virtual ~BaseFabricFixture() { tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED); }
 
     virtual void SetupDevices() = 0;
     virtual void TearDown() = 0;
@@ -156,9 +156,9 @@ public:
     Fabric1DFixture() : BaseFabricFixture() { this->SetupDevices(); }
 
     Fabric1DFixture(
-        tt::tt_metal::FabricConfig fabric_config,
-        tt::tt_metal::FabricReliabilityMode reliability_mode =
-            tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) :
+        tt::tt_fabric::FabricConfig fabric_config,
+        tt::tt_fabric::FabricReliabilityMode reliability_mode =
+            tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) :
         BaseFabricFixture(fabric_config, reliability_mode) {
         this->SetupDevices();
     }
@@ -217,9 +217,9 @@ public:
     Fabric1DDeviceInitFixture() : device_open(false) { this->SetupDevices(); }
 
     Fabric1DDeviceInitFixture(
-        tt::tt_metal::FabricConfig fabric_config,
-        tt::tt_metal::FabricReliabilityMode reliability_mode =
-            tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) :
+        tt::tt_fabric::FabricConfig fabric_config,
+        tt::tt_fabric::FabricReliabilityMode reliability_mode =
+            tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) :
         device_open(false) {
         tt::tt_fabric::SetFabricConfig(fabric_config, reliability_mode);
         this->SetupDevices();
@@ -227,7 +227,7 @@ public:
 
     ~Fabric1DDeviceInitFixture() {
         TearDown();
-        tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
     }
 };
 
@@ -251,9 +251,9 @@ public:
     MeshFabric1DFixture() : BaseFabricFixture() { this->SetupDevices(); }
 
     MeshFabric1DFixture(
-        tt::tt_metal::FabricConfig fabric_config,
-        tt::tt_metal::FabricReliabilityMode reliability_mode =
-            tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) :
+        tt::tt_fabric::FabricConfig fabric_config,
+        tt::tt_fabric::FabricReliabilityMode reliability_mode =
+            tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) :
         BaseFabricFixture(fabric_config, reliability_mode) {
         this->SetupDevices();
     }
@@ -267,36 +267,36 @@ public:
 
 class Fabric1DLineDeviceInitFixture : public Fabric1DFixture {
 public:
-    Fabric1DLineDeviceInitFixture() : Fabric1DFixture(tt::tt_metal::FabricConfig::FABRIC_1D) {}
+    Fabric1DLineDeviceInitFixture() : Fabric1DFixture(tt::tt_fabric::FabricConfig::FABRIC_1D) {}
 };
 
 class Fabric1DRingDeviceInitFixture : public Fabric1DFixture {
 public:
-    Fabric1DRingDeviceInitFixture() : Fabric1DFixture(tt::tt_metal::FabricConfig::FABRIC_1D_RING) {}
+    Fabric1DRingDeviceInitFixture() : Fabric1DFixture(tt::tt_fabric::FabricConfig::FABRIC_1D_RING) {}
 };
 class Fabric1DRingStrictDeviceInitFixture : public Fabric1DDeviceInitFixture {
 public:
     Fabric1DRingStrictDeviceInitFixture() :
         Fabric1DDeviceInitFixture(
-            tt::tt_metal::FabricConfig::FABRIC_1D_RING,
-            tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) {}
+            tt::tt_fabric::FabricConfig::FABRIC_1D_RING,
+            tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) {}
 };
 class Fabric1DRingRelaxedDeviceInitFixture : public Fabric1DDeviceInitFixture {
 public:
     Fabric1DRingRelaxedDeviceInitFixture() :
         Fabric1DDeviceInitFixture(
-            tt::tt_metal::FabricConfig::FABRIC_1D_RING,
-            tt::tt_metal::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE) {}
+            tt::tt_fabric::FabricConfig::FABRIC_1D_RING,
+            tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE) {}
 };
 
 class MeshFabric1DLineDeviceInitFixture : public MeshFabric1DFixture {
 public:
-    MeshFabric1DLineDeviceInitFixture() : MeshFabric1DFixture(tt::tt_metal::FabricConfig::FABRIC_1D) {}
+    MeshFabric1DLineDeviceInitFixture() : MeshFabric1DFixture(tt::tt_fabric::FabricConfig::FABRIC_1D) {}
 };
 
 class MeshFabric1DRingDeviceInitFixture : public MeshFabric1DFixture {
 public:
-    MeshFabric1DRingDeviceInitFixture() : MeshFabric1DFixture(tt::tt_metal::FabricConfig::FABRIC_1D_RING) {}
+    MeshFabric1DRingDeviceInitFixture() : MeshFabric1DFixture(tt::tt_fabric::FabricConfig::FABRIC_1D_RING) {}
 };
 
 struct BankedConfig {
@@ -2090,7 +2090,7 @@ void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_li
     }
 
     // Initialize MeshDevice with 1D Fabric
-    MeshFabric1DFixture test_fixture(tt::tt_metal::FabricConfig::FABRIC_1D);
+    MeshFabric1DFixture test_fixture(tt::tt_fabric::FabricConfig::FABRIC_1D);
     auto view = test_fixture.mesh_device_->get_view();
 
     // build a line of devices
@@ -2159,7 +2159,7 @@ void run_ring_all_gather_with_persistent_fabric(
     }
 
     // Initialize MeshDevice with 1D Fabric
-    MeshFabric1DFixture test_fixture(tt::tt_metal::FabricConfig::FABRIC_1D_RING);
+    MeshFabric1DFixture test_fixture(tt::tt_fabric::FabricConfig::FABRIC_1D_RING);
     test_fixture.mesh_device_->reshape(MeshShape(1, 8));
     auto view = test_fixture.mesh_device_->get_view();
 
@@ -2454,13 +2454,13 @@ void create_fabric_fixture(std::unique_ptr<Fabric1DFixture>& test_fixture, bool 
         auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
         return (
             // prev not Fabric1D, now Fabric1D
-            (fabric_config != tt::tt_metal::FabricConfig::DISABLED &&
+            (fabric_config != tt::tt_fabric::FabricConfig::DISABLED &&
              std::is_same_v<FABRIC_DEVICE_FIXTURE, Fabric1DFixture>) ||
             // prev not Fabric1DLine, now Fabric1DLine
-            (fabric_config != tt::tt_metal::FabricConfig::FABRIC_1D &&
+            (fabric_config != tt::tt_fabric::FabricConfig::FABRIC_1D &&
              std::is_same_v<FABRIC_DEVICE_FIXTURE, Fabric1DLineDeviceInitFixture>) ||
             // prev not Fabric1DRing, now Fabric1DRing
-            (fabric_config != tt::tt_metal::FabricConfig::FABRIC_1D_RING &&
+            (fabric_config != tt::tt_fabric::FabricConfig::FABRIC_1D_RING &&
              std::is_same_v<FABRIC_DEVICE_FIXTURE, Fabric1DRingDeviceInitFixture>));
     }();
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -114,10 +114,10 @@ public:
         tt::tt_metal::FabricReliabilityMode reliability_mode =
             tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) :
         device_open(false) {
-        tt::tt_metal::detail::SetFabricConfig(fabric_config, reliability_mode);
+        tt::tt_fabric::SetFabricConfig(fabric_config, reliability_mode);
     }
 
-    virtual ~BaseFabricFixture() { tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED); }
+    virtual ~BaseFabricFixture() { tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED); }
 
     virtual void SetupDevices() = 0;
     virtual void TearDown() = 0;
@@ -221,13 +221,13 @@ public:
         tt::tt_metal::FabricReliabilityMode reliability_mode =
             tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) :
         device_open(false) {
-        tt::tt_metal::detail::SetFabricConfig(fabric_config, reliability_mode);
+        tt::tt_fabric::SetFabricConfig(fabric_config, reliability_mode);
         this->SetupDevices();
     }
 
     ~Fabric1DDeviceInitFixture() {
         TearDown();
-        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
     }
 };
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -44,12 +44,10 @@ std::vector<IDevice*> get_line_devices(distributed::MeshDevice* mesh_device) {
 
 class T3000MultiCQFabricMeshDeviceFixture : public T3000MultiCQMeshDeviceFixture {
 protected:
-    T3000MultiCQFabricMeshDeviceFixture() {
-        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::FABRIC_1D);
-    }
+    T3000MultiCQFabricMeshDeviceFixture() { tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::FABRIC_1D); }
     void TearDown() override {
         T3000MultiCQMeshDeviceFixture::TearDown();
-        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
     }
 };
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -44,10 +44,12 @@ std::vector<IDevice*> get_line_devices(distributed::MeshDevice* mesh_device) {
 
 class T3000MultiCQFabricMeshDeviceFixture : public T3000MultiCQMeshDeviceFixture {
 protected:
-    T3000MultiCQFabricMeshDeviceFixture() { tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::FABRIC_1D); }
+    T3000MultiCQFabricMeshDeviceFixture() {
+        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_1D);
+    }
     void TearDown() override {
         T3000MultiCQMeshDeviceFixture::TearDown();
-        tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
     }
 };
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
@@ -50,7 +50,7 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
         log_info(tt::LogTest, "Test must be run on WH");
         return;
     }
-    MeshFabric1DFixture test_fixture(tt::tt_metal::FabricConfig::FABRIC_1D);
+    MeshFabric1DFixture test_fixture(tt::tt_fabric::FabricConfig::FABRIC_1D);
     auto view = test_fixture.mesh_device_->get_view();
 
     // build a line of devices

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -53,10 +53,12 @@ using tt::tt_metal::distributed::MeshShape;
 // Custom Fixture using 1D Fabric on a Multi-CQ MeshDevice
 class T3000MultiCQFabricMeshDeviceFixture : public T3000MultiCQMeshDeviceFixture {
 protected:
-    T3000MultiCQFabricMeshDeviceFixture() { tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::FABRIC_1D); }
+    T3000MultiCQFabricMeshDeviceFixture() {
+        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_1D);
+    }
     void TearDown() override {
         T3000MultiCQMeshDeviceFixture::TearDown();
-        tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
     }
 };
 

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -53,12 +53,10 @@ using tt::tt_metal::distributed::MeshShape;
 // Custom Fixture using 1D Fabric on a Multi-CQ MeshDevice
 class T3000MultiCQFabricMeshDeviceFixture : public T3000MultiCQMeshDeviceFixture {
 protected:
-    T3000MultiCQFabricMeshDeviceFixture() {
-        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::FABRIC_1D);
-    }
+    T3000MultiCQFabricMeshDeviceFixture() { tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::FABRIC_1D); }
     void TearDown() override {
         T3000MultiCQMeshDeviceFixture::TearDown();
-        tt::tt_metal::detail::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
     }
 };
 

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -58,7 +58,7 @@ public:
 
     // Converts chip level routing tables to per ethernet channel
     void configure_routing_tables_for_fabric_ethernet_channels(
-        tt::tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode);
+        tt::tt_fabric::FabricConfig fabric_config, tt_fabric::FabricReliabilityMode reliability_mode);
     void write_routing_tables_to_all_chips() const;
 
     // Return mesh_id, chip_id from physical chip id
@@ -127,7 +127,7 @@ public:
     void set_routing_mode(uint16_t mode);
     uint16_t get_routing_mode() const;
 
-    void initialize_fabric_context(tt_metal::FabricConfig fabric_config);
+    void initialize_fabric_context(tt_fabric::FabricConfig fabric_config);
 
     FabricContext& get_fabric_context() const;
 
@@ -219,8 +219,8 @@ private:
     size_t get_num_live_routing_planes(FabricNodeId fabric_node_id, RoutingDirection routing_direction) const;
     void initialize_dynamic_routing_plane_counts(
         const IntraMeshConnectivity& intra_mesh_connectivity,
-        tt_metal::FabricConfig fabric_config,
-        tt_metal::FabricReliabilityMode reliability_mode);
+        tt_fabric::FabricConfig fabric_config,
+        tt_fabric::FabricReliabilityMode reliability_mode);
     void trim_ethernet_channels_not_mapped_to_live_routing_planes();
 
     void validate_mesh_connections(MeshId mesh_id) const;

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -78,6 +78,8 @@ std::unordered_map<MeshId, tt::tt_metal::distributed::MeshShape> get_physical_me
 
 tt::tt_fabric::Topology get_fabric_topology();
 
+FabricConfig GetFabricConfig();
+
 namespace experimental {
 size_t get_number_of_available_routing_planes(
     const tt::tt_metal::distributed::MeshDevice& mesh_device, size_t cluster_axis, size_t row_or_col);

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -95,11 +95,11 @@ tt::tt_fabric::Topology get_fabric_topology();
  * | num_routing_planes | Number of routing planes for fabric | optional<uint8_t> |             | No       |
  */
 void SetFabricConfig(
-    tt_metal::FabricConfig fabric_config,
-    tt_metal::FabricReliabilityMode reliability_mode = tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+    FabricConfig fabric_config,
+    FabricReliabilityMode reliability_mode = FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
     std::optional<uint8_t> num_routing_planes = std::nullopt);
 
-tt_metal::FabricConfig GetFabricConfig();
+FabricConfig GetFabricConfig();
 
 namespace experimental {
 size_t get_number_of_available_routing_planes(

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/fabric_types.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/fabric_edm_types.hpp>
@@ -78,7 +79,27 @@ std::unordered_map<MeshId, tt::tt_metal::distributed::MeshShape> get_physical_me
 
 tt::tt_fabric::Topology get_fabric_topology();
 
-FabricConfig GetFabricConfig();
+/**
+ * Call before CreateDevices to enable fabric, which uses the specified number of routing planes.
+ * Currently, setting num_routing_planes dictates how many routing planes the fabric should be active on
+ * for that init sequence. The number of routing planes fabric will be initialized on will be the max
+ * of all the values specified by different clients. If a client wants to initialize fabric on all the
+ * available routing planes, num_routing_planes can be left unspecifed.
+ * NOTE: This does not 'reserve' routing planes for any clients, but is rather a global setting.
+ *
+ * Return value: void
+ *
+ * | Argument           | Description                         | Data type         | Valid range | Required |
+ * |--------------------|-------------------------------------|-------------------|-------------|----------|
+ * | fabric_config      | Fabric config to set                | FabricConfig      |             | Yes      |
+ * | num_routing_planes | Number of routing planes for fabric | optional<uint8_t> |             | No       |
+ */
+void SetFabricConfig(
+    tt_metal::FabricConfig fabric_config,
+    tt_metal::FabricReliabilityMode reliability_mode = tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+    std::optional<uint8_t> num_routing_planes = std::nullopt);
+
+tt_metal::FabricConfig GetFabricConfig();
 
 namespace experimental {
 size_t get_number_of_available_routing_planes(

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -13,7 +13,6 @@
 #include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
 #include <vector>
 #include <umd/device/tt_core_coordinates.h>
-#include <tt-metalium/fabric_types.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/api/tt-metalium/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/fabric_types.hpp
@@ -6,7 +6,7 @@
 
 #include <tt_stl/strong_type.hpp>
 
-namespace tt::tt_metal {
+namespace tt::tt_fabric {
 
 enum class FabricConfig : uint32_t {
     DISABLED = 0,

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -61,6 +61,8 @@ void SetFabricConfig(
     FabricReliabilityMode reliability_mode = FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
     std::optional<uint8_t> num_routing_planes = std::nullopt);
 
+FabricConfig GetFabricConfig();
+
 std::map<chip_id_t, IDevice*> CreateDevices(
     // TODO: delete this in favour of DevicePool
     const std::vector<chip_id_t>& device_ids,

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -41,26 +41,6 @@ namespace detail {
 
 bool DispatchStateCheck(bool isFastDispatch);
 
-/**
- * Call before CreateDevices to enable fabric, which uses the specified number of routing planes.
- * Currently, setting num_routing_planes dictates how many routing planes the fabric should be active on
- * for that init sequence. The number of routing planes fabric will be initialized on will be the max
- * of all the values specified by different clients. If a client wants to initialize fabric on all the
- * available routing planes, num_routing_planes can be left unspecifed.
- * NOTE: This does not 'reserve' routing planes for any clients, but is rather a global setting.
- *
- * Return value: void
- *
- * | Argument           | Description                         | Data type         | Valid range | Required |
- * |--------------------|-------------------------------------|-------------------|-------------|----------|
- * | fabric_config      | Fabric config to set                | FabricConfig      |             | Yes      |
- * | num_routing_planes | Number of routing planes for fabric | optional<uint8_t> |             | No       |
- */
-void SetFabricConfig(
-    FabricConfig fabric_config,
-    FabricReliabilityMode reliability_mode = FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
-    std::optional<uint8_t> num_routing_planes = std::nullopt);
-
 std::map<chip_id_t, IDevice*> CreateDevices(
     // TODO: delete this in favour of DevicePool
     const std::vector<chip_id_t>& device_ids,

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -61,8 +61,6 @@ void SetFabricConfig(
     FabricReliabilityMode reliability_mode = FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
     std::optional<uint8_t> num_routing_planes = std::nullopt);
 
-FabricConfig GetFabricConfig();
-
 std::map<chip_id_t, IDevice*> CreateDevices(
     // TODO: delete this in favour of DevicePool
     const std::vector<chip_id_t>& device_ids,

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -17,20 +17,12 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
-#include <tt-metalium/fabric_types.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/profiler_optional_metadata.hpp>
 #include <tt-metalium/profiler_types.hpp>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_soc_descriptor.h>
 #include <umd/device/types/cluster_descriptor_types.h>
-
-namespace tt {
-namespace tt_metal {
-enum class FabricConfig : uint32_t;
-enum class FabricReliabilityMode : uint32_t;
-}  // namespace tt_metal
-}  // namespace tt
 
 namespace tt::tt_metal {
 class Buffer;

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -31,16 +31,16 @@ std::unordered_map<MeshCoordinate, std::vector<std::pair<uint32_t, SocketConnect
 }
 
 void validate_fabric_config_for_sockets(
-    FabricConfig fabric_config, tt_fabric::FabricNodeId sender_node, tt_fabric::FabricNodeId recv_node) {
+    tt_fabric::FabricConfig fabric_config, tt_fabric::FabricNodeId sender_node, tt_fabric::FabricNodeId recv_node) {
     if (sender_node != recv_node) {
-        TT_FATAL(fabric_config != FabricConfig::DISABLED, "Can only create multi-device sockets with fabric enabled.");
+        TT_FATAL(fabric_config != tt_fabric::FabricConfig::DISABLED, "Can only create multi-device sockets with fabric enabled.");
     }
 
-    static const std::unordered_set<FabricConfig> supported_fabrics = {
-        FabricConfig::FABRIC_1D,
-        FabricConfig::FABRIC_1D_RING,
-        FabricConfig::FABRIC_2D_DYNAMIC,
-        FabricConfig::DISABLED  // Fabric can be disabled as long as socket endpoints are on the same physical device
+    static const std::unordered_set<tt_fabric::FabricConfig> supported_fabrics = {
+        tt_fabric::FabricConfig::FABRIC_1D,
+        tt_fabric::FabricConfig::FABRIC_1D_RING,
+        tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC,
+        tt_fabric::FabricConfig::DISABLED  // Fabric can be disabled as long as socket endpoints are on the same physical device
     };
 
     bool fabric_config_supported = supported_fabrics.count(fabric_config) > 0;
@@ -52,13 +52,13 @@ void validate_fabric_config_for_sockets(
 std::pair<tt_fabric::MeshId, uint32_t> get_sender_receiver_chip_fabric_encoding(
     tt_fabric::FabricNodeId sender_node_id,
     tt_fabric::FabricNodeId recv_node_id,
-    FabricConfig fabric_config,
+    tt_fabric::FabricConfig fabric_config,
     SocketEndpoint socket_endpoint) {
     bool is_sender = socket_endpoint == SocketEndpoint::SENDER;
 
     validate_fabric_config_for_sockets(fabric_config, sender_node_id, recv_node_id);
 
-    if (fabric_config == FabricConfig::FABRIC_1D or fabric_config == FabricConfig::FABRIC_1D_RING) {
+    if (fabric_config == tt_fabric::FabricConfig::FABRIC_1D or fabric_config == tt_fabric::FabricConfig::FABRIC_1D_RING) {
         // 1D Fabric requires passing in the number of hops between the sender and receiver
         // Assume 1D is a single mesh
         auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
@@ -234,7 +234,7 @@ void write_socket_configs(
     auto grouped_connections = group_socket_connections(config, socket_endpoint);
     auto peer_config_buf_addr = peer_descriptor.config_buffer_address;
 
-    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+    tt_fabric::FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
 
     if (is_sender) {
         std::vector<sender_socket_md> config_data(config_buffer->size() / sizeof(sender_socket_md), sender_socket_md());

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -135,9 +135,9 @@ std::vector<chip_id_t> get_adjacent_chips_from_ethernet_connections(
 
 void ControlPlane::initialize_dynamic_routing_plane_counts(
     const IntraMeshConnectivity& intra_mesh_connectivity,
-    tt_metal::FabricConfig fabric_config,
-    tt_metal::FabricReliabilityMode reliability_mode) {
-    if (fabric_config == tt_metal::FabricConfig::CUSTOM || fabric_config == tt_metal::FabricConfig::DISABLED) {
+    tt_fabric::FabricConfig fabric_config,
+    tt_fabric::FabricReliabilityMode reliability_mode) {
+    if (fabric_config == tt_fabric::FabricConfig::CUSTOM || fabric_config == tt_fabric::FabricConfig::DISABLED) {
         return;
     }
 
@@ -192,7 +192,7 @@ void ControlPlane::initialize_dynamic_routing_plane_counts(
     };
 
     const auto user_meshes = this->get_user_physical_mesh_ids();
-    if (reliability_mode == tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) {
+    if (reliability_mode == tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) {
         for (auto mesh_id : user_meshes) {
             size_t num_chips_in_mesh = intra_mesh_connectivity[mesh_id.get()].size();
             for (std::uint32_t chip_id = 0; chip_id < num_chips_in_mesh; chip_id++) {
@@ -786,7 +786,7 @@ void ControlPlane::order_ethernet_channels() {
 void ControlPlane::trim_ethernet_channels_not_mapped_to_live_routing_planes() {
     auto user_mesh_ids = this->get_user_physical_mesh_ids();
     std::unordered_set<MeshId> user_mesh_ids_set(user_mesh_ids.begin(), user_mesh_ids.end());
-    if (tt::tt_metal::MetalContext::instance().get_fabric_config() != tt_metal::FabricConfig::CUSTOM) {
+    if (tt::tt_metal::MetalContext::instance().get_fabric_config() != tt_fabric::FabricConfig::CUSTOM) {
         for (auto& [fabric_node_id, directional_eth_chans] : this->router_port_directions_to_physical_eth_chan_map_) {
             if (user_mesh_ids_set.count(fabric_node_id.mesh_id) == 0) {
                 continue;
@@ -852,7 +852,7 @@ size_t ControlPlane::get_num_live_routing_planes(
 // Only builds the routing table representation, does not actually populate the routing tables in memory of the
 // fabric routers on device
 void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
-    tt::tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode) {
+    tt::tt_fabric::FabricConfig fabric_config, tt_fabric::FabricReliabilityMode reliability_mode) {
     this->intra_mesh_routing_tables_.clear();
     this->inter_mesh_routing_tables_.clear();
     this->router_port_directions_to_physical_eth_chan_map_.clear();
@@ -888,7 +888,7 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
                                          connected_chips_and_eth_cores.end();
                 TT_FATAL(
                     connections_exist ||
-                        reliability_mode != tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+                        reliability_mode != tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
                     "Expected connections to exist for M{}D{} to D{}",
                     mesh_id,
                     chip_id,
@@ -898,7 +898,7 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
                 }
 
                 const auto& connected_eth_cores = connected_chips_and_eth_cores.at(physical_connected_chip_id);
-                if (reliability_mode == tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) {
+                if (reliability_mode == tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) {
                     TT_FATAL(
                         connected_eth_cores.size() >= edge.connected_chip_ids.size(),
                         "Expected {} eth links from physical chip {} to physical chip {}",
@@ -1566,7 +1566,7 @@ void ControlPlane::set_routing_mode(uint16_t mode) {
 
 uint16_t ControlPlane::get_routing_mode() const { return this->routing_mode_; }
 
-void ControlPlane::initialize_fabric_context(tt_metal::FabricConfig fabric_config) {
+void ControlPlane::initialize_fabric_context(tt_fabric::FabricConfig fabric_config) {
     TT_FATAL(this->fabric_context_ == nullptr, "Trying to re-initialize fabric context");
     this->fabric_context_ = std::make_unique<FabricContext>(fabric_config);
 }

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -242,13 +242,9 @@ tt::tt_fabric::Topology get_fabric_topology() {
 FabricConfig GetFabricConfig() { return tt::tt_metal::MetalContext::instance().get_fabric_config(); }
 
 void SetFabricConfig(
-    tt_metal::FabricConfig fabric_config,
-    tt_metal::FabricReliabilityMode reliability_mode,
-    std::optional<uint8_t> num_routing_planes) {
+    FabricConfig fabric_config, FabricReliabilityMode reliability_mode, std::optional<uint8_t> num_routing_planes) {
     tt::tt_metal::MetalContext::instance().set_fabric_config(fabric_config, reliability_mode, num_routing_planes);
 }
-
-tt_metal::FabricConfig GetFabricConfig() { return tt::tt_metal::MetalContext::instance().get_fabric_config(); }
 
 namespace experimental {
 

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -239,6 +239,8 @@ tt::tt_fabric::Topology get_fabric_topology() {
     return control_plane.get_fabric_context().get_fabric_topology();
 }
 
+FabricConfig GetFabricConfig() { return tt::tt_metal::MetalContext::instance().get_fabric_config(); }
+
 namespace experimental {
 
 size_t get_number_of_available_routing_planes(

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -241,6 +241,15 @@ tt::tt_fabric::Topology get_fabric_topology() {
 
 FabricConfig GetFabricConfig() { return tt::tt_metal::MetalContext::instance().get_fabric_config(); }
 
+void SetFabricConfig(
+    tt_metal::FabricConfig fabric_config,
+    tt_metal::FabricReliabilityMode reliability_mode,
+    std::optional<uint8_t> num_routing_planes) {
+    tt::tt_metal::MetalContext::instance().set_fabric_config(fabric_config, reliability_mode, num_routing_planes);
+}
+
+tt_metal::FabricConfig GetFabricConfig() { return tt::tt_metal::MetalContext::instance().get_fabric_config(); }
+
 namespace experimental {
 
 size_t get_number_of_available_routing_planes(

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -43,15 +43,15 @@ std::unordered_map<MeshId, bool> FabricContext::check_for_wrap_around_mesh() con
     return wrap_around_mesh;
 }
 
-tt::tt_fabric::Topology FabricContext::get_topology_from_config(tt::tt_metal::FabricConfig fabric_config) {
+tt::tt_fabric::Topology FabricContext::get_topology_from_config(tt::tt_fabric::FabricConfig fabric_config) {
     switch (fabric_config) {
-        case tt::tt_metal::FabricConfig::FABRIC_1D: return tt::tt_fabric::Topology::Linear;
-        case tt::tt_metal::FabricConfig::FABRIC_1D_RING: return tt::tt_fabric::Topology::Ring;
-        case tt::tt_metal::FabricConfig::FABRIC_2D: return tt::tt_fabric::Topology::Mesh;
-        case tt::tt_metal::FabricConfig::FABRIC_2D_TORUS: return tt::tt_fabric::Topology::Torus;
-        case tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC: return tt::tt_fabric::Topology::Mesh;
-        case tt::tt_metal::FabricConfig::DISABLED:
-        case tt::tt_metal::FabricConfig::CUSTOM:
+        case tt::tt_fabric::FabricConfig::FABRIC_1D: return tt::tt_fabric::Topology::Linear;
+        case tt::tt_fabric::FabricConfig::FABRIC_1D_RING: return tt::tt_fabric::Topology::Ring;
+        case tt::tt_fabric::FabricConfig::FABRIC_2D: return tt::tt_fabric::Topology::Mesh;
+        case tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS: return tt::tt_fabric::Topology::Torus;
+        case tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC: return tt::tt_fabric::Topology::Mesh;
+        case tt::tt_fabric::FabricConfig::DISABLED:
+        case tt::tt_fabric::FabricConfig::CUSTOM:
             TT_THROW("Unsupported fabric config: {}", magic_enum::enum_name(fabric_config));
     }
     return tt::tt_fabric::Topology::Linear;
@@ -59,7 +59,7 @@ tt::tt_fabric::Topology FabricContext::get_topology_from_config(tt::tt_metal::Fa
 
 size_t FabricContext::get_packet_header_size_bytes() const {
     if (this->topology_ == Topology::Mesh) {
-        return (this->fabric_config_ == tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC)
+        return (this->fabric_config_ == tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC)
                    ? sizeof(tt::tt_fabric::MeshPacketHeader)
                    : sizeof(tt::tt_fabric::LowLatencyMeshPacketHeader);
     } else {
@@ -95,9 +95,9 @@ std::unique_ptr<tt::tt_fabric::FabricEriscDatamoverConfig> FabricContext::get_ed
         this->channel_buffer_size_bytes_, this->topology_, edm_options);
 }
 
-FabricContext::FabricContext(tt::tt_metal::FabricConfig fabric_config) {
+FabricContext::FabricContext(tt::tt_fabric::FabricConfig fabric_config) {
     TT_FATAL(
-        fabric_config != tt::tt_metal::FabricConfig::DISABLED,
+        fabric_config != tt::tt_fabric::FabricConfig::DISABLED,
         "Trying to initialize fabric context for disabled fabric config");
 
     this->fabric_config_ = fabric_config;

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -20,15 +20,15 @@ public:
     static constexpr auto routing_directions = {
         RoutingDirection::N, RoutingDirection::S, RoutingDirection::E, RoutingDirection::W};
 
-    explicit FabricContext(tt::tt_metal::FabricConfig fabric_config);
+    explicit FabricContext(tt::tt_fabric::FabricConfig fabric_config);
     ~FabricContext() = default;
 
     bool is_wrap_around_mesh(MeshId mesh_id) const;
 
-    static tt::tt_fabric::Topology get_topology_from_config(tt::tt_metal::FabricConfig fabric_config);
+    static tt::tt_fabric::Topology get_topology_from_config(tt::tt_fabric::FabricConfig fabric_config);
 
     tt::tt_fabric::Topology get_fabric_topology() const;
-    tt::tt_metal::FabricConfig get_fabric_config() const { return fabric_config_; }
+    tt::tt_fabric::FabricConfig get_fabric_config() const { return fabric_config_; }
 
     size_t get_fabric_packet_header_size_bytes() const;
     size_t get_fabric_max_payload_size_bytes() const;
@@ -61,7 +61,7 @@ private:
         tt::tt_fabric::FabricEriscDatamoverType edm_type, tt::tt_fabric::FabricEriscDatamoverAxis edm_axis);
 
     bool initialized_ = false;
-    tt::tt_metal::FabricConfig fabric_config_{};
+    tt::tt_fabric::FabricConfig fabric_config_{};
 
     std::unordered_map<MeshId, bool> wrap_around_mesh_{};
     tt::tt_fabric::Topology topology_{};

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -25,18 +25,18 @@
 
 namespace tt::tt_fabric {
 
-bool is_tt_fabric_config(tt::tt_metal::FabricConfig fabric_config) {
-    return fabric_config == tt::tt_metal::FabricConfig::FABRIC_1D ||
-           fabric_config == tt::tt_metal::FabricConfig::FABRIC_1D_RING ||
-           fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D ||
-           fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D_TORUS ||
-           fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC;
+bool is_tt_fabric_config(tt::tt_fabric::FabricConfig fabric_config) {
+    return fabric_config == tt::tt_fabric::FabricConfig::FABRIC_1D ||
+           fabric_config == tt::tt_fabric::FabricConfig::FABRIC_1D_RING ||
+           fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D ||
+           fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS ||
+           fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC;
 }
 
-bool is_2d_fabric_config(tt::tt_metal::FabricConfig fabric_config) {
-    return fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D ||
-           fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D_TORUS ||
-           fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC;
+bool is_2d_fabric_config(tt::tt_fabric::FabricConfig fabric_config) {
+    return fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D ||
+           fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS ||
+           fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC;
 }
 
 uint32_t get_sender_channel_count(tt::tt_fabric::Topology topology) {
@@ -55,8 +55,8 @@ uint32_t get_downstream_edm_count(tt::tt_fabric::Topology topology) {
     }
 }
 
-FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::ClusterType cluster_type) {
-    if (cluster_type == tt::ClusterType::GALAXY && fabric_config == tt::tt_metal::FabricConfig::FABRIC_1D_RING) {
+FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config, tt::ClusterType cluster_type) {
+    if (cluster_type == tt::ClusterType::GALAXY && fabric_config == tt::tt_fabric::FabricConfig::FABRIC_1D_RING) {
         return FabricType::TORUS_XY;
     }
     return FabricType::MESH;
@@ -144,7 +144,7 @@ void set_routing_mode(uint16_t routing_mode) {
     control_plane.set_routing_mode(routing_mode);
 }
 
-void set_routing_mode(Topology topology, tt::tt_metal::FabricConfig fabric_config, uint32_t dimension /*, take more*/) {
+void set_routing_mode(Topology topology, tt::tt_fabric::FabricConfig fabric_config, uint32_t dimension /*, take more*/) {
     // TODO: take more parameters to set detail routing mode
     TT_FATAL(
         dimension == 1 || dimension == 2 || dimension == 3,
@@ -159,7 +159,7 @@ void set_routing_mode(Topology topology, tt::tt_metal::FabricConfig fabric_confi
     } else if (topology == Topology::Mesh) {
         mode |= (ROUTING_MODE_2D | ROUTING_MODE_MESH);
     }
-    if (fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC) {
+    if (fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC) {
         mode |= ROUTING_MODE_DYNAMIC;
     } else {
         mode |= ROUTING_MODE_LOW_LATENCY;

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -21,16 +21,16 @@
 namespace tt::tt_fabric {
 
 class FabricNodeId;
-bool is_tt_fabric_config(tt::tt_metal::FabricConfig fabric_config);
-bool is_2d_fabric_config(tt::tt_metal::FabricConfig fabric_config);
+bool is_tt_fabric_config(tt::tt_fabric::FabricConfig fabric_config);
+bool is_2d_fabric_config(tt::tt_fabric::FabricConfig fabric_config);
 
 uint32_t get_sender_channel_count(tt::tt_fabric::Topology topology);
 uint32_t get_downstream_edm_count(tt::tt_fabric::Topology topology);
 
 void set_routing_mode(uint16_t routing_mode);
-void set_routing_mode(Topology topology, tt::tt_metal::FabricConfig fabric_config, uint32_t dimension = 1);
+void set_routing_mode(Topology topology, tt::tt_fabric::FabricConfig fabric_config, uint32_t dimension = 1);
 
-FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::ClusterType cluster_type);
+FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config, tt::ClusterType cluster_type);
 
 std::vector<uint32_t> get_forwarding_link_indices_in_direction(
     const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id, RoutingDirection direction);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -378,7 +378,7 @@ void MetalContext::set_custom_control_plane_mesh_graph(
 
     global_control_plane_ = std::make_unique<tt::tt_fabric::GlobalControlPlane>(
         mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
-    this->set_fabric_config(fabric_config_, tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    this->set_fabric_config(fabric_config_, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
 }
 
 void MetalContext::set_default_control_plane_mesh_graph() {
@@ -386,11 +386,11 @@ void MetalContext::set_default_control_plane_mesh_graph() {
         !DevicePool::is_initialized() || DevicePool::instance().get_all_active_devices().size() == 0,
         "Modifying control plane requires no devices to be active");
     global_control_plane_.reset();
-    this->set_fabric_config(fabric_config_, tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    this->set_fabric_config(fabric_config_, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
 }
 
 void MetalContext::teardown_fabric_config() {
-    this->fabric_config_ = tt_metal::FabricConfig::DISABLED;
+    this->fabric_config_ = tt_fabric::FabricConfig::DISABLED;
     this->cluster_->configure_ethernet_cores_for_fabric_routers(this->fabric_config_);
     this->num_fabric_active_routing_planes_ = 0;
     // if (!rtoptions_.get_erisc_iram_env_var_enabled()) {
@@ -400,12 +400,12 @@ void MetalContext::teardown_fabric_config() {
 }
 
 void MetalContext::set_fabric_config(
-    const tt_metal::FabricConfig fabric_config,
-    tt_metal::FabricReliabilityMode reliability_mode,
+    const tt_fabric::FabricConfig fabric_config,
+    tt_fabric::FabricReliabilityMode reliability_mode,
     std::optional<uint8_t> num_routing_planes) {
     // Changes to fabric force a re-init. TODO: We should supply the fabric config in the same way as the dispatch config, not through this function exposed in the detail API.
     force_reinit_ = true;
-    if (this->fabric_config_ == tt_metal::FabricConfig::DISABLED || fabric_config == tt_metal::FabricConfig::DISABLED) {
+    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED || fabric_config == tt_fabric::FabricConfig::DISABLED) {
         this->fabric_config_ = fabric_config;
         this->fabric_reliability_mode_ = reliability_mode;
     } else {
@@ -416,7 +416,7 @@ void MetalContext::set_fabric_config(
             fabric_config);
     }
 
-    if (this->fabric_config_ == tt_metal::FabricConfig::DISABLED) {
+    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED) {
         if (num_routing_planes.has_value()) {
             log_warning(
                 tt::LogMetal,
@@ -455,7 +455,7 @@ void MetalContext::set_fabric_config(
 }
 
 void MetalContext::initialize_fabric_config() {
-    if (this->fabric_config_ == tt_metal::FabricConfig::DISABLED) {
+    if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED) {
         return;
     }
 
@@ -469,7 +469,7 @@ void MetalContext::initialize_fabric_config() {
         this->fabric_config_, this->fabric_reliability_mode_);
 }
 
-tt_metal::FabricConfig MetalContext::get_fabric_config() const {
+tt_fabric::FabricConfig MetalContext::get_fabric_config() const {
     return fabric_config_;
 }
 

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -78,12 +78,12 @@ public:
         const std::map<tt_fabric::FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping);
     void set_default_control_plane_mesh_graph();
     void set_fabric_config(
-        tt_metal::FabricConfig fabric_config,
-        tt_metal::FabricReliabilityMode reliability_mode =
-            tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+        tt_fabric::FabricConfig fabric_config,
+        tt_fabric::FabricReliabilityMode reliability_mode =
+            tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
         std::optional<uint8_t> num_routing_planes = std::nullopt);
     void initialize_fabric_config();
-    tt_metal::FabricConfig get_fabric_config() const;
+    tt_fabric::FabricConfig get_fabric_config() const;
 
     distributed::multihost::DistributedContext& get_distributed_context();
 
@@ -144,14 +144,14 @@ private:
     std::unique_ptr<WatcherServer> watcher_server_;
     std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
     std::unique_ptr<tt::tt_fabric::GlobalControlPlane> global_control_plane_;
-    tt_metal::FabricConfig fabric_config_ = tt_metal::FabricConfig::DISABLED;
+    tt_fabric::FabricConfig fabric_config_ = tt_fabric::FabricConfig::DISABLED;
     std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
 
     // Strict system health mode requires (expects) all links/devices to be live. When enabled, it
     // is expected that any downed devices/links will result in some sort of error condition being
     // reported. When set to false, the control plane is free to instantiate fewer routing planes
     // according to which links are available.
-    tt_metal::FabricReliabilityMode fabric_reliability_mode_ = tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
+    tt_fabric::FabricReliabilityMode fabric_reliability_mode_ = tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
     uint8_t num_fabric_active_routing_planes_ = 0;
 };
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -386,7 +386,7 @@ void DevicePool::initialize_active_devices() const {
     const auto& active_devices = this->get_all_active_devices();
 
     // Activate fabric (must be before FD)
-    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+    tt_fabric::FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (tt_fabric::is_tt_fabric_config(fabric_config)) {
         log_info(tt::LogMetal, "Initializing Fabric");
         tt::tt_metal::MetalContext::instance().get_control_plane().write_routing_tables_to_all_chips();
@@ -613,7 +613,7 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
     }
 
     // Only can launch Fabric if all devices are active
-    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+    tt_fabric::FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (tt_fabric::is_tt_fabric_config(fabric_config)) {
         for (int i = 0; i < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices(); i++) {
             // Fabric currently requires all devices to be active
@@ -627,7 +627,7 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
 }
 
 void DevicePool::wait_for_fabric_router_sync() const {
-    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+    tt_fabric::FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (!tt::tt_fabric::is_tt_fabric_config(fabric_config)) {
         return;
     }
@@ -918,7 +918,7 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
     }
 
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
-        tt::tt_fabric::SetFabricConfig(FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(tt_fabric::FabricConfig::DISABLED);
     }
 
     return pass;

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -311,17 +311,17 @@ void DevicePool::initialize(
     tt::tt_metal::MetalContext::instance().initialize_fabric_config();
 
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric() && any_remote_devices) {
-        FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
-        if (fabric_config == FabricConfig::DISABLED) {
-            tt::tt_metal::detail::SetFabricConfig(
-                FabricConfig::FABRIC_1D, tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
+        tt::tt_fabric::FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+        if (fabric_config == tt::tt_fabric::FabricConfig::DISABLED) {
+            tt::tt_fabric::SetFabricConfig(
+                tt::tt_fabric::FabricConfig::FABRIC_1D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
             // Call initialize again because previously it was a no-op
             tt::tt_metal::MetalContext::instance().initialize_fabric_config();
-            fabric_config = FabricConfig::FABRIC_1D;
+            fabric_config = tt::tt_fabric::FabricConfig::FABRIC_1D;
         } else {
             // Use the same mode
-            tt::tt_metal::detail::SetFabricConfig(
-                fabric_config, tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
+            tt::tt_fabric::SetFabricConfig(
+                fabric_config, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
         }
         log_info(tt::LogMetal, "Dispatch on {} with {} Command Queues\n", fabric_config, num_hw_cqs);
     }
@@ -918,7 +918,7 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
     }
 
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
-        tt::tt_metal::detail::SetFabricConfig(FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(FabricConfig::DISABLED);
     }
 
     return pass;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -206,7 +206,7 @@ void DispatchKernel::GenerateStaticConfigs() {
             tt_fabric::Topology::Mesh;
         static_config_.is_2d_fabric_dynamic =
             tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context().get_fabric_config() ==
-            tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC;
+            tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC;
     } else {
         static_config_.is_2d_fabric = false;
         static_config_.is_2d_fabric_dynamic = false;

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -225,7 +225,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
             tt_fabric::Topology::Mesh;
         static_config_.is_2d_fabric_dynamic =
             tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context().get_fabric_config() ==
-            tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC;
+            tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC;
     } else {
         static_config_.is_2d_fabric = false;
         static_config_.is_2d_fabric_dynamic = false;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1121,8 +1121,8 @@ std::unordered_set<chip_id_t> Cluster::get_ethernet_connected_device_ids(chip_id
 }
 
 void Cluster::configure_ethernet_cores_for_fabric_routers(
-    tt_metal::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes) {
-    if (fabric_config != tt_metal::FabricConfig::DISABLED) {
+    tt_fabric::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes) {
+    if (fabric_config != tt_fabric::FabricConfig::DISABLED) {
         TT_FATAL(num_routing_planes.has_value(), "num_routing_planes should be set for reserving cores for fabric");
         TT_FATAL(num_routing_planes.value() > 0, "Expected non-zero num_routing_planes for reserving cores for fabric");
         this->reserve_ethernet_cores_for_fabric_routers(num_routing_planes.value());

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -305,10 +305,10 @@ public:
 
     // Configures ethernet cores for fabric routers depending on whether fabric is enabled
     void configure_ethernet_cores_for_fabric_routers(
-        tt_metal::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt);
+        tt_fabric::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt);
 
     void initialize_fabric_config(
-        tt_metal::FabricConfig fabric_config, tt_metal::FabricReliabilityMode reliability_mode);
+        tt_fabric::FabricConfig fabric_config, tt_fabric::FabricReliabilityMode reliability_mode);
 
     // Returns whether we are running on Galaxy.
     bool is_galaxy_cluster() const;

--- a/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
@@ -108,7 +108,7 @@ inline void dumpRoutingInfo(const std::filesystem::path& filepath) {
     }
 
     topology_json["fabric_config"] = magic_enum::enum_name(tt::tt_metal::MetalContext::instance().get_fabric_config());
-    if (tt::tt_metal::MetalContext::instance().get_fabric_config() != FabricConfig::DISABLED) {
+    if (tt::tt_metal::MetalContext::instance().get_fabric_config() != tt_fabric::FabricConfig::DISABLED) {
         topology_json["routing_planes"] = nlohmann::ordered_json::array();
         topology_json["device_id_to_fabric_node_id"] = nlohmann::ordered_json::object();
         for (auto physical_chip_id : cluster.get_cluster_desc()->get_all_chips()) {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -373,11 +373,6 @@ bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t 
     return true;
 }
 
-void SetFabricConfig(
-    FabricConfig fabric_config, FabricReliabilityMode reliability_mode, std::optional<uint8_t> num_routing_planes) {
-    tt::tt_metal::MetalContext::instance().set_fabric_config(fabric_config, reliability_mode, num_routing_planes);
-}
-
 std::map<chip_id_t, IDevice*> CreateDevices(
     const std::vector<chip_id_t>& device_ids,
     const uint8_t num_hw_cqs,

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -378,6 +378,8 @@ void SetFabricConfig(
     tt::tt_metal::MetalContext::instance().set_fabric_config(fabric_config, reliability_mode, num_routing_planes);
 }
 
+FabricConfig GetFabricConfig() { return tt::tt_metal::MetalContext::instance().get_fabric_config(); }
+
 std::map<chip_id_t, IDevice*> CreateDevices(
     const std::vector<chip_id_t>& device_ids,
     const uint8_t num_hw_cqs,

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -378,8 +378,6 @@ void SetFabricConfig(
     tt::tt_metal::MetalContext::instance().set_fabric_config(fabric_config, reliability_mode, num_routing_planes);
 }
 
-FabricConfig GetFabricConfig() { return tt::tt_metal::MetalContext::instance().get_fabric_config(); }
-
 std::map<chip_id_t, IDevice*> CreateDevices(
     const std::vector<chip_id_t>& device_ids,
     const uint8_t num_hw_cqs,

--- a/ttnn/cpp/ttnn-pybind/fabric.cpp
+++ b/ttnn/cpp/ttnn-pybind/fabric.cpp
@@ -13,29 +13,29 @@
 namespace ttnn::fabric {
 
 void py_bind_fabric_api(py::module& module) {
-    py::enum_<tt::tt_metal::FabricConfig>(module, "FabricConfig")
-        .value("DISABLED", tt::tt_metal::FabricConfig::DISABLED)
-        .value("FABRIC_1D", tt::tt_metal::FabricConfig::FABRIC_1D)
-        .value("FABRIC_1D_RING", tt::tt_metal::FabricConfig::FABRIC_1D_RING)
-        .value("FABRIC_2D", tt::tt_metal::FabricConfig::FABRIC_2D)
-        .value("FABRIC_2D_DYNAMIC", tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC)
-        .value("CUSTOM", tt::tt_metal::FabricConfig::CUSTOM);  // DISABLED = 0, FABRIC_1D = 1, FABRIC_2D = 2, CUSTOM = 4
-    py::enum_<tt::tt_metal::FabricReliabilityMode>(module, "FabricReliabilityMode", R"(
+    py::enum_<tt::tt_fabric::FabricConfig>(module, "FabricConfig")
+        .value("DISABLED", tt::tt_fabric::FabricConfig::DISABLED)
+        .value("FABRIC_1D", tt::tt_fabric::FabricConfig::FABRIC_1D)
+        .value("FABRIC_1D_RING", tt::tt_fabric::FabricConfig::FABRIC_1D_RING)
+        .value("FABRIC_2D", tt::tt_fabric::FabricConfig::FABRIC_2D)
+        .value("FABRIC_2D_DYNAMIC", tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC)
+        .value("CUSTOM", tt::tt_fabric::FabricConfig::CUSTOM);  // DISABLED = 0, FABRIC_1D = 1, FABRIC_2D = 2, CUSTOM = 4
+    py::enum_<tt::tt_fabric::FabricReliabilityMode>(module, "FabricReliabilityMode", R"(
         Specifies how the fabric initialization handles system health and configuration.
         Values:
             STRICT_INIT: Initialize fabric such that the live links/devices must exactly match the mesh graph descriptor. Any downed devices/links will result in errors.
             RELAXED_INIT: Initialize the fabric with flexibility towards downed links/devices. The fabric will initialize with fewer routing planes than in mesh graph descriptor, based on live links.
             DYNAMIC_RECONFIG: [Unsupported] Placeholder for dynamic (runtime) reconfiguration based on live system events (such as hardware failures).
         )")
-        .value("STRICT_INIT", tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE)
-        .value("RELAXED_INIT", tt::tt_metal::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE)
-        .value("DYNAMIC_RECONFIG", tt::tt_metal::FabricReliabilityMode::DYNAMIC_RECONFIGURATION_SETUP_MODE);
+        .value("STRICT_INIT", tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE)
+        .value("RELAXED_INIT", tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE)
+        .value("DYNAMIC_RECONFIG", tt::tt_fabric::FabricReliabilityMode::DYNAMIC_RECONFIGURATION_SETUP_MODE);
 
     module.def(
         "set_fabric_config",
         &tt::tt_fabric::SetFabricConfig,
         py::arg("config"),
-        py::arg("reliability_mode") = tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+        py::arg("reliability_mode") = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
         py::arg("num_planes") = std::nullopt);
 }
 

--- a/ttnn/cpp/ttnn-pybind/fabric.cpp
+++ b/ttnn/cpp/ttnn-pybind/fabric.cpp
@@ -8,7 +8,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/fabric.hpp>
 
 namespace ttnn::fabric {
 
@@ -33,7 +33,7 @@ void py_bind_fabric_api(py::module& module) {
 
     module.def(
         "set_fabric_config",
-        &tt::tt_metal::detail::SetFabricConfig,
+        &tt::tt_fabric::SetFabricConfig,
         py::arg("config"),
         py::arg("reliability_mode") = tt::tt_metal::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
         py::arg("num_planes") = std::nullopt);


### PR DESCRIPTION
### Ticket
closes #24654 

### Problem description
tt_metal.hpp exposes a public SetFabricConfig() API, but it does not provide a corresponding GetFabricConfig() API. At times, we need to retrieve the fabric configuration that was initialized in the current context.

### What's changed
Expose MetalContext::get_fabric_config() as a public API.
Refactor FabricConfig-related APIs and enums by moving them to the tt::tt_fabric namespace and the corresponding file.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes