### PR TITLE
#15840: Unify `HostStorage` and `MultiDeviceHostStorage`

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -29,7 +29,7 @@ TensorSpec get_tensor_spec(const ttnn::Shape& shape, DataType dtype) {
 // Returns the number of unique buffers in host-side multi-device tensor.
 int count_unique_buffers(const Tensor& tensor) {
     std::unordered_set<const void*> buffer_addresses;
-    tensor.host_storage().distributed_buffer().apply(
+    tensor.host_storage().buffer().apply(
         [&buffer_addresses](const HostBuffer& buffer) { buffer_addresses.insert(buffer.view_bytes().data()); });
     return buffer_addresses.size();
 }

--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -28,9 +28,8 @@ TensorSpec get_tensor_spec(const ttnn::Shape& shape, DataType dtype) {
 
 // Returns the number of unique buffers in host-side multi-device tensor.
 int count_unique_buffers(const Tensor& tensor) {
-    const auto& storage = std::get<tt::tt_metal::MultiDeviceHostStorage>(tensor.storage());
     std::unordered_set<const void*> buffer_addresses;
-    storage.distributed_buffer().apply(
+    tensor.host_storage().distributed_buffer().apply(
         [&buffer_addresses](const HostBuffer& buffer) { buffer_addresses.insert(buffer.view_bytes().data()); });
     return buffer_addresses.size();
 }
@@ -45,9 +44,8 @@ TEST_F(TensorDistributionTest, DistributeToDevice) {
     auto mapper = replicate_tensor_to_mesh_mapper(*mesh_device_);
 
     // If no device is provided, the tensor is kept on host.
-    EXPECT_TRUE(distribute_tensor(input_tensor, *mapper).storage_type() == StorageType::MULTI_DEVICE_HOST);
-    EXPECT_TRUE(
-        distribute_tensor(input_tensor, *mapper, *mesh_device_).storage_type() != StorageType::MULTI_DEVICE_HOST);
+    EXPECT_TRUE(distribute_tensor(input_tensor, *mapper).storage_type() == StorageType::HOST);
+    EXPECT_TRUE(distribute_tensor(input_tensor, *mapper, *mesh_device_).storage_type() != StorageType::HOST);
 }
 
 TEST_F(TensorDistributionTest, SingleDeviceTensorReplication) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -110,7 +110,7 @@ TEST(MeshTensorHostTest, FromHostShards) {
         MeshShape(2));
 
     EXPECT_EQ(tensor.tensor_spec().logical_shape(), ttnn::Shape{10});
-    EXPECT_EQ(tensor.storage_type(), StorageType::MULTI_DEVICE_HOST);
+    EXPECT_EQ(tensor.storage_type(), StorageType::HOST);
 
     auto tensors = get_device_tensors(tensor);
     ASSERT_THAT(tensors, SizeIs(2));
@@ -174,7 +174,7 @@ TEST_F(MeshTensorTest, ReplicateHostStorageTensor) {
 
     // Read the tensor back, and compare it with input data.
     Tensor output_host_tensor = tensor_impl::to_host_mesh_tensor_wrapper(device_tensor);
-    EXPECT_TRUE(output_host_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+    EXPECT_TRUE(output_host_tensor.storage_type() == StorageType::HOST);
     EXPECT_EQ(output_host_tensor.tensor_spec().logical_shape(), shape);
 
     for (const auto& tensor : get_device_tensors(output_host_tensor)) {
@@ -309,7 +309,7 @@ TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {
     std::vector<float> host_data(shape.volume());
     std::iota(host_data.begin(), host_data.end(), 0);
     Tensor input_host_tensor_sharded = distribute_tensor(Tensor::from_vector(host_data, tensor_spec), *mapper);
-    EXPECT_TRUE(input_host_tensor_sharded.storage_type() == StorageType::MULTI_DEVICE_HOST);
+    EXPECT_TRUE(input_host_tensor_sharded.storage_type() == StorageType::HOST);
     EXPECT_EQ(input_host_tensor_sharded.distributed_tensor_config(), mapper->config());
     EXPECT_EQ(input_host_tensor_sharded.tensor_spec().logical_shape(), sharded_shape);
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
@@ -102,7 +102,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard1DTensorRoundtrip) {
     auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*mesh_device_, 1);
     Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);
 
-    ASSERT_TRUE(sharded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+    ASSERT_TRUE(sharded_tensor.storage_type() == StorageType::HOST);
 
     dump_tensor_flatbuffer(test_file.string(), sharded_tensor);
 
@@ -111,7 +111,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard1DTensorRoundtrip) {
     ASSERT_EQ(loaded_tensor.tensor_spec().logical_shape(), sharded_tensor.tensor_spec().logical_shape());
     ASSERT_EQ(loaded_tensor.dtype(), sharded_tensor.dtype());
     ASSERT_EQ(loaded_tensor.layout(), sharded_tensor.layout());
-    ASSERT_TRUE(loaded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+    ASSERT_TRUE(loaded_tensor.storage_type() == StorageType::HOST);
 
     std::vector<Tensor> original_device_tensors = ttnn::distributed::get_device_tensors(sharded_tensor);
     std::vector<Tensor> loaded_device_tensors = ttnn::distributed::get_device_tensors(loaded_tensor);
@@ -149,7 +149,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard2DTensorRoundtrip) {
 
     Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);
 
-    ASSERT_TRUE(sharded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+    ASSERT_TRUE(sharded_tensor.storage_type() == StorageType::HOST);
 
     dump_tensor_flatbuffer(test_file.string(), sharded_tensor);
 
@@ -158,7 +158,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard2DTensorRoundtrip) {
     ASSERT_EQ(loaded_tensor.tensor_spec().logical_shape(), sharded_tensor.tensor_spec().logical_shape());
     ASSERT_EQ(loaded_tensor.dtype(), sharded_tensor.dtype());
     ASSERT_EQ(loaded_tensor.layout(), sharded_tensor.layout());
-    ASSERT_TRUE(loaded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+    ASSERT_TRUE(loaded_tensor.storage_type() == StorageType::HOST);
 
     std::vector<Tensor> original_device_tensors = ttnn::distributed::get_device_tensors(sharded_tensor);
     std::vector<Tensor> loaded_device_tensors = ttnn::distributed::get_device_tensors(loaded_tensor);
@@ -188,7 +188,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard1DFewerShardsThanDevicesRoun
     auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*mesh_device_, 1);
     Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);
 
-    ASSERT_TRUE(sharded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+    ASSERT_TRUE(sharded_tensor.storage_type() == StorageType::HOST);
 
     dump_tensor_flatbuffer(test_file.string(), sharded_tensor);
 
@@ -197,7 +197,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard1DFewerShardsThanDevicesRoun
     ASSERT_EQ(loaded_tensor.tensor_spec().logical_shape(), sharded_tensor.tensor_spec().logical_shape());
     ASSERT_EQ(loaded_tensor.dtype(), sharded_tensor.dtype());
     ASSERT_EQ(loaded_tensor.layout(), sharded_tensor.layout());
-    ASSERT_TRUE(loaded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+    ASSERT_TRUE(loaded_tensor.storage_type() == StorageType::HOST);
 
     std::vector<Tensor> original_device_tensors = ttnn::distributed::get_device_tensors(sharded_tensor);
     std::vector<Tensor> loaded_device_tensors = ttnn::distributed::get_device_tensors(loaded_tensor);
@@ -237,7 +237,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard2x3SubmeshRoundtrip) {
 
     Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);
 
-    ASSERT_TRUE(sharded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+    ASSERT_TRUE(sharded_tensor.storage_type() == StorageType::HOST);
 
     dump_tensor_flatbuffer(test_file.string(), sharded_tensor);
 
@@ -246,7 +246,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard2x3SubmeshRoundtrip) {
     ASSERT_EQ(loaded_tensor.tensor_spec().logical_shape(), sharded_tensor.tensor_spec().logical_shape());
     ASSERT_EQ(loaded_tensor.dtype(), sharded_tensor.dtype());
     ASSERT_EQ(loaded_tensor.layout(), sharded_tensor.layout());
-    ASSERT_TRUE(loaded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+    ASSERT_TRUE(loaded_tensor.storage_type() == StorageType::HOST);
 
     std::vector<Tensor> original_device_tensors = ttnn::distributed::get_device_tensors(sharded_tensor);
     std::vector<Tensor> loaded_device_tensors = ttnn::distributed::get_device_tensors(loaded_tensor);
@@ -285,7 +285,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, PartiallyReplicatedRoundtrip) {
 
     Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);
 
-    ASSERT_TRUE(sharded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+    ASSERT_TRUE(sharded_tensor.storage_type() == StorageType::HOST);
 
     dump_tensor_flatbuffer(test_file.string(), sharded_tensor);
 
@@ -294,7 +294,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, PartiallyReplicatedRoundtrip) {
     ASSERT_EQ(loaded_tensor.tensor_spec().logical_shape(), sharded_tensor.tensor_spec().logical_shape());
     ASSERT_EQ(loaded_tensor.dtype(), sharded_tensor.dtype());
     ASSERT_EQ(loaded_tensor.layout(), sharded_tensor.layout());
-    ASSERT_TRUE(loaded_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+    ASSERT_TRUE(loaded_tensor.storage_type() == StorageType::HOST);
 
     std::vector<Tensor> original_device_tensors = ttnn::distributed::get_device_tensors(sharded_tensor);
     std::vector<Tensor> loaded_device_tensors = ttnn::distributed::get_device_tensors(loaded_tensor);

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -66,8 +66,6 @@ std::vector<tt::tt_metal::HostBuffer> get_as(const ttnn::Tensor& tensor) {
         [](auto&& storage) -> std::vector<tt::tt_metal::HostBuffer> {
             using StorageType = std::decay_t<decltype(storage)>;
             if constexpr (std::is_same_v<StorageType, tt::tt_metal::HostStorage>) {
-                return {storage.buffer};
-            } else if constexpr (std::is_same_v<StorageType, tt::tt_metal::MultiDeviceHostStorage>) {
                 std::vector<tt::tt_metal::HostBuffer> buffers;
                 buffers.reserve(storage.distributed_buffer().shard_coords().size());
                 storage.distributed_buffer().apply(

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -67,9 +67,8 @@ std::vector<tt::tt_metal::HostBuffer> get_as(const ttnn::Tensor& tensor) {
             using StorageType = std::decay_t<decltype(storage)>;
             if constexpr (std::is_same_v<StorageType, tt::tt_metal::HostStorage>) {
                 std::vector<tt::tt_metal::HostBuffer> buffers;
-                buffers.reserve(storage.distributed_buffer().shard_coords().size());
-                storage.distributed_buffer().apply(
-                    [&buffers](const tt::tt_metal::HostBuffer& shard) { buffers.push_back(shard); });
+                buffers.reserve(storage.buffer().shard_coords().size());
+                storage.buffer().apply([&buffers](const tt::tt_metal::HostBuffer& shard) { buffers.push_back(shard); });
                 return buffers;
             } else {
                 throw std::runtime_error("Tensor must be on host");

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -15,13 +15,28 @@
 
 namespace tt::tt_metal {
 
-struct HostStorage {
-    HostBuffer buffer;
-    HostStorage() = default;
-    HostStorage(HostBuffer buffer_) : buffer(std::move(buffer_)) {}
+class HostStorage {
+public:
+    // Creates HostStorage distributed over 1x1 mesh.
+    explicit HostStorage(HostBuffer buffer);
+
+    // Creates HostStorage distributed over a mesh that matches `buffer` shape.
+    explicit HostStorage(DistributedHostBuffer buffer);
+
+    // Returns the distributed host buffer.
+    const DistributedHostBuffer& distributed_buffer() const;
+
+    // Returns a vector of individual device buffers.
+    std::vector<HostBuffer> get_device_buffers() const;
+
+    // Applies a function to each device buffer, returning a new HostStorage.
+    HostStorage transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const;
 
     static constexpr auto attribute_names = std::forward_as_tuple();
     auto attribute_values() const { return std::forward_as_tuple(); }
+
+private:
+    DistributedHostBuffer distributed_buffer_;
 };
 
 struct DeviceStorage {
@@ -48,19 +63,6 @@ struct DeviceStorage {
     bool is_uniform_storage() const;
 };
 
-class MultiDeviceHostStorage {
-public:
-    explicit MultiDeviceHostStorage(DistributedHostBuffer buffer);
-
-    const DistributedHostBuffer& distributed_buffer() const;
-
-    static constexpr auto attribute_names = std::forward_as_tuple();
-    auto attribute_values() const { return std::forward_as_tuple(); }
-
-private:
-    DistributedHostBuffer distributed_buffer_;
-};
-
-using Storage = std::variant<HostStorage, DeviceStorage, MultiDeviceHostStorage>;
+using Storage = std::variant<HostStorage, DeviceStorage>;
 
 }  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -17,19 +17,16 @@ namespace tt::tt_metal {
 
 class HostStorage {
 public:
-    // Creates HostStorage distributed over 1x1 mesh.
-    explicit HostStorage(HostBuffer buffer);
-
     // Creates HostStorage distributed over a mesh that matches `buffer` shape.
     explicit HostStorage(DistributedHostBuffer buffer);
 
+    // Creates HostStorage distributed over 1x1 mesh.
+    explicit HostStorage(HostBuffer buffer);
+
     // Returns the distributed host buffer.
-    const DistributedHostBuffer& distributed_buffer() const;
+    const DistributedHostBuffer& buffer() const;
 
-    // Returns a vector of individual device buffers.
-    std::vector<HostBuffer> get_device_buffers() const;
-
-    // Applies a function to each device buffer, returning a new HostStorage.
+    // Applies a transformation function to each device buffer in parallel, returning a new HostStorage.
     HostStorage transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const;
 
     static constexpr auto attribute_names = std::forward_as_tuple();

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -242,8 +242,12 @@ public:
     Buffer* buffer() const;
 
     // Returns device `Storage`.
-    // Throws if the tensor is not allocated on a device.
+    // Throws if the tensor is not on device.
     const DeviceStorage& device_storage() const;
+
+    // Returns host `Storage`.
+    // Throws if the tensor is not on host.
+    const HostStorage& host_storage() const;
 
     // Returns device `MeshBuffer`.
     // Throws if the tensor is not allocated on a device.

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -262,10 +262,7 @@ enum class TensorPrintProfile {
 extern TensorPrintProfile TTNN_TENSOR_PRINT_PROFILE;
 
 template <typename T>
-std::string to_string(
-    const Tensor& tensor,
-    std::optional<DataType> original_dtype = std::nullopt,
-    std::optional<Layout> original_layout = std::nullopt);
+std::string to_string(const Tensor& tensor);
 
 template <typename T>
 Tensor extract_shard(const Tensor& tensor, const uint32_t& core_id);

--- a/ttnn/api/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_utils.hpp
@@ -36,19 +36,8 @@ bool is_arch_whb0(const tt::ARCH& arch);
 // Returns true if tensor has Host storage.
 bool is_cpu_tensor(const Tensor& tensor);
 
-// Returns true if tensor has MultiDeviceHost storage.
-// TODO: #19177 - Remove this once host and multi-device host tensors are unified.
-bool is_multi_device_host_tensor(const Tensor& tensor);
-
 // Returns true if tensor is on device.
 bool is_device_tensor(const Tensor& tensor);
-
-// Given a multi-device host tensor and a function that transforms a tensor, applies the function to all per-device
-// tensors.
-Tensor transform(const Tensor& tensor, const std::function<Tensor(const Tensor&)>& transform_func);
-
-// Given a multi-device host tensor and a callable, applies the function to all per-device tensors.
-void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& callable);
 
 template <class T>
 uint32_t get_batch_size(const T& shape) {

--- a/ttnn/api/ttnn/tensor/types.hpp
+++ b/ttnn/api/ttnn/tensor/types.hpp
@@ -72,7 +72,6 @@ bool is_block_float(DataType dtype);
 enum class StorageType {
     HOST = 0,
     DEVICE = 1,
-    MULTI_DEVICE_HOST = 4,  // host storage for multi-device context
 };
 
 tt::DataFormat datatype_to_dataformat_converter(DataType datatype);

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -45,10 +45,9 @@ std::shared_ptr<MeshDevice> open_mesh_device(
 void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device) { mesh_device->close(); }
 
 std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
-    if (std::holds_alternative<tt::tt_metal::MultiDeviceHostStorage>(tensor.storage())) {
+    if (std::holds_alternative<tt::tt_metal::HostStorage>(tensor.storage())) {
         std::vector<ttnn::Tensor> tensors;
-        auto& host_storage = std::get<tt::tt_metal::MultiDeviceHostStorage>(tensor.get_storage());
-        const auto& distributed_buffer = host_storage.distributed_buffer();
+        const auto& distributed_buffer = tensor.host_storage().distributed_buffer();
         distributed_buffer.apply(
             [&](const HostBuffer& buffer) { tensors.push_back(Tensor{buffer, tensor.get_tensor_spec()}); });
         return tensors;
@@ -82,14 +81,12 @@ Tensor from_host_shards(const std::vector<Tensor>& tensor_shards, const MeshShap
     auto distributed_host_buffer = DistributedHostBuffer::create(mesh_shape);
     auto shard_it = tensor_shards.begin();
     for (const auto& coord : distributed::MeshCoordinateRange(mesh_shape)) {
-        HostBuffer buffer = std::get<HostStorage>((shard_it++)->get_storage()).buffer;
+        HostBuffer buffer = host_buffer::get_host_buffer(*(shard_it++));
         distributed_host_buffer.emplace_shard(coord, [&]() { return std::move(buffer); });
     }
 
     return Tensor(
-        MultiDeviceHostStorage{std::move(distributed_host_buffer)},
-        reference_shard.get_tensor_spec(),
-        AllGatherTensor{});
+        HostStorage{std::move(distributed_host_buffer)}, reference_shard.get_tensor_spec(), AllGatherTensor{});
 }
 
 Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards) {
@@ -102,13 +99,13 @@ Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards) {
             "All tensor shards must have the same tensor spec");
     }
 
-    auto mesh_buffer = std::get<DeviceStorage>(reference_shard.storage()).mesh_buffer;
+    auto mesh_buffer = reference_shard.device_storage().mesh_buffer;
     TT_FATAL(
         mesh_buffer != nullptr,
         "Error aggregating multichip tensors: tensors shards must be allocated on a mesh buffer.");
     std::vector<MeshCoordinate> coords;
     for (const auto& shard : tensor_shards) {
-        const auto& shard_storage = std::get<DeviceStorage>(shard.storage());
+        const auto& shard_storage = shard.device_storage();
         TT_FATAL(
             shard_storage.mesh_buffer == mesh_buffer,
             "Error aggregating multichip tensors: tensor shards must be allocated on the same mesh buffer. "

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -47,7 +47,7 @@ void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device) { mesh_de
 std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
     if (std::holds_alternative<tt::tt_metal::HostStorage>(tensor.storage())) {
         std::vector<ttnn::Tensor> tensors;
-        const auto& distributed_buffer = tensor.host_storage().distributed_buffer();
+        const auto& distributed_buffer = tensor.host_storage().buffer();
         distributed_buffer.apply(
             [&](const HostBuffer& buffer) { tensors.push_back(Tensor{buffer, tensor.get_tensor_spec()}); });
         return tensors;

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -261,7 +261,7 @@ public:
             for (const auto& coord : MeshCoordinateRange(distribution_shape_)) {
                 distributed_buffer.emplace_shard(remap_fn(coord), [&b = replicated_buffer]() { return b; });
             }
-            return Tensor(tt::tt_metal::MultiDeviceHostStorage(std::move(distributed_buffer)), tensor_spec, config());
+            return Tensor(tt::tt_metal::HostStorage(std::move(distributed_buffer)), tensor_spec, config());
         }
 
         // Otherwise, use xtensor to chunk the data into shards.
@@ -365,7 +365,7 @@ private:
             }
         }
 
-        return Tensor(tt::tt_metal::MultiDeviceHostStorage(std::move(distributed_buffer)), shard_spec, config());
+        return Tensor(tt::tt_metal::HostStorage(std::move(distributed_buffer)), shard_spec, config());
     }
 
     // MeshDevice parameters.
@@ -395,8 +395,7 @@ public:
 
     template <typename T>
     std::pair<std::vector<T>, Shape> compose(const Tensor& tensor) const {
-        const auto src_buffer =
-            std::get<tt::tt_metal::MultiDeviceHostStorage>(tensor.cpu().storage()).distributed_buffer();
+        const auto& src_buffer = tensor.cpu().host_storage().distributed_buffer();
 
         auto remap_fn = get_remap_fn(distribution_mode_, &global_range_);
         auto dst_buffer = tt::tt_metal::DistributedHostBuffer::create(distribution_shape_);

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -395,7 +395,7 @@ public:
 
     template <typename T>
     std::pair<std::vector<T>, Shape> compose(const Tensor& tensor) const {
-        const auto& src_buffer = tensor.cpu().host_storage().distributed_buffer();
+        const auto& src_buffer = tensor.cpu().host_storage().buffer();
 
         auto remap_fn = get_remap_fn(distribution_mode_, &global_range_);
         auto dst_buffer = tt::tt_metal::DistributedHostBuffer::create(distribution_shape_);

--- a/ttnn/core/tensor/flatbuffer/tensor.fbs
+++ b/ttnn/core/tensor/flatbuffer/tensor.fbs
@@ -20,23 +20,10 @@ table TensorShard {
     mesh_coordinate: tt.tt_metal.distributed.flatbuffer.MeshCoordinate;
 }
 
-union TensorType {
-    ReplicatedTensor = 1,
-    ShardedTensor = 2,
-}
-
-table ReplicatedTensor {
-    buffer: TensorBuffer;
-}
-
-table ShardedTensor {
-    mesh_shape: MeshShape;
-    shards: [TensorShard];
-}
-
 table Tensor {
     tensor_spec: TensorSpec;
-    tensor_type: TensorType;
+    mesh_shape: MeshShape;
+    shards: [TensorShard];
 }
 
 root_type Tensor;

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -101,9 +101,9 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
     // Used to deduplicate buffer addresses for replicated tensor data.
     std::unordered_map<const std::byte*, uint64_t> buffer_to_offset;
     uint64_t next_buffer_offset = 0;
-    for (const auto& coord : host_storage.distributed_buffer().shard_coords()) {
+    for (const auto& coord : host_storage.buffer().shard_coords()) {
         // Iterate over local populated shards.
-        if (const auto& buffer = host_storage.distributed_buffer().get_shard(coord); buffer.has_value()) {
+        if (const auto& buffer = host_storage.buffer().get_shard(coord); buffer.has_value()) {
             const auto* buffer_address = buffer->view_bytes().data();
             const std::size_t buffer_size = buffer->view_bytes().size();
 
@@ -131,7 +131,7 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
     }
     auto shards = builder.CreateVector(shards_vector);
 
-    auto mesh_shape_offset = to_flatbuffer(host_storage.distributed_buffer().shape(), builder);
+    auto mesh_shape_offset = to_flatbuffer(host_storage.buffer().shape(), builder);
 
     auto tensor_offset = ttnn::flatbuffer::CreateTensor(builder, tensor_spec_offset, mesh_shape_offset, shards);
 

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -95,65 +95,47 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
 
     auto tensor_spec_offset = ttnn::to_flatbuffer(tensor.tensor_spec(), builder);
 
-    if (const auto* host_storage = std::get_if<tt::tt_metal::HostStorage>(&storage); host_storage != nullptr) {
-        buffers.push_back(host_storage->buffer);
+    const auto& host_storage = tensor.host_storage();
 
-        auto inline_storage =
-            ttnn::flatbuffer::InlineFileStorage(/*offset=*/0, host_storage->buffer.view_bytes().size());
+    std::vector<flatbuffers::Offset<ttnn::flatbuffer::TensorShard>> shards_vector;
+    // Used to deduplicate buffer addresses for replicated tensor data.
+    std::unordered_map<const std::byte*, uint64_t> buffer_to_offset;
+    uint64_t next_buffer_offset = 0;
+    for (const auto& coord : host_storage.distributed_buffer().shard_coords()) {
+        // Iterate over local populated shards.
+        if (const auto& buffer = host_storage.distributed_buffer().get_shard(coord); buffer.has_value()) {
+            const auto* buffer_address = buffer->view_bytes().data();
+            const std::size_t buffer_size = buffer->view_bytes().size();
 
-        auto replicated_tensor = ttnn::flatbuffer::CreateReplicatedTensor(
-            builder, ttnn::flatbuffer::TensorBuffer::InlineFileStorage, builder.CreateStruct(inline_storage).Union());
-
-        auto tensor_offset = ttnn::flatbuffer::CreateTensor(
-            builder, tensor_spec_offset, ttnn::flatbuffer::TensorType::ReplicatedTensor, replicated_tensor.Union());
-
-        return tensor_offset;
-    } else {
-        const auto* multi_device_storage = std::get_if<tt::tt_metal::MultiDeviceHostStorage>(&storage);
-        TT_FATAL(multi_device_storage != nullptr, "Sharded tensor requires MultiDeviceHostStorage");
-
-        std::vector<flatbuffers::Offset<ttnn::flatbuffer::TensorShard>> shards_vector;
-        // Used to deduplicate buffer addresses for replicated tensor data.
-        std::unordered_map<const std::byte*, uint64_t> buffer_to_offset;
-        uint64_t next_buffer_offset = 0;
-        for (const auto& coord : multi_device_storage->distributed_buffer().shard_coords()) {
-            // Iterate over local populated shards.
-            if (const auto& buffer = multi_device_storage->distributed_buffer().get_shard(coord); buffer.has_value()) {
-                const auto* buffer_address = buffer->view_bytes().data();
-                const std::size_t buffer_size = buffer->view_bytes().size();
-
-                uint64_t shard_buffer_offset = next_buffer_offset;
-                if (auto [it, inserted] = buffer_to_offset.try_emplace(buffer_address, shard_buffer_offset); inserted) {
-                    // Encountered a new buffer, add it to the buffers vector.
-                    next_buffer_offset += buffer_size;
-                    buffers.push_back(*buffer);
-                } else {
-                    // Point to the existing buffer.
-                    shard_buffer_offset = it->second;
-                }
-
-                auto inline_storage = ttnn::flatbuffer::InlineFileStorage(shard_buffer_offset, buffer_size);
-                auto mesh_coord_offset = to_flatbuffer(coord, builder);
-
-                auto shard_offset = ttnn::flatbuffer::CreateTensorShard(
-                    builder,
-                    ttnn::flatbuffer::TensorBuffer::InlineFileStorage,
-                    builder.CreateStruct(inline_storage).Union(),
-                    mesh_coord_offset);
-
-                shards_vector.push_back(shard_offset);
+            uint64_t shard_buffer_offset = next_buffer_offset;
+            if (auto [it, inserted] = buffer_to_offset.try_emplace(buffer_address, shard_buffer_offset); inserted) {
+                // Encountered a new buffer, add it to the buffers vector.
+                next_buffer_offset += buffer_size;
+                buffers.push_back(*buffer);
+            } else {
+                // Point to the existing buffer.
+                shard_buffer_offset = it->second;
             }
+
+            auto inline_storage = ttnn::flatbuffer::InlineFileStorage(shard_buffer_offset, buffer_size);
+            auto mesh_coord_offset = to_flatbuffer(coord, builder);
+
+            auto shard_offset = ttnn::flatbuffer::CreateTensorShard(
+                builder,
+                ttnn::flatbuffer::TensorBuffer::InlineFileStorage,
+                builder.CreateStruct(inline_storage).Union(),
+                mesh_coord_offset);
+
+            shards_vector.push_back(shard_offset);
         }
-        auto shards = builder.CreateVector(shards_vector);
-
-        auto mesh_shape_offset = to_flatbuffer(multi_device_storage->distributed_buffer().shape(), builder);
-
-        auto sharded_tensor = ttnn::flatbuffer::CreateShardedTensor(builder, mesh_shape_offset, shards);
-        auto tensor_offset = ttnn::flatbuffer::CreateTensor(
-            builder, tensor_spec_offset, ttnn::flatbuffer::TensorType::ShardedTensor, sharded_tensor.Union());
-
-        return tensor_offset;
     }
+    auto shards = builder.CreateVector(shards_vector);
+
+    auto mesh_shape_offset = to_flatbuffer(host_storage.distributed_buffer().shape(), builder);
+
+    auto tensor_offset = ttnn::flatbuffer::CreateTensor(builder, tensor_spec_offset, mesh_shape_offset, shards);
+
+    return tensor_offset;
 }
 
 Tensor from_flatbuffer(
@@ -162,71 +144,49 @@ Tensor from_flatbuffer(
     tt::tt_metal::MemoryPin memory_pin) {
     auto spec = ttnn::from_flatbuffer(fb_tensor->tensor_spec());
 
-    switch (fb_tensor->tensor_type_type()) {
-        case ttnn::flatbuffer::TensorType::NONE: TT_THROW("Invalid TensorType");
-        case ttnn::flatbuffer::TensorType::ReplicatedTensor: {
-            auto replicated = fb_tensor->tensor_type_as_ReplicatedTensor();
+    const auto* mesh_shape = fb_tensor->mesh_shape();
+    TT_FATAL(mesh_shape != nullptr, "Mesh shape is required for tensor");
+    const tt::tt_metal::distributed::MeshShape ttnn_mesh_shape = from_flatbuffer(mesh_shape);
 
-            auto* inline_storage = replicated->buffer_as<ttnn::flatbuffer::InlineFileStorage>();
-            TT_FATAL(inline_storage != nullptr, "Only InlineFileStorage is supported in flatbuffer deserialization");
+    auto distributed_buffer = tt::tt_metal::DistributedHostBuffer::create(ttnn_mesh_shape);
+    for (size_t i = 0; i < fb_tensor->shards()->size(); ++i) {
+        const auto* shard = fb_tensor->shards()->Get(i);
 
-            const uint64_t offset = inline_storage->offset();
-            const uint64_t size = inline_storage->size();
+        const auto* inline_storage = shard->buffer_as<ttnn::flatbuffer::InlineFileStorage>();
+        TT_FATAL(inline_storage != nullptr, "Only InlineFileStorage is supported in flatbuffer deserialization");
 
-            tt::tt_metal::HostBuffer host_buffer = create_host_buffer_from_bytes(
-                size, spec, tt::stl::Span<std::byte>(tensor_data.data() + offset, size), memory_pin);
-            return Tensor(std::move(host_buffer), spec);
-        }
-        case ttnn::flatbuffer::TensorType::ShardedTensor: {
-            const auto* sharded = fb_tensor->tensor_type_as_ShardedTensor();
+        const uint64_t offset = inline_storage->offset();
+        const uint64_t size = inline_storage->size();
 
-            const auto* mesh_shape = sharded->mesh_shape();
-            TT_FATAL(mesh_shape != nullptr, "Mesh shape is required for sharded tensor");
-            const tt::tt_metal::distributed::MeshShape ttnn_mesh_shape = from_flatbuffer(mesh_shape);
+        tt::tt_metal::HostBuffer host_buffer = create_host_buffer_from_bytes(
+            size, spec, tt::stl::Span<std::byte>(tensor_data.data() + offset, size), memory_pin);
 
-            auto distributed_buffer = tt::tt_metal::DistributedHostBuffer::create(ttnn_mesh_shape);
-            for (size_t i = 0; i < sharded->shards()->size(); ++i) {
-                const auto* shard = sharded->shards()->Get(i);
-
-                const auto* inline_storage = shard->buffer_as<ttnn::flatbuffer::InlineFileStorage>();
-                TT_FATAL(
-                    inline_storage != nullptr, "Only InlineFileStorage is supported in flatbuffer deserialization");
-
-                const uint64_t offset = inline_storage->offset();
-                const uint64_t size = inline_storage->size();
-
-                tt::tt_metal::HostBuffer host_buffer = create_host_buffer_from_bytes(
-                    size, spec, tt::stl::Span<std::byte>(tensor_data.data() + offset, size), memory_pin);
-
-                TT_FATAL(shard->mesh_coordinate() != nullptr, "Mesh coordinate is required for each shard");
-                const auto coord = from_flatbuffer(shard->mesh_coordinate());
-                distributed_buffer.emplace_shard(
-                    coord, [host_buffer = std::move(host_buffer)]() mutable { return std::move(host_buffer); });
-            }
-
-            // TODO: #24115 - `DistributedTensorConfig` will be replaced by distributed host buffer, which can be used
-            // directly in Tensor storage.
-            const auto strategy = [&]() -> tt::tt_metal::DistributedTensorConfig {
-                std::unordered_set<const std::byte*> buffer_addresses;
-                distributed_buffer.apply([&buffer_addresses](const tt::tt_metal::HostBuffer& shard) {
-                    buffer_addresses.insert(shard.view_bytes().data());
-                });
-                if (buffer_addresses.size() == 1) {
-                    return tt::tt_metal::ReplicateTensor();
-                } else if (ttnn_mesh_shape.dims() == 2) {
-                    return tt::tt_metal::ShardTensor2D{
-                        tt::tt_metal::ShardMesh{.y = ttnn_mesh_shape[0], .x = ttnn_mesh_shape[1]}};
-                } else {
-                    return tt::tt_metal::AllGatherTensor{};
-                }
-            }();
-
-            tt::tt_metal::MultiDeviceHostStorage multi_device_storage{std::move(distributed_buffer)};
-
-            return Tensor(std::move(multi_device_storage), spec, strategy);
-        }
+        TT_FATAL(shard->mesh_coordinate() != nullptr, "Mesh coordinate is required for each shard");
+        const auto coord = from_flatbuffer(shard->mesh_coordinate());
+        distributed_buffer.emplace_shard(
+            coord, [host_buffer = std::move(host_buffer)]() mutable { return std::move(host_buffer); });
     }
-    TT_THROW("Unreachable");
+
+    // TODO: #24115 - `DistributedTensorConfig` will be replaced by distributed host buffer, which can be used
+    // directly in Tensor storage.
+    const auto strategy = [&]() -> tt::tt_metal::DistributedTensorConfig {
+        std::unordered_set<const std::byte*> buffer_addresses;
+        distributed_buffer.apply([&buffer_addresses](const tt::tt_metal::HostBuffer& shard) {
+            buffer_addresses.insert(shard.view_bytes().data());
+        });
+        if (buffer_addresses.size() == 1) {
+            return tt::tt_metal::ReplicateTensor();
+        } else if (ttnn_mesh_shape.dims() == 2) {
+            return tt::tt_metal::ShardTensor2D{
+                tt::tt_metal::ShardMesh{.y = ttnn_mesh_shape[0], .x = ttnn_mesh_shape[1]}};
+        } else {
+            return tt::tt_metal::AllGatherTensor{};
+        }
+    }();
+
+    tt::tt_metal::HostStorage host_storage{std::move(distributed_buffer)};
+
+    return Tensor(std::move(host_storage), spec, strategy);
 }
 
 }  // namespace ttnn

--- a/ttnn/core/tensor/host_buffer/functions.cpp
+++ b/ttnn/core/tensor/host_buffer/functions.cpp
@@ -18,11 +18,11 @@ HostBuffer get_host_buffer(const Tensor& tensor) {
         tt::stl::overloaded{
             [](const HostStorage& storage) {
                 std::vector<HostBuffer> buffers;
-                storage.distributed_buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
+                storage.buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
                 TT_FATAL(
                     buffers.size() == 1,
                     "Can't get a single buffer from host storage distributed over mesh shape {}",
-                    storage.distributed_buffer().shape());
+                    storage.buffer().shape());
                 return buffers.front();
             },
             [](const auto&) -> HostBuffer { TT_THROW("Tensor must have HostStorage"); },

--- a/ttnn/core/tensor/host_buffer/functions.cpp
+++ b/ttnn/core/tensor/host_buffer/functions.cpp
@@ -16,17 +16,16 @@ namespace tt::tt_metal::host_buffer {
 HostBuffer get_host_buffer(const Tensor& tensor) {
     return std::visit(
         tt::stl::overloaded{
-            [](const HostStorage& storage) { return storage.buffer; },
-            [](const MultiDeviceHostStorage& storage) {
+            [](const HostStorage& storage) {
                 std::vector<HostBuffer> buffers;
                 storage.distributed_buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
                 TT_FATAL(
                     buffers.size() == 1,
-                    "Can't get a single buffer from multi device host storage of size: {}",
-                    buffers.size());
+                    "Can't get a single buffer from host storage distributed over mesh shape {}",
+                    storage.distributed_buffer().shape());
                 return buffers.front();
             },
-            [](const auto&) -> HostBuffer { TT_THROW("Tensor must have HostStorage or MultiDeviceHostStorage"); },
+            [](const auto&) -> HostBuffer { TT_THROW("Tensor must have HostStorage"); },
         },
         tensor.storage());
 }

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -38,6 +38,12 @@ using MeshDevice = distributed::MeshDevice;
 
 namespace {
 
+enum class SerializedStorageType {
+    HOST = 0,
+    DEVICE = 1,
+    MULTI_DEVICE_HOST = 4,
+};
+
 void validate_version(uint8_t version_id) {
     TT_FATAL(
         version_id >= 5,
@@ -98,7 +104,7 @@ TensorSpec load_tensor_spec(FILE* input_file) {
     return ttnn::from_flatbuffer(spec);
 }
 
-void dump_host_storage(FILE* output_file, const HostStorage& storage, DataType dtype) {
+void dump_host_storage(FILE* output_file, const HostBuffer& buffer, DataType dtype) {
     // TODO: #16067 - When dumping storage, we should not care about dtype.
     // We should dump the `size` of raw bytes, not the size of logical elements.
     const size_t element_size = [dtype]() {
@@ -117,7 +123,7 @@ void dump_host_storage(FILE* output_file, const HostStorage& storage, DataType d
         TT_THROW("Unreachable");
     }();
 
-    auto raw_bytes = storage.buffer.view_bytes();
+    auto raw_bytes = buffer.view_bytes();
     uint64_t size = raw_bytes.size() / element_size;
     safe_fwrite(&size, sizeof(size), 1, output_file);
     safe_fwrite(raw_bytes.data(), raw_bytes.size(), 1, output_file);
@@ -125,7 +131,7 @@ void dump_host_storage(FILE* output_file, const HostStorage& storage, DataType d
 
 void dump_multi_device_host_storage(
     FILE* output_file,
-    const MultiDeviceHostStorage& storage,
+    const HostStorage& storage,
     const DistributedTensorConfig& strategy,
     const TensorSpec& tensor_spec) {
     std::vector<HostBuffer> buffers;
@@ -157,7 +163,7 @@ HostStorage load_host_storage(FILE* input_file) {
     std::vector<T> data(size);
     safe_fread(data.data(), sizeof(T) * size, 1, input_file);
     auto buffer = HostBuffer(std::move(data));
-    return {buffer};
+    return HostStorage(std::move(buffer));
 }
 
 // Helper type to bundle storage and strategy together.
@@ -220,7 +226,7 @@ DistributedStorage load_multi_device_host_storage(
         distributed_host_buffer.emplace_shard(*dst_coord_it, [b = buffers[i]]() { return b; });
     }
 
-    return {MultiDeviceHostStorage{std::move(distributed_host_buffer)}, strategy};
+    return {HostStorage{std::move(distributed_host_buffer)}, strategy};
 }
 
 HostStorage load_host_storage(FILE* input_file, DataType data_type) {
@@ -267,8 +273,8 @@ DistributedStorage load_multi_device_host_storage(
 }
 
 DistributedStorage load_storage(
-    FILE* input_file, DataType data_type, Layout layout, StorageType storage_type, MeshDevice* device) {
-    if (storage_type == StorageType::MULTI_DEVICE_HOST or storage_type == StorageType::DEVICE) {
+    FILE* input_file, DataType data_type, Layout layout, SerializedStorageType storage_type, MeshDevice* device) {
+    if (storage_type == SerializedStorageType::MULTI_DEVICE_HOST || storage_type == SerializedStorageType::DEVICE) {
         // TODO: #22262 - Migrate to the new serialization format that embeds the required information into the tensor
         // file.
         TT_FATAL(device != nullptr, "MeshDevice is required for loading multi-device host storage");
@@ -298,7 +304,7 @@ Tensor load_tensor(const std::string& file_name, MeshDevice* device) {
     validate_version(version_id);
 
     auto spec = load_tensor_spec(input_file);
-    StorageType storage_type = StorageType::HOST;
+    SerializedStorageType storage_type = SerializedStorageType::HOST;
     safe_fread(&storage_type, sizeof(storage_type), 1, input_file);
     auto storage = load_storage(input_file, spec.data_type(), spec.layout(), storage_type, device);
     Tensor tensor(std::move(storage.storage), spec, storage.strategy);
@@ -320,7 +326,14 @@ void dump_tensor(const std::string& file_name, const Tensor& tensor) {
 
     dump_tensor_spec(tensor.tensor_spec(), output_file);
 
-    auto storage_type = tensor.storage_type();
+    auto storage_type = [&]() {
+        if (tensor.storage_type() == StorageType::HOST) {
+            const size_t size = tensor.host_storage().get_device_buffers().size();
+            return size > 1 ? SerializedStorageType::MULTI_DEVICE_HOST : SerializedStorageType::HOST;
+        } else {
+            return SerializedStorageType::DEVICE;
+        }
+    }();
     safe_fwrite(&storage_type, sizeof(storage_type), 1, output_file);
 
     bool is_on_device = is_device_tensor(tensor);
@@ -329,20 +342,22 @@ void dump_tensor(const std::string& file_name, const Tensor& tensor) {
         tensor_to_dump = tensor_to_dump.cpu();
     }
 
-    std::visit(
-        tt::stl::overloaded{
-            [output_file, dtype = tensor.dtype()](const HostStorage& storage) {
-                dump_host_storage(output_file, storage, dtype);
-            },
-            [output_file, dtype = tensor.dtype()](const DeviceStorage& storage) {
-                TT_THROW("Device storage isn't supported");
-            },
-            [output_file, &tensor](const MultiDeviceHostStorage& storage) {
-                dump_multi_device_host_storage(
-                    output_file, storage, tensor.distributed_tensor_config(), tensor.tensor_spec());
-            },
-        },
-        tensor_to_dump.storage());
+    switch (storage_type) {
+        case SerializedStorageType::HOST: {
+            const auto host_buffer = tensor_to_dump.host_storage().get_device_buffers().front();
+            dump_host_storage(output_file, host_buffer, tensor_to_dump.dtype());
+            break;
+        }
+        case SerializedStorageType::DEVICE:
+        case SerializedStorageType::MULTI_DEVICE_HOST: {
+            dump_multi_device_host_storage(
+                output_file,
+                tensor_to_dump.host_storage(),
+                tensor_to_dump.distributed_tensor_config(),
+                tensor_to_dump.tensor_spec());
+            break;
+        }
+    }
 }
 
 void dump_memory_config(FILE* output_file, const MemoryConfig& memory_config) {

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -11,6 +11,25 @@
 
 namespace tt::tt_metal {
 
+HostStorage::HostStorage(HostBuffer buffer) :
+    distributed_buffer_(DistributedHostBuffer::create(distributed::MeshShape(1, 1))) {
+    distributed_buffer_.emplace_shard(distributed::MeshCoordinate(0, 0), [&buffer]() { return std::move(buffer); });
+}
+HostStorage::HostStorage(DistributedHostBuffer buffer) : distributed_buffer_(std::move(buffer)) {}
+
+const DistributedHostBuffer& HostStorage::distributed_buffer() const { return distributed_buffer_; }
+
+std::vector<HostBuffer> HostStorage::get_device_buffers() const {
+    std::vector<HostBuffer> buffers;
+    distributed_buffer_.apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
+    return buffers;
+}
+
+HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const {
+    return HostStorage(
+        distributed_buffer_.transform(callable, DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL));
+}
+
 DeviceStorage::DeviceStorage(std::shared_ptr<Buffer> buffer_) { buffer = std::move(buffer_); }
 
 DeviceStorage::DeviceStorage(
@@ -51,9 +70,5 @@ bool DeviceStorage::is_uniform_storage() const {
     }
     return coords.size() == mesh_buffer->device()->num_devices();
 }
-
-const DistributedHostBuffer& MultiDeviceHostStorage::distributed_buffer() const { return distributed_buffer_; }
-
-MultiDeviceHostStorage::MultiDeviceHostStorage(DistributedHostBuffer buffer) : distributed_buffer_(std::move(buffer)) {}
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -17,13 +17,7 @@ HostStorage::HostStorage(HostBuffer buffer) :
 }
 HostStorage::HostStorage(DistributedHostBuffer buffer) : distributed_buffer_(std::move(buffer)) {}
 
-const DistributedHostBuffer& HostStorage::distributed_buffer() const { return distributed_buffer_; }
-
-std::vector<HostBuffer> HostStorage::get_device_buffers() const {
-    std::vector<HostBuffer> buffers;
-    distributed_buffer_.apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
-    return buffers;
-}
+const DistributedHostBuffer& HostStorage::buffer() const { return distributed_buffer_; }
 
 HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const {
     return HostStorage(

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -85,7 +85,7 @@ Tensor::Tensor(
     }
 
     init(
-        Storage(std::move(buffer)),
+        Storage(HostStorage(std::move(buffer))),
         TensorSpec(
             logical_shape,
             TensorLayout::fromPaddedShape(
@@ -94,7 +94,7 @@ Tensor::Tensor(
 }
 
 Tensor::Tensor(HostBuffer storage, TensorSpec tensor_spec) :
-    Tensor(Storage(std::move(storage)), std::move(tensor_spec), ReplicateTensor{}) {}
+    Tensor(Storage(HostStorage(std::move(storage))), std::move(tensor_spec), ReplicateTensor{}) {}
 
 Tensor::Tensor(Storage storage, TensorSpec tensor_spec, DistributedTensorConfig distributed_tensor_config) {
     init(Storage(std::move(storage)), std::move(tensor_spec), std::move(distributed_tensor_config));
@@ -152,7 +152,6 @@ void Tensor::deallocate_impl(bool force) {
         std::visit(
             tt::stl::overloaded{
                 [](HostStorage&) {},
-                [](MultiDeviceHostStorage&) {},
                 [this, force, &can_deallocate](DeviceStorage& storage) {
                     if (can_deallocate(storage.mesh_buffer, force)) {
                         storage.mesh_buffer->deallocate();
@@ -517,7 +516,6 @@ bool Tensor::is_allocated() const {
         tt::stl::overloaded{
             [](const DeviceStorage& storage) { return storage.is_allocated(); },
             [](const HostStorage&) { return true; },
-            [](const MultiDeviceHostStorage&) { return true; },
         },
         this->storage());
     return output;
@@ -528,7 +526,6 @@ StorageType Tensor::storage_type() const {
         tt::stl::overloaded{
             [](const HostStorage&) { return StorageType::HOST; },
             [](const DeviceStorage&) { return StorageType::DEVICE; },
-            [](const MultiDeviceHostStorage&) { return StorageType::MULTI_DEVICE_HOST; },
         },
         this->storage());
 }
@@ -737,14 +734,14 @@ Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshD
     distributed_host_buffer = distributed_host_buffer.transform(
         [&](const HostBuffer&) { return tensor_impl::allocate_host_buffer(tensor_spec); },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
-    return Tensor(MultiDeviceHostStorage(std::move(distributed_host_buffer)), tensor_spec, ReplicateTensor{});
+    return Tensor(HostStorage(std::move(distributed_host_buffer)), tensor_spec, ReplicateTensor{});
 }
 
 void write_tensor(const Tensor& src, Tensor& dst, bool blocking, QueueId cq_id) {
     ZoneScoped;
     TT_FATAL(
-        (is_device_tensor(src) && is_multi_device_host_tensor(dst)) ||                            // device to host
-            ((is_cpu_tensor(src) || is_multi_device_host_tensor(src)) && is_device_tensor(dst)),  // host to device
+        (is_device_tensor(src) && is_cpu_tensor(dst)) ||    // device to host
+            (is_cpu_tensor(src) && is_device_tensor(dst)),  // host to device
         "Unsupported data transfer direction; source storage type: {}, destination storage type: {}",
         src.storage_type(),
         dst.storage_type());
@@ -754,8 +751,7 @@ void write_tensor(const Tensor& src, Tensor& dst, bool blocking, QueueId cq_id) 
         return;
     }
 
-    auto& device_storage = std::get<DeviceStorage>(dst.storage());
-    if (auto mesh_buffer = device_storage.mesh_buffer; mesh_buffer != nullptr) {
+    if (auto mesh_buffer = dst.device_storage().mesh_buffer; mesh_buffer != nullptr) {
         TT_FATAL(!blocking, "Blocking is not supported for host to device copy");
         tensor_impl::copy_to_device_tensor_wrapper(src, dst, cq_id);
         return;
@@ -771,16 +767,11 @@ void write_tensor(const Tensor& src, Tensor& dst, bool blocking, QueueId cq_id) 
                 const void* host_data = std::visit(
                     tt::stl::overloaded{
                         [](const HostStorage& host_storage) -> const void* {
-                            return host_storage.buffer.view_bytes().data();
-                        },
-                        [](const MultiDeviceHostStorage& host_storage) -> const void* {
-                            std::vector<HostBuffer> buffers;
-                            host_storage.distributed_buffer().apply(
-                                [&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
+                            auto buffers = host_storage.get_device_buffers();
                             TT_FATAL(
                                 buffers.size() == 1,
-                                "Can't get a single buffer from multi device host storage of size: {}",
-                                buffers.size());
+                                "Can't get a single buffer from host storage distributed over mesh shape {}",
+                                host_storage.distributed_buffer().shape());
                             return buffers.front().view_bytes().data();
                         },
                         [](auto&&) -> const void* { TT_THROW("Unreachable"); },
@@ -822,10 +813,15 @@ const TensorSpec& Tensor::tensor_spec() const { return this->tensor_attributes->
 Buffer* Tensor::buffer() const { return device_storage().get_buffer(); }
 
 const DeviceStorage& Tensor::device_storage() const {
-    auto storage_type = this->storage_type();
-    TT_FATAL(
-        storage_type == tt::tt_metal::StorageType::DEVICE, "Expected Tensor with DeviceStorage, got {}", storage_type);
-    return std::get<DeviceStorage>(this->storage());
+    const auto* device_storage = std::get_if<DeviceStorage>(&this->storage());
+    TT_FATAL(device_storage != nullptr, "Expected Tensor with DeviceStorage, got {}", this->storage_type());
+    return *device_storage;
+}
+
+const HostStorage& Tensor::host_storage() const {
+    const auto* host_storage = std::get_if<HostStorage>(&this->storage());
+    TT_FATAL(host_storage != nullptr, "Expected Tensor with HostStorage, got {}", this->storage_type());
+    return *host_storage;
 }
 
 distributed::MeshDevice* Tensor::mesh_device() const {

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -17,13 +17,7 @@ TensorAttributes::TensorAttributes(
     Storage storage, TensorSpec tensor_spec, DistributedTensorConfig distributed_tensor_config) :
     storage_(std::move(storage)),
     tensor_spec_(std::move(tensor_spec)),
-    distributed_tensor_config_(std::move(distributed_tensor_config)) {
-    if (std::holds_alternative<HostStorage>(storage_)) {
-        TT_FATAL(
-            std::holds_alternative<ReplicateTensor>(distributed_tensor_config_),
-            "Host storage is a single shard that must be in replicated configuration.");
-    }
-}
+    distributed_tensor_config_(std::move(distributed_tensor_config)) {}
 
 const Storage& TensorAttributes::get_storage() const { return storage_; }
 Storage& TensorAttributes::get_storage() { return storage_; }

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -10,8 +10,10 @@
 
 #include "tt-metalium/assert.hpp"
 #include "tt-metalium/distributed_host_buffer.hpp"
+#include "tt-metalium/host_buffer.hpp"
 #include "tt-metalium/memory_pin.hpp"
 #include "tt-metalium/mesh_buffer.hpp"
+#include "tt-metalium/mesh_coord.hpp"
 #include "tt-metalium/mesh_device.hpp"
 #include "tt-metalium/mesh_command_queue.hpp"
 #include <tt_stl/overloaded.hpp>
@@ -342,10 +344,10 @@ inline constexpr int constexpr_strlen(const char* str) { return *str ? 1 + const
 constexpr auto TENSOR_TYPE_STRING = "ttnn.Tensor";
 constexpr auto TENSOR_TYPE_STRING_PLUS_OPEN_PARENTHESIS_LENGTH = constexpr_strlen(TENSOR_TYPE_STRING) + 1;
 
-template <typename BufferType>
+template <typename T>
 void to_string_row_major(
     std::stringstream& ss,
-    const BufferType& buffer,
+    tt::stl::Span<const T> buffer,
     const ttnn::Shape& shape,
     const tt::tt_metal::Strides& strides,
     std::size_t outer_index,
@@ -389,8 +391,7 @@ void to_string_row_major(
         }
 
         if (rank > 1) {
-            to_string_row_major<BufferType>(
-                ss, buffer, shape, strides, index, buffer_offset + index * stride, rank - 1, dim + 1);
+            to_string_row_major(ss, buffer, shape, strides, index, buffer_offset + index * stride, rank - 1, dim + 1);
         } else {
             print_datum(ss, buffer[buffer_offset + index]);
         }
@@ -401,57 +402,64 @@ void to_string_row_major(
     }
 }
 
-template <typename BufferType>
-std::string to_string(
-    const BufferType& buffer,
+template <typename T>
+void to_string(
+    std::stringstream& ss,
+    tt::stl::Span<const T> buffer,
     const ttnn::Shape& shape,
     const tt::tt_metal::Strides& strides,
     DataType dtype,
     Layout layout) {
-    std::stringstream ss;
     ss << TENSOR_TYPE_STRING << "(";
 
     if (TTNN_TENSOR_PRINT_PROFILE == TensorPrintProfile::Empty) {
         ss << "...";
     } else {
-        to_string_row_major<BufferType>(ss, buffer, shape, strides, 0, 0, shape.rank());
+        to_string_row_major<T>(ss, buffer, shape, strides, 0, 0, shape.rank());
     }
     ss << ", shape=" << fmt::format("{}", shape) << ", dtype=" << fmt::format("{}", dtype)
        << ", layout=" << fmt::format("{}", layout) << ")";
-    return ss.str();
 }
 
 }  // namespace detail
 
 template <typename T>
-std::string to_string(
-    const Tensor& tensor, std::optional<DataType> original_dtype, std::optional<Layout> original_layout) {
+std::string to_string(const Tensor& tensor) {
     const auto& shape = tensor.logical_shape();
-    const auto dtype = original_dtype.value_or(tensor.dtype());
-    const auto layout = original_layout.value_or(tensor.layout());
 
     if (!tensor.is_allocated()) {
         return fmt::format(
             "{}(<buffer is not allocated>, shape={}, dtype={}, layout={})",
             detail::TENSOR_TYPE_STRING,
             shape,
-            dtype,
-            layout);
+            tensor.dtype(),
+            tensor.layout());
     }
+
+    auto get_row_major_tensor = [&](const Tensor& tensor) -> Tensor {
+        if (tensor.layout() == Layout::ROW_MAJOR) {
+            return tensor;
+        } else if (tensor.dtype() == DataType::BFLOAT8_B || tensor.dtype() == DataType::BFLOAT4_B) {
+            return ttnn::to_layout(ttnn::to_dtype(tensor, DataType::FLOAT32), Layout::ROW_MAJOR);
+        } else {
+            return ttnn::to_layout(tensor, Layout::ROW_MAJOR);
+        }
+    };
 
     return std::visit(
         tt::stl::overloaded{
             [&](const HostStorage& storage) -> std::string {
-                if (tensor.layout() != Layout::ROW_MAJOR) {
-                    if (tensor.dtype() == DataType::BFLOAT8_B || tensor.dtype() == DataType::BFLOAT4_B) {
-                        return to_string<float>(ttnn::to_dtype(tensor, DataType::FLOAT32), dtype, layout);
+                const Tensor row_major_tensor = get_row_major_tensor(tensor);
+                const auto strides = row_major_tensor.tensor_spec().compute_strides();
+                const auto buffers = row_major_tensor.host_storage().get_device_buffers();
+                std::stringstream ss;
+                for (size_t i = 0; i < buffers.size(); i++) {
+                    detail::to_string(ss, buffers[i].view_as<T>(), shape, strides, tensor.dtype(), tensor.layout());
+                    if (i + 1 != buffers.size()) {
+                        ss << std::endl;
                     }
-                    return to_string<T>(ttnn::to_layout(tensor, Layout::ROW_MAJOR), dtype, layout);
                 }
-
-                const auto strides = tensor.tensor_spec().compute_strides();
-                const auto buffer = host_buffer::get_as<T>(storage.buffer);
-                return detail::to_string(buffer, shape, strides, dtype, layout);
+                return ss.str();
             },
             [&](const DeviceStorage& storage) -> std::string {
                 auto cpu_tensor = tensor.cpu();
@@ -464,22 +472,18 @@ std::string to_string(
                 if (mesh_device->num_devices() == 1) {
                     return to_string<T>(ttnn::distributed::get_device_tensors(cpu_tensor).at(0));
                 }
+
+                const Tensor row_major_tensor = get_row_major_tensor(cpu_tensor);
+                const auto strides = row_major_tensor.tensor_spec().compute_strides();
                 const auto& coords = storage.coords;
                 auto coords_it = coords.begin();
+                const auto buffers = row_major_tensor.host_storage().get_device_buffers();
                 std::stringstream ss;
-                apply(cpu_tensor, [&](const Tensor& device_shard) {
+                for (size_t i = 0; i < buffers.size(); i++) {
                     const distributed::MeshCoordinate coord = *coords_it++;
                     ss << "device_id: " << mesh_device->get_device(coord)->id() << ", " << coord << std::endl;
-                    ss << to_string<T>(device_shard) << std::endl;
-                });
-                return ss.str();
-            },
-            [&](const MultiDeviceHostStorage& storage) -> std::string {
-                std::stringstream ss;
-                auto device_tensors = ttnn::distributed::get_device_tensors(tensor);
-                for (size_t i = 0; i < device_tensors.size(); i++) {
-                    ss << to_string<T>(device_tensors[i]);
-                    if (i + 1 != device_tensors.size()) {
+                    detail::to_string(ss, buffers[i].view_as<T>(), shape, strides, tensor.dtype(), tensor.layout());
+                    if (i + 1 != buffers.size()) {
                         ss << std::endl;
                     }
                 }
@@ -488,29 +492,21 @@ std::string to_string(
         tensor.storage());
 }
 
-template std::string to_string<bfloat16>(
-    const Tensor& tensor, std::optional<DataType> original_dtype, std::optional<Layout> original_layout);
-template std::string to_string<float>(
-    const Tensor& tensor, std::optional<DataType> original_dtype, std::optional<Layout> original_layout);
-template std::string to_string<int32_t>(
-    const Tensor& tensor, std::optional<DataType> original_dtype, std::optional<Layout> original_layout);
-template std::string to_string<uint32_t>(
-    const Tensor& tensor, std::optional<DataType> original_dtype, std::optional<Layout> original_layout);
-template std::string to_string<uint16_t>(
-    const Tensor& tensor, std::optional<DataType> original_dtype, std::optional<Layout> original_layout);
-template std::string to_string<uint8_t>(
-    const Tensor& tensor, std::optional<DataType> original_dtype, std::optional<Layout> original_layout);
+template std::string to_string<bfloat16>(const Tensor& tensor);
+template std::string to_string<float>(const Tensor& tensor);
+template std::string to_string<int32_t>(const Tensor& tensor);
+template std::string to_string<uint32_t>(const Tensor& tensor);
+template std::string to_string<uint16_t>(const Tensor& tensor);
+template std::string to_string<uint8_t>(const Tensor& tensor);
 
 template <>
-std::string to_string<bfloat8_b>(
-    const Tensor& tensor, std::optional<DataType> original_dtype, std::optional<Layout> original_layout) {
-    return to_string<uint32_t>(tensor, original_dtype);
+std::string to_string<bfloat8_b>(const Tensor& tensor) {
+    return to_string<float>(tensor);
 }
 
 template <>
-std::string to_string<bfloat4_b>(
-    const Tensor& tensor, std::optional<DataType> original_dtype, std::optional<Layout> original_layout) {
-    return to_string<uint32_t>(tensor, original_dtype);
+std::string to_string<bfloat4_b>(const Tensor& tensor) {
+    return to_string<float>(tensor);
 }
 
 // ======================================================================================
@@ -582,7 +578,7 @@ Tensor to_host<bfloat8_b>(const Tensor& tensor, bool blocking, ttnn::QueueId cq_
 template <typename T>
 Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking, ttnn::QueueId cq_id) {
     TT_FATAL(tensor.is_allocated(), "Buffer must be allocated on device!");
-    const auto& storage = std::get<DeviceStorage>(tensor.storage());
+    const auto& storage = tensor.device_storage();
     const auto& mesh_buffer = storage.mesh_buffer;
     ttnn::MeshDevice* device = mesh_buffer->device();
     distributed::MeshCommandQueue& mesh_cq = device->mesh_command_queue(*cq_id);
@@ -599,7 +595,7 @@ Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking, ttnn::QueueId cq
 
     mesh_cq.enqueue_read(mesh_buffer, distributed_host_buffer, /*shards=*/std::nullopt, blocking);
 
-    MultiDeviceHostStorage host_storage(std::move(distributed_host_buffer));
+    HostStorage host_storage(std::move(distributed_host_buffer));
     return Tensor(std::move(host_storage), tensor.tensor_spec(), tensor.distributed_tensor_config());
 }
 
@@ -668,7 +664,12 @@ std::shared_ptr<Buffer> to_device_buffer(
     return std::visit(
         tt::stl::overloaded{
             [&device, &tensor_spec, cq_id](const HostStorage& storage) {
-                auto data_to_write = host_buffer::get_as<T>(storage.buffer);
+                auto buffers = storage.get_device_buffers();
+                TT_FATAL(
+                    buffers.size() == 1,
+                    "Can't get a single buffer from host storage distributed over mesh shape {}",
+                    storage.distributed_buffer().shape());
+                auto data_to_write = buffers.front().view_as<T>();
                 auto expected_packed_buffer_size_bytes = tensor_spec.compute_packed_buffer_size_bytes();
                 auto input_size_bytes = data_to_write.size() * sizeof(T);
                 TT_FATAL(
@@ -731,12 +732,12 @@ Tensor to_device<bfloat8_b>(
 namespace {
 
 DeviceStorage replicate_to_mesh_buffer(
-    const HostStorage& storage,
-    distributed::MeshDevice* mesh_device,
+    const HostBuffer& buffer,
     const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer,
     const TensorSpec& tensor_spec,
     ttnn::QueueId cq_id) {
-    auto data_to_write = storage.buffer.view_bytes();
+    auto* mesh_device = mesh_buffer->device();
+    auto data_to_write = buffer.view_bytes();
     const auto expected_packed_buffer_size_bytes = tensor_spec.compute_packed_buffer_size_bytes();
     const auto input_size_bytes = data_to_write.size();
     TT_FATAL(
@@ -782,18 +783,23 @@ DeviceStorage to_device_mesh_buffer(
     ttnn::QueueId cq_id) {
     return std::visit(
         tt::stl::overloaded{
-            [&mesh_buffer, &tensor_spec, cq_id](const HostStorage& storage) {
-                // Replicate data across devices in a mesh.
-                return replicate_to_mesh_buffer(storage, mesh_buffer->device(), mesh_buffer, tensor_spec, cq_id);
-            },
-            [&mesh_buffer, &tensor_spec, cq_id, &host_tensor_attributes](const MultiDeviceHostStorage& storage) {
-                // Sharded write from distributed host buffer.
-                TT_FATAL(
-                    storage.distributed_buffer().shape() == mesh_buffer->device()->shape(),
-                    "Distributed host buffer has different shape {} than the mesh device {}",
-                    storage.distributed_buffer().shape(),
-                    mesh_buffer->device()->shape());
-                return write_to_mesh_buffer(storage.distributed_buffer(), mesh_buffer, cq_id);
+            [&mesh_buffer, &tensor_spec, cq_id, &host_tensor_attributes](const HostStorage& storage) {
+                const auto& host_storage_shape = storage.distributed_buffer().shape();
+                const auto& mesh_device_shape = mesh_buffer->device()->shape();
+                if (host_storage_shape.mesh_size() < mesh_device_shape.mesh_size() &&
+                    host_storage_shape == distributed::MeshShape(1, 1)) {
+                    // Special case of replicating tensors on 1x1 mesh across the entire mesh device.
+                    const auto device_buffers = storage.get_device_buffers();
+                    TT_FATAL(device_buffers.size() == 1, "Expected 1 device buffer, got {}", device_buffers.size());
+                    return replicate_to_mesh_buffer(device_buffers.front(), mesh_buffer, tensor_spec, cq_id);
+                } else {
+                    TT_FATAL(
+                        host_storage_shape == mesh_device_shape,
+                        "Distributed host buffer has different shape {} than the mesh device {}",
+                        host_storage_shape,
+                        mesh_device_shape);
+                    return write_to_mesh_buffer(storage.distributed_buffer(), mesh_buffer, cq_id);
+                }
             },
             [](const auto& s) -> DeviceStorage { TT_THROW("Unexpected storage type {}", tt::stl::get_type_name(s)); }},
         host_storage);
@@ -823,8 +829,8 @@ Tensor to_device_mesh_tensor(
 template <typename T>
 void copy_to_host_tensor(const Tensor& device_tensor, Tensor& host_tensor, bool blocking, ttnn::QueueId cq_id) {
     ZoneScoped;
-    TT_FATAL(host_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST, "Host tensor is not multi device host.");
-    TT_FATAL(device_tensor.storage_type() == StorageType::DEVICE, "Device tensor is not on device.");
+    TT_FATAL(device_tensor.storage_type() == StorageType::DEVICE, "Source tensor is not on device.");
+    TT_FATAL(host_tensor.storage_type() == StorageType::HOST, "Destination tensor is not on host.");
     TT_FATAL(device_tensor.is_allocated(), "Buffer must be allocated on device.");
 
     TT_FATAL(host_tensor.logical_shape() == device_tensor.logical_shape(), "Host tensor has different shape");
@@ -833,12 +839,12 @@ void copy_to_host_tensor(const Tensor& device_tensor, Tensor& host_tensor, bool 
         host_tensor.tensor_spec().page_config() == device_tensor.tensor_spec().page_config(),
         "Host tensor has different page config");
 
-    const auto& device_storage = std::get<DeviceStorage>(device_tensor.storage());
+    const auto& device_storage = device_tensor.device_storage();
     const auto& mesh_buffer = device_storage.mesh_buffer;
     ttnn::MeshDevice* device = mesh_buffer->device();
     distributed::MeshCommandQueue& mesh_cq = device->mesh_command_queue(*cq_id);
 
-    const auto& distributed_host_buffer = std::get<MultiDeviceHostStorage>(host_tensor.storage()).distributed_buffer();
+    const auto& distributed_host_buffer = host_tensor.host_storage().distributed_buffer();
 
     // Host tensor must have pre-allocated buffers for all device shards.
     // However, it may have some extra shards. Drop them by "unwrapping" the distributed host buffer, and re-wrapping
@@ -870,7 +876,7 @@ void copy_to_host_tensor(const Tensor& device_tensor, Tensor& host_tensor, bool 
     mesh_cq.enqueue_read(mesh_buffer, dst_distributed_host_buffer, /*shards=*/std::nullopt, blocking);
 
     host_tensor = Tensor(
-        MultiDeviceHostStorage(std::move(dst_distributed_host_buffer)),
+        HostStorage(std::move(dst_distributed_host_buffer)),
         device_tensor.tensor_spec(),
         device_tensor.distributed_tensor_config());
 }
@@ -878,8 +884,8 @@ void copy_to_host_tensor(const Tensor& device_tensor, Tensor& host_tensor, bool 
 template <typename T>
 void copy_to_device_tensor(const Tensor& host_tensor, Tensor& device_tensor, ttnn::QueueId cq_id) {
     ZoneScoped;
-    TT_FATAL(host_tensor.storage_type() != StorageType::DEVICE, "Host tensor is on device.");
-    TT_FATAL(device_tensor.storage_type() == StorageType::DEVICE, "Mesh tensor is not on device.");
+    TT_FATAL(host_tensor.storage_type() == StorageType::HOST, "Source tensor is not on host.");
+    TT_FATAL(device_tensor.storage_type() == StorageType::DEVICE, "Destination tensor is not on device.");
     TT_FATAL(device_tensor.is_allocated(), "Buffer must be allocated on device.");
 
     TT_FATAL(host_tensor.logical_shape() == device_tensor.logical_shape(), "Host tensor has different shape");
@@ -888,7 +894,7 @@ void copy_to_device_tensor(const Tensor& host_tensor, Tensor& device_tensor, ttn
         host_tensor.tensor_spec().page_config() == device_tensor.tensor_spec().page_config(),
         "Host tensor has different page config");
 
-    auto mesh_buffer = std::get<DeviceStorage>(device_tensor.storage()).mesh_buffer;
+    auto mesh_buffer = device_tensor.device_storage().mesh_buffer;
 
     DeviceStorage mesh_storage = to_device_mesh_buffer<T>(
         host_tensor.storage(), mesh_buffer, device_tensor.tensor_spec(), *host_tensor.tensor_attributes, cq_id);
@@ -1235,16 +1241,12 @@ Tensor to_layout(const Tensor& tensor, Layout target_layout) {
         return tensor;
     }
 
-    // TODO: #15840 - Treat multi-device host vs owned/borrowed tensors uniformly.
-    if (is_multi_device_host_tensor(tensor)) {
-        return transform(tensor, [&](const Tensor& tensor_shard) { return to_layout<T>(tensor_shard, target_layout); });
-    }
-
     auto source_layout = tensor.layout();
     auto tile = tensor.tensor_spec().tile();
     auto physical_shape = tensor.tensor_spec().physical_shape();
     auto convert =
-        [tile, &physical_shape, source_layout, target_layout](tt::stl::Span<const T> input_data) -> std::vector<T> {
+        [tile, &physical_shape, source_layout, target_layout](const HostBuffer& input_host_buffer) -> std::vector<T> {
+        const auto input_data = input_host_buffer.view_as<T>();
         switch (source_layout) {
             case Layout::ROW_MAJOR:
                 TT_FATAL(target_layout == Layout::TILE, "Unsupported layout conversion");
@@ -1257,17 +1259,8 @@ Tensor to_layout(const Tensor& tensor, Layout target_layout) {
         TT_THROW("Unreachable");
     };
 
-    HostBuffer host_buffer = std::visit(
-        tt::stl::overloaded{
-            [&convert, target_layout](const HostStorage& storage) {
-                const auto input_data = host_buffer::get_as<T>(storage.buffer);
-                return HostBuffer(std::move(convert(input_data)));
-            },
-            [](const auto& s) -> HostBuffer { TT_THROW("Unsupported storage type {}", tt::stl::get_type_name(s)); }},
-        tensor.storage());
-
     return Tensor(
-        host_buffer,
+        tensor.host_storage().transform([&](const HostBuffer& buffer) { return HostBuffer(convert(buffer)); }),
         TensorSpec(
             tensor.logical_shape(),
             TensorLayout::fromPaddedShape(
@@ -1275,7 +1268,8 @@ Tensor to_layout(const Tensor& tensor, Layout target_layout) {
                 PageConfig(target_layout, tensor.tensor_spec().tile()),
                 MemoryConfig{},
                 tensor.logical_shape(),
-                tensor.padded_shape())));
+                tensor.padded_shape())),
+        tensor.distributed_tensor_config());
 }
 
 template Tensor to_layout<bfloat16>(const Tensor& tensor, Layout target_layout);
@@ -1321,13 +1315,6 @@ Tensor pad(
     float pad_value) {
     TT_FATAL(!is_device_tensor(tensor), "pad only supports host tensors");
 
-    // TODO: #15840 - Treat multi-device host vs owned/borrowed tensors uniformly.
-    if (is_multi_device_host_tensor(tensor)) {
-        return transform(tensor, [&](const Tensor& tensor_shard) {
-            return pad<T>(tensor_shard, output_padded_shape, input_tensor_start, pad_value);
-        });
-    }
-
     auto pad_value_ = static_cast<T>(pad_value);
     auto input_padded_shape = tensor.padded_shape();
     if (input_padded_shape.rank() < 2) {
@@ -1335,8 +1322,10 @@ Tensor pad(
     }
     const auto input_strides = tensor.strides();
 
-    auto pad = [&input_padded_shape, &output_padded_shape, &input_tensor_start, &pad_value_](const auto& input_buffer) {
-        const int rank = input_padded_shape.rank();
+    auto pad = [&input_padded_shape, &output_padded_shape, &input_tensor_start, &pad_value_](
+                   const HostBuffer& input_host_buffer) {
+        const auto input_buffer = input_host_buffer.view_as<T>();
+        const auto rank = input_padded_shape.rank();
 
         auto output_buffer = std::vector<T>(output_padded_shape.volume());
         std::fill(output_buffer.begin(), output_buffer.end(), pad_value_);
@@ -1395,21 +1384,17 @@ Tensor pad(
         return output_buffer;
     };
 
-    HostBuffer output_buffer = std::visit(
-        tt::stl::overloaded{
-            [&pad](const HostStorage& storage) {
-                const auto input_data = host_buffer::get_as<T>(storage.buffer);
-                return HostBuffer(pad(input_data));
-            },
-            [](const auto& s) -> HostBuffer { TT_THROW("Unexpected storage type {}", tt::stl::get_type_name(s)); }},
-        tensor.storage());
     return Tensor(
-        std::move(output_buffer),
-        tensor.logical_shape(),
-        output_padded_shape,
-        tensor.dtype(),
-        tensor.layout(),
-        tensor.tensor_spec().tile());
+        tensor.host_storage().transform([&](const HostBuffer& buffer) { return HostBuffer(pad(buffer)); }),
+        TensorSpec(
+            tensor.logical_shape(),
+            TensorLayout::fromPaddedShape(
+                tensor.dtype(),
+                PageConfig(tensor.layout(), tensor.tensor_spec().tile()),
+                MemoryConfig{},
+                tensor.logical_shape(),
+                output_padded_shape)),
+        tensor.distributed_tensor_config());
 }
 
 template Tensor pad<bfloat16>(
@@ -1465,13 +1450,6 @@ template <typename T>
 Tensor unpad(const Tensor& tensor, const ttnn::Shape& output_tensor_start, const ttnn::Shape& output_tensor_end) {
     TT_FATAL(!is_device_tensor(tensor), "unpad only supports host tensors");
 
-    // TODO: #15840 - Treat multi-device host vs owned/borrowed tensors uniformly.
-    if (is_multi_device_host_tensor(tensor)) {
-        return transform(tensor, [&](const Tensor& tensor_shard) {
-            return unpad<T>(tensor_shard, output_tensor_start, output_tensor_end);
-        });
-    }
-
     const auto& input_shape = tensor.padded_shape();
     const auto input_strides = tensor.strides();
 
@@ -1488,7 +1466,8 @@ Tensor unpad(const Tensor& tensor, const ttnn::Shape& output_tensor_start, const
     }
 
     auto unpad = [&input_shape, &input_strides, &output_shape, &output_tensor_start, &output_tensor_end](
-                     const auto& input_buffer) {
+                     const HostBuffer& input_host_buffer) {
+        const auto input_buffer = input_host_buffer.view_as<T>();
         ttnn::SmallVector<uint32_t> input_indices(input_shape.rank(), 0);
 
         auto flat_output_index = 0;
@@ -1510,20 +1489,15 @@ Tensor unpad(const Tensor& tensor, const ttnn::Shape& output_tensor_start, const
         return output_buffer;
     };
 
-    HostBuffer output_buffer = std::visit(
-        tt::stl::overloaded{
-            [&unpad](const HostStorage& storage) {
-                const auto input_data = host_buffer::get_as<T>(storage.buffer);
-                return HostBuffer(unpad(input_data));
-            },
-            [](const auto& s) -> HostBuffer { TT_THROW("Unexpected storage type {}", tt::stl::get_type_name(s)); }},
-        tensor.storage());
     return Tensor(
-        std::move(output_buffer),
-        ttnn::Shape(output_shape),
-        tensor.dtype(),
-        tensor.layout(),
-        tensor.tensor_spec().tile());
+        tensor.host_storage().transform([&](const HostBuffer& buffer) { return HostBuffer(unpad(buffer)); }),
+        TensorSpec(
+            ttnn::Shape(output_shape),
+            tt::tt_metal::TensorLayout(
+                tensor.dtype(),
+                tt::tt_metal::PageConfig(tensor.layout(), tensor.tensor_spec().tile()),
+                tt::tt_metal::MemoryConfig{})),
+        tensor.distributed_tensor_config());
 }
 
 template Tensor unpad<bfloat16>(

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -104,8 +104,7 @@ Tensor tensor_pad(
     ZoneScoped;
     GraphTracker::instance().track_function_start(
         "Tensor::pad", input_tensor, output_padded_shape, input_tensor_start, pad_value);
-    TT_ASSERT(
-        is_cpu_tensor(input_tensor) || is_multi_device_host_tensor(input_tensor), "Tensor must be on host for padding");
+    TT_ASSERT(is_cpu_tensor(input_tensor), "Tensor must be on host for padding");
     // TODO: Flip to assert when we remove use cases in python and c++
     if (input_tensor.layout() != Layout::ROW_MAJOR) {
         log_warning(

--- a/ttnn/core/tensor/tensor_utils.cpp
+++ b/ttnn/core/tensor/tensor_utils.cpp
@@ -95,51 +95,7 @@ bool is_arch_whb0(const tt::ARCH& arch) { return arch == tt::ARCH::WORMHOLE_B0; 
 
 bool is_cpu_tensor(const Tensor& tensor) { return tensor.storage_type() == StorageType::HOST; }
 
-bool is_multi_device_host_tensor(const Tensor& tensor) {
-    return tensor.storage_type() == StorageType::MULTI_DEVICE_HOST;
-}
-
 bool is_device_tensor(const Tensor& tensor) { return tensor.storage_type() == StorageType::DEVICE; }
-
-Tensor transform(const Tensor& tensor, const std::function<Tensor(const Tensor&)>& transform_func) {
-    TT_FATAL(is_multi_device_host_tensor(tensor), "transform only supports multi-device host tensors");
-    // TODO: #15840 - Push this down to OPs, so that instead of transforming the multi-device shards as `Tensor`, we
-    // operate on buffers directly. OPs code should not differentiate between host and multi-device host storage.
-    std::optional<TensorSpec> transformed_spec;
-    std::mutex transformed_buffer_mutex;
-    DistributedHostBuffer transformed_buffer =
-        std::get<MultiDeviceHostStorage>(tensor.storage())
-            .distributed_buffer()
-            .transform(
-                [&](const HostBuffer& buffer) {
-                    auto transformed_tensor = transform_func(Tensor(buffer, tensor.get_tensor_spec()));
-                    auto* host_storage = std::get_if<HostStorage>(&transformed_tensor.get_storage());
-                    TT_FATAL(host_storage != nullptr, "transform function must return a host tensor");
-                    {
-                        std::lock_guard<std::mutex> lock(transformed_buffer_mutex);
-                        if (transformed_spec.has_value()) {
-                            TT_FATAL(
-                                *transformed_spec == transformed_tensor.get_tensor_spec(),
-                                "All shards must have the same spec");
-                        } else {
-                            transformed_spec = transformed_tensor.get_tensor_spec();
-                        }
-                    }
-                    return host_storage->buffer;
-                },
-                DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
-    return Tensor(
-        MultiDeviceHostStorage(std::move(transformed_buffer)),
-        transformed_spec.value_or(tensor.get_tensor_spec()),
-        tensor.get_distributed_tensor_config());
-}
-
-void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& callable) {
-    TT_FATAL(is_multi_device_host_tensor(tensor), "apply only supports multi-device host tensors");
-    std::get<MultiDeviceHostStorage>(tensor.storage()).distributed_buffer().apply([&](const HostBuffer& buffer) {
-        callable(Tensor(buffer, tensor.get_tensor_spec()));
-    });
-}
 
 ShardDivisionSpec compute_shard_division_spec(const Shape2D& shape, const Shape2D& shard_shape) {
     const auto num_shards_height = tt::div_up(shape.height(), shard_shape.height());

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
@@ -19,20 +19,22 @@ namespace ttnn {
 namespace operations::conv {
 namespace conv_transpose2d {
 
-
 template <typename T>
 Tensor _transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor, bool mirror_kernel = true) {
-    auto in_w_shape = conv_weight_tensor.padded_shape();
-    auto dtype = conv_weight_tensor.dtype();
+    TT_FATAL(is_cpu_tensor(conv_weight_tensor), "transform_weights_for_conv_transpose2d only supports host tensors");
+
     // in_w_shape = {in_channels, out_channels, kernel_height, kernel_width}
     // out_w_shape = {out_channels, in_channels, kernel_height, kernel_width}
     // Flip kernel_height and kernel_width
-    auto compute = [&in_w_shape, &dtype, mirror_kernel](const auto& input_buffer) {
-        uint32_t in_channels = in_w_shape[0];
-        uint32_t out_channels = in_w_shape[1];
-        uint32_t kernel_height = in_w_shape[2];
-        uint32_t kernel_width = in_w_shape[3];
-        ttnn::Shape output_shape{out_channels, in_channels, kernel_height, kernel_width};
+    const auto& in_w_shape = conv_weight_tensor.padded_shape();
+    const uint32_t in_channels = in_w_shape[0];
+    const uint32_t out_channels = in_w_shape[1];
+    const uint32_t kernel_height = in_w_shape[2];
+    const uint32_t kernel_width = in_w_shape[3];
+    const ttnn::Shape output_shape{out_channels, in_channels, kernel_height, kernel_width};
+    auto compute = [&output_shape, in_channels, out_channels, kernel_height, kernel_width, mirror_kernel](
+                       const tt::tt_metal::HostBuffer& input_host_buffer) {
+        auto input_buffer = tt::tt_metal::host_buffer::get_as<T>(input_host_buffer);
         auto owned_buffer = std::vector<T>(output_shape.volume());
 
         for (uint32_t out_channels_index = 0; out_channels_index < out_channels; out_channels_index++) {
@@ -65,26 +67,18 @@ Tensor _transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor,
                 }
             }
         }
-        return Tensor(tt::tt_metal::HostBuffer(std::move(owned_buffer)), output_shape, dtype, Layout::ROW_MAJOR);
+        return tt::tt_metal::HostBuffer(std::move(owned_buffer));
     };
-    auto convert_tensor = [&compute](const auto& conv_weight_tensor) {
-        return std::visit(
-            [&compute](auto&& storage) -> Tensor {
-                using StorageType = std::decay_t<decltype(storage)>;
-                if constexpr (std::is_same_v<StorageType, tt::tt_metal::HostStorage>) {
-                    return compute(storage.buffer.template view_as<T>());
-                } else {
-                    TT_THROW("Unsupported storage type");
-                }
-            },
-            conv_weight_tensor.storage());
-    };
-    TT_FATAL(
-        !is_device_tensor(conv_weight_tensor), "transform_weights_for_conv_transpose2d only supports host tensors");
 
-    // TODO: #15840 - Treat multi-device host vs owned/borrowed tensors uniformly.
-    return tt::tt_metal::is_multi_device_host_tensor(conv_weight_tensor) ? transform(conv_weight_tensor, convert_tensor)
-                                                                         : convert_tensor(conv_weight_tensor);
+    const TensorSpec output_spec(
+        output_shape,
+        tt::tt_metal::TensorLayout(
+            conv_weight_tensor.dtype(), tt::tt_metal::PageConfig(Layout::ROW_MAJOR), MemoryConfig{}));
+
+    return Tensor(
+        conv_weight_tensor.host_storage().transform(compute),
+        output_spec,
+        conv_weight_tensor.distributed_tensor_config());
 }
 
 Tensor transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor, bool mirror_kernel) {

--- a/ttnn/cpp/ttnn/operations/core/core.cpp
+++ b/ttnn/cpp/ttnn/operations/core/core.cpp
@@ -18,10 +18,6 @@
 namespace ttnn::operations::core {
 
 ttnn::Tensor unsqueeze_to_4D(const ttnn::Tensor& tensor) {
-    if (tt::tt_metal::is_multi_device_host_tensor(tensor)) {
-        return transform(tensor, [&](const Tensor& device_tensor) { return unsqueeze_to_4D(device_tensor); });
-    }
-
     const auto rank = tensor.logical_shape().rank();
     if (rank == 4) {
         return tensor;

--- a/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.hpp
@@ -21,41 +21,32 @@ namespace core {
 namespace detail {
 
 inline Tensor convert_to_cpp_supported_dtype(const Tensor& input_tensor) {
-    auto input_dtype = input_tensor.dtype();
+    TT_FATAL(
+        input_tensor.storage_type() == StorageType::HOST, "convert_to_cpp_supported_dtype only supports host tensors");
+    const auto input_dtype = input_tensor.dtype();
 
-    auto buffer = std::visit(
-        tt::stl::overloaded{
-            [](const tt::tt_metal::HostStorage& storage) -> tt::tt_metal::HostBuffer { return storage.buffer; },
-            [](const auto& storage) -> tt::tt_metal::HostBuffer { TT_THROW("Unsupported storage type."); },
-        },
-        input_tensor.storage());
-
-    auto create_tensor = [&](tt::tt_metal::HostBuffer&& buffer, DataType dtype) -> Tensor {
-        return Tensor(
-            std::move(buffer),
-            TensorSpec(
-                input_tensor.logical_shape(),
-                tt::tt_metal::TensorLayout::fromPaddedShape(
-                    dtype,
-                    tt::tt_metal::PageConfig(input_tensor.layout()),
-                    MemoryConfig{},
-                    input_tensor.logical_shape(),
-                    input_tensor.padded_shape())));
-    };
-
-    if (input_dtype == DataType::BFLOAT8_B) {
-        tt::stl::Span<const uint32_t> uint32_data = tt::tt_metal::host_buffer::get_as<uint32_t>(buffer);
-        auto float_unpacked_data =
-            unpack_bfp8_tiles_into_float_vec(uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false);
-        return create_tensor(tt::tt_metal::HostBuffer(std::move(float_unpacked_data)), DataType::FLOAT32);
-    } else if (input_dtype == DataType::BFLOAT4_B) {
-        tt::stl::Span<const uint32_t> uint32_data = tt::tt_metal::host_buffer::get_as<uint32_t>(buffer);
-        auto float_unpacked_data =
-            unpack_bfp4_tiles_into_float_vec(uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false);
-        return create_tensor(tt::tt_metal::HostBuffer(std::move(float_unpacked_data)), DataType::FLOAT32);
-    } else {
+    if (input_dtype != DataType::BFLOAT8_B && input_dtype != DataType::BFLOAT4_B) {
         return input_tensor;
     }
+
+    return Tensor(
+        input_tensor.host_storage().transform([&](const tt::tt_metal::HostBuffer& buffer) {
+            tt::stl::Span<const uint32_t> uint32_data = tt::tt_metal::host_buffer::get_as<uint32_t>(buffer);
+            auto float_unpacked_data =
+                input_dtype == DataType::BFLOAT8_B
+                    ? unpack_bfp8_tiles_into_float_vec(uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false)
+                    : unpack_bfp4_tiles_into_float_vec(uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false);
+            return tt::tt_metal::HostBuffer(std::move(float_unpacked_data));
+        }),
+        TensorSpec(
+            input_tensor.logical_shape(),
+            tt::tt_metal::TensorLayout::fromPaddedShape(
+                DataType::FLOAT32,
+                tt::tt_metal::PageConfig(input_tensor.layout()),
+                MemoryConfig{},
+                input_tensor.logical_shape(),
+                input_tensor.padded_shape())),
+        input_tensor.distributed_tensor_config());
 }
 
 template <typename NewT, typename OldT>
@@ -63,9 +54,9 @@ std::vector<NewT> cast(tt::stl::Span<const OldT> input_buffer) {
     std::vector<NewT> output_vector(input_buffer.size());
     for (auto index = 0; index < input_buffer.size(); ++index) {
         auto convert_value = [](auto&& value) {
-            if constexpr (std::is_same_v<OldT, ::bfloat16>) {
+            if constexpr (std::is_same_v<OldT, bfloat16>) {
                 return value.to_float();
-            } else if constexpr (std::is_same_v<NewT, ::bfloat16>) {
+            } else if constexpr (std::is_same_v<NewT, bfloat16>) {
                 return static_cast<float>(value);
             } else {
                 return value;
@@ -78,43 +69,15 @@ std::vector<NewT> cast(tt::stl::Span<const OldT> input_buffer) {
 }
 
 template <typename T>
-Tensor create_tensor_from_span(
-    tt::stl::Span<const T> input_buffer,
-    const Shape& logical_shape,
-    const Shape& padded_shape,
-    const Layout& input_layout,
-    const DataType& dtype) {
+tt::tt_metal::HostBuffer create_host_buffer_from_span(
+    tt::stl::Span<const T> input_buffer, const Shape& logical_shape, const Shape& padded_shape, const DataType& dtype) {
     switch (dtype) {
-        case DataType::UINT16: {
-            auto data = cast<uint16_t, T>(input_buffer);
-            return Tensor(
-                       tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to_layout(input_layout);
-        }
-        case DataType::INT32: {
-            auto data = cast<int32_t, T>(input_buffer);
-            return Tensor(
-                       tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to_layout(input_layout);
-        }
-        case DataType::UINT32: {
-            auto data = cast<uint32_t, T>(input_buffer);
-            return Tensor(
-                       tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to_layout(input_layout);
-        }
-        case DataType::FLOAT32: {
-            auto data = cast<float, T>(input_buffer);
-            return Tensor(
-                       tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to_layout(input_layout);
-        }
-        case DataType::BFLOAT16: {
-            auto data = cast<::bfloat16, T>(input_buffer);
-            return Tensor(
-                       tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to_layout(input_layout);
-        }
+        case DataType::UINT8: return tt::tt_metal::HostBuffer(cast<uint8_t, T>(input_buffer));
+        case DataType::UINT16: return tt::tt_metal::HostBuffer(cast<uint16_t, T>(input_buffer));
+        case DataType::UINT32: return tt::tt_metal::HostBuffer(cast<uint32_t, T>(input_buffer));
+        case DataType::INT32: return tt::tt_metal::HostBuffer(cast<int32_t, T>(input_buffer));
+        case DataType::BFLOAT16: return tt::tt_metal::HostBuffer(cast<bfloat16, T>(input_buffer));
+        case DataType::FLOAT32: return tt::tt_metal::HostBuffer(cast<float, T>(input_buffer));
         case DataType::BFLOAT8_B:
         case DataType::BFLOAT4_B: {
             auto data = cast<float, T>(input_buffer);
@@ -126,56 +89,64 @@ Tensor create_tensor_from_span(
                 dtype == DataType::BFLOAT8_B
                     ? pack_fp32_vec_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false)
                     : pack_fp32_vec_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
-            return Tensor(
-                tt::tt_metal::HostBuffer(std::move(output_packed_data)),
-                logical_shape,
-                padded_shape,
-                dtype,
-                Layout::TILE);  // has to be in tile layout
+            return tt::tt_metal::HostBuffer(std::move(output_packed_data));
         }
-        default: {
-            TT_THROW("Unsupported DataType: {}", dtype);
-            break;
-        }
+        case DataType::INVALID: TT_THROW("Unsupported DataType: {}", dtype);
     }
+    TT_THROW("Unreachable");
 }
 
-inline Tensor convert_to_dtype(const Tensor& input_tensor, const Layout& input_layout, const DataType& dtype) {
+inline Tensor convert_to_dtype(const Tensor& input_tensor, const Layout& input_layout, const DataType& target_dtype) {
     auto input_dtype = input_tensor.dtype();
     const auto& logical_shape = input_tensor.logical_shape();
     const auto& padded_shape = input_tensor.padded_shape();
 
-    auto convert_dtype =
-        [&input_layout, &input_dtype, &dtype, &logical_shape, &padded_shape](const Tensor& input_tensor) {
-            switch (input_dtype) {
-                case DataType::UINT16: {
-                    auto buffer = tt::tt_metal::host_buffer::get_as<uint16_t>(input_tensor);
-                    return create_tensor_from_span(buffer, logical_shape, padded_shape, input_layout, dtype);
-                }
-                case DataType::INT32: {
-                    auto buffer = tt::tt_metal::host_buffer::get_as<int32_t>(input_tensor);
-                    return create_tensor_from_span(buffer, logical_shape, padded_shape, input_layout, dtype);
-                }
-                case DataType::UINT32: {
-                    auto buffer = tt::tt_metal::host_buffer::get_as<uint32_t>(input_tensor);
-                    return create_tensor_from_span(buffer, logical_shape, padded_shape, input_layout, dtype);
-                }
-                case DataType::FLOAT32: {
-                    auto buffer = tt::tt_metal::host_buffer::get_as<float>(input_tensor);
-                    return create_tensor_from_span(buffer, logical_shape, padded_shape, input_layout, dtype);
-                }
-                case DataType::BFLOAT16: {
-                    auto buffer = tt::tt_metal::host_buffer::get_as<::bfloat16>(input_tensor);
-                    return create_tensor_from_span(buffer, logical_shape, padded_shape, input_layout, dtype);
-                }
-                default: TT_THROW("Unsupported DataType: {}", input_dtype); break;
-            }
-        };
-    TT_FATAL(!is_device_tensor(input_tensor), "to_dtype only supports host tensors");
+    auto convert_dtype = [&input_layout, &input_dtype, target_dtype, &logical_shape, &padded_shape](
+                             const tt::tt_metal::HostBuffer& input_host_buffer) {
+        switch (input_dtype) {
+            case DataType::UINT8:
+                return create_host_buffer_from_span(
+                    input_host_buffer.view_as<uint8_t>(), logical_shape, padded_shape, target_dtype);
+            case DataType::UINT16:
+                return create_host_buffer_from_span(
+                    input_host_buffer.view_as<uint16_t>(), logical_shape, padded_shape, target_dtype);
+            case DataType::INT32:
+                return create_host_buffer_from_span(
+                    input_host_buffer.view_as<int32_t>(), logical_shape, padded_shape, target_dtype);
+            case DataType::UINT32:
+                return create_host_buffer_from_span(
+                    input_host_buffer.view_as<uint32_t>(), logical_shape, padded_shape, target_dtype);
+            case DataType::FLOAT32:
+                return create_host_buffer_from_span(
+                    input_host_buffer.view_as<float>(), logical_shape, padded_shape, target_dtype);
+            case DataType::BFLOAT16:
+                return create_host_buffer_from_span(
+                    input_host_buffer.view_as<bfloat16>(), logical_shape, padded_shape, target_dtype);
+            // Block float types should have been converted earlier to float32.
+            case DataType::BFLOAT8_B:
+            case DataType::BFLOAT4_B:
+            case DataType::INVALID: TT_THROW("Unsupported DataType: {}", input_dtype);
+        }
+        TT_THROW("Unreachable");
+    };
 
-    // TODO: #15840 - Treat multi-device host vs owned/borrowed tensors uniformly.
-    return tt::tt_metal::is_multi_device_host_tensor(input_tensor) ? transform(input_tensor, convert_dtype)
-                                                                   : convert_dtype(input_tensor);
+    const Layout converted_layout =
+        (target_dtype == DataType::BFLOAT8_B || target_dtype == DataType::BFLOAT4_B) ? Layout::TILE : Layout::ROW_MAJOR;
+    const Layout target_layout =
+        (target_dtype == DataType::BFLOAT8_B || target_dtype == DataType::BFLOAT4_B) ? Layout::TILE : input_layout;
+
+    return Tensor(
+               input_tensor.host_storage().transform(convert_dtype),
+               TensorSpec(
+                   logical_shape,
+                   tt::tt_metal::TensorLayout::fromPaddedShape(
+                       target_dtype,
+                       tt::tt_metal::PageConfig(converted_layout),
+                       MemoryConfig{},
+                       logical_shape,
+                       padded_shape)),
+               input_tensor.distributed_tensor_config())
+        .to_layout(target_layout);
 }
 
 }  // namespace detail
@@ -190,14 +161,10 @@ struct ToDtype {
             return input_tensor;
         }
 
-        TT_FATAL(!is_device_tensor(input_tensor), "to_dtype only supports host tensors");
-
+        TT_FATAL(is_cpu_tensor(input_tensor), "to_dtype only supports host tensors");
         auto row_major_input_tensor = input_tensor.to_layout(ttnn::ROW_MAJOR_LAYOUT);
 
-        // TODO: #15840 - Treat multi-device host vs owned/borrowed tensors uniformly.
-        auto intermediate_tensor = tt::tt_metal::is_multi_device_host_tensor(row_major_input_tensor)
-                                       ? transform(row_major_input_tensor, detail::convert_to_cpp_supported_dtype)
-                                       : detail::convert_to_cpp_supported_dtype(row_major_input_tensor);
+        auto intermediate_tensor = detail::convert_to_cpp_supported_dtype(row_major_input_tensor);
         return detail::convert_to_dtype(intermediate_tensor, input_layout, dtype);
     };
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -31,14 +31,14 @@ static Tensor manual_insertion(
         logical_shape.volume(),
         input_tensor.logical_volume());
     auto cpu_tensor = input_tensor.cpu();
-    auto host_buffer = tt::tt_metal::host_buffer::get_host_buffer(cpu_tensor);
     auto output =
         Tensor(
-            std::move(host_buffer),
+            cpu_tensor.storage(),
             TensorSpec(
                 logical_shape,
                 TensorLayout::fromPaddedShape(
-                    DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
+                    DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)),
+            cpu_tensor.distributed_tensor_config())
             .to_layout(Layout::ROW_MAJOR);
     if (device != nullptr) {
         output = output.to_device(device, output_mem_config);


### PR DESCRIPTION
### Ticket
[15840](https://github.com/tenstorrent/tt-metal/issues/15840)

### Problem description
Difference between `HostStorage` and `MultiDeviceHostStorage` should be hidden from users.

### What's changed
Treat `HostStorage` with a single tensor shard as a "unit mesh" 1x1. Add special handling for this case:
1. When writing the unit tensor to mesh device, replicate the tensor across all devices in the mesh.
2. When reading the unit tensor from mesh device, allow `to_torch` path without specifying a mesh composer.

In addition, introduce `HostStorage::transform` API - performs a given transformation over all `HostBuffer` in storage in parallel. This is the main entry point for Ops that wish to make modifications to the host-side storage.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16187141636)
- [x] [BH post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16202697077)
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/runs/16202693953)
- [x] [Single device pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/16185025737)
- [x] [TG tests](https://github.com/tenstorrent/tt-metal/actions/runs/16185028359)
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/16178948713) (known flaky tests)
- [X] New/Existing tests provide coverage for changes