### PR TITLE
Add synchronization to fabric infra

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
@@ -465,7 +465,7 @@ struct LineSyncConfig {
 
     void global_sync_finish() {
         // sync wait
-        while (line_sync_ptr[0] != line_sync_val);
+        noc_semaphore_wait(line_sync_ptr, line_sync_val);
     }
 
 private:
@@ -945,7 +945,7 @@ private:
             if constexpr (MASTER_SYNC_CORE) {
                 uint32_t line_sync_val = get_arg_val<uint32_t>(arg_idx++);
                 for (uint8_t i = 0; i < NUM_SYNC_FABRIC_CONNECTIONS; i++) {
-                    uint32_t packet_header_address = this->memory_allocator.get_packet_header_address();
+                    uint32_t packet_header_address = this->memory_map.get_packet_header_address();
                     new (&line_sync_configs()[i])
                         LineSyncConfig(&sync_fabric_connections()[i], packet_header_address, line_sync_val);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_receiver.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_receiver.cpp
@@ -28,26 +28,30 @@ void kernel_main() {
         packets_left_to_validate = false;
         for (uint8_t i = 0; i < NUM_TRAFFIC_CONFIGS; i++) {
             auto* traffic_config = receiver_config.traffic_configs[i];
-            if (!traffic_config->has_packets_to_validate()) {
-                continue;
-            }
+            if constexpr (!BENCHMARK_MODE) {
+                if (!traffic_config->has_packets_to_validate()) {
+                    continue;
+                }
 
-            // if we are here, this means that we have atleast 1 packet left to validate
-            packets_left_to_validate = true;
-            bool got_new_data = traffic_config->poll();
-            if (!got_new_data) {
-                continue;
-            }
+                // if we are here, this means that we have atleast 1 packet left to validate
+                packets_left_to_validate = true;
+                bool got_new_data = traffic_config->poll();
+                if (!got_new_data) {
+                    continue;
+                }
 
-            bool data_valid = traffic_config->validate();
-            if (!data_valid) {
-                failed = true;
-                break;
-            }
+                bool data_valid = traffic_config->validate();
+                if (!data_valid) {
+                    failed = true;
+                    break;
+                }
 
-            traffic_config->advance();
-            total_packets_received++;
-            packets_left_to_validate |= traffic_config->has_packets_to_validate();
+                traffic_config->advance();
+                total_packets_received++;
+                packets_left_to_validate |= traffic_config->has_packets_to_validate();
+            } else {
+                total_packets_received += traffic_config->metadata.num_packets;
+            }
         }
 
         if (failed) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
@@ -28,6 +28,7 @@ void kernel_main() {
     uint64_t total_packets_sent = 0;
     uint64_t total_elapsed_cycles = 0;
 
+    // Round-robin packet sending: send one packet from each config per iteration
     while (packets_left_to_send) {
         packets_left_to_send = false;
         for (uint8_t i = 0; i < NUM_TRAFFIC_CONFIGS; i++) {
@@ -39,7 +40,8 @@ void kernel_main() {
             // TODO: might want to check if the buffer has wrapped or not
             // if wrapped, then wait for credits from the receiver
 
-            traffic_config->send_packets<BENCHMARK_MODE>();
+            // Always send exactly one packet per config per round
+            traffic_config->send_one_packet<BENCHMARK_MODE>();
             packets_left_to_send |= traffic_config->has_packets_to_send();
         }
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
@@ -14,12 +14,10 @@ constexpr uint8_t NUM_LOCAL_SYNC_CORES = get_compile_time_arg_val(6);
 
 using SenderKernelConfig = tt::tt_fabric::fabric_tests::SenderKernelConfig<
     NUM_FABRIC_CONNECTIONS,
-    0,  // No sync fabric connections in regular sender
     NUM_TRAFFIC_CONFIGS,
     IS_2D_FABRIC,
     USE_DYNAMIC_ROUTING,
     LINE_SYNC,
-    false,  // Not master sync core
     NUM_LOCAL_SYNC_CORES>;
 
 void kernel_main() {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
@@ -10,18 +10,16 @@ constexpr uint8_t NUM_FABRIC_CONNECTIONS = get_compile_time_arg_val(2);
 constexpr uint8_t NUM_TRAFFIC_CONFIGS = get_compile_time_arg_val(3);
 constexpr bool BENCHMARK_MODE = get_compile_time_arg_val(4);
 constexpr bool LINE_SYNC = get_compile_time_arg_val(5);
-constexpr bool MASTER_SYNC_CORE = get_compile_time_arg_val(6);
-constexpr uint8_t NUM_LOCAL_SYNC_CORES = get_compile_time_arg_val(7);
-constexpr uint8_t NUM_SYNC_FABRIC_CONNECTIONS = get_compile_time_arg_val(8);
+constexpr uint8_t NUM_LOCAL_SYNC_CORES = get_compile_time_arg_val(6);
 
 using SenderKernelConfig = tt::tt_fabric::fabric_tests::SenderKernelConfig<
     NUM_FABRIC_CONNECTIONS,
-    NUM_SYNC_FABRIC_CONNECTIONS,
+    0,  // No sync fabric connections in regular sender
     NUM_TRAFFIC_CONFIGS,
     IS_2D_FABRIC,
     USE_DYNAMIC_ROUTING,
     LINE_SYNC,
-    MASTER_SYNC_CORE,
+    false,  // Not master sync core
     NUM_LOCAL_SYNC_CORES>;
 
 void kernel_main() {
@@ -33,16 +31,9 @@ void kernel_main() {
         sender_config.get_result_buffer_address(), sender_config.get_result_buffer_size());
     tt::tt_fabric::fabric_tests::write_test_status(sender_config.get_result_buffer_address(), TT_FABRIC_STATUS_STARTED);
 
-    // add line sync here
+    // Local sync (as participant, not master)
     if constexpr (LINE_SYNC) {
-        if constexpr (MASTER_SYNC_CORE) {
-            sender_config.global_sync();
-            sender_config.local_sync();
-            // master sync core doesn't process any subsequent traffic.
-            return;
-        } else {
-            sender_config.local_sync();
-        }
+        sender_config.local_sync();
     }
 
     sender_config.open_connections();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sync.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sync.cpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_fabric_test_kernels_utils.hpp"
+
+constexpr uint8_t IS_2D_FABRIC = get_compile_time_arg_val(0);
+constexpr uint8_t USE_DYNAMIC_ROUTING = get_compile_time_arg_val(1);
+constexpr uint8_t NUM_SYNC_FABRIC_CONNECTIONS = get_compile_time_arg_val(2);
+constexpr uint8_t NUM_LOCAL_SYNC_CORES = get_compile_time_arg_val(3);
+
+using SyncKernelConfig = tt::tt_fabric::fabric_tests::
+    SyncKernelConfig<NUM_SYNC_FABRIC_CONNECTIONS, IS_2D_FABRIC, USE_DYNAMIC_ROUTING, NUM_LOCAL_SYNC_CORES>;
+
+void kernel_main() {
+    size_t rt_args_idx = 0;
+    auto sync_config = SyncKernelConfig::build_from_args(rt_args_idx);
+
+    // Clear test results area and mark as started
+    tt::tt_fabric::fabric_tests::clear_test_results(
+        sync_config.get_result_buffer_address(), sync_config.get_result_buffer_size());
+    tt::tt_fabric::fabric_tests::write_test_status(sync_config.get_result_buffer_address(), TT_FABRIC_STATUS_STARTED);
+
+    // Perform global sync (master sync core)
+    sync_config.global_sync();
+
+    // Perform local sync
+    sync_config.local_sync();
+
+    // Mark test as passed. TODO: might need a local sync after all test done (TBD).
+    tt::tt_fabric::fabric_tests::write_test_status(sync_config.get_result_buffer_address(), TT_FABRIC_STATUS_PASS);
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
@@ -1,5 +1,6 @@
 Tests:
   - name: "SimpleUnicastWriteLinear"
+    sync: true
     fabric_setup:
       topology: Linear
 
@@ -14,6 +15,7 @@ Tests:
               device: [0, 1]
 
   - name: "TestNocSendTypesLinear"
+    sync: true
     fabric_setup:
       topology: Linear
 
@@ -30,6 +32,7 @@ Tests:
               device: [0, 1]
 
   - name: "AllToAllUnicastWriteLinear"
+    sync: true
     fabric_setup:
       topology: Linear
 
@@ -43,6 +46,7 @@ Tests:
       - type: all_to_all_unicast
 
   - name: "AllToAllUnicastTestNocSendTypesLinear"
+    sync: true
     fabric_setup:
       topology: Linear
 
@@ -58,6 +62,7 @@ Tests:
       - type: all_to_all_unicast
 
   - name: "AllToAllMulticastLinear"
+    sync: true
     fabric_setup:
       topology: Linear
 
@@ -71,6 +76,7 @@ Tests:
       - type: all_to_all_multicast
 
   - name: "UnidirectionalMulticastLinear"
+    sync: true
     fabric_setup:
       topology: Linear
 
@@ -84,6 +90,7 @@ Tests:
       - type: unidirectional_linear_multicast
 
   - name: "FullDevicePairingLinear"
+    sync: true
     fabric_setup:
       topology: Linear
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_t3k.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_t3k.yaml
@@ -32,7 +32,7 @@ Tests:
 
   - name: "HalfRingMulticast"
     benchmark_mode: true
-    sync: false
+    sync: true
     fabric_setup:
       topology: Ring
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_t3k.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_t3k.yaml
@@ -1,6 +1,23 @@
 Tests:
+  - name: "LinearMulticast"
+    benchmark_mode: true
+    sync: true
+    fabric_setup:
+      topology: Linear
+
+    defaults:
+      ftype: mcast
+      ntype: unicast_write
+      size: 1024
+      num_packets: 100
+
+    patterns:
+      - type: unidirectional_linear_multicast
+
+
   - name: "FullRingMulticast"
     benchmark_mode: true
+    sync: true
     fabric_setup:
       topology: Ring
 
@@ -15,6 +32,7 @@ Tests:
 
   - name: "HalfRingMulticast"
     benchmark_mode: true
+    sync: false
     fabric_setup:
       topology: Ring
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_t3k.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_t3k.yaml
@@ -1,26 +1,28 @@
 Tests:
   - name: "FullRingMulticast"
+    benchmark_mode: true
     fabric_setup:
       topology: Ring
 
     defaults:
       ftype: mcast
       ntype: unicast_write
-      size: 1024
-      num_packets: 100
+      size: 4096
+      num_packets: 200000
 
     patterns:
       - type: full_ring_multicast
 
   - name: "HalfRingMulticast"
+    benchmark_mode: true
     fabric_setup:
       topology: Ring
 
     defaults:
       ftype: mcast
       ntype: unicast_write
-      size: 1024
-      num_packets: 100
+      size: 4096
+      num_packets: 200000
 
     patterns:
       - type: half_ring_multicast

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -63,16 +63,27 @@ public:
     void reset_devices();
     void process_traffic_config(TestConfig& config);
     void open_devices(Topology topology, RoutingType routing_type);
+    void initialize_sync_memory();
     void compile_programs();
     void launch_programs();
     void wait_for_prorgams();
     void validate_results();
     void close_devices();
     void set_benchmark_mode(bool benchmark_mode) { benchmark_mode_ = benchmark_mode; }
+    void set_global_sync(bool global_sync) { global_sync_ = global_sync; }
+    void set_global_sync_val(uint32_t val) { global_sync_val_ = val; }
+    uint32_t get_global_sync_address() { return sender_memory_map_.get_global_sync_address(); }
+    uint32_t get_global_sync_region_size() { return sender_memory_map_.get_global_sync_region_size(); }
+    uint32_t get_local_sync_address() { return sender_memory_map_.get_local_sync_address(); }
+    uint32_t get_local_sync_region_size() { return sender_memory_map_.get_local_sync_region_size(); }
 
 private:
     void add_traffic_config(const TestTrafficConfig& traffic_config);
     void initialize_memory_maps();
+
+    // Track sync cores for each device
+    std::unordered_map<FabricNodeId, CoreCoord> device_global_sync_cores_;
+    std::unordered_map<FabricNodeId, std::vector<CoreCoord>> device_local_sync_cores_;
 
     std::shared_ptr<TestFixture> fixture_;
     std::unordered_map<MeshCoordinate, TestDevice> test_devices_;
@@ -83,6 +94,8 @@ private:
     tt::tt_fabric::fabric_tests::ReceiverMemoryMap receiver_memory_map_;
     tt::tt_fabric::fabric_tests::AllocatorPolicies allocation_policies_;
     bool benchmark_mode_ = false;  // Benchmark mode for current test
+    bool global_sync_ = false;     // Line sync for current test
+    uint32_t global_sync_val_ = 0;
 };
 
 void TestContext::add_traffic_config(const TestTrafficConfig& traffic_config) {
@@ -189,6 +202,8 @@ void TestContext::setup_devices() {
 
 void TestContext::reset_devices() {
     test_devices_.clear();
+    device_global_sync_cores_.clear();
+    device_local_sync_cores_.clear();
     this->allocator_->reset();
 }
 
@@ -196,11 +211,50 @@ void TestContext::open_devices(Topology topology, RoutingType routing_type) {
     fixture_->open_devices(topology, routing_type);
 }
 
+void TestContext::initialize_sync_memory() {
+    if (!global_sync_) {
+        return;  // Only initialize sync memory if line sync is enabled
+    }
+
+    log_info(tt::LogTest, "Initializing sync memory for line sync");
+
+    // Initialize sync memory location with 16 bytes of zeros on all devices
+    uint32_t global_sync_address = this->get_global_sync_address();
+    uint32_t global_sync_memory_size = this->get_global_sync_region_size();
+    uint32_t local_sync_address = this->get_local_sync_address();
+    uint32_t local_sync_memory_size = this->get_local_sync_region_size();
+
+    // clear the global sync cores in device_global_sync_cores_ using zero_out_buffer_on_cores
+    for (const auto& [device_id, sync_core] : device_global_sync_cores_) {
+        const auto& device_coord = fixture_->get_device_coord(device_id);
+        std::vector<CoreCoord> cores = {sync_core};
+        fixture_->zero_out_buffer_on_cores(device_coord, cores, global_sync_address, global_sync_memory_size);
+    }
+
+    // clear the local sync cores in device_local_sync_cores_ using zero_out_buffer_on_cores
+    for (const auto& [device_id, sync_cores] : device_local_sync_cores_) {
+        const auto& device_coord = fixture_->get_device_coord(device_id);
+        fixture_->zero_out_buffer_on_cores(device_coord, sync_cores, local_sync_address, local_sync_memory_size);
+    }
+
+    log_info(
+        tt::LogTest,
+        "Sync memory initialization complete at address: {} and address: {}",
+        global_sync_address,
+        local_sync_address);
+}
+
 void TestContext::compile_programs() {
     fixture_->setup_workload();
     // TODO: should we be taking const ref?
     for (auto& [coord, test_device] : test_devices_) {
         test_device.set_benchmark_mode(benchmark_mode_);
+        test_device.set_global_sync(global_sync_);
+        test_device.set_global_sync_val(global_sync_val_);
+
+        auto device_id = test_device.get_node_id();
+        test_device.set_sync_core(device_global_sync_cores_[device_id]);
+
         test_device.create_kernels();
         auto& program_handle = test_device.get_program_handle();
         if (program_handle.num_kernels()) {
@@ -225,8 +279,90 @@ void TestContext::process_traffic_config(TestConfig& config) {
     this->allocator_->allocate_resources(config);
     log_info(tt::LogTest, "Resource allocation complete");
 
+    if (config.global_sync) {
+        // set it only after the test_config is built since it needs set the sync value during expand the high-level
+        // patterns.
+        this->set_global_sync_val(config.global_sync_val);
+
+        for (const auto& sync_sender : config.global_sync_configs) {
+            CoreCoord sync_core = sync_sender.core.value();
+            const auto& device_coord = this->fixture_->get_device_coord(sync_sender.device);
+
+            // Track global sync core for this device
+            device_global_sync_cores_[sync_sender.device] = sync_core;
+
+            // Process each already-split sync pattern for this device
+            for (const auto& sync_pattern : sync_sender.patterns) {
+                // Convert sync pattern to TestTrafficSenderConfig format
+                const auto& dest = sync_pattern.destination.value();
+
+                // Patterns are now already split into single-direction hops
+                const auto& single_direction_hops = dest.hops.value();
+
+                TrafficParameters sync_traffic_parameters = {
+                    .chip_send_type = sync_pattern.ftype.value(),
+                    .noc_send_type = sync_pattern.ntype.value(),
+                    .payload_size_bytes = sync_pattern.size.value(),
+                    .num_packets = sync_pattern.num_packets.value(),
+                    .atomic_inc_val = sync_pattern.atomic_inc_val,
+                    .atomic_inc_wrap = sync_pattern.atomic_inc_wrap,
+                    .mcast_start_hops = sync_pattern.mcast_start_hops,
+                    .seed = config.seed,
+                    .topology = config.fabric_setup.topology,
+                    .mesh_shape = this->fixture_->get_mesh_shape(),
+                };
+
+                // For sync patterns, we use a dummy destination core and fixed sync address
+                // The actual sync will be handled by atomic operations
+                CoreCoord dummy_dst_core = {0, 0};                        // Sync doesn't need specific dst core
+                uint32_t sync_address = this->get_global_sync_address();  // Hard-coded sync address
+                uint32_t dst_noc_encoding = this->fixture_->get_worker_noc_encoding(
+                    sync_sender.device, sync_core);  // populate the master coord
+
+                TestTrafficSenderConfig sync_config = {
+                    .parameters = sync_traffic_parameters,
+                    .src_node_id = sync_sender.device,
+                    .dst_node_ids = {},             // Empty for multicast sync
+                    .hops = single_direction_hops,  // Use already single-direction hops
+                    .dst_logical_core = dummy_dst_core,
+                    .target_address = sync_address,
+                    .atomic_inc_address = sync_address,
+                    .dst_noc_encoding = dst_noc_encoding};
+
+                // Add sync config to the master sender on this device
+                this->test_devices_.at(device_coord).add_sender_sync_config(sync_core, std::move(sync_config));
+            }
+        }
+
+        // Validate that all sync cores have the same coordinate
+        if (!device_global_sync_cores_.empty()) {
+            CoreCoord reference_sync_core = device_global_sync_cores_.begin()->second;
+            for (const auto& [device_id, sync_core] : device_global_sync_cores_) {
+                if (sync_core.x != reference_sync_core.x || sync_core.y != reference_sync_core.y) {
+                    TT_THROW(
+                        "Global sync requires all devices to use the same sync core coordinate. "
+                        "Device {} uses sync core ({}, {}) but expected ({}, {}) based on first device.",
+                        device_id.chip_id,
+                        sync_core.x,
+                        sync_core.y,
+                        reference_sync_core.x,
+                        reference_sync_core.y);
+                }
+            }
+            log_info(
+                tt::LogTest,
+                "Validated sync core consistency: all {} devices use sync core ({}, {})",
+                device_global_sync_cores_.size(),
+                reference_sync_core.x,
+                reference_sync_core.y);
+        }
+    }
+
     for (const auto& sender : config.senders) {
         for (const auto& pattern : sender.patterns) {
+            // Track local sync core for this device
+            device_local_sync_cores_[sender.device].push_back(sender.core.value());
+
             // The allocator has already filled in all the necessary details.
             // We just need to construct the TrafficConfig and pass it to add_traffic_config.
             const auto& dest = pattern.destination.value();
@@ -341,8 +477,9 @@ int main(int argc, char** argv) {
         test_context.open_devices(topology, routing_type);
 
         log_info(tt::LogTest, "Building tests");
-        // Set benchmark mode for this test group
+        // Set benchmark mode and line sync for this test group
         test_context.set_benchmark_mode(test_config.benchmark_mode);
+        test_context.set_global_sync(test_config.global_sync);
 
         auto built_tests = builder.build_tests({test_config});
 
@@ -354,6 +491,9 @@ int main(int argc, char** argv) {
 
             test_context.process_traffic_config(built_test);
             log_info(tt::LogTest, "Traffic config processed");
+
+            // Initialize sync memory if line sync is enabled
+            test_context.initialize_sync_memory();
 
             if (dump_built_tests) {
                 YamlTestConfigSerializer::dump({built_test}, output_stream);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -72,10 +72,6 @@ public:
     void set_benchmark_mode(bool benchmark_mode) { benchmark_mode_ = benchmark_mode; }
     void set_global_sync(bool global_sync) { global_sync_ = global_sync; }
     void set_global_sync_val(uint32_t val) { global_sync_val_ = val; }
-    uint32_t get_global_sync_address() { return sender_memory_map_.get_global_sync_address(); }
-    uint32_t get_global_sync_region_size() { return sender_memory_map_.get_global_sync_region_size(); }
-    uint32_t get_local_sync_address() { return sender_memory_map_.get_local_sync_address(); }
-    uint32_t get_local_sync_region_size() { return sender_memory_map_.get_local_sync_region_size(); }
 
 private:
     void add_traffic_config(const TestTrafficConfig& traffic_config);
@@ -226,10 +222,10 @@ void TestContext::initialize_sync_memory() {
     log_info(tt::LogTest, "Initializing sync memory for line sync");
 
     // Initialize sync memory location with 16 bytes of zeros on all devices
-    uint32_t global_sync_address = this->get_global_sync_address();
-    uint32_t global_sync_memory_size = this->get_global_sync_region_size();
-    uint32_t local_sync_address = this->get_local_sync_address();
-    uint32_t local_sync_memory_size = this->get_local_sync_region_size();
+    uint32_t global_sync_address = this->sender_memory_map_.get_global_sync_address();
+    uint32_t global_sync_memory_size = this->sender_memory_map_.get_global_sync_region_size();
+    uint32_t local_sync_address = this->sender_memory_map_.get_local_sync_address();
+    uint32_t local_sync_memory_size = this->sender_memory_map_.get_local_sync_region_size();
 
     // clear the global sync cores in device_global_sync_cores_ using zero_out_buffer_on_cores
     for (const auto& [device_id, global_sync_core] : device_global_sync_cores_) {
@@ -328,7 +324,7 @@ void TestContext::process_traffic_config(TestConfig& config) {
                 // For sync patterns, we use a dummy destination core and fixed sync address
                 // The actual sync will be handled by atomic operations
                 CoreCoord dummy_dst_core = {0, 0};                        // Sync doesn't need specific dst core
-                uint32_t sync_address = this->get_global_sync_address();  // Hard-coded sync address
+                uint32_t sync_address = this->sender_memory_map_.get_global_sync_address();  // Hard-coded sync address
                 uint32_t dst_noc_encoding = this->fixture_->get_worker_noc_encoding(
                     sync_sender.device, sync_core);  // populate the master coord
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -693,6 +693,22 @@ public:
         return std::make_pair(dst_node_forward, dst_node_backward);
     }
 
+    uint32_t get_linear_topology_num_sync_devices() const override {
+        uint32_t num_devices = mesh_shape_[NS_DIM] + mesh_shape_[EW_DIM] - 1;
+        return num_devices;
+    }
+
+    uint32_t get_wrap_around_mesh_ring_topology_num_sync_devices() const override {
+        // sync using full ring mcast, ie, mcast on both forward/backward path.
+        uint32_t num_devices = 2 * (mesh_shape_[NS_DIM] - 1 + mesh_shape_[EW_DIM] - 1);
+        return num_devices;
+    }
+
+    uint32_t get_mesh_topology_num_sync_devices() const override {
+        uint32_t num_devices = mesh_shape_[NS_DIM] * mesh_shape_[EW_DIM];
+        return num_devices;
+    }
+
     std::unordered_map<RoutingDirection, uint32_t> get_full_or_half_ring_mcast_hops(
         const FabricNodeId& src_node_id,
         const FabricNodeId& dst_node_forward_id,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -693,20 +693,24 @@ public:
         return std::make_pair(dst_node_forward, dst_node_backward);
     }
 
-    uint32_t get_linear_topology_num_sync_devices() const override {
-        uint32_t num_devices = mesh_shape_[NS_DIM] + mesh_shape_[EW_DIM] - 1;
-        return num_devices;
-    }
-
-    uint32_t get_wrap_around_mesh_ring_topology_num_sync_devices() const override {
-        // sync using full ring mcast, ie, mcast on both forward/backward path.
-        uint32_t num_devices = 2 * (mesh_shape_[NS_DIM] - 1 + mesh_shape_[EW_DIM] - 1);
-        return num_devices;
-    }
-
-    uint32_t get_mesh_topology_num_sync_devices() const override {
-        uint32_t num_devices = mesh_shape_[NS_DIM] * mesh_shape_[EW_DIM];
-        return num_devices;
+    uint32_t get_num_sync_devices() const override {
+        uint32_t num_devices;
+        switch (topology_) {
+            case tt::tt_fabric::Topology::Linear: {
+                num_devices = mesh_shape_[NS_DIM] + mesh_shape_[EW_DIM] - 1;
+                return num_devices;
+            }
+            case tt::tt_fabric::Topology::Ring: {
+                // sync using full ring mcast, ie, mcast on both forward/backward path.
+                num_devices = 2 * (mesh_shape_[NS_DIM] - 1 + mesh_shape_[EW_DIM] - 1);
+                return num_devices;
+            }
+            case tt::tt_fabric::Topology::Mesh: {
+                num_devices = mesh_shape_[NS_DIM] * mesh_shape_[EW_DIM];
+                return num_devices;
+            }
+            default: TT_THROW("Unsupported topology for get_num_sync_devices: {}", static_cast<int>(topology_));
+        }
     }
 
     std::unordered_map<RoutingDirection, uint32_t> get_full_or_half_ring_mcast_hops(
@@ -846,6 +850,53 @@ public:
         const FabricNodeId& src_node_id, const RoutingDirection& direction) const override {
         const auto& neighbor_node_id = get_neighbor_node_id(src_node_id, direction);
         return this->get_forwarding_link_indices_in_direction(src_node_id, neighbor_node_id, direction);
+    }
+
+    /// Helper to compute per‐direction hops and the global sync value
+    std::pair<std::unordered_map<RoutingDirection, uint32_t>, uint32_t> get_sync_hops_and_val(
+        const FabricNodeId& src_device, const std::vector<FabricNodeId>& devices) const override {
+        std::unordered_map<RoutingDirection, uint32_t> multi_directional_hops;
+        uint32_t global_sync_val = 0;
+
+        switch (topology_) {
+            case tt::tt_fabric::Topology::Ring: {
+                // Get ring neighbors - returns nullopt for non-perimeter devices
+                auto ring_neighbors = this->get_wrap_around_mesh_ring_neighbors(src_device, devices);
+
+                // Check if the result is valid (has value)
+                if (!ring_neighbors.has_value()) {
+                    // Skip this device as it's not on the perimeter and can't participate in ring multicast
+                    log_info(LogTest, "Skipping device {} as it's not on the perimeter ring", src_device.chip_id);
+                    return {{}, 0};
+                }
+
+                // Extract the valid ring neighbors
+                auto [dst_node_forward, dst_node_backward] = ring_neighbors.value();
+
+                multi_directional_hops = this->get_full_or_half_ring_mcast_hops(
+                    src_device, dst_node_forward, dst_node_backward, HighLevelTrafficPattern::FullRingMulticast);
+
+                // minus 2 because full ring pattern traverse each node twice.
+                auto num_sync_devices = this->get_num_sync_devices();
+                global_sync_val =
+                    2 * num_sync_devices - 2;  // minus 2 because in a full ring pattern we dont mcast to self (twice).
+                break;
+            }
+            case tt::tt_fabric::Topology::Linear: {
+                multi_directional_hops = this->get_full_mcast_hops(src_device);
+                global_sync_val = this->get_num_sync_devices() - 1;
+                break;
+            }
+            case tt::tt_fabric::Topology::Mesh: {
+                multi_directional_hops = this->get_full_mcast_hops(src_device);
+                global_sync_val = this->get_num_sync_devices() - 1;
+                TT_THROW("We need mcast support for mesh topology to perform sync");
+                break;
+            }
+            default: TT_THROW("Unsupported topology for line sync: {}", static_cast<int>(topology_));
+        }
+
+        return {std::move(multi_directional_hops), global_sync_val};
     }
 
 private:

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -113,9 +113,14 @@ struct ParsedTestConfig {
     std::optional<ParametrizationOptionsMap> parametrization_params;
     // A test can be defined by either a concrete list of senders or a high-level pattern.
     std::optional<std::vector<HighLevelPatternConfig>> patterns;
+    // add sync sender configs here, each config contains current device and the patterns
+    std::vector<SenderConfig> global_sync_configs;
     std::vector<ParsedSenderConfig> senders;
     std::optional<std::string> bw_calc_func;
     bool benchmark_mode = false;  // Enable benchmark mode for performance testing
+    bool global_sync = false;     // Enable sync for device synchronization. Typically used for benchmarking to minimize
+                                  // cross-chip start-skew effects
+    uint32_t global_sync_val = 0;
     uint32_t seed;
 };
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -127,9 +127,14 @@ struct TestConfig {
     std::optional<ParametrizationOptionsMap> parametrization_params;
     // A test can be defined by either a concrete list of senders or a high-level pattern.
     std::optional<std::vector<HighLevelPatternConfig>> patterns;
+    // add sync sender configs here, each config contains current device and the patterns
+    std::vector<SenderConfig> global_sync_configs;
     std::vector<SenderConfig> senders;
     std::optional<std::string> bw_calc_func;
     bool benchmark_mode = false;  // Enable benchmark mode for performance testing
+    bool global_sync = false;     // Enable sync for device synchronization. Typically used for benchmarking to minimize
+                                  // cross-chip start-skew effects
+    uint32_t global_sync_val = 0;
     uint32_t seed;
 };
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -115,6 +115,7 @@ struct ParsedTestConfig {
     std::optional<std::vector<HighLevelPatternConfig>> patterns;
     std::vector<ParsedSenderConfig> senders;
     std::optional<std::string> bw_calc_func;
+    bool benchmark_mode = false;  // Enable benchmark mode for performance testing
     uint32_t seed;
 };
 
@@ -128,6 +129,7 @@ struct TestConfig {
     std::optional<std::vector<HighLevelPatternConfig>> patterns;
     std::vector<SenderConfig> senders;
     std::optional<std::string> bw_calc_func;
+    bool benchmark_mode = false;  // Enable benchmark mode for performance testing
     uint32_t seed;
 };
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -847,6 +847,10 @@ private:
         resolved_test.patterns = parsed_test.patterns;
         resolved_test.bw_calc_func = parsed_test.bw_calc_func;
         resolved_test.seed = parsed_test.seed;
+        resolved_test.global_sync_configs = parsed_test.global_sync_configs;
+        resolved_test.benchmark_mode = parsed_test.benchmark_mode;
+        resolved_test.global_sync = parsed_test.global_sync;
+        resolved_test.global_sync_val = parsed_test.global_sync_val;
 
         // Resolve defaults
         if (parsed_test.defaults.has_value()) {
@@ -1320,7 +1324,7 @@ private:
         }
     }
 
-    void expand_sync_patterns(TestConfig& test) {
+    void expand_sync_patterns(ParsedTestConfig& test) {
         log_info(
             LogTest,
             "Expanding line sync patterns for test: {} with topology: {}",

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -455,6 +455,10 @@ inline ParsedTestConfig YamlConfigParser::parse_test_config(const YAML::Node& te
         test_config.bw_calc_func = parse_scalar<std::string>(test_yaml["bw_calc_func"]);
     }
 
+    if (test_yaml["benchmark_mode"]) {
+        test_config.benchmark_mode = parse_scalar<bool>(test_yaml["benchmark_mode"]);
+    }
+
     return test_config;
 }
 
@@ -1589,6 +1593,11 @@ private:
         if (config.seed != 0) {
             out << YAML::Key << "seed";
             out << YAML::Value << config.seed;
+        }
+
+        if (config.benchmark_mode) {
+            out << YAML::Key << "benchmark_mode";
+            out << YAML::Value << config.benchmark_mode;
         }
 
         out << YAML::Key << "fabric_setup";

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
@@ -103,6 +103,7 @@ public:
     void add_sender_traffic_config(CoreCoord logical_core, TestTrafficSenderConfig config);
     void add_receiver_traffic_config(CoreCoord logical_core, const TestTrafficReceiverConfig& config);
     void create_kernels();
+    void set_benchmark_mode(bool benchmark_mode) { benchmark_mode_ = benchmark_mode; }
     RoutingDirection get_forwarding_direction(const std::unordered_map<RoutingDirection, uint32_t>& hops) const;
     std::vector<uint32_t> get_forwarding_link_indices_in_direction(const RoutingDirection& direction) const;
     void validate_results() const;
@@ -129,6 +130,8 @@ private:
     std::unordered_map<CoreCoord, TestReceiver> receivers_;
 
     std::unordered_map<RoutingDirection, std::set<uint32_t>> used_fabric_connections_{};
+
+    bool benchmark_mode_ = false;
 
     // controller?
 };
@@ -405,7 +408,7 @@ inline void TestDevice::create_sender_kernels() {
             use_dynamic_routing,
             sender.fabric_connections_.size(), /* num fabric connections */
             sender.configs_.size(),
-            0 /* benchmark mode */};
+            benchmark_mode_ ? 1u : 0u /* benchmark mode */};
 
         // Get memory layout from sender memory map
         TT_FATAL(sender_memory_map_ != nullptr, "Sender memory map is required for creating sender kernels");
@@ -472,7 +475,7 @@ inline void TestDevice::create_receiver_kernels() {
     for (const auto& [core, receiver] : this->receivers_) {
         // get ct args
         // TODO: fix these
-        std::vector<uint32_t> ct_args = {receiver.configs_.size(), 0 /* benchmark mode */};
+        std::vector<uint32_t> ct_args = {receiver.configs_.size(), benchmark_mode_ ? 1u : 0u /* benchmark mode */};
 
         // Get memory layout from receiver memory map
         TT_FATAL(receiver_memory_map_ != nullptr, "Receiver memory map is required for creating receiver kernels");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
@@ -63,8 +63,12 @@ struct TestSender : TestWorker {
 public:
     TestSender(CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src);
     void add_config(TestTrafficSenderConfig config);
+    void add_sync_config(TestTrafficSenderConfig sync_config);
     void connect_to_fabric_router();
     bool validate_results(std::vector<uint32_t>& data) const override;
+
+    // global line sync configs - stores sync traffic configs with their fabric connection indices
+    std::vector<std::pair<TestTrafficSenderConfig, uint32_t>> global_sync_configs_;
 
     // stores traffic config and the correspoding fabric_connection idx to use
     std::vector<std::pair<TestTrafficSenderConfig, uint32_t>> configs_;
@@ -72,6 +76,10 @@ public:
     // book-keeping for all the fabric connections needed for this sender
     // [RoutingDirection][link_idx]
     std::vector<std::pair<RoutingDirection, uint32_t>> fabric_connections_;
+
+    // book-keeping for sync-specific fabric connections
+    // [RoutingDirection][link_idx]
+    std::vector<std::pair<RoutingDirection, uint32_t>> sync_fabric_connections_;
 };
 
 struct TestReceiver : TestWorker {
@@ -99,22 +107,30 @@ public:
         const ReceiverMemoryMap* receiver_memory_map = nullptr);
     tt::tt_metal::Program& get_program_handle();
     const FabricNodeId& get_node_id();
-    uint32_t add_fabric_connection(RoutingDirection direction, const std::vector<uint32_t>& link_indices);
+    uint32_t add_fabric_connection(
+        RoutingDirection direction, const std::vector<uint32_t>& link_indices, bool is_sync_fabric);
     void add_sender_traffic_config(CoreCoord logical_core, TestTrafficSenderConfig config);
+    void add_sender_sync_config(CoreCoord logical_core, TestTrafficSenderConfig sync_config);
     void add_receiver_traffic_config(CoreCoord logical_core, const TestTrafficReceiverConfig& config);
     void create_kernels();
     void set_benchmark_mode(bool benchmark_mode) { benchmark_mode_ = benchmark_mode; }
+    void set_global_sync(bool global_sync) { global_sync_ = global_sync; }
+    void set_global_sync_val(uint32_t global_sync_val) { global_sync_val_ = global_sync_val; }
     RoutingDirection get_forwarding_direction(const std::unordered_map<RoutingDirection, uint32_t>& hops) const;
     std::vector<uint32_t> get_forwarding_link_indices_in_direction(const RoutingDirection& direction) const;
     void validate_results() const;
+    void set_sync_core(CoreCoord coord) { sync_core_coord_ = coord; };
 
 private:
     void add_worker(TestWorkerType worker_type, CoreCoord logical_core);
     std::vector<uint32_t> get_fabric_connection_args(CoreCoord core, RoutingDirection direction, uint32_t link_idx);
+    std::vector<uint32_t> generate_fabric_connection_args(
+        CoreCoord core, const std::vector<std::pair<RoutingDirection, uint32_t>>& fabric_connections);
     void create_sender_kernels();
     void create_receiver_kernels();
     void validate_sender_results() const;
     void validate_receiver_results() const;
+    void create_sync_kernel();
 
     MeshCoordinate coord_;
     std::shared_ptr<IDeviceInfoProvider> device_info_provider_;
@@ -128,10 +144,15 @@ private:
 
     std::unordered_map<CoreCoord, TestSender> senders_;
     std::unordered_map<CoreCoord, TestReceiver> receivers_;
+    std::unordered_map<CoreCoord, TestSender> sync_senders_;  // Separate sync cores
 
     std::unordered_map<RoutingDirection, std::set<uint32_t>> used_fabric_connections_{};
+    std::unordered_map<RoutingDirection, std::set<uint32_t>> used_sync_fabric_connections_{};
 
     bool benchmark_mode_ = false;
+    bool global_sync_ = false;
+    uint32_t global_sync_val_ = 0;
+    CoreCoord sync_core_coord_;
 
     // controller?
 };
@@ -228,12 +249,46 @@ inline void TestSender::add_config(TestTrafficSenderConfig config) {
     if (!fabric_connection_idx.has_value()) {
         // insert a new fabric connection by first checking the device for unused links
         auto new_link_idx =
-            this->test_device_ptr_->add_fabric_connection(outgoing_direction.value(), outgoing_link_indices);
+            this->test_device_ptr_->add_fabric_connection(outgoing_direction.value(), outgoing_link_indices, false);
         this->fabric_connections_.emplace_back(outgoing_direction.value(), new_link_idx);
         fabric_connection_idx = this->fabric_connections_.size() - 1;
     }
 
     this->configs_.emplace_back(std::move(config), fabric_connection_idx.value());
+}
+
+inline void TestSender::add_sync_config(TestTrafficSenderConfig sync_config) {
+    // Similar to add_config but for sync patterns - uses separate sync fabric connections
+    std::optional<RoutingDirection> outgoing_direction;
+    std::vector<uint32_t> outgoing_link_indices;
+
+    // Sync configs should always have hops specified (multicast pattern)
+    outgoing_direction = this->test_device_ptr_->get_forwarding_direction(sync_config.hops);
+    outgoing_link_indices =
+        this->test_device_ptr_->get_forwarding_link_indices_in_direction(outgoing_direction.value());
+
+    std::optional<uint32_t> sync_fabric_connection_idx;
+    // Try to re-use existing sync fabric connection first
+    for (const auto& idx : outgoing_link_indices) {
+        auto it = std::find(
+            this->sync_fabric_connections_.begin(),
+            this->sync_fabric_connections_.end(),
+            std::make_pair(outgoing_direction.value(), idx));
+        if (it != this->sync_fabric_connections_.end()) {
+            sync_fabric_connection_idx = std::distance(this->sync_fabric_connections_.begin(), it);
+            break;
+        }
+    }
+
+    if (!sync_fabric_connection_idx.has_value()) {
+        // Add new sync fabric connection
+        auto new_link_idx =
+            this->test_device_ptr_->add_fabric_connection(outgoing_direction.value(), outgoing_link_indices, true);
+        this->sync_fabric_connections_.emplace_back(outgoing_direction.value(), new_link_idx);
+        sync_fabric_connection_idx = this->sync_fabric_connections_.size() - 1;
+    }
+
+    this->global_sync_configs_.emplace_back(std::move(sync_config), sync_fabric_connection_idx.value());
 }
 
 inline void TestSender::connect_to_fabric_router() {}
@@ -330,14 +385,16 @@ inline tt::tt_metal::Program& TestDevice::get_program_handle() { return this->pr
 inline const FabricNodeId& TestDevice::get_node_id() { return this->fabric_node_id_; }
 
 inline uint32_t TestDevice::add_fabric_connection(
-    RoutingDirection direction, const std::vector<uint32_t>& link_indices) {
+    RoutingDirection direction, const std::vector<uint32_t>& link_indices, bool is_sync_fabric) {
+    auto& used_fabric_connections =
+        is_sync_fabric ? this->used_sync_fabric_connections_ : this->used_fabric_connections_;
     // if all the connections have already been used by another worker, then its an error
     // else try to add whichever is not used
-    if (this->used_fabric_connections_.count(direction) == 0) {
-        this->used_fabric_connections_[direction] = {};
+    if (used_fabric_connections.count(direction) == 0) {
+        used_fabric_connections[direction] = {};
     }
 
-    const auto& used_link_indices = this->used_fabric_connections_.at(direction);
+    const auto& used_link_indices = used_fabric_connections.at(direction);
     std::optional<uint32_t> unused_link_idx;
     for (const auto& link_idx : link_indices) {
         if (used_link_indices.count(link_idx)) {
@@ -353,7 +410,7 @@ inline uint32_t TestDevice::add_fabric_connection(
         this->fabric_node_id_,
         direction);
 
-    this->used_fabric_connections_[direction].insert(unused_link_idx.value());
+    used_fabric_connections[direction].insert(unused_link_idx.value());
     return unused_link_idx.value();
 }
 
@@ -395,10 +452,129 @@ inline std::vector<uint32_t> TestDevice::get_fabric_connection_args(
     return fabric_connection_args;
 }
 
+inline std::vector<uint32_t> TestDevice::generate_fabric_connection_args(
+    CoreCoord core, const std::vector<std::pair<RoutingDirection, uint32_t>>& fabric_connections) {
+    std::vector<uint32_t> fabric_connection_args;
+    for (const auto& [direction, link_idx] : fabric_connections) {
+        const auto& args = get_fabric_connection_args(core, direction, link_idx);
+        fabric_connection_args.insert(fabric_connection_args.end(), args.begin(), args.end());
+    }
+    return fabric_connection_args;
+}
+
+inline void TestDevice::create_sync_kernel() {
+    log_info(tt::LogTest, "creating sync kernel on node: {}", fabric_node_id_);
+
+    // TODO: fetch these dynamically
+    const bool is_2d_fabric = this->device_info_provider_->is_2d_fabric();
+    const bool use_dynamic_routing = this->device_info_provider_->use_dynamic_routing();
+
+    // Assuming single sync core per device for now
+    TT_FATAL(
+        sync_senders_.size() == 1,
+        "Currently expecting exactly one sync core per device, got {}",
+        sync_senders_.size());
+
+    auto& [sync_core, sync_sender] = *sync_senders_.begin();
+
+    uint32_t is_mater_sync_core = 1;
+    uint32_t num_test_traffic_fabric_connections = 0;
+    uint32_t num_test_traffic_configs = 0;
+
+    // get ct args
+    std::vector<uint32_t> ct_args = {
+        is_2d_fabric,
+        use_dynamic_routing,
+        num_test_traffic_fabric_connections,        /* num fabric connections */
+        num_test_traffic_configs,                   /* num regular traffic configs (sync core has none) */
+        (uint32_t)benchmark_mode_,                  /* benchmark mode */
+        (uint32_t)global_sync_,                     /* line sync enabled */
+        is_mater_sync_core,                         /* is master sync core */
+        static_cast<uint32_t>(senders_.size() + 1), /* num local sync cores (all senders + sync core) */
+        sync_sender.global_sync_configs_.size() /* num sync configs */};
+
+    // memory map args
+    std::vector<uint32_t> memory_map_args = sender_memory_map_->get_memory_map_args();
+
+    // Sync fabric connection args (no regular fabric connections for sync core)
+    std::vector<uint32_t> sync_fabric_connection_args;
+    if (!sync_sender.sync_fabric_connections_.empty()) {
+        sync_fabric_connection_args = generate_fabric_connection_args(sync_core, sync_sender.sync_fabric_connections_);
+    }
+
+    // Add line sync runtime args (both global and local sync)
+    std::vector<uint32_t> global_sync_args;
+
+    // ===== GLOBAL SYNC ARGS =====
+    // Expected sync value for global sync
+    global_sync_args.push_back(
+        sender_memory_map_->get_global_sync_address());  // Use the stored line sync value from test config
+
+    for (size_t i = 0; i < sync_sender.global_sync_configs_.size(); ++i) {
+        const auto& [sync_config, fabric_conn_idx] = sync_sender.global_sync_configs_[i];
+
+        // Add sync routing args (chip send type + routing info)
+        auto sync_traffic_args = sync_config.get_args(true);
+        log_debug(
+            tt::LogTest,
+            "fabric connection {} has sync config src_node_id: {} dst_node_ids {} hops {} mcast_start_hops {} ",
+            fabric_conn_idx,
+            sync_config.src_node_id,
+            sync_config.dst_node_ids,
+            sync_config.hops,
+            sync_config.parameters.mcast_start_hops);
+        global_sync_args.insert(global_sync_args.end(), sync_traffic_args.begin(), sync_traffic_args.end());
+    }
+
+    // ===== LOCAL SYNC ARGS =====
+    // Add local sync configuration args
+    uint32_t local_sync_val =
+        static_cast<uint32_t>(senders_.size() + 1);  // Expected sync value (all senders + sync core)
+    global_sync_args.push_back(sender_memory_map_->get_local_sync_address());
+    global_sync_args.push_back(local_sync_val);
+
+    // Add sync core's own NOC encoding first
+    uint32_t sync_core_noc_encoding = this->device_info_provider_->get_worker_noc_encoding(this->coord_, sync_core);
+    global_sync_args.push_back(sync_core_noc_encoding);
+
+    // Add other sender core coordinates for local sync
+    for (const auto& [sender_core, _] : this->senders_) {
+        uint32_t sender_noc_encoding = this->device_info_provider_->get_worker_noc_encoding(this->coord_, sender_core);
+        global_sync_args.push_back(sender_noc_encoding);
+    }
+
+    // No traffic config mapping or traffic config args for sync core
+    std::vector<uint32_t> traffic_config_to_fabric_connection_args;
+    std::vector<uint32_t> traffic_config_args;
+
+    std::vector<uint32_t> rt_args;
+    rt_args.reserve(
+        memory_map_args.size() + sync_fabric_connection_args.size() + global_sync_args.size() +
+        traffic_config_to_fabric_connection_args.size() + traffic_config_args.size());
+    rt_args.insert(rt_args.end(), memory_map_args.begin(), memory_map_args.end());
+    rt_args.insert(rt_args.end(), sync_fabric_connection_args.begin(), sync_fabric_connection_args.end());
+    rt_args.insert(rt_args.end(), global_sync_args.begin(), global_sync_args.end());
+    rt_args.insert(
+        rt_args.end(),
+        traffic_config_to_fabric_connection_args.begin(),
+        traffic_config_to_fabric_connection_args.end());
+    rt_args.insert(rt_args.end(), traffic_config_args.begin(), traffic_config_args.end());
+
+    // create sync kernel
+    sync_sender.create_kernel(coord_, ct_args, rt_args, {});
+    log_info(tt::LogTest, "created sync kernel on core: {}", sync_core);
+}
+
 inline void TestDevice::create_sender_kernels() {
     // TODO: fetch these dynamically
     const bool is_2d_fabric = this->device_info_provider_->is_2d_fabric();
     const bool use_dynamic_routing = this->device_info_provider_->use_dynamic_routing();
+
+    // all local senders + one sync core
+    uint32_t num_local_sync_cores = static_cast<uint32_t>(this->senders_.size()) + 1;
+
+    uint32_t is_mater_sync_core = 0;
+    uint32_t num_sync_fabric_connections = 0;
 
     for (const auto& [core, sender] : this->senders_) {
         // get ct args
@@ -408,7 +584,11 @@ inline void TestDevice::create_sender_kernels() {
             use_dynamic_routing,
             sender.fabric_connections_.size(), /* num fabric connections */
             sender.configs_.size(),
-            benchmark_mode_ ? 1u : 0u /* benchmark mode */};
+            (uint32_t)benchmark_mode_, /* benchmark mode */
+            (uint32_t)global_sync_,    /* sync */
+            is_mater_sync_core,        /* master sync core */
+            num_local_sync_cores,      /* num local sync cores */
+            num_sync_fabric_connections /* num sync fabric connections */};
 
         // Get memory layout from sender memory map
         TT_FATAL(sender_memory_map_ != nullptr, "Sender memory map is required for creating sender kernels");
@@ -419,15 +599,34 @@ inline void TestDevice::create_sender_kernels() {
 
         std::vector<uint32_t> fabric_connection_args;
         if (!sender.fabric_connections_.empty()) {
-            const auto& first_args = get_fabric_connection_args(
-                core, sender.fabric_connections_[0].first, sender.fabric_connections_[0].second);
-            fabric_connection_args.reserve(sender.fabric_connections_.size() * first_args.size());
-            fabric_connection_args.insert(fabric_connection_args.end(), first_args.begin(), first_args.end());
+            fabric_connection_args = generate_fabric_connection_args(core, sender.fabric_connections_);
+        }
 
-            for (size_t i = 1; i < sender.fabric_connections_.size(); ++i) {
-                const auto& args = get_fabric_connection_args(
-                    core, sender.fabric_connections_[i].first, sender.fabric_connections_[i].second);
-                fabric_connection_args.insert(fabric_connection_args.end(), args.begin(), args.end());
+        // Add sync fabric connection args
+        std::vector<uint32_t> sync_fabric_connection_args;
+        if (!sender.sync_fabric_connections_.empty()) {
+            sync_fabric_connection_args = generate_fabric_connection_args(core, sender.sync_fabric_connections_);
+        }
+
+        // Add local sync args for regular senders (they participate as sync receivers)
+        std::vector<uint32_t> local_sync_args;
+        if (global_sync_) {
+            // Add local sync configuration args (same as sync core, but no global sync)
+            uint32_t local_sync_val =
+                static_cast<uint32_t>(senders_.size() + 1);  // Expected sync value (all senders + sync core)
+            local_sync_args.push_back(sender_memory_map_->get_local_sync_address());
+            local_sync_args.push_back(local_sync_val);
+
+            // Add sync core's NOC encoding (the master for local sync)
+            uint32_t sync_core_noc_encoding =
+                this->device_info_provider_->get_worker_noc_encoding(this->coord_, sync_core_coord_);
+            local_sync_args.push_back(sync_core_noc_encoding);
+
+            // Add other sender core coordinates for local sync
+            for (const auto& [sender_core, _] : this->senders_) {
+                uint32_t sender_noc_encoding =
+                    this->device_info_provider_->get_worker_noc_encoding(this->coord_, sender_core);
+                local_sync_args.push_back(sender_noc_encoding);
             }
         }
 
@@ -459,6 +658,7 @@ inline void TestDevice::create_sender_kernels() {
         rt_args.reserve(total_rt_args_size);
         rt_args.insert(rt_args.end(), memory_map_args.begin(), memory_map_args.end());
         rt_args.insert(rt_args.end(), fabric_connection_args.begin(), fabric_connection_args.end());
+        rt_args.insert(rt_args.end(), local_sync_args.begin(), local_sync_args.end());
         rt_args.insert(
             rt_args.end(),
             traffic_config_to_fabric_connection_args.begin(),
@@ -512,6 +712,10 @@ inline void TestDevice::create_receiver_kernels() {
 
 inline void TestDevice::create_kernels() {
     log_info(tt::LogTest, "creating kernels on node: {}", fabric_node_id_);
+    // create sync kernels
+    if (global_sync_) {
+        this->create_sync_kernel();
+    }
     // create sender kernels
     this->create_sender_kernels();
 
@@ -531,6 +735,14 @@ inline void TestDevice::add_sender_traffic_config(CoreCoord logical_core, TestTr
         this->add_worker(TestWorkerType::SENDER, logical_core);
     }
     this->senders_.at(logical_core).add_config(std::move(config));
+}
+
+inline void TestDevice::add_sender_sync_config(CoreCoord logical_core, TestTrafficSenderConfig sync_config) {
+    // Create sync sender if it doesn't exist
+    if (this->sync_senders_.find(logical_core) == this->sync_senders_.end()) {
+        this->sync_senders_.emplace(logical_core, TestSender(logical_core, this, default_sender_kernel_src));
+    }
+    this->sync_senders_.at(logical_core).add_sync_config(std::move(sync_config));
 }
 
 inline RoutingDirection TestDevice::get_forwarding_direction(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
@@ -507,8 +507,7 @@ inline void TestDevice::create_sync_kernel() {
 
     // ===== GLOBAL SYNC ARGS =====
     // Expected sync value for global sync
-    global_sync_args.push_back(
-        sender_memory_map_->get_global_sync_address());  // Use the stored line sync value from test config
+    global_sync_args.push_back(this->global_sync_val_);  // Use the stored line sync value from test config
 
     for (size_t i = 0; i < sync_sender.global_sync_configs_.size(); ++i) {
         const auto& [sync_config, fabric_conn_idx] = sync_sender.global_sync_configs_[i];

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -78,6 +78,9 @@ public:
         const FabricNodeId& src_node_id, uint32_t dim) const = 0;
     virtual std::optional<std::pair<FabricNodeId, FabricNodeId>> get_wrap_around_mesh_ring_neighbors(
         const FabricNodeId& src_node, const std::vector<FabricNodeId>& devices) const = 0;
+    virtual uint32_t get_linear_topology_num_sync_devices() const = 0;
+    virtual uint32_t get_wrap_around_mesh_ring_topology_num_sync_devices() const = 0;
+    virtual uint32_t get_mesh_topology_num_sync_devices() const = 0;
     virtual std::unordered_map<RoutingDirection, uint32_t> get_full_or_half_ring_mcast_hops(
         const FabricNodeId& src_node_id,
         const FabricNodeId& dst_node_forward_id,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -78,9 +78,7 @@ public:
         const FabricNodeId& src_node_id, uint32_t dim) const = 0;
     virtual std::optional<std::pair<FabricNodeId, FabricNodeId>> get_wrap_around_mesh_ring_neighbors(
         const FabricNodeId& src_node, const std::vector<FabricNodeId>& devices) const = 0;
-    virtual uint32_t get_linear_topology_num_sync_devices() const = 0;
-    virtual uint32_t get_wrap_around_mesh_ring_topology_num_sync_devices() const = 0;
-    virtual uint32_t get_mesh_topology_num_sync_devices() const = 0;
+    virtual uint32_t get_num_sync_devices() const = 0;
     virtual std::unordered_map<RoutingDirection, uint32_t> get_full_or_half_ring_mcast_hops(
         const FabricNodeId& src_node_id,
         const FabricNodeId& dst_node_forward_id,
@@ -95,6 +93,9 @@ public:
         const std::unordered_map<RoutingDirection, uint32_t>& hops) const = 0;
     virtual std::vector<uint32_t> get_forwarding_link_indices_in_direction(
         const FabricNodeId& src_node_id, const RoutingDirection& direction) const = 0;
+
+    virtual std::pair<std::unordered_map<RoutingDirection, uint32_t>, uint32_t> get_sync_hops_and_val(
+        const FabricNodeId& src_device, const std::vector<FabricNodeId>& devices) const = 0;
     virtual std::vector<uint32_t> get_forwarding_link_indices_in_direction(
         const FabricNodeId& src_node_id, const FabricNodeId& dst_node_id, const RoutingDirection& direction) const = 0;
     virtual FabricNodeId get_neighbor_node_id(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_memory_map.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_memory_map.hpp
@@ -109,7 +109,7 @@ struct SenderMemoryMap {
         uint32_t local_sync_region_base = current_addr;
         uint32_t local_sync_region_size = l1_alignment;
         current_addr += local_sync_region_size;
-        global_sync_region = BaseMemoryRegion(local_sync_region_base, local_sync_region_size);
+        local_sync_region = BaseMemoryRegion(local_sync_region_base, local_sync_region_size);
 
         TT_FATAL(
             current_addr <= highest_usable_address,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_memory_map.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_memory_map.hpp
@@ -64,6 +64,10 @@ struct SenderMemoryMap {
     BaseMemoryRegion packet_headers;
     BaseMemoryRegion payload_buffers;
 
+    // sync addresses
+    BaseMemoryRegion global_sync_region;
+    BaseMemoryRegion local_sync_region;
+
     // Calculated values needed for kernel arguments
     uint32_t highest_usable_address;
 
@@ -95,6 +99,18 @@ struct SenderMemoryMap {
         current_addr += payload_buffer_size;
         payload_buffers = BaseMemoryRegion(payload_buffer_base, payload_buffer_size);
 
+        // global sync region
+        uint32_t global_sync_region_base = current_addr;
+        uint32_t global_sync_region_size = l1_alignment;
+        current_addr += global_sync_region_size;
+        global_sync_region = BaseMemoryRegion(global_sync_region_base, global_sync_region_size);
+
+        // local sync region
+        uint32_t local_sync_region_base = current_addr;
+        uint32_t local_sync_region_size = l1_alignment;
+        current_addr += local_sync_region_size;
+        global_sync_region = BaseMemoryRegion(local_sync_region_base, local_sync_region_size);
+
         TT_FATAL(
             current_addr <= highest_usable_address,
             "Sender memory layout overflow: need {} bytes but only have {} bytes available",
@@ -113,6 +129,12 @@ struct SenderMemoryMap {
 
         return args;
     }
+
+    uint32_t get_global_sync_address() const { return global_sync_region.start; }
+    uint32_t get_local_sync_address() const { return local_sync_region.start; }
+
+    uint32_t get_global_sync_region_size() const { return global_sync_region.size; }
+    uint32_t get_local_sync_region_size() const { return local_sync_region.size; }
 
     // Convenience methods for reading results
     uint32_t get_result_buffer_address() const { return common.get_result_buffer_address(); }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24535#event-18516280777)

### Problem description
two-level sync, first level is global sync across all devices in the mesh. second level is the local sync across all sender cores in a device.
algo:
1. sync core start fabric connection on all possible directions (linear topology: open on forward/backward on N/S and E/S directions. ring: for the wrapped around mesh config, open on 2 directions. for real ring with torus setup, currently not tested. mesh: not supported until 2d mcast is supported)

2. sync core mcast credit to all the ring/line devices. 
3. wait for enough credits back, then proceed to local sync.
4. local sync, sync core send credit to local sender core
5. local sender core wait and write a ack back to sync core.
6. sync core exit.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes