### PR TITLE
Generic Pool DST Accumulation For Large Kernels

### DIFF
--- a/models/demos/yolov4/tests/perf/test_perf.py
+++ b/models/demos/yolov4/tests/perf/test_perf.py
@@ -77,7 +77,7 @@ def test_perf_e2e_yolov4(device, batch_size, act_dtype, weight_dtype, resolution
 @pytest.mark.parametrize(
     "batch_size, model_name, expected_perf",
     [
-        (1, "yolov4", 93.3),
+        (1, "yolov4", 93.6),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
@@ -100,11 +100,6 @@ def run_avg_pool2d(
 
     ## Assertion
     pcc_thresh = 0.99
-    # for very large kernel sizes we get poor PCC due to buildup of floating point error
-    # during multiple reduction stages, so we lower the threshold since allclose will
-    # still rigorously check the values
-    if kernel_size[0] * kernel_size[1] > 32 * 31:
-        pcc_thresh = 0.95
     assert_with_pcc(torch_output, ttnn_output, pcc_thresh)
     allclose = torch.allclose(ttnn_output, torch_output, rtol=0.02)
     assert allclose, " Reference and output tensor are not close"

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core.cpp
@@ -54,24 +54,21 @@ namespace NAMESPACE {
 
 void MAIN {
     // NOTE: here it is assumed that in_ntiles_hw == 1. General cases not handled yet.
-    constexpr uint32_t in_ntiles_hw = get_compile_time_arg_val(0);
-    constexpr uint32_t in_ntiles_c = get_compile_time_arg_val(1);
-    constexpr uint32_t window_size_hw = get_compile_time_arg_val(2);
-    constexpr uint32_t out_h = get_compile_time_arg_val(3);
-    constexpr uint32_t out_w = get_compile_time_arg_val(4);
+    constexpr uint32_t in_ntiles_c = get_compile_time_arg_val(0);
+    constexpr uint32_t window_size_hw = get_compile_time_arg_val(1);
 
-    constexpr uint32_t split_reader = get_compile_time_arg_val(5);
+    constexpr uint32_t split_reader = get_compile_time_arg_val(2);
 
-    constexpr uint32_t nsticks_per_core = get_compile_time_arg_val(6);
-    constexpr uint32_t in_c = get_compile_time_arg_val(7);
-    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(8);
+    constexpr uint32_t nsticks_per_core = get_compile_time_arg_val(3);
+    constexpr uint32_t in_c = get_compile_time_arg_val(4);
+    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(5);
 
-    constexpr uint32_t in_cb_id_0 = get_compile_time_arg_val(10);
-    constexpr uint32_t in_cb_id_1 = get_compile_time_arg_val(11);
-    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(12);
-    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(13);
-    constexpr uint32_t out_cb_id = get_compile_time_arg_val(14);
-    constexpr bool one_scalar_per_core = get_compile_time_arg_val(17);
+    constexpr uint32_t in_cb_id_0 = get_compile_time_arg_val(7);
+    constexpr uint32_t in_cb_id_1 = get_compile_time_arg_val(8);
+    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(9);
+    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(10);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(11);
+    constexpr bool one_scalar_per_core = get_compile_time_arg_val(12);
 
     constexpr bool is_partial_tile = in_c < 32;
     static_assert((!is_partial_tile || (in_c == 16)), "Partial tile must have c_dim 16");

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core_large_kernel.cpp
@@ -15,78 +15,27 @@
 #include "debug/dprint_tensix.h"
 #endif
 
-template <
-    uint32_t num_output_tiles,
-    uint32_t num_faces_in_input_tile,
-    uint32_t num_faces_in_output_tile,
-    uint32_t unpA_face_r_dim,
-    bool neginf_srca_maxpool,
-    bool zero_srca_avgpool>
-inline void reduce_h_fused(
-    const uint32_t in_cb_id,
-    const uint32_t in_scalar_cb_id,
-    const uint32_t output_row_index,
-    const uint32_t out_cb_id) {
-    constexpr uint32_t num_out_rows = 1;
-
-    tile_regs_acquire();
-    unpack_tilizeA_B_block<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
-        in_cb_id,
-        in_scalar_cb_id,
-        num_output_tiles,
-        0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/,
-        num_faces_in_input_tile /* unpack 1 or 2 faces ) */,
-        unpA_face_r_dim);
-    for (uint32_t c_i = 0; c_i < num_output_tiles; ++c_i) {
-        reduce_tile_math(c_i, num_faces_in_input_tile /* reduce 1 or 2 faces */);
-    }
-    tile_regs_wait();
-    tile_regs_commit();
-    pack_untilize_dest<num_output_tiles>(
-        out_cb_id,
-        1 /*out_subblock_h*/,
-        output_row_index,
-        num_out_rows,
-        num_faces_in_output_tile); /* pack 1 row (1x16 or 1x32) */
-    tile_regs_release();
-}
-
 namespace NAMESPACE {
 
 void MAIN {
     // NOTE: here it is assumed that in_ntiles_hw == 1. General cases not handled yet. When ntiles_hw > 1 the large
     // kernel is called
-    constexpr uint32_t in_ntiles_hw = get_compile_time_arg_val(0);
-    constexpr uint32_t in_ntiles_c = get_compile_time_arg_val(1);
-    constexpr uint32_t window_size_hw = get_compile_time_arg_val(2);
-    constexpr uint32_t out_h = get_compile_time_arg_val(3);
-    constexpr uint32_t out_w = get_compile_time_arg_val(4);
+    constexpr uint32_t in_ntiles_c = get_compile_time_arg_val(0);
+    constexpr uint32_t window_size_hw = get_compile_time_arg_val(1);
 
-    constexpr uint32_t split_reader = get_compile_time_arg_val(5);
+    constexpr uint32_t split_reader = get_compile_time_arg_val(2);
 
-    constexpr uint32_t nsticks_per_core_by_nblocks = get_compile_time_arg_val(6);
-    constexpr uint32_t in_c = get_compile_time_arg_val(7);
-    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(8);
-    constexpr uint32_t max_rows_for_reduction = get_compile_time_arg_val(9);
+    constexpr uint32_t nsticks_per_core_by_nblocks = get_compile_time_arg_val(3);
+    constexpr uint32_t in_c = get_compile_time_arg_val(4);
+    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(5);
+    constexpr uint32_t max_rows_for_reduction = get_compile_time_arg_val(6);
 
-    constexpr uint32_t in_cb_id_0 = get_compile_time_arg_val(10);
-    constexpr uint32_t in_cb_id_1 = get_compile_time_arg_val(11);  // for split reader
-    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(12);
-    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(13);
-    constexpr uint32_t out_cb_id = get_compile_time_arg_val(14);
-    constexpr uint32_t interm_cb_id = get_compile_time_arg_val(15);
-    constexpr uint32_t in_one_cb_id = get_compile_time_arg_val(16);
-    constexpr bool one_scalar_per_core = get_compile_time_arg_val(17);
-    constexpr uint32_t sync_cb_id1 =
-        get_compile_time_arg_val(18);  // wait for reader 0 to signal that it is done initializing
-    constexpr uint32_t sync_cb_id2 =
-        get_compile_time_arg_val(19);  // wait for reader 1 to signal that it is done initializing
-    constexpr uint32_t sync_cb_id3 =
-        get_compile_time_arg_val(20);  // signal to reader 0 that compute needs CBs reset or to output written
-    constexpr uint32_t sync_cb_id4 =
-        get_compile_time_arg_val(21);  // signal to reader 1 that compute needs CBs reset or to output written
-    constexpr uint32_t sync_cb_id5 =
-        get_compile_time_arg_val(22);  // sync PACK and UNPACK threads between intermediate and final reduction
+    constexpr uint32_t in_cb_id_0 = get_compile_time_arg_val(7);
+    constexpr uint32_t in_cb_id_1 = get_compile_time_arg_val(8);  // for split reader
+    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(9);
+    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(10);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(11);
+    constexpr bool one_scalar_per_core = get_compile_time_arg_val(12);
 
     constexpr bool is_partial_tile = in_c < 32;
     static_assert((!is_partial_tile || (in_c == 16)), "Partial tile must have c_dim 16");
@@ -94,97 +43,72 @@ void MAIN {
     constexpr uint32_t num_faces_in_output_tile = is_partial_tile ? 1 : 2;
     constexpr uint32_t num_out_rows = 1;
 
-    constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
+    constexpr bool is_avg_pool = REDUCE_OP == PoolType::SUM;
+    // average pool requires fp32 accumulation so we can only reduce 4 tiles at a time, otherwise we can reduce 8 tiles
+    // at a time.
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = is_avg_pool ? 4 : 8;
     constexpr uint32_t max_tiles_per_iter =
         in_ntiles_c < MAX_TILES_PER_REDUCTION ? in_ntiles_c : MAX_TILES_PER_REDUCTION;
     constexpr uint32_t partial_iter_output_tiles =
         in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
 
-    constexpr bool is_avg_pool = REDUCE_OP == PoolType::SUM;
     static_assert(REDUCE_OP == PoolType::MAX || REDUCE_OP == PoolType::SUM, "Only supports REDUCE_OP = MAX or Sum");
     constexpr bool neginf_srca_maxpool = (REDUCE_OP == PoolType::MAX) ? true : false;
     constexpr bool zero_srca_avgpool = (REDUCE_OP == PoolType::SUM) ? true : false;
 
     constexpr uint32_t face_r_dim = 16;
     tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
-        in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, interm_cb_id, num_faces_in_input_tile, face_r_dim);
-    pack_untilize_dest_init<max_tiles_per_iter>(interm_cb_id, num_out_rows, num_faces_in_output_tile);
+        in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, out_cb_id, num_faces_in_input_tile, face_r_dim);
+    pack_untilize_dest_init<max_tiles_per_iter>(out_cb_id, num_out_rows, num_faces_in_output_tile);
 
     constexpr uint32_t remaining_elems = window_size_hw % max_rows_for_reduction;
     constexpr uint32_t interm_reduction_chunks =
         remaining_elems ? window_size_hw / max_rows_for_reduction + 1 : window_size_hw / max_rows_for_reduction;
 
     // wait for initialization to complete
-    if constexpr (split_reader) {
-        cb_wait_front(sync_cb_id2, 2);
+    if constexpr (one_scalar_per_core) {
+        cb_wait_front(in_scalar_cb_id_0, 1);
     }
-    cb_wait_front(sync_cb_id1, 2);
 
     for (uint32_t n = 0; n < nsticks_per_core_by_nblocks; ++n) {
         const bool reader0 = !(split_reader && (n & 0x1));
         const uint32_t curr_scalar_cb_id = (!reader0 && !one_scalar_per_core) ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
         const uint32_t curr_in_cb_id = !reader0 ? in_cb_id_1 : in_cb_id_0;
-        const uint32_t curr_sync_cb_id = reader0 ? sync_cb_id3 : sync_cb_id4;
         if constexpr (!one_scalar_per_core) {
             cb_wait_front(curr_scalar_cb_id, 1);
         }
         for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
-            // For 5x5 kernel as an example, reduction over first 16 sticks AND next 9 sticks. It runs
-            // twice, and both results are written to interm_cb_id. interm_cb_id will be the input to the
-            // next level of reduction.
+            bool last_c_block = c_i == in_nblocks_c - 1;
+            uint32_t tiles_to_reduce = last_c_block ? partial_iter_output_tiles : max_tiles_per_iter;
+            tile_regs_acquire();
             for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {
-                uint32_t max_rows_interm_remainder =
-                    chunk % (max_rows_for_reduction - 1);  // reduce 31 interm rows at a time
-
                 cb_wait_front(curr_in_cb_id, 1);
-                reduce_h_fused<
-                    max_tiles_per_iter,
-                    num_faces_in_input_tile,
-                    num_faces_in_output_tile,
-                    face_r_dim,
-                    neginf_srca_maxpool,
-                    zero_srca_avgpool>(
+                unpack_tilizeA_B_block<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
                     curr_in_cb_id,
-                    is_avg_pool ? in_one_cb_id : curr_scalar_cb_id,
-                    max_rows_interm_remainder + 1,  // skip the first row where we are accumulating
-                    interm_cb_id);
-                cb_pop_front(curr_in_cb_id, 1);
-
-                if (max_rows_interm_remainder == max_rows_for_reduction - 2 || chunk == interm_reduction_chunks - 1) {
-                    // sync PACK and UNPACK so intermediate reduction gets packed before the final reduction is unpacked
-                    cb_reserve_back(sync_cb_id5, 1);
-                    cb_push_back(sync_cb_id5, 1);
-                    cb_wait_front(sync_cb_id5, 1);
-                    cb_pop_front(sync_cb_id5, 1);
-
-                    // perform the final reduction over the first N - 1 whole chunks // Reduction of final 2 sticks.
-                    reduce_h_fused<
-                        max_tiles_per_iter,
-                        num_faces_in_input_tile,
-                        num_faces_in_output_tile,
-                        face_r_dim,
-                        neginf_srca_maxpool,
-                        zero_srca_avgpool>(
-                        interm_cb_id,
-                        !is_avg_pool || (chunk == interm_reduction_chunks - 1) ? curr_scalar_cb_id : in_one_cb_id,
-                        0,
-                        interm_cb_id);
-
-                    // either write output stick or for avg pool notify the reader that we need the interm CB cleared
-                    if (chunk == interm_reduction_chunks - 1 || is_avg_pool) {
-                        cb_push_back(curr_sync_cb_id, 1);
-                        // wait for reader to finish task before continuing
-                        cb_reserve_back(curr_sync_cb_id, 1);
-                    }
+                    curr_scalar_cb_id,
+                    max_tiles_per_iter,
+                    0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/,
+                    num_faces_in_input_tile,
+                    face_r_dim);
+                for (uint32_t math_tile_idx = 0; math_tile_idx < max_tiles_per_iter; ++math_tile_idx) {
+                    reduce_tile_math(math_tile_idx, num_faces_in_input_tile);
                 }
+                cb_pop_front(curr_in_cb_id, 1);
             }
+            tile_regs_commit();
+            tile_regs_wait();
+            if (last_c_block) {
+                pack_untilize_dest<partial_iter_output_tiles>(out_cb_id, 1, 0, num_out_rows, num_faces_in_output_tile);
+                cb_push_back(out_cb_id, partial_iter_output_tiles);
+            } else {
+                pack_untilize_dest<max_tiles_per_iter>(out_cb_id, 1, 0, num_out_rows, num_faces_in_output_tile);
+                cb_push_back(out_cb_id, max_tiles_per_iter);
+            }
+            tile_regs_release();
         }
         if constexpr (!one_scalar_per_core) {
             cb_pop_front(curr_scalar_cb_id, 1);
         }
-    }
-    if constexpr (one_scalar_per_core) {
-        cb_pop_front(in_scalar_cb_id_0, 1);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded.cpp
@@ -130,11 +130,11 @@ void kernel_main() {
     // compile time args
     // BF16 value packed in UINT32. For maxpool, value is 1, for avgpool value is 1/kernel_size.
     constexpr uint32_t bf16_scalar = get_compile_time_arg_val(9);
-    constexpr uint32_t bf16_init_value = get_compile_time_arg_val(11);
+    constexpr uint32_t bf16_init_value = get_compile_time_arg_val(10);
 
-    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(12);
+    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(11);
 
-    constexpr uint32_t ceil_pad_w = get_compile_time_arg_val(15);
+    constexpr uint32_t ceil_pad_w = get_compile_time_arg_val(14);
 
     constexpr uint32_t TILE_HEIGHT = 32;
     constexpr uint32_t TILE_WIDTH = 32;
@@ -142,18 +142,18 @@ void kernel_main() {
     constexpr uint32_t BYTES_PER_DATUM = 2;
     constexpr uint32_t MAX_BYTES_PER_REDUCTION = TILE_WIDTH * MAX_TILES_PER_REDUCTION * BYTES_PER_DATUM;
 
-    constexpr uint32_t in_cb_id = (reader_id == 1) ? get_compile_time_arg_val(17) : get_compile_time_arg_val(16);
-    constexpr uint32_t in_shard_cb_id = get_compile_time_arg_val(18);
-    constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(19);
-    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(20);
-    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(21);
-    constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(24);
-    constexpr uint32_t pool_type = (bool)get_compile_time_arg_val(25);
-    constexpr bool one_scalar_per_core = get_compile_time_arg_val(26);
-    constexpr uint32_t config_cb_id = get_compile_time_arg_val(27);
+    constexpr uint32_t in_cb_id = (reader_id == 1) ? get_compile_time_arg_val(16) : get_compile_time_arg_val(15);
+    constexpr uint32_t in_shard_cb_id = get_compile_time_arg_val(17);
+    constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(18);
+    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(19);
+    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(20);
+    constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(21);
+    constexpr uint32_t pool_type = (bool)get_compile_time_arg_val(22);
+    constexpr bool one_scalar_per_core = get_compile_time_arg_val(23);
+    constexpr uint32_t config_cb_id = get_compile_time_arg_val(24);
     constexpr uint32_t in_scalar_cb_id =
         split_reader && reader_id == 1 && !one_scalar_per_core ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
-    constexpr uint32_t stride_w = get_compile_time_arg_val(34);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(26);
 
     constexpr uint32_t in_nbytes_leftover = (in_c % (TILE_WIDTH * MAX_TILES_PER_REDUCTION)) * BYTES_PER_DATUM;
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -89,7 +89,8 @@ static Tensor pool2d_invoke(
                 0);
         } else {  // auto-sharding
             std::optional<sliding_window::ParallelConfig> sw_parallel_config =
-                pool::determine_pool_config_for_auto_shard(input_tensor, sliding_window_config, channels, pool_type);
+                pool::determine_pool_config_for_auto_shard(
+                    input_tensor, sliding_window_config, channels, pool_type, count_include_pad, divisor_override);
             TT_FATAL(
                 sw_parallel_config.has_value(),
                 "autosharding could not determine valid shard scheme, please check tensor dimensions");

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -43,6 +43,20 @@ uint32_t get_bf16_pool_init_value(Pool2DType pool_type) {
     return bfloat16(value).to_packed();
 }
 
+bool is_pool_op_one_scalar_per_core(
+    const Pool2DType pool_type,
+    bool ceil_mode,
+    uint32_t ceil_h,
+    uint32_t ceil_w,
+    bool count_include_pad,
+    uint32_t pad_h,
+    uint32_t pad_w,
+    std::optional<int32_t> divisor_override) {
+    return pool_type != Pool2DType::AVG_POOL2D || divisor_override.has_value() ||
+           ((ceil_mode == false || (ceil_h == 0 && ceil_w == 0)) &&
+            (count_include_pad == true || (pad_h == 0 && pad_w == 0)));
+}
+
 std::map<std::string, std::string> get_defines(Pool2DType pool_type) {
     std::map<std::string, std::string> defines;
     switch (pool_type) {
@@ -116,13 +130,20 @@ std::optional<ParallelConfig> determine_valid_parallel_config(
 
 uint32_t calculate_L1_usage(
     const Tensor& input,
+    const uint32_t pad_h,
+    const uint32_t pad_w,
+    const uint32_t ceil_pad_h,
+    const uint32_t ceil_pad_w,
+    const bool ceil_mode,
     const uint32_t kernel_h,
     const uint32_t kernel_w,
     const uint32_t out_h,
     const uint32_t out_w,
     const MemoryConfig& input_memory,
     const MemoryConfig& output_memory,
-    Pool2DType pool_type) {
+    Pool2DType pool_type,
+    bool count_include_pad,
+    std::optional<int32_t> divisor_override) {
     const auto& input_shape = input.get_padded_shape();
 
     auto in_dtype = input.dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input.dtype();
@@ -151,11 +172,11 @@ uint32_t calculate_L1_usage(
     }
     const bool is_partial_tile = (input_shape[3] / num_shards_c) == 16;
 
-    constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
-    const bool is_wide_reduction = in_ntiles_c > MAX_TILES_PER_REDUCTION;
-
+    bool is_avg_pool = pool_type == Pool2DType::AVG_POOL2D;
     const bool is_large_kernel =
         is_partial_tile ? kernel_size_hw > tt::constants::TILE_HEIGHT / 2 : kernel_size_hw > tt::constants::TILE_HEIGHT;
+    const uint32_t MAX_TILES_PER_REDUCTION = is_avg_pool && is_large_kernel ? 4 : 8;
+    const bool is_wide_reduction = in_ntiles_c > MAX_TILES_PER_REDUCTION;
 
     // ToDo: enable 32 sticks per tile for reduction for all cases.
     const uint32_t max_rows_for_reduction =
@@ -165,8 +186,6 @@ uint32_t calculate_L1_usage(
     if (input_shape[3] < tt::constants::TILE_WIDTH) {
         TT_FATAL(input_shape[3] == 16, "Error");
     }
-
-    uint32_t nblocks = 1;
 
     // CBs
     uint32_t multi_buffering_factor = 2;
@@ -179,16 +198,11 @@ uint32_t calculate_L1_usage(
     uint32_t in_scalar_cb_size_0 = in_scalar_cb_npages * in_scalar_cb_pagesize;
     uint32_t in_scalar_cb_size_1 = 0;
 
-    // For avgpool, instantiate and use this CB, which consists of 1s. We don't want to divide
-    // twice by kernel size for large kernel case.
-    uint32_t in_one_cb_size = 0;
-    if (pool_type == Pool2DType::AVG_POOL2D) {
-        uint32_t in_one_cb_pagesize = tile_size(in_df);
-        uint32_t in_one_cb_npages = 1;
-        in_one_cb_size = in_one_cb_pagesize * in_one_cb_npages;
-        if (split_reader) {
-            in_scalar_cb_size_1 = in_scalar_cb_npages * in_scalar_cb_pagesize;
-        }
+    bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
+        pool_type, ceil_mode, ceil_pad_h, ceil_pad_w, count_include_pad, pad_h, pad_w, divisor_override);
+
+    if (pool_type == Pool2DType::AVG_POOL2D && split_reader && !one_scalar_per_core) {
+        in_scalar_cb_size_1 = in_scalar_cb_npages * in_scalar_cb_pagesize;
     }
 
     uint32_t clear_value_cb_size = 0;
@@ -201,7 +215,6 @@ uint32_t calculate_L1_usage(
     }
 
     uint32_t in_cb_sz = 0;
-    // uint32_t in_nblocks_c = 1;
     if (is_wide_reduction) {
         in_cb_sz = MAX_TILES_PER_REDUCTION * tt::constants::TILE_HW;
     } else {
@@ -212,7 +225,7 @@ uint32_t calculate_L1_usage(
         in_cb_sz,
         tt::constants::TILE_HW);  // NOTE: ceil to tile size since triscs work with tilesize instead of pagesize
     uint32_t in_cb_pagesize = in_nbytes * in_cb_page_padded;
-    uint32_t in_cb_npages = multi_buffering_factor * nblocks;
+    uint32_t in_cb_npages = multi_buffering_factor;
     uint32_t in_cb_config_0_size = in_cb_npages * in_cb_pagesize;
     uint32_t in_cb_config_1_size = 0;
 
@@ -227,13 +240,6 @@ uint32_t calculate_L1_usage(
     uint32_t out_cb_npages = output_memory.shard_spec().value().shape[0] * in_ntiles_c;
     uint32_t out_cb_config_size = out_cb_npages * out_cb_pagesize;
 
-    uint32_t max_pool_partials_cb_config_size = 0;
-    if (is_large_kernel) {
-        uint32_t max_pool_partials_cb_pagesize = in_cb_pagesize;
-        uint32_t max_pool_partials_cb_npages = nblocks;
-        max_pool_partials_cb_config_size = max_pool_partials_cb_npages * max_pool_partials_cb_pagesize;
-    }
-
     uint32_t alignment_bytes = 32;
     if (is_blackhole) {
         alignment_bytes = 64;
@@ -243,23 +249,17 @@ uint32_t calculate_L1_usage(
         return factor * alignment_bytes;
     };
 
-    // 5 sync CBs, each with 2 bytes per page, 2 or 1 pages.
-    uint32_t sync_cb_1_3_5 = 2 * (2 + 1 + 1);
-    uint32_t sync_cb_2_4 = 0;
-    if (split_reader) {
-        sync_cb_2_4 = 2 * (2 + 1);  // 2 pages, 1 byte per page
-    }
-
-    return in_scalar_cb_size_0 + in_scalar_cb_size_1 + in_one_cb_size + clear_value_cb_size + in_cb_config_0_size +
-           in_cb_config_1_size + align(out_cb_config_size) /* global, involved */
-           + max_pool_partials_cb_config_size + sync_cb_1_3_5 + sync_cb_2_4;
+    return in_scalar_cb_size_0 + in_scalar_cb_size_1 + clear_value_cb_size + in_cb_config_0_size + in_cb_config_1_size +
+           align(out_cb_config_size) /* global, involved */;
 }
 
 std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
     const Tensor& input_tensor,
     const SlidingWindowConfig& sliding_window_config,
     uint32_t channels,
-    Pool2DType pool_type) {
+    Pool2DType pool_type,
+    bool count_include_pad,
+    std::optional<int32_t> divisor_override) {
     uint32_t batch_size = sliding_window_config.batch_size;
     auto output_shape = sliding_window_config.get_output_shape();
     auto compute_grid_size = input_tensor.device()->compute_with_storage_grid_size();
@@ -295,13 +295,20 @@ std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
         }
         uint32_t l1_usage = calculate_L1_usage(
             input_tensor,
+            sliding_window_config.get_pad_h(),
+            sliding_window_config.get_pad_w(),
+            sliding_window_config.get_ceil_pad_h(),
+            sliding_window_config.get_ceil_pad_w(),
+            sliding_window_config.ceil_mode,
             sliding_window_config.window_hw.first,
             sliding_window_config.window_hw.second,
             sliding_window_config.get_output_shape()[1],
             sliding_window_config.get_output_shape()[2],
             get_memconfig(input_parallel_config.value()),
             get_memconfig(input_parallel_config.value()),
-            pool_type);
+            pool_type,
+            count_include_pad,
+            divisor_override);
 
         return {l1_usage, input_parallel_config};
     };

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -44,7 +44,7 @@ uint32_t get_bf16_pool_init_value(Pool2DType pool_type) {
 }
 
 bool is_pool_op_one_scalar_per_core(
-    const Pool2DType pool_type,
+    Pool2DType pool_type,
     bool ceil_mode,
     uint32_t ceil_h,
     uint32_t ceil_w,
@@ -130,15 +130,15 @@ std::optional<ParallelConfig> determine_valid_parallel_config(
 
 uint32_t calculate_L1_usage(
     const Tensor& input,
-    const uint32_t pad_h,
-    const uint32_t pad_w,
-    const uint32_t ceil_pad_h,
-    const uint32_t ceil_pad_w,
-    const bool ceil_mode,
-    const uint32_t kernel_h,
-    const uint32_t kernel_w,
-    const uint32_t out_h,
-    const uint32_t out_w,
+    uint32_t pad_h,
+    uint32_t pad_w,
+    uint32_t ceil_pad_h,
+    uint32_t ceil_pad_w,
+    bool ceil_mode,
+    uint32_t kernel_h,
+    uint32_t kernel_w,
+    uint32_t out_h,
+    uint32_t out_w,
     const MemoryConfig& input_memory,
     const MemoryConfig& output_memory,
     Pool2DType pool_type,

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -310,7 +310,7 @@ std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
             count_include_pad,
             divisor_override);
 
-        return {l1_usage, input_parallel_config};
+        return {.l1_usage = l1_usage, .config = input_parallel_config};
     };
 
     auto l1_config_height = calc_l1_usage_inner(TensorMemoryLayout::HEIGHT_SHARDED, ShardOrientation::ROW_MAJOR);

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
@@ -42,6 +42,16 @@ uint32_t get_bf16_pool_scalar(
 uint32_t get_bf16_pool_init_value(Pool2DType pool_type);
 std::map<std::string, std::string> get_defines(Pool2DType pool_type);
 
+bool is_pool_op_one_scalar_per_core(
+    const Pool2DType pool_type,
+    bool ceil_mode,
+    uint32_t ceil_h,
+    uint32_t ceil_w,
+    bool count_include_pad,
+    uint32_t pad_h,
+    uint32_t pad_w,
+    std::optional<int32_t> divisor_override);
+
 std::optional<sliding_window::ParallelConfig> determine_valid_parallel_config(
     tt::tt_metal::TensorMemoryLayout shard_layout,
     uint32_t batch_size,
@@ -59,16 +69,25 @@ std::optional<sliding_window::ParallelConfig> determine_pool_config_for_auto_sha
     const Tensor& input_tensor,
     const sliding_window::SlidingWindowConfig& sliding_window_config,
     uint32_t channels,
-    Pool2DType pool_type);
+    Pool2DType pool_type,
+    bool count_include_pad,
+    std::optional<int32_t> divisor_override);
 
 uint32_t calculate_L1_usage(
     const Tensor& input,
+    const uint32_t pad_h,
+    const uint32_t pad_w,
+    const uint32_t ceil_pad_h,
+    const uint32_t ceil_pad_w,
+    const bool ceil_mode,
     uint32_t kernel_h,
     uint32_t kernel_w,
     uint32_t out_h,
     uint32_t out_w,
     const tt::tt_metal::MemoryConfig& input_memory,
     const tt::tt_metal::MemoryConfig& output_memory,
-    Pool2DType pool_type);
+    Pool2DType pool_type,
+    bool count_include_pad,
+    std::optional<int32_t> divisor_override);
 
 }  // namespace ttnn::operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
@@ -43,7 +43,7 @@ uint32_t get_bf16_pool_init_value(Pool2DType pool_type);
 std::map<std::string, std::string> get_defines(Pool2DType pool_type);
 
 bool is_pool_op_one_scalar_per_core(
-    const Pool2DType pool_type,
+    Pool2DType pool_type,
     bool ceil_mode,
     uint32_t ceil_h,
     uint32_t ceil_w,
@@ -75,11 +75,11 @@ std::optional<sliding_window::ParallelConfig> determine_pool_config_for_auto_sha
 
 uint32_t calculate_L1_usage(
     const Tensor& input,
-    const uint32_t pad_h,
-    const uint32_t pad_w,
-    const uint32_t ceil_pad_h,
-    const uint32_t ceil_pad_w,
-    const bool ceil_mode,
+    uint32_t pad_h,
+    uint32_t pad_w,
+    uint32_t ceil_pad_h,
+    uint32_t ceil_pad_w,
+    bool ceil_mode,
     uint32_t kernel_h,
     uint32_t kernel_w,
     uint32_t out_h,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24487

### Problem description
Currently for large kernels Generic Pool uses an intermediate CB to store temporary results from partial reductions before reducing these partial results to get the final result. Since the intermediate results are stored in FP16, this causes significant floating point precision errors.

For instance, averaging integers 0 through 4095 (a 64x64 kernel) should result in a value of 2047.5. Torch gets a result of 2048 but TTNN main currently gets 2080.

### What's changed
This PR reworks the large kernel implementation to do accumulation in DST instead. For average pool accumulation is now done in FP32 which greatly reduces floating point errors. For instance, with the 64x64 kernel mentioned above this PR gets a result of 2048 instead of 2080, matching Torch's precision.

This DST accumulation method also allows simplifications of many elements of the kernel. Improvements include:
- eliminates the intermediate CB saving 8 tiles of L1
- eliminates the ones scalar CB and associated switching logic
- eliminates all 5 sync CBs and associated synchronization points
- eliminates the reduce_h_fused function and associated tilize/untilize re-initializations
- improves perf by eliminating multiple reduction stages and associated synchronization overhead
- improves perf by re-implementing compute packing directly to output
- enables FP32 accumulation for average pool to reduce floating point error - this hurts perf since it limits max tiles per reduction to 4 instead of 8, but the floating point error with FP16 is unacceptably severe so this compromise is necessary

It should also now be possible to combine the small and large kernel implementations resulting in one kernel suitable for all generic pool parameterizations, but this will be saved for a follow on PR.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16130698185
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16130699608
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16130703946
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16130701558
failing on main, this PR hits same error
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
(wormhole) https://github.com/tenstorrent/tt-metal/actions/runs/16130707958
(blackhole) https://github.com/tenstorrent/tt-metal/actions/runs/16130709330
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16130705509
failing on main, this PR hits same error
- [x] New/Existing tests provide coverage for changes