### PR TITLE
Rd/reduce w fp32

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
@@ -15,9 +15,11 @@ template <
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
     int num_fidelity_phases = 0,
+    bool fp32_transpose = false,
     bool is_int_fpu_en = false>
 inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en>(dst_index, false, num_faces);
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, fp32_transpose, is_int_fpu_en>(
+        dst_index, false, num_faces);
 }
 
 template <
@@ -25,12 +27,14 @@ template <
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
     int num_fidelity_phases = 0,
+    bool fp32_transpose = false,
     bool is_int_fpu_en = false>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     const std::uint32_t operand_id = get_operand_id(operandA);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en>(dst_index, false, num_faces);
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, fp32_transpose, is_int_fpu_en>(
+        dst_index, false, num_faces);
 }
 
 template <PoolType type, ReduceDim dim, int num_fidelity_phases = 0>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
@@ -15,10 +15,10 @@ template <
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
     int num_fidelity_phases = 0,
-    bool fp32_transpose = false,
-    bool is_int_fpu_en = false>
+    bool is_int_fpu_en = false,
+    bool fp32_transpose = false>
 inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, fp32_transpose, is_int_fpu_en>(
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, fp32_transpose>(
         dst_index, false, num_faces);
 }
 
@@ -27,13 +27,13 @@ template <
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
     int num_fidelity_phases = 0,
-    bool fp32_transpose = false,
-    bool is_int_fpu_en = false>
+    bool is_int_fpu_en = false,
+    bool fp32_transpose = false>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     const std::uint32_t operand_id = get_operand_id(operandA);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, fp32_transpose, is_int_fpu_en>(
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, fp32_transpose>(
         dst_index, false, num_faces);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -85,7 +85,7 @@ inline void llk_unpack_AB(
     WAYPOINT("UABD");
 }
 
-template <ReduceDim dim, BroadcastType BType = BroadcastType::NONE>
+template <ReduceDim dim, BroadcastType BType = BroadcastType::NONE, bool fp32_transpose = false>
 inline void llk_unpack_AB_reduce_init(
     const std::uint32_t operandA,
     const std::uint32_t operandB,
@@ -97,6 +97,12 @@ inline void llk_unpack_AB_reduce_init(
     const std::uint32_t num_faces = get_operand_num_faces(operandA_id);
     const bool narrow_tile =
         get_operand_narrow_tile(operandA_id);  // if narrow tile read face 0 twice for row broadcast
+
+    if constexpr (fp32_transpose) {
+        // Set necessary config regs for MOVB2D hi16/lo16 to work
+        _llk_unpack_dbg_feature_disable_();
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
 
     // REDUCE_ROW requires transpose itself; additionaly, within_face_16x16_transpose flag could require transpose;
     // if we have the flag set with REDUCE_ROW, we don't need to do anything

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
@@ -15,9 +15,10 @@ template <
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
     int num_fidelity_phases = 0,
+    bool fp32_transpose = false,
     bool is_int_fpu_en = false>
 inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en>(dst_index, false, num_faces);
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, fp32_transpose, is_int_fpu_en>(dst_index, false, num_faces);
 }
 
 template <
@@ -25,11 +26,12 @@ template <
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
     int num_fidelity_phases = 0,
+    bool fp32_transpose = false,
     bool is_int_fpu_en = false>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     const std::uint32_t operand_id = get_operand_id(operandA);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en>(dst_index, false, num_faces);
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, fp32_transpose, is_int_fpu_en>(dst_index, false, num_faces);
 }
 
 template <PoolType type, ReduceDim dim, int num_fidelity_phases = 0>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
@@ -15,10 +15,11 @@ template <
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
     int num_fidelity_phases = 0,
-    bool fp32_transpose = false,
-    bool is_int_fpu_en = false>
+    bool is_int_fpu_en = false,
+    bool fp32_transpose = false>
 inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, fp32_transpose, is_int_fpu_en>(dst_index, false, num_faces);
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, fp32_transpose>(
+        dst_index, false, num_faces);
 }
 
 template <
@@ -26,12 +27,13 @@ template <
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
     int num_fidelity_phases = 0,
-    bool fp32_transpose = false,
-    bool is_int_fpu_en = false>
+    bool is_int_fpu_en = false,
+    bool fp32_transpose = false>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     const std::uint32_t operand_id = get_operand_id(operandA);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, fp32_transpose, is_int_fpu_en>(dst_index, false, num_faces);
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, fp32_transpose>(
+        dst_index, false, num_faces);
 }
 
 template <PoolType type, ReduceDim dim, int num_fidelity_phases = 0>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -85,7 +85,7 @@ inline void llk_unpack_AB(
     WAYPOINT("UABD");
 }
 
-template <ReduceDim dim, BroadcastType BType = BroadcastType::NONE>
+template <ReduceDim dim, BroadcastType BType = BroadcastType::NONE, bool fp32_transpose = false>
 inline void llk_unpack_AB_reduce_init(
     const std::uint32_t operandA,
     const std::uint32_t operandB,
@@ -97,6 +97,12 @@ inline void llk_unpack_AB_reduce_init(
     const std::uint32_t num_faces = get_operand_num_faces(operandA_id);
     const bool narrow_tile =
         get_operand_narrow_tile(operandA_id);  // if narrow tile read face 0 twice for row broadcast
+
+    if constexpr (fp32_transpose) {
+        // Set necessary config regs for MOVB2D hi16/lo16 to work
+        _llk_unpack_dbg_feature_disable_();
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
 
     // REDUCE_ROW requires transpose itself; additionaly, within_face_16x16_transpose flag could require transpose;
     // if we have the flag set with REDUCE_ROW, we don't need to do anything

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -63,7 +63,7 @@ ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
  *
  * | Param Type | Name | Description                                      | Type | Valid Range | Required |
  * |------------|------|--------------------------------------------------|------|-------------|----------|
- * | Function   | -    | No parameters                                    |  -   |      -      |    -     |
+ * | Function   | —    | No parameters                                    |  —   |      —      |    —     |
  */
 // clang-format on
 ALWI void reduce_uninit() { PACK((llk_pack_reduce_mask_clear())); }

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -35,13 +35,14 @@ namespace ckernel {
  *
  * Return value: None
  *
- * | Param Type | Name         | Description                                                     | Type      | Valid Range                                    | Required |
- * |------------|--------------|-----------------------------------------------------------------|-----------|------------------------------------------------|----------|
- * | Template   | reduce_type  | The type of reduce op - sum, average or maximum                 | PoolType  | {SUM, AVG, MAX}                                | True     |
- * | Template   | reduce_dim   | The dimension of reduce op - row, column or both                | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
- * | Function   | icb          | The identifier of the circular buffer (CB) containing operand A | uint32_t  | 0 to 31                                        | True     |
- * | Function   | icb_scaler   | CB holding scaling factors (see above)                          | uint32_t  | 0 to 31                                        | True     |
- * | Function   | ocb          | The identifier of the output circular buffer (CB)               | uint32_t  | 0 to 31                                        | True     |
+ * | Param Type | Name           | Description                                                     | Type      | Valid Range                                    | Required |
+ * |------------|----------------|-----------------------------------------------------------------|-----------|------------------------------------------------|----------|
+ * | Template   | reduce_type    | The type of reduce op - sum, average or maximum                 | PoolType  | {SUM, AVG, MAX}                                | True     |
+ * | Template   | reduce_dim     | The dimension of reduce op - row, column or both                | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
+ * | Template   | fp32_transpose | Enable accumulation of reduction in full FP32 precision         | bool      | {true, false}                                  | True     |
+ * | Function   | icb            | The identifier of the circular buffer (CB) containing operand A | uint32_t  | 0 to 31                                        | True     |
+ * | Function   | icb_scaler     | CB holding scaling factors (see above)                          | uint32_t  | 0 to 31                                        | True     |
+ * | Function   | ocb            | The identifier of the output circular buffer (CB)               | uint32_t  | 0 to 31                                        | True     |
  */
 // clang-format on
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool fp32_transpose = false>
@@ -50,6 +51,22 @@ ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
     MATH((llk_math_reduce_init<reduce_type, reduce_dim, MATH_FIDELITY>()));
     PACK((llk_pack_reduce_mask_config<false /*untilize*/, reduce_dim>()));
 }
+
+// clang-format off
+/**
+ * Resets the packer edge mask configuration to its default state by clearing any previously set masks. Needs to be called after
+ * reduce_tile if the next operation requires default packer state. In case that the next operation is reduce operation across the
+ * same dimension, this call can be omitted. If this function is not called, the packer will continue to use the edge masks set
+ * by the latest reduce_init call, which may lead to incorrect packing behavior in subsequent operations.
+ *
+ * NOTE: This function is not in line with our programming model, and will be removed by the end of 2025.
+ *
+ * | Param Type | Name | Description                                      | Type | Valid Range | Required |
+ * |------------|------|--------------------------------------------------|------|-------------|----------|
+ * | Function   | -    | No parameters                                    |  -   |      -      |    -     |
+ */
+// clang-format on
+ALWI void reduce_uninit() { PACK((llk_pack_reduce_mask_clear())); }
 
 // clang-format off
 /**
@@ -74,15 +91,16 @@ ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
  * NOTE: For other valid ways of populating the `icb_scaler`, refer to the ISA documentation.
  * Return value: None
  *
- * | Param Type | Name     | Description                                                     | Type     | Valid Range                                    | Required |
- * |------------|----------|-----------------------------------------------------------------|----------|------------------------------------------------|----------|
- * | Template   | reduce_type | The type of reduce op - sum, average or maximum              | PoolType | {SUM, AVG, MAX}                                | True     |
- * | Template   | reduce_dim  | The dimension of reduce op - row, column or both             | ReduceDim| {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
- * | Function   | icb      | The identifier of the circular buffer (CB) containing operand A | uint32_t | 0 to 31                                        | True     |
- * | Function   | icb_scaler  | CB holding scaling factors (see above)                          | uint32_t | 0 to 31                                        | True     |
- * | Function   | itile    | The index of the tile within the first CB                       | uint32_t | Must be less than the size of the CB           | True     |
- * | Function   | itile_sclaer | The index of the tile within the scaling factor CB.             | uint32_t | Must be less than the size of the CB           | True     |
- * | Function   | idst     | The index of the tile in DST REG for the result                 | uint32_t | Must be less than the acquired size of DST REG | True     |
+ * | Param Type | Name           | Description                                                     | Type      | Valid Range                                    | Required |
+ * |------------|----------------|-----------------------------------------------------------------|-----------|------------------------------------------------|----------|
+ * | Template   | reduce_type    | The type of reduce op - sum, average or maximum                 | PoolType  | {SUM, AVG, MAX}                                | True     |
+ * | Template   | reduce_dim     | The dimension of reduce op - row, column or both                | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
+ * | Template   | fp32_transpose | Enable accumulation of reduction in full FP32 precision         | bool      | {true, false}                                  | True     |
+ * | Function   | icb            | The identifier of the circular buffer (CB) containing operand A | uint32_t  | 0 to 31                                        | True     |
+ * | Function   | icb_scaler     | CB holding scaling factors (see above)                          | uint32_t  | 0 to 31                                        | True     |
+ * | Function   | itile          | The index of the tile within the first CB                       | uint32_t  | Must be less than the size of the CB           | True     |
+ * | Function   | itile_sclaer   | The index of the tile within the scaling factor CB.             | uint32_t  | Must be less than the size of the CB           | True     |
+ * | Function   | idst           | The index of the tile in DST REG for the result                 | uint32_t  | Must be less than the acquired size of DST REG | True     |
  */
 // clang-format on
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool fp32_transpose = false>
@@ -95,12 +113,13 @@ ALWI void reduce_tile(uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_
 /**
  * Performs a math-only reduction operation on a tile in the DST register. Assumes that source tiles are already in source registers.
  *
- * | Param Type | Name         | Description                                                     | Type      | Valid Range                                    | Required |
- * |------------|--------------|-----------------------------------------------------------------|-----------|------------------------------------------------|----------|
- * | Template   | reduce_type  | The type of reduce op - sum, average or maximum                 | PoolType  | {SUM, AVG, MAX}                                | True     |
- * | Template   | reduce_dim   | The dimension of reduce op - row, column or both                | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
- * | Function   | idst         | The index of the tile in DST REG for the result                 | uint32_t  | Must be less than the acquired size of DST REG | True     |
- * | Function   | num_faces    | Number of faces to reduce (optional, default 4)                 | uint32_t  | >= 1                                           | False    |
+ * | Param Type | Name           | Description                                                     | Type      | Valid Range                                    | Required |
+ * |------------|----------------|-----------------------------------------------------------------|-----------|------------------------------------------------|----------|
+ * | Template   | reduce_type    | The type of reduce op - sum, average or maximum                 | PoolType  | {SUM, AVG, MAX}                                | True     |
+ * | Template   | reduce_dim     | The dimension of reduce op - row, column or both                | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
+ * | Template   | fp32_transpose | Enable accumulation of reduction in full FP32 precision         | bool      | {true, false}                                  | True     |
+ * | Function   | idst           | The index of the tile in DST REG for the result                 | uint32_t  | Must be less than the acquired size of DST REG | True     |
+ * | Function   | num_faces      | Number of faces to reduce (optional, default 4)                 | uint32_t  | >= 1                                           | False    |
  */
 // clang-format on
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool fp32_transpose = false>

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -119,7 +119,7 @@ ALWI void reduce_tile(uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_
  * | Template   | reduce_dim     | The dimension of reduce op - row, column or both                | ReduceDim | {REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR}        | True     |
  * | Template   | fp32_transpose | Enable accumulation of reduction in full FP32 precision         | bool      | {true, false}                                  | True     |
  * | Function   | idst           | The index of the tile in DST REG for the result                 | uint32_t  | Must be less than the acquired size of DST REG | True     |
- * | Function   | num_faces      | Number of faces to reduce (optional, default 4)                 | uint32_t  | >= 1                                           | False    |
+ * | Function   | num_faces      | Number of faces to reduce (optional, default 4)                 | uint32_t  | 1 to 4                                         | False    |
  */
 // clang-format on
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool fp32_transpose = false>

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -49,6 +49,7 @@ ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
     UNPACK((llk_unpack_AB_reduce_init<reduce_dim, BroadcastType::NONE, fp32_transpose>(icb, icb_scaler)));
     MATH((llk_math_reduce_init<reduce_type, reduce_dim, MATH_FIDELITY>()));
     PACK((llk_pack_reduce_mask_config<false /*untilize*/, reduce_dim>()));
+}
 
 // clang-format off
 /**

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -105,7 +105,8 @@ ALWI void reduce_uninit() { PACK((llk_pack_reduce_mask_clear())); }
 // clang-format on
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool fp32_transpose = false>
 ALWI void reduce_tile(uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_t itile_sclaer, uint32_t idst) {
-    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, fp32_transpose>(icb, icb_scaler, idst)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, false, fp32_transpose>(
+        icb, icb_scaler, idst)));
     UNPACK((llk_unpack_AB(icb, icb_scaler, itile, itile_sclaer)));
 }
 
@@ -124,7 +125,8 @@ ALWI void reduce_tile(uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_
 // clang-format on
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool fp32_transpose = false>
 ALWI void reduce_tile_math(uint32_t idst, uint32_t num_faces = 4) {
-    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, fp32_transpose>(idst, num_faces)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, false, fp32_transpose>(
+        idst, num_faces)));
 }
 
 }  // namespace ckernel


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-llk/issues/122
https://github.com/tenstorrent/tt-metal/issues/23850

### Problem description
Reduce W implementation performs transpose of Dest register in Tf32 losing a significant amount of precision in the accumulated result.

### What's changed
Performing a 32bit transpose of Dest can be done by performing it on hi16 and lo16 bits separately, and can be used to maintain the fp32 accumulated result precision in the reduce OP.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16202867978) CI has same api failure as main
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16202871834) CI with demo tests passes (if applicable)