### PR TITLE
Slice (Split) program cache bug

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -321,6 +321,18 @@ def slice_test(
     return a_pt, a_ref, device.num_program_cache_entries()
 
 
+# from https://github.com/tenstorrent/tt-metal/issues/23237
+def test_slice_rm_program_cache_collison(device):
+    shape = (32, 64, 4096)
+    torch_input = torch.rand(shape, dtype=torch.bfloat16)
+    tt_input = ttnn.from_torch(torch_input, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    for i in range(shape[-1]):
+        tt_out = tt_input[:, :, i : i + 1]
+        torch_out = torch_input[:, :, i : i + 1]
+        assert_with_pcc(torch_out, ttnn.to_torch(tt_out), 0.99)
+
+
 @pytest.mark.parametrize(
     "dtype",
     (ttnn.bfloat16, ttnn.float32),

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
@@ -12,17 +12,17 @@ void kernel_main() {
     const uint32_t unpadded_stick_size = get_arg_val<uint32_t>(2);
     const uint32_t stick_size_offset = get_arg_val<uint32_t>(3);
     const uint32_t num_dims = get_arg_val<uint32_t>(4);
-    const uint32_t start_id = get_arg_val<uint32_t>(5);
-    const uint32_t num_sticks_per_core = get_arg_val<uint32_t>(6);
-    const uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(7);
-    const uint32_t num_read_per_barrier = get_arg_val<uint32_t>(8);
+    const uint32_t misalignment = get_arg_val<uint32_t>(5);
+    const uint32_t start_id = get_arg_val<uint32_t>(6);
+    const uint32_t num_sticks_per_core = get_arg_val<uint32_t>(7);
+    const uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(8);
+    const uint32_t num_read_per_barrier = get_arg_val<uint32_t>(9);
 
-    tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(9));
+    tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(10));
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
 
     constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t misalignment = get_compile_time_arg_val(1);
     uint32_t read_size = unpadded_stick_size + misalignment;
 
     const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = padded_stick_size};
@@ -39,7 +39,7 @@ void kernel_main() {
             sticks_read++;
             uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
             noc_async_read(src_noc_addr, src_buffer_l1_addr, read_size);
-            if constexpr (misalignment != 0) {
+            if (misalignment != 0) {
                 noc_async_read_barrier();
                 tt::data_movement::common::tt_memmove<false, false, false, 0>(
                     src_buffer_l1_addr, src_buffer_l1_addr + misalignment, unpadded_stick_size);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23237

### Problem description
- A `split` unit test was failing when program cache was enabled. `split` uses `slice` under the hood, so this was actually a bug due to the latter. Interestingly, the program cache utilization in this case was erroneous due to a hash collision but the `override_runtime_arguments` functionality _should_ still be able cover it.

### What's changed
- `slice` override runtime arguments missed some alignment and CB size parameters. Added those.
- Added specific unit test.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16128747634
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16153892825
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16145835170
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16153908728 (squeezebert skipped in main)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). https://github.com/tenstorrent/tt-metal/actions/runs/16153925116 (mistral, falcon, mamba also failing in main)
- [x] New/Existing tests provide coverage for changes