### PR TITLE
#24631: Extend mesh coord infra to compute neighbors along any dims.

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_coord.cpp
+++ b/tests/tt_metal/distributed/test_mesh_coord.cpp
@@ -74,19 +74,19 @@ TEST(MeshShapeTest, Equality) {
 }
 
 TEST(MeshShapeTest, LinearTopology) {
-    EXPECT_TRUE(is_line_topology(MeshShape(1)));
-    EXPECT_TRUE(is_line_topology(MeshShape(3)));
-    EXPECT_TRUE(is_line_topology(MeshShape(1, 1)));
-    EXPECT_TRUE(is_line_topology(MeshShape(1, 3)));
-    EXPECT_TRUE(is_line_topology(MeshShape(3, 1)));
-    EXPECT_FALSE(is_line_topology(MeshShape(3, 3)));
-    EXPECT_TRUE(is_line_topology(MeshShape(1, 1, 1)));
-    EXPECT_TRUE(is_line_topology(MeshShape(1, 1, 3)));
-    EXPECT_TRUE(is_line_topology(MeshShape(1, 3, 1)));
-    EXPECT_TRUE(is_line_topology(MeshShape(3, 1, 1)));
-    EXPECT_FALSE(is_line_topology(MeshShape(1, 3, 3)));
-    EXPECT_FALSE(is_line_topology(MeshShape(3, 1, 3)));
-    EXPECT_FALSE(is_line_topology(MeshShape(3, 3, 3)));
+    EXPECT_TRUE(MeshShape(1).is_line_topology());
+    EXPECT_TRUE(MeshShape(3).is_line_topology());
+    EXPECT_TRUE(MeshShape(1, 1).is_line_topology());
+    EXPECT_TRUE(MeshShape(1, 3).is_line_topology());
+    EXPECT_TRUE(MeshShape(3, 1).is_line_topology());
+    EXPECT_FALSE(MeshShape(3, 3).is_line_topology());
+    EXPECT_TRUE(MeshShape(1, 1, 1).is_line_topology());
+    EXPECT_TRUE(MeshShape(1, 1, 3).is_line_topology());
+    EXPECT_TRUE(MeshShape(1, 3, 1).is_line_topology());
+    EXPECT_TRUE(MeshShape(3, 1, 1).is_line_topology());
+    EXPECT_FALSE(MeshShape(1, 3, 3).is_line_topology());
+    EXPECT_FALSE(MeshShape(3, 1, 3).is_line_topology());
+    EXPECT_FALSE(MeshShape(3, 3, 3).is_line_topology());
 }
 
 TEST(MeshCoordinateTest, Construction) {
@@ -617,27 +617,27 @@ TEST(MeshCoordinateRangeSetTest, Coords) {
 TEST(ToLinearIndexTest, Basic) {
     MeshShape shape(2, 2, 3);
 
-    EXPECT_EQ(to_linear_index(shape, MeshCoordinate(0, 0, 0)), 0);
-    EXPECT_EQ(to_linear_index(shape, MeshCoordinate(0, 0, 1)), 1);
-    EXPECT_EQ(to_linear_index(shape, MeshCoordinate(0, 0, 2)), 2);
-    EXPECT_EQ(to_linear_index(shape, MeshCoordinate(0, 1, 0)), 3);
-    EXPECT_EQ(to_linear_index(shape, MeshCoordinate(0, 1, 1)), 4);
-    EXPECT_EQ(to_linear_index(shape, MeshCoordinate(0, 1, 2)), 5);
-    EXPECT_EQ(to_linear_index(shape, MeshCoordinate(1, 0, 0)), 6);
-    EXPECT_EQ(to_linear_index(shape, MeshCoordinate(1, 0, 1)), 7);
-    EXPECT_EQ(to_linear_index(shape, MeshCoordinate(1, 0, 2)), 8);
-    EXPECT_EQ(to_linear_index(shape, MeshCoordinate(1, 1, 0)), 9);
-    EXPECT_EQ(to_linear_index(shape, MeshCoordinate(1, 1, 1)), 10);
-    EXPECT_EQ(to_linear_index(shape, MeshCoordinate(1, 1, 2)), 11);
+    EXPECT_EQ(MeshCoordinate(0, 0, 0).to_linear_index(shape), 0);
+    EXPECT_EQ(MeshCoordinate(0, 0, 1).to_linear_index(shape), 1);
+    EXPECT_EQ(MeshCoordinate(0, 0, 2).to_linear_index(shape), 2);
+    EXPECT_EQ(MeshCoordinate(0, 1, 0).to_linear_index(shape), 3);
+    EXPECT_EQ(MeshCoordinate(0, 1, 1).to_linear_index(shape), 4);
+    EXPECT_EQ(MeshCoordinate(0, 1, 2).to_linear_index(shape), 5);
+    EXPECT_EQ(MeshCoordinate(1, 0, 0).to_linear_index(shape), 6);
+    EXPECT_EQ(MeshCoordinate(1, 0, 1).to_linear_index(shape), 7);
+    EXPECT_EQ(MeshCoordinate(1, 0, 2).to_linear_index(shape), 8);
+    EXPECT_EQ(MeshCoordinate(1, 1, 0).to_linear_index(shape), 9);
+    EXPECT_EQ(MeshCoordinate(1, 1, 1).to_linear_index(shape), 10);
+    EXPECT_EQ(MeshCoordinate(1, 1, 2).to_linear_index(shape), 11);
 }
 
 TEST(ToLinearIndexTest, MismatchedDimensions) {
-    EXPECT_ANY_THROW(to_linear_index(MeshShape(1, 2, 3), MeshCoordinate(0, 0)));
+    EXPECT_ANY_THROW(MeshCoordinate(0, 0).to_linear_index(MeshShape(1, 2, 3)));
 }
 
 TEST(ToLinearIndexTest, OutOfBounds) {
-    EXPECT_ANY_THROW(to_linear_index(MeshShape(2, 3), MeshCoordinate(2, 0)));
-    EXPECT_ANY_THROW(to_linear_index(MeshShape(2, 3), MeshCoordinate(0, 3)));
+    EXPECT_ANY_THROW(MeshCoordinate(2, 0).to_linear_index(MeshShape(2, 3)));
+    EXPECT_ANY_THROW(MeshCoordinate(0, 3).to_linear_index(MeshShape(2, 3)));
 }
 
 TEST(MeshContainerTest, InitialValues) {
@@ -821,13 +821,13 @@ TEST(GetNeighborTest, Basic1D) {
     MeshCoordinate coord(2);
 
     // Move forward
-    EXPECT_THAT(get_neighbor(shape, coord, 1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(3)));
+    EXPECT_THAT(coord.get_neighbor(shape, 1, 0, MeshCoordinate::BoundaryMode::WRAP), Optional(MeshCoordinate(3)));
 
     // Move backward
-    EXPECT_THAT(get_neighbor(shape, coord, -1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(1)));
+    EXPECT_THAT(coord.get_neighbor(shape, -1, 0, MeshCoordinate::BoundaryMode::WRAP), Optional(MeshCoordinate(1)));
 
     // Move multiple steps
-    EXPECT_THAT(get_neighbor(shape, coord, 2, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(4)));
+    EXPECT_THAT(coord.get_neighbor(shape, 2, 0, MeshCoordinate::BoundaryMode::WRAP), Optional(MeshCoordinate(4)));
 }
 
 TEST(GetNeighborTest, Basic2D) {
@@ -835,12 +835,12 @@ TEST(GetNeighborTest, Basic2D) {
     MeshCoordinate coord(1, 2);
 
     // Move along dimension 0 (row)
-    EXPECT_THAT(get_neighbor(shape, coord, 1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(2, 2)));
-    EXPECT_THAT(get_neighbor(shape, coord, -1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(0, 2)));
+    EXPECT_THAT(coord.get_neighbor(shape, 1, 0, MeshCoordinate::BoundaryMode::WRAP), Optional(MeshCoordinate(2, 2)));
+    EXPECT_THAT(coord.get_neighbor(shape, -1, 0, MeshCoordinate::BoundaryMode::WRAP), Optional(MeshCoordinate(0, 2)));
 
     // Move along dimension 1 (column)
-    EXPECT_THAT(get_neighbor(shape, coord, 1, 1, BoundaryMode::WRAP), Optional(MeshCoordinate(1, 3)));
-    EXPECT_THAT(get_neighbor(shape, coord, -1, 1, BoundaryMode::WRAP), Optional(MeshCoordinate(1, 1)));
+    EXPECT_THAT(coord.get_neighbor(shape, 1, 1, MeshCoordinate::BoundaryMode::WRAP), Optional(MeshCoordinate(1, 3)));
+    EXPECT_THAT(coord.get_neighbor(shape, -1, 1, MeshCoordinate::BoundaryMode::WRAP), Optional(MeshCoordinate(1, 1)));
 }
 
 TEST(GetNeighborTest, BoundaryModeWrap) {
@@ -848,21 +848,21 @@ TEST(GetNeighborTest, BoundaryModeWrap) {
 
     // Wrap around at edges
     EXPECT_THAT(
-        get_neighbor(shape, MeshCoordinate(0, 0), -1, 0, BoundaryMode::WRAP),
+        MeshCoordinate(0, 0).get_neighbor(shape, -1, 0, MeshCoordinate::BoundaryMode::WRAP),
         Optional(MeshCoordinate(2, 0)));  // Wraps to last row
 
     EXPECT_THAT(
-        get_neighbor(shape, MeshCoordinate(2, 3), 1, 1, BoundaryMode::WRAP),
+        MeshCoordinate(2, 3).get_neighbor(shape, 1, 1, MeshCoordinate::BoundaryMode::WRAP),
         Optional(MeshCoordinate(2, 0)));  // Wraps to first column
 
     // Wrap with larger offsets
     EXPECT_THAT(
-        get_neighbor(shape, MeshCoordinate(1, 1), 5, 1, BoundaryMode::WRAP),
+        MeshCoordinate(1, 1).get_neighbor(shape, 5, 1, MeshCoordinate::BoundaryMode::WRAP),
         Optional(MeshCoordinate(1, 2)));  // (1 + 5) % 4 = 2
 
     // Negative wrap with larger offsets
     EXPECT_THAT(
-        get_neighbor(shape, MeshCoordinate(1, 1), -6, 1, BoundaryMode::WRAP),
+        MeshCoordinate(1, 1).get_neighbor(shape, -6, 1, MeshCoordinate::BoundaryMode::WRAP),
         Optional(MeshCoordinate(1, 3)));  // (1 - 6) wrapped = 3
 }
 
@@ -871,20 +871,20 @@ TEST(GetNeighborTest, BoundaryModeClamp) {
 
     // Clamp at boundaries
     EXPECT_THAT(
-        get_neighbor(shape, MeshCoordinate(0, 0), -1, 0, BoundaryMode::CLAMP),
+        MeshCoordinate(0, 0).get_neighbor(shape, -1, 0, MeshCoordinate::BoundaryMode::CLAMP),
         Optional(MeshCoordinate(0, 0)));  // Clamped to boundary
 
     EXPECT_THAT(
-        get_neighbor(shape, MeshCoordinate(2, 3), 1, 1, BoundaryMode::CLAMP),
+        MeshCoordinate(2, 3).get_neighbor(shape, 1, 1, MeshCoordinate::BoundaryMode::CLAMP),
         Optional(MeshCoordinate(2, 3)));  // Clamped to boundary
 
     // Clamp with larger offsets
     EXPECT_THAT(
-        get_neighbor(shape, MeshCoordinate(1, 1), 10, 0, BoundaryMode::CLAMP),
+        MeshCoordinate(1, 1).get_neighbor(shape, 10, 0, MeshCoordinate::BoundaryMode::CLAMP),
         Optional(MeshCoordinate(2, 1)));  // Clamped to max
 
     EXPECT_THAT(
-        get_neighbor(shape, MeshCoordinate(1, 1), -10, 1, BoundaryMode::CLAMP),
+        MeshCoordinate(1, 1).get_neighbor(shape, -10, 1, MeshCoordinate::BoundaryMode::CLAMP),
         Optional(MeshCoordinate(1, 0)));  // Clamped to min
 }
 
@@ -892,14 +892,16 @@ TEST(GetNeighborTest, BoundaryModeNone) {
     MeshShape shape(3, 4);
 
     // Valid neighbors
-    EXPECT_THAT(get_neighbor(shape, MeshCoordinate(1, 1), 1, 0, BoundaryMode::NONE), Optional(MeshCoordinate(2, 1)));
+    EXPECT_THAT(
+        MeshCoordinate(1, 1).get_neighbor(shape, 1, 0, MeshCoordinate::BoundaryMode::NONE),
+        Optional(MeshCoordinate(2, 1)));
 
     // Out of bounds returns nullopt
-    EXPECT_THAT(get_neighbor(shape, MeshCoordinate(0, 0), -1, 0, BoundaryMode::NONE), Eq(std::nullopt));
-    EXPECT_THAT(get_neighbor(shape, MeshCoordinate(2, 3), 1, 1, BoundaryMode::NONE), Eq(std::nullopt));
+    EXPECT_THAT(MeshCoordinate(0, 0).get_neighbor(shape, -1, 0, MeshCoordinate::BoundaryMode::NONE), Eq(std::nullopt));
+    EXPECT_THAT(MeshCoordinate(2, 3).get_neighbor(shape, 1, 1, MeshCoordinate::BoundaryMode::NONE), Eq(std::nullopt));
 
     // Larger offsets that go out of bounds
-    EXPECT_THAT(get_neighbor(shape, MeshCoordinate(1, 1), 2, 0, BoundaryMode::NONE), Eq(std::nullopt));
+    EXPECT_THAT(MeshCoordinate(1, 1).get_neighbor(shape, 2, 0, MeshCoordinate::BoundaryMode::NONE), Eq(std::nullopt));
 }
 
 TEST(GetNeighborTest, NegativeDimensionIndex) {
@@ -908,15 +910,15 @@ TEST(GetNeighborTest, NegativeDimensionIndex) {
 
     // Negative dimension indexing (Python-style)
     EXPECT_THAT(
-        get_neighbor(shape, coord, 1, -1, BoundaryMode::WRAP),  // Last dimension
+        coord.get_neighbor(shape, 1, -1, MeshCoordinate::BoundaryMode::WRAP),  // Last dimension
         Optional(MeshCoordinate(1, 2, 4)));
 
     EXPECT_THAT(
-        get_neighbor(shape, coord, 1, -2, BoundaryMode::WRAP),  // Second to last dimension
+        coord.get_neighbor(shape, 1, -2, MeshCoordinate::BoundaryMode::WRAP),  // Second to last dimension
         Optional(MeshCoordinate(1, 3, 3)));
 
     EXPECT_THAT(
-        get_neighbor(shape, coord, 1, -3, BoundaryMode::WRAP),  // Third to last (first) dimension
+        coord.get_neighbor(shape, 1, -3, MeshCoordinate::BoundaryMode::WRAP),  // Third to last (first) dimension
         Optional(MeshCoordinate(2, 2, 3)));
 }
 
@@ -926,16 +928,16 @@ TEST(GetNeighborTest, DirectionalMovement2D) {
     MeshCoordinate src(1, 2);
 
     // North (negative along dimension 0)
-    EXPECT_THAT(get_neighbor(shape, src, -1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(0, 2)));
+    EXPECT_THAT(src.get_neighbor(shape, -1, 0, MeshCoordinate::BoundaryMode::WRAP), Optional(MeshCoordinate(0, 2)));
 
     // East (positive along dimension 1)
-    EXPECT_THAT(get_neighbor(shape, src, 1, 1, BoundaryMode::WRAP), Optional(MeshCoordinate(1, 3)));
+    EXPECT_THAT(src.get_neighbor(shape, 1, 1, MeshCoordinate::BoundaryMode::WRAP), Optional(MeshCoordinate(1, 3)));
 
     // South (positive along dimension 0)
-    EXPECT_THAT(get_neighbor(shape, src, 1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(2, 2)));
+    EXPECT_THAT(src.get_neighbor(shape, 1, 0, MeshCoordinate::BoundaryMode::WRAP), Optional(MeshCoordinate(2, 2)));
 
     // West (negative along dimension 1)
-    EXPECT_THAT(get_neighbor(shape, src, -1, 1, BoundaryMode::WRAP), Optional(MeshCoordinate(1, 1)));
+    EXPECT_THAT(src.get_neighbor(shape, -1, 1, MeshCoordinate::BoundaryMode::WRAP), Optional(MeshCoordinate(1, 1)));
 }
 
 TEST(GetNeighborTest, TorusTopology) {
@@ -946,18 +948,23 @@ TEST(GetNeighborTest, TorusTopology) {
     MeshCoordinate corner(0, 0);
 
     EXPECT_THAT(
-        get_neighbor(shape, corner, -1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(2, 0)));  // Wraps to bottom
+        corner.get_neighbor(shape, -1, 0, MeshCoordinate::BoundaryMode::WRAP),
+        Optional(MeshCoordinate(2, 0)));  // Wraps to bottom
 
     EXPECT_THAT(
-        get_neighbor(shape, corner, -1, 1, BoundaryMode::WRAP), Optional(MeshCoordinate(0, 2)));  // Wraps to right
+        corner.get_neighbor(shape, -1, 1, MeshCoordinate::BoundaryMode::WRAP),
+        Optional(MeshCoordinate(0, 2)));  // Wraps to right
 
     // Opposite corner
     corner = MeshCoordinate(2, 2);
 
-    EXPECT_THAT(get_neighbor(shape, corner, 1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(0, 2)));  // Wraps to top
+    EXPECT_THAT(
+        corner.get_neighbor(shape, 1, 0, MeshCoordinate::BoundaryMode::WRAP),
+        Optional(MeshCoordinate(0, 2)));  // Wraps to top
 
     EXPECT_THAT(
-        get_neighbor(shape, corner, 1, 1, BoundaryMode::WRAP), Optional(MeshCoordinate(2, 0)));  // Wraps to left
+        corner.get_neighbor(shape, 1, 1, MeshCoordinate::BoundaryMode::WRAP),
+        Optional(MeshCoordinate(2, 0)));  // Wraps to left
 }
 
 TEST(GetNeighborTest, DimensionMismatch) {
@@ -965,7 +972,7 @@ TEST(GetNeighborTest, DimensionMismatch) {
     MeshCoordinate coord(1, 2, 3);  // 3D coordinate
 
     // Should throw due to dimension mismatch
-    EXPECT_ANY_THROW(get_neighbor(shape, coord, 1, 0, BoundaryMode::WRAP));
+    EXPECT_ANY_THROW(coord.get_neighbor(shape, 1, 0, MeshCoordinate::BoundaryMode::WRAP));
 }
 
 TEST(GetNeighborTest, InvalidDimension) {
@@ -973,8 +980,8 @@ TEST(GetNeighborTest, InvalidDimension) {
     MeshCoordinate coord(1, 2);
 
     // Out of range dimension
-    EXPECT_ANY_THROW(get_neighbor(shape, coord, 1, 2, BoundaryMode::WRAP));
-    EXPECT_ANY_THROW(get_neighbor(shape, coord, 1, -3, BoundaryMode::WRAP));
+    EXPECT_ANY_THROW(coord.get_neighbor(shape, 1, 2, MeshCoordinate::BoundaryMode::WRAP));
+    EXPECT_ANY_THROW(coord.get_neighbor(shape, 1, -3, MeshCoordinate::BoundaryMode::WRAP));
 }
 
 TEST(GetNeighborTest, OutOfBoundsInputCoordinate) {
@@ -982,19 +989,19 @@ TEST(GetNeighborTest, OutOfBoundsInputCoordinate) {
 
     // Coordinate with first dimension out of bounds
     MeshCoordinate out_of_bounds1(3, 2);  // First dim is 3, but shape is only 3 (valid: 0-2)
-    EXPECT_ANY_THROW(get_neighbor(shape, out_of_bounds1, 1, 0, BoundaryMode::WRAP));
-    EXPECT_ANY_THROW(get_neighbor(shape, out_of_bounds1, 1, 0, BoundaryMode::CLAMP));
-    EXPECT_ANY_THROW(get_neighbor(shape, out_of_bounds1, 1, 0, BoundaryMode::NONE));
+    EXPECT_ANY_THROW(out_of_bounds1.get_neighbor(shape, 1, 0, MeshCoordinate::BoundaryMode::WRAP));
+    EXPECT_ANY_THROW(out_of_bounds1.get_neighbor(shape, 1, 0, MeshCoordinate::BoundaryMode::CLAMP));
+    EXPECT_ANY_THROW(out_of_bounds1.get_neighbor(shape, 1, 0, MeshCoordinate::BoundaryMode::NONE));
 
     // Coordinate with second dimension out of bounds
     MeshCoordinate out_of_bounds2(1, 4);  // Second dim is 4, but shape is only 4 (valid: 0-3)
-    EXPECT_ANY_THROW(get_neighbor(shape, out_of_bounds2, 1, 1, BoundaryMode::WRAP));
-    EXPECT_ANY_THROW(get_neighbor(shape, out_of_bounds2, 1, 1, BoundaryMode::CLAMP));
-    EXPECT_ANY_THROW(get_neighbor(shape, out_of_bounds2, 1, 1, BoundaryMode::NONE));
+    EXPECT_ANY_THROW(out_of_bounds2.get_neighbor(shape, 1, 1, MeshCoordinate::BoundaryMode::WRAP));
+    EXPECT_ANY_THROW(out_of_bounds2.get_neighbor(shape, 1, 1, MeshCoordinate::BoundaryMode::CLAMP));
+    EXPECT_ANY_THROW(out_of_bounds2.get_neighbor(shape, 1, 1, MeshCoordinate::BoundaryMode::NONE));
 
     // Coordinate with both dimensions out of bounds
     MeshCoordinate out_of_bounds3(5, 10);
-    EXPECT_ANY_THROW(get_neighbor(shape, out_of_bounds3, 0, 0, BoundaryMode::WRAP));
+    EXPECT_ANY_THROW(out_of_bounds3.get_neighbor(shape, 0, 0, MeshCoordinate::BoundaryMode::WRAP));
 }
 
 }  // namespace

--- a/tests/tt_metal/distributed/test_mesh_coord.cpp
+++ b/tests/tt_metal/distributed/test_mesh_coord.cpp
@@ -21,6 +21,7 @@ namespace {
 using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::IsEmpty;
+using ::testing::Optional;
 using ::testing::UnorderedElementsAre;
 
 TEST(MeshShapeTest, Construction) {
@@ -162,6 +163,39 @@ TEST(MeshCoordinateTest, ZeroCoordinate) {
     EXPECT_EQ(MeshCoordinate::zero_coordinate(1), MeshCoordinate(0));
     EXPECT_EQ(MeshCoordinate::zero_coordinate(2), MeshCoordinate(0, 0));
     EXPECT_EQ(MeshCoordinate::zero_coordinate(3), MeshCoordinate(0, 0, 0));
+}
+
+TEST(MeshCoordinateTest, NegativeIndexing) {
+    MeshCoordinate coord(10, 20, 30);
+
+    // Positive indexing
+    EXPECT_EQ(coord[0], 10);
+    EXPECT_EQ(coord[1], 20);
+    EXPECT_EQ(coord[2], 30);
+
+    // Negative indexing
+    EXPECT_EQ(coord[-1], 30);  // Last element
+    EXPECT_EQ(coord[-2], 20);  // Second to last
+    EXPECT_EQ(coord[-3], 10);  // Third to last (first element)
+
+    // Out of bounds negative indexing
+    EXPECT_ANY_THROW(coord[-4]);
+}
+
+TEST(MeshCoordinateTest, MutableIndexAccess) {
+    MeshCoordinate coord(10, 20, 30);
+
+    // Modify through positive index
+    coord[0] = 15;
+    EXPECT_EQ(coord[0], 15);
+
+    // Modify through negative index
+    coord[-1] = 35;
+    EXPECT_EQ(coord[2], 35);
+    EXPECT_EQ(coord[-1], 35);
+
+    // Verify final state
+    EXPECT_THAT(coord.coords(), ElementsAre(15, 20, 35));
 }
 
 TEST(MeshCoordinateRangeTest, FromShape) {
@@ -780,6 +814,187 @@ TEST(MeshContainerIteratorTraitsTest, STLAlgorithmsCompatibility) {
         return proxy.value() > 10;
     });
     EXPECT_TRUE(none_greater_than_10);
+}
+
+TEST(GetNeighborTest, Basic1D) {
+    MeshShape shape(5);
+    MeshCoordinate coord(2);
+
+    // Move forward
+    EXPECT_THAT(get_neighbor(shape, coord, 1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(3)));
+
+    // Move backward
+    EXPECT_THAT(get_neighbor(shape, coord, -1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(1)));
+
+    // Move multiple steps
+    EXPECT_THAT(get_neighbor(shape, coord, 2, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(4)));
+}
+
+TEST(GetNeighborTest, Basic2D) {
+    MeshShape shape(3, 4);
+    MeshCoordinate coord(1, 2);
+
+    // Move along dimension 0 (row)
+    EXPECT_THAT(get_neighbor(shape, coord, 1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(2, 2)));
+    EXPECT_THAT(get_neighbor(shape, coord, -1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(0, 2)));
+
+    // Move along dimension 1 (column)
+    EXPECT_THAT(get_neighbor(shape, coord, 1, 1, BoundaryMode::WRAP), Optional(MeshCoordinate(1, 3)));
+    EXPECT_THAT(get_neighbor(shape, coord, -1, 1, BoundaryMode::WRAP), Optional(MeshCoordinate(1, 1)));
+}
+
+TEST(GetNeighborTest, BoundaryModeWrap) {
+    MeshShape shape(3, 4);
+
+    // Wrap around at edges
+    EXPECT_THAT(
+        get_neighbor(shape, MeshCoordinate(0, 0), -1, 0, BoundaryMode::WRAP),
+        Optional(MeshCoordinate(2, 0)));  // Wraps to last row
+
+    EXPECT_THAT(
+        get_neighbor(shape, MeshCoordinate(2, 3), 1, 1, BoundaryMode::WRAP),
+        Optional(MeshCoordinate(2, 0)));  // Wraps to first column
+
+    // Wrap with larger offsets
+    EXPECT_THAT(
+        get_neighbor(shape, MeshCoordinate(1, 1), 5, 1, BoundaryMode::WRAP),
+        Optional(MeshCoordinate(1, 2)));  // (1 + 5) % 4 = 2
+
+    // Negative wrap with larger offsets
+    EXPECT_THAT(
+        get_neighbor(shape, MeshCoordinate(1, 1), -6, 1, BoundaryMode::WRAP),
+        Optional(MeshCoordinate(1, 3)));  // (1 - 6) wrapped = 3
+}
+
+TEST(GetNeighborTest, BoundaryModeClamp) {
+    MeshShape shape(3, 4);
+
+    // Clamp at boundaries
+    EXPECT_THAT(
+        get_neighbor(shape, MeshCoordinate(0, 0), -1, 0, BoundaryMode::CLAMP),
+        Optional(MeshCoordinate(0, 0)));  // Clamped to boundary
+
+    EXPECT_THAT(
+        get_neighbor(shape, MeshCoordinate(2, 3), 1, 1, BoundaryMode::CLAMP),
+        Optional(MeshCoordinate(2, 3)));  // Clamped to boundary
+
+    // Clamp with larger offsets
+    EXPECT_THAT(
+        get_neighbor(shape, MeshCoordinate(1, 1), 10, 0, BoundaryMode::CLAMP),
+        Optional(MeshCoordinate(2, 1)));  // Clamped to max
+
+    EXPECT_THAT(
+        get_neighbor(shape, MeshCoordinate(1, 1), -10, 1, BoundaryMode::CLAMP),
+        Optional(MeshCoordinate(1, 0)));  // Clamped to min
+}
+
+TEST(GetNeighborTest, BoundaryModeNone) {
+    MeshShape shape(3, 4);
+
+    // Valid neighbors
+    EXPECT_THAT(get_neighbor(shape, MeshCoordinate(1, 1), 1, 0, BoundaryMode::NONE), Optional(MeshCoordinate(2, 1)));
+
+    // Out of bounds returns nullopt
+    EXPECT_THAT(get_neighbor(shape, MeshCoordinate(0, 0), -1, 0, BoundaryMode::NONE), Eq(std::nullopt));
+    EXPECT_THAT(get_neighbor(shape, MeshCoordinate(2, 3), 1, 1, BoundaryMode::NONE), Eq(std::nullopt));
+
+    // Larger offsets that go out of bounds
+    EXPECT_THAT(get_neighbor(shape, MeshCoordinate(1, 1), 2, 0, BoundaryMode::NONE), Eq(std::nullopt));
+}
+
+TEST(GetNeighborTest, NegativeDimensionIndex) {
+    MeshShape shape(3, 4, 5);
+    MeshCoordinate coord(1, 2, 3);
+
+    // Negative dimension indexing (Python-style)
+    EXPECT_THAT(
+        get_neighbor(shape, coord, 1, -1, BoundaryMode::WRAP),  // Last dimension
+        Optional(MeshCoordinate(1, 2, 4)));
+
+    EXPECT_THAT(
+        get_neighbor(shape, coord, 1, -2, BoundaryMode::WRAP),  // Second to last dimension
+        Optional(MeshCoordinate(1, 3, 3)));
+
+    EXPECT_THAT(
+        get_neighbor(shape, coord, 1, -3, BoundaryMode::WRAP),  // Third to last (first) dimension
+        Optional(MeshCoordinate(2, 2, 3)));
+}
+
+TEST(GetNeighborTest, DirectionalMovement2D) {
+    // Test N/E/S/W movement as in the user's example
+    MeshShape shape(3, 4);
+    MeshCoordinate src(1, 2);
+
+    // North (negative along dimension 0)
+    EXPECT_THAT(get_neighbor(shape, src, -1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(0, 2)));
+
+    // East (positive along dimension 1)
+    EXPECT_THAT(get_neighbor(shape, src, 1, 1, BoundaryMode::WRAP), Optional(MeshCoordinate(1, 3)));
+
+    // South (positive along dimension 0)
+    EXPECT_THAT(get_neighbor(shape, src, 1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(2, 2)));
+
+    // West (negative along dimension 1)
+    EXPECT_THAT(get_neighbor(shape, src, -1, 1, BoundaryMode::WRAP), Optional(MeshCoordinate(1, 1)));
+}
+
+TEST(GetNeighborTest, TorusTopology) {
+    // Test torus wrapping behavior
+    MeshShape shape(3, 3);
+
+    // Corner wrapping
+    MeshCoordinate corner(0, 0);
+
+    EXPECT_THAT(
+        get_neighbor(shape, corner, -1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(2, 0)));  // Wraps to bottom
+
+    EXPECT_THAT(
+        get_neighbor(shape, corner, -1, 1, BoundaryMode::WRAP), Optional(MeshCoordinate(0, 2)));  // Wraps to right
+
+    // Opposite corner
+    corner = MeshCoordinate(2, 2);
+
+    EXPECT_THAT(get_neighbor(shape, corner, 1, 0, BoundaryMode::WRAP), Optional(MeshCoordinate(0, 2)));  // Wraps to top
+
+    EXPECT_THAT(
+        get_neighbor(shape, corner, 1, 1, BoundaryMode::WRAP), Optional(MeshCoordinate(2, 0)));  // Wraps to left
+}
+
+TEST(GetNeighborTest, DimensionMismatch) {
+    MeshShape shape(3, 4);
+    MeshCoordinate coord(1, 2, 3);  // 3D coordinate
+
+    // Should throw due to dimension mismatch
+    EXPECT_ANY_THROW(get_neighbor(shape, coord, 1, 0, BoundaryMode::WRAP));
+}
+
+TEST(GetNeighborTest, InvalidDimension) {
+    MeshShape shape(3, 4);
+    MeshCoordinate coord(1, 2);
+
+    // Out of range dimension
+    EXPECT_ANY_THROW(get_neighbor(shape, coord, 1, 2, BoundaryMode::WRAP));
+    EXPECT_ANY_THROW(get_neighbor(shape, coord, 1, -3, BoundaryMode::WRAP));
+}
+
+TEST(GetNeighborTest, OutOfBoundsInputCoordinate) {
+    MeshShape shape(3, 4);
+
+    // Coordinate with first dimension out of bounds
+    MeshCoordinate out_of_bounds1(3, 2);  // First dim is 3, but shape is only 3 (valid: 0-2)
+    EXPECT_ANY_THROW(get_neighbor(shape, out_of_bounds1, 1, 0, BoundaryMode::WRAP));
+    EXPECT_ANY_THROW(get_neighbor(shape, out_of_bounds1, 1, 0, BoundaryMode::CLAMP));
+    EXPECT_ANY_THROW(get_neighbor(shape, out_of_bounds1, 1, 0, BoundaryMode::NONE));
+
+    // Coordinate with second dimension out of bounds
+    MeshCoordinate out_of_bounds2(1, 4);  // Second dim is 4, but shape is only 4 (valid: 0-3)
+    EXPECT_ANY_THROW(get_neighbor(shape, out_of_bounds2, 1, 1, BoundaryMode::WRAP));
+    EXPECT_ANY_THROW(get_neighbor(shape, out_of_bounds2, 1, 1, BoundaryMode::CLAMP));
+    EXPECT_ANY_THROW(get_neighbor(shape, out_of_bounds2, 1, 1, BoundaryMode::NONE));
+
+    // Coordinate with both dimensions out of bounds
+    MeshCoordinate out_of_bounds3(5, 10);
+    EXPECT_ANY_THROW(get_neighbor(shape, out_of_bounds3, 0, 0, BoundaryMode::WRAP));
 }
 
 }  // namespace

--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -96,7 +96,7 @@ TEST_P(MeshDeviceReshapeRoundtripTest, ReshapeBetweenConfigurations) {
     if (old_shape.mesh_size() != new_shape.mesh_size()) {
         GTEST_SKIP() << "Device counts don't match; we test this in InvalidReshapeDimensions";
     }
-    if (is_line_topology(old_shape) or is_line_topology(new_shape)) {
+    if (old_shape.is_line_topology() or new_shape.is_line_topology()) {
         GTEST_SKIP() << "Either old or new shape is in line configuration; we test this in From1x4To2x2Invalid";
     }
 

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -80,8 +80,10 @@ public:
     // Returns the coordinate values as a span.
     tt::stl::Span<const uint32_t> coords() const;
 
-    // Returns the coordinate value at the given index.
-    uint32_t operator[](size_t dim) const;
+    // Provides access to the coordinate value at the given index.
+    // Supports negative indexing.
+    uint32_t operator[](int32_t dim) const;
+    uint32_t& operator[](int32_t dim);
 
     // Needed for reflect / fmt
     static constexpr auto attribute_names = std::forward_as_tuple("value");
@@ -105,6 +107,18 @@ std::ostream& operator<<(std::ostream& os, const MeshCoordinate& shape);
 // Converts a MeshCoordinate to a linear index.
 // Throws if `coord` is out of bounds of `shape`.
 size_t to_linear_index(const MeshShape& shape, const MeshCoordinate& coord);
+
+// Returns a neighbor along the given dimension.
+// `BoundaryMode` specifies how to handle coordinates that are out of bounds.
+// Negative offsets and dim are allowed, and the input coordinate must be within bounds.
+enum class BoundaryMode { WRAP, CLAMP, NONE };
+
+std::optional<MeshCoordinate> get_neighbor(
+    const MeshShape& shape,
+    const MeshCoordinate& coord,
+    int32_t offset,
+    int32_t dim,
+    BoundaryMode mode = BoundaryMode::WRAP);
 
 // Represents a range of MeshCoordinates. Requires that mesh coordinates have the same dimensionality.
 class MeshCoordinateRange {
@@ -144,6 +158,7 @@ public:
     static constexpr auto attribute_names = std::forward_as_tuple("start", "end");
     auto attribute_values() const { return std::forward_as_tuple(start_, end_); }
 
+    // Iterator over the range, provides access to coordinates in row-major order.
     class Iterator {
     public:
         Iterator& operator++();

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -40,6 +40,9 @@ public:
     // Returns the total number of elements in the mesh.
     size_t mesh_size() const;
 
+    // Returns true if the mesh shape is in a line topology: at most 1 dimension can be non-unit.
+    bool is_line_topology() const;
+
     // Needed for reflect / fmt
     static constexpr auto attribute_names = std::forward_as_tuple("value");
     auto attribute_values() const { return std::forward_as_tuple(value_); }
@@ -56,9 +59,6 @@ private:
     void compute_strides();
     tt::stl::SmallVector<size_t> strides_;
 };
-
-// Returns true if the mesh shape is in a line topology: at most 1 dimension can be non-unit.
-bool is_line_topology(const MeshShape& shape);
 
 class MeshCoordinate {
 public:
@@ -85,6 +85,18 @@ public:
     uint32_t operator[](int32_t dim) const;
     uint32_t& operator[](int32_t dim);
 
+    // Converts a MeshCoordinate to a linear index.
+    // Throws if `coord` is out of bounds of `shape`.
+    size_t to_linear_index(const MeshShape& shape) const;
+
+    // Returns a neighbor along the given dimension.
+    // `BoundaryMode` specifies how to handle coordinates that are out of bounds.
+    // Negative offsets and dim are allowed, and the input coordinate must be within bounds.
+    enum class BoundaryMode { WRAP, CLAMP, NONE };
+
+    std::optional<MeshCoordinate> get_neighbor(
+        const MeshShape& shape, int32_t offset, int32_t dim, BoundaryMode mode = BoundaryMode::WRAP) const;
+
     // Needed for reflect / fmt
     static constexpr auto attribute_names = std::forward_as_tuple("value");
     auto attribute_values() const { return std::forward_as_tuple(value_); }
@@ -103,22 +115,6 @@ bool operator<=(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
 bool operator>=(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
 
 std::ostream& operator<<(std::ostream& os, const MeshCoordinate& shape);
-
-// Converts a MeshCoordinate to a linear index.
-// Throws if `coord` is out of bounds of `shape`.
-size_t to_linear_index(const MeshShape& shape, const MeshCoordinate& coord);
-
-// Returns a neighbor along the given dimension.
-// `BoundaryMode` specifies how to handle coordinates that are out of bounds.
-// Negative offsets and dim are allowed, and the input coordinate must be within bounds.
-enum class BoundaryMode { WRAP, CLAMP, NONE };
-
-std::optional<MeshCoordinate> get_neighbor(
-    const MeshShape& shape,
-    const MeshCoordinate& coord,
-    int32_t offset,
-    int32_t dim,
-    BoundaryMode mode = BoundaryMode::WRAP);
 
 // Represents a range of MeshCoordinates. Requires that mesh coordinates have the same dimensionality.
 class MeshCoordinateRange {
@@ -402,12 +398,12 @@ const MeshCoordinateRange& MeshContainer<T>::coord_range() const {
 
 template <typename T>
 T& MeshContainer<T>::at(const MeshCoordinate& coord) {
-    return values_.at(to_linear_index(shape_, coord));
+    return values_.at(coord.to_linear_index(shape_));
 }
 
 template <typename T>
 const T& MeshContainer<T>::at(const MeshCoordinate& coord) const {
-    return values_.at(to_linear_index(shape_, coord));
+    return values_.at(coord.to_linear_index(shape_));
 }
 
 template <typename T>

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -65,6 +65,21 @@ bool check_mergeable(const MeshCoordinateRange& a, const MeshCoordinateRange& b)
     }
 }
 
+int32_t normalize_index(int32_t index, int32_t size) {
+    int32_t normalized_index = index;
+    if (normalized_index < 0) {
+        normalized_index += size;
+    }
+    TT_FATAL(
+        normalized_index >= 0 && normalized_index < size,
+        "Index out of bounds: {} not in [{}, {})",
+        index,
+        -size,
+        size);
+
+    return normalized_index;
+}
+
 }  // namespace
 
 MeshShape::MeshShape(uint32_t s) : MeshShape({s}) {}
@@ -124,7 +139,41 @@ MeshCoordinate MeshCoordinate::zero_coordinate(size_t dimensions) {
 
 size_t MeshCoordinate::dims() const { return value_.size(); }
 tt::stl::Span<const uint32_t> MeshCoordinate::coords() const { return value_; }
-uint32_t MeshCoordinate::operator[](size_t dim) const { return value_[dim]; }
+uint32_t MeshCoordinate::operator[](int32_t dim) const { return value_[normalize_index(dim, dims())]; }
+uint32_t& MeshCoordinate::operator[](int32_t dim) { return value_[normalize_index(dim, dims())]; }
+
+std::optional<MeshCoordinate> get_neighbor(
+    const MeshShape& shape, const MeshCoordinate& coord, int32_t offset, int32_t dim, BoundaryMode mode) {
+    TT_FATAL(
+        shape.dims() == coord.dims(),
+        "Shape and coordinate dimensions do not match: {} != {}",
+        shape.dims(),
+        coord.dims());
+    dim = normalize_index(dim, shape.dims());
+
+    for (size_t i = 0; i < coord.dims(); ++i) {
+        TT_FATAL(coord[i] < shape[i], "Coordinate {} is out of bounds for shape {}", coord, shape);
+    }
+
+    const auto boundary = static_cast<int32_t>(shape[dim]);
+    const int32_t current_pos = static_cast<int32_t>(coord[dim]);
+    const int32_t new_pos = current_pos + offset;
+
+    MeshCoordinate result = coord;
+
+    switch (mode) {
+        case BoundaryMode::WRAP: result[dim] = ((new_pos % boundary) + boundary) % boundary; break;
+        case BoundaryMode::CLAMP: result[dim] = std::clamp(new_pos, 0, boundary - 1); break;
+        case BoundaryMode::NONE:
+            if (new_pos < 0 || new_pos >= boundary) {
+                return std::nullopt;
+            }
+            result[dim] = new_pos;
+            break;
+    }
+
+    return result;
+}
 
 bool operator==(const MeshCoordinate& lhs, const MeshCoordinate& rhs) {
     return lhs.dims() == rhs.dims() && std::equal(lhs.coords().begin(), lhs.coords().end(), rhs.coords().begin());
@@ -239,17 +288,13 @@ MeshCoordinateRange::Iterator MeshCoordinateRange::Iterator::operator++(int) {
 
 MeshCoordinateRange::Iterator& MeshCoordinateRange::Iterator::operator++() {
     ++linear_index_;
-
-    tt::stl::SmallVector<uint32_t> new_coords(current_coord_.coords().begin(), current_coord_.coords().end());
-    for (int i = new_coords.size() - 1; i >= 0; --i) {
-        auto& dimension_value = new_coords[i];
-        if (++dimension_value > range_->end_coord()[i]) {
-            dimension_value = range_->start_coord()[i];
+    for (int i = current_coord_.dims() - 1; i >= 0; --i) {
+        if (++current_coord_[i] > range_->end_coord()[i]) {
+            current_coord_[i] = range_->start_coord()[i];
         } else {
             break;
         }
     }
-    current_coord_ = MeshCoordinate(new_coords);
     return *this;
 }
 const MeshCoordinate& MeshCoordinateRange::Iterator::operator*() const { return current_coord_; }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -449,7 +449,7 @@ std::vector<IDevice*> MeshDevice::get_row_major_devices(const MeshShape& new_sha
 
     // From an MxN mesh, we can always reduce rank to a 1xM*N Line mesh.
     // However, going from a Line mesh to an MxN mesh is not always possible.
-    if (is_line_topology(new_shape)) {
+    if (new_shape.is_line_topology()) {
         return view_->get_line_devices();
     }
 

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -95,7 +95,7 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(
         }
     }();
 
-    if (is_line_topology(shape)) {
+    if (shape.is_line_topology()) {
         // TODO: consider if we can do this in 3D.
         TT_FATAL(system_shape.dims() == 2, "Line topology is only supported for 2D meshes");
         TT_FATAL(


### PR DESCRIPTION
### Ticket
#24631

### Problem description
Need convenience functions for computing neighbors along particular dimensions.

### What's changed
Add `get_neighbor` to mesh coordinate infra. 

Also added `operator[]` overload to mutate `MeshCoordinate` in-place.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16129219165)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/16129222659)
- [x] New/Existing tests provide coverage for changes