### PR TITLE
#24668: Fix call to memcpy to not read extra bytes

### DIFF
--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -414,7 +414,10 @@ void populate_interleaved_buffer_write_dispatch_cmds(
                 src_address_offset += dispatch_params.data_size_to_copy;
             }
         } else {
-            command_sequence.add_data((char*)src + src_address_offset, buffer.size(), data_size_bytes);
+            command_sequence.add_data(
+                (char*)src + src_address_offset,
+                dispatch_params.data_size_to_copy * dispatch_params.pages_per_txn,
+                data_size_bytes);
         }
     }
 }

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -414,7 +414,7 @@ void populate_interleaved_buffer_write_dispatch_cmds(
                 src_address_offset += dispatch_params.data_size_to_copy;
             }
         } else {
-            command_sequence.add_data((char*)src + src_address_offset, data_size_bytes, data_size_bytes);
+            command_sequence.add_data((char*)src + src_address_offset, buffer.size(), data_size_bytes);
         }
     }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24668

### Problem description
We sometimes issued memcpy calls that were larger than the src buffer, as we were using the size of dst.

### What's changed
Copy only up to the src buffer size.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16132637718
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] New/Existing tests provide coverage for changes