### PR TITLE
Implement support for sharded buffers with page sizes > max prefetch command size

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -153,10 +153,9 @@ void clear_buffer(CommandQueue& cq, Buffer& buffer) {
 vector<ShardedSubBufferStressTestConfig> generate_sharded_sub_buffer_test_configs(uint32_t max_buffer_size) {
     vector<ShardedSubBufferStressTestConfig> configs;
 
-    const uint32_t max_prefetch_command_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
-    uint32_t buffer_size = 10 * max_prefetch_command_size;
+    uint32_t buffer_size = 0;
     while (buffer_size <= max_buffer_size) {
-        uint32_t page_size = max_prefetch_command_size;
+        uint32_t page_size = 4;
         while (page_size <= buffer_size) {
             uint32_t region_offset = 0;
             while (buffer_size % page_size == 0 && region_offset < buffer_size) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
@@ -15,6 +15,7 @@ struct TestBufferConfig {
     uint32_t num_pages;
     uint32_t page_size;
     BufferType buftype;
+    std::optional<BufferShardingArgs> sharding_args = std::nullopt;  // only used for sharded buffers
 };
 
 struct CoreCoordsL1 {

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -506,17 +506,13 @@ void FDMeshCommandQueue::read_shard_from_device(
             }
         }
     } else {
-        buffer_dispatch::BufferReadDispatchParamsVariant dispatch_params_variant =
+        buffer_dispatch::BufferReadDispatchParams dispatch_params =
             buffer_dispatch::initialize_interleaved_buf_read_dispatch_params(
                 *shard_view, id_, expected_num_workers_completed_);
 
-        buffer_dispatch::BufferReadDispatchParams* dispatch_params = std::visit(
-            [](auto& val) { return static_cast<buffer_dispatch::BufferReadDispatchParams*>(&val); },
-            dispatch_params_variant);
-
         buffer_dispatch::copy_interleaved_buffer_to_completion_queue(
-            *dispatch_params, *shard_view, sub_device_ids, this->dispatch_core_type());
-        if (dispatch_params->pages_per_txn > 0) {
+            dispatch_params, *shard_view, sub_device_ids, this->dispatch_core_type());
+        if (dispatch_params.pages_per_txn > 0) {
             num_txns_per_device[device]++;
             auto& read_descriptor_queue = this->get_read_descriptor_queue(device);
             read_descriptor_queue.push(

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -59,7 +59,7 @@ struct BufferWriteDispatchParams {
     IDevice* device = nullptr;
     uint32_t cq_id = 0;
 
-    virtual void calculate_issue_wait() {
+    void calculate_issue_wait() {
         this->issue_wait = this->total_pages_written == 0;  // only stall for the first write of the buffer
     }
 };

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -749,6 +749,7 @@ void write_to_device_buffer(
                 return nullptr;
             },
             dispatch_params_variant);
+        TT_ASSERT(dispatch_params != nullptr);
 
         const std::vector<CoreCoord>& cores = dispatch_params->buffer_page_mapping->all_cores;
         // Since we read core by core we are reading the device pages sequentially
@@ -781,6 +782,7 @@ void write_to_device_buffer(
                 return nullptr;
             },
             dispatch_params_variant);
+        TT_ASSERT(dispatch_params != nullptr);
 
         write_interleaved_buffer_to_device(
             src, *dispatch_params, *root_buffer, buf_dispatch_constants, sub_device_ids, dispatch_core_type);

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -262,112 +262,100 @@ public:
         this->device = buffer.device();
         this->expected_num_workers_completed = expected_num_workers_completed;
         this->buffer_page_mapping = buffer.get_buffer_page_mapping();
-        this->total_pages_to_write = total_pages_to_write;
         this->total_pages_written = 0;
-        this->data_size_to_copy = buffer.page_size();
-        this->page_size_to_write = buffer.aligned_page_size();
+        this->are_pages_large = are_pages_larger_than_max_prefetch_cmd_size(buffer);
+
+        if (this->are_pages_large) {
+            const PartialPageSpec partial_page_spec = calculate_partial_page_spec(buffer);
+            this->size_of_partial_page = partial_page_spec.partial_page_size;
+            this->page_size_to_write = partial_page_spec.partial_page_size;
+            this->data_size_to_copy = partial_page_spec.partial_page_size;
+            this->total_pages_to_write = total_pages_to_write * partial_page_spec.num_partial_pages_per_full_page;
+            this->num_partial_pages_in_single_full_page = partial_page_spec.num_partial_pages_per_full_page;
+        } else {
+            this->total_pages_to_write = total_pages_to_write;
+            this->page_size_to_write = buffer.aligned_page_size();
+            this->data_size_to_copy = buffer.page_size();
+            this->num_partial_pages_in_single_full_page = 1;
+            this->size_of_partial_page = buffer.aligned_page_size();
+        }
     }
 
-    virtual ~ShardedBufferWriteDispatchParams() = default;
+    ~ShardedBufferWriteDispatchParams() = default;
 
-    virtual void reset_params_for_core(const CoreCoord& core, const BufferCorePageMapping& core_page_mapping) {
+    void reset_params_for_core(const CoreCoord& core, const BufferCorePageMapping& core_page_mapping) {
         this->core = core;
         this->core_page_mapping_it = core_page_mapping.begin();
-        this->core_num_pages_remaining_to_write = core_page_mapping.num_pages;
         this->address = this->buffer.address() + core_page_mapping.device_start_page * this->buffer.aligned_page_size();
         if (this->buffer.is_dram()) {
             this->address += this->buffer.device()->allocator()->get_bank_offset(
                 BufferType::DRAM, this->buffer.device()->dram_channel_from_logical_core(core));
         }
-    }
-
-    virtual bool write_large_pages() const { return false; }
-
-    virtual uint32_t partial_page_size() const { return this->page_size_to_write; }
-
-    virtual uint32_t num_partial_pages_written_for_current_transaction_full_page() const { return 1; }
-
-    virtual void calculate_params_for_write_transaction(uint32_t num_pages_available_in_cq) {
-        this->pages_per_txn = std::min(this->core_num_pages_remaining_to_write, num_pages_available_in_cq);
-    }
-
-    virtual void update_params_after_write_transaction() {
-        this->total_pages_to_write -= this->pages_per_txn;
-        this->total_pages_written += this->pages_per_txn;
-        this->address += this->pages_per_txn * this->page_size_to_write;
-        this->core_num_pages_remaining_to_write -= this->pages_per_txn;
-    }
-
-protected:
-    const Buffer& buffer;
-};
-
-class ShardedBufferWriteLargePageDispatchParams : public ShardedBufferWriteDispatchParams {
-public:
-    ShardedBufferWriteLargePageDispatchParams(
-        Buffer& buffer,
-        const PartialPageSpec& partial_page_spec,
-        uint32_t total_pages_to_write,
-        uint32_t num_full_pages,
-        uint32_t cq_id,
-        tt::stl::Span<const uint32_t> expected_num_workers_completed) :
-        ShardedBufferWriteDispatchParams(buffer, total_pages_to_write, cq_id, expected_num_workers_completed) {
-        this->size_of_partial_page = partial_page_spec.partial_page_size;
-        this->page_size_to_write = partial_page_spec.partial_page_size;
-        this->data_size_to_copy = partial_page_spec.partial_page_size;
-        this->num_partial_pages_in_single_full_page = partial_page_spec.num_partial_pages_per_full_page;
-    }
-
-    void reset_params_for_core(const CoreCoord& core, const BufferCorePageMapping& core_page_mapping) override {
-        ShardedBufferWriteDispatchParams::reset_params_for_core(core, core_page_mapping);
-        this->core_num_pages_remaining_to_write *= this->num_partial_pages_in_single_full_page;
-    }
-
-    bool write_large_pages() const override { return true; }
-
-    uint32_t partial_page_size() const override { return this->size_of_partial_page; }
-
-    uint32_t num_partial_pages_written_for_current_transaction_full_page() const override {
-        return this->num_partial_pages_written_for_curr_full_page;
-    }
-
-    void calculate_params_for_write_transaction(uint32_t num_pages_available_in_cq) override {
-        const int32_t num_partial_pages_remaining_in_curr_full_page =
-            this->num_partial_pages_in_single_full_page - this->num_partial_pages_written_for_curr_full_page;
-        TT_ASSERT(num_partial_pages_remaining_in_curr_full_page > 0);
-        const uint32_t max_num_partial_pages_to_write_in_curr_txn =
-            (num_partial_pages_remaining_in_curr_full_page == 1) ? 1
-                                                                 : num_partial_pages_remaining_in_curr_full_page - 1;
-        this->pages_per_txn = std::min(
-            {this->core_num_pages_remaining_to_write,
-             max_num_partial_pages_to_write_in_curr_txn,
-             num_pages_available_in_cq});
-
-        if (num_partial_pages_remaining_in_curr_full_page == 1) {
-            this->page_size_to_write =
-                this->buffer.aligned_page_size() -
-                (this->num_partial_pages_written_for_curr_full_page * this->size_of_partial_page);
-            this->data_size_to_copy = this->buffer.page_size() -
-                                      (this->num_partial_pages_written_for_curr_full_page * this->size_of_partial_page);
+        if (this->are_pages_large) {
+            this->core_num_pages_remaining_to_write =
+                core_page_mapping.num_pages * this->num_partial_pages_in_single_full_page;
+        } else {
+            this->core_num_pages_remaining_to_write = core_page_mapping.num_pages;
         }
     }
 
-    void update_params_after_write_transaction() override {
+    bool write_large_pages() const { return this->are_pages_large; }
+
+    uint32_t partial_page_size() const { return this->size_of_partial_page; }
+
+    uint32_t num_partial_pages_written_for_current_transaction_full_page() const {
+        return this->num_partial_pages_written_for_curr_full_page;
+    }
+
+    void calculate_params_for_write_transaction(uint32_t num_pages_available_in_cq) {
+        if (this->are_pages_large) {
+            const int32_t num_partial_pages_remaining_in_curr_full_page =
+                this->num_partial_pages_in_single_full_page - this->num_partial_pages_written_for_curr_full_page;
+            TT_ASSERT(num_partial_pages_remaining_in_curr_full_page > 0);
+            const uint32_t max_num_partial_pages_to_write_in_curr_txn =
+                (num_partial_pages_remaining_in_curr_full_page == 1)
+                    ? 1
+                    : num_partial_pages_remaining_in_curr_full_page - 1;
+            this->pages_per_txn = std::min(
+                {this->core_num_pages_remaining_to_write,
+                 max_num_partial_pages_to_write_in_curr_txn,
+                 num_pages_available_in_cq});
+
+            if (num_partial_pages_remaining_in_curr_full_page == 1) {
+                this->page_size_to_write =
+                    this->buffer.aligned_page_size() -
+                    (this->num_partial_pages_written_for_curr_full_page * this->size_of_partial_page);
+                this->data_size_to_copy =
+                    this->buffer.page_size() -
+                    (this->num_partial_pages_written_for_curr_full_page * this->size_of_partial_page);
+            }
+        } else {
+            this->pages_per_txn = std::min(this->core_num_pages_remaining_to_write, num_pages_available_in_cq);
+        }
+    }
+
+    void update_params_after_write_transaction() {
         this->total_pages_to_write -= this->pages_per_txn;
         this->total_pages_written += this->pages_per_txn;
-        this->num_partial_pages_written_for_curr_full_page += this->pages_per_txn;
         this->address += this->pages_per_txn * this->page_size_to_write;
         this->core_num_pages_remaining_to_write -= this->pages_per_txn;
-        if (this->num_partial_pages_written_for_curr_full_page == this->num_partial_pages_in_single_full_page) {
-            this->page_size_to_write = this->size_of_partial_page;
-            this->data_size_to_copy = this->size_of_partial_page;
+        if (this->are_pages_large) {
+            this->num_partial_pages_written_for_curr_full_page += this->pages_per_txn;
+            if (this->num_partial_pages_written_for_curr_full_page == this->num_partial_pages_in_single_full_page) {
+                this->page_size_to_write = this->size_of_partial_page;
+                this->data_size_to_copy = this->size_of_partial_page;
 
-            this->num_partial_pages_written_for_curr_full_page = 0;
-            ++this->core_page_mapping_it;
+                this->num_partial_pages_written_for_curr_full_page = 0;
+                ++this->core_page_mapping_it;
+            }
+        } else {
+            this->num_partial_pages_written_for_curr_full_page = 1;
         }
     }
 
 private:
+    const Buffer& buffer;
+    bool are_pages_large = false;
     uint32_t size_of_partial_page = 0;
     uint32_t num_partial_pages_written_for_curr_full_page = 0;
     uint32_t num_partial_pages_in_single_full_page = 0;
@@ -426,30 +414,6 @@ void update_offset_on_issue_wait_cmd(uint32_t& byte_offset, bool issue_wait, uin
         // commands prefixed with CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
         byte_offset += (MetalContext::instance().hal().get_alignment(HalMemType::HOST) * num_sub_devices);
     }
-}
-
-using ShardedBufferWriteDispatchParamsVariant =
-    std::variant<std::monostate, ShardedBufferWriteDispatchParams, ShardedBufferWriteLargePageDispatchParams>;
-
-// Initialize Dispatch Parameters - reused across write txns
-ShardedBufferWriteDispatchParamsVariant initialize_sharded_buf_dispatch_params(
-    Buffer& buffer, uint32_t cq_id, tt::stl::Span<const uint32_t> expected_num_workers_completed) {
-    ShardedBufferWriteDispatchParamsVariant dispatch_params;
-
-    uint32_t total_pages_to_write = buffer.size() / buffer.page_size();
-
-    if (are_pages_larger_than_max_prefetch_cmd_size(buffer)) {
-        const PartialPageSpec partial_page_spec = calculate_partial_page_spec(buffer);
-        const uint32_t num_full_pages = total_pages_to_write;
-        total_pages_to_write = num_full_pages * partial_page_spec.num_partial_pages_per_full_page;
-        dispatch_params.emplace<ShardedBufferWriteLargePageDispatchParams>(
-            buffer, partial_page_spec, total_pages_to_write, num_full_pages, cq_id, expected_num_workers_completed);
-    } else {
-        dispatch_params.emplace<ShardedBufferWriteDispatchParams>(
-            buffer, total_pages_to_write, cq_id, expected_num_workers_completed);
-    }
-
-    return dispatch_params;
 }
 
 using InterleavedBufferWriteDispatchParamsVariant =
@@ -739,29 +703,19 @@ void write_to_device_buffer(
     // TODO: When writing to L1, modify this function to use enqueue_write_to_core
 
     if (is_sharded(buffer.buffer_layout())) {
-        ShardedBufferWriteDispatchParamsVariant dispatch_params_variant =
-            initialize_sharded_buf_dispatch_params(buffer, cq_id, expected_num_workers_completed);
-        ShardedBufferWriteDispatchParams* dispatch_params = std::visit(
-            [](auto& val) -> ShardedBufferWriteDispatchParams* {
-                if constexpr (!std::is_same_v<std::decay_t<decltype(val)>, std::monostate>) {
-                    return static_cast<ShardedBufferWriteDispatchParams*>(&val);
-                }
-                return nullptr;
-            },
-            dispatch_params_variant);
-        TT_ASSERT(dispatch_params != nullptr);
-
-        const std::vector<CoreCoord>& cores = dispatch_params->buffer_page_mapping->all_cores;
+        ShardedBufferWriteDispatchParams dispatch_params(
+            buffer, buffer.size() / buffer.page_size(), cq_id, expected_num_workers_completed);
+        const std::vector<CoreCoord>& cores = dispatch_params.buffer_page_mapping->all_cores;
         // Since we read core by core we are reading the device pages sequentially
         for (uint32_t core_id = 0; core_id < buffer.num_cores(); ++core_id) {
             for (const BufferCorePageMapping& core_page_mapping :
-                 dispatch_params->buffer_page_mapping->core_page_mappings[core_id]) {
+                 dispatch_params.buffer_page_mapping->core_page_mappings[core_id]) {
                 write_sharded_buffer_to_core(
                     src,
                     core_id,
                     core_page_mapping,
                     buffer,
-                    *dispatch_params,
+                    dispatch_params,
                     buf_dispatch_constants,
                     sub_device_ids,
                     cores[core_id],

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -13,6 +13,7 @@
 #include <utility>
 
 #include "assert.hpp"
+#include "buffer_page_mapping.hpp"
 #include "buffer_types.hpp"
 #include "dispatch.hpp"
 #include "impl/context/metal_context.hpp"
@@ -50,7 +51,6 @@ struct BufferDispatchConstants {
 struct BufferWriteDispatchParams {
     tt::stl::Span<const uint32_t> expected_num_workers_completed;
     uint32_t address = 0;
-    uint32_t dst_page_index = 0;
     uint32_t page_size_to_write = 0;
     uint32_t total_pages_to_write = 0;
     uint32_t total_pages_written = 0;
@@ -63,6 +63,7 @@ struct BufferWriteDispatchParams {
 // Parameters specific to interleaved buffers
 class InterleavedBufferWriteDispatchParams : public BufferWriteDispatchParams {
 public:
+    uint32_t dst_page_index = 0;
     uint32_t data_size_to_copy = 0;
 
     InterleavedBufferWriteDispatchParams(
@@ -245,14 +246,154 @@ private:
 };
 
 // Parameters specific to sharded buffers
-struct ShardedBufferWriteDispatchParams : BufferWriteDispatchParams {
+class ShardedBufferWriteDispatchParams : public BufferWriteDispatchParams {
+public:
     std::shared_ptr<const BufferPageMapping> buffer_page_mapping = nullptr;
     BufferCorePageMapping::Iterator core_page_mapping_it;
     CoreCoord core;
+    uint32_t core_num_pages_remaining_to_write = 0;
+    uint32_t data_size_to_copy = 0;
+
+    ShardedBufferWriteDispatchParams(
+        Buffer& buffer,
+        uint32_t total_pages_to_write,
+        uint32_t cq_id,
+        tt::stl::Span<const uint32_t> expected_num_workers_completed) :
+        buffer(buffer) {
+        this->cq_id = cq_id;
+        this->device = buffer.device();
+        this->expected_num_workers_completed = expected_num_workers_completed;
+        this->buffer_page_mapping = buffer.get_buffer_page_mapping();
+        this->total_pages_to_write = total_pages_to_write;
+        this->total_pages_written = 0;
+        this->data_size_to_copy = buffer.page_size();
+        this->page_size_to_write = buffer.aligned_page_size();
+    }
+
+    virtual ~ShardedBufferWriteDispatchParams() = default;
+
+    void calculate_issue_wait() {
+        this->issue_wait = this->total_pages_written == 0;  // only stall for the first write of the buffer
+    }
+
+    virtual void reset_params_for_core(const CoreCoord& core, const BufferCorePageMapping& core_page_mapping) {
+        this->core = core;
+        this->core_page_mapping_it = core_page_mapping.begin();
+        this->core_num_pages_remaining_to_write =
+            core_page_mapping.num_pages;  // this needs to be updated for large pages
+        this->address = this->buffer.address() + core_page_mapping.device_start_page * this->buffer.aligned_page_size();
+        if (this->buffer.is_dram()) {
+            this->address += this->buffer.device()->allocator()->get_bank_offset(
+                BufferType::DRAM, this->buffer.device()->dram_channel_from_logical_core(core));
+        }
+    }
+
+    virtual bool write_large_pages() const { return false; }
+
+    virtual uint32_t partial_page_size() const { return this->page_size_to_write; }
+
+    virtual uint32_t num_partial_pages_written_for_current_transaction_full_page() const { return 1; }
+
+    virtual void calculate_params_for_write_transaction(uint32_t num_pages_available_in_cq) {
+        this->pages_per_txn = std::min(this->core_num_pages_remaining_to_write, num_pages_available_in_cq);
+    }
+
+    virtual void update_params_after_write_transaction() {
+        this->total_pages_to_write -= this->pages_per_txn;
+        this->total_pages_written += this->pages_per_txn;
+        this->address += this->pages_per_txn * this->page_size_to_write;
+        this->core_num_pages_remaining_to_write -= this->pages_per_txn;
+    }
+
+protected:
+    const Buffer& buffer;
+};
+
+class ShardedBufferWriteLargePageDispatchParams : public ShardedBufferWriteDispatchParams {
+public:
+    uint32_t size_of_partial_page = 0;
+    // uint32_t full_pages_to_write = 0;
+
+    ShardedBufferWriteLargePageDispatchParams(
+        Buffer& buffer,
+        const PartialPageSpec& partial_page_spec,
+        uint32_t total_pages_to_write,
+        uint32_t num_full_pages,
+        uint32_t cq_id,
+        tt::stl::Span<const uint32_t> expected_num_workers_completed) :
+        ShardedBufferWriteDispatchParams(buffer, total_pages_to_write, cq_id, expected_num_workers_completed) {
+        this->size_of_partial_page = partial_page_spec.partial_page_size;
+        this->page_size_to_write = partial_page_spec.partial_page_size;
+        this->data_size_to_copy = partial_page_spec.partial_page_size;
+        // this->full_pages_to_write = num_full_pages;
+        this->num_partial_pages_in_single_full_page = partial_page_spec.num_partial_pages_per_full_page;
+    }
+
+    void reset_params_for_core(const CoreCoord& core, const BufferCorePageMapping& core_page_mapping) override {
+        ShardedBufferWriteDispatchParams::reset_params_for_core(core, core_page_mapping);
+        this->core_num_pages_remaining_to_write *= this->num_partial_pages_in_single_full_page;
+    }
+
+    bool write_large_pages() const override { return true; }
+
+    uint32_t partial_page_size() const override { return this->size_of_partial_page; }
+
+    uint32_t num_partial_pages_written_for_current_transaction_full_page() const override {
+        return this->num_partial_pages_written_for_curr_full_page;
+    }
+
+    void calculate_params_for_write_transaction(uint32_t num_pages_available_in_cq) override {
+        const uint32_t num_partial_pages_remaining_in_curr_full_page =
+            this->num_partial_pages_in_single_full_page - this->num_partial_pages_written_for_curr_full_page;
+        TT_ASSERT(num_partial_pages_remaining_in_curr_full_page > 0);
+        const uint32_t max_num_partial_pages_to_write_in_curr_txn =
+            (num_partial_pages_remaining_in_curr_full_page == 1) ? 1
+                                                                 : num_partial_pages_remaining_in_curr_full_page - 1;
+        this->pages_per_txn = std::min(
+            {this->core_num_pages_remaining_to_write,
+             max_num_partial_pages_to_write_in_curr_txn,
+             num_pages_available_in_cq});
+
+        if (num_partial_pages_remaining_in_curr_full_page == 1) {
+            this->page_size_to_write =
+                this->buffer.aligned_page_size() -
+                (this->num_partial_pages_written_for_curr_full_page * this->size_of_partial_page);
+            this->data_size_to_copy = this->buffer.page_size() -
+                                      (this->num_partial_pages_written_for_curr_full_page * this->size_of_partial_page);
+        }
+    }
+
+    void update_params_after_write_transaction() override {
+        this->total_pages_to_write -= this->pages_per_txn;
+        this->total_pages_written += this->pages_per_txn;
+        this->num_partial_pages_written_for_curr_full_page += this->pages_per_txn;
+        this->address += this->pages_per_txn * this->page_size_to_write;
+        this->core_num_pages_remaining_to_write -= this->pages_per_txn;
+        if (this->num_partial_pages_written_for_curr_full_page == this->num_partial_pages_in_single_full_page) {
+            // this->full_pages_to_write -= 1;
+            // this->full_pages_written += 1;
+
+            this->page_size_to_write = this->size_of_partial_page;
+            this->data_size_to_copy = this->size_of_partial_page;
+
+            this->num_partial_pages_written_for_curr_full_page = 0;
+            ++this->core_page_mapping_it;
+        }
+        // if (this->will_full_page_be_written_in_next_write_transaction()) {
+        //     this->page_size_to_write =
+        //         this->buffer.aligned_page_size() - (this->address - this->curr_full_pages_start_address);
+        //     this->data_size_to_copy = this->buffer.page_size() - (this->address -
+        //     this->curr_full_pages_start_address);
+        // }
+    }
+
+private:
+    uint32_t num_partial_pages_written_for_curr_full_page = 0;
+    uint32_t num_partial_pages_in_single_full_page = 0;
 };
 
 int32_t calculate_num_pages_available_in_cq(
-    const InterleavedBufferWriteDispatchParams& dispatch_params,
+    const BufferWriteDispatchParams& dispatch_params,
     const BufferDispatchConstants& dispatch_constants,
     uint32_t byte_offset_in_cq) {
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
@@ -268,6 +409,22 @@ bool are_pages_larger_than_max_prefetch_cmd_size(const Buffer& buffer) {
     const CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     const uint32_t max_data_size = calculate_max_prefetch_data_size_bytes(dispatch_core_type);
     return buffer.aligned_page_size() > max_data_size;
+}
+
+uint32_t calculate_partial_page_size(const Buffer& buffer) {
+    const HalMemType buffer_mem_type = buffer.memory_type();
+    const uint32_t partial_page_size = tt::align(
+        DispatchSettings::BASE_PARTIAL_PAGE_SIZE_DISPATCH,
+        MetalContext::instance().hal().get_common_alignment_with_pcie(buffer_mem_type));
+    return partial_page_size;
+}
+
+PartialPageSpec calculate_partial_page_spec(const Buffer& buffer) {
+    PartialPageSpec partial_page_spec;
+    partial_page_spec.partial_page_size = calculate_partial_page_size(buffer);
+    partial_page_spec.num_partial_pages_per_full_page =
+        tt::div_up(buffer.aligned_page_size(), partial_page_spec.partial_page_size);
+    return partial_page_spec;
 }
 
 // Generate dispatch constants
@@ -290,43 +447,28 @@ void update_offset_on_issue_wait_cmd(uint32_t& byte_offset, bool issue_wait, uin
     }
 }
 
+using ShardedBufferWriteDispatchParamsVariant =
+    std::variant<std::monostate, ShardedBufferWriteDispatchParams, ShardedBufferWriteLargePageDispatchParams>;
+
 // Initialize Dispatch Parameters - reused across write txns
-ShardedBufferWriteDispatchParams initialize_sharded_buf_dispatch_params(
-    Buffer& buffer,
-    uint32_t cq_id,
-    tt::stl::Span<const uint32_t> expected_num_workers_completed,
-    const BufferDispatchConstants& buf_dispatch_constants) {
-    ShardedBufferWriteDispatchParams dispatch_params;
-    dispatch_params.total_pages_to_write = buffer.size() / buffer.page_size();
-    dispatch_params.buffer_page_mapping = buffer.get_buffer_page_mapping();
-    dispatch_params.total_pages_written = 0;
-    dispatch_params.page_size_to_write = buffer.aligned_page_size();
-    dispatch_params.dst_page_index = 0;
-    dispatch_params.device = buffer.device();
-    dispatch_params.cq_id = cq_id;
-    dispatch_params.expected_num_workers_completed = expected_num_workers_completed;
+ShardedBufferWriteDispatchParamsVariant initialize_sharded_buf_dispatch_params(
+    Buffer& buffer, uint32_t cq_id, tt::stl::Span<const uint32_t> expected_num_workers_completed) {
+    ShardedBufferWriteDispatchParamsVariant dispatch_params;
 
-    TT_FATAL(
-        buf_dispatch_constants.max_data_sizeB >= dispatch_params.page_size_to_write,
-        "Writing padded page size > {} is currently unsupported for sharded tensors.",
-        buf_dispatch_constants.max_data_sizeB);
+    uint32_t total_pages_to_write = buffer.size() / buffer.page_size();
+
+    if (are_pages_larger_than_max_prefetch_cmd_size(buffer)) {
+        const PartialPageSpec partial_page_spec = calculate_partial_page_spec(buffer);
+        const uint32_t num_full_pages = total_pages_to_write;
+        total_pages_to_write = num_full_pages * partial_page_spec.num_partial_pages_per_full_page;
+        dispatch_params.emplace<ShardedBufferWriteLargePageDispatchParams>(
+            buffer, partial_page_spec, total_pages_to_write, num_full_pages, cq_id, expected_num_workers_completed);
+    } else {
+        dispatch_params.emplace<ShardedBufferWriteDispatchParams>(
+            buffer, total_pages_to_write, cq_id, expected_num_workers_completed);
+    }
+
     return dispatch_params;
-}
-
-uint32_t calculate_partial_page_size(const Buffer& buffer) {
-    const HalMemType buffer_mem_type = buffer.memory_type();
-    const uint32_t partial_page_size = tt::align(
-        DispatchSettings::BASE_PARTIAL_PAGE_SIZE_DISPATCH,
-        MetalContext::instance().hal().get_common_alignment_with_pcie(buffer_mem_type));
-    return partial_page_size;
-}
-
-PartialPageSpec calculate_partial_page_spec(const Buffer& buffer) {
-    PartialPageSpec partial_page_spec;
-    partial_page_spec.partial_page_size = calculate_partial_page_size(buffer);
-    partial_page_spec.num_partial_pages_per_full_page =
-        tt::div_up(buffer.aligned_page_size(), partial_page_spec.partial_page_size);
-    return partial_page_spec;
 }
 
 using InterleavedBufferWriteDispatchParamsVariant =
@@ -334,7 +476,6 @@ using InterleavedBufferWriteDispatchParamsVariant =
 
 InterleavedBufferWriteDispatchParamsVariant initialize_interleaved_buf_dispatch_params(
     const Buffer& buffer,
-    const BufferDispatchConstants& /*buf_dispatch_constants*/,
     uint32_t cq_id,
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
     const BufferRegion& region) {
@@ -427,20 +568,34 @@ void populate_sharded_buffer_write_dispatch_cmds(
     HugepageDeviceCommand& command_sequence,
     Buffer& buffer,
     ShardedBufferWriteDispatchParams& dispatch_params) {
-    uint32_t data_size_bytes = dispatch_params.pages_per_txn * dispatch_params.page_size_to_write;
-    auto noc_index = k_dispatch_downstream_noc;
+    const uint32_t data_size_bytes = dispatch_params.pages_per_txn * dispatch_params.page_size_to_write;
     const CoreCoord virtual_core =
         buffer.device()->virtual_core_from_logical_core(dispatch_params.core, buffer.core_type());
     command_sequence.add_dispatch_write_linear(
         0,
-        buffer.device()->get_noc_unicast_encoding(noc_index, virtual_core),
+        buffer.device()->get_noc_unicast_encoding(k_dispatch_downstream_noc, virtual_core),
         dispatch_params.address,
         data_size_bytes);
 
     uint8_t* dst = command_sequence.reserve_space<uint8_t*, true>(data_size_bytes);
     // TODO: Expose getter for cmd_write_offsetB?
     uint32_t dst_offset = dst - (uint8_t*)command_sequence.data();
-    if (buffer.page_size() == dispatch_params.page_size_to_write) {
+    if (dispatch_params.write_large_pages()) {
+        for (uint32_t i = 0; i < dispatch_params.pages_per_txn; ++i) {
+            const auto cur_host_page = *dispatch_params.core_page_mapping_it;
+            if (!cur_host_page) {
+                dst_offset += dispatch_params.page_size_to_write;
+                continue;
+            }
+            const uint32_t src_offset =
+                (*cur_host_page * buffer.page_size()) +
+                (dispatch_params.num_partial_pages_written_for_current_transaction_full_page() + i) *
+                    dispatch_params.partial_page_size();
+            command_sequence.update_cmd_sequence(
+                dst_offset, (char*)(src) + src_offset, dispatch_params.data_size_to_copy);
+            dst_offset += dispatch_params.page_size_to_write;
+        }
+    } else if (buffer.page_size() == dispatch_params.page_size_to_write) {
         uint32_t start_device_page_offset = dispatch_params.core_page_mapping_it.device_page_offset();
         uint32_t end_device_page_offset = start_device_page_offset + dispatch_params.pages_per_txn;
         while (true) {
@@ -558,52 +713,51 @@ void write_sharded_buffer_to_core(
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     const CoreCoord core,
     CoreType dispatch_core_type) {
-    // Skip writing the padded pages along the bottom
-    // Currently since writing sharded tensors uses write_linear, we write the padded pages on width
-    // Alternative write each page row into separate commands, or have a strided linear write
-    SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
-    uint32_t num_pages = core_page_mapping.num_pages;
+    // // Skip writing the padded pages along the bottom
+    // // Currently since writing sharded tensors uses write_linear, we write the padded pages on width
+    // // Alternative write each page row into separate commands, or have a strided linear write
+    // dispatch_params.core_num_pages_remaining_to_write = core_page_mapping.num_pages;
 
-    uint32_t bank_base_address = buffer.address();
-    bank_base_address += core_page_mapping.device_start_page * buffer.aligned_page_size();
-    if (buffer.is_dram()) {
-        bank_base_address += buffer.device()->allocator()->get_bank_offset(
-            BufferType::DRAM, buffer.device()->dram_channel_from_logical_core(core));
-    }
+    // // reset dispatch params for core
+    // uint32_t bank_base_address = buffer.address();
+    // bank_base_address += core_page_mapping.device_start_page * buffer.aligned_page_size();
+    // if (buffer.is_dram()) {
+    //     bank_base_address += buffer.device()->allocator()->get_bank_offset(
+    //         BufferType::DRAM, buffer.device()->dram_channel_from_logical_core(core));
+    // }
 
-    dispatch_params.core_page_mapping_it = core_page_mapping.begin();
+    // dispatch_params.core_page_mapping_it = core_page_mapping.begin();
+    // dispatch_params.core = core;
 
-    while (num_pages != 0) {
+    dispatch_params.reset_params_for_core(core, core_page_mapping);
+
+    while (dispatch_params.core_num_pages_remaining_to_write != 0) {
         // data appended after CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_PAGED
         uint32_t data_offset_bytes = (sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd));
-        dispatch_params.issue_wait =
-            dispatch_params.total_pages_written == 0;  // only stall for the first write of the buffer
+
+        dispatch_params.calculate_issue_wait();
 
         update_offset_on_issue_wait_cmd(data_offset_bytes, dispatch_params.issue_wait, sub_device_ids.size());
 
-        uint32_t space_available_bytes = std::min(
-            buf_dispatch_constants.issue_queue_cmd_limit -
-                sysmem_manager.get_issue_queue_write_ptr(dispatch_params.cq_id),
-            buf_dispatch_constants.max_prefetch_cmd_size);
-        int32_t num_pages_available =
-            (int32_t(space_available_bytes) - int32_t(data_offset_bytes)) / int32_t(dispatch_params.page_size_to_write);
-
-        if (num_pages_available <= 0) {
+        const int32_t num_pages_available_in_cq =
+            calculate_num_pages_available_in_cq(dispatch_params, buf_dispatch_constants, data_offset_bytes);
+        if (num_pages_available_in_cq <= 0) {
+            SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
             sysmem_manager.wrap_issue_queue_wr_ptr(dispatch_params.cq_id);
             continue;
         }
 
-        dispatch_params.pages_per_txn = std::min(num_pages, (uint32_t)num_pages_available);
-        dispatch_params.address =
-            bank_base_address + (core_page_mapping.num_pages - num_pages) * dispatch_params.page_size_to_write;
-        dispatch_params.core = core;
+        log_debug(tt::LogDispatch, "EnqueueWriteBuffer for command queue {}", dispatch_params.cq_id);
 
-        log_debug(tt::LogDispatch, "EnqueueWriteBuffer for channel {}", dispatch_params.cq_id);
-
+        // calculate dispatch params before write
+        // dispatch_params.pages_per_txn = std::min(dispatch_params.core_num_pages_remaining_to_write,
+        // (uint32_t)num_pages_available_in_cq); dispatch_params.address =
+        //     bank_base_address + (core_page_mapping.num_pages - dispatch_params.core_num_pages_remaining_to_write) *
+        //     dispatch_params.page_size_to_write;
+        dispatch_params.calculate_params_for_write_transaction(num_pages_available_in_cq);
         issue_buffer_dispatch_command_sequence(src, buffer, dispatch_params, sub_device_ids, dispatch_core_type);
-        num_pages -= dispatch_params.pages_per_txn;
-        dispatch_params.total_pages_to_write -= dispatch_params.pages_per_txn;
-        dispatch_params.total_pages_written += dispatch_params.pages_per_txn;
+        // update dispatch params after write
+        dispatch_params.update_params_after_write_transaction();
     }
 }
 
@@ -622,18 +776,28 @@ void write_to_device_buffer(
     // TODO: When writing to L1, modify this function to use enqueue_write_to_core
 
     if (is_sharded(buffer.buffer_layout())) {
-        ShardedBufferWriteDispatchParams dispatch_params = initialize_sharded_buf_dispatch_params(
-            buffer, cq_id, expected_num_workers_completed, buf_dispatch_constants);
-        const auto& cores = dispatch_params.buffer_page_mapping->all_cores;
+        ShardedBufferWriteDispatchParamsVariant dispatch_params_variant =
+            initialize_sharded_buf_dispatch_params(buffer, cq_id, expected_num_workers_completed);
+        ShardedBufferWriteDispatchParams* dispatch_params = std::visit(
+            [](auto& val) -> ShardedBufferWriteDispatchParams* {
+                if constexpr (!std::is_same_v<std::decay_t<decltype(val)>, std::monostate>) {
+                    return static_cast<ShardedBufferWriteDispatchParams*>(&val);
+                }
+                return nullptr;
+            },
+            dispatch_params_variant);
+
+        const std::vector<CoreCoord>& cores = dispatch_params->buffer_page_mapping->all_cores;
         // Since we read core by core we are reading the device pages sequentially
         for (uint32_t core_id = 0; core_id < buffer.num_cores(); ++core_id) {
-            for (const auto& core_page_mapping : dispatch_params.buffer_page_mapping->core_page_mappings[core_id]) {
+            for (const BufferCorePageMapping& core_page_mapping :
+                 dispatch_params->buffer_page_mapping->core_page_mappings[core_id]) {
                 write_sharded_buffer_to_core(
                     src,
                     core_id,
                     core_page_mapping,
                     buffer,
-                    dispatch_params,
+                    *dispatch_params,
                     buf_dispatch_constants,
                     sub_device_ids,
                     cores[core_id],
@@ -644,8 +808,7 @@ void write_to_device_buffer(
         auto root_buffer = buffer.root_buffer();
         auto region = buffer.root_buffer_region();
         InterleavedBufferWriteDispatchParamsVariant dispatch_params_variant =
-            initialize_interleaved_buf_dispatch_params(
-                *root_buffer, buf_dispatch_constants, cq_id, expected_num_workers_completed, region);
+            initialize_interleaved_buf_dispatch_params(*root_buffer, cq_id, expected_num_workers_completed, region);
 
         InterleavedBufferWriteDispatchParams* dispatch_params = std::visit(
             [](auto& val) -> InterleavedBufferWriteDispatchParams* {
@@ -677,6 +840,8 @@ ShardedBufferReadDispatchParams initialize_sharded_buf_read_dispatch_params(
     dispatch_params.unpadded_dst_offset = 0;
     dispatch_params.buffer_page_mapping = buffer.get_buffer_page_mapping();
     dispatch_params.total_pages_to_read = buffer.size() / buffer.page_size();
+    log_info(tt::LogDispatch, "total_pages_to_read: {}", dispatch_params.total_pages_to_read);
+    log_info(tt::LogDispatch, "padded_page_size: {}", dispatch_params.padded_page_size);
     dispatch_params.total_pages_read = 0;
     dispatch_params.expected_num_workers_completed = expected_num_workers_completed;
     return dispatch_params;

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -694,21 +694,9 @@ void write_sharded_buffer_to_core(
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     const CoreCoord core,
     CoreType dispatch_core_type) {
-    // // Skip writing the padded pages along the bottom
-    // // Currently since writing sharded tensors uses write_linear, we write the padded pages on width
-    // // Alternative write each page row into separate commands, or have a strided linear write
-    // dispatch_params.core_num_pages_remaining_to_write = core_page_mapping.num_pages;
-
-    // // reset dispatch params for core
-    // uint32_t bank_base_address = buffer.address();
-    // bank_base_address += core_page_mapping.device_start_page * buffer.aligned_page_size();
-    // if (buffer.is_dram()) {
-    //     bank_base_address += buffer.device()->allocator()->get_bank_offset(
-    //         BufferType::DRAM, buffer.device()->dram_channel_from_logical_core(core));
-    // }
-
-    // dispatch_params.core_page_mapping_it = core_page_mapping.begin();
-    // dispatch_params.core = core;
+    // Skip writing the padded pages along the bottom
+    // Currently since writing sharded tensors uses write_linear, we write the padded pages on width
+    // Alternative write each page row into separate commands, or have a strided linear write
 
     dispatch_params.reset_params_for_core(core, core_page_mapping);
 
@@ -730,14 +718,8 @@ void write_sharded_buffer_to_core(
 
         log_debug(tt::LogDispatch, "EnqueueWriteBuffer for command queue {}", dispatch_params.cq_id);
 
-        // calculate dispatch params before write
-        // dispatch_params.pages_per_txn = std::min(dispatch_params.core_num_pages_remaining_to_write,
-        // (uint32_t)num_pages_available_in_cq); dispatch_params.address =
-        //     bank_base_address + (core_page_mapping.num_pages - dispatch_params.core_num_pages_remaining_to_write) *
-        //     dispatch_params.page_size_to_write;
         dispatch_params.calculate_params_for_write_transaction(num_pages_available_in_cq);
         issue_buffer_dispatch_command_sequence(src, buffer, dispatch_params, sub_device_ids, dispatch_core_type);
-        // update dispatch params after write
         dispatch_params.update_params_after_write_transaction();
     }
 }

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -96,12 +96,6 @@ struct PartialPageSpec {
     uint32_t num_partial_pages_per_full_page = 0;
 };
 
-struct BufferReadLargePageDispatchParams : BufferReadDispatchParams {
-    PartialPageSpec partial_page_spec;
-};
-
-using BufferReadDispatchParamsVariant = std::variant<BufferReadDispatchParams, BufferReadLargePageDispatchParams>;
-
 struct ShardedBufferReadDispatchParams : BufferReadDispatchParams {
     std::shared_ptr<const BufferPageMapping> buffer_page_mapping = nullptr;
     const BufferCorePageMapping* core_page_mapping = nullptr;
@@ -120,7 +114,7 @@ void write_to_device_buffer(
 ShardedBufferReadDispatchParams initialize_sharded_buf_read_dispatch_params(
     Buffer& buffer, uint32_t cq_id, tt::stl::Span<const uint32_t> expected_num_workers_completed);
 
-BufferReadDispatchParamsVariant initialize_interleaved_buf_read_dispatch_params(
+BufferReadDispatchParams initialize_interleaved_buf_read_dispatch_params(
     Buffer& buffer, uint32_t cq_id, tt::stl::Span<const uint32_t> expected_num_workers_completed);
 
 void copy_sharded_buffer_from_core_to_completion_queue(
@@ -153,7 +147,7 @@ tt::stl::Span<const SubDeviceId> select_sub_device_ids(
 std::shared_ptr<::tt::tt_metal::CompletionReaderVariant> generate_sharded_buffer_read_descriptor(
     void* dst, ShardedBufferReadDispatchParams& dispatch_params, Buffer& buffer);
 std::shared_ptr<::tt::tt_metal::CompletionReaderVariant> generate_interleaved_buffer_read_descriptor(
-    void* dst, BufferReadDispatchParams* dispatch_params, Buffer& buffer);
+    void* dst, const BufferReadDispatchParams& dispatch_params, Buffer& buffer);
 
 bool are_pages_larger_than_max_prefetch_cmd_size(const Buffer& buffer);
 

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -283,20 +283,16 @@ void HWCommandQueue::enqueue_read_buffer(
     } else {
         // Forward data from device to the completion queue.
         // Then have the completion queue reader thread copy this data to user space.
-        buffer_dispatch::BufferReadDispatchParamsVariant dispatch_params_variant =
+        buffer_dispatch::BufferReadDispatchParams dispatch_params =
             buffer_dispatch::initialize_interleaved_buf_read_dispatch_params(
                 *buffer_obj, this->id_, this->expected_num_workers_completed_);
 
-        buffer_dispatch::BufferReadDispatchParams* dispatch_params = std::visit(
-            [](auto& val) { return static_cast<buffer_dispatch::BufferReadDispatchParams*>(&val); },
-            dispatch_params_variant);
-
         buffer_dispatch::copy_interleaved_buffer_to_completion_queue(
-            *dispatch_params,
+            dispatch_params,
             *buffer_obj,
             sub_device_ids,
             MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type());
-        if (dispatch_params->pages_per_txn > 0) {
+        if (dispatch_params.pages_per_txn > 0) {
             this->issued_completion_q_reads_.push(
                 buffer_dispatch::generate_interleaved_buffer_read_descriptor(dst, dispatch_params, *buffer_obj));
             this->increment_num_entries_in_completion_q();


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/23788

This PR adds support for reading from and writing to sharded buffers with page sizes > the max prefetch command size. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16146923043)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/16146930369)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16146940625)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16146947624)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16146955437)
- [x] New/Existing tests provide coverage for changes