### PR TITLE
Add API to get consumed memory per bank from TensorSpec

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
@@ -321,6 +321,31 @@ INSTANTIATE_TEST_SUITE_P(
         },
         ConsumedMemoryBytesPerBankTestParams{
             .shape = Shape{1, 1},
+            .tensor_layout = TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), DefaultMemoryConfig),
+            .expected_consumed_memory_bytes_per_bank = 32,
+        },
+        ConsumedMemoryBytesPerBankTestParams{
+            .shape = Shape{12, 1},
+            .tensor_layout = TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), DefaultMemoryConfig),
+            .expected_consumed_memory_bytes_per_bank = 32,
+        },
+        ConsumedMemoryBytesPerBankTestParams{
+            .shape = Shape{12, 16},
+            .tensor_layout = TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), DefaultMemoryConfig),
+            .expected_consumed_memory_bytes_per_bank = 32,
+        },
+        ConsumedMemoryBytesPerBankTestParams{
+            .shape = Shape{13, 16},
+            .tensor_layout = TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), DefaultMemoryConfig),
+            .expected_consumed_memory_bytes_per_bank = 64,
+        },
+        ConsumedMemoryBytesPerBankTestParams{
+            .shape = Shape{13, 17},
+            .tensor_layout = TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), DefaultMemoryConfig),
+            .expected_consumed_memory_bytes_per_bank = 128,
+        },
+        ConsumedMemoryBytesPerBankTestParams{
+            .shape = Shape{1, 1},
             .tensor_layout = TensorLayout(DataType::UINT8, PageConfig(Layout::ROW_MAJOR), L1MemoryConfig),
             .expected_consumed_memory_bytes_per_bank = 16,
         },
@@ -345,6 +370,31 @@ INSTANTIATE_TEST_SUITE_P(
             .expected_consumed_memory_bytes_per_bank = 64,
         },
         ConsumedMemoryBytesPerBankTestParams{
+            .shape = Shape{1, 1},
+            .tensor_layout = TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), L1MemoryConfig),
+            .expected_consumed_memory_bytes_per_bank = 16,
+        },
+        ConsumedMemoryBytesPerBankTestParams{
+            .shape = Shape{64, 1},
+            .tensor_layout = TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), L1MemoryConfig),
+            .expected_consumed_memory_bytes_per_bank = 16,
+        },
+        ConsumedMemoryBytesPerBankTestParams{
+            .shape = Shape{64, 8},
+            .tensor_layout = TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), L1MemoryConfig),
+            .expected_consumed_memory_bytes_per_bank = 16,
+        },
+        ConsumedMemoryBytesPerBankTestParams{
+            .shape = Shape{65, 8},
+            .tensor_layout = TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), L1MemoryConfig),
+            .expected_consumed_memory_bytes_per_bank = 32,
+        },
+        ConsumedMemoryBytesPerBankTestParams{
+            .shape = Shape{65, 9},
+            .tensor_layout = TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), L1MemoryConfig),
+            .expected_consumed_memory_bytes_per_bank = 64,
+        },
+        ConsumedMemoryBytesPerBankTestParams{
             .shape = Shape{7 * 32, 7 * 32},
             .tensor_layout = TensorLayout(
                 DataType::UINT8,
@@ -354,6 +404,17 @@ INSTANTIATE_TEST_SUITE_P(
                     BufferType::DRAM,
                     ShardSpec(CoreRangeSet(CoreRange{CoreCoord{0, 0}, CoreCoord{12, 0}}), Shape2D{32, 7 * 32}))),
             .expected_consumed_memory_bytes_per_bank = 32 * 7 * 32,
+        },
+        ConsumedMemoryBytesPerBankTestParams{
+            .shape = Shape{7 * 32, 7 * 32},
+            .tensor_layout = TensorLayout(
+                DataType::BFLOAT16,
+                PageConfig(Layout::TILE),
+                MemoryConfig(
+                    TensorMemoryLayout::HEIGHT_SHARDED,
+                    BufferType::DRAM,
+                    ShardSpec(CoreRangeSet(CoreRange{CoreCoord{0, 0}, CoreCoord{12, 0}}), Shape2D{32, 7 * 32}))),
+            .expected_consumed_memory_bytes_per_bank = 32 * 7 * 32 * 2,
         },
         ConsumedMemoryBytesPerBankTestParams{
             .shape = Shape{125 * 32, 125 * 32},
@@ -367,4 +428,17 @@ INSTANTIATE_TEST_SUITE_P(
                         .grid = CoreRangeSet(CoreRange{CoreCoord{0, 0}, CoreCoord{7, 7}}),
                     })),
             .expected_consumed_memory_bytes_per_bank = 63 * 2 * 32 * 2 * 32,
+        },
+        ConsumedMemoryBytesPerBankTestParams{
+            .shape = Shape{125 * 32, 125 * 32},
+            .tensor_layout = TensorLayout(
+                DataType::BFLOAT16,
+                PageConfig(Layout::TILE),
+                MemoryConfig(
+                    BufferType::L1,
+                    NdShardSpec{
+                        .shard_shape = Shape{2 * 32, 2 * 32},
+                        .grid = CoreRangeSet(CoreRange{CoreCoord{0, 0}, CoreCoord{7, 7}}),
+                    })),
+            .expected_consumed_memory_bytes_per_bank = 63 * 2 * 32 * 2 * 32 * 2,
         }));

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <umd/device/types/arch.h>
 #include <boost/move/utility_core.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/shape2d.hpp>
 #include <initializer_list>
 #include <memory>
@@ -13,7 +11,6 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include "common_tensor_test_utils.hpp"
-#include "core_coord.hpp"
 #include "ttnn_test_fixtures.hpp"
 #include "gtest/gtest.h"
 #include <tt-metalium/shape.hpp>

--- a/ttnn/api/ttnn/tensor/layout/tensor_layout.hpp
+++ b/ttnn/api/ttnn/tensor/layout/tensor_layout.hpp
@@ -14,6 +14,8 @@
 
 namespace tt::tt_metal {
 
+class IDevice;
+
 using Strides = std::vector<size_t>;
 
 // TensorLayout describes how a tensor is laid out in memory
@@ -46,6 +48,8 @@ public:
 
     size_t compute_packed_buffer_size_bytes(const ttnn::Shape& shape) const;
     size_t compute_page_size_bytes(const ttnn::Shape& shape) const;
+
+    size_t compute_consumed_memory_bytes_per_bank(const ttnn::Shape& shape, const IDevice& device) const;
 
     // This method is deprecated and should be replaced with get_strides() / get_physical_size()
     // It computes padded shape on the fly from shape and alignment

--- a/ttnn/api/ttnn/tensor/layout/tensor_layout.hpp
+++ b/ttnn/api/ttnn/tensor/layout/tensor_layout.hpp
@@ -50,6 +50,8 @@ public:
     size_t compute_page_size_bytes(const ttnn::Shape& shape) const;
 
     size_t compute_consumed_memory_bytes_per_bank(const ttnn::Shape& shape, const IDevice& device) const;
+    size_t compute_consumed_memory_bytes_per_bank(
+        const ttnn::Shape& shape, size_t page_alignment, size_t num_banks) const;
 
     // This method is deprecated and should be replaced with get_strides() / get_physical_size()
     // It computes padded shape on the fly from shape and alignment

--- a/ttnn/api/ttnn/tensor/tensor_spec.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_spec.hpp
@@ -43,6 +43,9 @@ public:
     size_t compute_consumed_memory_bytes_per_bank(const IDevice& device) const {
         return tensor_layout_.compute_consumed_memory_bytes_per_bank(logical_shape_, device);
     }
+    size_t compute_consumed_memory_bytes_per_bank(size_t page_alignment, size_t num_banks) const {
+        return tensor_layout_.compute_consumed_memory_bytes_per_bank(logical_shape_, page_alignment, num_banks);
+    }
 
     TensorSpec with_memory_config(MemoryConfig memory_config) const;
 

--- a/ttnn/api/ttnn/tensor/tensor_spec.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_spec.hpp
@@ -40,6 +40,10 @@ public:
     }
     size_t compute_page_size_bytes() const { return tensor_layout_.compute_page_size_bytes(logical_shape_); }
 
+    size_t compute_consumed_memory_bytes_per_bank(const IDevice& device) const {
+        return tensor_layout_.compute_consumed_memory_bytes_per_bank(logical_shape_, device);
+    }
+
     TensorSpec with_memory_config(MemoryConfig memory_config) const;
 
     static constexpr auto attribute_names = std::forward_as_tuple("logical_shape", "tensor_layout");

--- a/ttnn/core/tensor/layout/tensor_layout.cpp
+++ b/ttnn/core/tensor/layout/tensor_layout.cpp
@@ -4,6 +4,10 @@
 
 #include "ttnn/tensor/layout/tensor_layout.hpp"
 
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/allocator.hpp>
+#include "tt-metalium/math.hpp"
+
 namespace tt::tt_metal {
 
 namespace {
@@ -257,6 +261,39 @@ size_t TensorLayout::compute_page_size_bytes(const ttnn::Shape& shape) const {
 
 size_t TensorLayout::compute_page_size_bytes(const Shape2D& page_size) const {
     return page_config_.get_page_size_bytes(page_size, dtype_);
+}
+
+size_t TensorLayout::compute_consumed_memory_bytes_per_bank(const ttnn::Shape& shape, const IDevice& device) const {
+    const Shape2D physical_shape = compute_physical_shape(shape);
+    const Shape2D page_shape = compute_page_shape(physical_shape);
+
+    size_t num_pages_per_bank = 0;
+    if (!memory_config_.is_sharded()) {
+        const size_t num_pages =
+            physical_shape.height() * physical_shape.width() / page_shape.height() / page_shape.width();
+        size_t num_banks = 0;
+        if (memory_config_.is_l1()) {
+            num_banks = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y;
+        } else {
+            num_banks = device.num_dram_channels();
+        }
+        num_pages_per_bank = div_up(num_pages, num_banks);
+    } else if (const auto& shard_spec = memory_config_.shard_spec()) {
+        Shape2D shard_shape = Shape2D(shard_spec->shape);
+        if (shard_spec->physical_shard_shape.has_value()) {
+            shard_shape = shard_spec->physical_shard_shape.value();
+        }
+        num_pages_per_bank =
+            div_up(shard_shape.height(), page_shape.height()) * div_up(shard_shape.width(), page_shape.width());
+    } else {
+        auto sharding_args = compute_buffer_sharding_args(shape);
+        const auto& dist_spec = sharding_args.buffer_distribution_spec().value();
+        num_pages_per_bank = dist_spec.max_num_dev_pages_per_core();
+    }
+
+    const size_t alignment = device.allocator()->get_alignment(memory_config_.buffer_type());
+    const size_t aligned_page_size = round_up(compute_page_size_bytes(page_shape), alignment);
+    return num_pages_per_bank * aligned_page_size;
 }
 
 Shape2D TensorLayout::get_logical_shard_shape() const {

--- a/ttnn/core/tensor/layout/tensor_layout.cpp
+++ b/ttnn/core/tensor/layout/tensor_layout.cpp
@@ -4,8 +4,9 @@
 
 #include "ttnn/tensor/layout/tensor_layout.hpp"
 
-#include <tt-metalium/device.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/math.hpp>
 
 namespace tt::tt_metal {
 
@@ -19,8 +20,6 @@ size_t round_up(size_t value, size_t multiple) {
 
     return ((value + multiple - 1) / multiple) * multiple;
 };
-
-size_t div_up(size_t value, size_t multiple) { return (value + multiple - 1) / multiple; }
 
 Alignment legacyShapeToAlignment(
     const ttnn::Shape& logical_shape,
@@ -264,7 +263,8 @@ size_t TensorLayout::compute_page_size_bytes(const Shape2D& page_size) const {
     return page_config_.get_page_size_bytes(page_size, dtype_);
 }
 
-size_t TensorLayout::compute_consumed_memory_bytes_per_bank(const ttnn::Shape& shape, const IDevice& device) const {
+size_t TensorLayout::compute_consumed_memory_bytes_per_bank(
+    const ttnn::Shape& shape, size_t page_alignment, size_t num_banks) const {
     const Shape2D physical_shape = compute_physical_shape(shape);
     const Shape2D page_shape = compute_page_shape(physical_shape);
 
@@ -272,29 +272,33 @@ size_t TensorLayout::compute_consumed_memory_bytes_per_bank(const ttnn::Shape& s
     if (!memory_config_.is_sharded()) {
         const size_t num_pages =
             physical_shape.height() * physical_shape.width() / page_shape.height() / page_shape.width();
-        size_t num_banks = 0;
-        if (memory_config_.is_l1()) {
-            num_banks = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y;
-        } else {
-            num_banks = device.num_dram_channels();
-        }
-        num_pages_per_bank = CMAKE_UNIQUE_NAMESPACE::div_up(num_pages, num_banks);
+        num_pages_per_bank = div_up(num_pages, num_banks);
     } else if (const auto& shard_spec = memory_config_.shard_spec()) {
         Shape2D shard_shape = Shape2D(shard_spec->shape);
         if (shard_spec->physical_shard_shape.has_value()) {
             shard_shape = shard_spec->physical_shard_shape.value();
         }
-        num_pages_per_bank = CMAKE_UNIQUE_NAMESPACE::div_up(shard_shape.height(), page_shape.height()) *
-                             CMAKE_UNIQUE_NAMESPACE::div_up(shard_shape.width(), page_shape.width());
+        num_pages_per_bank =
+            div_up(shard_shape.height(), page_shape.height()) * div_up(shard_shape.width(), page_shape.width());
     } else {
         auto sharding_args = compute_buffer_sharding_args(shape);
         const auto& dist_spec = sharding_args.buffer_distribution_spec().value();
         num_pages_per_bank = dist_spec.max_num_dev_pages_per_core();
     }
 
-    const size_t alignment = device.allocator()->get_alignment(memory_config_.buffer_type());
-    const size_t aligned_page_size = round_up(compute_page_size_bytes(page_shape), alignment);
+    const size_t aligned_page_size = round_up(compute_page_size_bytes(page_shape), page_alignment);
     return num_pages_per_bank * aligned_page_size;
+}
+
+size_t TensorLayout::compute_consumed_memory_bytes_per_bank(const ttnn::Shape& shape, const IDevice& device) const {
+    const size_t page_alignment = device.allocator()->get_alignment(memory_config_.buffer_type());
+    size_t num_banks = 0;
+    if (memory_config_.is_l1()) {
+        num_banks = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y;
+    } else {
+        num_banks = device.num_dram_channels();
+    }
+    return compute_consumed_memory_bytes_per_bank(shape, page_alignment, num_banks);
 }
 
 Shape2D TensorLayout::get_logical_shard_shape() const {

--- a/ttnn/core/tensor/layout/tensor_layout.cpp
+++ b/ttnn/core/tensor/layout/tensor_layout.cpp
@@ -6,7 +6,6 @@
 
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/allocator.hpp>
-#include "tt-metalium/math.hpp"
 
 namespace tt::tt_metal {
 
@@ -20,6 +19,8 @@ size_t round_up(size_t value, size_t multiple) {
 
     return ((value + multiple - 1) / multiple) * multiple;
 };
+
+size_t div_up(size_t value, size_t multiple) { return (value + multiple - 1) / multiple; }
 
 Alignment legacyShapeToAlignment(
     const ttnn::Shape& logical_shape,
@@ -277,14 +278,14 @@ size_t TensorLayout::compute_consumed_memory_bytes_per_bank(const ttnn::Shape& s
         } else {
             num_banks = device.num_dram_channels();
         }
-        num_pages_per_bank = div_up(num_pages, num_banks);
+        num_pages_per_bank = CMAKE_UNIQUE_NAMESPACE::div_up(num_pages, num_banks);
     } else if (const auto& shard_spec = memory_config_.shard_spec()) {
         Shape2D shard_shape = Shape2D(shard_spec->shape);
         if (shard_spec->physical_shard_shape.has_value()) {
             shard_shape = shard_spec->physical_shard_shape.value();
         }
-        num_pages_per_bank =
-            div_up(shard_shape.height(), page_shape.height()) * div_up(shard_shape.width(), page_shape.width());
+        num_pages_per_bank = CMAKE_UNIQUE_NAMESPACE::div_up(shard_shape.height(), page_shape.height()) *
+                             CMAKE_UNIQUE_NAMESPACE::div_up(shard_shape.width(), page_shape.width());
     } else {
         auto sharding_args = compute_buffer_sharding_args(shape);
         const auto& dist_spec = sharding_args.buffer_distribution_spec().value();


### PR DESCRIPTION
### Ticket

### Problem description
We need to provide an API to able to get consumed memory per bank based on TensorSpec to be able to check whether we have enough memory to allocate a Tensor.

### What's changed
Added `compute_consumed_memory_bytes_per_bank` API to TensorSpec and TensorLayout
Added tests for the new functionality

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16132341567)
- [x] New/Existing tests provide coverage for changes