### PR TITLE
Fix build with a different python version in a virtual environment

### DIFF
--- a/build_metal.sh
+++ b/build_metal.sh
@@ -361,6 +361,9 @@ fi
 
 if [ "$with_python_bindings" = "ON" ]; then
     cmake_args+=("-DWITH_PYTHON_BINDINGS=ON")
+    cmake_args+=("-DPython3_EXECUTABLE=$(which python3)")
+    cmake_args+=("-DPython3_INCLUDE_DIR=$(python3 -c "from sysconfig import get_paths as gp; print(gp()['include'])")")
+    cmake_args+=("-DPython3_LIBRARY=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR') + '/libpython' + sysconfig.get_config_var('LDVERSION') + '.so')")")
 else
     cmake_args+=("-DWITH_PYTHON_BINDINGS=OFF")
 fi


### PR DESCRIPTION
### Ticket

### Problem description
Currently if you create a virtual environment with a Python version (for example 3.10) which is different from the main Python version in your distro (for example 3.12), CMake has issues with identifying the correct python version resulting in build issues.

### What's changed
Updated build_metal.sh to forcefully use Python from the current environment

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16132528833)
- [x] New/Existing tests provide coverage for changes