### PR TITLE
enable use of two txqs in TT-Fabric on Blackhole

### DIFF
--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -59,6 +59,26 @@ protected:
     }
 };
 
+class TwoDeviceBlackholeFixture : public DispatchFixture {
+protected:
+    void SetUp() override {
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
+        if (slow_dispatch) {
+            log_info(tt::LogTest, "This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
+            GTEST_SKIP();
+        }
+
+        const size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
+        const size_t num_pci_devices = tt::tt_metal::GetNumPCIeDevices();
+        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        if (this->arch_ == tt::ARCH::BLACKHOLE && num_devices == 2 && num_pci_devices >= 1) {
+            DispatchFixture::SetUp();
+        } else {
+            GTEST_SKIP() << "This suite can only be run on two chip Blackhole systems";
+        }
+    }
+};
+
 class MeshDeviceFixtureBase : public ::testing::Test {
 public:
     std::shared_ptr<tt::tt_metal::distributed::MeshDevice> get_mesh_device() {
@@ -257,6 +277,12 @@ protected:
             .mesh_device_types = {MeshDeviceType::T3000},
             .num_cqs = 1,
             .fabric_config = tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC}) {}
+};
+
+class P300MeshDevice2DNoFabricFixture : public MeshDeviceFixtureBase {
+protected:
+    P300MeshDevice2DNoFabricFixture() :
+        MeshDeviceFixtureBase(Config{.mesh_device_types = {MeshDeviceType::P300}, .num_cqs = 1}) {}
 };
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/eth/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/eth/CMakeLists.txt
@@ -2,6 +2,7 @@ set(UNIT_TESTS_ETH_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_basic_eth.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_buffer_movement_kernels.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_erisc_app_direct_send.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_eth_multi_txq_rxq.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_ring_gather_kernels.cpp
 )
 

--- a/tests/tt_metal/tt_metal/eth/test_eth_multi_txq_rxq.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_eth_multi_txq_rxq.cpp
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/base.h>
+#include <gtest/gtest.h>
+#include <stdlib.h>
+#include <umd/device/types/arch.h>
+#include <tt-metalium/host_api.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <cstdint>
+
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/device.hpp>
+#include "dispatch_fixture.hpp"
+#include "multi_device_fixture.hpp"
+#include <tt-metalium/program.hpp>
+#include "impl/context/metal_context.hpp"
+
+using namespace tt;
+using namespace tt::test_utils;
+namespace unit_tests::erisc::direct_send {
+
+static void eth_direct_send_multi_txq_rxq(
+    tt_metal::DispatchFixture* fixture,
+    tt_metal::IDevice* sender_device,
+    tt_metal::IDevice* receiver_device,
+    const CoreCoord& eth_sender_core,
+    const CoreCoord& eth_receiver_core,
+    uint32_t data_txq_id,
+    uint32_t ack_txq_id,
+    uint32_t num_messages) {
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Sender Device
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Program sender_program = tt_metal::Program();
+
+    constexpr size_t PAYLOAD_SIZE = 32;
+    const size_t unreserved_l1_start = tt::tt_metal::MetalContext::instance().hal().get_dev_size(
+        tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED);
+    auto eth_sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_multi_txq_rxq_bidirectional.cpp",
+        eth_sender_core,
+        tt_metal::EthernetConfig{.compile_args = {data_txq_id, ack_txq_id, PAYLOAD_SIZE}});
+
+    size_t local_eth_l1_src_addr = unreserved_l1_start + 16;
+    size_t receiver_credit_ack_src = local_eth_l1_src_addr + PAYLOAD_SIZE;
+    size_t receiver_credit_ack_dest = receiver_credit_ack_src + 32;
+    size_t remote_eth_l1_dst_addr = receiver_credit_ack_dest + 32;
+
+    tt_metal::SetRuntimeArgs(
+        sender_program,
+        eth_sender_kernel,
+        eth_sender_core,
+        {unreserved_l1_start,
+         true,  // HS sender
+         local_eth_l1_src_addr,
+         receiver_credit_ack_src,
+         receiver_credit_ack_dest,
+         remote_eth_l1_dst_addr,
+         num_messages});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Receiver Device
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Program receiver_program = tt_metal::Program();
+
+    auto eth_receiver_kernel = tt_metal::CreateKernel(
+        receiver_program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_multi_txq_rxq_bidirectional.cpp",
+        eth_receiver_core,
+        tt_metal::EthernetConfig{
+            .compile_args = {data_txq_id, ack_txq_id, PAYLOAD_SIZE}});  // probably want to use NOC_1 here
+
+    tt_metal::SetRuntimeArgs(
+        receiver_program,
+        eth_receiver_kernel,
+        eth_receiver_core,
+        {unreserved_l1_start,
+         false,  // HS sender
+         local_eth_l1_src_addr,
+         receiver_credit_ack_src,
+         receiver_credit_ack_dest,
+         remote_eth_l1_dst_addr,
+         num_messages});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Execute Programs
+    ////////////////////////////////////////////////////////////////////////////
+    std::jthread t1;
+    std::jthread t2;
+    if (fixture->IsSlowDispatch()) {
+        t1 = std::jthread([&]() { fixture->RunProgram(sender_device, sender_program); });
+        t2 = std::jthread([&]() { fixture->RunProgram(receiver_device, receiver_program); });
+    } else {
+        fixture->RunProgram(sender_device, sender_program, true);
+        fixture->RunProgram(receiver_device, receiver_program, true);
+    }
+
+    fixture->FinishCommands(sender_device);
+    fixture->FinishCommands(receiver_device);
+}
+
+}  // namespace unit_tests::erisc::direct_send
+
+namespace tt::tt_metal {
+
+static void run_multi_txq_rxq_test(
+    DispatchFixture* fixture,
+    IDevice* device_0,
+    IDevice* device_1,
+    uint32_t data_txq_id,
+    uint32_t ack_txq_id,
+    uint32_t num_messages) {
+    // Find ethernet cores that connect device_0 and device_1 using standard metal APIs
+    std::optional<CoreCoord> sender_core_0;
+    std::optional<CoreCoord> receiver_core_0;
+
+    // Get active ethernet cores from device_0
+    const auto& active_eth_cores = device_0->get_active_ethernet_cores(false);
+
+    // Find an ethernet core on device_0 that connects to device_1
+    for (const auto& eth_core : active_eth_cores) {
+        chip_id_t connected_device_id;
+        CoreCoord connected_eth_core;
+        std::tie(connected_device_id, connected_eth_core) = device_0->get_connected_ethernet_core(eth_core);
+
+        if (connected_device_id == device_1->id()) {
+            sender_core_0 = eth_core;
+            receiver_core_0 = connected_eth_core;
+            break;
+        }
+    }
+
+    // Verify we found a connection
+    TT_ASSERT(
+        sender_core_0.has_value() && receiver_core_0.has_value(),
+        "No ethernet connection found between device_0 and device_1");
+
+    unit_tests::erisc::direct_send::eth_direct_send_multi_txq_rxq(
+        fixture,
+        device_0,
+        device_1,
+        sender_core_0.value(),
+        receiver_core_0.value(),
+        data_txq_id,
+        ack_txq_id,
+        num_messages);
+
+}  // namespace tt::tt_metal
+
+TEST_F(TwoDeviceBlackholeFixture, ActiveEthChipToChipMultiTxqRxq_Both0) {
+    run_multi_txq_rxq_test(this, this->devices_.at(0), this->devices_.at(1), 0, 0, 100000);
+}
+TEST_F(TwoDeviceBlackholeFixture, ActiveEthChipToChipMultiTxqRxq_Qs_0_and_1) {
+    run_multi_txq_rxq_test(this, this->devices_.at(0), this->devices_.at(1), 0, 1, 100000);
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_multi_txq_rxq_bidirectional.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_multi_txq_rxq_bidirectional.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "risc_common.h"
+#include "tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp"
+#include "tt_metal/hw/inc/ethernet/tunneling.h"
+#include "tt_metal/hw/inc/ethernet/tt_eth_api.h"
+#include <tuple>
+#include <cstdint>
+#include <cstddef>
+#include "debug/dprint.h"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_txq_setup.h"
+constexpr uint32_t data_txq_id = get_compile_time_arg_val(0);
+constexpr uint32_t ack_txq_id = get_compile_time_arg_val(1);
+constexpr uint32_t PAYLOAD_SIZE = get_compile_time_arg_val(2);
+
+static constexpr uint32_t CREDITS_STREAM_ID = 0;
+static constexpr uint32_t ACK_STREAM_ID = 1;
+
+void kernel_main() {
+    size_t arg_idx = 0;
+    uint32_t handshake_addr = get_arg_val<uint32_t>(arg_idx++);
+    bool is_handshake_sender = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t local_eth_l1_src_addr = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t receiver_credit_ack_src = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t receiver_credit_ack_dest = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t remote_eth_l1_dst_addr = get_arg_val<uint32_t>(arg_idx++);
+    int num_messages = get_arg_val<uint32_t>(arg_idx++);
+
+    // Clear our counters for receiver credits src + dest
+    *reinterpret_cast<volatile uint32_t*>(receiver_credit_ack_src) = 0;
+    *reinterpret_cast<volatile uint32_t*>(receiver_credit_ack_dest) = 0;
+
+    if constexpr (data_txq_id != ack_txq_id) {
+        eth_enable_packet_mode(ack_txq_id);
+    }
+
+    init_ptr_val(CREDITS_STREAM_ID, 0);
+
+    // Handshake to make sure it's safe to start sending
+    if (is_handshake_sender) {
+        erisc::datamover::handshake::sender_side_handshake(handshake_addr);
+    } else {
+        erisc::datamover::handshake::receiver_side_handshake(handshake_addr);
+    }
+
+    bool has_unsent_messages = true;
+    bool has_unsent_acks = true;
+    int num_messages_sent = 0;
+    int num_acks_sent = 0;
+    int last_printed_ack = 0;
+    size_t idle_count = 0;
+    while (has_unsent_messages || has_unsent_acks) {
+        // Send Messages
+        bool current_ack = *reinterpret_cast<volatile int32_t*>(receiver_credit_ack_dest);
+        if (current_ack != last_printed_ack) {
+            last_printed_ack = current_ack;
+        }
+        if (has_unsent_messages) {
+            *reinterpret_cast<volatile uint32_t*>(local_eth_l1_src_addr) = num_messages_sent + 1;
+            while (internal_::eth_txq_is_busy(data_txq_id)) {
+            }
+            internal_::eth_send_packet_bytes_unsafe(
+                data_txq_id, local_eth_l1_src_addr, remote_eth_l1_dst_addr, PAYLOAD_SIZE);
+            while (internal_::eth_txq_is_busy(data_txq_id)) {
+            }
+            remote_update_ptr_val<CREDITS_STREAM_ID, data_txq_id>(1);
+            num_messages_sent++;
+            has_unsent_messages = num_messages_sent < num_messages;
+            idle_count = 0;
+        }
+
+        // Send Acks
+        if (has_unsent_acks) {
+            if (get_ptr_val<CREDITS_STREAM_ID>() > num_acks_sent) {
+                *reinterpret_cast<volatile uint32_t*>(receiver_credit_ack_src) = num_acks_sent + 1;
+                while (internal_::eth_txq_is_busy(ack_txq_id)) {
+                }
+                internal_::eth_send_packet_bytes_unsafe(
+                    ack_txq_id, receiver_credit_ack_src, receiver_credit_ack_dest, 16);
+                num_acks_sent++;
+                has_unsent_acks = num_acks_sent < num_messages;
+                idle_count = 0;
+            }
+        }
+        idle_count++;
+    }
+
+    while (*reinterpret_cast<volatile int32_t*>(receiver_credit_ack_dest) < num_messages_sent) {
+        invalidate_l1_cache();
+    }
+
+    // Validate that at the very least we got the correct last value in the payload buffer
+    while (*reinterpret_cast<volatile int32_t*>(remote_eth_l1_dst_addr) != num_messages_sent) {
+        invalidate_l1_cache();
+    }
+}

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -188,6 +188,14 @@ struct FabricEriscDatamoverConfig {
     std::array<std::size_t, max_downstream_edms> receiver_channels_downstream_flow_control_semaphore_address = {};
     std::array<std::size_t, max_downstream_edms> receiver_channels_downstream_teardown_semaphore_address = {};
 
+    // Conditionally used fields. BlackHole with 2-erisc uses these fields for sending credits back to sender.
+    // We use/have these fields because we can't send reg-writes over Ethernet on both TXQs. Therefore,
+    // use use a different crediting scheme.
+    std::array<std::size_t, num_sender_channels> to_sender_channel_remote_ack_counter_addrs = {};
+    std::array<std::size_t, num_sender_channels> to_sender_channel_remote_completion_counter_addrs = {};
+    std::array<std::size_t, num_receiver_channels> receiver_channel_remote_ack_counter_addrs = {};
+    std::array<std::size_t, num_receiver_channels> receiver_channel_remote_completion_counter_addrs = {};
+
     // Channel Allocations
     std::size_t max_l1_loading_size = 0;
     std::size_t buffer_region_start = 0;

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(
             hw/inc/edm_fabric/fabric_connection_manager.hpp
             hw/inc/edm_fabric/fabric_edm_packet_header_validate.hpp
             hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+            hw/inc/edm_fabric/fabric_txq_setup.h
             hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
 )
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp
@@ -159,3 +159,13 @@ template <bool GET_THE_ARG, size_t ARG_IDX>
 constexpr auto conditional_get_compile_time_arg() -> typename std::enable_if<!GET_THE_ARG, uint32_t>::type {
     return 0;
 }
+
+template <bool GET_THE_ARG, typename T, size_t CT_ARGS_START_IDX, size_t NUM_ELEMS_TO_TAKE>
+constexpr auto conditional_get_next_n_args() -> typename std::enable_if<GET_THE_ARG, std::array<T, NUM_ELEMS_TO_TAKE>>::type {
+    return fill_array_with_next_n_args<T, CT_ARGS_START_IDX, NUM_ELEMS_TO_TAKE>();
+}
+
+template <bool GET_THE_ARG, typename T, size_t CT_ARGS_START_IDX, size_t NUM_ELEMS_TO_TAKE>
+constexpr auto conditional_get_next_n_args() -> typename std::enable_if<!GET_THE_ARG, std::array<T, NUM_ELEMS_TO_TAKE>>::type {
+    return std::array<T, NUM_ELEMS_TO_TAKE>{};
+}

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_flow_control.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_flow_control.hpp
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp"
+#include "tt_metal/hw/inc/ethernet/tt_eth_api.h"
+#include "tt_metal/hw/inc/ethernet/tunneling.h"
+
+struct ReceiverChannelCounterBasedResponseCreditSender {
+    ReceiverChannelCounterBasedResponseCreditSender() = default;
+    ReceiverChannelCounterBasedResponseCreditSender(size_t receiver_channel_index) :
+        completion_counter_ptr(
+            reinterpret_cast<volatile uint32_t*>(local_receiver_completion_counter_ptrs[receiver_channel_index])),
+        ack_counter_ptr(reinterpret_cast<volatile uint32_t*>(local_receiver_ack_counter_ptrs[receiver_channel_index])),
+        completion_counter(0),
+        ack_counter(0) {}
+
+    FORCE_INLINE void send_completion_credit(uint8_t src_id) {
+        completion_counter++;
+        *completion_counter_ptr = completion_counter;
+        internal_::eth_send_packet_bytes_unsafe(
+            receiver_txq_id,
+            reinterpret_cast<uint32_t>(this->completion_counter_ptr),
+            to_sender_remote_completion_counter_addrs[src_id],
+            ETH_WORD_SIZE_BYTES);
+    }
+
+    // Assumes !eth_txq_is_busy() -- PLEASE CHECK BEFORE CALLING
+    FORCE_INLINE void send_ack_credit(uint8_t src_id) {
+        ack_counter++;
+        *ack_counter_ptr = ack_counter;
+        internal_::eth_send_packet_bytes_unsafe(
+            receiver_txq_id,
+            reinterpret_cast<uint32_t>(this->ack_counter_ptr),
+            to_sender_remote_ack_counter_addrs[src_id],
+            ETH_WORD_SIZE_BYTES);
+    }
+
+    volatile tt_l1_ptr uint32_t* completion_counter_ptr;
+    volatile tt_l1_ptr uint32_t* ack_counter_ptr;
+    // Local memory copy to save an L1 load
+    uint32_t completion_counter;
+    uint32_t ack_counter;
+};
+
+struct ReceiverChannelStreamRegisterFreeSlotsBasedCreditSender {
+    ReceiverChannelStreamRegisterFreeSlotsBasedCreditSender() {}
+
+    FORCE_INLINE void send_completion_credit(uint8_t src_id) {
+        remote_update_ptr_val<receiver_txq_id>(to_sender_packets_completed_streams[src_id], 1);
+    }
+
+    // Assumes !eth_txq_is_busy() -- PLEASE CHECK BEFORE CALLING
+    FORCE_INLINE void send_ack_credit(uint8_t src_id) {
+        remote_update_ptr_val<receiver_txq_id>(to_sender_packets_acked_streams[src_id], 1);
+    }
+};
+
+using ReceiverChannelResponseCreditSender = typename std::conditional_t<
+    multi_txq_enabled,
+    ReceiverChannelCounterBasedResponseCreditSender,
+    ReceiverChannelStreamRegisterFreeSlotsBasedCreditSender>;
+
+template <typename T = void>
+struct init_receiver_channel_response_credit_senders_impl;
+
+// Implementation for ReceiverChannelStreamRegisterFreeSlotsBasedCreditSender
+template <>
+struct init_receiver_channel_response_credit_senders_impl<ReceiverChannelStreamRegisterFreeSlotsBasedCreditSender> {
+    template <uint8_t NUM_RECEIVER_CHANNELS>
+    static constexpr auto init()
+        -> std::array<ReceiverChannelStreamRegisterFreeSlotsBasedCreditSender, NUM_RECEIVER_CHANNELS> {
+        std::array<ReceiverChannelStreamRegisterFreeSlotsBasedCreditSender, NUM_RECEIVER_CHANNELS> credit_senders;
+        for (size_t i = 0; i < NUM_RECEIVER_CHANNELS; i++) {
+            credit_senders[i] = ReceiverChannelStreamRegisterFreeSlotsBasedCreditSender();
+        }
+        return credit_senders;
+    }
+};
+
+// Implementation for ReceiverChannelCounterBasedResponseCreditSender
+template <>
+struct init_receiver_channel_response_credit_senders_impl<ReceiverChannelCounterBasedResponseCreditSender> {
+    template <uint8_t NUM_RECEIVER_CHANNELS>
+    static constexpr auto init() -> std::array<ReceiverChannelCounterBasedResponseCreditSender, NUM_RECEIVER_CHANNELS> {
+        std::array<ReceiverChannelCounterBasedResponseCreditSender, NUM_RECEIVER_CHANNELS> credit_senders;
+        for (size_t i = 0; i < NUM_RECEIVER_CHANNELS; i++) {
+            credit_senders[i] = ReceiverChannelCounterBasedResponseCreditSender(i);
+        }
+        return credit_senders;
+    }
+};
+
+template <uint8_t NUM_RECEIVER_CHANNELS>
+constexpr FORCE_INLINE auto init_receiver_channel_response_credit_senders()
+    -> std::array<ReceiverChannelResponseCreditSender, NUM_RECEIVER_CHANNELS> {
+    return init_receiver_channel_response_credit_senders_impl<ReceiverChannelResponseCreditSender>::template init<
+        NUM_RECEIVER_CHANNELS>();
+}
+struct SenderChannelFromReceiverCounterBasedCreditsReceiver {
+    SenderChannelFromReceiverCounterBasedCreditsReceiver() = default;
+    SenderChannelFromReceiverCounterBasedCreditsReceiver(size_t sender_channel_index) :
+        acks_received_counter_ptr(
+            reinterpret_cast<volatile uint32_t*>(to_sender_remote_ack_counter_addrs[sender_channel_index])),
+        completions_received_counter_ptr(
+            reinterpret_cast<volatile uint32_t*>(to_sender_remote_completion_counter_addrs[sender_channel_index])),
+        acks_received_and_processed(0),
+        completions_received_and_processed(0) {}
+
+    FORCE_INLINE uint32_t get_num_unprocessed_acks_from_receiver() {
+        invalidate_l1_cache();
+        return *acks_received_counter_ptr - acks_received_and_processed;
+    }
+
+    FORCE_INLINE void increment_num_processed_acks(size_t num_acks) { acks_received_and_processed += num_acks; }
+
+    FORCE_INLINE uint32_t get_num_unprocessed_completions_from_receiver() {
+        invalidate_l1_cache();
+        return *completions_received_counter_ptr - completions_received_and_processed;
+    }
+
+    FORCE_INLINE void increment_num_processed_completions(size_t num_completions) {
+        completions_received_and_processed += num_completions;
+    }
+
+    volatile uint32_t* acks_received_counter_ptr;
+    volatile uint32_t* completions_received_counter_ptr;
+    uint32_t acks_received_and_processed = 0;
+    uint32_t completions_received_and_processed = 0;
+};
+
+struct SenderChannelFromReceiverStreamRegisterFreeSlotsBasedCreditsReceiver {
+    SenderChannelFromReceiverStreamRegisterFreeSlotsBasedCreditsReceiver() = default;
+    SenderChannelFromReceiverStreamRegisterFreeSlotsBasedCreditsReceiver(size_t sender_channel_index) :
+        to_sender_packets_acked_stream(to_sender_packets_acked_streams[sender_channel_index]),
+        to_sender_packets_completed_stream(to_sender_packets_completed_streams[sender_channel_index]) {}
+
+    FORCE_INLINE uint32_t get_num_unprocessed_acks_from_receiver() {
+        return get_ptr_val(to_sender_packets_acked_stream);
+    }
+
+    FORCE_INLINE void increment_num_processed_acks(size_t num_acks) {
+        increment_local_update_ptr_val(to_sender_packets_acked_stream, -num_acks);
+    }
+
+    FORCE_INLINE uint32_t get_num_unprocessed_completions_from_receiver() {
+        return get_ptr_val(to_sender_packets_completed_stream);
+    }
+
+    FORCE_INLINE void increment_num_processed_completions(size_t num_completions) {
+        increment_local_update_ptr_val(to_sender_packets_completed_stream, -num_completions);
+    }
+
+    uint32_t to_sender_packets_acked_stream;
+    uint32_t to_sender_packets_completed_stream;
+};
+
+template <typename T = void>
+struct init_sender_channel_from_receiver_credits_flow_controllers_impl;
+
+// Implementation for SenderChannelFromReceiverStreamRegisterFreeSlotsBasedCreditsReceiver
+
+template <>
+struct init_sender_channel_from_receiver_credits_flow_controllers_impl<
+    SenderChannelFromReceiverStreamRegisterFreeSlotsBasedCreditsReceiver> {
+    template <uint8_t NUM_SENDER_CHANNELS>
+    static constexpr auto init()
+        -> std::array<SenderChannelFromReceiverStreamRegisterFreeSlotsBasedCreditsReceiver, NUM_SENDER_CHANNELS> {
+        std::array<SenderChannelFromReceiverStreamRegisterFreeSlotsBasedCreditsReceiver, NUM_SENDER_CHANNELS>
+            flow_controllers;
+        for (size_t i = 0; i < NUM_SENDER_CHANNELS; i++) {
+            new (&flow_controllers[i]) SenderChannelFromReceiverStreamRegisterFreeSlotsBasedCreditsReceiver(i);
+        }
+        return flow_controllers;
+    }
+};
+
+// Implementation for SenderChannelFromReceiverCounterBasedCreditsReceiver
+template <>
+struct init_sender_channel_from_receiver_credits_flow_controllers_impl<
+    SenderChannelFromReceiverCounterBasedCreditsReceiver> {
+    template <uint8_t NUM_SENDER_CHANNELS>
+    static constexpr auto init()
+        -> std::array<SenderChannelFromReceiverCounterBasedCreditsReceiver, NUM_SENDER_CHANNELS> {
+        std::array<SenderChannelFromReceiverCounterBasedCreditsReceiver, NUM_SENDER_CHANNELS> flow_controllers;
+        for (size_t i = 0; i < NUM_SENDER_CHANNELS; i++) {
+            new (&flow_controllers[i]) SenderChannelFromReceiverCounterBasedCreditsReceiver(i);
+        }
+        return flow_controllers;
+    }
+};
+
+using SenderChannelFromReceiverCredits = typename std::conditional_t<
+    multi_txq_enabled,
+    SenderChannelFromReceiverCounterBasedCreditsReceiver,
+    SenderChannelFromReceiverStreamRegisterFreeSlotsBasedCreditsReceiver>;
+
+// SFINAE-based overload for multi_txq_enabled case
+template <uint8_t NUM_SENDER_CHANNELS>
+constexpr FORCE_INLINE auto init_sender_channel_from_receiver_credits_flow_controllers()
+    -> std::enable_if_t<!multi_txq_enabled, std::array<SenderChannelFromReceiverCredits, NUM_SENDER_CHANNELS>> {
+    return init_sender_channel_from_receiver_credits_flow_controllers_impl<
+        SenderChannelFromReceiverStreamRegisterFreeSlotsBasedCreditsReceiver>::template init<NUM_SENDER_CHANNELS>();
+}
+
+// SFINAE-based overload for !multi_txq_enabled case
+template <uint8_t NUM_SENDER_CHANNELS>
+constexpr FORCE_INLINE auto init_sender_channel_from_receiver_credits_flow_controllers()
+    -> std::enable_if_t<multi_txq_enabled, std::array<SenderChannelFromReceiverCredits, NUM_SENDER_CHANNELS>> {
+    return init_sender_channel_from_receiver_credits_flow_controllers_impl<
+        SenderChannelFromReceiverCounterBasedCreditsReceiver>::template init<NUM_SENDER_CHANNELS>();
+}

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_txq_setup.h
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_txq_setup.h
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/hw/inc/ethernet/tt_eth_api.h"
+
+constexpr uint64_t BCAST_MAC_ADDR = 0xFFFF'FFFF'FFFF;
+constexpr uint64_t UNICAST_MAC_ADDR = 0x0000'0000'0000;
+constexpr uint64_t MCAST_MAC_ADDR = 0x0100'0000'0001;
+
+constexpr uint64_t RXQ0_MAC_ADDR = BCAST_MAC_ADDR;
+constexpr uint64_t RXQ1_MAC_ADDR = MCAST_MAC_ADDR;
+
+constexpr uint64_t TXQ0_MAC_ADDR = BCAST_MAC_ADDR;
+constexpr uint64_t TXQ1_MAC_ADDR = MCAST_MAC_ADDR;
+
+#define ETH_CORE_A_ETH_CTRL_A_MAC_RX_ADDR_ROUTING_REG_ADDR (0xFFB98154)
+#define ETH_CORE_A_ETH_CTRL_A_MAC_RX_ROUTING_REG_ADDR (0xFFB98150)
+#define ETH_CORE_A_ETH_TXQ_0_CTRL_REG_OFFSET (0x00000000)
+#define ETH_CORE_A_ETH_TXQ_1_CTRL_REG_OFFSET (0x00000000)
+#define ETH_CORE_A_ETH_CTRL_A_ETH_TXPKT_CFG_A_1__MAC_DA_HI_REG_ADDR (0xFFB9829C)
+#define ETH_CORE_A_ETH_CTRL_A_ETH_TXPKT_CFG_A_1__MAC_DA_LO_REG_ADDR (0xFFB98298)
+#define ETH_CORE_A_ETH_TXQ_0_CTRL_REG_ADDR (0xFFB90000)
+#define ETH_CORE_A_ETH_TXQ_1_CTRL_REG_ADDR (0xFFB91000)
+#define ETH_CORE_A_ETH_TXQ_0_TXPKT_CFG_SEL_HW_REG_ADDR (0xFFB90084)
+#define ETH_CORE_A_ETH_TXQ_1_TXPKT_CFG_SEL_HW_REG_ADDR (0xFFB91084)
+#define ETH_CORE_A_ETH_RXQ_0_CTRL_REG_ADDR (0xFFB94000)
+#define ETH_CORE_A_ETH_RXQ_1_CTRL_REG_ADDR (0xFFB95000)
+#define ETH_CORE_A_ETH_TXQ_0_TXPKT_CFG_SEL_SW_REG_ADDR (0xFFB90080)
+#define ETH_CORE_A_ETH_TXQ_1_TXPKT_CFG_SEL_SW_REG_ADDR (0xFFB91080)
+
+static void map_tx_queues_to_rx_queues() {
+    static constexpr uint32_t rx_chan_bcast_data_bit_offset = 0;
+    static constexpr uint32_t rx_chan_bcast_regwrite_bit_offset = 2;
+    static constexpr uint32_t rx_chan_mcast_data_bit_offset = 4;
+    static constexpr uint32_t rx_chan_mcast_regwrite_bit_offset = 6;
+    static constexpr uint32_t rx_chan_other_data_bit_offset = 8;
+    static constexpr uint32_t rx_chan_other_regwrite_bit_offset = 10;
+
+    uint32_t register_fields_value = eth_reg_read(ETH_CORE_A_ETH_CTRL_A_MAC_RX_ADDR_ROUTING_REG_ADDR) & ~0xFF;
+
+    auto apply_rxq_side_routing = [](uint32_t RXQ_ID, uint64_t ADDR_MAPPING, uint32_t& register_fields_value_out) {
+        if (ADDR_MAPPING == BCAST_MAC_ADDR) {
+            for (auto offset : {rx_chan_bcast_data_bit_offset, rx_chan_bcast_regwrite_bit_offset}) {
+                register_fields_value_out |= (RXQ_ID << offset);
+            }
+        } else if (ADDR_MAPPING == UNICAST_MAC_ADDR) {
+            for (auto offset : {rx_chan_other_data_bit_offset, rx_chan_other_regwrite_bit_offset}) {
+                register_fields_value_out |= (RXQ_ID << offset);
+            }
+        } else if (ADDR_MAPPING == MCAST_MAC_ADDR) {
+            for (auto offset : {rx_chan_mcast_data_bit_offset, rx_chan_mcast_regwrite_bit_offset}) {
+                register_fields_value_out |= (RXQ_ID << offset);
+            }
+        }
+    };
+
+    // send all TXQ1 packets to RXQ1 -- we mapped TXQ1 to mcast,bcast packet types
+    apply_rxq_side_routing(0, RXQ0_MAC_ADDR, register_fields_value);
+    apply_rxq_side_routing(1, RXQ1_MAC_ADDR, register_fields_value);
+    eth_reg_write(ETH_CORE_A_ETH_CTRL_A_MAC_RX_ADDR_ROUTING_REG_ADDR, register_fields_value);
+    eth_reg_write(ETH_CORE_A_ETH_CTRL_A_MAC_RX_ROUTING_REG_ADDR, 0);
+}
+typedef struct {
+    uint32_t packet_resend_mode_active : 1;
+    uint32_t rsvd_0 : 2;
+    uint32_t disable_remote_drop_notification : 1;
+} ETH_TXQ_CTRL_reg_t;
+
+typedef union {
+    uint32_t val;
+    ETH_TXQ_CTRL_reg_t f;
+} ETH_TXQ_CTRL_reg_u;
+
+static void eth_enable_packet_mode(uint32_t qnum) {
+    // enable packet resend
+    ETH_TXQ_CTRL_reg_u txq_ctrl_reg;
+    txq_ctrl_reg.f.packet_resend_mode_active = 1;
+    eth_txq_reg_write(qnum, ETH_CORE_A_ETH_TXQ_0_CTRL_REG_OFFSET, txq_ctrl_reg.val);
+    eth_txq_reg_write(qnum, ETH_CORE_A_ETH_TXQ_1_CTRL_REG_OFFSET, txq_ctrl_reg.val);
+
+    // What are we doing here?
+    // Essentially we are abusing the ethernet protocol and arbitrarily deciding to use mcast/bcast vs unicast
+    // message types to distinguish destination receiver queue.
+    //
+    // For TXQ0, we are we are setting the destination mac address to 0 (RXQ0)
+    //  -> these will map to "unicast" packets
+    // For TXQ1, we are we are setting the destination mac address to 1 (RXQ1)
+    //  -> these will map to "bcast"/"mcast" packets
+    //
+    // Further down, we will initialize the RX queues to be forwarded the ethernet packets of each
+    // respective type described above.
+    eth_reg_write(ETH_CORE_A_ETH_CTRL_A_ETH_TXPKT_CFG_A_1__MAC_DA_HI_REG_ADDR, (TXQ1_MAC_ADDR >> 32) & 0xFFFF);
+    eth_reg_write(ETH_CORE_A_ETH_CTRL_A_ETH_TXPKT_CFG_A_1__MAC_DA_LO_REG_ADDR, TXQ1_MAC_ADDR & 0xFFFFFFFF);
+
+    // enable packet resend on each TXQ:
+    auto enable_packet_resend_txq = [](uint32_t addr) {
+        constexpr uint32_t txq_packet_resend_mode_active_bit_offset = 0;
+        uint32_t val = 0;
+        val |= (1 << txq_packet_resend_mode_active_bit_offset);
+        eth_reg_write(addr, val);
+    };
+    enable_packet_resend_txq(ETH_CORE_A_ETH_TXQ_0_CTRL_REG_ADDR);
+    enable_packet_resend_txq(ETH_CORE_A_ETH_TXQ_1_CTRL_REG_ADDR);
+
+    // Set each TXQ to use separate entries in the tx pkt config table
+    eth_reg_write(ETH_CORE_A_ETH_TXQ_0_TXPKT_CFG_SEL_HW_REG_ADDR, 0);
+    eth_reg_write(ETH_CORE_A_ETH_TXQ_1_TXPKT_CFG_SEL_HW_REG_ADDR, 1);
+    auto set_txq_config_table_mapping = [](uint32_t txpkt_cfg_sel_sw_reg_addr, uint32_t mapping) {
+        constexpr uint32_t raw_bit_offset = 0;
+        constexpr uint32_t eth_reg_writes_bit_offset = 4;
+        constexpr uint32_t eth_packet_sends_bit_offset = 8;
+        uint32_t val = 0;
+        val |= (mapping << raw_bit_offset);
+        val |= (mapping << eth_reg_writes_bit_offset);
+        val |= (mapping << eth_packet_sends_bit_offset);
+        eth_reg_write(txpkt_cfg_sel_sw_reg_addr, val);
+    };
+    // Set each TXQ to use separate entries in the tx pkt config table
+    set_txq_config_table_mapping(ETH_CORE_A_ETH_TXQ_0_TXPKT_CFG_SEL_SW_REG_ADDR, 0);
+    set_txq_config_table_mapping(ETH_CORE_A_ETH_TXQ_1_TXPKT_CFG_SEL_SW_REG_ADDR, 1);
+
+    auto enable_packet_mode_rxq = [](uint32_t addr) {
+        constexpr uint32_t rxq_packet_mode_bit_offset = 1;
+        uint32_t val = 0;
+        val |= (1 << rxq_packet_mode_bit_offset);
+        eth_reg_write(addr, val);
+    };
+    enable_packet_mode_rxq(ETH_CORE_A_ETH_RXQ_0_CTRL_REG_ADDR);
+    enable_packet_mode_rxq(ETH_CORE_A_ETH_RXQ_1_CTRL_REG_ADDR);
+
+    map_tx_queues_to_rx_queues();
+}

--- a/tt_metal/fabric/hw/inc/tt_fabric_utils.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_utils.h
@@ -17,6 +17,7 @@ namespace tt::tt_fabric {
 /* Termination signal handling*/
 FORCE_INLINE bool got_immediate_termination_signal(volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
     // mailboxes defined in tt_metal/hw/inc/ethernet/tunneling.h
+    invalidate_l1_cache();
     uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
     tt_l1_ptr launch_msg_t* const launch_msg = GET_MAILBOX_ADDRESS_DEV(launch[launch_msg_rd_ptr]);
     return (*termination_signal_ptr == tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE) ||

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,14 +21,17 @@
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_utils.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_tmp_utils.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_router_flow_control.hpp"
 
 #include "noc_overlay_parameters.h"
 #include "tt_metal/hw/inc/utils/utils.h"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_txq_setup.h"
 #include <fabric_host_interface.h>
 
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 using namespace tt::tt_fabric;
 
@@ -323,7 +326,7 @@ struct ChannelPointersTupleImpl<ChannelType, BufferSizes, std::index_sequence<Is
     }
 };
 
-// Simplify the “builder” so that make() returns the Impl<…> directly:
+// Simplify the "builder" so that make() returns the Impl<…> directly:
 template <template <uint8_t> class ChannelType, auto& BufferSizes>
 struct ChannelPointersTuple {
     static constexpr size_t N = std::size(BufferSizes);
@@ -446,6 +449,7 @@ template <uint8_t RECEIVER_NUM_BUFFERS>
 FORCE_INLINE void receiver_send_received_ack(
     // currently the pointer is working multiple jobs (ack, completion, read) because we haven't implemented the
     // decoupling of those jobs yet to separate pointrers
+    ReceiverChannelResponseCreditSender& receiver_channel_response_credit_sender,
     BufferIndex receiver_buffer_index,
     const tt::tt_fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS>& local_receiver_buffer_channel) {
     // Set the acknowledgement bits
@@ -453,18 +457,21 @@ FORCE_INLINE void receiver_send_received_ack(
     volatile tt_l1_ptr auto* pkt_header = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(
         local_receiver_buffer_channel.get_buffer_address(receiver_buffer_index));
     const auto src_id = pkt_header->src_ch_id;
+
     while (internal_::eth_txq_is_busy(receiver_txq_id)) {
     };
-    remote_update_ptr_val<receiver_txq_id>(to_sender_packets_acked_streams[src_id], 1);
+
+    receiver_channel_response_credit_sender.send_ack_credit(src_id);
 }
 
 // MUST CHECK !is_eth_txq_busy() before calling
-FORCE_INLINE void receiver_send_completion_ack(uint8_t src_id) {
+FORCE_INLINE void receiver_send_completion_ack(
+    ReceiverChannelResponseCreditSender& receiver_channel_response_credit_sender, uint8_t src_id) {
     if constexpr (ETH_TXQ_SPIN_WAIT_RECEIVER_SEND_COMPLETION_ACK) {
         while (internal_::eth_txq_is_busy(receiver_txq_id)) {
         };
     }
-    remote_update_ptr_val<receiver_txq_id>(to_sender_packets_completed_streams[src_id], 1);
+    receiver_channel_response_credit_sender.send_completion_credit(src_id);
 }
 
 template <uint8_t SENDER_NUM_BUFFERS>
@@ -1170,7 +1177,8 @@ void run_sender_channel_step_impl(
     tt::tt_fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS>& remote_receiver_channel,
     PacketHeaderRecorder& packet_header_recorder,
     bool& channel_connection_established,
-    uint32_t sender_channel_free_slots_stream_id) {
+    uint32_t sender_channel_free_slots_stream_id,
+    SenderChannelFromReceiverCredits& sender_channel_from_receiver_credits) {
     // If the receiver has space, and we have one or more packets unsent from producer, then send one
     // TODO: convert to loop to send multiple packets back to back (or support sending multiple packets in one shot)
     //       when moving to stream regs to manage rd/wr ptrs
@@ -1203,11 +1211,11 @@ void run_sender_channel_step_impl(
     }
 
     // Process COMPLETIONs from receiver
-    int32_t completions_since_last_check = get_ptr_val(to_sender_packets_completed_streams[sender_channel_index]);
+    int32_t completions_since_last_check =
+        sender_channel_from_receiver_credits.get_num_unprocessed_completions_from_receiver();
     if (completions_since_last_check) {
         outbound_to_receiver_channel_pointers.num_free_slots += completions_since_last_check;
-        increment_local_update_ptr_val(
-            to_sender_packets_completed_streams[sender_channel_index], -completions_since_last_check);
+        sender_channel_from_receiver_credits.increment_num_processed_completions(completions_since_last_check);
         if constexpr (!enable_first_level_ack) {
             if constexpr (SKIP_CONNECTION_LIVENESS_CHECK) {
                 local_sender_channel_worker_interface
@@ -1235,7 +1243,7 @@ void run_sender_channel_step_impl(
     // we are guaranteed to see equal to or greater the number of acks than completions
     if constexpr (enable_first_level_ack) {
         ASSERT(false);
-        auto acks_since_last_check = get_ptr_val(to_sender_packets_acked_streams[sender_channel_index]);
+        auto acks_since_last_check = sender_channel_from_receiver_credits.get_num_unprocessed_acks_from_receiver();
         if (acks_since_last_check > 0) {
             if constexpr (SKIP_CONNECTION_LIVENESS_CHECK) {
                 local_sender_channel_worker_interface
@@ -1253,8 +1261,7 @@ void run_sender_channel_step_impl(
                     local_sender_channel_worker_interface.worker_location_info_ptr->edm_local_write_counter = new_val;
                 }
             }
-            increment_local_update_ptr_val(
-                to_sender_packets_acked_streams[sender_channel_index], -acks_since_last_check);
+            sender_channel_from_receiver_credits.increment_num_processed_acks(acks_since_last_check);
         }
     }
 
@@ -1287,7 +1294,8 @@ FORCE_INLINE void run_sender_channel_step(
     RemoteEthReceiverChannels& remote_receiver_channels,
     std::array<PacketHeaderRecorder, MAX_NUM_SENDER_CHANNELS>& sender_channel_packet_recorders,
     std::array<bool, NUM_SENDER_CHANNELS>& channel_connection_established,
-    std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids_ordered) {
+    std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids_ordered,
+    std::array<SenderChannelFromReceiverCredits, NUM_SENDER_CHANNELS>& sender_channel_from_receiver_credits) {
     if constexpr (is_sender_channel_serviced[sender_channel_index]) {
         run_sender_channel_step_impl<
             enable_packet_header_recording,
@@ -1301,7 +1309,8 @@ FORCE_INLINE void run_sender_channel_step(
             remote_receiver_channels.template get<VC_RECEIVER_CHANNEL>(),
             sender_channel_packet_recorders[sender_channel_index],
             channel_connection_established[sender_channel_index],
-            local_sender_channel_free_slots_stream_ids_ordered[sender_channel_index]);
+            local_sender_channel_free_slots_stream_ids_ordered[sender_channel_index],
+            sender_channel_from_receiver_credits[sender_channel_index]);
     }
 }
 
@@ -1317,7 +1326,8 @@ void run_receiver_channel_step_impl(
         downstream_edm_interface,
     ReceiverChannelPointers<RECEIVER_NUM_BUFFERS>& receiver_channel_pointers,
     WriteTridTracker& receiver_channel_trid_tracker,
-    std::array<uint8_t, num_eth_ports>& port_direction_table) {
+    std::array<uint8_t, num_eth_ports>& port_direction_table,
+    ReceiverChannelResponseCreditSender& receiver_channel_response_credit_sender) {
     auto pkts_received_since_last_check = get_ptr_val<to_receiver_pkts_sent_id>();
     auto& wr_sent_counter = receiver_channel_pointers.wr_sent_counter;
     bool unwritten_packets;
@@ -1328,7 +1338,8 @@ void run_receiver_channel_step_impl(
         if (pkts_received) {
             // currently only support processing one packet at a time, so we only decrement by 1
             increment_local_update_ptr_val<to_receiver_pkts_sent_id>(-1);
-            receiver_send_received_ack(ack_counter.get_buffer_index(), local_receiver_channel);
+            receiver_send_received_ack(
+                receiver_channel_response_credit_sender, ack_counter.get_buffer_index(), local_receiver_channel);
             ack_counter.increment();
         }
         unwritten_packets = !wr_sent_counter.is_caught_up_to(ack_counter);
@@ -1424,7 +1435,9 @@ void run_receiver_channel_step_impl(
         if (unsent_completions) {
             // completion ptr incremented in callee
             auto receiver_buffer_index = wr_flush_counter.get_buffer_index();
-            receiver_send_completion_ack(receiver_channel_pointers.get_src_chan_id(receiver_buffer_index));
+            receiver_send_completion_ack(
+                receiver_channel_response_credit_sender,
+                receiver_channel_pointers.get_src_chan_id(receiver_buffer_index));
             completion_counter.increment();
         }
     } else {
@@ -1440,7 +1453,9 @@ void run_receiver_channel_step_impl(
             can_send_completion = can_send_completion && !internal_::eth_txq_is_busy(DEFAULT_ETH_TXQ);
         }
         if (can_send_completion) {
-            receiver_send_completion_ack(receiver_channel_pointers.get_src_chan_id(receiver_buffer_index));
+            receiver_send_completion_ack(
+                receiver_channel_response_credit_sender,
+                receiver_channel_pointers.get_src_chan_id(receiver_buffer_index));
             receiver_channel_trid_tracker.clear_trid_at_buffer_slot(receiver_buffer_index);
             completion_counter.increment();
         }
@@ -1459,14 +1474,16 @@ FORCE_INLINE void run_receiver_channel_step(
         downstream_edm_interface,
     ReceiverChannelPointers<RECEIVER_NUM_BUFFERS>& receiver_channel_pointers,
     WriteTridTracker& receiver_channel_trid_tracker,
-    std::array<uint8_t, num_eth_ports>& port_direction_table) {
+    std::array<uint8_t, num_eth_ports>& port_direction_table,
+    std::array<ReceiverChannelResponseCreditSender, NUM_RECEIVER_CHANNELS>& receiver_channel_response_credit_senders) {
     if constexpr (is_receiver_channel_serviced[receiver_channel]) {
         run_receiver_channel_step_impl<receiver_channel, to_receiver_packets_sent_streams[receiver_channel]>(
             local_receiver_channels.template get<receiver_channel>(),
             downstream_edm_interface,
             receiver_channel_pointers,
             receiver_channel_trid_tracker,
-            port_direction_table);
+            port_direction_table,
+            receiver_channel_response_credit_senders[receiver_channel]);
     }
 }
 
@@ -1527,7 +1544,11 @@ void run_fabric_edm_main_loop(
     std::array<bool, NUM_SENDER_CHANNELS> channel_connection_established =
         initialize_array<NUM_SENDER_CHANNELS, bool, false>();
 
-    // This value defines the number of loop iterations we perform of the main control sequence before exiting
+    auto receiver_channel_response_credit_senders =
+        init_receiver_channel_response_credit_senders<NUM_RECEIVER_CHANNELS>();
+    auto sender_channel_from_receiver_credits =
+        init_sender_channel_from_receiver_credits_flow_controllers<NUM_SENDER_CHANNELS>();
+    // This value defines the number of loop iterations we perform of the main control sequence before exiting
     // to check for termination and context switch. Removing the these checks from the inner loop can drastically
     // improve performance. The value of 32 was chosen somewhat empirically and then raised up slightly.
 
@@ -1546,14 +1567,16 @@ void run_fabric_edm_main_loop(
                 remote_receiver_channels,
                 sender_channel_packet_recorders,
                 channel_connection_established,
-                local_sender_channel_free_slots_stream_ids_ordered);
+                local_sender_channel_free_slots_stream_ids_ordered,
+                sender_channel_from_receiver_credits);
             if constexpr (!dateline_connection) {
                 run_receiver_channel_step<0>(
                     local_receiver_channels,
                     downstream_edm_noc_interfaces,
                     receiver_channel_pointers_ch0,
                     receiver_channel_0_trid_tracker,
-                    port_direction_table);
+                    port_direction_table,
+                    receiver_channel_response_credit_senders);
             }
             if constexpr (enable_ring_support && !skip_receiver_channel_1_connection) {
                 run_receiver_channel_step<1>(
@@ -1561,7 +1584,8 @@ void run_fabric_edm_main_loop(
                     downstream_edm_noc_interfaces,
                     receiver_channel_pointers_ch1,
                     receiver_channel_1_trid_tracker,
-                    port_direction_table);
+                    port_direction_table,
+                    receiver_channel_response_credit_senders);
             }
 
             if constexpr (is_sender_channel_serviced[1] && !skip_sender_channel_1_connection) {
@@ -1572,7 +1596,8 @@ void run_fabric_edm_main_loop(
                     remote_receiver_channels,
                     sender_channel_packet_recorders,
                     channel_connection_established,
-                    local_sender_channel_free_slots_stream_ids_ordered);
+                    local_sender_channel_free_slots_stream_ids_ordered,
+                    sender_channel_from_receiver_credits);
             }
             if constexpr (is_2d_fabric) {
                 run_sender_channel_step<enable_packet_header_recording, VC0_RECEIVER_CHANNEL, 2>(
@@ -1582,7 +1607,8 @@ void run_fabric_edm_main_loop(
                     remote_receiver_channels,
                     sender_channel_packet_recorders,
                     channel_connection_established,
-                    local_sender_channel_free_slots_stream_ids_ordered);
+                    local_sender_channel_free_slots_stream_ids_ordered,
+                    sender_channel_from_receiver_credits);
                 run_sender_channel_step<enable_packet_header_recording, VC0_RECEIVER_CHANNEL, 3>(
                     local_sender_channels,
                     local_sender_channel_worker_interfaces,
@@ -1590,7 +1616,8 @@ void run_fabric_edm_main_loop(
                     remote_receiver_channels,
                     sender_channel_packet_recorders,
                     channel_connection_established,
-                    local_sender_channel_free_slots_stream_ids_ordered);
+                    local_sender_channel_free_slots_stream_ids_ordered,
+                    sender_channel_from_receiver_credits);
             }
             if constexpr (enable_ring_support && !dateline_connection && !skip_sender_vc1_channel_connection) {
                 run_sender_channel_step<enable_packet_header_recording, VC1_RECEIVER_CHANNEL, NUM_SENDER_CHANNELS - 1>(
@@ -1600,7 +1627,8 @@ void run_fabric_edm_main_loop(
                     remote_receiver_channels,
                     sender_channel_packet_recorders,
                     channel_connection_established,
-                    local_sender_channel_free_slots_stream_ids_ordered);
+                    local_sender_channel_free_slots_stream_ids_ordered,
+                    sender_channel_from_receiver_credits);
             }
         }
 
@@ -1759,11 +1787,27 @@ void populate_local_sender_channel_free_slots_stream_id_ordered_map(
     }
 }
 
+void initialize_state_for_txq1_active_mode() {
+    eth_txq_reg_write(receiver_txq_id, ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD, DEFAULT_NUM_ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD);
+
+    eth_enable_packet_mode(receiver_txq_id);
+    for (size_t i = 0; i < NUM_SENDER_CHANNELS; i++) {
+        *reinterpret_cast<volatile uint32_t*>(to_sender_remote_ack_counter_addrs[i]) = 0;
+        *reinterpret_cast<volatile uint32_t*>(to_sender_remote_completion_counter_addrs[i]) = 0;
+    }
+    for (size_t i = 0; i < NUM_RECEIVER_CHANNELS; i++) {
+        *reinterpret_cast<volatile uint32_t*>(local_receiver_ack_counter_ptrs[i]) = 0;
+        *reinterpret_cast<volatile uint32_t*>(local_receiver_completion_counter_ptrs[i]) = 0;
+    }
+}
+
 void kernel_main() {
     eth_txq_reg_write(sender_txq_id, ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD, DEFAULT_NUM_ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD);
+    static_assert(
+        receiver_txq_id == sender_txq_id || receiver_txq_id == 1,
+        "For multi-txq mode, the only currently supported configuration is sender_txq_id=0 and receiver_txq_id=1");
     if constexpr (receiver_txq_id != sender_txq_id) {
-        eth_txq_reg_write(
-            receiver_txq_id, ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD, DEFAULT_NUM_ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD);
+        initialize_state_for_txq1_active_mode();
     }
     //
     // COMMON CT ARGS (not specific to sender or receiver)

--- a/tt_metal/hw/inc/ethernet/tt_eth_api.h
+++ b/tt_metal/hw/inc/ethernet/tt_eth_api.h
@@ -12,6 +12,8 @@
 #define ETH_WRITE_REG(addr, val) ((*((volatile uint32_t*)((addr)))) = (val))
 #define ETH_READ_REG(addr) (*((volatile uint32_t*)((addr))))
 
+#define ETH_WORD_SIZE_BYTES 16
+
 inline void eth_txq_reg_write(uint32_t qnum, uint32_t offset, uint32_t val) {
     ETH_WRITE_REG(ETH_TXQ0_REGS_START + (qnum * ETH_TXQ_REGS_SIZE) + offset, val);
 }
@@ -19,6 +21,10 @@ inline void eth_txq_reg_write(uint32_t qnum, uint32_t offset, uint32_t val) {
 inline uint32_t eth_txq_reg_read(uint32_t qnum, uint32_t offset) {
     return ETH_READ_REG(ETH_TXQ0_REGS_START + (qnum * ETH_TXQ_REGS_SIZE) + offset);
 }
+
+void eth_reg_write(uint32_t addr, uint32_t val) { ETH_WRITE_REG(addr, val); }
+
+uint32_t eth_reg_read(uint32_t addr) { return ETH_READ_REG(addr); }
 
 inline void eth_risc_reg_write(uint32_t offset, uint32_t val) { ETH_WRITE_REG(ETH_RISC_REGS_START + offset, val); }
 inline uint32_t eth_risc_reg_read(uint32_t offset) { return ETH_READ_REG(ETH_RISC_REGS_START + offset); }

--- a/tt_metal/hw/inc/ethernet/tt_eth_ss_regs.h
+++ b/tt_metal/hw/inc/ethernet/tt_eth_ss_regs.h
@@ -36,6 +36,10 @@
 #define ETH_TXQ_REGS_SIZE 0x1000
 #define ETH_TXQ_REGS_SIZE_BIT 12
 
+//////////////////////////////
+// RX queue controllers
+#define ETH_RXQ_REGS_SIZE 0x1000
+
 // TXQ_CTRL[0]: set to enable packet resend mode (must be set on both sides)
 // TXQ_CTRL[1]: reserved, should be 0
 // TXQ_CTRL[2]: 0 = use Length field, 1 = use Type field (from ETH_TXQ_ETH_TYPE)


### PR DESCRIPTION
With this change, both TXQ0 and TXQ1 are used by Blackhole. Sender channel traffic (payloads and departing credits) are mapped to TXQ0 and receiver channel traffic (departing ack/completion credits) are mapped to TXQ1.

The implementation is sub-optimal but is due to a HW bug in Blackhole Ethernet subsystem. The bug prevents concurrent Ethernet remote register writes across multiple TXQs. Specifically, on the receive side, register writes over Ethernet can only be (statically) directed to one RXQ at a time, configured through a register write. The register writes cannot be dynamically be directed to different receivers, based on sender or payload contents.

As a work-around, specifically for Blackhole in two TXQ operating mode, the receiver -> send credit scheme moves to counter based credits. These credits are sent using using the Ethernet send packet path (i.e. not a register write) . This approach is race-safe. The reason this approach is race-safe is because we use unbounded counters, as opposed to credits that indicate an increment of some kind. Since it's an unbounded counter, where the actual value is used as is directly, then it is okay if a value is sent multiple times. A value could be sent multiple times if the Erisc updates the values multiple times before the ethernet subsystem is able to dispatch the write over Ethernet. 

Note that in the abstract, there is a roll-over/overflow concern for unbounded counters. In practice, this is not an issue because of how subtraction is implemented in hardware. If the sender channel is comparing two unsigned counters: one that has wrapped around against one that hasn't. From the uint counter perspective, the wrap doesn't matter. A snippet such as the following running on the risc demonstrates it.

```
    uint32_t trailing = std::numeric_limits<uint32_t>::max() - 3;
    uint32_t leading = 4; // indicating that leading wrapped recently (current offset is 4 past wrap)

    uint32_t delta = leading - trailing;
    
    uint32_t counted_delta = 0;
    for (uint32_t ctr = trailing; ctr != leading; ctr++)  {
        counted_delta++;
    }

    assert(counted_delta == delta);
```

In addition to integration into the TT-Fabric router, this approach is implemented in the unit test for basic bringup and validation.

Additionally, a unit test to program this two-txq mode is added to test the programming sequence to set TXQ1 to packet mode in isolation. This unit test also loosely models the general traffic patterns sent by fabric routers.

To support the new behaviour, the fabric router code was updated to start formalizing these credit receivers/senders into separate types which are compile time selectable now.

```
                          ┌─── now a compile time configurable type                 
                          │                          ───┐                           
               Chip 0     │                             │      Chip 1               
            Fabric Router │            srcId            │   Fabric Router           
   ┌──────────────────────┼───────┐     │          ┌────┼─────────────────────────┐ 
   │                      │       │     │          │    │                         │ 
   │                      ▼       │    \│          │    ▼                         │ 
   │ ┌──────────────┐──────────┐  │   │ \          │ ┌────────┬────────────────┐  │ 
   │ │ Inbound 0    │ Credit   │  │   │  \ Credit  │ │Credit  │ Inbound 0      │  │ 
   │ │ Channel      │ Receiver │◄─┼───┤  |     ┌───┼─┤Sender  │ Channel        │  │ 
   │ └───────┬──────┘──────────┘  │   │  |◄────┘   │ └────────┴────────────────┘  │ 
 ┌─┼─────────┘                    │ ┌─┤  |         │                  ▲           │ 
 │ │ ┌──────────────┐──────────┐  │ │ │  /         │                  │           │ 
 │ │ │ Inbound 1    │ Credit   │  │ │ │ /          │                  │           │ 
 │ │ │ Channel      │ Receiver │◄─┼─┘  /           │                  │           │ 
 │ │ └───────┬──────┘──────────┘  │◄──────────────►│                  │           │ 
 │ │         │                    │     Ethernet   │                  │           │ 
 │ │         │                    │                │                  │           │ 
 │ │         │                    │                │                  │           │ 
 └─┼────────►└────────────────────┼────────────────┼──────────────────┘           │ 
   │                              │                │                              │ 
   │                              │                │                              │ 
   │                              │                │                              │ 
   │                              │                │                              │ 
   │                              │                │                              │ 
   └──────────────────────────────┘                └──────────────────────────────┘ 
```

In this change, the direction of credit send/receive (relative to Ethernet link) still hardcoded by type but in the future they will likely be generalized further to support various interfaces (Ethernet-subsystem, noc). 



### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/16209520690
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/16243051049
- [x] BH LLMbox: https://github.com/tenstorrent/tt-metal/actions/runs/16243041071
  - note on reruns: Each run passed. Wanted to confirm basic stability/robustness. Also ran locally fabric tests locally 200x without failures
- [x] BH Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/16243050111
- [x] T3K Unit Tests: https://github.com/tenstorrent/tt-metal/actions/runs/16206003333
- [x] Metal microbenchmarks: https://github.com/tenstorrent/tt-metal/actions/runs/16209524287
- [X] New/Existing tests provide coverage for changes