### PR TITLE
Change data-parallel batch size calculation in tt_transformers

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -107,7 +107,7 @@ class Generator:
                     continue
 
                 user_id = group_user_id + model_id * max_batch_size_per_model
-                out = out_list[group_user_id]
+                out = out_list[user_id]
 
                 seq_len = int(prompt_lens[user_id])
                 last_token_idx = seq_len - 1

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1258,7 +1258,7 @@ class Generator:
         """
         Returns the maximum batch size per model and a list of batch sizes for each model.
         """
-        max_batch_size_per_model = (batch_size + self.data_parallel - 1) // self.data_parallel
+        max_batch_size_per_model = self.model_args[0].max_batch_size
 
         # The logic ensures that the total batch size is divided as evenly as possible
         # among the models, with any remainder distributed to the earlier models in the list.


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24280

### Problem description
Incorrect batching was causing low accuracy on the vllm side when `data_parallel > 1`

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [TG demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16141391286) CI passes
- [x] [tt-inference-server DP=4 test](https://github.com/tenstorrent/tt-shield/actions/runs/16147158518)