### PR TITLE
#23015: Migrate hardshrink as a device op

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -645,29 +645,6 @@ def test_unary_swiglu_ttnn(input_shapes, dim, device):
 )
 @pytest.mark.parametrize(
     "param",
-    {0.45, 7.7, 36.89, 58.4, 97.2},
-)
-def test_unary_hardshrink(input_shapes, param, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-
-    output_tensor = ttnn.hardshrink(input_tensor, lambd=param)
-    golden_function = ttnn.get_golden_function(ttnn.hardshrink)
-    golden_tensor = golden_function(in_data, lambd=param)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
-@pytest.mark.parametrize(
-    "param",
     {0.45, 7.7, 36.89, 58.4, 89.9},
 )
 def test_unary_softshrink(input_shapes, param, device):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -927,3 +927,59 @@ def test_unary_atanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, low, high, devi
     golden_tensor = golden_function(in_data1)
 
     assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([100])),
+        (torch.Size([64, 128])),
+        (torch.Size([3, 128, 32])),
+        (torch.Size([1, 3, 320, 384])),
+        (torch.Size([1, 1, 32, 320, 12])),
+    ),
+)
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype",
+    [
+        (torch.float32, ttnn.float32),
+        (torch.bfloat16, ttnn.bfloat16),
+        (torch.bfloat16, ttnn.bfloat8_b),
+    ],
+)
+@pytest.mark.parametrize(
+    "param",
+    {0.65, 7.7, 36.49, 58.6, 97.2},
+)
+def test_unary_hardshrink(input_shapes, param, torch_dtype, ttnn_dtype, device):
+    in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
+    input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    if ttnn_dtype == ttnn.bfloat8_b:
+        in_data = ttnn.to_torch(input_tensor, dtype=torch_dtype)
+
+    output_tensor = ttnn.hardshrink(input_tensor, lambd=param)
+    golden_function = ttnn.get_golden_function(ttnn.hardshrink)
+    golden_tensor = golden_function(in_data, lambd=param)
+
+    assert_with_ulp(output_tensor, golden_tensor)
+    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 5, 512, 1024])),),
+)
+@pytest.mark.parametrize(
+    "param",
+    {0.45, 7.7, 197.2, 1e5},
+)
+def test_unary_hardshrink_edge_case_ttnn(input_shapes, param, device):
+    in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.hardshrink(input_tensor)
+    golden_function = ttnn.get_golden_function(ttnn.hardshrink)
+    golden_tensor = golden_function(in_data)
+
+    assert_with_ulp(output_tensor, golden_tensor)
+    assert_with_pcc(ttnn.to_torch(output_tensor), golden_tensor, pcc=0.999)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -102,6 +102,7 @@ enum class UnaryOpType {
     MAXIMUM,
     MINIMUM,
     TANHSHRINK,
+    HARDSHRINK,
 };
 
 enum class VecMode {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -76,7 +76,8 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::FMOD:
         case UnaryOpType::MINIMUM:
         case UnaryOpType::MAXIMUM:
-        case UnaryOpType::LOG1P: return true;
+        case UnaryOpType::LOG1P:
+        case UnaryOpType::HARDSHRINK: return true;
         default: return false;
     }
     return false;
@@ -84,6 +85,7 @@ bool is_parametrized_type(T val) {
 
 void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string>& defines);
 
-std::string get_compute_kernel_path(UnaryOpType op_type, const std::string& compute_root);
+std::string get_compute_kernel_path(
+    UnaryOpType op_type, const std::string& compute_root, std::optional<DataType> input_dtype = std::nullopt);
 
 }  // namespace ttnn::operations::unary::utils

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardshrink_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardshrink_kernel.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <cstring>
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/eltwise_unary/fill.h"
+#include "compute_kernel_api/eltwise_unary/comp.h"
+
+namespace NAMESPACE {
+void MAIN {
+    const uint32_t packed_scalar = get_arg_val<uint32_t>(0);
+    const auto lambd = reinterpret_cast<const float*>(&packed_scalar);
+    uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
+    uint32_t per_core_block_dim = get_compile_time_arg_val(1);
+    constexpr auto cb_input = tt::CBIndex::c_0;
+    constexpr auto cb_output = tt::CBIndex::c_2;
+    constexpr auto cb_tmp0 = tt::CBIndex::c_1;
+    init_sfpu(cb_input, cb_output);
+
+    // a⋅1(a+λ<0)+a⋅1(a−λ>0)
+    for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
+        cb_reserve_back(cb_output, per_core_block_dim);
+        for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
+            cb_wait_front(cb_input, 1);
+            cb_reserve_back(cb_tmp0, 1);
+            tile_regs_acquire();
+
+            fill_tile(0, *lambd);
+
+            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_input);
+            binary_dest_reuse_tiles<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
+                cb_input, 0, 0);
+            ltz_tile(0);
+            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_input);
+            binary_dest_reuse_tiles<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
+                cb_input, 0, 0);
+
+            tile_regs_commit();
+
+            tile_regs_wait();
+
+            pack_tile(0, cb_tmp0);
+            tile_regs_release();
+
+            cb_push_back(cb_tmp0, 1);
+            cb_wait_front(cb_tmp0, 1);
+            tile_regs_acquire();
+
+            fill_tile(0, *lambd);
+            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWSUB, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_input);
+            binary_dest_reuse_tiles<EltwiseBinaryType::ELWSUB, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+                cb_input, 0, 0);
+            gtz_tile(0);
+            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_input);
+            binary_dest_reuse_tiles<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
+                cb_input, 0, 0);
+
+            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_tmp0);
+            binary_dest_reuse_tiles<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_tmp0, 0, 0);
+
+            tile_regs_commit();
+
+            tile_regs_wait();
+
+            pack_tile(0, cb_output);
+            tile_regs_release();
+
+            cb_pop_front(cb_input, 1);
+            cb_pop_front(cb_tmp0, 1);
+        }
+        cb_push_back(cb_output, per_core_block_dim);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardshrink_kernel_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardshrink_kernel_sfpu.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <cstring>
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_binary_sfpu.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/eltwise_unary/fill.h"
+#include "compute_kernel_api/eltwise_unary/comp.h"
+
+namespace NAMESPACE {
+void MAIN {
+    const uint32_t packed_scalar = get_arg_val<uint32_t>(0);
+    const auto lambd = reinterpret_cast<const float*>(&packed_scalar);
+    uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
+    uint32_t per_core_block_dim = get_compile_time_arg_val(1);
+    constexpr auto cb_input = tt::CBIndex::c_0;
+    constexpr auto cb_output = tt::CBIndex::c_2;
+    constexpr auto cb_tmp0 = tt::CBIndex::c_1;
+    init_sfpu(cb_input, cb_output);
+
+    // a⋅1(a+λ<0)+a⋅1(a−λ>0)
+    for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
+        cb_reserve_back(cb_output, per_core_block_dim);
+        for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
+            cb_wait_front(cb_input, 1);
+            cb_reserve_back(cb_tmp0, 1);
+            tile_regs_acquire();
+
+            fill_tile(0, *lambd);
+            copy_tile_to_dst_init_short(cb_input);
+            copy_tile(cb_input, 0, 1);
+            add_binary_tile_init();
+            add_binary_tile(0, 1);
+            ltz_tile(0);
+            mul_binary_tile_init();
+            mul_binary_tile(0, 1);
+
+            tile_regs_commit();
+
+            tile_regs_wait();
+
+            pack_tile(0, cb_tmp0);
+            tile_regs_release();
+
+            cb_push_back(cb_tmp0, 1);
+            cb_wait_front(cb_tmp0, 1);
+            tile_regs_acquire();
+
+            fill_tile(1, *lambd);
+
+            copy_tile_to_dst_init_short(cb_input);
+            copy_tile(cb_input, 0, 0);
+            sub_binary_tile_init();
+            sub_binary_tile(0, 1);
+            gtz_tile(0);
+            copy_tile_to_dst_init_short(cb_input);
+            copy_tile(cb_input, 0, 1);
+            mul_binary_tile_init();
+            mul_binary_tile(0, 1);
+            copy_tile_to_dst_init_short(cb_tmp0);
+            copy_tile(cb_tmp0, 0, 1);
+            add_binary_tile_init();
+            add_binary_tile(0, 1);
+
+            tile_regs_commit();
+
+            tile_regs_wait();
+
+            pack_tile(0, cb_output);
+            tile_regs_release();
+
+            cb_pop_front(cb_input, 1);
+            cb_pop_front(cb_tmp0, 1);
+        }
+        cb_push_back(cb_output, per_core_block_dim);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -602,17 +602,6 @@ Tensor ExecuteRdiv::invoke(
         ttnn::eqz(queue_id, input_tensor, memory_config), t_inf, result, memory_config, optional_output_tensor);
 }
 
-// Function: hardshrink
-// Ref: https://pytorch.org/docs/stable/generated/torch.nn.Hardshrink.html
-Tensor _hardshrink(const Tensor& a, float param, const std::optional<MemoryConfig>& output_mem_config) {
-    TT_ASSERT(param >= 0);
-    Tensor t1 = ttnn::multiply(
-        ttnn::ltz(ttnn::add(a, param, std::nullopt, output_mem_config)), a, std::nullopt, output_mem_config);
-    Tensor t2 = ttnn::multiply(
-        ttnn::gtz(ttnn::subtract(a, param, std::nullopt, output_mem_config)), a, std::nullopt, output_mem_config);
-    return ttnn::add(t1, t2, std::nullopt, output_mem_config);
-}
-
 // Function: softshrink
 // Ref: https://pytorch.org/docs/stable/generated/torch.nn.Softshrink.html
 Tensor _softshrink(const Tensor& a, float param, const std::optional<MemoryConfig>& output_mem_config) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
@@ -38,7 +38,6 @@ enum class UnaryCompositeOpType {
     TRIL,
     TRIU,
     POLYGAMMA,
-    HARDSHRINK,
     SOFTSHRINK,
     LOGIT,
     CELU,
@@ -86,8 +85,6 @@ Tensor _swiglu(const Tensor&, int32_t, const std::optional<MemoryConfig>&);
 Tensor _tril(const Tensor&, int32_t diag = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _triu(const Tensor&, int32_t diag = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _polygamma(const Tensor&, int32_t, const std::optional<MemoryConfig>&);
-Tensor _hardshrink(
-    const Tensor& a, float lambd = 0.5f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _softshrink(
     const Tensor& a, float lambd = 0.5f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _logit(const Tensor& a, float eps = 0.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
@@ -248,13 +245,6 @@ template <>
 struct OpHandler<UnaryCompositeOpType::SWIGLU> {
     static Tensor handle(const Tensor& t1, int32_t dim, const std::optional<MemoryConfig>& mem_cfg) {
         return _swiglu(t1, dim, mem_cfg);
-    }
-};
-
-template <>
-struct OpHandler<UnaryCompositeOpType::HARDSHRINK> {
-    static Tensor handle(const Tensor& t1, float lambd, const std::optional<MemoryConfig>& mem_cfg) {
-        return _hardshrink(t1, lambd, mem_cfg);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -25,6 +25,10 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
 
     const auto& input = tensor_args.input;
     const auto& ops_chain = args.op_chain;
+    float value = 0.0f;
+    if (!ops_chain[0].params.empty()) {
+        value = ops_chain[0].params[0];
+    }
 
     tt::tt_metal::Program program{};
 
@@ -48,6 +52,14 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
         tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
             .set_page_size(src0_cb_index, single_tile_size);
     auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    uint32_t tmp0_cb_index = tt::CBIndex::c_1;  // temporary buffer for intermediate results
+    if (ops_chain[0].op_type == UnaryOpType::HARDSHRINK) {
+        tt::tt_metal::CircularBufferConfig cb_tmp0_config =
+            tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{tmp0_cb_index, cb_data_format}})
+                .set_page_size(tmp0_cb_index, single_tile_size);
+        auto cb_tmp0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_tmp0_config);
+    }
 
     uint32_t output_cb_index = tt::CBIndex::c_2;
     uint32_t num_output_tiles = 2;
@@ -79,18 +91,19 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
 
     std::vector<uint32_t> compute_kernel_args_group_1 = {
         num_tiles_per_core_group_1,  // per_core_block_cnt
-        1                            // per_core_block_size
+        1,                           // per_core_block_size
     };
 
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (args.preserve_fp32_precision) {
         unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[tmp0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
     }
 
     bool math_approx_mode = std::all_of(
         args.op_chain.begin(), args.op_chain.end(), [](const auto& u) { return utils::get_op_approx_mode(u.op_type); });
     std::map<std::string, std::string> unary_defines = utils::get_block_defines(args.op_chain, "0", "0", input.dtype());
-    auto path = utils::get_compute_kernel_path(ops_chain[0].op_type, compute_root);
+    auto path = utils::get_compute_kernel_path(ops_chain[0].op_type, compute_root, input.dtype());
 
     auto eltwise_unary_kernel_group_1_id = tt::tt_metal::CreateKernel(
         program,
@@ -105,13 +118,14 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
             .compile_args = compute_kernel_args_group_1,
             .defines = unary_defines});
 
+    auto eltwise_unary_kernel_group_2_id = 0;
     if (!core_group_2.ranges().empty()) {
         std::vector<uint32_t> compute_kernel_args_group_2 = {
             num_tiles_per_core_group_2,  // per_core_block_cnt
-            1                            // per_core_block_size
+            1,                           // per_core_block_size
         };
 
-        auto eltwise_unary_kernel_group_2_id = tt::tt_metal::CreateKernel(
+        eltwise_unary_kernel_group_2_id = tt::tt_metal::CreateKernel(
             program,
             path,
             core_group_2,
@@ -125,13 +139,17 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
                 .defines = unary_defines});
     }
 
+    const auto packed_scalar = std::bit_cast<uint32_t>(value);
+
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_tiles_per_core = 0;
+        auto kernel_id = eltwise_unary_kernel_group_1_id;
         if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
         } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
+            kernel_id = eltwise_unary_kernel_group_2_id;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");
         }
@@ -141,6 +159,8 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
 
         tt::tt_metal::SetRuntimeArgs(
             program, unary_writer_kernel_id, core, {dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+
+        tt::tt_metal::SetRuntimeArgs(program, kernel_id, core, {packed_scalar});
         num_tiles_written += num_tiles_per_core;
     }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
@@ -26,6 +26,10 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
 
     const auto& input = tensor_args.input;
     const auto& ops_chain = args.op_chain;
+    float value = 0.0f;
+    if (!ops_chain[0].params.empty()) {
+        value = ops_chain[0].params[0];
+    }
 
     tt::tt_metal::Program program = CreateProgram();
     tt::tt_metal::IDevice* device = input.device();
@@ -79,6 +83,15 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
             .set_globally_allocated_address(*input.buffer());
     auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
+    // tmp sharded CB
+    uint32_t tmp_cb_id = tt::CBIndex::c_1;  // temporary buffer for intermediate results
+    if (ops_chain[0].op_type == UnaryOpType::HARDSHRINK) {
+        tt::tt_metal::CircularBufferConfig cb_tmp0_config =
+            tt::tt_metal::CircularBufferConfig(in_cb_pagesize * in_cb_npages, {{tmp_cb_id, act_df}})
+                .set_page_size(tmp_cb_id, in_cb_pagesize);
+        auto cb_tmp0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_tmp0_config);
+    }
+
     // output sharded CB
     uint32_t out_cb_id = tt::CBIndex::c_2;
     tt::tt_metal::CircularBufferConfig out_cb_config =
@@ -117,12 +130,14 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (args.preserve_fp32_precision) {
         unpack_to_dest_mode[in_cb_id] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[tmp_cb_id] = UnpackToDestMode::UnpackToDestFp32;
     }
 
     bool math_approx_mode = std::all_of(
         args.op_chain.begin(), args.op_chain.end(), [](const auto& u) { return utils::get_op_approx_mode(u.op_type); });
     std::map<std::string, std::string> unary_defines = utils::get_block_defines(args.op_chain, "0", "0", input.dtype());
-    auto path = utils::get_compute_kernel_path(ops_chain[0].op_type, compute_root_sharded);
+    auto path = utils::get_compute_kernel_path(ops_chain[0].op_type, compute_root_sharded, input.dtype());
+    const auto packed_scalar = std::bit_cast<uint32_t>(value);
 
     auto eltwise_unary_kernel_group_1_id = tt::tt_metal::CreateKernel(
         program,
@@ -144,6 +159,8 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
         {
             (uint32_t)(num_tile_per_core),
         });
+
+    tt::tt_metal::SetRuntimeArgs(program, eltwise_unary_kernel_group_1_id, all_cores, {packed_scalar});
 
     return cached_program_t{std::move(program), {cb_src0, out_cb}};
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -361,6 +361,22 @@ Tensor Tanhshrink::invoke(
     return detail::unary_impl(queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
 }
 
+Tensor Hardshrink::invoke(
+    QueueId queue_id,
+    const Tensor& input_tensor,
+    const float lambda,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    UnaryOpType op_type = UnaryOpType::HARDSHRINK;
+    TT_ASSERT(lambda >= 0);
+    return detail::unary_impl(
+        queue_id,
+        input_tensor,
+        {UnaryWithParam{op_type, static_cast<float>(lambda)}},
+        memory_config,
+        optional_output_tensor);
+}
+
 Tensor Deg2Rad::invoke(
     QueueId queue_id,
     const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -246,6 +246,15 @@ struct Tanhshrink {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
+struct Hardshrink {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input_tensor,
+        float lambda = 0.5f,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
 struct Deg2Rad {
     static Tensor invoke(
         QueueId queue_id,
@@ -392,6 +401,7 @@ constexpr auto abs = ttnn::register_operation<"ttnn::abs", ttnn::operations::una
 constexpr auto eqz = ttnn::register_operation<"ttnn::eqz", ttnn::operations::unary::Eqz>();
 constexpr auto mish = ttnn::register_operation<"ttnn::mish", ttnn::operations::unary::Mish>();
 constexpr auto tanhshrink = ttnn::register_operation<"ttnn::tanhshrink", ttnn::operations::unary::Tanhshrink>();
+constexpr auto hardshrink = ttnn::register_operation<"ttnn::hardshrink", ttnn::operations::unary::Hardshrink>();
 constexpr auto deg2rad = ttnn::register_operation<"ttnn::deg2rad", ttnn::operations::unary::Deg2Rad>();
 constexpr auto rad2deg = ttnn::register_operation<"ttnn::rad2deg", ttnn::operations::unary::Rad2Deg>();
 constexpr auto softplus = ttnn::register_operation<"ttnn::softplus", ttnn::operations::unary::Softplus>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -217,9 +217,6 @@ constexpr auto geglu = ttnn::register_operation<
 constexpr auto swiglu = ttnn::register_operation<
     "ttnn::swiglu",
     operations::unary::ExecuteUnaryCompositeOpWithDim<operations::unary::UnaryCompositeOpType::SWIGLU>>();
-constexpr auto hardshrink = ttnn::register_operation<
-    "ttnn::hardshrink",
-    operations::unary::ExecuteUnaryCompositeOpWithFloat<operations::unary::UnaryCompositeOpType::HARDSHRINK>>();
 constexpr auto logical_not_ = ttnn::register_operation<
     "ttnn::logical_not_",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::LOGICAL_NOT_>>();


### PR DESCRIPTION
### Ticket
Link to Github Issue #23015

### Problem description
Hardshrink operation have been implemented as a composite version.

### What's changed

Updated hardshrink as a device op (HLK).

### Performance Results
Composite version:
![Screenshot 2025-06-26 at 2 38 05 PM](https://github.com/user-attachments/assets/818b1550-517c-4c7f-918a-3989e3e8a796)

Compute kernel  version:
BF16
<img width="360" alt="Screenshot 2025-07-08 at 3 32 10 PM" src="https://github.com/user-attachments/assets/78e743ee-1e98-4480-be3c-3a1a293bb0a9" />
So it is 86% faster compared to previous approach.

FP32
![Screenshot 2025-07-08 at 3 39 05 PM](https://github.com/user-attachments/assets/84d58322-9203-4a96-a1e5-c56c38090084)
So it is 70% faster compared to previous approach.

### Checklist
- [ ] [All post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/16197226315)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16197237328)