### PR TITLE
Refine memcpy.hpp

### DIFF
--- a/tt_metal/impl/dispatch/memcpy.hpp
+++ b/tt_metal/impl/dispatch/memcpy.hpp
@@ -15,20 +15,26 @@
 #include <emmintrin.h>
 #endif
 
-#define LOAD_STREAM_32                                                             \
-    _mm256_stream_si256((__m256i*)dst8, _mm256_loadu_si256((const __m256i*)src8)); \
-    src8 += sizeof(__m256i);                                                       \
-    dst8 += sizeof(__m256i);
+#define LOAD_STREAM_32                                                                 \
+    do {                                                                               \
+        _mm256_stream_si256((__m256i*)dst8, _mm256_loadu_si256((const __m256i*)src8)); \
+        src8 += sizeof(__m256i);                                                       \
+        dst8 += sizeof(__m256i);                                                       \
+    } while (0)
 
-#define LOAD_STREAM_16                                                       \
-    _mm_stream_si128((__m128i*)dst8, _mm_loadu_si128((const __m128i*)src8)); \
-    src8 += sizeof(__m128i);                                                 \
-    dst8 += sizeof(__m128i);
+#define LOAD_STREAM_16                                                           \
+    do {                                                                         \
+        _mm_stream_si128((__m128i*)dst8, _mm_loadu_si128((const __m128i*)src8)); \
+        src8 += sizeof(__m128i);                                                 \
+        dst8 += sizeof(__m128i);                                                 \
+    } while (0)
 
-#define LOAD_STREAM_4                                 \
-    _mm_stream_si32((int32_t*)dst8, *(int32_t*)src8); \
-    src8 += sizeof(int32_t);                          \
-    dst8 += sizeof(int32_t);
+#define LOAD_STREAM_4                                     \
+    do {                                                  \
+        _mm_stream_si32((int32_t*)dst8, *(int32_t*)src8); \
+        src8 += sizeof(int32_t);                          \
+        dst8 += sizeof(int32_t);                          \
+    } while (0)
 
 namespace tt::tt_metal {
 
@@ -142,3 +148,7 @@ __attribute((nonnull(1, 2))) static inline void memcpy_to_device(
 #endif
 
 }  // namespace tt::tt_metal
+
+#undef LOAD_STREAM_32
+#undef LOAD_STREAM_16
+#undef LOAD_STREAM_4

--- a/tt_metal/impl/dispatch/memcpy.hpp
+++ b/tt_metal/impl/dispatch/memcpy.hpp
@@ -15,6 +15,21 @@
 #include <emmintrin.h>
 #endif
 
+#define LOAD_STREAM_32                                                             \
+    _mm256_stream_si256((__m256i*)dst8, _mm256_loadu_si256((const __m256i*)src8)); \
+    src8 += sizeof(__m256i);                                                       \
+    dst8 += sizeof(__m256i);
+
+#define LOAD_STREAM_16                                                       \
+    _mm_stream_si128((__m128i*)dst8, _mm_loadu_si128((const __m128i*)src8)); \
+    src8 += sizeof(__m128i);                                                 \
+    dst8 += sizeof(__m128i);
+
+#define LOAD_STREAM_4                                 \
+    _mm_stream_si32((int32_t*)dst8, *(int32_t*)src8); \
+    src8 += sizeof(int32_t);                          \
+    dst8 += sizeof(int32_t);
+
 namespace tt::tt_metal {
 
 // Ideally would work by cachelines, but the min size is less than that
@@ -24,83 +39,98 @@ namespace tt::tt_metal {
 #if defined(__x86_64__) || defined(__i386__)
 template <bool debug_sync = false>
 static inline void memcpy_to_device(void* __restrict dst, const void* __restrict src, size_t n) {
+    // Ensure destination is properly aligned for optimal SIMD performance
     TT_ASSERT((uintptr_t)dst % MEMCPY_ALIGNMENT == 0);
 
+    // Configuration for bulk processing: inner loop processes 8 x 32-byte operations
+    // This creates 256-byte blocks (8 * 32 = 256 bytes) for maximum throughput
     static constexpr uint32_t inner_loop = 8;
-    static constexpr uint32_t inner_blk_size = inner_loop * sizeof(__m256i);
+    static constexpr uint32_t inner_blk_size = inner_loop * sizeof(__m256i);  // 256 bytes
 
     uint8_t* src8 = (uint8_t*)src;
     uint8_t* dst8 = (uint8_t*)dst;
 
-    if (size_t num_lines = n / inner_blk_size) {
+    size_t num_lines = n / inner_blk_size;  // Number of 256-byte blocks to process
+
+    // PHASE 1: Process 256-byte blocks 32 bytes at a time
+    // This is the main bulk processing phase for maximum efficiency
+    if (num_lines > 0) {
+        // Handle potential misalignment by processing a single 16-byte chunk first
+        // This ensures subsequent 32-byte operations are properly aligned
+        // WARNING: This does not cover the case where dst is not 16-byte aligned
         if ((uintptr_t)dst8 % sizeof(__m256i) != 0) {
-            __m128i blk = _mm_loadu_si128((const __m128i*)src8);
-            _mm_stream_si128((__m128i*)dst8, blk);
-            src8 += sizeof(__m128i);
-            dst8 += sizeof(__m128i);
+            LOAD_STREAM_16;
             n -= sizeof(__m128i);
-            num_lines = n / inner_blk_size;
+            num_lines = n / inner_blk_size;  // Recalculate after alignment adjustment
         }
+
+        // Main bulk processing loop: process 32-byte chunks
         for (size_t i = 0; i < num_lines; ++i) {
-            for (size_t j = 0; j < inner_loop; ++j) {
-                __m256i blk = _mm256_loadu_si256((const __m256i*)src8);
-                _mm256_stream_si256((__m256i*)dst8, blk);
-                src8 += sizeof(__m256i);
-                dst8 += sizeof(__m256i);
-            }
+            LOAD_STREAM_32;
+            LOAD_STREAM_32;
+            LOAD_STREAM_32;
+            LOAD_STREAM_32;
+            LOAD_STREAM_32;
+            LOAD_STREAM_32;
+            LOAD_STREAM_32;
+            LOAD_STREAM_32;
             n -= inner_blk_size;
         }
     }
 
+    // PHASE 2: Process remaining data that doesn't fill a complete 256-byte block
     if (n > 0) {
-        if (size_t num_lines = n / sizeof(__m256i)) {
+        // Phase 2.1: Process remaining 32-byte chunks
+        num_lines = n / sizeof(__m256i);  // Number of 32-byte blocks to process
+        if (num_lines > 0) {
+            // Handle alignment for 32-byte operations if needed
+            // WARNING: This does not cover the case where dst is not 16-byte aligned
             if ((uintptr_t)dst8 % sizeof(__m256i) != 0) {
-                __m128i blk = _mm_loadu_si128((const __m128i*)src8);
-                _mm_stream_si128((__m128i*)dst8, blk);
-                src8 += sizeof(__m128i);
-                dst8 += sizeof(__m128i);
+                LOAD_STREAM_16;
                 n -= sizeof(__m128i);
-                num_lines = n / sizeof(__m256i);
+                num_lines = n / sizeof(__m256i);  // Recalculate after alignment adjustment
             }
+
+            // Process individual 32-byte blocks
             for (size_t i = 0; i < num_lines; ++i) {
-                __m256i blk = _mm256_loadu_si256((const __m256i*)src8);
-                _mm256_stream_si256((__m256i*)dst8, blk);
-                src8 += sizeof(__m256i);
-                dst8 += sizeof(__m256i);
+                LOAD_STREAM_32;
             }
             n -= num_lines * sizeof(__m256i);
         }
-        if (size_t num_lines = n / sizeof(__m128i)) {
+
+        // PHASE 2.2: Process remaining 16-byte chunks
+        num_lines = n / sizeof(__m128i);  // Number of 16-byte blocks to process
+        if (num_lines > 0) {
             for (size_t i = 0; i < num_lines; ++i) {
-                __m128i blk = _mm_loadu_si128((const __m128i*)src8);
-                _mm_stream_si128((__m128i*)dst8, blk);
-                src8 += sizeof(__m128i);
-                dst8 += sizeof(__m128i);
+                LOAD_STREAM_16;
             }
-            n -= n / sizeof(__m128i) * sizeof(__m128i);
+            n -= num_lines * sizeof(__m128i);
         }
+
+        // PHASE 2.3: Process remaining 4-byte chunks
+        num_lines = n / sizeof(int32_t);  // Number of 4-byte blocks to process
+        if (num_lines > 0) {
+            for (size_t i = 0; i < num_lines; ++i) {
+                LOAD_STREAM_4;
+            }
+            n -= num_lines * sizeof(int32_t);
+        }
+
+        // PHASE 2.4: Handle the final few bytes (< 4 bytes)
         if (n > 0) {
-            for (size_t i = 0; i < n / sizeof(int32_t); ++i) {
-                _mm_stream_si32((int32_t*)dst8, *(int32_t*)src8);
-                src8 += sizeof(int32_t);
-                dst8 += sizeof(int32_t);
-            }
-            n -= n / sizeof(int32_t) * sizeof(int32_t);
-            // Copying the last few bytes (n < 4).
-            // Overrunning dst buffer is safe, because the actual allocated space for dst is guaranteed to be at least 4
-            // byte aligned.
-            if (n > 0) {
-                int32_t val = 0;
-                std::memcpy(&val, src8, n);
-                _mm_stream_si32((int32_t*)dst8, val);
-            }
+            std::memcpy(dst8, src8, n);
         }
     }
+
+    // Optional memory fence for debugging/synchronization
+    // Ensures all streaming stores complete before function returns
     if constexpr (debug_sync) {
         tt_driver_atomics::sfence();
     }
 }
 #else
+// Fallback implementation for non-x86 architectures
+// Uses standard memcpy since SIMD optimizations aren't available
 template <bool debug_sync = false>
 __attribute((nonnull(1, 2))) static inline void memcpy_to_device(
     void* __restrict dst, const void* __restrict src, size_t n) {

--- a/tt_metal/impl/dispatch/memcpy.hpp
+++ b/tt_metal/impl/dispatch/memcpy.hpp
@@ -117,7 +117,7 @@ void memcpy_to_device(void* __restrict dst, const void* __restrict src, size_t n
             n -= num_lines * sizeof(int32_t);
         }
 
-        // PHASE 2.4: Handle the final few bytes (< 4 bytes)i
+        // PHASE 2.4: Handle the final few bytes (< 4 bytes)
         // We are the ones in control of and allocating the dst buffer,
         // so writing a few bytes extra is okay because we are guaranteeing the size is adequate.
         if (n > 0) {

--- a/tt_metal/impl/dispatch/memcpy.hpp
+++ b/tt_metal/impl/dispatch/memcpy.hpp
@@ -44,7 +44,7 @@ namespace tt::tt_metal {
 // TODO: ditto alignment isues
 #if defined(__x86_64__) || defined(__i386__)
 template <bool debug_sync = false>
-static inline void memcpy_to_device(void* __restrict dst, const void* __restrict src, size_t n) {
+void memcpy_to_device(void* __restrict dst, const void* __restrict src, size_t n) {
     // Ensure destination is properly aligned for optimal SIMD performance
     TT_ASSERT((uintptr_t)dst % MEMCPY_ALIGNMENT == 0);
 

--- a/tt_metal/impl/dispatch/memcpy.hpp
+++ b/tt_metal/impl/dispatch/memcpy.hpp
@@ -53,7 +53,7 @@ void memcpy_to_device(void* __restrict dst, const void* __restrict src, size_t n
     static constexpr uint32_t inner_loop = 8;
     constexpr uint32_t inner_blk_size = inner_loop * sizeof(__m256i);  // 256 bytes
 
-    uint8_t* src8 = (uint8_t*)src;
+    const auto* src8 = static_cast<const uint8_t *>(src);
     uint8_t* dst8 = (uint8_t*)dst;
 
     size_t num_lines = n / inner_blk_size;  // Number of 256-byte blocks to process

--- a/tt_metal/impl/dispatch/memcpy.hpp
+++ b/tt_metal/impl/dispatch/memcpy.hpp
@@ -64,7 +64,7 @@ static inline void memcpy_to_device(void* __restrict dst, const void* __restrict
             num_lines = n / inner_blk_size;  // Recalculate after alignment adjustment
         }
 
-        // Main bulk processing loop: process 32-byte chunks
+        // Main bulk processing loop: Each iteration processes a 256 byte block. Blocks are processed 32 bytes at a time.
         for (size_t i = 0; i < num_lines; ++i) {
             LOAD_STREAM_32;
             LOAD_STREAM_32;

--- a/tt_metal/impl/dispatch/memcpy.hpp
+++ b/tt_metal/impl/dispatch/memcpy.hpp
@@ -41,7 +41,7 @@ namespace tt::tt_metal {
 // Ideally would work by cachelines, but the min size is less than that
 // Benchmarked to be approximately 1.4x - 1.8x faster than std::memcpy
 // TODO: Revisit this w/ regard to possibly eliminating min sizes and orphan writes at the end
-// TODO: ditto alignment isues
+// TODO: ditto alignment issues
 #if defined(__x86_64__) || defined(__i386__)
 template <bool debug_sync = false>
 void memcpy_to_device(void* __restrict dst, const void* __restrict src, size_t n) {

--- a/tt_metal/impl/dispatch/memcpy.hpp
+++ b/tt_metal/impl/dispatch/memcpy.hpp
@@ -51,7 +51,7 @@ void memcpy_to_device(void* __restrict dst, const void* __restrict src, size_t n
     // Configuration for bulk processing: inner loop processes 8 x 32-byte operations
     // This creates 256-byte blocks (8 * 32 = 256 bytes) for maximum throughput
     static constexpr uint32_t inner_loop = 8;
-    static constexpr uint32_t inner_blk_size = inner_loop * sizeof(__m256i);  // 256 bytes
+    constexpr uint32_t inner_blk_size = inner_loop * sizeof(__m256i);  // 256 bytes
 
     uint8_t* src8 = (uint8_t*)src;
     uint8_t* dst8 = (uint8_t*)dst;


### PR DESCRIPTION
### Ticket
NA

### Problem description
- Difficult to read and understand this code

### What's changed
- Add comments explaining each section
- Highlight that this code only supports 16 byte or 32 byte aligned destination buffer.
- Introduce macros to avoid repeating code, improve readability
- Remove unnecessary `static` `inline` keywords
- Use C++ style casts

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16154790841) CI passes
- [x] [Model Perf](https://github.com/tenstorrent/tt-metal/actions/runs/16173886273) CI passes
- [x] New/Existing tests provide coverage for changes