### PR TITLE
#24175: Revert z and y dim to default in uninit

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -57,6 +57,10 @@ inline void llk_unpack_tilize_uninit(const std::uint32_t operand, const std::uin
     std::uint32_t operand_id = get_operand_id(operand);
     unpack_config_u config = {0};
 
+    // Revert Z and Y dim value back to default.
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 16, 0xffff0000>(4);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0x0000ffff>(1);
+
     config.f.out_data_format = (uint)unpack_dst_format[operand_id];
     config.f.throttle_mode = 2;
     TT_SETDMAREG(0, LOWER_HALFWORD(config.val[0]), 0, LO_16(p_gpr_unpack::TMP0));


### PR DESCRIPTION
### Ticket
#24175 

### Problem description
We don't reset z and y dim back to default on WH when doing tilize uninit.

### What's changed
Revert z and y dim back to default when uninitializing tilize.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/16189898515
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes