### PR TITLE
fix Mobilenet_v2 PCC failure & yolov11 in device perf CI

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -90,7 +90,6 @@ jobs:
             pytest models/demos/roberta/tests/ -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/resnet50/tests -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
             #WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/ufld_v2/tests -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
-            # WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/yolov11/tests -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
             # WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/sentence_bert/tests -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
             WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/functional_unet/tests/test_unet_perf.py -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/mamba/tests -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
@@ -98,7 +97,6 @@ jobs:
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/bert_tiny/tests -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov4/tests -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/distilbert/tests -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
-            # issue 24652: https://github.com/tenstorrent/tt-metal/issues/24652
             # WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/mobilenetv2/tests -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
             # WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8x/tests -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
             # WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/yolov8s/tests -m models_device_performance_bare_metal || FAILED=$((FAILED+1))

--- a/models/demos/ufld_v2/tests/test_ufld_v2_e2e_performant.py
+++ b/models/demos/ufld_v2/tests/test_ufld_v2_e2e_performant.py
@@ -13,6 +13,7 @@ from models.utility_functions import run_for_wormhole_b0
 
 
 @run_for_wormhole_b0()
+@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "device_params", [{"l1_small_size": 24576, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
 )

--- a/models/demos/ufld_v2/tests/test_ufld_v2_perf.py
+++ b/models/demos/ufld_v2/tests/test_ufld_v2_perf.py
@@ -74,17 +74,10 @@ def test_ufld_v2_perf(device, batch_size, input_channels, height, width, use_pre
     )
     ttnn_model = TtnnUFLDv2(conv_args=parameters.conv_args, conv_pth=parameters, device=device)
     n, c, h, w = torch_input_tensor.shape
-    if c == 3:  # for sharding config of padded input
-        c = min_channels
-    input_mem_config = ttnn.create_sharded_memory_config(
-        [n, c, h, w],
-        ttnn.CoreGrid(x=8, y=8),
-        ttnn.ShardStrategy.HEIGHT,
-    )
     ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
     durations = []
     for i in range(2):
-        ttnn_input_tensor_sharded = ttnn_input_tensor.to(device, input_mem_config)
+        ttnn_input_tensor_sharded = ttnn_input_tensor.to(device, ttnn.L1_MEMORY_CONFIG)
         start = time.time()
         ttnn_model_output = ttnn_model(ttnn_input_tensor_sharded, batch_size=batch_size)
         end = time.time()
@@ -119,7 +112,7 @@ def test_ufld_v2_perf(device, batch_size, input_channels, height, width, use_pre
 @pytest.mark.parametrize(
     "batch_size, expected_perf,test",
     [
-        [1, 340, "UFLD-v2"],
+        [1, 295, "UFLD-v2"],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/tests/ttnn/integration_tests/ufld_v2/test_ttnn_ufld_v2.py
+++ b/tests/ttnn/integration_tests/ufld_v2/test_ttnn_ufld_v2.py
@@ -377,15 +377,8 @@ def test_ufld_v2_model(device, batch_size, input_channels, height, width, use_pr
                 new_state_dict[new_key] = value
             torch_model.load_state_dict(new_state_dict)
     n, c, h, w = torch_input_tensor.shape
-    if c == 3:  # for sharding config of padded input
-        c = min_channels
-    input_mem_config = ttnn.create_sharded_memory_config(
-        [n, c, h, w],
-        ttnn.CoreGrid(x=8, y=8),
-        ttnn.ShardStrategy.HEIGHT,
-    )
     ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
-    ttnn_input_tensor = ttnn_input_tensor.to(device, input_mem_config)
+    ttnn_input_tensor = ttnn_input_tensor.to(device, ttnn.L1_MEMORY_CONFIG)
     parameters = preprocess_model_parameters(
         initialize_model=lambda: torch_model,
         custom_preprocessor=custom_preprocessor_whole_model,


### PR DESCRIPTION
### Ticket
Link to Github Issue - #24652 

### Problem description
- Device perf fails with mobilenet_v2 PCC Assertion.
- Sharded Permute op configuration in ufld_v2 is contributing to mobilenet_v2 PCC Assertion.

### What's changed
- Use Interleaved format of Permute in ufld_v2 tests
- Removed the redundant yolov11 (experimental folder) path in device perf [yaml](https://github.com/tenstorrent/tt-metal/pull/24696/files#diff-f7da3885fd5a800a06f6a93a5b887313f0cd46f8264901299769c5e9ba81ad17L87).
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/16408398136)
- [ ] [Device perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/16408385023/job/46358553270#step:5:3774) (Mobilenet_v2 Passes)
- [ ] [ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/16408389868)
- [x] [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/16408382039/job/46358518991#step:8:3641)