### PR TITLE
Avoid pool l1 usage assert in no-dispatch mode

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -636,8 +636,11 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         input, kernel_size_h, kernel_size_w, out_h, out_w, input.memory_config(), output.memory_config(), pool_type);
     uint32_t output_cb_size = post_allocate_size - memory_used;
 
+    // For now assume that if post_op_l1_allocation_size == 0 op is being run
+    // in graph capture NO_DISPATCH mode.
+    bool is_graph_capture_no_dispatch_mode = post_allocate_size == 0;
     TT_FATAL(
-        temporary_size + output_cb_size == l1_usage,
+        temporary_size + output_cb_size == l1_usage || is_graph_capture_no_dispatch_mode,
         "Calculated CB size {} does not match with the actual CB size {}  ",
         temporary_size + output_cb_size,
         l1_usage);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24358

### Problem description
We have an assert in pool op that checks if calculated and allocated L1 memory is the same. In NO_DISPATCH mode, we cannot check allocator state since no memory is allocated.

### What's changed
We check if allocated memory is zero, if so, we assume it is NO_DISPATCH mode and avoid the assert. There is no way for op to know if it is running in NO_DISPATCH mode, and it is still being discussed how we should resolve this problem in a clean way, but in the meanwhile we need to unblock Forge as they are the ones using this mode.

We already do the same for conv2d.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16119373253) passes
- [x] Nightly tt-metal L1 passes [wormhole](https://github.com/tenstorrent/tt-metal/actions/runs/16119377991) [blackhole](https://github.com/tenstorrent/tt-metal/actions/runs/16119384471)
- [x] [Frequent ttnn and models](https://github.com/tenstorrent/tt-metal/actions/runs/16119390661) - same errors as on main