### PR TITLE
Removing int32 tests that cause an ND PCC issue due to an LLK bug

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -674,8 +674,16 @@ def test_transpose_2D(dtype, shape, layout, device):
 
 @pytest.mark.parametrize(
     "dtype",
-    (ttnn.bfloat16, ttnn.float32, ttnn.int32),
-    ids=["bfloat16", "float", "int32"],
+    (
+        ttnn.bfloat16,
+        # ttnn.int32,
+        ttnn.float32,
+    ),
+    ids=[
+        "bfloat16",
+        # "int32",
+        "float",
+    ],
 )
 @pytest.mark.parametrize(
     "shape",

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -83,8 +83,16 @@ def test_fold_transpose(device):
 
 @pytest.mark.parametrize(
     "dtype",
-    (ttnn.bfloat16, ttnn.float32, ttnn.int32),
-    ids=["bfloat16", "float", "int32"],
+    (
+        ttnn.bfloat16,
+        # ttnn.int32, issue 24704
+        ttnn.float32,
+    ),
+    ids=[
+        "bfloat16",
+        # "int32",
+        "float",
+    ],
 )
 def test_transpose_hc_unit(dtype, device):
     logger.info("transpose on C H dim")
@@ -117,8 +125,16 @@ def test_transpose_wh_bfp4(device):
 
 @pytest.mark.parametrize(
     "dtype",
-    (ttnn.bfloat16, ttnn.float32, ttnn.int32),
-    ids=["bfloat16", "float", "int32"],
+    (
+        ttnn.bfloat16,
+        # ttnn.int32, issue 24704
+        ttnn.float32,
+    ),
+    ids=[
+        "bfloat16",
+        # "int32",
+        "float",
+    ],
 )
 def test_transpose_hc_program_cache(dtype, device):
     N = 3
@@ -147,8 +163,16 @@ def test_transpose_hc_program_cache(dtype, device):
 
 @pytest.mark.parametrize(
     "dtype",
-    (ttnn.bfloat16, ttnn.float32, ttnn.int32),
-    ids=["bfloat16", "float", "int32"],
+    (
+        ttnn.bfloat16,
+        # ttnn.int32, issue 24704
+        ttnn.float32,
+    ),
+    ids=[
+        "bfloat16",
+        # "int32",
+        "float",
+    ],
 )
 def test_transpose_cn_program_cache(dtype, device):
     N = 3
@@ -168,8 +192,18 @@ def test_transpose_cn_program_cache(dtype, device):
 
 @pytest.mark.parametrize(
     "dtype",
-    (ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b, ttnn.int32),
-    ids=["bfloat16", "float", "bfloat8_b", "int32"],
+    (
+        ttnn.bfloat16,
+        # ttnn.int32, issue 24704
+        ttnn.float32,
+        ttnn.bfloat8_b,
+    ),
+    ids=[
+        "bfloat16",
+        # "int32",
+        "float",
+        "bfloat8_b",
+    ],
 )
 def test_transpose_wh_program_cache(dtype, device):
     N = 3
@@ -200,8 +234,16 @@ def test_transpose_wh_program_cache(dtype, device):
 @skip_for_blackhole("GH #15234")
 @pytest.mark.parametrize(
     "dtype",
-    (ttnn.bfloat8_b, ttnn.float32, ttnn.int32),
-    ids=["bfloat8_b", "float", "int32"],
+    (
+        ttnn.bfloat8_b,
+        # ttnn.int32, issue 24704
+        ttnn.float32,
+    ),
+    ids=[
+        "bfloat8_b",
+        # "int32",
+        "float",
+    ],
 )
 def test_transpose_wh_sharded_program_cache(dtype, device):
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -634,8 +676,16 @@ def test_transpose_bfloat8_b(device, shape, swap_dims):
 
 @pytest.mark.parametrize(
     "dtype",
-    (ttnn.bfloat16, ttnn.float32, ttnn.int32),
-    ids=["bfloat16", "float", "int32"],
+    (
+        ttnn.bfloat16,
+        # ttnn.int32, issue 24704
+        ttnn.float32,
+    ),
+    ids=[
+        "bfloat16",
+        # "int32",
+        "float",
+    ],
 )
 @pytest.mark.parametrize(
     "shape",
@@ -649,8 +699,16 @@ def test_transpose_hc(dtype, shape, device):
 
 @pytest.mark.parametrize(
     "dtype",
-    (ttnn.bfloat16, ttnn.float32, ttnn.int32),
-    ids=["bfloat16", "float", "int32"],
+    (
+        ttnn.bfloat16,
+        # ttnn.int32, issue 24704
+        ttnn.float32,
+    ),
+    ids=[
+        "bfloat16",
+        # "int32",
+        "float",
+    ],
 )
 @pytest.mark.parametrize(
     "shape",
@@ -676,7 +734,7 @@ def test_transpose_2D(dtype, shape, layout, device):
     "dtype",
     (
         ttnn.bfloat16,
-        # ttnn.int32,
+        # ttnn.int32, issue 24704
         ttnn.float32,
     ),
     ids=[


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24704)

Deletes offending tests

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes