### PR TITLE
Disable yolov8x and squeezebert from (Single-card) Device perf pipeline by pytest skip

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -25,8 +25,9 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          {name: "N300 WH B0 not yet ported", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "e13cs03"], machine-type: "bare_metal", civ2-compatible: false, timeout: 30},
-          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["tt-beta-ubuntu-2204-n300-large-stable"], machine-type: "CIv2", civ2-compatible: true, timeout: 120},
+          #{name: "N300 WH B0 not yet ported", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "e13cs03"], machine-type: "bare_metal", civ2-compatible: false, timeout: 30},
+          #{name: "N300 WH B0", arch: wormhole_b0, runs-on: ["tt-beta-ubuntu-2204-n300-large-stable"], machine-type: "CIv2", civ2-compatible: true, timeout: 120},
+          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "e13cs03"], machine-type: "bare_metal", civ2-compatible: false, timeout: 120}
         ]
     name: "${{ matrix.test-info.name }} device perf"
     runs-on: ${{ matrix.test-info.runs-on }}

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          {name: "N300 WH B0 not yet ported", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal", civ2-compatible: false, timeout: 30},
+          {name: "N300 WH B0 not yet ported", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "e13cs03"], machine-type: "bare_metal", civ2-compatible: false, timeout: 30},
           {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["tt-beta-ubuntu-2204-n300-large-stable"], machine-type: "CIv2", civ2-compatible: true, timeout: 120},
         ]
     name: "${{ matrix.test-info.name }} device perf"
@@ -92,9 +92,11 @@ jobs:
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov4/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/distilbert/tests -m models_device_performance_bare_metal
             # issue 24652: https://github.com/tenstorrent/tt-metal/issues/24652
-            # WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/mobilenetv2/tests -m models_device_performance_bare_metal
+            pytest.mark.skip()
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/mobilenetv2/tests -m models_device_performance_bare_metal
             # issue 24706: https://github.com/tenstorrent/tt-metal/issues/24706
-            # WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8x/tests -m models_device_performance_bare_metal
+            pytest.mark.skip()
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8x/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8s/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/functional_vanilla_unet/test -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8s_world/tests -m models_device_performance_bare_metal

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -93,10 +93,8 @@ jobs:
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov4/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/distilbert/tests -m models_device_performance_bare_metal
             # issue 24652: https://github.com/tenstorrent/tt-metal/issues/24652
-            pytest.mark.skip()
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/mobilenetv2/tests -m models_device_performance_bare_metal
             # issue 24706: https://github.com/tenstorrent/tt-metal/issues/24706
-            pytest.mark.skip()
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8x/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8s/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/functional_vanilla_unet/test -m models_device_performance_bare_metal

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          {name: "N300 WH B0 not yet ported", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "e13cs03"], machine-type: "bare_metal", civ2-compatible: false, timeout: 30},
+          {name: "N300 WH B0 not yet ported", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal", civ2-compatible: false, timeout: 30},
           {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["tt-beta-ubuntu-2204-n300-large-stable"], machine-type: "CIv2", civ2-compatible: true, timeout: 120},
         ]
     name: "${{ matrix.test-info.name }} device perf"
@@ -92,8 +92,7 @@ jobs:
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov4/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/distilbert/tests -m models_device_performance_bare_metal
             # issue 24652: https://github.com/tenstorrent/tt-metal/issues/24652
-            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/mobilenetv2/tests -m models_device_performance_bare_metal
-            # issue 24706: https://github.com/tenstorrent/tt-metal/issues/24706
+            # WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/mobilenetv2/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8x/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8s/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/functional_vanilla_unet/test -m models_device_performance_bare_metal

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -91,7 +91,9 @@ jobs:
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/bert_tiny/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov4/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/distilbert/tests -m models_device_performance_bare_metal
+            # issue 24652: https://github.com/tenstorrent/tt-metal/issues/24652
             # WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/mobilenetv2/tests -m models_device_performance_bare_metal
+            # issue 24706: https://github.com/tenstorrent/tt-metal/issues/24706
             # WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8x/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8s/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/functional_vanilla_unet/test -m models_device_performance_bare_metal

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -92,7 +92,7 @@ jobs:
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov4/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/distilbert/tests -m models_device_performance_bare_metal
             # WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/mobilenetv2/tests -m models_device_performance_bare_metal
-            WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8x/tests -m models_device_performance_bare_metal
+            # WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8x/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8s/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/functional_vanilla_unet/test -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8s_world/tests -m models_device_performance_bare_metal

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -25,9 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          #{name: "N300 WH B0 not yet ported", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "e13cs03"], machine-type: "bare_metal", civ2-compatible: false, timeout: 30},
-          #{name: "N300 WH B0", arch: wormhole_b0, runs-on: ["tt-beta-ubuntu-2204-n300-large-stable"], machine-type: "CIv2", civ2-compatible: true, timeout: 120},
-          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "e13cs03"], machine-type: "bare_metal", civ2-compatible: false, timeout: 120}
+          {name: "N300 WH B0 not yet ported", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "e13cs03"], machine-type: "bare_metal", civ2-compatible: false, timeout: 30},
+          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["tt-beta-ubuntu-2204-n300-large-stable"], machine-type: "CIv2", civ2-compatible: true, timeout: 120},
         ]
     name: "${{ matrix.test-info.name }} device perf"
     runs-on: ${{ matrix.test-info.runs-on }}

--- a/models/demos/mobilenetv2/tests/test_perf_mobilenetv2.py
+++ b/models/demos/mobilenetv2/tests/test_perf_mobilenetv2.py
@@ -23,7 +23,7 @@ def get_expected_times(name):
     base = {"mobilenetv2": (63.3, 0.14)}
     return base[name]
 
-
+@pytest.mark.skip(reason="https://github.com/tenstorrent/tt-metal/issues/24652")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("device_params", [{"l1_small_size": MOBILENETV2_L1_SMALL_SIZE}], indirect=True)

--- a/models/demos/squeezebert/tests/test_perf_device_squeezebert.py
+++ b/models/demos/squeezebert/tests/test_perf_device_squeezebert.py
@@ -7,7 +7,7 @@ import pytest
 from models.perf.device_perf_utils import check_device_perf, prep_device_perf_report, run_device_perf
 from models.utility_functions import is_grayskull
 
-
+@pytest.mark.skip(reason="https://github.com/tenstorrent/tt-metal/actions/runs/16153189289/job/45589808973#step:5:2322")
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch_size, test",

--- a/models/demos/yolov8x/tests/test_perf_yolov8x.py
+++ b/models/demos/yolov8x/tests/test_perf_yolov8x.py
@@ -20,7 +20,7 @@ def get_expected_times(name):
     base = {"yolov8x": (128.267, 0.56)}
     return base[name]
 
-
+@pytest.mark.skip(reason="https://github.com/tenstorrent/tt-metal/issues/24706")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-metal/issues/24706 and https://github.com/tenstorrent/tt-metal/issues/24738

### Problem description
The model test for yolov8x and squeezebert has been failing and causing the (Single-card) Device perf pipeline to fail. 
https://github.com/tenstorrent/tt-metal/actions/runs/16140164833/job/45546065424#step:5:3354
https://github.com/tenstorrent/tt-metal/actions/runs/16153189289/job/45589808973#step:5:2322

```
post_processed_results = {'AVG DEVICE BRISC KERNEL DURATION [ns]': 19040553.0, 'AVG DEVICE BRISC KERNEL SAMPLES/S': 52.519483021317704, 'AVG DEVICE FW DURATION [ns]': 26680056.0, 'AVG DEVICE FW SAMPLES/S': 37.48118069917095, ...}
margin = 0.03, expected_perf_cols = {'AVG DEVICE KERNEL SAMPLES/S': 51.2}

...

FAILED models/demos/yolov8x/tests/test_perf_yolov8x.py::test_perf_device_bare_metal_yolov8x[1-51.2] - AssertionError: Some performance metrics are outside of expected range, see above for details.
```

```
2025-07-08 20:32:32.702 | ERROR    | models.perf.device_perf_utils:check_device_perf:172 - AVG DEVICE KERNEL SAMPLES/S 272.2999073057078 is outside of expected range (290.709, 308.691)
Error: test_perf_device_bare_metal[8-sequence_size=384-batch_size=8-model_name=squeezebert/squeezebert-uncased]
```

### What's changed
Disable yolov8x and squeezebert from (Single-card) Device perf pipeline by pytest skip