### PR TITLE
#0: fixes for dram sharded matmul

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -2242,7 +2242,10 @@ std::vector<ttnn::TensorSpec> Matmul::compute_output_specs(
 
                     TT_FATAL(
                         K % per_core_K == 0,
-                        "in DRAM sharded Matmul we don't have support for un-even sharding currently.");
+                        "in DRAM sharded Matmul we don't have support for un-even sharding currently. K: {}, "
+                        "per_core_K: {}.",
+                        K,
+                        per_core_K);
 
                     TT_FATAL(
                         per_core_N % tile_width_ratio == 0,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -2234,9 +2234,15 @@ std::vector<ttnn::TensorSpec> Matmul::compute_output_specs(
                     uint32_t M =
                         input_tensor_a.physical_volume() / input_tensor_a.padded_shape()[-1] / in0_tile_shape[0];
                     uint32_t N = input_tensor_b.padded_shape()[-1] / in1_tile_shape[1];
+                    uint32_t K = input_tensor_a.padded_shape()[-1] / in0_tile_shape[1];
 
                     uint32_t per_core_M = program_config.per_core_M;
                     uint32_t per_core_N = program_config.per_core_N;
+                    uint32_t per_core_K = input_tensor_a.shard_spec().value().shape[1] / in0_tile_shape[1];
+
+                    TT_FATAL(
+                        K % per_core_K == 0,
+                        "in DRAM sharded Matmul we don't have support for un-even sharding currently.");
 
                     TT_FATAL(
                         per_core_N % tile_width_ratio == 0,
@@ -2245,8 +2251,7 @@ std::vector<ttnn::TensorSpec> Matmul::compute_output_specs(
                     uint32_t num_blocks_y = (M - 1) / per_core_M + 1;
                     uint32_t num_blocks_x = (N - 1) / per_core_N + 1;
                     uint32_t num_cores = num_blocks_x * num_blocks_y;
-                    auto end_core = input_tensor_a.shard_spec()->grid.bounding_box().end_coord;
-                    auto grid_size = CoreCoord{end_core.x + 1, end_core.y + 1};
+                    auto grid_size = input_tensor_a.device()->compute_with_storage_grid_size();
                     CoreRangeSet all_cores = num_cores_to_corerangeset(num_cores, grid_size, true);
                     ShardSpec shard_spec = ShardSpec{
                         all_cores,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -59,7 +59,8 @@ void get_optimal_dram_bank_to_reader_assignment(
 
 tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
     tt::tt_metal::IDevice* device,
-    const CoreRangeSet& all_storage_cores,
+    const CoreRangeSet& input_all_storage_cores,
+    const CoreRangeSet& output_all_storage_cores,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
     bool math_approx_mode,
@@ -233,17 +234,17 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
     uint32_t num_worker_cores = num_dram_banks;
 
     // move conflict coord from mcast receiver to mcast sender
-    std::vector<CoreCoord> all_storage_cores_vec = corerange_to_cores(all_storage_cores);
+    std::vector<CoreCoord> input_all_storage_cores_vec = corerange_to_cores(input_all_storage_cores);
     std::vector<CoreCoord> all_worker_cores_vec = corerange_to_cores(all_worker_cores);
     std::vector<CoreCoord> storage_worker_common;
-    move_common_entries(all_storage_cores_vec, all_worker_cores_vec, storage_worker_common);
+    move_common_entries(input_all_storage_cores_vec, all_worker_cores_vec, storage_worker_common);
 
-    std::vector<CoreRange> all_storage_cores_range;
-    all_storage_cores_range.reserve(all_storage_cores_vec.size());
+    std::vector<CoreRange> input_all_storage_cores_range;
+    input_all_storage_cores_range.reserve(input_all_storage_cores_vec.size());
     std::transform(
-        all_storage_cores_vec.begin(),
-        all_storage_cores_vec.end(),
-        std::back_inserter(all_storage_cores_range),
+        input_all_storage_cores_vec.begin(),
+        input_all_storage_cores_vec.end(),
+        std::back_inserter(input_all_storage_cores_range),
         [](const CoreCoord& coord) { return CoreRange(coord); });
 
     std::vector<CoreRange> all_worker_cores_range;
@@ -254,9 +255,10 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
         std::back_inserter(all_worker_cores_range),
         [](const CoreCoord& coord) { return CoreRange(coord); });
 
-    std::set<CoreRange> all_storage_cores_set(all_storage_cores_range.begin(), all_storage_cores_range.end());
+    std::set<CoreRange> input_all_storage_cores_set(
+        input_all_storage_cores_range.begin(), input_all_storage_cores_range.end());
     std::set<CoreRange> all_worker_cores_set(all_worker_cores_range.begin(), all_worker_cores_range.end());
-    CoreRangeSet mcast_senders = CoreRangeSet(all_storage_cores_set);
+    CoreRangeSet mcast_senders = CoreRangeSet(input_all_storage_cores_set);
     CoreRangeSet mcast_receivers = CoreRangeSet(all_worker_cores_set);
 
     for (auto core : corerange_to_cores(mcast_senders)) {
@@ -296,7 +298,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
     uint32_t in0_num_subblocks = (per_core_M / out_subblock_h);
     uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
 
-    uint32_t num_blocks_per_shard = num_blocks / all_storage_cores_vec.size();
+    uint32_t num_blocks_per_shard = num_blocks / input_all_storage_cores_vec.size();
     log_debug(tt::LogOp, "num_blocks_per_shard: {}", num_blocks_per_shard);
     if (per_core_M > 1) {
         TT_FATAL(
@@ -609,7 +611,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
         mm_in0_sender_args.push_back((std::uint32_t)worker_core_type);
         mm_in0_sender_args.push_back((std::uint32_t)sender_id);
         mm_in0_sender_args.push_back(
-            (std::uint32_t)((core == all_storage_cores_vec.back()) and (in0_last_ktile_w > 0)));
+            (std::uint32_t)((core == input_all_storage_cores_vec.back()) and (in0_last_ktile_w > 0)));
         mm_in0_sender_args.insert(
             mm_in0_sender_args.end(), in0_mcast_sender_noc_x.begin(), in0_mcast_sender_noc_x.end());
         mm_in0_sender_args.insert(
@@ -693,6 +695,18 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
         }
     }
 
+    std::vector<uint32_t> output_noc_x;
+    std::vector<uint32_t> output_noc_y;
+    std::vector<CoreCoord> output_coords = corerange_to_cores(output_all_storage_cores, std::nullopt, true);
+    output_noc_x.reserve(output_coords.size());
+    for (auto core : output_coords) {
+        output_noc_x.push_back((std::uint32_t)device->worker_core_from_logical_core(core).x);
+    }
+    output_noc_y.reserve(output_coords.size());
+    for (auto core : output_coords) {
+        output_noc_y.push_back((std::uint32_t)device->worker_core_from_logical_core(core).y);
+    }
+
     uint32_t num_cores_written_back = (N + per_core_N_storage - 1) / per_core_N_storage;
     uint32_t expected_max_total_width = num_cores_written_back * per_core_N_storage;
     log_debug(tt::LogOp, "per_core_N_storage: {}", per_core_N_storage);
@@ -747,16 +761,14 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
                     i,
                     per_core_N_reshard_1,
                     curr_storage_core_idx,
-                    mcast_senders_coords[curr_storage_core_idx]);
+                    output_coords[curr_storage_core_idx]);
 
                 mm_in1_sender_writer_args.push_back(
                     per_core_N_storage_curr_stride * output_single_tile_size);  // reshard_tensor_start_offset
                 mm_in1_sender_writer_args.push_back(
                     per_core_N_reshard_1 * output_single_tile_size);  // per_core_N_reshard_bytes_1
-                mm_in1_sender_writer_args.push_back(
-                    in0_mcast_sender_noc_x[curr_storage_core_idx]);  // in0_mcast_sender_noc_x
-                mm_in1_sender_writer_args.push_back(
-                    in0_mcast_sender_noc_y[curr_storage_core_idx]);  // in0_mcast_sender_noc_y
+                mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core_idx]);  // output_noc_x
+                mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core_idx]);  // output_noc_y
 
                 total_tensor_width_written_back += per_core_N_reshard_1;
 
@@ -767,14 +779,12 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
                         i,
                         per_core_N_reshard_2,
                         curr_storage_core_idx + 1,
-                        mcast_senders_coords[curr_storage_core_idx + 1]);
+                        output_coords[curr_storage_core_idx + 1]);
 
                     mm_in1_sender_writer_args.push_back(
                         per_core_N_reshard_2 * output_single_tile_size);  // per_core_N_reshard_bytes_2
-                    mm_in1_sender_writer_args.push_back(
-                        in0_mcast_sender_noc_x[curr_storage_core_idx + 1]);  // in0_mcast_sender_noc_x
-                    mm_in1_sender_writer_args.push_back(
-                        in0_mcast_sender_noc_y[curr_storage_core_idx + 1]);  // in0_mcast_sender_noc_y
+                    mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core_idx + 1]);  // output_noc_x
+                    mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core_idx + 1]);  // output_noc_y
 
                     total_tensor_width_written_back += per_core_N_reshard_2;
                 }
@@ -797,16 +807,14 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
                     curr_worker_core,
                     worker_core_stride,
                     curr_storage_core,
-                    mcast_senders_coords[curr_storage_core]);
+                    output_coords[curr_storage_core]);
 
                 mm_in1_sender_writer_args.push_back(
                     storage_core_stride * output_single_tile_size);  // reshard_tensor_start_offset
                 mm_in1_sender_writer_args.push_back(
                     worker_core_stride * output_single_tile_size);  // per_core_N_reshard
-                mm_in1_sender_writer_args.push_back(
-                    in0_mcast_sender_noc_x[curr_storage_core]);  // in0_mcast_sender_noc_x
-                mm_in1_sender_writer_args.push_back(
-                    in0_mcast_sender_noc_y[curr_storage_core]);  // in0_mcast_sender_noc_y
+                mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core]);  // output_noc_x
+                mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core]);  // output_noc_y
 
                 curr_storage_core += (storage_core_stride + worker_core_stride) / per_core_N_storage;
                 storage_core_stride = (storage_core_stride + worker_core_stride) % per_core_N_storage;
@@ -831,7 +839,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
                         curr_worker_core,
                         current_worker_write_back_tiles,
                         curr_storage_core,
-                        mcast_senders_coords[curr_storage_core]);
+                        output_coords[curr_storage_core]);
 
                     if (increment_worker_core) {
                         curr_worker_core += 1;
@@ -839,10 +847,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
 
                     mm_in1_sender_writer_args.push_back(
                         current_worker_write_back_tiles * output_single_tile_size);  // per_core_N_reshard
-                    mm_in1_sender_writer_args.push_back(
-                        in0_mcast_sender_noc_x[curr_storage_core]);  // in0_mcast_sender_noc_x
-                    mm_in1_sender_writer_args.push_back(
-                        in0_mcast_sender_noc_y[curr_storage_core]);  // in0_mcast_sender_noc_y
+                    mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core]);  // output_noc_x
+                    mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core]);  // output_noc_y
 
                     total_tensor_width_written_back += current_worker_write_back_tiles;
 
@@ -958,7 +964,8 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_shard
     tt::tt_metal::IDevice* device = a.mesh_device()->get_device(mesh_coord);
 
     TT_FATAL(a.shard_spec().has_value() && output.shard_spec().has_value(), "Error");
-    CoreRangeSet all_cores_storage = a.shard_spec().value().grid;
+    CoreRangeSet input_all_cores_storage = a.shard_spec().value().grid;
+    CoreRangeSet output_all_cores_storage = output.shard_spec().value().grid;
 
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
@@ -1002,7 +1009,8 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_shard
     ////////////////////////////////////////////////////////////////////////////
     return reuse_dram_sharded_optimized_helpers::create_program_dram_sharded(
         device,
-        all_cores_storage,
+        input_all_cores_storage,
+        output_all_cores_storage,
         math_fidelity,
         fp32_dest_acc_en,
         math_approx_mode,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24681#issuecomment-3048989512)

### Problem description
in dram sharded matmul,
1. it misses an assert for the case K divisible by per_core_K, where un-even sharding occurred.
2. Relax the constraint that output and input 0 using the same core ranges.


### Checklist
- [ ] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/16147527471
- [ ] t3K https://github.com/tenstorrent/tt-metal/actions/runs/16147537328