### PR TITLE
Remove watcher singleton, move the server under MetalContext

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <gtest/gtest.h>
-#include "debug/watcher_server.hpp"
 #include "tt_metal/tt_metal/common/dispatch_fixture.hpp"
 
 namespace tt::tt_metal {
@@ -138,8 +137,8 @@ public:
         // Wait for watcher to run a full dump before finishing, need to wait for dump count to
         // increase because we'll likely check in the middle of a dump.
         if (wait_for_dump) {
-            int curr_count = tt::watcher_get_dump_count();
-            while (tt::watcher_get_dump_count() < curr_count + 2) {;}
+            int curr_count = MetalContext::instance().watcher_server()->dump_count();
+            while (MetalContext::instance().watcher_server()->dump_count() < curr_count + 2) {;}
         }
     }
 
@@ -167,10 +166,10 @@ protected:
         tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_auto_unpause(true);
         tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_noinline(true);
         tt::tt_metal::MetalContext::instance().rtoptions().set_test_mode_enabled(true);
-        tt::watcher_clear_log();
 
         // Parent class initializes devices and any necessary flags
         DebugToolsFixture::SetUp();
+        MetalContext::instance().watcher_server()->clear_log();
     }
 
     void TearDown() override {
@@ -178,7 +177,9 @@ protected:
         DebugToolsFixture::TearDown();
 
         // If test induced a watcher error, re-initialize the context.
-        if (watcher_server_killed_due_to_error() or reset_server) {
+        if (MetalContext::instance().watcher_server() and
+                MetalContext::instance().watcher_server()->killed_due_to_error() or
+            reset_server) {
             // Special case for watcher_dump testing, keep the error for watcher dump to look at later. TODO: remove
             // when watcher_dump is removed.
             if (getenv("TT_METAL_WATCHER_KEEP_ERRORS") == nullptr) {
@@ -195,7 +196,9 @@ protected:
         tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_noinline(watcher_previous_noinline);
         tt::tt_metal::MetalContext::instance().rtoptions().set_test_mode_enabled(test_mode_previous);
         tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_enabled(watcher_previous_enabled);
-        tt::watcher_server_set_error_flag(false);
+        if (MetalContext::instance().watcher_server()) {
+            MetalContext::instance().watcher_server()->set_killed_due_to_error_flag(false);
+        }
     }
 
     void RunTestOnDevice(
@@ -205,7 +208,7 @@ protected:
         DebugToolsFixture::RunTestOnDevice(run_function, device);
         // Wait for a final watcher poll and then clear the log.
         std::this_thread::sleep_for(std::chrono::milliseconds(interval_ms));
-        tt::watcher_clear_log();
+        MetalContext::instance().watcher_server()->clear_log();
     }
 };
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -23,7 +23,6 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/utils.hpp>
-#include "watcher_server.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher asserts.
@@ -155,6 +154,9 @@ static void RunTest(
 
     // Run the kernel, don't expect an issue here.
     log_info(LogTest, "Running args that shouldn't assert...");
+    // TODO: #24887, ND issue with this test - only run once below when issue is fixed
+    fixture->RunProgram(device, program);
+    fixture->RunProgram(device, program);
     fixture->RunProgram(device, program);
     log_info(LogTest, "Args did not assert!");
 
@@ -163,17 +165,8 @@ static void RunTest(
     SetRuntimeArgs(program, assert_kernel, logical_core, unsafe_args);
 
     // Run the kerel, expect an exit due to the assert.
-    try {
-        log_info(LogTest, "Running args that should assert...");
-        fixture->RunProgram(device, program);
-    } catch (std::runtime_error &e) {
-        std::string expected =
-            "Command Queue could not finish: device hang due to illegal NoC transaction. See {} for details.\n";
-        expected += tt::watcher_get_log_file_name();
-        const std::string error = std::string(e.what());
-        log_info(LogTest, "Caught exception (one is expected in this test)");
-        EXPECT_TRUE(error.find(expected) != std::string::npos);
-    }
+    log_info(LogTest, "Running args that should assert...");
+    fixture->RunProgram(device, program);
 
     // We should be able to find the expected watcher error in the log as well,
     // expected error message depends on the risc we're running on and the assert type.
@@ -226,10 +219,10 @@ static void RunTest(
     log_info(LogTest, "Expected error: {}", expected);
     std::string exception = "";
     do {
-        exception = get_watcher_exception_message();
+        exception = MetalContext::instance().watcher_server()->exception_message();
     } while (exception == "");
     log_info(LogTest, "Reported error: {}", exception);
-    EXPECT_TRUE(expected == get_watcher_exception_message());
+    EXPECT_TRUE(expected == MetalContext::instance().watcher_server()->exception_message());
 }
 }
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -39,7 +39,6 @@
 #include <tt_stl/span.hpp>
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/utils.hpp>
-#include "watcher_server.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher NOC sanitization.
@@ -218,7 +217,7 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
     } catch (std::runtime_error& e) {
         std::string expected =
             "Command Queue could not finish: device hang due to illegal NoC transaction. See {} for details.\n";
-        expected += tt::watcher_get_log_file_name();
+        expected += MetalContext::instance().watcher_server()->log_file_name();
         const std::string error = std::string(e.what());
         log_info(tt::LogTest, "Caught exception (one is expected in this test)");
         EXPECT_TRUE(error.find(expected) != std::string::npos);
@@ -348,10 +347,10 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
     log_info(LogTest, "Expected error: {}", expected);
     std::string exception = "";
     do {
-        exception = get_watcher_exception_message();
+        exception = MetalContext::instance().watcher_server()->exception_message();
     } while (exception == "");
     log_info(LogTest, "Reported error: {}", exception);
-    EXPECT_EQ(get_watcher_exception_message(), expected);
+    EXPECT_EQ(MetalContext::instance().watcher_server()->exception_message(), expected);
 }
 
 void RunTestEth(WatcherFixture* fixture, IDevice* device, watcher_features_t feature) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
@@ -10,7 +10,6 @@
 #include <gtest/gtest.h>
 #include "debug_tools_fixture.hpp"
 #include "debug_tools_test_utils.hpp"
-#include <watcher_server.hpp>
 #include <fmt/base.h>
 #include <string>
 #include <vector>

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
@@ -23,7 +23,6 @@
 #include "impl/dispatch/dispatch_settings.hpp"
 #include "impl/dispatch/system_memory_manager.hpp"
 #include "gtest/gtest.h"
-#include "impl/debug/watcher_server.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
@@ -157,12 +156,12 @@ TEST_F(CommandQueueEventFixture, TestEventsEnqueueRecordEventAndSynchronizeHang)
     auto future = std::async(std::launch::async, [this, future_event]() { return EventSynchronize(future_event); });
 
     bool seen_expected_hang = future.wait_for(std::chrono::seconds(1)) == std::future_status::timeout;
-    tt::watcher_server_set_error_flag(
+    MetalContext::instance().watcher_server()->set_killed_due_to_error_flag(
         seen_expected_hang);  // Signal to terminate thread. Don't care about it's exception.
 
     // Briefly wait before clearing error flag, and wrapping up via finish.
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    tt::watcher_server_set_error_flag(false);
+    MetalContext::instance().watcher_server()->set_killed_due_to_error_flag(false);
     Finish(this->device_->command_queue());
 
     log_info(
@@ -190,12 +189,12 @@ TEST_F(CommandQueueEventFixture, TestEventsQueueWaitForEventHang) {
     auto future = std::async(std::launch::async, [this]() { return Finish(this->device_->command_queue()); });
 
     bool seen_expected_hang = future.wait_for(std::chrono::seconds(1)) == std::future_status::timeout;
-    tt::watcher_server_set_error_flag(
+    MetalContext::instance().watcher_server()->set_killed_due_to_error_flag(
         seen_expected_hang);  // Signal to terminate thread. Don't care about it's exception.
 
     // Clear error flag before exiting to restore state for next test.
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    tt::watcher_server_set_error_flag(false);
+    MetalContext::instance().watcher_server()->set_killed_due_to_error_flag(false);
 
     log_info(
         tt::LogTest,

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -18,6 +18,7 @@
 #include <impl/dispatch/dispatch_mem_map.hpp>
 #include <impl/dispatch/dispatch_query_manager.hpp>
 #include <impl/debug/dprint_server.hpp>
+#include <impl/debug/watcher_server.hpp>
 
 #include <array>
 #include <unordered_set>
@@ -59,6 +60,7 @@ public:
         return inspector_data_.get();
     }
     std::unique_ptr<DPrintServer>& dprint_server() { return dprint_server_; }
+    std::unique_ptr<WatcherServer>& watcher_server() { return watcher_server_; }
 
     void initialize(
         const DispatchCoreConfig& dispatch_core_config,
@@ -139,6 +141,7 @@ private:
     std::unique_ptr<DispatchQueryManager> dispatch_query_manager_;
     std::unique_ptr<inspector::Data> inspector_data_;
     std::unique_ptr<DPrintServer> dprint_server_;
+    std::unique_ptr<WatcherServer> watcher_server_;
     std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
     std::unique_ptr<tt::tt_fabric::GlobalControlPlane> global_control_plane_;
     tt_metal::FabricConfig fabric_config_ = tt_metal::FabricConfig::DISABLED;

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -19,7 +19,7 @@
 #include <umd/device/tt_soc_descriptor.h>
 #include <umd/device/types/cluster_descriptor_types.h>
 
-namespace tt::watcher {
+namespace tt::tt_metal {
 
 constexpr uint64_t DEBUG_SANITIZE_NOC_SENTINEL_OK_64 = 0xbadabadabadabada;
 constexpr uint32_t DEBUG_SANITIZE_NOC_SENTINEL_OK_32 = 0xbadabada;
@@ -35,11 +35,7 @@ struct stack_usage_info_t {
 
 class WatcherDeviceReader {
 public:
-    WatcherDeviceReader(
-        FILE* f,
-        chip_id_t device_id,
-        std::vector<std::string>& kernel_names,
-        void (*set_watcher_exception_message)(const std::string&));
+    WatcherDeviceReader(FILE* f, chip_id_t device_id, const std::vector<std::string>& kernel_names);
     ~WatcherDeviceReader();
     void Dump(FILE* file = nullptr);
 
@@ -66,8 +62,7 @@ private:
 
     FILE* f;
     chip_id_t device_id;
-    std::vector<std::string>& kernel_names;
-    void (*set_watcher_exception_message)(const std::string&);
+    const std::vector<std::string>& kernel_names;
 
     // Information that needs to be kept around on a per-dump basis
     std::set<std::pair<CoreCoord, riscv_id_t>> paused_cores;
@@ -76,4 +71,4 @@ private:
     std::map<CoreCoord, uint32_t> logical_core_to_eth_link_retraining_count;
 };
 
-}  // namespace tt::watcher
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,6 +12,7 @@
 #include <cstdio>
 #include <condition_variable>
 #include <filesystem>
+#include <future>
 #include <map>
 #include <mutex>
 #include <set>
@@ -37,8 +38,64 @@
 
 using namespace tt::tt_metal;
 
-namespace tt {
-namespace watcher {
+namespace tt::tt_metal {
+class WatcherServer::Impl {
+public:
+    // Implementation of WatcherServer public functions
+    void init_devices();
+    void attach_devices();
+    void detach_devices();
+    void __attribute__((noinline)) dump(FILE* f);  // noinline so that this fn exists to be called from gdb
+    void dump() { dump(logfile_); }
+    void isolated_dump(std::vector<chip_id_t>& device_ids);
+    void clear_log() {
+        const std::lock_guard<std::mutex> lock(watch_mutex_);
+        create_log_file();
+    }
+    std::string log_file_name();
+    int register_kernel(const std::string& name);
+    void register_kernel_elf_paths(int id, std::vector<std::string>& paths);
+    void read_kernel_ids_from_file();
+    bool killed_due_to_error() { return server_killed_due_to_error_; }
+    void set_killed_due_to_error_flag(bool val) { server_killed_due_to_error_ = val; }
+    std::string exception_message();
+    void set_exception_message(const std::string& message);
+    int dump_count() { return dump_count_.load(); }
+    std::unique_lock<std::mutex> get_lock() { return std::unique_lock<std::mutex>(watch_mutex_); }
+
+private:
+    double get_elapsed_secs();
+    void create_log_file();
+    void create_kernel_file();
+    void create_kernel_elf_file();
+    void init_device(chip_id_t device_id);
+    void poll_watcher_data();
+
+    std::atomic<bool> stop_server_ = false;
+    std::condition_variable stop_server_cv_;
+    std::atomic<bool> server_running_ = false;
+    std::atomic<bool> server_killed_due_to_error_ = false;
+    std::atomic<int> dump_count_ = 0;
+
+    std::map<chip_id_t, WatcherDeviceReader> device_id_to_reader_;
+    std::vector<std::string> kernel_names_;
+    inline static std::chrono::time_point start_time = std::chrono::system_clock::now();
+    std::mutex watch_mutex_;  // Guards server internal state + logfile + device watcher mailbox
+
+    std::thread* server_thread_;
+
+    FILE* logfile_ = nullptr;
+    FILE* kernel_file_ = nullptr;
+    FILE* kernel_elf_file_ = nullptr;
+
+    std::string exception_message_ = "";
+    std::mutex exception_message_mutex_;
+
+    inline static const std::string LOG_FILE_PATH = "generated/watcher/";
+    inline static const std::string LOG_FILE_NAME = "watcher.log";
+    inline static const std::string KERNEL_FILE_NAME = "kernel_names.txt";
+    inline static const std::string KERNEL_ELF_FILE_NAME = "kernel_elf_paths.txt";
+};
 
 #define GET_WATCHER_TENSIX_DEV_ADDR() \
     MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::WATCHER)
@@ -49,55 +106,170 @@ namespace watcher {
 #define GET_WATCHER_IERISC_DEV_ADDR() \
     MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::WATCHER)
 
-static std::atomic<bool> enabled = false;
-static std::atomic<bool> server_running = false;
-static std::atomic<int> dump_count = 0;
-static std::mutex watch_mutex;
-static std::condition_variable enabled_cv;
-
-static std::map<chip_id_t, watcher::WatcherDeviceReader> devices;
-static std::string logfile_path = "generated/watcher/";
-static std::string logfile_name = "watcher.log";
-static FILE* logfile = nullptr;
-static std::chrono::time_point start_time = std::chrono::system_clock::now();
-static std::vector<std::string> kernel_names;
-static FILE* kernel_file = nullptr;
-static std::string kernel_file_name = "kernel_names.txt";
-static FILE* kernel_elf_file = nullptr;
-static std::string kernel_elf_file_name = "kernel_elf_paths.txt";
-
-// Flag to signal whether the watcher server has been killed due to a thrown exception.
-static std::atomic<bool> watcher_killed_due_to_error = false;
-
-static std::mutex watcher_exception_message_mutex;
-
-// Function to get the static string
-static std::string& watcher_exception_message() {
-    static std::string message = "";
-    return message;
+void WatcherServer::Impl::init_devices() {
+    auto all_devices = MetalContext::instance().get_cluster().all_chip_ids();
+    for (chip_id_t device_id : all_devices) {
+        init_device(device_id);
+    }
 }
 
-// Function to set the static string
-static void set_watcher_exception_message(const std::string& message) {
-    std::lock_guard<std::mutex> lock(watcher_exception_message_mutex);
-    watcher_exception_message() = message;
+void WatcherServer::Impl::attach_devices() {
+    auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    if (!rtoptions.get_watcher_enabled()) {
+        return;
+    }
+
+    {
+        const std::lock_guard<std::mutex> lock(watch_mutex_);
+        create_log_file();
+        create_kernel_file();
+        auto all_devices = MetalContext::instance().get_cluster().all_chip_ids();
+        for (chip_id_t device_id : all_devices) {
+            device_id_to_reader_.try_emplace(device_id, logfile_, device_id, kernel_names_);
+            log_info(LogLLRuntime, "Watcher attached device {}", device_id);
+            fprintf(logfile_, "At %.3lfs attach device %d\n", get_elapsed_secs(), device_id);
+        }
+
+        // Since dma library is not thread-safe, disable it when watcher runs.
+        rtoptions.set_disable_dma_ops(true);
+    }
+
+    // Spin off thread to run the server.
+    server_thread_ = new std::thread(&WatcherServer::Impl::poll_watcher_data, this);
 }
 
-static double get_elapsed_secs() {
+void WatcherServer::Impl::detach_devices() {
+    // If server isn't running, and wasn't killed due to an error, nothing to do here.
+    if (!server_thread_ and !server_killed_due_to_error_) {
+        return;
+    }
+
+    if (server_thread_) {
+        // Signal the server thread to finish
+        stop_server_ = true;
+        stop_server_cv_.notify_all();
+
+        // Wait for the thread to end, with a timeout
+        auto future = std::async(std::launch::async, &std::thread::join, server_thread_);
+        if (future.wait_for(std::chrono::seconds(2)) == std::future_status::timeout) {
+            log_fatal(tt::LogMetal, "Timed out waiting on watcher server thread to terminate.");
+        }
+        delete server_thread_;
+        server_thread_ = nullptr;
+    }
+
+    // Detach all devices
+    {
+        const std::lock_guard<std::mutex> lock(watch_mutex_);
+        auto all_devices = MetalContext::instance().get_cluster().all_chip_ids();
+        for (chip_id_t device_id : all_devices) {
+            TT_ASSERT(device_id_to_reader_.count(device_id) > 0);
+            device_id_to_reader_.erase(device_id);
+            log_info(LogLLRuntime, "Watcher detached device {}", device_id);
+            fprintf(logfile_, "At %.3lfs detach device %d\n", get_elapsed_secs(), device_id);
+        }
+
+        // Watcher server closed, can use dma library again.
+        MetalContext::instance().rtoptions().set_disable_dma_ops(false);
+
+        // Close files
+        std::fclose(logfile_);
+        logfile_ = nullptr;
+    }
+}
+
+void WatcherServer::Impl::dump(FILE* f) {
+    for (auto& device_id_and_reader : device_id_to_reader_) {
+        device_id_and_reader.second.Dump(f);
+    }
+}
+
+void WatcherServer::Impl::isolated_dump(std::vector<chip_id_t>& device_ids) {
+    // No init, so we don't clear mailboxes
+    clear_log();
+    read_kernel_ids_from_file();
+    for (chip_id_t device_id : device_ids) {
+        device_id_to_reader_.try_emplace(device_id, logfile_, device_id, kernel_names_);
+        log_info(LogLLRuntime, "Watcher attached device {}", device_id);
+        fprintf(logfile_, "At %.3lfs attach device %d\n", get_elapsed_secs(), device_id);
+    }
+    dump();
+    device_id_to_reader_.clear();
+}
+
+std::string WatcherServer::Impl::log_file_name() {
+    return tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + LOG_FILE_PATH + LOG_FILE_NAME;
+}
+
+int WatcherServer::Impl::register_kernel(const std::string& name) {
+    const std::lock_guard<std::mutex> lock(watch_mutex_);
+
+    if (!kernel_file_) {
+        create_kernel_file();
+    }
+    int k_id = kernel_names_.size();
+    kernel_names_.push_back(name);
+    fprintf(kernel_file_, "%d: %s\n", k_id, name.c_str());
+    fflush(kernel_file_);
+
+    return k_id;
+}
+
+void WatcherServer::Impl::register_kernel_elf_paths(int id, std::vector<std::string>& paths) {
+    const std::lock_guard<std::mutex> lock(watch_mutex_);
+    if (!kernel_elf_file_) {
+        create_kernel_elf_file();
+    }
+    std::string combined_paths = paths[0];
+    for (int i = 1; i < paths.size(); i++) {
+        combined_paths += ":" + paths[i];
+    }
+    fprintf(kernel_elf_file_, "%d: %s\n", id, combined_paths.c_str());
+    fflush(kernel_elf_file_);
+}
+
+void WatcherServer::Impl::read_kernel_ids_from_file() {
+    std::filesystem::path output_dir(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + LOG_FILE_PATH);
+    std::string fname = output_dir.string() + KERNEL_FILE_NAME;
+    FILE* f;
+    if ((f = fopen(fname.c_str(), "r")) == nullptr) {
+        TT_THROW("Watcher failed to open kernel name file: {}\n", fname);
+    }
+
+    char* line = nullptr;
+    size_t len;
+    while (getline(&line, &len, f) != -1) {
+        std::string s(line);
+        s = s.substr(0, s.length() - 1);            // Strip newline
+        int k_id = stoi(s.substr(0, s.find(":")));  // Format is {k_id}: {kernel}
+        kernel_names_.push_back(s.substr(s.find(":") + 2));
+    }
+}
+
+std::string WatcherServer::Impl::exception_message() {
+    std::lock_guard<std::mutex> lock(exception_message_mutex_);
+    return exception_message_;
+}
+
+void WatcherServer::Impl::set_exception_message(const std::string& message) {
+    std::lock_guard<std::mutex> lock(exception_message_mutex_);
+    exception_message_ = message;
+}
+
+double WatcherServer::Impl::get_elapsed_secs() {
     std::chrono::time_point now_time = std::chrono::system_clock::now();
     std::chrono::duration<double> elapsed_secs = now_time - start_time;
-
     return elapsed_secs.count();
 }
 
-void create_log_file() {
+void WatcherServer::Impl::create_log_file() {
     FILE* f;
 
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
     const char* fmode = rtoptions.get_watcher_append() ? "a" : "w";
-    std::filesystem::path output_dir(rtoptions.get_root_dir() + watcher::logfile_path);
+    std::filesystem::path output_dir(rtoptions.get_root_dir() + LOG_FILE_PATH);
     std::filesystem::create_directories(output_dir);
-    std::string fname = output_dir.string() + watcher::logfile_name;
+    std::string fname = output_dir.string() + LOG_FILE_NAME;
     if (rtoptions.get_watcher_skip_logging()) {
         fname = "/dev/null";
     }
@@ -106,7 +278,7 @@ void create_log_file() {
     }
     log_info(LogLLRuntime, "Watcher log file: {}", fname);
 
-    fprintf(f, "At %.3lfs starting\n", watcher::get_elapsed_secs());
+    fprintf(f, "At %.3lfs starting\n", get_elapsed_secs());
     fprintf(f, "Legend:\n");
     fprintf(f, "\tComma separated list specifices waypoint for BRISC,NCRISC,TRISC0,TRISC1,TRISC2\n");
     fprintf(f, "\tI=initialization sequence\n");
@@ -127,114 +299,43 @@ void create_log_file() {
     fprintf(f, "\n");
     fflush(f);
 
-    watcher::logfile = f;
+    logfile_ = f;
 }
 
-void create_kernel_file() {
+void WatcherServer::Impl::create_kernel_file() {
     FILE* f;
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
     const char* fmode = rtoptions.get_watcher_append() ? "a" : "w";
-    std::filesystem::path output_dir(rtoptions.get_root_dir() + watcher::logfile_path);
+    std::filesystem::path output_dir(rtoptions.get_root_dir() + LOG_FILE_PATH);
     std::filesystem::create_directories(output_dir);
-    std::string fname = output_dir.string() + watcher::kernel_file_name;
+    std::string fname = output_dir.string() + KERNEL_FILE_NAME;
     if ((f = fopen(fname.c_str(), fmode)) == nullptr) {
         TT_THROW("Watcher failed to create kernel name file\n");
     }
-    watcher::kernel_names.clear();
-    watcher::kernel_names.push_back("blank");
+    kernel_names_.clear();
+    kernel_names_.push_back("blank");
     fprintf(f, "0: blank\n");
     fflush(f);
 
-    watcher::kernel_file = f;
+    kernel_file_ = f;
 }
 
-void create_kernel_elf_file() {
+void WatcherServer::Impl::create_kernel_elf_file() {
     FILE* f;
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-    std::filesystem::path output_dir(rtoptions.get_root_dir() + watcher::logfile_path);
+    std::filesystem::path output_dir(rtoptions.get_root_dir() + LOG_FILE_PATH);
     std::filesystem::create_directories(output_dir);
-    std::string fname = output_dir.string() + watcher::kernel_elf_file_name;
+    std::string fname = output_dir.string() + KERNEL_ELF_FILE_NAME;
     if ((f = fopen(fname.c_str(), "w")) == nullptr) {
         TT_THROW("Watcher failed to create kernel ELF file\n");
     }
-    watcher::kernel_elf_file = f;
+    kernel_elf_file_ = f;
     fprintf(f, "0: blank\n");
     fflush(f);
 }
 
-// noinline so that this fn exists to be called from dgb
-static void __attribute__((noinline)) dump(FILE* f) {
-    for (auto& device_and_reader : devices) {
-        device_and_reader.second.Dump(f);
-    }
-}
-
-static void watcher_loop(std::chrono::microseconds sleep_duration) {
-    TT_ASSERT(watcher::server_running == false);
-    watcher::server_running = true;
-    watcher::dump_count = 1;
-    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-
-    // Print to the user which features are disabled via env vars.
-    std::string disabled_features = "";
-    auto& disabled_features_set = rtoptions.get_watcher_disabled_features();
-    if (!disabled_features_set.empty()) {
-        for (auto& feature : disabled_features_set) {
-            disabled_features += feature + ",";
-        }
-        disabled_features.pop_back();
-    } else {
-        disabled_features = "None";
-    }
-    log_info(LogLLRuntime, "Watcher server initialized, disabled features: {}", disabled_features);
-
-    while (true) {
-        std::unique_lock<std::mutex> lock(watch_mutex);
-        if (enabled_cv.wait_for(lock, sleep_duration, [&] { return !watcher::enabled.load(); })) {
-            // Watcher has been disabled
-            break;
-        }
-
-            // If all devices are detached, we can turn off the server, it will be turned back on
-            // when a new device is attached.
-            if (!watcher::enabled) {
-                break;
-            }
-
-            fprintf(logfile, "-----\n");
-            fprintf(logfile, "Dump #%d at %.3lfs\n", watcher::dump_count.load(), watcher::get_elapsed_secs());
-
-            if (devices.size() == 0) {
-                fprintf(logfile, "No active devices\n");
-            }
-
-            try {
-                dump(logfile);
-            } catch (std::runtime_error& e) {
-                // Depending on whether test mode is enabled, catch and stop server, or re-throw.
-                if (rtoptions.get_test_mode_enabled()) {
-                    watcher::watcher_killed_due_to_error = true;
-                    watcher::enabled = false;
-                    enabled_cv.notify_all();
-                    break;
-                } else {
-                    throw e;
-                }
-            }
-
-            fprintf(logfile, "Dump #%d completed at %.3lfs\n", watcher::dump_count.load(), watcher::get_elapsed_secs());
-            fflush(logfile);
-            watcher::dump_count++;
-    }
-
-    log_info(LogLLRuntime, "Watcher thread stopped watching...");
-    watcher::server_running = false;
-}
-
-}  // namespace watcher
-
-void watcher_init(chip_id_t device_id) {
-    const std::lock_guard<std::mutex> lock(watcher::watch_mutex);
+void WatcherServer::Impl::init_device(chip_id_t device_id) {
+    const std::lock_guard<std::mutex> lock(watch_mutex_);
     std::vector<uint32_t> watcher_init_val;
     watcher_init_val.resize(sizeof(watcher_msg_t) / sizeof(uint32_t), 0);
     watcher_msg_t* data = reinterpret_cast<watcher_msg_t*>(&(watcher_init_val[0]));
@@ -251,20 +352,20 @@ void watcher_init(chip_id_t device_id) {
     // Initialize debug sanity L1/NOC addresses to sentinel "all ok"
     const auto NUM_NOCS = tt::tt_metal::MetalContext::instance().hal().get_num_nocs();
     for (int i = 0; i < NUM_NOCS; i++) {
-        data->sanitize_noc[i].noc_addr = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_64;
-        data->sanitize_noc[i].l1_addr = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_32;
-        data->sanitize_noc[i].len = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_32;
-        data->sanitize_noc[i].which_risc = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
+        data->sanitize_noc[i].noc_addr = DEBUG_SANITIZE_NOC_SENTINEL_OK_64;
+        data->sanitize_noc[i].l1_addr = DEBUG_SANITIZE_NOC_SENTINEL_OK_32;
+        data->sanitize_noc[i].len = DEBUG_SANITIZE_NOC_SENTINEL_OK_32;
+        data->sanitize_noc[i].which_risc = DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
         data->sanitize_noc[i].return_code = DebugSanitizeNocOK;
-        data->sanitize_noc[i].is_multicast = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
-        data->sanitize_noc[i].is_write = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
-        data->sanitize_noc[i].is_target = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
+        data->sanitize_noc[i].is_multicast = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
+        data->sanitize_noc[i].is_write = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
+        data->sanitize_noc[i].is_target = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
     }
 
     // Initialize debug asserts to not tripped.
-    data->assert_status.line_num = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
+    data->assert_status.line_num = DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
     data->assert_status.tripped = DebugAssertOK;
-    data->assert_status.which = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
+    data->assert_status.which = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
 
     // Initialize pause flags to 0
     for (int idx = 0; idx < DebugNumUniqueRiscs; idx++) {
@@ -419,154 +520,78 @@ void watcher_init(chip_id_t device_id) {
     log_debug(LogLLRuntime, "Watcher initialized device {}", device_id);
 }
 
-void watcher_attach(chip_id_t device_id) {
-    const std::lock_guard<std::mutex> lock(watcher::watch_mutex);
-    auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+void WatcherServer::Impl::poll_watcher_data() {
+    TT_ASSERT(server_running_ == false);
+    server_running_ = true;
+    dump_count_ = 1;
+    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    auto sleep_duration = std::chrono::milliseconds(rtoptions.get_watcher_interval());
 
-    if (!watcher::enabled && rtoptions.get_watcher_enabled()) {
-        watcher::create_log_file();
-        if (!watcher::kernel_file) {
-            watcher::create_kernel_file();
+    // Print to the user which features are disabled via env vars.
+    std::string disabled_features = "";
+    auto& disabled_features_set = rtoptions.get_watcher_disabled_features();
+    if (!disabled_features_set.empty()) {
+        for (auto& feature : disabled_features_set) {
+            disabled_features += feature + ",";
         }
-        watcher::watcher_killed_due_to_error = false;
-        watcher::set_watcher_exception_message("");
-
-        watcher::enabled = true;
-        watcher::enabled_cv.notify_all();
-
-        rtoptions.set_disable_dma_ops(true);
-
-        auto sleep_duration = std::chrono::milliseconds(rtoptions.get_watcher_interval());
-        std::thread watcher_thread = std::thread(&watcher::watcher_loop, sleep_duration);
-        watcher_thread.detach();
+        disabled_features.pop_back();
+    } else {
+        disabled_features = "None";
     }
+    log_info(LogLLRuntime, "Watcher server initialized, disabled features: {}", disabled_features);
 
-    if (watcher::logfile != nullptr) {
-        fprintf(watcher::logfile, "At %.3lfs attach device %d\n", watcher::get_elapsed_secs(), device_id);
-    }
-
-    if (watcher::enabled) {
-        log_info(LogLLRuntime, "Watcher attached device {}", device_id);
-    }
-
-    // Always register the device w/ watcher, even if disabled
-    // This allows dump() to be called from debugger
-    watcher::devices.try_emplace(
-        device_id, watcher::logfile, device_id, watcher::kernel_names, &watcher::set_watcher_exception_message);
-}
-
-void watcher_detach(chip_id_t device_id) {
-    {
-        const std::lock_guard<std::mutex> lock(watcher::watch_mutex);
-        if (!watcher::enabled) {
-            // TODO: reinstate this after watcher server singleton is removed.
-            return;
+    while (true) {
+        std::unique_lock<std::mutex> lock(watch_mutex_);
+        if (stop_server_cv_.wait_for(lock, sleep_duration, [&] { return stop_server_.load(); })) {
+            break;
         }
 
-        TT_ASSERT(watcher::devices.find(device_id) != watcher::devices.end());
-        if (watcher::enabled && watcher::logfile != nullptr) {
-            log_info(LogLLRuntime, "Watcher detached device {}", device_id);
-            fprintf(watcher::logfile, "At %.3lfs detach device %d\n", watcher::get_elapsed_secs(), device_id);
+        fprintf(logfile_, "-----\n");
+        fprintf(logfile_, "Dump #%d at %.3lfs\n", dump_count_.load(), get_elapsed_secs());
+
+        if (device_id_to_reader_.size() == 0) {
+            fprintf(logfile_, "No active devices\n");
         }
-        watcher::devices.erase(device_id);
-        if (watcher::enabled && watcher::devices.empty()) {
-            // If no devices remain, shut down the watcher server.
-            watcher::enabled = false;
-            watcher::enabled_cv.notify_all();
-            if (watcher::logfile != nullptr) {
-                std::fclose(watcher::logfile);
-                watcher::logfile = nullptr;
-            }
-            if (watcher::kernel_file != nullptr) {
-                std::fclose(watcher::kernel_file);
-                watcher::kernel_file = nullptr;
+
+        try {
+            dump();
+        } catch (std::runtime_error& e) {
+            // Depending on whether test mode is enabled, catch and stop server, or re-throw.
+            if (rtoptions.get_test_mode_enabled()) {
+                server_killed_due_to_error_ = true;
+                break;
+            } else {
+                throw e;
             }
         }
+
+        fprintf(logfile_, "Dump #%d completed at %.3lfs\n", dump_count_.load(), get_elapsed_secs());
+        fflush(logfile_);
+        dump_count_++;
     }
 
-    // If we shut down the watcher server, wait until it finishes up. Do this without holding the
-    // lock because the watcher server may be waiting on it before it does its exit check.
-    if (watcher::devices.empty()) {
-        while (watcher::server_running) {
-            ;
-        }
-
-        tt::tt_metal::MetalContext::instance().rtoptions().set_disable_dma_ops(false);
-    }
+    log_info(LogLLRuntime, "Watcher thread stopped watching...");
+    server_running_ = false;
+    stop_server_ = false;
 }
 
-int watcher_register_kernel(const std::string& name) {
-    const std::lock_guard<std::mutex> lock(watcher::watch_mutex);
-
-    if (!watcher::kernel_file) {
-        watcher::create_kernel_file();
-    }
-    int k_id = watcher::kernel_names.size();
-    watcher::kernel_names.push_back(name);
-    fprintf(watcher::kernel_file, "%d: %s\n", k_id, name.c_str());
-    fflush(watcher::kernel_file);
-
-    return k_id;
+// Wrapper class functions
+WatcherServer::WatcherServer() : impl_(std::make_unique<Impl>()) {};
+WatcherServer::~WatcherServer() = default;
+void WatcherServer::init_devices() { impl_->init_devices(); }
+void WatcherServer::attach_devices() { impl_->attach_devices(); }
+void WatcherServer::detach_devices() { impl_->detach_devices(); }
+void WatcherServer::clear_log() { impl_->clear_log(); }
+std::string WatcherServer::log_file_name() { return impl_->log_file_name(); }
+int WatcherServer::register_kernel(const std::string& name) { return impl_->register_kernel(name); }
+void WatcherServer::register_kernel_elf_paths(int id, std::vector<std::string>& paths) {
+    impl_->register_kernel_elf_paths(id, paths);
 }
-
-void watcher_register_kernel_elf_paths(int id, std::vector<std::string> paths) {
-    const std::lock_guard<std::mutex> lock(watcher::watch_mutex);
-    if (!watcher::kernel_elf_file) {
-        watcher::create_kernel_elf_file();
-    }
-    std::string combined_paths = paths[0];
-    for (int i = 1; i < paths.size(); i++) {
-        combined_paths += ":" + paths[i];
-    }
-    fprintf(watcher::kernel_elf_file, "%d: %s\n", id, combined_paths.c_str());
-    fflush(watcher::kernel_elf_file);
-}
-
-bool watcher_server_killed_due_to_error() { return watcher::watcher_killed_due_to_error; }
-
-void watcher_server_set_error_flag(bool val) { watcher::watcher_killed_due_to_error = val; }
-
-void watcher_clear_log() { watcher::create_log_file(); }
-
-std::string watcher_get_log_file_name() {
-    return tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + watcher::logfile_path +
-           watcher::logfile_name;
-}
-
-int watcher_get_dump_count() { return watcher::dump_count; }
-
-void watcher_dump() {
-    if (!watcher::logfile) {
-        watcher::create_log_file();
-    }
-    watcher::dump(watcher::logfile);
-}
-
-void watcher_read_kernel_ids_from_file() {
-    std::filesystem::path output_dir(
-        tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + watcher::logfile_path);
-    std::string fname = output_dir.string() + watcher::kernel_file_name;
-    FILE* f;
-    if ((f = fopen(fname.c_str(), "r")) == nullptr) {
-        TT_THROW("Watcher failed to open kernel name file: {}\n", fname);
-    }
-
-    char* line = nullptr;
-    size_t len;
-    while (getline(&line, &len, f) != -1) {
-        std::string s(line);
-        s = s.substr(0, s.length() - 1);            // Strip newline
-        int k_id = stoi(s.substr(0, s.find(":")));  // Format is {k_id}: {kernel}
-        watcher::kernel_names.push_back(s.substr(s.find(":") + 2));
-    }
-}
-
-// Function to get the static string value
-std::string get_watcher_exception_message() {
-    std::lock_guard<std::mutex> lock(watcher::watcher_exception_message_mutex);
-    return watcher::watcher_exception_message();
-}
-
-std::unique_lock<std::mutex> watcher_get_lock() { return std::unique_lock<std::mutex>(watcher::watch_mutex); }
-
-}  // namespace tt
+bool WatcherServer::killed_due_to_error() { return impl_->killed_due_to_error(); }
+void WatcherServer::set_killed_due_to_error_flag(bool val) { impl_->set_killed_due_to_error_flag(val); }
+std::string WatcherServer::exception_message() { return impl_->exception_message(); }
+void WatcherServer::set_exception_message(const std::string& msg) { impl_->set_exception_message(msg); }
+int WatcherServer::dump_count() { return impl_->dump_count(); }
+std::unique_lock<std::mutex> WatcherServer::get_lock() { return impl_->get_lock(); }
+void WatcherServer::isolated_dump(std::vector<chip_id_t>& device_ids) { impl_->isolated_dump(device_ids); }
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -10,40 +10,40 @@
 
 struct metal_SocDescriptor;
 
-namespace tt {
+namespace tt::tt_metal {
+class WatcherServer {
+public:
+    WatcherServer();
+    ~WatcherServer();
 
-void watcher_init(chip_id_t device_id);
-void watcher_attach(chip_id_t device_id);
-void watcher_detach(chip_id_t device_id);
+    void init_devices();    // Always runs, puts watcher mailboxes in a default state
+    void attach_devices();  // Start watcher server and attach all devices
+    void detach_devices();  // Detach all devices and stop watcher server
 
-void watcher_sanitize_host_noc_read(const metal_SocDescriptor& soc_d, CoreCoord core, uint64_t addr, uint32_t len);
-void watcher_sanitize_host_noc_write(const metal_SocDescriptor& soc_d, CoreCoord core, uint64_t addr, uint32_t len);
+    // Helper function to clear the log file, get the log file name
+    void clear_log();
+    std::string log_file_name();
 
-int watcher_register_kernel(const std::string& name);
-void watcher_register_kernel_elf_paths(int id, std::vector<std::string> paths);
+    // Functions to register kernel ids & elf paths with the watcher server, which is responsible for dumping them to
+    // files for use after the metal run is completed.
+    int register_kernel(const std::string& name);
+    void register_kernel_elf_paths(int id, std::vector<std::string>& paths);
 
-// Helper functions for manually dumping watcher contents.
-void watcher_dump();
-void watcher_read_kernel_ids_from_file();
+    // Test-only helper functions
+    bool killed_due_to_error();
+    void set_killed_due_to_error_flag(bool val);
+    std::string exception_message();
+    void set_exception_message(const std::string& msg);
+    int dump_count();
 
-// Check whether the watcher server has been killed due to an error detected, and a function to set
-// that flag. Used in test mode only.
-bool watcher_server_killed_due_to_error();
-void watcher_server_set_error_flag(bool val);
+    // Helper to return the watcher mutex lock. Use this when writing to mailboxes if watcher server has started.
+    std::unique_lock<std::mutex> get_lock();
 
-// Description of thrown exception from watcher server, used for testing purposes.
-std::string get_watcher_exception_message();
+    // Helper function for manually dumping watcher contents. TODO: remove when watcher_dump tool is removed.
+    void isolated_dump(std::vector<chip_id_t>& device_ids);
 
-// Helper function to clear the watcher log file
-void watcher_clear_log();
-
-// Helper function to get the current watcher log file name/path
-std::string watcher_get_log_file_name();
-
-// Helper function to get the current watcher dump count
-int watcher_get_dump_count();
-
-// Helper to return the watcher mutex lock
-std::unique_lock<std::mutex> watcher_get_lock();
-
-}  // namespace tt
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;  // Pointer to implementation
+};
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -67,7 +67,6 @@
 #include "tracy/Tracy.hpp"
 #include "tt_memory.h"
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
-#include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/dispatch/hardware_command_queue.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/sub_device/sub_device_manager.hpp"
@@ -314,7 +313,7 @@ void Device::init_command_queue_device() {
     auto storage_only_cores_set = std::unordered_set<CoreCoord>(storage_only_cores.begin(), storage_only_cores.end());
     std::optional<std::unique_lock<std::mutex>> watcher_lock;
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
-        watcher_lock = watcher_get_lock();
+        watcher_lock = MetalContext::instance().watcher_server()->get_lock();
     }
     for (uint32_t y = 0; y < logical_grid_size().y; y++) {
         for (uint32_t x = 0; x < logical_grid_size().x; x++) {

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -37,7 +37,6 @@
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/impl/debug/noc_logging.hpp"
-#include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/dispatch/system_memory_manager.hpp"
 #include "tt_metal/common/executor.hpp"

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -36,7 +36,6 @@
 #include <tt_stl/strong_type.hpp>
 #include "system_memory_manager.hpp"
 #include "trace/trace_node.hpp"
-#include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/program/dispatch.hpp"
 #include "tt_metal/impl/trace/dispatch.hpp"
 #include <umd/device/tt_xy_pair.h>
@@ -722,7 +721,7 @@ void HWCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids) {
                 // DPrint Server hang, early exit. We're in test mode, so main thread will assert.
                 this->set_exit_condition();
                 return;
-            } else if (tt::watcher_server_killed_due_to_error()) {
+            } else if (MetalContext::instance().watcher_server()->killed_due_to_error()) {
                 // Illegal NOC txn killed watcher, early exit. We're in test mode, so main thread will assert.
                 this->set_exit_condition();
                 return;

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -32,7 +32,6 @@
 #include <tt_stl/span.hpp>
 #include "system_memory_manager.hpp"
 #include "tracy/Tracy.hpp"
-#include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/dispatch/data_collection.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include "tt_metal/impl/program/dispatch.hpp"
@@ -308,11 +307,11 @@ void EventSynchronize(const std::shared_ptr<Event>& event) {
 
     while (event->device->sysmem_manager().get_last_completed_event(event->cq_id) < event->event_id) {
         if (tt::tt_metal::MetalContext::instance().rtoptions().get_test_mode_enabled() &&
-            tt::watcher_server_killed_due_to_error()) {
+            MetalContext::instance().watcher_server()->killed_due_to_error()) {
             TT_FATAL(
                 false,
                 "Command Queue could not complete EventSynchronize. See {} for details.",
-                tt::watcher_get_log_file_name());
+                MetalContext::instance().watcher_server()->log_file_name());
             return;
         }
         std::this_thread::sleep_for(std::chrono::microseconds(5));
@@ -344,9 +343,9 @@ void Finish(CommandQueue& cq, tt::stl::Span<const SubDeviceId> sub_device_ids) {
             !(MetalContext::instance().dprint_server() and MetalContext::instance().dprint_server()->hang_detected()),
             "Command Queue could not finish: device hang due to unanswered DPRINT WAIT.");
         TT_FATAL(
-            !(tt::watcher_server_killed_due_to_error()),
+            !(MetalContext::instance().watcher_server()->killed_due_to_error()),
             "Command Queue could not finish: device hang due to illegal NoC transaction. See {} for details.",
-            tt::watcher_get_log_file_name());
+            MetalContext::instance().watcher_server()->log_file_name());
     }
 }
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -26,7 +26,6 @@
 #include <tt_stl/span.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_memory.h"
-#include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/jit_build/genfiles.hpp"
 #include <umd/device/types/arch.h>
@@ -75,16 +74,18 @@ Kernel::Kernel(
 
 void Kernel::register_kernel_with_watcher() {
     if (this->kernel_src_.source_type_ == KernelSource::FILE_PATH) {
-        this->watcher_kernel_id_ = watcher_register_kernel(this->kernel_src_.source_);
+        this->watcher_kernel_id_ =
+            MetalContext::instance().watcher_server()->register_kernel(this->kernel_src_.source_);
     } else {
         TT_FATAL(this->kernel_src_.source_type_ == KernelSource::SOURCE_CODE, "Unsupported kernel source type!");
-        this->watcher_kernel_id_ = watcher_register_kernel(this->name());
+        this->watcher_kernel_id_ = MetalContext::instance().watcher_server()->register_kernel(this->name());
     }
 }
 
 void KernelImpl::register_kernel_elf_paths_with_watcher(IDevice& device) const {
     TT_ASSERT(this->kernel_full_name_.size() > 0, "Kernel full name not set!");
-    watcher_register_kernel_elf_paths(this->watcher_kernel_id_, this->file_paths(device));
+    auto paths = this->file_paths(device);
+    MetalContext::instance().watcher_server()->register_kernel_elf_paths(this->watcher_kernel_id_, paths);
 }
 
 std::string Kernel::name() const { return this->kernel_src_.name(); }

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -12,7 +12,6 @@
 #include "dispatch_core_common.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/debug/noc_logging.hpp"
-#include "impl/debug/watcher_server.hpp"
 #include "impl/dispatch/debug_tools.hpp"
 #include "impl/dispatch/system_memory_manager.hpp"
 
@@ -49,7 +48,7 @@ void dump_data(
         cout << "Dumping Command Queues into: " << cq_dir.string() << endl;
     }
     if (dump_watcher) {
-        cout << "Dumping Watcher Log into: " << watcher_get_log_file_name() << endl;
+        cout << "Dumping Watcher Log into: " << MetalContext::instance().watcher_server()->log_file_name() << endl;
     }
 
     // Only look at user-specified devices
@@ -67,16 +66,11 @@ void dump_data(
             std::unique_ptr<SystemMemoryManager> sysmem_manager = std::make_unique<SystemMemoryManager>(id, num_hw_cqs);
             internal::dump_cqs(cq_file, iq_file, *sysmem_manager, dump_cqs_raw_data);
         }
-        // Watcher attach wthout watcher init - to avoid clearing mailboxes.
-        if (dump_watcher) {
-            watcher_attach(device->id());
-        }
     }
 
     // Watcher doesn't have kernel ids since we didn't create them here, need to read from file.
     if (dump_watcher) {
-        watcher_read_kernel_ids_from_file();
-        watcher_dump();
+        MetalContext::instance().watcher_server()->isolated_dump(device_ids);
     }
 
     // Dump noc data if requested


### PR DESCRIPTION
One of the last remaining singletons, remove it and place ownership under MetalContext to keep init/teardown ordering clean. `watcher_server_*` free functions become `WatcherServer` member functions, accessed through `MetalContext`.

CI: https://github.com/tenstorrent/tt-metal/actions/runs/16208120634
https://github.com/tenstorrent/tt-metal/actions/runs/16154882607