### PR TITLE
Add compute kernel config input to batch norm

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -10,7 +10,7 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     compare_results_batch_norm,
 )
 from itertools import product
-from models.utility_functions import skip_for_grayskull
+from models.utility_functions import skip_for_grayskull, comp_pcc
 
 
 @skip_for_grayskull("Unsupported dtype for Grayskull")
@@ -422,3 +422,96 @@ def test_batch_norm_output_Default(input_shapes, device):
     torch_result = torch.nn.functional.batch_norm(input=in_data, running_mean=mean_data, running_var=var_data)
     comp_BN_Output = compare_results_batch_norm([tt_output], [torch_result])
     assert comp_BN_Output
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        torch.Size([2, 3, 64, 64]),
+    ],
+)
+@pytest.mark.parametrize(
+    "training, weight, bias",
+    [
+        (True, True, True),
+        (True, False, False),
+        (False, True, True),
+        (False, False, False),
+    ],
+)
+def test_batch_norm_compute_config(input_shapes, training, weight, bias, device):
+    N, H, W, C = input_shapes
+    d_type = "float32"
+    torch.manual_seed(0)
+
+    # Generate the inputs
+    torch_input_tensor, tt_input_tensor = data_gen_with_range_batch_norm(
+        input_shapes, 5, 10, device, is_input=True, testing_dtype=d_type
+    )
+    torch_mean_tensor, tt_mean_tensor = data_gen_with_range_batch_norm(
+        input_shapes, 4, 10, device, testing_dtype=d_type
+    )
+    torch_var_tensor, tt_var_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 20, device, testing_dtype=d_type)
+    torch_weight_tensor, tt_weight_tensor = (
+        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=d_type) if weight else (None, None)
+    )
+    torch_bias_tensor, tt_bias_tensor = (
+        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=d_type) if bias else (None, None)
+    )
+
+    # Compute the torch result
+    torch_output_tensor = torch.nn.functional.batch_norm(
+        input=torch_input_tensor,
+        running_mean=torch_mean_tensor,
+        running_var=torch_var_tensor,
+        weight=torch_weight_tensor,
+        bias=torch_bias_tensor,
+        training=training,
+    )
+
+    # Helper function to execute batch_norm for a given compute config
+    # and return torch and tt tensors to compare
+    def do_batch_norm_for_config(compute_config):
+        tt_mean = ttnn.clone(tt_mean_tensor)
+        tt_var = ttnn.clone(tt_var_tensor)
+
+        tt_output_tensor = ttnn.batch_norm(
+            input=tt_input_tensor,
+            running_mean=tt_mean,
+            running_var=tt_var,
+            training=training,
+            weight=tt_weight_tensor,
+            bias=tt_bias_tensor,
+            compute_kernel_config=compute_config,
+        )
+
+        if training:
+            tt_tensors = [ttnn.to_torch(tt_mean), ttnn.to_torch(tt_var)]
+            torch_tensors = [torch_mean_tensor, torch_var_tensor]
+        else:
+            tt_tensors = [ttnn.to_torch(tt_output_tensor)]
+            torch_tensors = [torch_output_tensor]
+
+        return torch_tensors, tt_tensors
+
+    def compute_pccs_for_tensors(torch_tensors, tt_tensors):
+        pccs = []
+        for torch_tensor, tt_tensor in zip(torch_tensors, tt_tensors):
+            _, pcc = comp_pcc(torch_tensor, tt_tensor)
+            pccs.append(pcc)
+        return pccs
+
+    # Execute low-accuracy groupnorm
+    config_low = ttnn.WormholeComputeKernelConfig(fp32_dest_acc_en=False)
+    torch_tensors_low, tt_tensors_low = do_batch_norm_for_config(config_low)
+    pccs_low = compute_pccs_for_tensors(torch_tensors_low, tt_tensors_low)
+
+    # Execute high-accuracy groupnorm
+    config_high = ttnn.WormholeComputeKernelConfig(fp32_dest_acc_en=True)
+    torch_tensors_high, tt_tensors_high = do_batch_norm_for_config(config_high)
+    pccs_high = compute_pccs_for_tensors(torch_tensors_high, tt_tensors_high)
+
+    print(f"PCCs low: {pccs_low}, PCCs high: {pccs_high}")
+    assert all(
+        high > low for high, low in zip(pccs_high, pccs_low)
+    ), "High-accuracy config should have higher PCC than low-accuracy config"

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -502,7 +502,8 @@ def test_batch_norm_compute_config(input_shapes, training, weight, bias, device)
         return pccs
 
     # Execute low-accuracy groupnorm
-    config_low = ttnn.WormholeComputeKernelConfig(
+    config_low = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi4,
         math_approx_mode=False,
         fp32_dest_acc_en=False,
@@ -511,7 +512,8 @@ def test_batch_norm_compute_config(input_shapes, training, weight, bias, device)
     pccs_low = compute_pccs_for_tensors(torch_tensors, tt_tensors)
 
     # Execute high-accuracy groupnorm
-    config_high = ttnn.WormholeComputeKernelConfig(
+    config_high = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi4,
         math_approx_mode=False,
         fp32_dest_acc_en=True,

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -502,16 +502,23 @@ def test_batch_norm_compute_config(input_shapes, training, weight, bias, device)
         return pccs
 
     # Execute low-accuracy groupnorm
-    config_low = ttnn.WormholeComputeKernelConfig(fp32_dest_acc_en=False)
-    torch_tensors_low, tt_tensors_low = do_batch_norm_for_config(config_low)
-    pccs_low = compute_pccs_for_tensors(torch_tensors_low, tt_tensors_low)
+    config_low = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+    )
+    torch_tensors, tt_tensors = do_batch_norm_for_config(config_low)
+    pccs_low = compute_pccs_for_tensors(torch_tensors, tt_tensors)
 
     # Execute high-accuracy groupnorm
-    config_high = ttnn.WormholeComputeKernelConfig(fp32_dest_acc_en=True)
-    torch_tensors_high, tt_tensors_high = do_batch_norm_for_config(config_high)
-    pccs_high = compute_pccs_for_tensors(torch_tensors_high, tt_tensors_high)
+    config_high = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+    )
+    torch_tensors, tt_tensors = do_batch_norm_for_config(config_high)
+    pccs_high = compute_pccs_for_tensors(torch_tensors, tt_tensors)
 
-    print(f"PCCs low: {pccs_low}, PCCs high: {pccs_high}")
     assert all(
         high > low for high, low in zip(pccs_high, pccs_low)
     ), "High-accuracy config should have higher PCC than low-accuracy config"

--- a/ttnn/cpp/ttnn/operations/normalization/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/normalization/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(
         batch_norm/device/batch_norm_program_factory.cpp
         batch_norm/device/running_statistics_device_operation.cpp
         batch_norm/device/running_statistics_program_factory.cpp
+        batch_norm/device/batch_norm_utils.cpp
         groupnorm/device/groupnorm_op.cpp
         groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
         groupnorm/groupnorm.cpp

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -9,16 +9,20 @@
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/eltwise/unary/device/unary_composite_op.hpp"
 #include "device/running_statistics_device_operation.hpp"
+#include "device/batch_norm_utils.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::normalization {
 
-inline Tensor mean_NHW(const Tensor& input_tensor, const std::optional<MemoryConfig>& memory_config) {
+inline Tensor mean_NHW(
+    const Tensor& input_tensor,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     auto output_mem_config = memory_config.value_or(input_tensor.memory_config());
     ttnn::SmallVector<int> dims = {2, 3};
-    Tensor mean_hw = ttnn::mean(input_tensor, dims, true);
-    return ttnn::mean(mean_hw, 0, true);
+    Tensor mean_hw = ttnn::mean(input_tensor, dims, true, std::nullopt, compute_kernel_config);
+    return ttnn::mean(mean_hw, 0, true, std::nullopt, compute_kernel_config);
 }
 
 Tensor BatchNorm::invoke(
@@ -32,6 +36,7 @@ Tensor BatchNorm::invoke(
     const std::optional<Tensor>& bias,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     QueueId queue_id) {
     TT_FATAL(
         input.logical_shape().rank() >= 4,
@@ -50,11 +55,11 @@ Tensor BatchNorm::invoke(
 
     Tensor batch_mean, batch_var;
     if (training) {
-        batch_mean = mean_NHW(input, memory_config);
-        auto mean_sq = mean_NHW(ttnn::square(input, memory_config), memory_config);
+        batch_mean = mean_NHW(input, memory_config, compute_kernel_config);
+        auto mean_sq = mean_NHW(ttnn::square(input, memory_config), memory_config, compute_kernel_config);
         batch_var = ttnn::subtract(mean_sq, ttnn::square(batch_mean, memory_config), std::nullopt, memory_config);
-        Tensor stats =
-            ttnn::prim::running_statistics(batch_mean, batch_var, momentum, running_mean, running_var, memory_config);
+        Tensor stats = ttnn::prim::running_statistics(
+            batch_mean, batch_var, momentum, running_mean, running_var, memory_config, compute_kernel_config);
     } else {
         TT_FATAL(
             (running_mean.has_value() && running_var.has_value()),
@@ -62,6 +67,7 @@ Tensor BatchNorm::invoke(
         batch_mean = running_mean.value();
         batch_var = running_var.value();
     }
-    return ttnn::prim::batch_norm(input, batch_mean, batch_var, eps, weight, bias, output, memory_config);
+    return ttnn::prim::batch_norm(
+        input, batch_mean, batch_var, eps, weight, bias, output, memory_config, compute_kernel_config);
 }
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.hpp
@@ -20,6 +20,7 @@ struct BatchNorm {
         const std::optional<Tensor>& bias = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
         QueueId queue_id = DefaultQueueId);
 };
 }  // namespace operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
@@ -36,6 +36,7 @@ void bind_batch_norm_operation(py::module& module) {
             training (bool, optional): Selection between training mode and inference (evaluation) mode. Defaults to `False` (Inference mode).
             output (ttnn.Tensor, optional): Preallocated output tensor to store batch norm result of shape `[N, C, H, W]`. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): device compute kernel configuration for the operation. Defaults to `None`.
             queue_id (int, optional): command queue id. Defaults to 0.
 
 
@@ -82,6 +83,7 @@ void bind_batch_norm_operation(py::module& module) {
             py::arg("bias") = std::nullopt,
             py::arg("output") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
+            py::arg("compute_kernel_config") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
 }  // namespace ttnn::operations::normalization::detail

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -6,6 +6,7 @@
 
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include "batch_norm_utils.hpp"
 
 namespace ttnn::operations::normalization {
 
@@ -163,7 +164,7 @@ tt::stl::hash::hash_t BatchNormOperation::compute_program_hash(
 }
 
 tt::stl::hash::hash_t BatchNormOperation::operation_attributes_t::to_hash() const {
-    return tt::stl::hash::hash_objects_with_default_seed(eps, memory_config, get_dtype());
+    return tt::stl::hash::hash_objects_with_default_seed(eps, memory_config, get_dtype(), compute_kernel_config);
 }
 
 std::tuple<BatchNormOperation::operation_attributes_t, BatchNormOperation::tensor_args_t> BatchNormOperation::invoke(
@@ -174,8 +175,13 @@ std::tuple<BatchNormOperation::operation_attributes_t, BatchNormOperation::tenso
     std::optional<Tensor> weight,
     std::optional<Tensor> bias,
     std::optional<Tensor> output,
-    const std::optional<MemoryConfig>& memory_config) {
-    operation_attributes_t operation_attributes{eps, memory_config.value_or(input.memory_config()), input.dtype()};
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    operation_attributes_t operation_attributes{
+        eps,
+        memory_config.value_or(input.memory_config()),
+        batch_norm::utils::resolve_compute_kernel_config(compute_kernel_config, input),
+        input.dtype()};
     tensor_args_t tensor_args{input, batch_mean, batch_var, std::move(weight), std::move(bias), std::move(output)};
     return {operation_attributes, tensor_args};
 }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
@@ -13,6 +13,7 @@ struct BatchNormOperation {
     struct operation_attributes_t {
         const float eps;
         const MemoryConfig memory_config;
+        const DeviceComputeKernelConfig compute_kernel_config;
 
         DataType input_dtype;
         std::optional<DataType> dtype;
@@ -71,7 +72,8 @@ struct BatchNormOperation {
         std::optional<Tensor> weight,
         std::optional<Tensor> bias,
         std::optional<Tensor> output,
-        const std::optional<MemoryConfig>& memory_config);
+        const std::optional<MemoryConfig>& memory_config,
+        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::normalization
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -254,8 +254,8 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
             std::move(writer_defines)));
 
     // COMPUTE KERNEL
-    bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
-                            c_data_format == tt::DataFormat::Float32;
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
 
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "batch_norm_utils.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/assert.hpp>
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::normalization::batch_norm::utils {
+
+DeviceComputeKernelConfig resolve_compute_kernel_config(
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config, const Tensor& input) {
+    TT_FATAL(
+        input.storage_type() == StorageType::DEVICE,
+        "Invalid input tensor storage type: Input tensor must be on device. (storage type={})",
+        input.storage_type());
+
+    const auto arch = input.device()->arch();
+    const auto input_data_format = datatype_to_dataformat_converter(input.dtype());
+    const auto default_math_fidelity = MathFidelity::HiFi4;
+    const auto default_approx_mode = true;
+    const auto default_fp32_acc = input_data_format == tt::DataFormat::UInt32 ||
+                                  input_data_format == tt::DataFormat::Int32 ||
+                                  input_data_format == tt::DataFormat::Float32;
+    const auto default_l1_acc = false;
+    const auto default_dst_full_sync_en = false;
+    return init_device_compute_kernel_config(
+        arch,
+        compute_kernel_config,
+        default_math_fidelity,
+        default_approx_mode,
+        default_fp32_acc,
+        default_l1_acc,
+        default_dst_full_sync_en);
+}
+
+}  // namespace ttnn::operations::normalization::batch_norm::utils

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
@@ -20,7 +20,7 @@ DeviceComputeKernelConfig resolve_compute_kernel_config(
     const auto arch = input.device()->arch();
     const auto input_data_format = datatype_to_dataformat_converter(input.dtype());
     const auto default_math_fidelity = MathFidelity::HiFi4;
-    const auto default_approx_mode = true;
+    const auto default_approx_mode = false;
     const auto default_fp32_acc = input_data_format == tt::DataFormat::UInt32 ||
                                   input_data_format == tt::DataFormat::Int32 ||
                                   input_data_format == tt::DataFormat::Float32;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
@@ -24,7 +24,7 @@ DeviceComputeKernelConfig resolve_compute_kernel_config(
     const auto default_fp32_acc = input_data_format == tt::DataFormat::UInt32 ||
                                   input_data_format == tt::DataFormat::Int32 ||
                                   input_data_format == tt::DataFormat::Float32;
-    const auto default_l1_acc = false;
+    const auto default_l1_acc = true;
     const auto default_dst_full_sync_en = false;
     return init_device_compute_kernel_config(
         arch,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <optional>
+
+namespace tt::tt_metal {
+class Tensor;
+};
+
+namespace ttnn::operations::normalization::batch_norm::utils {
+
+// resolve an optional compute kernel config or compute
+// a default based on input tensor's data type
+DeviceComputeKernelConfig resolve_compute_kernel_config(
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config, const tt::tt_metal::Tensor& input);
+
+}  // namespace ttnn::operations::normalization::batch_norm::utils

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
@@ -6,6 +6,7 @@
 
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include "batch_norm_utils.hpp"
 
 namespace ttnn::operations::normalization {
 
@@ -113,9 +114,13 @@ std::tuple<RunningStatistics::operation_attributes_t, RunningStatistics::tensor_
     const float momentum,
     std::optional<Tensor> running_mean,
     std::optional<Tensor> running_var,
-    const std::optional<MemoryConfig>& memory_config) {
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     operation_attributes_t operation_attributes{
-        momentum, memory_config.value_or(batch_mean.memory_config()), batch_mean.dtype()};
+        momentum,
+        memory_config.value_or(batch_mean.memory_config()),
+        batch_norm::utils::resolve_compute_kernel_config(compute_kernel_config, batch_mean),
+        batch_mean.dtype()};
     tensor_args_t tensor_args{batch_mean, batch_var, std::move(running_mean), std::move(running_var)};
     return {operation_attributes, tensor_args};
 }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.hpp
@@ -13,6 +13,7 @@ struct RunningStatistics {
     struct operation_attributes_t {
         const float momentum;
         const MemoryConfig memory_config;
+        const DeviceComputeKernelConfig compute_kernel_config;
 
         DataType input_dtype;
         std::optional<DataType> dtype;
@@ -65,7 +66,8 @@ struct RunningStatistics {
         float momentum,
         std::optional<Tensor> running_mean,
         std::optional<Tensor> running_var,
-        const std::optional<MemoryConfig>& memory_config);
+        const std::optional<MemoryConfig>& memory_config,
+        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::normalization
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -287,8 +287,8 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
             std::move(writer_defines)));
 
     // COMPUTE KERNEL
-    bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
-                            c_data_format == tt::DataFormat::Float32;
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
 
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_dest_acc_en) {


### PR DESCRIPTION
### Ticket
#24167

### Problem description
Compute kernel config is not an input to batch norm like other ops. It should be provided to the user to control compute accuracy

### What's changed
Plumbed through the compute config and exposed it to Python

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16324224758
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16354552065
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16324236057
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16324242592
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16324258193
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) https://github.com/tenstorrent/tt-metal/actions/runs/16324272889
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/16324278373