### PR TITLE
Fixing synchronization in CCLs for BH compatibility

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
@@ -850,6 +850,7 @@ void try_advance(command_context_t<Addrgen>& cmd_ctx) {
                 cmd_ctx.cmd_specific_ctx.inline_value_ctx.value) {
                 DPRINT << "Completing waitval command\n";
                 cmd_ctx.complete_current_command();
+                invalidate_l1_cache();
             }
             break;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_rm_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_rm_writer.cpp
@@ -171,7 +171,7 @@ void kernel_main() {
 
     // 4. global semaphore reset
     if (reset_global_semaphore) {
-        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr) = 0;
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
     }
 
     if (fabric_connection.is_logically_connected()) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_tile_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/kernels/all_broadcast_tile_writer.cpp
@@ -172,7 +172,7 @@ void kernel_main() {
 
     // 4. global semaphore reset
     if (reset_global_semaphore) {
-        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr) = 0;
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
     }
 
     if (fabric_connection.is_logically_connected()) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_reader.cpp
@@ -122,7 +122,7 @@ void kernel_main() {
         // In the linear case, I expect num_targets_forward_direction slices from the right
         // In the ring case, I expect num_targets_forward_direction slices from the right (keep in mind this differs for
         // odd/even chips)
-        while (*reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem) <= slices_received);
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), slices_received + 1);
         // Got it
         slices_received++;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
@@ -154,12 +154,13 @@ void kernel_main() {
 
     // 3. wait for mcast output ready semaphore
     if (wait_output_semaphore) {
-        while (*reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr) < out_ready_sem_wait_value);
+        noc_semaphore_wait_min(
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), out_ready_sem_wait_value);
     }
 
     // 4. global semaphore reset
     if (reset_global_semaphore) {
-        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr) = 0;
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
     }
 
     noc_async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
@@ -168,7 +168,8 @@ void kernel_main() {
 
     // 3. wait for mcast output ready semaphore
     if (wait_output_semaphore) {
-        while (*reinterpret_cast<volatile uint32_t*>(out_ready_sem_bank_addr) != out_ready_sem_wait_value);
+        noc_semaphore_wait(
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), out_ready_sem_wait_value);
     }
 
     // Set up for mcasting to concat workers
@@ -228,7 +229,7 @@ void kernel_main() {
     }
 
     if (reset_global_semaphore) {
-        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr) = 0;
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
     }
 
     // noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_reader.cpp
@@ -101,7 +101,7 @@ void kernel_main() {
                 uint32_t current_chunk_id = packet_id / chunk_granularity;
                 uint32_t wait_chunk_id = current_chunk_id + 1;  // Chunks are 1-based
                 // Ensure that current chunk has been sent
-                while (*global_semaphore_ptr < wait_chunk_id);
+                noc_semaphore_wait_min(global_semaphore_ptr, wait_chunk_id);
 
                 for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
                     uint32_t global_id = sender_relative_ring_id + packet_id * NUM_SENDERS;
@@ -121,5 +121,5 @@ void kernel_main() {
     }
 
     // Reset global semaphore
-    *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(global_semaphore_addr) = 0;
+    noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(global_semaphore_addr), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduce_scatter_minimal_async_reader.cpp
@@ -124,10 +124,10 @@ void kernel_main() {
              * after ring_size-1 steps, we've transferred all tiles
              */
             if (do_reduce) {
-                while (*reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem) <= i - 1);
+                noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), i);
                 if (i == (ring_size - 1)) {
                     // Reset the semaphore before the next batch
-                    *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem) = 0;
+                    noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
                 }
             }
             while (tiles_read < tiles_to_read) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduce_scatter_minimal_async_writer.cpp
@@ -306,8 +306,8 @@ void kernel_main() {
             }
         }
         // Reset the global semaphore before the next batch
-        while (*reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_ready_sem) < ring_size - 1);
-        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_ready_sem) = 0;
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_ready_sem), ring_size - 1);
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_ready_sem), 0);
     }
 
     if (fabric_connection.is_logically_connected()) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -138,7 +138,7 @@ void kernel_main() {
         // In the linear case, I expect num_targets_forward_direction slices from the right
         // In the ring case, I expect num_targets_forward_direction slices from the right (keep in mind this differs for
         // odd/even chips)
-        while (*reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem) <= slices_received);
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), slices_received + 1);
         // Got it
         slices_received++;
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/worker_writer.cpp
@@ -163,7 +163,7 @@ void kernel_main() {
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
 
     // 3. wait for mcast output ready semaphore
-    while (*reinterpret_cast<volatile uint32_t*>(out_ready_sem_bank_addr) != out_ready_sem_wait_value);
+    noc_semaphore_wait(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), out_ready_sem_wait_value);
 
     // loop over mcast ranges
     for (uint32_t i = 0; i < num_mcast_ranges; i++) {
@@ -183,7 +183,7 @@ void kernel_main() {
     }
 
     // 4. global semaphore reset
-    *reinterpret_cast<volatile uint32_t*>(out_ready_sem_bank_addr) = 0;
+    noc_semaphore_set(reinterpret_cast<volatile uint32_t*>(out_ready_sem_bank_addr), 0);
 
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.close();


### PR DESCRIPTION
Redoing this PR as I had a rebase error previously expanding this PR to having 50+ changed files

### Problem description
Blackhole was having hangs when synchronizing devices after CCL OP. Root cause was that the OPs were not invalidating the L1 cache correctly when they were manually performing the semaphore checks. We have moved the manual checks to the common APIs which perform the correct invalidation.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16149658998
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16185082909
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes