### PR TITLE
Handle BH Scatter-Write for AG and RS

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -148,8 +148,12 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
     const size_t packet_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
     uint32_t l1_scratch_cb_page_size_bytes = op_config.get_page_size();
 
-    // scatter-write currently only supports 2 distinct noc addresses
+    // scatter-write currently only supports 2 distinct noc addresses, and is only supported for wormhole
+#ifdef ARCH_WORMHOLE
     uint32_t max_target_noc_addresses_per_packet = 2;
+#else
+    uint32_t max_target_noc_addresses_per_packet = 1;
+#endif
 
     // for bfloat8_b, tile_num_per_link=6, we would need to send 2 packages, but they can be of size 3 instead of 4
     uint32_t num_pages_per_packet = packet_size_bytes / l1_scratch_cb_page_size_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -152,7 +152,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
     // scatter-write currently only supports 2 distinct noc addresses, and is only supported for wormhole
     uint32_t max_target_noc_addresses_per_packet = 1;
     if (tt::tt_metal::hal::get_arch() == tt::ARCH::WORMHOLE_B0) {
-        uint32_t max_target_noc_addresses_per_packet = 2;
+        max_target_noc_addresses_per_packet = 2;
     }
 
     // for bfloat8_b, tile_num_per_link=6, we would need to send 2 packages, but they can be of size 3 instead of 4

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/fabric.hpp>
+#include <tt-metalium/hal.hpp>
 #include "ttnn/tensor/tensor_impl.hpp"
 #include "ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
 #include "ttnn/operations/experimental/ccl/llama_common.hpp"
@@ -149,11 +150,10 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
     uint32_t l1_scratch_cb_page_size_bytes = op_config.get_page_size();
 
     // scatter-write currently only supports 2 distinct noc addresses, and is only supported for wormhole
-#ifdef ARCH_WORMHOLE
-    uint32_t max_target_noc_addresses_per_packet = 2;
-#else
     uint32_t max_target_noc_addresses_per_packet = 1;
-#endif
+    if (tt::tt_metal::hal::get_arch() == tt::ARCH::WORMHOLE_B0) {
+        uint32_t max_target_noc_addresses_per_packet = 2;
+    }
 
     // for bfloat8_b, tile_num_per_link=6, we would need to send 2 packages, but they can be of size 3 instead of 4
     uint32_t num_pages_per_packet = packet_size_bytes / l1_scratch_cb_page_size_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_writer.cpp
@@ -106,6 +106,7 @@ void kernel_main() {
 
             // Will have more cases once scatter-write supports more than 2 distinct addresses
             switch (tiles_to_put_in_current_packet) {
+#ifdef ARCH_WORMHOLE
                 case 2: {
                     uint32_t tile_one_id = tile_id_start + row_offset + pages_read_in_row;
                     pages_read_in_row++;
@@ -152,8 +153,10 @@ void kernel_main() {
                                 output_page_size);
                         }
                     }
+                    tiles_read += 2;
                     break;
                 }
+#endif
                 case 1:
                 default: {
                     uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
@@ -178,10 +181,11 @@ void kernel_main() {
                                 noc0_dest_noc_addr, pkt_hdr, fabric_connection, l1_read_addr, output_page_size);
                         }
                     }
+                    tiles_read++;
                     break;
                 }
             }
-            tiles_read += tiles_to_put_in_current_packet;
+
             cb_pop_front(cb_output_id, num_tiles_to_write_per_packet);
         }
 
@@ -282,6 +286,7 @@ void kernel_main() {
 
                 // Will have more cases once scatter-write supports more than 2 distinct addresses
                 switch (tiles_to_put_in_current_packet) {
+#ifdef ARCH_WORMHOLE
                     case 2: {
                         uint32_t tile_one_id = tile_id_start + row_offset + pages_read_in_row;
                         pages_read_in_row++;
@@ -321,8 +326,10 @@ void kernel_main() {
                                 output_page_size,
                                 output_page_size);
                         }
+                        tiles_read += 2;
                         break;
                     }
+#endif
                     case 1:
                     default: {
                         uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
@@ -341,10 +348,11 @@ void kernel_main() {
                             write_for_fabric_write_forward(
                                 noc0_dest_noc_addr, pkt_hdr, fabric_connection, l1_read_addr, output_page_size);
                         }
+                        tiles_read++;
                         break;
                     }
                 }
-                tiles_read += tiles_to_put_in_current_packet;
+
                 cb_pop_front(cb_output_id, num_tiles_to_write_per_packet);
             }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
@@ -48,6 +48,7 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
     l1_read_addr += payload_size_bytes;
 }
 
+#ifdef ARCH_WORMHOLE
 FORCE_INLINE void scatter_write_for_fabric_write_forward(
     uint64_t first_noc0_dest_noc_addr,
     uint64_t second_noc0_dest_noc_addr,
@@ -68,6 +69,7 @@ FORCE_INLINE void scatter_write_for_fabric_write_forward(
         (uint32_t)pkt_hdr_forward, sizeof(PACKET_HEADER_TYPE));
     noc_async_writes_flushed();
 }
+#endif
 
 FORCE_INLINE void write_for_fabric_write_forward(
     uint64_t noc0_dest_noc_addr,
@@ -86,6 +88,7 @@ FORCE_INLINE void write_for_fabric_write_forward(
     noc_async_writes_flushed();
 }
 
+#ifdef ARCH_WORMHOLE
 FORCE_INLINE void scatter_write_for_fabric_write_backward(
     uint64_t first_noc0_dest_noc_addr,
     uint64_t second_noc0_dest_noc_addr,
@@ -106,6 +109,7 @@ FORCE_INLINE void scatter_write_for_fabric_write_backward(
         (uint32_t)pkt_hdr_backward, sizeof(PACKET_HEADER_TYPE));
     noc_async_writes_flushed();
 }
+#endif
 
 FORCE_INLINE void write_for_fabric_write_backward(
     uint64_t noc0_dest_noc_addr,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/minimal_ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/minimal_ccl_common.hpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <utility>
 
+#ifdef ARCH_WORMHOLE
 FORCE_INLINE void scatter_write_and_advance_local_read_address_for_fabric(
     uint64_t first_noc0_dest_noc_addr,
     uint64_t second_noc0_dest_noc_addr,
@@ -33,6 +34,7 @@ FORCE_INLINE void scatter_write_and_advance_local_read_address_for_fabric(
 
     l1_read_addr += first_payload_size_bytes + second_payload_size_bytes;
 }
+#endif
 
 FORCE_INLINE void write_and_advance_local_read_address_for_fabric(
     uint64_t noc0_dest_noc_addr,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -149,6 +149,7 @@ void kernel_main() {
 
                         // Will have more cases once scatter-write supports more than 2 distinct addresses
                         switch (tiles_to_put_in_current_packet) {
+#ifdef ARCH_WORMHOLE
                             case 2: {
                                 uint32_t tile_one_id = input_tile_id_start + row_offset + pages_read_in_row;
                                 pages_read_in_row++;
@@ -177,8 +178,11 @@ void kernel_main() {
                                     l1_read_addr,
                                     intermediate_page_size,
                                     intermediate_page_size);
+                                tiles_read += 2;
+                                tiles_read_in_current_direction += 2;
                                 break;
                             }
+#endif
                             case 1:
                             default: {
                                 uint32_t tile_id = input_tile_id_start + row_offset + pages_read_in_row;
@@ -197,11 +201,11 @@ void kernel_main() {
                                     fabric_direction_connection,
                                     l1_read_addr,
                                     intermediate_page_size);
+                                tiles_read++;
+                                tiles_read_in_current_direction++;
                                 break;
                             }
                         }
-                        tiles_read += tiles_to_put_in_current_packet;
-                        tiles_read_in_current_direction += tiles_to_put_in_current_packet;
                     }
                     cb_pop_front(cb_output_id, tile_granularity);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -195,8 +195,12 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
     CoreRangeSet sender_forward_core_range_set = CoreRangeSet(sender_forward_core_ranges);
     CoreRangeSet sender_backward_core_range_set = CoreRangeSet(sender_backward_core_ranges);
 
-    // scatter-write currently only supports 2 distinct noc addresses
+    // scatter-write currently only supports 2 distinct noc addresses, and is only supported for wormhole
+#ifdef ARCH_WORMHOLE
     uint32_t max_target_noc_addresses_per_packet = 2;
+#else
+    uint32_t max_target_noc_addresses_per_packet = 1;
+#endif
 
     // L1 Scratch CB Creation
     const size_t packet_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -541,7 +541,10 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
     const size_t packet_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
     uint32_t l1_scratch_cb_page_size_bytes = op_config.get_page_size();
     uint32_t num_pages_per_packet = packet_size_bytes / l1_scratch_cb_page_size_bytes;
-    const uint32_t max_scatter_write_pages = 2;
+    uint32_t max_scatter_write_pages = 1;
+    if (tt::tt_metal::hal::get_arch() == tt::ARCH::WORMHOLE_B0) {
+        max_scatter_write_pages = 2;
+    }
     const uint32_t max_dst_size = 8;  // TODO: generalize based on arch and fp32 acc
     uint32_t tiles_to_write_per_packet = std::min(num_pages_per_packet, max_scatter_write_pages);
     uint32_t tile_granularity = std::min(4 * num_pages_per_packet, max_dst_size);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/fabric.hpp>
+#include <tt-metalium/hal.hpp>
 #include "ttnn/tensor/tensor_impl.hpp"
 #include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.hpp"
 #include "ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -198,7 +198,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
     // scatter-write currently only supports 2 distinct noc addresses, and is only supported for wormhole
     uint32_t max_target_noc_addresses_per_packet = 1;
     if (tt::tt_metal::hal::get_arch() == tt::ARCH::WORMHOLE_B0) {
-        uint32_t max_target_noc_addresses_per_packet = 2;
+        max_target_noc_addresses_per_packet = 2;
     }
 
     // L1 Scratch CB Creation

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -196,11 +196,10 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
     CoreRangeSet sender_backward_core_range_set = CoreRangeSet(sender_backward_core_ranges);
 
     // scatter-write currently only supports 2 distinct noc addresses, and is only supported for wormhole
-#ifdef ARCH_WORMHOLE
-    uint32_t max_target_noc_addresses_per_packet = 2;
-#else
     uint32_t max_target_noc_addresses_per_packet = 1;
-#endif
+    if (tt::tt_metal::hal::get_arch() == tt::ARCH::WORMHOLE_B0) {
+        uint32_t max_target_noc_addresses_per_packet = 2;
+    }
 
     // L1 Scratch CB Creation
     const size_t packet_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();


### PR DESCRIPTION
### Problem description
- BH does not currently support scatter-write, so running these CCLs on BH causes compilation errors (undefined scatter-write symbols) and breaks some logic

### What's changed
- Adds `ifdefs` to check whether or not to use scatter-write logic (this is the same symbol used in the scatter-write infra, [see here](https://github.com/tenstorrent/tt-metal/blob/5635e909b7af40a1f4ede2ffd7f4de24acc6f4b9/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp#L92))
- It sounds like scatter-write will be supported on BH sometime in August, at which point we can remove these checks


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16334724819
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16282745649
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16334725743
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). https://github.com/tenstorrent/tt-metal/actions/runs/16334726743
- [ ] New/Existing tests provide coverage for changes
- [x] TG Quick https://github.com/tenstorrent/tt-metal/actions/runs/16282765057
- [x] TG Demo https://github.com/tenstorrent/tt-metal/actions/runs/16334730046