### PR TITLE
Disable yolov8x and squeezebert from (Single-card) Device perf pipeline by pytest skip

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -91,6 +91,7 @@ jobs:
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/bert_tiny/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov4/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/distilbert/tests -m models_device_performance_bare_metal
+            # issue 24652: https://github.com/tenstorrent/tt-metal/issues/24652
             # WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/mobilenetv2/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8x/tests -m models_device_performance_bare_metal
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov8s/tests -m models_device_performance_bare_metal

--- a/models/demos/squeezebert/tests/test_perf_device_squeezebert.py
+++ b/models/demos/squeezebert/tests/test_perf_device_squeezebert.py
@@ -7,7 +7,7 @@ import pytest
 from models.perf.device_perf_utils import check_device_perf, prep_device_perf_report, run_device_perf
 from models.utility_functions import is_grayskull
 
-
+@pytest.mark.skip(reason="https://github.com/tenstorrent/tt-metal/issues/24738")
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch_size, test",

--- a/models/demos/yolov8x/tests/perf/test_perf_yolov8x.py
+++ b/models/demos/yolov8x/tests/perf/test_perf_yolov8x.py
@@ -20,7 +20,7 @@ def get_expected_times(name):
     base = {"yolov8x": (128.267, 0.56)}
     return base[name]
 
-
+@pytest.mark.skip(reason="https://github.com/tenstorrent/tt-metal/issues/24706")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize("input_tensor", [torch.rand((1, 3, 640, 640))], ids=["input_tensor"])
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-metal/issues/24706 and https://github.com/tenstorrent/tt-metal/issues/24738

### Problem description
The model test for yolov8x and squeezebert has been failing and causing the (Single-card) Device perf pipeline to fail. 
https://github.com/tenstorrent/tt-metal/actions/runs/16140164833/job/45546065424#step:5:3354
https://github.com/tenstorrent/tt-metal/actions/runs/16153189289/job/45589808973#step:5:2322

```
post_processed_results = {'AVG DEVICE BRISC KERNEL DURATION [ns]': 19040553.0, 'AVG DEVICE BRISC KERNEL SAMPLES/S': 52.519483021317704, 'AVG DEVICE FW DURATION [ns]': 26680056.0, 'AVG DEVICE FW SAMPLES/S': 37.48118069917095, ...}
margin = 0.03, expected_perf_cols = {'AVG DEVICE KERNEL SAMPLES/S': 51.2}

...

FAILED models/demos/yolov8x/tests/test_perf_yolov8x.py::test_perf_device_bare_metal_yolov8x[1-51.2] - AssertionError: Some performance metrics are outside of expected range, see above for details.
```

```
2025-07-08 20:32:32.702 | ERROR    | models.perf.device_perf_utils:check_device_perf:172 - AVG DEVICE KERNEL SAMPLES/S 272.2999073057078 is outside of expected range (290.709, 308.691)
Error: test_perf_device_bare_metal[8-sequence_size=384-batch_size=8-model_name=squeezebert/squeezebert-uncased]
```

### What's changed
Disable yolov8x and squeezebert from (Single-card) Device perf pipeline by pytest skip