### PR TITLE
Fix T3K Dispatch on Fabric on IRAM

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1047,6 +1047,7 @@ void test_basic_dispatch_functions(IDevice* device, int cq_id) {
     }
 
     // non blocking fast data movement APIs
+    log_info(tt::LogMetal, "Writing data from buffer after non-blocking writes");
     for (int iteration = 0; iteration < k_Iterations; ++iteration) {
         for (int i = 0; i < k_LoopPerDev; ++i) {
             EnqueueWriteBuffer(cq, *buffer, src_data_1, false);
@@ -1054,6 +1055,7 @@ void test_basic_dispatch_functions(IDevice* device, int cq_id) {
     }
 
     std::vector<uint32_t> dst_data;
+    log_info(tt::LogMetal, "Reading data from buffer after non-blocking writes");
     for (int iteration = 0; iteration < k_Iterations; ++iteration) {
         for (int i = 0; i < k_LoopPerDev; ++i) {
             EnqueueReadBuffer(cq, *buffer, dst_data, false);

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -342,7 +342,12 @@ public:
         }
     }
     inline std::string get_compile_hash_string() const {
-        std::string compile_hash_str = fmt::format("{}_{}", get_watcher_enabled(), get_kernels_early_return());
+        std::string compile_hash_str = fmt::format(
+            "{}_{}_{}_{}",
+            get_watcher_enabled(),
+            get_kernels_early_return(),
+            get_fd_fabric(),
+            get_erisc_iram_enabled());
         for (int i = 0; i < RunTimeDebugFeatureCount; i++) {
             compile_hash_str += "_";
             compile_hash_str += get_feature_hash_string((llrt::RunTimeDebugFeatures)i);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
- Dispatch on Fabric tests hanging on CI after IRAM enablement

### What's changed
- Update rtoptions compile hash to take into account IRAM and Dispatch on Fabric setting
- Cache results of UMD call. Fabric routers may not context switch as much and in the case where only 1 link is connected the UMD call will be blocked when the fabric router is using the eth core

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/16164124115
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/16164819092