### PR TITLE
Update swin_v2 and yolov6l model name in fast_dispatch_full_regressions yaml file

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -87,7 +87,7 @@ jobs:
       fail-fast: false
       matrix:
         card: [N150, N300]
-        model: [common_models, functional_unet, ttt-llama3.2-1B, qwen, ttt-mistral-7B-v0.3, resnet50, whisper, yolov8s_world, yolov9c, vgg_unet, ufld_v2, mobilenetv2, vanilla_unet, yolov10, openpdn_mnist, yolov8x, vit, sentence_bert, yolov7, yolov8s, swin_s, yolov11, yolov6, lswin_v2]
+        model: [common_models, functional_unet, ttt-llama3.2-1B, qwen, ttt-mistral-7B-v0.3, resnet50, whisper, yolov8s_world, yolov9c, vgg_unet, ufld_v2, mobilenetv2, vanilla_unet, yolov10, openpdn_mnist, yolov8x, vit, sentence_bert, yolov7, yolov8s, swin_s, yolov11, yolov6l, swin_v2]
         # SDXL model requires test run over 30min to successfully execute pcc test on the entire UNet loop
         include:
           - model: stable_diffusion_xl_base

--- a/models/experimental/swin_v2/tt/common.py
+++ b/models/experimental/swin_v2/tt/common.py
@@ -40,7 +40,6 @@ class Conv:
         )
         self.use_shallow_conv_variant = (use_shallow_conv_variant,)
         self.conv_config = ttnn.Conv2dConfig(
-            dtype=self.dtype,
             weights_dtype=ttnn.bfloat16,
             activation=self.activation,
             shard_layout=self.shard_layout,
@@ -60,6 +59,7 @@ class Conv:
 
         [output_tensor, [_out_height, _out_width], [self.weights, self.bias]] = ttnn.conv2d(
             input_tensor=input_tensor,
+            dtype=self.dtype,
             weight_tensor=self.weights,
             bias_tensor=self.bias,
             in_channels=input_tensor.shape[3],


### PR DESCRIPTION
### Problem description
- While rebasing the PR using github feature of rebase branch, the yolov6l became yolov6 and swin_v2 became lswin_v2 in fast-dispatch-full-regressions-and-models-impl.yaml file. And the PR got merged to main.

![Screenshot 1947-04-18 at 5 04 08 PM](https://github.com/user-attachments/assets/991cf82b-e82b-42da-b8fa-b96c221edf4c)

- Fix, swin_v2 conv operation


### What's changed
Corrected the model names in fast-dispatch-full-regressions-and-models-impl.yaml file.
Fixed conv operation in swin_v2 model

CI, https://github.com/tenstorrent/tt-metal/actions/runs/16169717277
