### PR TITLE
#24752: Remove hugepages from PR and Merge gates and use viommu CIv2 runners to get some viommu-only test coverage in PR and Merge gates

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -31,7 +31,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /dev/hugepages-1G:${{ contains(inputs.runner, 'viommu') && '/hugepages_unused:ro' && '/dev/hugepages-1G' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -31,7 +31,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - ${{ contains(inputs.runner, 'viommu') && '' || '/dev/hugepages-1G:/dev/hugepages-1G' }}
+        - ${{ (contains(inputs.runner, 'viommu') && '') || '/dev/hugepages-1G:/dev/hugepages-1G' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -31,7 +31,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - /dev/hugepages-1G:${{ contains(inputs.runner, 'viommu') && '/hugepages_unused:ro' && '/dev/hugepages-1G' }}
+        - /dev/hugepages-1G:${{ contains(inputs.runner, 'viommu') && '/hugepages_unused:ro' || '/dev/hugepages-1G' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -31,7 +31,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        ${{ !(contains(inputs.runner, 'viommu') && '-/dev/hugepages-1G:/dev/hugepages-1G') || '' }}
+        - ${{ !(contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -31,7 +31,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - ${{ !(contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages:ro' }}
+        - ${{ !(contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -31,7 +31,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - ${{ (contains(inputs.runner, 'viommu') && '') || '/dev/hugepages-1G:/dev/hugepages-1G' }}
+        - ${{ !(contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -31,7 +31,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - ${{ !(contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '' }}
+        ${{ !(contains(inputs.runner, 'viommu') && '-/dev/hugepages-1G:/dev/hugepages-1G') || '' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -31,7 +31,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - /dev/hugepages-1G:${{ contains(inputs.runner, 'viommu') && '/hugepages_unused:ro' || '/dev/hugepages-1G' }}
+        - ${{ contains(inputs.runner, 'viommu') && '' || '/dev/hugepages-1G:/dev/hugepages-1G' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -31,7 +31,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - ${{ !(contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '' }}
+        - ${{ !(contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages:ro' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -116,7 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "N300",
+          "N300-viommu",
           "N300-llmbox",
           "P150b-viommu",
         ]
@@ -139,7 +139,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "N300",
+          "N300-viommu",
           "N300-llmbox",
           "P150b-viommu",
         ]
@@ -179,7 +179,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "N150",
+          "N150-viommu",
           "P150b-viommu",
         ]
     uses: ./.github/workflows/basic.yaml
@@ -201,7 +201,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "N150",
+          "N150-viommu",
           "P150b-viommu",
         ]
     uses: ./.github/workflows/basic.yaml

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "N300",
+          "N300-viommu",
           "P150b-viommu",
         ]
     uses: ./.github/workflows/smoke.yaml
@@ -111,7 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "N300",
+          "N300-viommu",
           "P150b-viommu",
         ]
     uses: ./.github/workflows/smoke.yaml
@@ -149,7 +149,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "N300",
+          "N300-viommu",
         ]
     uses: ./.github/workflows/sdk-examples.yaml
     with:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -24,11 +24,11 @@ jobs:
   smoke:
     runs-on: >-
       ${{
-        ((inputs.runner == 'N150' || inputs.runner == 'N300' || inputs.runner == 'N300-llmbox' || inputs.runner == 'P150b-viommu') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner))
+        ((inputs.runner == 'N150' || inputs.runner == 'N300' || inputs.runner == 'N300-llmbox' || inputs.runner == 'P150b' || contains(inputs.runner, 'viommu')) && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner))
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner))
       }}
     container:
-      image: ${{ (inputs.runner == 'N150' || inputs.runner == 'N300' || inputs.runner == 'N300-llmbox' || inputs.runner == 'P150b-viommu') && 'harbor.ci.tenstorrent.net/' || '' }}${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      image: ${{ (inputs.runner == 'N150' || inputs.runner == 'N300' || inputs.runner == 'N300-llmbox' || inputs.runner == 'P150b' || contains(inputs.runner, 'viommu')) && 'harbor.ci.tenstorrent.net/' || '' }}${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         ASAN_OPTIONS: "color=always"
         TSAN_OPTIONS: "color=always"

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -35,7 +35,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /dev/hugepages-1G:${{ contains(inputs.runner, 'viommu') && '/hugepages_unused:ro' && '/dev/hugepages-1G' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -35,7 +35,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - /dev/hugepages-1G:${{ contains(inputs.runner, 'viommu') && '/hugepages_unused:ro' && '/dev/hugepages-1G' }}
+        - /dev/hugepages-1G:${{ contains(inputs.runner, 'viommu') && '/hugepages_unused:ro' || '/dev/hugepages-1G' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -35,7 +35,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - ${{ !(contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages:ro' }}
+        - ${{ !(contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -35,7 +35,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - /dev/hugepages-1G:${{ contains(inputs.runner, 'viommu') && '/hugepages_unused:ro' || '/dev/hugepages-1G' }}
+        - ${{ contains(inputs.runner, 'viommu') && '' || '/dev/hugepages-1G:/dev/hugepages-1G' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -35,7 +35,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - ${{ !(contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '' }}
+        ${{ !(contains(inputs.runner, 'viommu') && '-/dev/hugepages-1G:/dev/hugepages-1G') || '' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -51,7 +51,8 @@ jobs:
       - name: DEBUG output the needful
         run: |
           echo ${{ inputs.runner }}
-          echo ${{ (contains(inputs.runner, 'viommu') }}
+          echo ${{ contains(inputs.runner, 'viommu') }}
+          echo ${{ (contains(inputs.runner, 'viommu') && '') }}
           echo ${{ (contains(inputs.runner, 'viommu') && '') || '/dev/hugepages-1G:/dev/hugepages-1G' }}
 
       - name: Install packages

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -35,7 +35,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        ${{ !(contains(inputs.runner, 'viommu') && '-/dev/hugepages-1G:/dev/hugepages-1G') || '' }}
+        - ${{ !(contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -35,7 +35,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - ${{ !(contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '' }}
+        - ${{ !(contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages:ro' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -35,7 +35,7 @@ jobs:
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
       volumes:
         - /work
-        - ${{ contains(inputs.runner, 'viommu') && '' || '/dev/hugepages-1G:/dev/hugepages-1G' }}
+        - ${{ !(contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '' }}
       options: --device /dev/tenstorrent
     defaults:
       run:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -48,13 +48,6 @@ jobs:
           name: ${{ inputs.package-artifact-name || 'packages artifact unresolved!' }}
           path: /work/pkgs/
 
-      - name: DEBUG output the needful
-        run: |
-          echo ${{ inputs.runner }}
-          echo ${{ contains(inputs.runner, 'viommu') }}
-          echo ${{ (contains(inputs.runner, 'viommu') && '') }}
-          echo ${{ (contains(inputs.runner, 'viommu') && '') || '/dev/hugepages-1G:/dev/hugepages-1G' }}
-
       - name: Install packages
         run: |
           # Ideally only ${{ inputs.product }}-validation, but APT doesn't resolve dependencies from files on disk without being told about them.

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -48,6 +48,12 @@ jobs:
           name: ${{ inputs.package-artifact-name || 'packages artifact unresolved!' }}
           path: /work/pkgs/
 
+      - name: DEBUG output the needful
+        run: |
+          echo ${{ inputs.runner }}
+          echo ${{ (contains(inputs.runner, 'viommu') }}
+          echo ${{ (contains(inputs.runner, 'viommu') && '') || '/dev/hugepages-1G:/dev/hugepages-1G' }}
+
       - name: Install packages
         run: |
           # Ideally only ${{ inputs.product }}-validation, but APT doesn't resolve dependencies from files on disk without being told about them.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.24...3.30)
 
+# HIIIIIIII LET'S FORCE EVERYTHING TO RUNNN
+
 # Sanity check, forgetting to clone submodules is a common omission and results in a poor error message
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/umd/CMakeLists.txt")
     message(FATAL_ERROR "Missing submodules.  Run: git submodule update --init --recursive")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.24...3.30)
 
-# HIIIIIIII LET'S FORCE EVERYTHING TO RUNNN
-
 # Sanity check, forgetting to clone submodules is a common omission and results in a poor error message
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/umd/CMakeLists.txt")
     message(FATAL_ERROR "Missing submodules.  Run: git submodule update --init --recursive")


### PR DESCRIPTION
### Ticket

#24752

### Problem description

THE TIME HAS FINALLY COME

Let's start a slow march towards vIOMMU, starting with CIv2 which is easiest.

### What's changed

- Move PR and merge gates to use viommu CIv2 runners.
- Do not mount hugepages into the container if it's an iommu runner as it doesn't need it

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes
- [ ] merge gate https://github.com/tenstorrent/tt-metal/actions/runs/16172411630