### PR TITLE
SDXL: binary gen set for UNet

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
@@ -139,7 +139,7 @@ def run_unet_model(
 
     ttnn.DumpDeviceProfiler(device)
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.994)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
     logger.info(f"PCC of first iteration is: {pcc_message}")
 
     for _ in range(iterations - 1):

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
@@ -440,7 +440,8 @@ def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, cla
         plt.savefig("pcc_plot.png", dpi=300, bbox_inches="tight")
         plt.close()
 
-    assert_with_pcc(latents, torch_tt_latents, 0.822)
+    _, pcc_message = assert_with_pcc(latents, torch_tt_latents, 0.86)
+    logger.info(f"PCC of the last iteration is: {pcc_message}")
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)

--- a/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
@@ -224,7 +224,9 @@ def split_conv2d(
                 dram_intermediate = ttnn.to_memory_config(intermediate, ttnn.DRAM_MEMORY_CONFIG)
                 intermediate.deallocate(True)
             else:
-                dram_intermediate = ttnn.add(dram_intermediate, intermediate, output_tensor=dram_intermediate)
+                dram_intermediate = ttnn.add(
+                    dram_intermediate, intermediate, output_tensor=dram_intermediate, use_legacy=False
+                )
                 intermediate.deallocate(True)
 
         if dram_intermediate.memory_config() != ttnn.DRAM_MEMORY_CONFIG:

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_geglu.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_geglu.py
@@ -63,5 +63,5 @@ class TtGEGLU(nn.Module):
             compute_kernel_config=self.compute_config,
         )
         ttnn.deallocate(input_tensor)
-        hidden_states = ttnn.mul_(hidden_states, gate)
+        hidden_states = ttnn.mul_(hidden_states, gate, use_legacy=False)
         return hidden_states

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -255,7 +255,8 @@ class TtResnetBlock2D(nn.Module):
         )
 
         hidden_states = ttnn.sharded_to_interleaved(hidden_states, ttnn.L1_MEMORY_CONFIG)
-        hidden_states = ttnn.add(hidden_states, temb)
+        # Note: moving this add to NG has perf impact, to be investigated
+        hidden_states = ttnn.add(hidden_states, temb, use_legacy=True)
 
         hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
         grid_coord = ttnn.CoreCoord(self.norm_core_grid_2.x - 1, self.norm_core_grid_2.y - 1)
@@ -325,7 +326,8 @@ class TtResnetBlock2D(nn.Module):
                 input_tensor = ttnn.sharded_to_interleaved(input_tensor, ttnn.L1_MEMORY_CONFIG)
 
             hidden_states = ttnn.sharded_to_interleaved(hidden_states, ttnn.L1_MEMORY_CONFIG)
-        ttnn.add_(hidden_states, input_tensor)
+        # Note: Moving this to NG results in error caused by shard shape, to be investigated
+        ttnn.add_(hidden_states, input_tensor, use_legacy=True)
         hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
 
         return hidden_states, [C, H, W]

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_timesteps.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_timesteps.py
@@ -32,8 +32,8 @@ class TtTimesteps:
         )
 
     def forward(self, timesteps):
-        emb = ttnn.multiply(ttnn.unsqueeze(timesteps, -1), ttnn.unsqueeze(self.emb, 0))
-        emb = ttnn.multiply(emb, self.scale)
+        emb = ttnn.multiply(ttnn.unsqueeze(timesteps, -1), ttnn.unsqueeze(self.emb, 0), use_legacy=False)
+        emb = ttnn.multiply(emb, self.scale, use_legacy=False)
 
         emb = ttnn.concat([ttnn.sin(emb), ttnn.cos(emb)], dim=-1)
 

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
@@ -101,7 +101,7 @@ class TtBasicTransformerBlock(nn.Module):
             memory_config=ttnn.L1_MEMORY_CONFIG,
         )
         attn_hidden_states = self.attn2(attn_hidden_states, attention_mask, encoder_hidden_states)
-        hidden_states = ttnn.add(hidden_states, attn_hidden_states)
+        hidden_states = ttnn.add(hidden_states, attn_hidden_states, use_legacy=False)
 
         attn_hidden_states = ttnn.layer_norm(
             hidden_states,
@@ -111,6 +111,6 @@ class TtBasicTransformerBlock(nn.Module):
             compute_kernel_config=self.ln_compute_kernel_config,
         )
         attn_hidden_states = self.ff(attn_hidden_states)
-        hidden_states = ttnn.add(hidden_states, attn_hidden_states)
+        hidden_states = ttnn.add(hidden_states, attn_hidden_states, use_legacy=False)
 
         return hidden_states

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
@@ -109,6 +109,6 @@ class TtTransformer2DModel(nn.Module):
             compute_kernel_config=self.compute_config_out,
         )
 
-        hidden_states = ttnn.add(hidden_states, input_tensor)
+        hidden_states = ttnn.add(hidden_states, input_tensor, use_legacy=False)
 
         return hidden_states

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
@@ -182,7 +182,7 @@ class TtUNet2DConditionModel(nn.Module):
         temb_add = ttnn.to_layout(temb_add, ttnn.TILE_LAYOUT)
         temb_add = self.add_embedding.forward(temb_add)
 
-        temb = ttnn.add(temb, temb_add)
+        temb = ttnn.add(temb, temb_add, use_legacy=False)
         ttnn.deallocate(temb_add)
 
         [sample, [H, W], [self.tt_conv1_weights, self.tt_conv1_bias]] = ttnn.conv2d(


### PR DESCRIPTION
### What's changed
To avoid depending of logic for choosing legacy binary vs binary ng, version of the binary op is fixed in UNet. The version of the op has impact on model accuracy.

### Checklist

- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16169811071) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/16188713437) CI passes