### PR TITLE
#24171: Introduce TensorTopology in Tensor to encapsulate multi-device properties

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -167,6 +167,7 @@ target_sources(
         tensor/test_create_tensor_multi_device.cpp
         tensor/test_create_tensor_with_layout.cpp
         tensor/test_distributed_tensor.cpp
+        tensor/test_tensor_topology.cpp
         tensor/test_mesh_tensor.cpp
         tensor/test_partition.cpp
         tensor/test_tensor_layout.cpp

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -121,9 +121,11 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
                     host_data[j] = bfloat16(static_cast<float>(dev_idx));
                 }
 
+                // TODO (#25340): Switch to use create_device_tensor? (TensorTopology logic should mirror
+                // create_device_tensor)
                 auto input_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
                 auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
-                Tensor input_tensor = Tensor(input_storage, tensor_spec, ReplicateTensor{});
+                Tensor input_tensor = Tensor(input_storage, tensor_spec, ReplicateTensor{}, TensorTopology{});
 
                 // Enqueue write_buffer to the read/write command queue and record the event
                 ttnn::write_buffer(ttnn::QueueId(op_cq_id), input_tensor, {host_data});
@@ -169,7 +171,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
                 }
                 auto dummy_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
                 auto dummy_storage = tt::tt_metal::DeviceStorage{dummy_buffer};
-                Tensor dummy_tensor = Tensor(dummy_storage, tensor_spec, ReplicateTensor{});
+                Tensor dummy_tensor = Tensor(dummy_storage, tensor_spec, ReplicateTensor{}, TensorTopology{});
                 ttnn::write_buffer(ttnn::QueueId(op_cq_id), dummy_tensor, {dummy_data});
                 dispatch_ops_to_device(device, dummy_tensor, ttnn::QueueId(op_cq_id));
                 promise->set_value();
@@ -274,7 +276,9 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
                 auto input_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
                 auto dummy_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
                 auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
-                Tensor input_tensor = Tensor(input_storage, tensor_spec, ReplicateTensor{});
+                // TODO (#25340): Switch to use create_device_tensor? (TensorTopology logic should mirror
+                // create_device_tensor)
+                Tensor input_tensor = Tensor(input_storage, tensor_spec, ReplicateTensor{}, TensorTopology{});
 
                 // Enqueue write_buffer to the operation`s command queue and record the event
                 ttnn::write_buffer(ttnn::QueueId(op_cq_id), input_tensor, {host_data});
@@ -328,7 +332,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
                 }
                 auto dummy_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
                 auto dummy_storage = tt::tt_metal::DeviceStorage{dummy_buffer};
-                Tensor dummy_tensor = Tensor(dummy_storage, tensor_spec, ReplicateTensor{});
+                Tensor dummy_tensor = Tensor(dummy_storage, tensor_spec, ReplicateTensor{}, TensorTopology{});
                 ttnn::write_buffer(ttnn::QueueId(op_cq_id), dummy_tensor, {dummy_data});
                 dispatch_ops_to_device(device, dummy_tensor, ttnn::QueueId(op_cq_id));
                 promise->set_value();

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -64,7 +64,7 @@ void run_create_tensor_test(tt::tt_metal::distributed::MeshDevice* device, const
 
     auto input_storage = tt::tt_metal::DeviceStorage{input_buffer, {tt::tt_metal::distributed::MeshCoordinate{0, 0}}};
 
-    Tensor input_tensor = Tensor(input_storage, tensor_spec, ReplicateTensor{});
+    Tensor input_tensor = Tensor(input_storage, tensor_spec, ReplicateTensor{}, TensorTopology{});
 
     ttnn::write_buffer(io_cq, input_tensor, {host_data});
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -46,6 +46,10 @@ TEST_F(TensorDistributionTest, DistributeToDevice) {
     // If no device is provided, the tensor is kept on host.
     EXPECT_TRUE(distribute_tensor(input_tensor, *mapper).storage_type() == StorageType::HOST);
     EXPECT_TRUE(distribute_tensor(input_tensor, *mapper, *mesh_device_).storage_type() != StorageType::HOST);
+
+    // Tensor topology is a single device
+    const auto& tensor_topology = input_tensor.tensor_topology();
+    EXPECT_EQ(tensor_topology.mesh_shape(), MeshShape(1));
 }
 
 TEST_F(TensorDistributionTest, SingleDeviceTensorReplication) {
@@ -54,6 +58,10 @@ TEST_F(TensorDistributionTest, SingleDeviceTensorReplication) {
 
     auto mapper = replicate_tensor_to_mesh_mapper(*mesh_device_);
     Tensor replicated_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
+
+    // Tensor topology for tensor replicated across entire mesh should be 1D shape with number of devices
+    const auto& tensor_topology = replicated_tensor.tensor_topology();
+    EXPECT_EQ(tensor_topology.mesh_shape(), MeshShape(mesh_device_->num_devices()));
 
     std::vector<Tensor> device_tensors = get_device_tensors(replicated_tensor);
     EXPECT_EQ(device_tensors.size(), mesh_device_->num_devices());
@@ -91,6 +99,11 @@ TEST_F(TensorDistributionT3000Test, Shard1DFewerShardsThanDevices) {
     auto mapper = shard_tensor_to_mesh_mapper(*mesh_device_, 1);
     Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
 
+    // Tensor topology for tensor sharded across 1 dimension should be 1D shape with number of actual shards (ie.
+    // num_devices - 1)
+    const auto& tensor_topology = sharded_tensor.tensor_topology();
+    EXPECT_EQ(tensor_topology.mesh_shape(), MeshShape(mesh_device_->num_devices() - 1));
+
     EXPECT_EQ(count_unique_buffers(sharded_tensor), mesh_device_->num_devices() - 1);
 
     std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
@@ -117,6 +130,11 @@ TEST_F(TensorDistributionT3000Test, Shard1DNegativeDim) {
     auto mapper = shard_tensor_to_mesh_mapper(*mesh_device_, -1);
     Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
 
+    // Tensor topology for tensor sharded across 1 dimension should be 1D shape with number of actual shards (ie.
+    // num_devices)
+    const auto& tensor_topology = sharded_tensor.tensor_topology();
+    EXPECT_EQ(tensor_topology.mesh_shape(), MeshShape(mesh_device_->num_devices()));
+
     std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
     EXPECT_EQ(device_tensors.size(), mesh_device_->num_devices());
     for (int i = 0; i < device_tensors.size(); i++) {
@@ -135,6 +153,11 @@ TEST_F(TensorDistributionT3000Test, Shard1D) {
 
     auto mapper = shard_tensor_to_mesh_mapper(*mesh_device_, 1);
     Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    // Tensor topology for tensor sharded across 1 dimension should be 1D shape with number of actual shards (ie.
+    // num_devices)
+    const auto& tensor_topology = sharded_tensor.tensor_topology();
+    EXPECT_EQ(tensor_topology.mesh_shape(), MeshShape(mesh_device_->num_devices()));
 
     EXPECT_EQ(count_unique_buffers(sharded_tensor), mesh_device_->num_devices());
 
@@ -168,6 +191,10 @@ TEST_F(TensorDistributionT3000Test, PartialConcat) {
             .placements = {MeshMapperConfig::Shard{1}, MeshMapperConfig::Replicate{}},
         });
     Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    // Tensor topology for tensor sharded/replicated across 2D should be mesh device shape.
+    const auto& tensor_topology = sharded_tensor.tensor_topology();
+    EXPECT_EQ(tensor_topology.mesh_shape(), mesh_device_->shape());
 
     EXPECT_EQ(count_unique_buffers(sharded_tensor), kNumRows);
 
@@ -212,13 +239,18 @@ TEST_P(TensorDistributionT3000Test2D, FullyReplicated) {
     Tensor input_tensor =
         Tensor::from_vector(test_data, get_tensor_spec(ttnn::Shape{1, num_rows, num_cols, 1}, DataType::FLOAT32));
 
+    const auto mesh_shape_override = MeshShape(num_rows, num_cols);
     auto mapper = create_mesh_mapper(
         *mesh_device_,
         MeshMapperConfig{
             .placements = {MeshMapperConfig::Replicate{}, MeshMapperConfig::Replicate{}},
-            .mesh_shape_override = MeshShape(num_rows, num_cols),
+            .mesh_shape_override = mesh_shape_override,
         });
     Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    // Tensor topology for tensor replicated across 2D (with override) should be same as mesh shape override
+    const auto& tensor_topology = sharded_tensor.tensor_topology();
+    EXPECT_EQ(tensor_topology.mesh_shape(), mesh_shape_override);
 
     EXPECT_EQ(count_unique_buffers(sharded_tensor), 1);
 
@@ -249,13 +281,18 @@ TEST_P(TensorDistributionT3000Test2D, ReplicateDim) {
     Tensor input_tensor =
         Tensor::from_vector(test_data, get_tensor_spec(ttnn::Shape{1, num_rows, num_cols, 1}, DataType::FLOAT32));
 
+    const auto mesh_shape_override = MeshShape(num_rows, num_cols);
     auto mapper = create_mesh_mapper(
         *mesh_device_,
         MeshMapperConfig{
             .placements = {MeshMapperConfig::Shard{1}, MeshMapperConfig::Replicate{}},
-            .mesh_shape_override = MeshShape(num_rows, num_cols),
+            .mesh_shape_override = mesh_shape_override,
         });
     Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    // Tensor topology for tensor sharded/replicated across 2D (with override) should be same as mesh shape override
+    const auto& tensor_topology = sharded_tensor.tensor_topology();
+    EXPECT_EQ(tensor_topology.mesh_shape(), mesh_shape_override);
 
     EXPECT_EQ(count_unique_buffers(sharded_tensor), num_rows);
 
@@ -285,13 +322,18 @@ TEST_P(TensorDistributionT3000Test2D, ShardDims) {
     Tensor input_tensor =
         Tensor::from_vector(test_data, get_tensor_spec(ttnn::Shape{1, num_rows, num_cols, 3}, DataType::FLOAT32));
 
+    const auto mesh_shape_override = MeshShape(num_rows, num_cols);
     auto mapper = create_mesh_mapper(
         *mesh_device_,
         MeshMapperConfig{
             .placements = {MeshMapperConfig::Shard{1}, MeshMapperConfig::Shard{2}},
-            .mesh_shape_override = MeshShape(num_rows, num_cols),
+            .mesh_shape_override = mesh_shape_override,
         });
     Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    // Tensor topology for tensor sharded across 2D (with override) should be same as mesh shape override
+    const auto& tensor_topology = sharded_tensor.tensor_topology();
+    EXPECT_EQ(tensor_topology.mesh_shape(), mesh_shape_override);
 
     EXPECT_EQ(count_unique_buffers(sharded_tensor), num_rows * num_cols);
 
@@ -397,6 +439,7 @@ TEST_F(TensorDistributionT3000Test, NdMapperShard3D) {
     Tensor input_tensor = Tensor::from_vector(
         test_data, get_tensor_spec(ttnn::Shape{kOuterDim, kNumRows, kNumCols, kInnerDim}, DataType::FLOAT32));
 
+    const auto mesh_shape_override = MeshShape(2, 2, 2);
     auto mapper = create_mesh_mapper(
         *mesh_device_,
         MeshMapperConfig{
@@ -406,9 +449,13 @@ TEST_F(TensorDistributionT3000Test, NdMapperShard3D) {
                     MeshMapperConfig::Shard{2},
                     MeshMapperConfig::Shard{1},
                 },
-            .mesh_shape_override = MeshShape(2, 2, 2),
+            .mesh_shape_override = mesh_shape_override,
         });
     Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    // Tensor topology for tensor sharded across 3D (with override) should be same as mesh shape override
+    const auto& tensor_topology = sharded_tensor.tensor_topology();
+    EXPECT_EQ(tensor_topology.mesh_shape(), mesh_shape_override);
 
     EXPECT_EQ(count_unique_buffers(sharded_tensor), 2 * 2);
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
@@ -408,7 +408,8 @@ TEST_F(NDShardingSqueezeRankStressTests, TestSqueezeRankStress) {
     iterate_shapes(Shape({4, 4, 4, 4}), [&](const Shape& tensor_shape) {
         iterate_shapes(tensor_shape, [&](const Shape& shard_shape) {
             BufferDistributionSpec dspec(tensor_shape, shard_shape, cores, ShardOrientation::ROW_MAJOR);
-            auto expected_page_mapping = detail::compute_page_mapping(tensor_shape, shard_shape, dspec.cores());
+            auto expected_page_mapping =
+                tt::tt_metal::detail::compute_page_mapping(tensor_shape, shard_shape, dspec.cores());
             EXPECT_EQ(
                 dspec.compute_page_mapping().core_host_page_indices, expected_page_mapping.core_host_page_indices);
         });

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_topology.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_topology.cpp
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include <tt-metalium/mesh_coord.hpp>
+
+#include "ttnn/distributed/api.hpp"
+#include "ttnn_test_fixtures.hpp"
+#include <ttnn/distributed/types.hpp>
+#include <ttnn/distributed/distributed_tensor.hpp>
+
+namespace ttnn::distributed::test {
+
+using ::testing::HasSubstr;
+using ::testing::ThrowsMessage;
+
+using TensorTopologyTest = GenericMeshDeviceFixture;
+using TensorTopologyT3000Test = T3000MeshDeviceFixture;
+
+TEST_F(TensorTopologyTest, SingleDevice) {
+    const auto tensor_spec =
+        TensorSpec(ttnn::Shape{1, 1, 1, 3}, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+    Tensor input_tensor = Tensor::from_vector(std::vector<float>{42.F, 13.F, -99.F}, tensor_spec);
+
+    const auto mesh_shape_override = MeshShape(1);
+    auto mapper = create_mesh_mapper(
+        *mesh_device_,
+        MeshMapperConfig{
+            .placements = {MeshMapperConfig::Replicate{}},
+            .mesh_shape_override = mesh_shape_override,
+        });
+    Tensor replicated_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
+
+    // Tensor topology for tensor replicated across 2D (with override) should be same as mesh shape override
+    const auto& tensor_topology = replicated_tensor.tensor_topology();
+    EXPECT_EQ(tensor_topology.mesh_shape(), mesh_shape_override);
+
+    auto coord = MeshCoordinate(0);
+
+    // Check that get_device_coord returns the correct device coordinate
+    EXPECT_EQ(tensor_topology.get_device_coord(coord), MeshCoordinate(0, 0));
+
+    // Check that get_neighbor returns the correct neighbor coordinate (ie. same coordinate)
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, 1, 0), coord);
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, 2, 0), coord);
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, -1, 0), coord);
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, -2, 0), coord);
+
+    // Check that get_neighbor throws for invalid dimension
+    EXPECT_THAT(
+        std::function<void()>([&tensor_topology, &coord]() { tensor_topology.get_neighbor(coord, 0, 1); }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("Index out of bounds: 1 not in [-1, 1)")));
+
+    // Check that get_next_neighbor and get_prev_neighbor return the correct neighbor coordinate
+    EXPECT_EQ(tensor_topology.get_next_neighbor(coord, 0), coord);
+    EXPECT_EQ(tensor_topology.get_prev_neighbor(coord, 0), coord);
+}
+
+TEST_F(TensorTopologyT3000Test, Replicate2D) {
+    const auto tensor_spec =
+        TensorSpec(ttnn::Shape{1, 1, 1, 3}, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+    Tensor input_tensor = Tensor::from_vector(std::vector<float>{42.F, 13.F, -99.F}, tensor_spec);
+
+    const auto mesh_shape_override = MeshShape(2, 3);
+    auto mapper = create_mesh_mapper(
+        *mesh_device_,
+        MeshMapperConfig{
+            .placements = {MeshMapperConfig::Replicate{}, MeshMapperConfig::Replicate{}},
+            .mesh_shape_override = mesh_shape_override,
+        });
+    Tensor replicated_tensor = distribute_tensor(input_tensor, *mapper, *mesh_device_);
+
+    // Tensor topology for tensor replicated across 2D (with override) should be same as mesh shape override
+    const auto& tensor_topology = replicated_tensor.tensor_topology();
+    EXPECT_EQ(tensor_topology.mesh_shape(), mesh_shape_override);
+
+    auto check_neighbors_2d = [&tensor_topology](const MeshCoordinate& coord) {
+        EXPECT_EQ(tensor_topology.get_next_neighbor(coord, 0), tensor_topology.get_neighbor(coord, 1, 0));
+        EXPECT_EQ(tensor_topology.get_prev_neighbor(coord, 0), tensor_topology.get_neighbor(coord, -1, 0));
+        EXPECT_EQ(tensor_topology.get_next_neighbor(coord, 1), tensor_topology.get_neighbor(coord, 1, 1));
+        EXPECT_EQ(tensor_topology.get_prev_neighbor(coord, 1), tensor_topology.get_neighbor(coord, -1, 1));
+    };
+
+    auto coord = MeshCoordinate(0, 0);
+    EXPECT_EQ(tensor_topology.get_device_coord(coord), MeshCoordinate(0, 0));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, 1, 0), MeshCoordinate(1, 0));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, 2, 0), MeshCoordinate(0, 0));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, -1, 0), MeshCoordinate(1, 0));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, -2, 0), MeshCoordinate(0, 0));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, 1, 1), MeshCoordinate(0, 1));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, 2, 1), MeshCoordinate(0, 2));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, -1, 1), MeshCoordinate(0, 2));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, -2, 1), MeshCoordinate(0, 1));
+
+    check_neighbors_2d(coord);
+
+    coord = MeshCoordinate(1, 1);
+    EXPECT_EQ(tensor_topology.get_device_coord(coord), MeshCoordinate(1, 1));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, 1, 0), MeshCoordinate(0, 1));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, 2, 0), MeshCoordinate(1, 1));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, -1, 0), MeshCoordinate(0, 1));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, -2, 0), MeshCoordinate(1, 1));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, 1, 1), MeshCoordinate(1, 2));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, 2, 1), MeshCoordinate(1, 0));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, -1, 1), MeshCoordinate(1, 0));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, -2, 1), MeshCoordinate(1, 2));
+
+    check_neighbors_2d(coord);
+
+    coord = MeshCoordinate(1, 2);
+    EXPECT_EQ(tensor_topology.get_device_coord(coord), MeshCoordinate(1, 2));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, 1, 0), MeshCoordinate(0, 2));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, 2, 0), MeshCoordinate(1, 2));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, -1, 0), MeshCoordinate(0, 2));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, -2, 0), MeshCoordinate(1, 2));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, 1, 1), MeshCoordinate(1, 0));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, 2, 1), MeshCoordinate(1, 1));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, -1, 1), MeshCoordinate(1, 1));
+    EXPECT_EQ(tensor_topology.get_neighbor(coord, -2, 1), MeshCoordinate(1, 0));
+
+    check_neighbors_2d(coord);
+}
+
+TEST_F(TensorTopologyT3000Test, Shard1DRowMajor) {
+    const int num_devices = mesh_device_->num_devices();
+    // Test only works on 8 devices in 2x4 mesh
+    ASSERT_EQ(num_devices, 8);
+    ASSERT_EQ(mesh_device_->shape(), MeshShape(2, 4));
+
+    std::vector<float> test_data;
+    for (int i = 0; i < num_devices; i++) {
+        test_data.insert(test_data.end(), {i * 1.F, i * 2.F, i * 3.F});
+    }
+    const auto tensor_spec = TensorSpec(
+        ttnn::Shape{1, num_devices, 3, 1}, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+    Tensor input_tensor = Tensor::from_vector(test_data, tensor_spec);
+
+    auto mapper = shard_tensor_to_mesh_mapper(*mesh_device_, 1);
+    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    // Tensor topology for tensor sharded across 1 dimension should be 1D shape with number of actual shards (ie.
+    // num_devices)
+    const auto& tensor_topology = sharded_tensor.tensor_topology();
+    EXPECT_EQ(tensor_topology.mesh_shape(), MeshShape(num_devices));
+
+    const auto& mesh_coords = tensor_topology.mesh_coords();
+    EXPECT_EQ(mesh_coords.size(), num_devices);
+    EXPECT_EQ(mesh_coords[0], MeshCoordinate(0, 0));
+    EXPECT_EQ(mesh_coords[1], MeshCoordinate(0, 1));
+    EXPECT_EQ(mesh_coords[2], MeshCoordinate(0, 2));
+    EXPECT_EQ(mesh_coords[3], MeshCoordinate(0, 3));
+    EXPECT_EQ(mesh_coords[4], MeshCoordinate(1, 0));
+    EXPECT_EQ(mesh_coords[5], MeshCoordinate(1, 1));
+    EXPECT_EQ(mesh_coords[6], MeshCoordinate(1, 2));
+    EXPECT_EQ(mesh_coords[7], MeshCoordinate(1, 3));
+}
+}  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
@@ -222,7 +222,8 @@ TYPED_TEST(BorrowedStorageVectorConversionTest, Roundtrip) {
         EXPECT_EQ(ctor_count, 1);
         EXPECT_EQ(dtor_count, 0);
         {
-            Tensor copy(tensor.storage(), tensor.tensor_spec(), tensor.distributed_tensor_config());
+            Tensor copy(
+                tensor.storage(), tensor.tensor_spec(), tensor.distributed_tensor_config(), tensor.tensor_topology());
             EXPECT_EQ(ctor_count, 2);
             EXPECT_EQ(dtor_count, 0);
         }
@@ -254,7 +255,8 @@ TYPED_TEST(BorrowedStorageVectorConversionTest, Callbacks) {
     EXPECT_EQ(ctor_count, 1);
     EXPECT_EQ(dtor_count, 0);
     {
-        Tensor copy(tensor.storage(), tensor.tensor_spec(), tensor.distributed_tensor_config());
+        Tensor copy(
+            tensor.storage(), tensor.tensor_spec(), tensor.distributed_tensor_config(), tensor.tensor_topology());
         EXPECT_EQ(ctor_count, 2);
         EXPECT_EQ(dtor_count, 0);
     }

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -49,7 +49,7 @@ target_sources(
         core/distributed/api.cpp
         core/distributed/distributed_tensor.cpp
         core/distributed/distributed_tensor_config.cpp
-        core/distributed/distributed_tensor_config.cpp
+        core/distributed/tensor_topology.cpp
         core/events.cpp
         core/global_circular_buffer.cpp
         core/global_semaphore.cpp

--- a/ttnn/api/ttnn/distributed/tensor_topology.hpp
+++ b/ttnn/api/ttnn/distributed/tensor_topology.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/mesh_coord.hpp>
+
+namespace tt::tt_metal {
+class TensorTopology {
+public:
+    TensorTopology() :
+        mesh_shape_(tt::tt_metal::distributed::MeshShape{1}),
+        mesh_coords_({tt::tt_metal::distributed::MeshCoordinate{0}}) {}
+
+    TensorTopology(
+        tt::tt_metal::distributed::MeshShape mesh_shape,
+        std::vector<tt::tt_metal::distributed::MeshCoordinate> mesh_coords) :
+        mesh_shape_(std::move(mesh_shape)), mesh_coords_(std::move(mesh_coords)) {}
+
+    const tt::tt_metal::distributed::MeshShape& mesh_shape() const { return mesh_shape_; }
+    const std::vector<tt::tt_metal::distributed::MeshCoordinate>& mesh_coords() const { return mesh_coords_; }
+
+    tt::tt_metal::distributed::MeshCoordinate get_neighbor(
+        const tt::tt_metal::distributed::MeshCoordinate& coord, int32_t offset, int32_t dim) const;
+
+    tt::tt_metal::distributed::MeshCoordinate get_next_neighbor(
+        const tt::tt_metal::distributed::MeshCoordinate& coord, int32_t dim) const;
+
+    tt::tt_metal::distributed::MeshCoordinate get_prev_neighbor(
+        const tt::tt_metal::distributed::MeshCoordinate& coord, int32_t dim) const;
+
+    tt::tt_metal::distributed::MeshCoordinate get_device_coord(
+        const tt::tt_metal::distributed::MeshCoordinate& coord) const;
+
+private:
+    tt::tt_metal::distributed::MeshShape mesh_shape_;
+    std::vector<tt::tt_metal::distributed::MeshCoordinate> mesh_coords_;
+};
+
+}  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/distributed/distributed_tensor_config.hpp"
+#include "ttnn/distributed/tensor_topology.hpp"
 #include <tt-metalium/host_buffer.hpp>
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/tensor/storage.hpp"
@@ -61,8 +62,12 @@ public:
     Tensor& operator=(Tensor&& other) noexcept;
     ~Tensor();
 
-    // Constructs a tensor with `Storage` and `TensorSpec`.
-    [[nodiscard]] Tensor(Storage storage, TensorSpec tensor_spec, DistributedTensorConfig distributed_tensor_config);
+    // Constructs a tensor with `Storage`, `TensorSpec`, and `TensorTopology`.
+    [[nodiscard]] Tensor(
+        Storage storage,
+        TensorSpec tensor_spec,
+        DistributedTensorConfig distributed_tensor_config,
+        TensorTopology tensor_topology);
 
     // Constructors of `Tensor` that take physical data encoded in `HostBuffer`.
     // The encoded data type and physical size of the data must match the specified tensor physical shape and data type.
@@ -213,6 +218,9 @@ public:
     const DistributedTensorConfig& distributed_tensor_config() const;
     const MemoryConfig& memory_config() const;
 
+    // Multi-device topology configuration - tracks how tensor is distributed across mesh devices
+    const TensorTopology& tensor_topology() const;
+
     // For sharded tensors, at least one of ShardSpec or NdShardSpec will be provided.
     const std::optional<ShardSpec>& shard_spec() const;
     const std::optional<NdShardSpec>& nd_shard_spec() const;
@@ -264,7 +272,11 @@ public:
     }
 
 private:
-    void init(Storage storage, TensorSpec tensor_spec, DistributedTensorConfig distributed_tensor_config);
+    void init(
+        Storage storage,
+        TensorSpec tensor_spec,
+        DistributedTensorConfig distributed_tensor_config,
+        TensorTopology tensor_topology);
     void deallocate_impl(bool force);
 };
 

--- a/ttnn/api/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_attributes.hpp
@@ -8,23 +8,30 @@
 
 #include "ttnn/tensor/storage.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"
+#include "ttnn/distributed/tensor_topology.hpp"
 
 namespace tt::tt_metal {
 
 class TensorAttributes : public std::enable_shared_from_this<TensorAttributes> {
 public:
-    TensorAttributes(Storage storage, TensorSpec tensor_spec, DistributedTensorConfig distributed_tensor_config);
+    TensorAttributes(
+        Storage storage,
+        TensorSpec tensor_spec,
+        DistributedTensorConfig distributed_tensor_config,
+        TensorTopology tensor_topology);
 
     // Getters and setters.
     const Storage& get_storage() const;
     Storage& get_storage();
     const TensorSpec& get_tensor_spec() const;
     const DistributedTensorConfig& get_distributed_tensor_config() const;
+    const TensorTopology& get_tensor_topology() const;
 
 private:
     Storage storage_;
     TensorSpec tensor_spec_;
     DistributedTensorConfig distributed_tensor_config_;
+    TensorTopology tensor_topology_;
 };
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -58,7 +58,8 @@ std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
             tensors.reserve(device_storage.coords.size());
             for (const auto& coord : device_storage.coords) {
                 DeviceStorage shard_storage(mesh_buffer, {coord});
-                tensors.push_back(Tensor(std::move(shard_storage), tensor.tensor_spec(), AllGatherTensor{}));
+                tensors.push_back(Tensor(
+                    std::move(shard_storage), tensor.tensor_spec(), AllGatherTensor{}, tensor.tensor_topology()));
             }
             return tensors;
         } else {
@@ -85,7 +86,12 @@ Tensor from_host_shards(const std::vector<Tensor>& tensor_shards, const MeshShap
         distributed_host_buffer.emplace_shard(coord, [&]() { return std::move(buffer); });
     }
 
-    return Tensor(HostStorage{std::move(distributed_host_buffer)}, reference_shard.tensor_spec(), AllGatherTensor{});
+    // TODO (#25340): Implement correct logic and add test for this
+    return Tensor(
+        HostStorage{std::move(distributed_host_buffer)},
+        reference_shard.tensor_spec(),
+        AllGatherTensor{},
+        TensorTopology{});
 }
 
 Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards) {
@@ -116,8 +122,12 @@ Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards) {
     auto duplicate =
         std::adjacent_find(coords.begin(), coords.end(), [](const auto& a, const auto& b) { return a == b; });
     TT_FATAL(duplicate == coords.end(), "Found a tensor shard at duplicate coordinate {}", *duplicate);
+    // TODO (#25340): Implement correct logic and add test for this
     return Tensor(
-        DeviceStorage(std::move(mesh_buffer), std::move(coords)), reference_shard.tensor_spec(), AllGatherTensor{});
+        DeviceStorage(std::move(mesh_buffer), std::move(coords)),
+        reference_shard.tensor_spec(),
+        AllGatherTensor{},
+        TensorTopology{});
 }
 
 std::vector<int> get_t3k_physical_device_ids_ring() {

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -26,6 +26,7 @@
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/tensor/xtensor/conversion_utils.hpp"
 #include "ttnn/tensor/xtensor/partition.hpp"
+#include "ttnn/distributed/tensor_topology.hpp"
 
 namespace ttnn::distributed {
 namespace {
@@ -257,10 +258,17 @@ public:
 
             auto distributed_buffer = tt::tt_metal::DistributedHostBuffer::create(mesh_device_view_);
             auto remap_fn = get_remap_fn(distribution_mode_, &global_range_);
+            std::vector<MeshCoordinate> buffer_coords;
             for (const auto& coord : MeshCoordinateRange(distribution_shape_)) {
-                distributed_buffer.emplace_shard(remap_fn(coord), [&b = replicated_buffer]() { return b; });
+                const auto mapped_coord = remap_fn(coord);
+                buffer_coords.push_back(mapped_coord);
+                distributed_buffer.emplace_shard(mapped_coord, [&b = replicated_buffer]() { return b; });
             }
-            return Tensor(tt::tt_metal::HostStorage(std::move(distributed_buffer)), tensor_spec, config());
+
+            const auto tensor_topology = tt::tt_metal::TensorTopology(distribution_shape_, buffer_coords);
+
+            return Tensor(
+                tt::tt_metal::HostStorage(std::move(distributed_buffer)), tensor_spec, config(), tensor_topology);
         }
 
         // Otherwise, use xtensor to chunk the data into shards.
@@ -337,10 +345,14 @@ private:
         using XTensorViewKey = decltype(&sharded_xtensor_views.values().front()->get());
         std::unordered_map<XTensorViewKey, tt::tt_metal::HostBuffer> converted_buffers;
 
+        std::vector<MeshCoordinate> buffer_coords;
+        size_t num_views_with_value = 0;
         for (const auto& [coord, xtensor_view] : sharded_xtensor_views) {
             if (xtensor_view.has_value()) {
+                const auto mapped_coord = remap_fn(coord);
+                buffer_coords.push_back(mapped_coord);
                 distributed_buffer.emplace_shard(
-                    remap_fn(coord), [&converted_buffers, &xtensor_view, &shard_spec, &coord, pad_value]() {
+                    mapped_coord, [&converted_buffers, &xtensor_view, &shard_spec, &coord, pad_value]() {
                         // The callable makes a copy from the strided xtensor view to a vector; on multi-host systems,
                         // executed only for shards that are local to this host.
 
@@ -360,10 +372,18 @@ private:
                         converted_buffers.emplace(&xtensor_view->get(), buffer);
                         return buffer;
                     });
+                num_views_with_value++;
             }
         }
 
-        return Tensor(tt::tt_metal::HostStorage(std::move(distributed_buffer)), shard_spec, config());
+        // If the distribution shape is 1D and we have less shards than devices, set the distribution shape to the
+        // number of chunks.
+        const auto actual_distribution_shape =
+            (distribution_shape_.dims() == 1) ? MeshShape(num_views_with_value) : distribution_shape_;
+
+        const auto tensor_topology = tt::tt_metal::TensorTopology(actual_distribution_shape, buffer_coords);
+
+        return Tensor(tt::tt_metal::HostStorage(std::move(distributed_buffer)), shard_spec, config(), tensor_topology);
     }
 
     // MeshDevice parameters.

--- a/ttnn/core/distributed/tensor_topology.cpp
+++ b/ttnn/core/distributed/tensor_topology.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/distributed/tensor_topology.hpp"
+
+namespace tt::tt_metal {
+
+tt::tt_metal::distributed::MeshCoordinate TensorTopology::get_neighbor(
+    const tt::tt_metal::distributed::MeshCoordinate& coord, int32_t offset, int32_t dim) const {
+    const auto neighbor_coord =
+        coord.get_neighbor(mesh_shape_, offset, dim, tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::WRAP);
+    TT_FATAL(
+        neighbor_coord.has_value(),
+        "Failed to get neighbor for coordinate {} at dim {} with offset {}",
+        coord,
+        dim,
+        offset);
+
+    return neighbor_coord.value();
+}
+
+tt::tt_metal::distributed::MeshCoordinate TensorTopology::get_next_neighbor(
+    const tt::tt_metal::distributed::MeshCoordinate& coord, int32_t dim) const {
+    const auto next_coord =
+        coord.get_neighbor(mesh_shape_, 1, dim, tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::WRAP);
+    TT_FATAL(next_coord.has_value(), "Failed to get next neighbor for coordinate {} at dim {}", coord, dim);
+
+    return next_coord.value();
+}
+
+tt::tt_metal::distributed::MeshCoordinate TensorTopology::get_prev_neighbor(
+    const tt::tt_metal::distributed::MeshCoordinate& coord, int32_t dim) const {
+    const auto prev_coord =
+        coord.get_neighbor(mesh_shape_, -1, dim, tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::WRAP);
+    TT_FATAL(prev_coord.has_value(), "Failed to get previous neighbor for coordinate {} at dim {}", coord, dim);
+
+    return prev_coord.value();
+}
+
+tt::tt_metal::distributed::MeshCoordinate TensorTopology::get_device_coord(
+    const tt::tt_metal::distributed::MeshCoordinate& coord) const {
+    // Convert mesh coordinate to flattened index (row-major order)
+    std::size_t flattened_index = 0;
+
+    // Calculate row-major flattened index
+    for (std::size_t i = 0; i < mesh_shape_.dims(); ++i) {
+        flattened_index += coord[i] * mesh_shape_.get_stride(i);
+    }
+
+    // Return the mesh coordinate at the flattened position
+    return mesh_coords_[flattened_index];
+}
+
+}  // namespace tt::tt_metal

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -186,7 +186,8 @@ Tensor from_flatbuffer(
 
     tt::tt_metal::HostStorage host_storage{std::move(distributed_buffer)};
 
-    return Tensor(std::move(host_storage), spec, strategy);
+    // TODO (#25340): Add TensorTopology to flatbuffer serialization and properly handle it in deserialization.
+    return Tensor(std::move(host_storage), spec, strategy, tt::tt_metal::TensorTopology{});
 }
 
 }  // namespace ttnn

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -307,7 +307,8 @@ Tensor load_tensor(const std::string& file_name, MeshDevice* device) {
     SerializedStorageType storage_type = SerializedStorageType::HOST;
     safe_fread(&storage_type, sizeof(storage_type), 1, input_file);
     auto storage = load_storage(input_file, spec.data_type(), spec.layout(), storage_type, device);
-    Tensor tensor(std::move(storage.storage), spec, storage.strategy);
+    // TODO (#25340): Switch to new serialization format and remove this code path
+    Tensor tensor(std::move(storage.storage), spec, storage.strategy, TensorTopology{});
     if (device != nullptr) {
         tensor = tensor.to_device(device, spec.memory_config());
     }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -74,9 +74,14 @@ Tensor::Tensor(
     const ttnn::Shape& padded_shape,
     DataType dtype,
     Layout layout,
-    const std::optional<Tile>& tile) {
+    const std::optional<Tile>& tile) :
+    Tensor(
+        std::move(buffer),
+        TensorSpec(
+            logical_shape,
+            TensorLayout::fromPaddedShape(
+                dtype, PageConfig(layout, tile), MemoryConfig{}, logical_shape, padded_shape))) {
     using namespace tt::constants;
-
     if (tile.has_value() and  //
         (tile->get_tile_shape()[0] != TILE_WIDTH or tile->get_tile_shape()[1] != TILE_HEIGHT)) {
         log_warning(
@@ -84,26 +89,30 @@ Tensor::Tensor(
             "only matmul op and ccl all-gather currently supports the customized tile shape: {}",
             tile->get_tile_shape());
     }
+}
 
+Tensor::Tensor(HostBuffer buffer, TensorSpec tensor_spec) :
+    Tensor(Storage(HostStorage(std::move(buffer))), std::move(tensor_spec), ReplicateTensor{}, TensorTopology{}) {}
+
+Tensor::Tensor(
+    Storage storage,
+    TensorSpec tensor_spec,
+    DistributedTensorConfig distributed_tensor_config,
+    TensorTopology tensor_topology) {
     init(
-        Storage(HostStorage(std::move(buffer))),
-        TensorSpec(
-            logical_shape,
-            TensorLayout::fromPaddedShape(
-                dtype, PageConfig(layout, tile), MemoryConfig{}, logical_shape, padded_shape)),
-        ReplicateTensor{});
+        Storage(std::move(storage)),
+        std::move(tensor_spec),
+        std::move(distributed_tensor_config),
+        std::move(tensor_topology));
 }
 
-Tensor::Tensor(HostBuffer storage, TensorSpec tensor_spec) :
-    Tensor(Storage(HostStorage(std::move(storage))), std::move(tensor_spec), ReplicateTensor{}) {}
-
-Tensor::Tensor(Storage storage, TensorSpec tensor_spec, DistributedTensorConfig distributed_tensor_config) {
-    init(Storage(std::move(storage)), std::move(tensor_spec), std::move(distributed_tensor_config));
-}
-
-void Tensor::init(Storage storage, TensorSpec tensor_spec, DistributedTensorConfig distributed_tensor_config) {
+void Tensor::init(
+    Storage storage,
+    TensorSpec tensor_spec,
+    DistributedTensorConfig distributed_tensor_config,
+    TensorTopology tensor_topology) {
     tensor_attributes = std::make_shared<TensorAttributes>(
-        std::move(storage), std::move(tensor_spec), std::move(distributed_tensor_config));
+        std::move(storage), std::move(tensor_spec), std::move(distributed_tensor_config), std::move(tensor_topology));
 
     if (auto* device_storage = std::get_if<DeviceStorage>(&tensor_attributes->get_storage());
         device_storage != nullptr && device_storage->mesh_buffer != nullptr) {
@@ -560,7 +569,7 @@ Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device) {
         output = allocate_tensor_on_device(tensor_spec, mesh_device);
     } else {
         auto device_buffer = tensor_impl::allocate_buffer_on_device(device, tensor_spec);
-        output = Tensor(DeviceStorage{device_buffer}, tensor_spec, ReplicateTensor{});
+        output = Tensor(DeviceStorage{device_buffer}, tensor_spec, ReplicateTensor{}, TensorTopology{});
     }
     output = tt::tt_metal::set_tensor_id(output);
 
@@ -727,7 +736,8 @@ Tensor allocate_tensor_on_device(const TensorSpec& tensor_spec, distributed::Mes
         coords.push_back(coord);
     }
     DeviceStorage device_storage(std::move(mesh_buffer), std::move(coords));
-    return Tensor(std::move(device_storage), tensor_spec, ReplicateTensor{});
+    // TODO (#25340): Implement correct logic and add test for this
+    return Tensor(std::move(device_storage), tensor_spec, ReplicateTensor{}, TensorTopology{});
 }
 
 Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshDevice* device) {
@@ -739,7 +749,8 @@ Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshD
     distributed_host_buffer = distributed_host_buffer.transform(
         [&](const HostBuffer&) { return tensor_impl::allocate_host_buffer(tensor_spec); },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
-    return Tensor(HostStorage(std::move(distributed_host_buffer)), tensor_spec, ReplicateTensor{});
+    // TODO (#25340): Implement correct logic and add test for this
+    return Tensor(HostStorage(std::move(distributed_host_buffer)), tensor_spec, ReplicateTensor{}, TensorTopology{});
 }
 
 void write_tensor(const Tensor& src, Tensor& dst, bool blocking, QueueId cq_id) {
@@ -864,5 +875,7 @@ const std::optional<NdShardSpec>& Tensor::nd_shard_spec() const { return this->m
 const DistributedTensorConfig& Tensor::distributed_tensor_config() const {
     return this->tensor_attributes->get_distributed_tensor_config();
 }
+
+const TensorTopology& Tensor::tensor_topology() const { return this->tensor_attributes->get_tensor_topology(); }
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -14,10 +14,14 @@
 namespace tt::tt_metal {
 
 TensorAttributes::TensorAttributes(
-    Storage storage, TensorSpec tensor_spec, DistributedTensorConfig distributed_tensor_config) :
+    Storage storage,
+    TensorSpec tensor_spec,
+    DistributedTensorConfig distributed_tensor_config,
+    TensorTopology tensor_topology) :
     storage_(std::move(storage)),
     tensor_spec_(std::move(tensor_spec)),
-    distributed_tensor_config_(std::move(distributed_tensor_config)) {}
+    distributed_tensor_config_(std::move(distributed_tensor_config)),
+    tensor_topology_(std::move(tensor_topology)) {}
 
 const Storage& TensorAttributes::get_storage() const { return storage_; }
 Storage& TensorAttributes::get_storage() { return storage_; }
@@ -25,5 +29,6 @@ const TensorSpec& TensorAttributes::get_tensor_spec() const { return tensor_spec
 const DistributedTensorConfig& TensorAttributes::get_distributed_tensor_config() const {
     return distributed_tensor_config_;
 }
+const TensorTopology& TensorAttributes::get_tensor_topology() const { return tensor_topology_; }
 
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -53,7 +53,10 @@ template <typename T, typename Fn>
 Tensor convert_tensor(const Tensor& input_tensor, const Fn& compute, const TensorSpec& output_spec) {
     TT_FATAL(is_cpu_tensor(input_tensor), "convert_tensor only supports cpu tensors");
     return Tensor(
-        input_tensor.host_storage().transform(compute), output_spec, input_tensor.distributed_tensor_config());
+        input_tensor.host_storage().transform(compute),
+        output_spec,
+        input_tensor.distributed_tensor_config(),
+        input_tensor.tensor_topology());
 }
 
 template <typename Func, typename... Args>
@@ -604,7 +607,8 @@ static Tensor to_folded_weight_layout(const Tensor& conv_weight_tensor, std::arr
             TensorSpec(
                 output_shape,
                 tt::tt_metal::TensorLayout(dtype, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), MemoryConfig{})),
-            conv_weight_tensor.distributed_tensor_config());
+            conv_weight_tensor.distributed_tensor_config(),
+            conv_weight_tensor.tensor_topology());
     };
 
     const auto& storage = conv_weight_tensor.host_storage();

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
@@ -78,7 +78,8 @@ Tensor _transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor,
     return Tensor(
         conv_weight_tensor.host_storage().transform(compute),
         output_spec,
-        conv_weight_tensor.distributed_tensor_config());
+        conv_weight_tensor.distributed_tensor_config(),
+        conv_weight_tensor.tensor_topology());
 }
 
 Tensor transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor, bool mirror_kernel) {

--- a/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.cpp
@@ -109,7 +109,8 @@ tt::tt_metal::Tensor transform_type(const tt::tt_metal::Tensor& input_tensor, co
             input_tensor.logical_shape(),
             input_tensor.padded_shape()));
 
-    return Tensor(std::move(output_storage), spec, input_tensor.distributed_tensor_config());
+    return Tensor(
+        std::move(output_storage), spec, input_tensor.distributed_tensor_config(), input_tensor.tensor_topology());
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -38,7 +38,8 @@ static Tensor manual_insertion(
                 logical_shape,
                 TensorLayout::fromPaddedShape(
                     DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)),
-            cpu_tensor.distributed_tensor_config())
+            cpu_tensor.distributed_tensor_config(),
+            cpu_tensor.tensor_topology())
             .to_layout(Layout::ROW_MAJOR);
     if (device != nullptr) {
         output = output.to_device(device, output_mem_config);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24171)

### Problem description
For multi-device tensors, information about how a tensor is sharded/replicated is lost after tensor creation. In OPs, developers have to rely on properties of MeshDevice to infer what each local device shard represents. This programming model is error prone since it relies on knowledge of how tensors are created and an implicit contract that MeshDevice properties won't change after tensor creation.

### What's changed
This PR introduces TensorTopology as a property of Tensor that describes how its buffers (ie. shards) are distributed across devices. The goal is to migrate multi-device OPs to directly query information (eg. neighbors of a given shard) from Tensor as the single source of truth. 

Changes:
- Add TensorTopology checks in existing test_distributed_tensor use cases
- Add test_tensor_topology to test TensorTopology implementation

Minor refactor:
- Make HostBuffer constructor with tiny tiles call HostBuffer constructor with TensorSpec

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/16451367202
  - T3K: https://github.com/tenstorrent/tt-metal/actions/runs/16451382851
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes