### PR TITLE
Conv config updated as per new changes in main

### DIFF
--- a/models/experimental/swin_v2/tt/common.py
+++ b/models/experimental/swin_v2/tt/common.py
@@ -40,7 +40,6 @@ class Conv:
         )
         self.use_shallow_conv_variant = (use_shallow_conv_variant,)
         self.conv_config = ttnn.Conv2dConfig(
-            dtype=self.dtype,
             weights_dtype=ttnn.bfloat16,
             activation=self.activation,
             shard_layout=self.shard_layout,


### PR DESCRIPTION
### Ticket
Frequent Model tests fail for Swin V2
In followup to: https://github.com/tenstorrent/tt-metal/pull/19901#pullrequestreview-2999014882

### Problem description
The `common.py` file has Conv config mentioned to use the argument `dtype`. This argument is removed and conv uses input dtype as output dtype.

### What's changed
Argument of dtype removed from conv_config in `common.py`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16176112639) ([![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=arg%2Fswin_v2_config_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml))
- [ ] [Frequent Models and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/16176127950) ([![(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml/badge.svg?branch=arg%2Fswin_v2_config_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))