### PR TITLE
[skip ci] Add `unit_tests_ttnn_tensor` to t3k tests

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -78,7 +78,8 @@ run_t3000_ttnn_tests() {
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_ttnn_tests"
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./build/test/ttnn/unit_tests_ttnn
+  ./build/test/ttnn/unit_tests_ttnn
+  ./build/test/ttnn/unit_tests_ttnn_tensor
   ./build/test/ttnn/unit_tests_ttnn_ccl
   ./build/test/ttnn/unit_tests_ttnn_ccl_multi_tensor
   ./build/test/ttnn/unit_tests_ttnn_ccl_ops


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`unit_tests_ttnn_tensor` missing from t3k ttnn tests.

### Checklist
- [X] [T3K TTNN unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/16177051083/job/45664947998)