### PR TITLE
CP: bring up changes for big mesh

### DIFF
--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -3,6 +3,7 @@ set(UNIT_TESTS_FABRIC_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_routing_tables.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_control_plane_logical_to_physical.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_intermesh_apis.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_multi_host.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_fabric_apis.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_1d_fabric.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_fabric_mux.cpp

--- a/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <tt-metalium/control_plane.hpp>
+#include <tt-metalium/mesh_graph.hpp>
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+#include "fabric_fixture.hpp"
+#include <tt-metalium/fabric_types.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include "impl/context/metal_context.hpp"
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/distributed_context.hpp>
+
+namespace tt::tt_fabric {
+namespace multi_host_tests {
+
+TEST(MultiHost, TestDualGalaxyControlPlaneInit) {
+    const std::filesystem::path dual_galaxy_mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.yaml";
+    auto control_plane = std::make_unique<ControlPlane>(dual_galaxy_mesh_graph_desc_path.string());
+
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels(
+        tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC,
+        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+}
+
+TEST(MultiHost, TestDualGalaxyFabricSanity) {
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
+        tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC,
+        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+}
+
+}  // namespace multi_host_tests
+}  // namespace tt::tt_fabric

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -50,11 +50,26 @@ namespace tt::tt_fabric::fabric_router_tests {
 
 using ::testing::ElementsAre;
 
-TEST_F(ControlPlaneFixture, TestTGMeshGraphInit) {
+TEST(MeshGraphValidation, TestTGMeshGraphInit) {
     const std::filesystem::path tg_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
     auto mesh_graph_desc = std::make_unique<MeshGraph>(tg_mesh_graph_desc_path.string());
+    EXPECT_EQ(
+        mesh_graph_desc->get_coord_range(MeshId{0}, HostRankId(0)),
+        MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 0)));
+    EXPECT_EQ(
+        mesh_graph_desc->get_coord_range(MeshId{1}, HostRankId(0)),
+        MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 0)));
+    EXPECT_EQ(
+        mesh_graph_desc->get_coord_range(MeshId{2}, HostRankId(0)),
+        MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 0)));
+    EXPECT_EQ(
+        mesh_graph_desc->get_coord_range(MeshId{3}, HostRankId(0)),
+        MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 0)));
+    EXPECT_EQ(
+        mesh_graph_desc->get_coord_range(MeshId{4}, HostRankId(0)),
+        MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(3, 7)));
 }
 
 TEST_F(ControlPlaneFixture, TestTGControlPlaneInit) {
@@ -89,11 +104,14 @@ TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
     }
 }
 
-TEST_F(ControlPlaneFixture, TestT3kMeshGraphInit) {
+TEST(MeshGraphValidation, TestT3kMeshGraphInit) {
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
     auto mesh_graph_desc = std::make_unique<MeshGraph>(t3k_mesh_graph_desc_path.string());
+    EXPECT_EQ(
+        mesh_graph_desc->get_coord_range(MeshId{0}, HostRankId(0)),
+        MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 3)));
 }
 
 TEST_F(ControlPlaneFixture, TestT3kControlPlaneInit) {
@@ -728,4 +746,18 @@ TEST(RoutingTableValidation, TestSingleGalaxyTorusY) {
     EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][sw_fabric_id], RoutingDirection::W);
     EXPECT_EQ(intra_mesh_routing_table[0][se_fabric_id][se_fabric_id], RoutingDirection::C);
 }
+
+TEST(MeshGraphValidation, TestDualGalaxyMeshGraph) {
+    const std::filesystem::path mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.yaml";
+    auto mesh_graph_desc = std::make_unique<MeshGraph>(mesh_graph_desc_path.string());
+    EXPECT_EQ(
+        mesh_graph_desc->get_coord_range(MeshId{0}, HostRankId(0)),
+        MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(7, 3)));
+    EXPECT_EQ(
+        mesh_graph_desc->get_coord_range(MeshId{0}, HostRankId(1)),
+        MeshCoordinateRange(MeshCoordinate(0, 4), MeshCoordinate(7, 7)));
+}
+
 }  // namespace tt::tt_fabric::fabric_router_tests

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -227,10 +227,8 @@ TEST(Cluster, ReportSystemHealth) {
                     const auto& [connected_chip_unique_id, connected_eth_core] =
                         cluster.get_connected_ethernet_core_to_remote_mmio_device(std::make_tuple(chip_id, eth_core));
                     eth_ss << " link UP " << connection_type << ", retrain: " << read_vec[0] << ", connected to chip "
-                           << connected_chip_unique_id;
-                    if (cluster_type == tt::ClusterType::GALAXY) {
-                        eth_ss << " " << get_ubb_id_str(connected_chip_unique_id);
-                    }
+                           << std::hex << connected_chip_unique_id;
+                    // Cannot use get_ubb_id_str here as connected_chip_unique_id is on other host
                     eth_ss << " " << connected_eth_core.str();
                 }
                 if (read_vec[0] > 0) {

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -188,13 +188,17 @@ private:
     std::map<FabricNodeId, std::vector<std::vector<chan_id_t>>>
         inter_mesh_routing_tables_;  // table that will be written to each ethernet core
     // map[phys_chip_id] has a vector of (eth_core, channel) pairs used for intermesh routing
+    // TODO: remove once UMD can provide all intermesh links
     std::unordered_map<chip_id_t, std::vector<std::pair<CoreCoord, chan_id_t>>> intermesh_eth_links_;
     // Stores a table of all local intermesh links (board_id, chan_id) and the corresponding remote intermesh links
     IntermeshLinkTable intermesh_link_table_;
 
-    std::unordered_map<MeshId, std::map<EthChanDescriptor, EthChanDescriptor>> peer_intermesh_link_tables_;
+    std::unordered_map<MeshId, std::unordered_map<HostRankId, std::map<EthChanDescriptor, EthChanDescriptor>>>
+        peer_intermesh_link_tables_;
 
+    // TODO: remove once UMD can provide all intermesh links
     std::unordered_map<chip_id_t, uint64_t> chip_id_to_asic_id_;
+
     // custom logic to order eth channels
     void order_ethernet_channels();
 
@@ -237,15 +241,18 @@ private:
     void write_routing_tables_to_tensix_cores(MeshId mesh_id, chip_id_t chip_id) const;
     void write_fabric_connections_to_tensix_cores(MeshId mesh_id, chip_id_t chip_id) const;
 
+    // TODO: remove once UMD can provide all intermesh links
     // Populate the local intermesh link to remote intermesh link table
     void generate_local_intermesh_link_table();
 
     // All to All exchange of intermesh link tables between all hosts in the system
     void exchange_intermesh_link_tables();
 
+    // TODO: remove once UMD can provide all intermesh links
     // Initialize internal map of physical chip_id to intermesh ethernet links
     void initialize_intermesh_eth_links();
 
+    // TODO: remove once UMD can provide all intermesh links
     // Check if intermesh links are available by reading SPI ROM config from first chip
     bool is_intermesh_enabled() const;
 
@@ -275,14 +282,10 @@ public:
         const std::map<FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping);
     ~GlobalControlPlane();
 
-    void initialize_host_mapping();
-
     tt::tt_fabric::ControlPlane& get_local_node_control_plane() { return *control_plane_; }
 
 private:
     std::unique_ptr<RoutingTableGenerator> routing_table_generator_;
-    // Host rank to sub mesh shape
-    std::unordered_map<HostRankId, std::vector<MeshCoordinate>> host_rank_to_sub_mesh_shape_;
     std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane_;
 
     std::string mesh_graph_desc_file_;

--- a/tt_metal/api/tt-metalium/multi_mesh_types.hpp
+++ b/tt_metal/api/tt-metalium/multi_mesh_types.hpp
@@ -33,6 +33,7 @@ struct EthChanDescriptor {
 struct IntermeshLinkTable {
     // Local mesh ID
     MeshId local_mesh_id = MeshId{0};
+    HostRankId local_host_rank_id = HostRankId{0};
     // Maps local eth channel to remote eth channel
     std::map<EthChanDescriptor, EthChanDescriptor> intermesh_links;
 };

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -177,31 +177,13 @@ void ControlPlane::initialize_dynamic_routing_plane_counts(
             }
         };
 
-    auto get_chip_coord = [this](FabricNodeId fabric_node_id) -> MeshCoordinate {
-        auto mesh_id = fabric_node_id.mesh_id;
-        auto chip_id = fabric_node_id.chip_id;
-
-        // Get mesh dimensions from the mesh graph descriptor
-        auto mesh_ew_size = this->routing_table_generator_->mesh_graph->get_mesh_shape(mesh_id)[1];
-
-        // Convert linear chip_id to 2D mesh coordinates
-        auto coord_y = chip_id / mesh_ew_size;
-        auto coord_x = chip_id % mesh_ew_size;
-
-        return MeshCoordinate(coord_x, coord_y);
-    };
-
-    const auto user_meshes = this->get_user_physical_mesh_ids();
+    // For each mesh in the system
+    auto user_meshes = this->get_user_physical_mesh_ids();
     if (reliability_mode == tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) {
-        for (auto mesh_id : user_meshes) {
-            size_t num_chips_in_mesh = intra_mesh_connectivity[mesh_id.get()].size();
-            for (std::uint32_t chip_id = 0; chip_id < num_chips_in_mesh; chip_id++) {
-                const auto fabric_node_id = FabricNodeId(MeshId{mesh_id}, chip_id);
-                for (const auto& [direction, eth_chans] :
-                     this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)) {
-                    this->router_port_directions_to_num_routing_planes_map_[fabric_node_id][direction] =
-                        eth_chans.size();
-                }
+        for (const auto& [fabric_node_id, directions_and_eth_chans] :
+             this->router_port_directions_to_physical_eth_chan_map_) {
+            for (const auto& [direction, eth_chans] : directions_and_eth_chans) {
+                this->router_port_directions_to_num_routing_planes_map_[fabric_node_id][direction] = eth_chans.size();
             }
         }
     }
@@ -241,40 +223,43 @@ void ControlPlane::initialize_dynamic_routing_plane_counts(
         size_t num_chips_in_mesh = intra_mesh_connectivity[mesh_id.get()].size();
         bool is_single_chip = num_chips_in_mesh == 1 && user_meshes.size() == 1;
         bool may_have_intra_mesh_connectivity = !is_single_chip;
+
         if (may_have_intra_mesh_connectivity) {
-            for (std::uint32_t chip_id = 0; chip_id < num_chips_in_mesh; chip_id++) {
-                const auto fabric_node_id = FabricNodeId(MeshId{mesh_id}, chip_id);
-                const auto chip_coord = get_chip_coord(fabric_node_id);
-                auto chip_coord_x = chip_coord[0];
-                auto chip_coord_y = chip_coord[1];
+            const auto& local_mesh_coord_range = this->get_coord_range(mesh_id, MeshScope::LOCAL);
+            for (const auto& mesh_coord : local_mesh_coord_range) {
+                auto fabric_chip_id =
+                    this->routing_table_generator_->mesh_graph->coordinate_to_chip(mesh_id, mesh_coord);
+                const auto fabric_node_id = FabricNodeId(mesh_id, fabric_chip_id);
+                auto mesh_coord_x = mesh_coord[0];
+                auto mesh_coord_y = mesh_coord[1];
 
                 const auto& port_directions = this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id);
 
-                const auto& golden_counts = golden_link_counts.at(MeshId{mesh_id}).at(chip_id);
+                const auto& golden_counts = golden_link_counts.at(MeshId{mesh_id}).at(fabric_chip_id);
                 apply_min(
                     fabric_node_id,
                     port_directions,
                     RoutingDirection::E,
                     golden_counts,
-                    row_min_planes.at(chip_coord_y));
+                    row_min_planes.at(mesh_coord_x));
                 apply_min(
                     fabric_node_id,
                     port_directions,
                     RoutingDirection::W,
                     golden_counts,
-                    row_min_planes.at(chip_coord_y));
+                    row_min_planes.at(mesh_coord_x));
                 apply_min(
                     fabric_node_id,
                     port_directions,
                     RoutingDirection::N,
                     golden_counts,
-                    col_min_planes.at(chip_coord_x));
+                    col_min_planes.at(mesh_coord_y));
                 apply_min(
                     fabric_node_id,
                     port_directions,
                     RoutingDirection::S,
                     golden_counts,
-                    col_min_planes.at(chip_coord_x));
+                    col_min_planes.at(mesh_coord_y));
             }
 
             // TODO: specialize by topology for better perf
@@ -287,16 +272,17 @@ void ControlPlane::initialize_dynamic_routing_plane_counts(
             }
 
             // Second pass: Apply minimums to each device
-            for (std::uint32_t chip_id = 0; chip_id < num_chips_in_mesh; chip_id++) {
-                const auto fabric_node_id = FabricNodeId(MeshId{mesh_id}, chip_id);
-                const auto chip_coord = get_chip_coord(fabric_node_id);
-                auto chip_coord_x = chip_coord[0];
-                auto chip_coord_y = chip_coord[1];
+            for (const auto& mesh_coord : local_mesh_coord_range) {
+                auto fabric_chip_id =
+                    this->routing_table_generator_->mesh_graph->coordinate_to_chip(mesh_id, mesh_coord);
+                const auto fabric_node_id = FabricNodeId(mesh_id, fabric_chip_id);
+                auto mesh_coord_x = mesh_coord[0];
+                auto mesh_coord_y = mesh_coord[1];
 
-                apply_count(fabric_node_id, RoutingDirection::E, row_min_planes.at(chip_coord_y));
-                apply_count(fabric_node_id, RoutingDirection::W, row_min_planes.at(chip_coord_y));
-                apply_count(fabric_node_id, RoutingDirection::N, col_min_planes.at(chip_coord_x));
-                apply_count(fabric_node_id, RoutingDirection::S, col_min_planes.at(chip_coord_x));
+                apply_count(fabric_node_id, RoutingDirection::E, row_min_planes.at(mesh_coord_x));
+                apply_count(fabric_node_id, RoutingDirection::W, row_min_planes.at(mesh_coord_x));
+                apply_count(fabric_node_id, RoutingDirection::N, col_min_planes.at(mesh_coord_y));
+                apply_count(fabric_node_id, RoutingDirection::S, col_min_planes.at(mesh_coord_y));
             }
         }
     }
@@ -365,8 +351,6 @@ ControlPlane::ControlPlane(const std::string& mesh_graph_desc_file) {
     this->local_mesh_binding_ = this->initialize_local_mesh_binding();
     // Printing, only enabled with log_debug
     this->routing_table_generator_->mesh_graph->print_connectivity();
-    // Printing, only enabled with log_debug
-    this->routing_table_generator_->print_routing_tables();
 
     // Initialize the control plane routers based on mesh graph
     const auto& logical_mesh_chip_id_to_physical_chip_id_mapping =
@@ -375,6 +359,7 @@ ControlPlane::ControlPlane(const std::string& mesh_graph_desc_file) {
     // Query and generate intermesh ethernet links per physical chip
     this->initialize_intermesh_eth_links();
     this->generate_local_intermesh_link_table();
+
 }
 
 ControlPlane::ControlPlane(
@@ -384,8 +369,6 @@ ControlPlane::ControlPlane(
     this->local_mesh_binding_ = this->initialize_local_mesh_binding();
     // Printing, only enabled with log_debug
     this->routing_table_generator_->mesh_graph->print_connectivity();
-    // Printing, only enabled with log_debug
-    this->routing_table_generator_->print_routing_tables();
 
     // Initialize the control plane routers based on mesh graph
     this->load_physical_chip_mapping(logical_mesh_chip_id_to_physical_chip_id_mapping);
@@ -406,46 +389,39 @@ void ControlPlane::validate_mesh_connections(MeshId mesh_id) const {
     std::uint32_t mesh_ew_size = mesh_shape[1];
     std::uint32_t num_ports_per_side =
         routing_table_generator_->mesh_graph->get_chip_spec().num_eth_ports_per_direction;
-    for (std::uint32_t i = 0; i < mesh_ns_size; i++) {
-        for (std::uint32_t j = 0; j < mesh_ew_size - 1; j++) {
-            chip_id_t logical_chip_id = i * mesh_ew_size + j;
-            FabricNodeId fabric_node_id{mesh_id, logical_chip_id};
-            FabricNodeId fabric_node_id_next{mesh_id, logical_chip_id + 1};
-            chip_id_t physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
-            chip_id_t physical_chip_id_next = logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id_next);
-
-            const auto& eth_links = get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
-            auto eth_links_to_next = eth_links.find(physical_chip_id_next);
-            TT_FATAL(
-                eth_links_to_next != eth_links.end(),
-                "Chip {} not connected to chip {}",
-                physical_chip_id,
-                physical_chip_id_next);
-            TT_FATAL(
-                eth_links_to_next->second.size() >= num_ports_per_side,
-                "Chip {} to chip {} has {} links but expecting {}",
-                physical_chip_id,
-                physical_chip_id_next,
-                eth_links.at(physical_chip_id_next).size(),
-                num_ports_per_side);
-            if (i != mesh_ns_size - 1) {
-                FabricNodeId fabric_node_id_next_row{mesh_id, logical_chip_id + mesh_ew_size};
-                chip_id_t physical_chip_id_next_row =
-                    logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id_next_row);
-                auto eth_links_to_next_row = eth_links.find(physical_chip_id_next_row);
-                TT_FATAL(
-                    eth_links_to_next_row != eth_links.end(),
-                    "Chip {} not connected to chip {}",
-                    physical_chip_id,
-                    physical_chip_id_next_row);
-                TT_FATAL(
-                    eth_links_to_next_row->second.size() >= num_ports_per_side,
-                    "Chip {} to chip {} has {} links but expecting {}",
-                    physical_chip_id,
-                    physical_chip_id_next_row,
-                    eth_links.at(physical_chip_id_next_row).size(),
-                    num_ports_per_side);
-            }
+    auto get_physical_chip_id = [&](const MeshCoordinate& mesh_coord) {
+        auto fabric_chip_id = this->routing_table_generator_->mesh_graph->coordinate_to_chip(mesh_id, mesh_coord);
+        return logical_mesh_chip_id_to_physical_chip_id_mapping_.at(FabricNodeId(mesh_id, fabric_chip_id));
+    };
+    auto validate_chip_connections = [&](const MeshCoordinate& mesh_coord, const MeshCoordinate& other_mesh_coord) {
+        chip_id_t physical_chip_id = get_physical_chip_id(mesh_coord);
+        chip_id_t physical_chip_id_other = get_physical_chip_id(other_mesh_coord);
+        auto eth_links = get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
+        auto eth_links_to_other = eth_links.find(physical_chip_id_other);
+        TT_FATAL(
+            eth_links_to_other != eth_links.end(),
+            "Chip {} not connected to chip {}",
+            physical_chip_id,
+            physical_chip_id_other);
+        TT_FATAL(
+            eth_links_to_other->second.size() >= num_ports_per_side,
+            "Chip {} to chip {} has {} links but expecting {}",
+            physical_chip_id,
+            physical_chip_id_other,
+            eth_links.at(physical_chip_id_other).size(),
+            num_ports_per_side);
+    };
+    const auto& mesh_coord_range = this->get_coord_range(mesh_id, MeshScope::LOCAL);
+    for (const auto& mesh_coord : mesh_coord_range) {
+        chip_id_t physical_chip_id = get_physical_chip_id(mesh_coord);
+        MeshCoordinate mesh_coord_next{mesh_coord[0], mesh_coord[1] + 1};
+        MeshCoordinate mesh_coord_next_row{mesh_coord[0] + 1, mesh_coord[1]};
+        const auto& eth_links = get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
+        if (mesh_coord_range.contains(mesh_coord_next)) {
+            validate_chip_connections(mesh_coord, mesh_coord_next);
+        }
+        if (mesh_coord_range.contains(mesh_coord_next_row)) {
+            validate_chip_connections(mesh_coord, mesh_coord_next_row);
         }
     }
 }
@@ -458,14 +434,14 @@ void ControlPlane::validate_mesh_connections() const {
     }
 }
 
+// TODO: refactor mesh_ns_size/mesh_ew_size to use MeshCoordinateRange
+// TODO: update logical_mesh_chip_id_to_physical_chip_id_mapping_ to be updated here probably
 std::vector<chip_id_t> ControlPlane::get_mesh_physical_chip_ids(
     const tt::tt_metal::distributed::MeshContainer<chip_id_t>& mesh_container,
     std::optional<chip_id_t> nw_corner_chip_id) const {
     // Convert the coordinate range to a set of chip IDs using MeshContainer iterator
-    std::set<chip_id_t> user_chip_ids;
-    for (const auto& [coord, chip_id] : mesh_container) {
-        user_chip_ids.insert(chip_id);
-    }
+    const auto& user_chip_ids = tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids();
+    TT_ASSERT(user_chip_ids.size() >= mesh_container.size());
 
     // Special case for 1x1 mesh
     if (mesh_container.shape() == tt::tt_metal::distributed::MeshShape(1, 1)) {
@@ -525,7 +501,6 @@ std::map<FabricNodeId, chip_id_t> ControlPlane::get_logical_chip_to_physical_chi
 
         auto nw_chip_physical_id =
             tt::tt_metal::MetalContext::instance().get_cluster().get_physical_chip_id_from_eth_coord({0, 3, 7, 0, 1});
-        auto mesh_shape = routing_table_generator_->mesh_graph->get_mesh_shape(MeshId{4});
         // Main board
         const auto& mesh_container = this->routing_table_generator_->mesh_graph->get_chip_ids(MeshId{4});
         const auto& physical_chip_ids = this->get_mesh_physical_chip_ids(mesh_container, nw_chip_physical_id);
@@ -566,12 +541,20 @@ std::map<FabricNodeId, chip_id_t> ControlPlane::get_logical_chip_to_physical_chi
         // Iterate over every mesh defined in the mesh-graph descriptor and embed it on top of
         // the physical cluster using the generic helper.
         for (const auto& mesh_id : this->routing_table_generator_->mesh_graph->get_mesh_ids()) {
-            const auto& mesh_container = this->routing_table_generator_->mesh_graph->get_chip_ids(mesh_id);
-            const auto& physical_chip_ids = this->get_mesh_physical_chip_ids(mesh_container);
+            if (!this->is_local_mesh(mesh_id)) {
+                continue;
+            }
+            auto host_rank_id = this->get_local_host_rank_id_binding();
+            const auto& mesh_container = this->routing_table_generator_->mesh_graph->get_chip_ids(mesh_id, host_rank_id);
 
-            for (std::uint32_t i = 0; i < physical_chip_ids.size(); ++i) {
+            std::optional<chip_id_t> nw_chip_physical_id = std::nullopt;
+            const auto& physical_chip_ids = this->get_mesh_physical_chip_ids(mesh_container, nw_chip_physical_id);
+
+            std::uint32_t i = 0;
+            for (const auto& [_, fabric_chip_id] : mesh_container) {
                 logical_mesh_chip_id_to_physical_chip_id_mapping.emplace(
-                    FabricNodeId(mesh_id, i), physical_chip_ids[i]);
+                    FabricNodeId(mesh_id, fabric_chip_id), physical_chip_ids[i]);
+                i++;
             }
         }
     }
@@ -641,16 +624,18 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
     // Routing tables contain direction from chip to chip
     // Convert it to be unique per ethernet channel
 
+    auto host_rank_id = this->get_local_host_rank_id_binding();
     const auto& router_intra_mesh_routing_table = this->routing_table_generator_->get_intra_mesh_table();
-    for (std::uint32_t mesh_id = 0; mesh_id < router_intra_mesh_routing_table.size(); mesh_id++) {
-        if (!this->is_local_mesh(MeshId{mesh_id})) {
+    for (std::uint32_t mesh_id_val = 0; mesh_id_val < router_intra_mesh_routing_table.size(); mesh_id_val++) {
+        MeshId mesh_id{mesh_id_val};
+        if (!this->is_local_mesh(mesh_id)) {
             continue;
         }
-        for (std::uint32_t src_chip_id = 0; src_chip_id < router_intra_mesh_routing_table[mesh_id].size();
-             src_chip_id++) {
-            FabricNodeId src_fabric_node_id{MeshId{mesh_id}, src_chip_id};
-            const auto& physical_chip_id =
-                this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(src_fabric_node_id);
+        const auto& local_mesh_chip_id_container =
+            this->routing_table_generator_->mesh_graph->get_chip_ids(mesh_id, host_rank_id);
+        for (const auto& [_, src_fabric_chip_id] : local_mesh_chip_id_container) {
+            const auto src_fabric_node_id = FabricNodeId(mesh_id, src_fabric_chip_id);
+            auto physical_chip_id = get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
             std::uint32_t num_ports_per_chip = tt::tt_metal::MetalContext::instance()
                                                    .get_cluster()
                                                    .get_soc_desc(physical_chip_id)
@@ -661,28 +646,31 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
             for (int i = 0; i < num_ports_per_chip; i++) {
                 // Size the routing table to the number of chips in the mesh
                 this->intra_mesh_routing_tables_[src_fabric_node_id][i].resize(
-                    router_intra_mesh_routing_table[mesh_id][src_chip_id].size());
+                    router_intra_mesh_routing_table[mesh_id_val][src_fabric_chip_id].size());
             }
-            for (chip_id_t dst_chip_id = 0; dst_chip_id < router_intra_mesh_routing_table[mesh_id][src_chip_id].size();
-                 dst_chip_id++) {
+            // Dst is looped over all chips in the mesh, regardless of whether they are local or not
+            for (chip_id_t dst_fabric_chip_id = 0;
+                 dst_fabric_chip_id < router_intra_mesh_routing_table[mesh_id_val][src_fabric_chip_id].size();
+                 dst_fabric_chip_id++) {
                 // Target direction is the direction to the destination chip for all ethernet channesl
-                const auto& target_direction = router_intra_mesh_routing_table[mesh_id][src_chip_id][dst_chip_id];
+                const auto& target_direction =
+                    router_intra_mesh_routing_table[mesh_id_val][src_fabric_chip_id][dst_fabric_chip_id];
                 // We view ethernet channels on one side of the chip as parallel planes. So N[0] talks to S[0], E[0],
                 // W[0] and so on For all live ethernet channels on this chip, set the routing table entry to the
                 // destination chip as the ethernet channel on the same plane
                 for (const auto& [direction, eth_chans_on_side] :
                      this->router_port_directions_to_physical_eth_chan_map_.at(src_fabric_node_id)) {
                     for (const auto& src_chan_id : eth_chans_on_side) {
-                        if (src_chip_id == dst_chip_id) {
+                        if (src_fabric_chip_id == dst_fabric_chip_id) {
                             TT_ASSERT(
                                 (target_direction == RoutingDirection::C),
                                 "Expecting same direction for intra mesh routing");
                             // This entry represents chip to itself, should not be used by FW
-                            this->intra_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_chip_id] =
+                            this->intra_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_fabric_chip_id] =
                                 src_chan_id;
                         } else if (target_direction == direction) {
                             // This entry represents an outgoing eth channel
-                            this->intra_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_chip_id] =
+                            this->intra_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_fabric_chip_id] =
                                 src_chan_id;
                         } else {
                             const auto& eth_chans_in_target_direction =
@@ -690,7 +678,7 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
                                     src_fabric_node_id)[target_direction];
                             const auto src_routing_plane_id =
                                 this->get_routing_plane_id(src_chan_id, eth_chans_on_side);
-                            this->intra_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_chip_id] =
+                            this->intra_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_fabric_chip_id] =
                                 this->get_downstream_eth_chan_id(src_routing_plane_id, eth_chans_in_target_direction);
                         }
                     }
@@ -700,13 +688,16 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
     }
 
     const auto& router_inter_mesh_routing_table = this->routing_table_generator_->get_inter_mesh_table();
-    for (std::uint32_t src_mesh_id = 0; src_mesh_id < router_inter_mesh_routing_table.size(); src_mesh_id++) {
+    for (std::uint32_t src_mesh_id_val = 0; src_mesh_id_val < router_inter_mesh_routing_table.size();
+         src_mesh_id_val++) {
+        MeshId src_mesh_id{src_mesh_id_val};
         if (!this->is_local_mesh(MeshId{src_mesh_id})) {
             continue;
         }
-        for (std::uint32_t src_chip_id = 0; src_chip_id < router_inter_mesh_routing_table[src_mesh_id].size();
-             src_chip_id++) {
-            FabricNodeId src_fabric_node_id{MeshId{src_mesh_id}, src_chip_id};
+        const auto& local_mesh_chip_id_container =
+            this->routing_table_generator_->mesh_graph->get_chip_ids(src_mesh_id, host_rank_id);
+        for (const auto& [_, src_fabric_chip_id] : local_mesh_chip_id_container) {
+            const auto src_fabric_node_id = FabricNodeId(src_mesh_id, src_fabric_chip_id);
             const auto& physical_chip_id =
                 this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(src_fabric_node_id);
             std::uint32_t num_ports_per_chip = tt::tt_metal::MetalContext::instance()
@@ -719,13 +710,14 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
             for (int i = 0; i < num_ports_per_chip; i++) {
                 // Size the routing table to the number of meshes
                 this->inter_mesh_routing_tables_[src_fabric_node_id][i].resize(
-                    router_inter_mesh_routing_table[src_mesh_id][src_chip_id].size());
+                    router_inter_mesh_routing_table[src_mesh_id_val][src_fabric_chip_id].size());
             }
-            for (chip_id_t dst_mesh_id = 0;
-                 dst_mesh_id < router_inter_mesh_routing_table[src_mesh_id][src_chip_id].size();
-                 dst_mesh_id++) {
+            for (chip_id_t dst_mesh_id_val = 0;
+                 dst_mesh_id_val < router_inter_mesh_routing_table[src_mesh_id_val][src_fabric_chip_id].size();
+                 dst_mesh_id_val++) {
                 // Target direction is the direction to the destination mesh for all ethernet channesl
-                const auto& target_direction = router_inter_mesh_routing_table[src_mesh_id][src_chip_id][dst_mesh_id];
+                const auto& target_direction =
+                    router_inter_mesh_routing_table[src_mesh_id_val][src_fabric_chip_id][dst_mesh_id_val];
 
                 // We view ethernet channels on one side of the chip as parallel planes. So N[0] talks to S[0], E[0],
                 // W[0] and so on For all live ethernet channels on this chip, set the routing table entry to the
@@ -733,21 +725,21 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
                 for (const auto& [direction, eth_chans_on_side] :
                      this->router_port_directions_to_physical_eth_chan_map_.at(src_fabric_node_id)) {
                     for (const auto& src_chan_id : eth_chans_on_side) {
-                        if (src_mesh_id == dst_mesh_id) {
+                        if (src_mesh_id_val == dst_mesh_id_val) {
                             TT_ASSERT(
                                 (target_direction == RoutingDirection::C),
                                 "ControlPlane: Expecting same direction for inter mesh routing");
                             // This entry represents mesh to itself, should not be used by FW
-                            this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_mesh_id] =
+                            this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_mesh_id_val] =
                                 src_chan_id;
                         } else if (target_direction == RoutingDirection::NONE) {
                             // This entry represents a mesh to mesh connection that is not reachable
                             // Set to an invalid channel id
-                            this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_mesh_id] =
+                            this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_mesh_id_val] =
                                 eth_chan_magic_values::INVALID_DIRECTION;
                         } else if (target_direction == direction) {
                             // This entry represents an outgoing eth channel
-                            this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_mesh_id] =
+                            this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_mesh_id_val] =
                                 src_chan_id;
                         } else {
                             const auto& eth_chans_in_target_direction =
@@ -755,7 +747,7 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
                                     src_fabric_node_id)[target_direction];
                             const auto src_routing_plane_id =
                                 this->get_routing_plane_id(src_chan_id, eth_chans_on_side);
-                            this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_mesh_id] =
+                            this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_mesh_id_val] =
                                 this->get_downstream_eth_chan_id(src_routing_plane_id, eth_chans_in_target_direction);
                         }
                     }
@@ -774,6 +766,7 @@ void ControlPlane::order_ethernet_channels() {
         for (auto& [_, eth_chans] : eth_chans_by_dir) {
             auto phys_chip_id = this->get_physical_chip_id_from_fabric_node_id(fabric_node_id);
             const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(phys_chip_id);
+
             std::sort(eth_chans.begin(), eth_chans.end(), [&soc_desc](const auto& a, const auto& b) {
                 auto virt_coords_a = soc_desc.get_eth_core_for_channel(a, CoordSystem::VIRTUAL);
                 auto virt_coords_b = soc_desc.get_eth_core_for_channel(b, CoordSystem::VIRTUAL);
@@ -870,57 +863,106 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
         }
     }
 
-    for (std::uint32_t mesh_id = 0; mesh_id < intra_mesh_connectivity.size(); mesh_id++) {
-        if (!this->is_local_mesh(MeshId{mesh_id})) {
+    auto host_rank_id = this->get_local_host_rank_id_binding();
+    for (std::uint32_t mesh_id_val = 0; mesh_id_val < intra_mesh_connectivity.size(); mesh_id_val++) {
+        // TODO: we can probably remove this check, in general should update these loops to iterate over local meshes
+        MeshId mesh_id{mesh_id_val};
+        if (!this->is_local_mesh(mesh_id)) {
             continue;
         }
-        for (std::uint32_t chip_id = 0; chip_id < intra_mesh_connectivity[mesh_id].size(); chip_id++) {
-            const auto fabric_node_id = FabricNodeId(MeshId{mesh_id}, chip_id);
-            auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
-            const auto& connected_chips_and_eth_cores =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_cores_grouped_by_connected_chips(
-                    physical_chip_id);
-            for (const auto& [logical_connected_chip_id, edge] : intra_mesh_connectivity[mesh_id][chip_id]) {
-                const auto& physical_connected_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(
-                    FabricNodeId(MeshId{mesh_id}, logical_connected_chip_id));
+        const auto& local_mesh_coord_range = this->get_coord_range(mesh_id, MeshScope::LOCAL);
+        const auto& local_mesh_chip_id_container =
+            this->routing_table_generator_->mesh_graph->get_chip_ids(mesh_id, host_rank_id);
+        for (const auto& [_, fabric_chip_id] : local_mesh_chip_id_container) {
+            const auto fabric_node_id = FabricNodeId(mesh_id, fabric_chip_id);
+            auto physical_chip_id = this->get_physical_chip_id_from_fabric_node_id(fabric_node_id);
 
-                bool connections_exist = connected_chips_and_eth_cores.find(physical_connected_chip_id) !=
-                                         connected_chips_and_eth_cores.end();
-                TT_FATAL(
-                    connections_exist ||
-                        reliability_mode != tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
-                    "Expected connections to exist for M{}D{} to D{}",
-                    mesh_id,
-                    chip_id,
-                    logical_connected_chip_id);
-                if (!connections_exist) {
-                    continue;
-                }
+            for (const auto& [logical_connected_chip_id, edge] : intra_mesh_connectivity[*mesh_id][fabric_chip_id]) {
+                auto connected_mesh_coord =
+                    this->routing_table_generator_->mesh_graph->chip_to_coordinate(mesh_id, logical_connected_chip_id);
+                if (local_mesh_coord_range.contains(connected_mesh_coord)) {
+                    // This is a local chip, so we can use the logical chip id directly
+                    TT_ASSERT(
+                        this->logical_mesh_chip_id_to_physical_chip_id_mapping_.contains(
+                            FabricNodeId(mesh_id, logical_connected_chip_id)),
+                        "Mesh {} Chip {} not found in logical mesh chip id to physical chip id mapping",
+                        mesh_id,
+                        logical_connected_chip_id);
+                    const auto& physical_connected_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(
+                        FabricNodeId(mesh_id, logical_connected_chip_id));
 
-                const auto& connected_eth_cores = connected_chips_and_eth_cores.at(physical_connected_chip_id);
-                if (reliability_mode == tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) {
+                    const auto& connected_chips_and_eth_cores =
+                        tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_cores_grouped_by_connected_chips(
+                            physical_chip_id);
+
+                    bool connections_exist = connected_chips_and_eth_cores.find(physical_connected_chip_id) !=
+                                             connected_chips_and_eth_cores.end();
                     TT_FATAL(
-                        connected_eth_cores.size() >= edge.connected_chip_ids.size(),
-                        "Expected {} eth links from physical chip {} to physical chip {}",
-                        edge.connected_chip_ids.size(),
-                        physical_chip_id,
-                        physical_connected_chip_id);
-                }
+                        connections_exist ||
+                            reliability_mode != tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+                        "Expected connections to exist for M{}D{} to D{}",
+                        mesh_id,
+                        fabric_chip_id,
+                        logical_connected_chip_id);
+                    if (!connections_exist) {
+                        continue;
+                    }
 
-                for (const auto& eth_core : connected_eth_cores) {
-                    // There could be an optimization here to create entry for both chips here, assuming links are
-                    // bidirectional
-                    this->assign_direction_to_fabric_eth_core(fabric_node_id, eth_core, edge.port_direction);
+                    const auto& connected_eth_cores = connected_chips_and_eth_cores.at(physical_connected_chip_id);
+                    if (reliability_mode == tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) {
+                        TT_FATAL(
+                            connected_eth_cores.size() >= edge.connected_chip_ids.size(),
+                            "Expected {} eth links from physical chip {} to physical chip {}",
+                            edge.connected_chip_ids.size(),
+                            physical_chip_id,
+                            physical_connected_chip_id);
+                    }
+
+                    for (const auto& eth_core : connected_eth_cores) {
+                        // There could be an optimization here to create entry for both chips here, assuming links are
+                        // bidirectional
+                        this->assign_direction_to_fabric_eth_core(fabric_node_id, eth_core, edge.port_direction);
+                    }
+                } else {
+                    TT_ASSERT(
+                        this->routing_table_generator_->mesh_graph
+                            ->get_host_rank_for_chip(mesh_id, logical_connected_chip_id)
+                            .has_value(),
+                        "Mesh {} Chip {} does not have a host rank associated with it",
+                        mesh_id,
+                        fabric_chip_id);
+                    auto connected_host_rank_id = this->routing_table_generator_->mesh_graph
+                                                      ->get_host_rank_for_chip(mesh_id, logical_connected_chip_id)
+                                                      .value();
+                    const auto& intermesh_links = this->get_intermesh_eth_links(physical_chip_id);
+                    auto unique_chip_id =
+                        tt::tt_metal::MetalContext::instance().get_cluster().get_unique_chip_ids().at(physical_chip_id);
+                    // Look up connected chip's intermesh link table and grab local desc channel
+                    // TODO: need to add validate to make sure there is bidrectional traffic
+                    for (const auto& [local_desc, peer_desc] :
+                         peer_intermesh_link_tables_[mesh_id][connected_host_rank_id]) {
+                        if (peer_desc.board_id == unique_chip_id) {
+                            tt::umd::CoreCoord eth_core =
+                                tt::tt_metal::MetalContext::instance()
+                                    .get_cluster()
+                                    .get_soc_desc(physical_chip_id)
+                                    .get_eth_core_for_channel(local_desc.chan_id, CoordSystem::LOGICAL);
+                            this->assign_direction_to_fabric_eth_core(fabric_node_id, eth_core, edge.port_direction);
+                        }
+                    }
                 }
             }
         }
     }
 
     const auto& distributed_context = tt::tt_metal::MetalContext::instance().get_distributed_context();
-    for (std::uint32_t mesh_id = 0; mesh_id < inter_mesh_connectivity.size(); mesh_id++) {
-        for (std::uint32_t chip_id = 0; chip_id < inter_mesh_connectivity[mesh_id].size(); chip_id++) {
-            if (this->is_local_mesh(MeshId{mesh_id})) {
-                const auto fabric_node_id = FabricNodeId(MeshId{mesh_id}, chip_id);
+    for (std::uint32_t mesh_id_val = 0; mesh_id_val < inter_mesh_connectivity.size(); mesh_id_val++) {
+        MeshId mesh_id{mesh_id_val};
+        if (this->is_local_mesh(mesh_id)) {
+            const auto& local_mesh_chip_id_container =
+                this->routing_table_generator_->mesh_graph->get_chip_ids(mesh_id, host_rank_id);
+            for (const auto& [_, fabric_chip_id] : local_mesh_chip_id_container) {
+                const auto fabric_node_id = FabricNodeId(mesh_id, fabric_chip_id);
                 if (*(distributed_context.size()) > 1) {
                     this->assign_intermesh_link_directions_to_remote_host(fabric_node_id);
                 } else {
@@ -929,7 +971,6 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
             }
         }
     }
-
     this->initialize_dynamic_routing_plane_counts(intra_mesh_connectivity, fabric_config, reliability_mode);
 
     // Order the ethernet channels so that when we use them for deciding connections, indexing into ports per direction
@@ -1590,32 +1631,8 @@ void ControlPlane::initialize_intermesh_eth_links() {
 
     // Iterate over all chips in the cluster and populate the intermesh_eth_links
     for (const auto& chip_id : cluster.all_chip_ids()) {
-        const auto& soc_desc = cluster.get_soc_desc(chip_id);
-        if (soc_desc.logical_eth_core_to_chan_map.empty()) {
-            intermesh_eth_links_[chip_id] = {};
-            continue;
-        }
-        // Remote connections not visible to UMD
-        // Read multi-mesh configuration from the first available eth core
-        auto first_eth_core = soc_desc.logical_eth_core_to_chan_map.begin()->first;
-        tt_cxy_pair virtual_eth_core(
-            chip_id, cluster.get_virtual_coordinate_from_logical_coordinates(chip_id, first_eth_core, CoreType::ETH));
-
-        std::vector<uint32_t> config_data(1, 0);
-        auto multi_mesh_config_addr = tt_metal::MetalContext::instance().hal().get_dev_addr(
-            tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::INTERMESH_ETH_LINK_CONFIG);
-        cluster.read_core(config_data, sizeof(uint32_t), virtual_eth_core, multi_mesh_config_addr);
         std::vector<std::pair<CoreCoord, chan_id_t>> intermesh_eth_links;
-        for (auto link : extract_intermesh_eth_links(config_data[0], chip_id)) {
-            // Find the CoreCoord for this channel
-            for (const auto& [core_coord, channel] : soc_desc.logical_eth_core_to_chan_map) {
-                if (channel == link) {
-                    intermesh_eth_links.push_back({core_coord, link});
-                    break;
-                }
-            }
-        }
-
+        const auto& soc_desc = cluster.get_soc_desc(chip_id);
         // Remote connections visible to UMD
         auto remote_connections = cluster.get_ethernet_connections_to_remote_devices().find(chip_id);
         if (remote_connections != cluster.get_ethernet_connections_to_remote_devices().end()) {
@@ -1629,11 +1646,41 @@ void ControlPlane::initialize_intermesh_eth_links() {
                 }
             }
         }
+        if (cluster.get_board_type(chip_id) != BoardType::UBB) {
+            // TODO: remove branch here once get_ethernet_connections_to_remote_devices() contains
+            // all cross host links, currently on T3K there are some cross host links that are not
+            // visible to UMD
+            if (soc_desc.logical_eth_core_to_chan_map.empty()) {
+                intermesh_eth_links_[chip_id] = {};
+                continue;
+            }
+            // Remote connections not visible to UMD
+            // Read multi-mesh configuration from the first available eth core
+            auto first_eth_core = soc_desc.logical_eth_core_to_chan_map.begin()->first;
+            tt_cxy_pair virtual_eth_core(
+                chip_id,
+                cluster.get_virtual_coordinate_from_logical_coordinates(chip_id, first_eth_core, CoreType::ETH));
 
+            std::vector<uint32_t> config_data(1, 0);
+            auto multi_mesh_config_addr = tt_metal::MetalContext::instance().hal().get_dev_addr(
+                tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::INTERMESH_ETH_LINK_CONFIG);
+            cluster.read_core(config_data, sizeof(uint32_t), virtual_eth_core, multi_mesh_config_addr);
+            for (auto link : extract_intermesh_eth_links(config_data[0], chip_id)) {
+                // Find the CoreCoord for this channel
+                for (const auto& [core_coord, channel] : soc_desc.logical_eth_core_to_chan_map) {
+                    if (channel == link) {
+                        intermesh_eth_links.push_back({core_coord, link});
+                        break;
+                    }
+                }
+            }
+        }
         intermesh_eth_links_[chip_id] = intermesh_eth_links;
     }
 }
 
+// TODO: all of this can be removed once cluster.get_ethernet_connections_to_remote_devices()
+// contains all the cross host links
 bool ControlPlane::is_intermesh_enabled() const {
     // Check if the architecture and system support intermesh routing
     if (not tt_metal::MetalContext::instance().hal().intermesh_eth_links_enabled()) {
@@ -1688,6 +1735,14 @@ bool ControlPlane::is_intermesh_eth_link_trained(chip_id_t chip_id, CoreCoord et
     TT_FATAL(
         this->is_intermesh_eth_link(chip_id, eth_core), "Can only call {} on intermesh ethernet links.", __FUNCTION__);
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    auto remote_connections = cluster.get_ethernet_connections_to_remote_devices();
+    const auto& soc_desc = cluster.get_soc_desc(chip_id);
+    auto chan_id = soc_desc.logical_eth_core_to_chan_map.at(eth_core);
+
+    if (remote_connections.find(chip_id) != remote_connections.end() and
+        remote_connections.at(chip_id).find(chan_id) != remote_connections.at(chip_id).end()) {
+        return true;
+    }
     // Read the link status from designated L1 address
     tt_cxy_pair virtual_eth_core(
         chip_id, cluster.get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
@@ -1804,6 +1859,7 @@ void ControlPlane::generate_local_intermesh_link_table() {
     const auto& distributed_context = tt::tt_metal::MetalContext::instance().get_distributed_context();
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     intermesh_link_table_.local_mesh_id = local_mesh_binding_.mesh_ids[0];
+    intermesh_link_table_.local_host_rank_id = this->get_local_host_rank_id_binding();
     const uint32_t remote_config_base_addr = tt_metal::MetalContext::instance().hal().get_dev_addr(
         tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::ETH_LINK_REMOTE_INFO);
     for (const auto& chip_id : cluster.user_exposed_chip_ids()) {
@@ -1813,6 +1869,8 @@ void ControlPlane::generate_local_intermesh_link_table() {
                     // Link is untrained/unusuable
                     continue;
                 }
+                // TODO: remove below logic, should at very least be using UMD apis to get ids
+                // But all this data can be provided by UMD
                 tt_cxy_pair virtual_eth_core(
                     chip_id, cluster.get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
                 uint64_t local_board_id = 0;
@@ -1874,9 +1932,11 @@ void ControlPlane::exchange_intermesh_link_tables() {
         // No need to exchange intermesh link tables when running a single process
         return;
     }
+
     auto serialized_table = tt::tt_fabric::serialize_to_bytes(intermesh_link_table_);
     std::vector<uint8_t> serialized_remote_table;
     auto my_rank = *(distributed_context.rank());
+
     for (std::size_t bcast_root = 0; bcast_root < *(distributed_context.size()); ++bcast_root) {
         if (my_rank == bcast_root) {
             // Issue the broadcast from the current process to all other processes in the world
@@ -1904,8 +1964,9 @@ void ControlPlane::exchange_intermesh_link_tables() {
                 tt::tt_metal::distributed::multihost::Rank{bcast_root});
             tt_fabric::IntermeshLinkTable deserialized_remote_table =
                 tt::tt_fabric::deserialize_from_bytes(serialized_remote_table);
-            peer_intermesh_link_tables_[deserialized_remote_table.local_mesh_id] =
-                std::move(deserialized_remote_table.intermesh_links);
+            peer_intermesh_link_tables_[deserialized_remote_table.local_mesh_id]
+                                       [deserialized_remote_table.local_host_rank_id] =
+                                           std::move(deserialized_remote_table.intermesh_links);
         }
         // Barrier here for safety - Ensure that all ranks have completed the bcast op before proceeding to the next
         // root
@@ -1981,7 +2042,12 @@ void ControlPlane::assign_intermesh_link_directions_to_remote_host(const FabricN
         for (const auto& [connected_mesh_id, edge] :
              inter_mesh_connectivity[*fabric_node_id.mesh_id][fabric_node_id.chip_id]) {
             bool connection_found = false;
-            for (const auto& [candidate_desc, candidate_peer_desc] : peer_intermesh_link_tables_[connected_mesh_id]) {
+            // TODO: untested, but should work. We would need two big meshes connected to test this
+            auto connected_host_rank_id = this->routing_table_generator_->mesh_graph
+                                              ->get_host_rank_for_chip(connected_mesh_id, fabric_node_id.chip_id)
+                                              .value();
+            for (const auto& [candidate_desc, candidate_peer_desc] :
+                 peer_intermesh_link_tables_[connected_mesh_id][connected_host_rank_id]) {
                 if (candidate_desc == remote_eth_chan_desc && candidate_peer_desc == curr_eth_chan_desc) {
                     // Found the matching intermesh link
                     num_directions_assigned++;
@@ -1994,8 +2060,10 @@ void ControlPlane::assign_intermesh_link_directions_to_remote_host(const FabricN
                 break;  // No need to check other edges, we found the matching intermesh link
             }
         }
-        router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)[intermesh_routing_direction].push_back(
-            eth_chan);
+        if (intermesh_routing_direction != RoutingDirection::NONE) {
+            router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)[intermesh_routing_direction].push_back(
+                eth_chan);
+        }
     }
     // Compute the number of intermesh links requsted by the user and ensure that they could be mapped to physical links
     // on the fabric node
@@ -2049,7 +2117,6 @@ ControlPlane::~ControlPlane() = default;
 GlobalControlPlane::GlobalControlPlane(const std::string& mesh_graph_desc_file) {
     mesh_graph_desc_file_ = mesh_graph_desc_file;
     // Initialize host mappings
-    this->initialize_host_mapping();
     control_plane_ = std::make_unique<ControlPlane>(mesh_graph_desc_file);
 }
 
@@ -2057,24 +2124,8 @@ GlobalControlPlane::GlobalControlPlane(
     const std::string& mesh_graph_desc_file,
     const std::map<FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
     mesh_graph_desc_file_ = mesh_graph_desc_file;
-    this->initialize_host_mapping();
     control_plane_ =
         std::make_unique<ControlPlane>(mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
-}
-
-void GlobalControlPlane::initialize_host_mapping() {
-    this->routing_table_generator_ = std::make_unique<RoutingTableGenerator>(mesh_graph_desc_file_);
-    // Grab available hosts in the system and map to physical chip ids
-    // ping for all hosts in cluster, grab mapping of all physical chip ids/physical hosts
-    const auto& mesh_ids = this->routing_table_generator_->mesh_graph->get_mesh_ids();
-
-    for (const auto& mesh_id : mesh_ids) {
-        MeshShape mesh_shape = this->routing_table_generator_->mesh_graph->get_mesh_shape(mesh_id);
-        const auto& host_ranks = this->routing_table_generator_->mesh_graph->get_host_ranks(mesh_id);
-        for (const auto& [coord, rank] : host_ranks) {
-            this->host_rank_to_sub_mesh_shape_[rank].push_back(coord);
-        }
-    }
 }
 
 GlobalControlPlane::~GlobalControlPlane() = default;

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -255,7 +255,6 @@ IntraMeshAdjacencyMap build_mesh_adjacency_map(
 
         // Get adjacent chips using the provided adjacency function
         std::vector<chip_id_t> adjacent_chips = get_adjacent_chips_func(current_chip);
-
         // Count neighbours: CORNER_ADJACENT_CHIPS → corner, EDGE_ADJACENT_CHIPS → edge, INTERIOR_ADJACENT_CHIPS →
         // interior (we treat only links with ≥ num_ports_per_side lanes as neighbours)
         bool is_corner = false;

--- a/tt_metal/fabric/intermesh_constants.hpp
+++ b/tt_metal/fabric/intermesh_constants.hpp
@@ -6,6 +6,7 @@
 
 namespace tt::tt_fabric {
 namespace intermesh_constants {
+// TODO: remove once UMD can provide all intermesh links
 
 // Constants used to derive the intermesh ethernet links config
 static constexpr uint32_t MULTI_MESH_ENABLED_VALUE = 0x2;

--- a/tt_metal/fabric/serialization/intermesh_link_table.cpp
+++ b/tt_metal/fabric/serialization/intermesh_link_table.cpp
@@ -12,6 +12,8 @@ std::vector<uint8_t> serialize_to_bytes(const IntermeshLinkTable& intermesh_link
     flatbuffers::FlatBufferBuilder builder;
 
     auto mesh_id = tt::tt_fabric::flatbuffer::CreateMeshId(builder, *(intermesh_link_table.local_mesh_id));
+    auto host_rank_id =
+        tt::tt_fabric::flatbuffer::CreateHostRankId(builder, *(intermesh_link_table.local_host_rank_id));
 
     // Create vector of EthernetLink objects (flatbuffers dont support std::unordered_map directly)
     std::vector<flatbuffers::Offset<tt::tt_fabric::flatbuffer::EthernetLink>> ethernet_links;
@@ -34,7 +36,7 @@ std::vector<uint8_t> serialize_to_bytes(const IntermeshLinkTable& intermesh_link
 
     // Create the root IntermeshLinkTable
     auto serialized_intermesh_link_table =
-        tt::tt_fabric::flatbuffer::CreateIntermeshLinkTable(builder, mesh_id, ethernet_links_vector);
+        tt::tt_fabric::flatbuffer::CreateIntermeshLinkTable(builder, mesh_id, host_rank_id, ethernet_links_vector);
 
     // Finish the buffer
     builder.Finish(serialized_intermesh_link_table);
@@ -55,6 +57,10 @@ IntermeshLinkTable deserialize_from_bytes(const std::vector<uint8_t>& data) {
 
     if (intermesh_link_table->local_mesh_id()) {
         result.local_mesh_id = MeshId{intermesh_link_table->local_mesh_id()->value()};
+    }
+
+    if (intermesh_link_table->local_host_rank_id()) {
+        result.local_host_rank_id = HostRankId{intermesh_link_table->local_host_rank_id()->value()};
     }
 
     // Extract intermesh links into unordered_map

--- a/tt_metal/fabric/serialization/intermesh_link_table.fbs
+++ b/tt_metal/fabric/serialization/intermesh_link_table.fbs
@@ -4,6 +4,10 @@ table MeshId {
   value: uint32;
 }
 
+table HostRankId {
+  value: uint32;
+}
+
 table EthChanDescriptor {
     board_id: uint64;
     chan_id: uint32;
@@ -16,6 +20,7 @@ table EthernetLink {
 
 table IntermeshLinkTable {
   local_mesh_id: MeshId;
+  local_host_rank_id: HostRankId;
   intermesh_links: [EthernetLink];
 }
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1084,23 +1084,15 @@ void Cluster::reserve_ethernet_cores_for_tunneling() {
                         }
                     }
                 }
-                // We want to also add the eth cores that are connected to other chips possibly outside the opened
-                // cluster.
-                const auto& soc_desc = get_soc_desc(chip_id);
-                for (const auto& eth_channel : cluster_desc_->get_active_eth_channels(chip_id)) {
-                    auto eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
-                    if (this->device_eth_routing_info_.at(chip_id).find(eth_core) ==
-                        this->device_eth_routing_info_.at(chip_id).end()) {
-                        this->device_eth_routing_info_.at(chip_id).insert({eth_core, EthRouterMode::IDLE});
-                    }
-                }
-            } else {
-                // Slow dispatch mode
-                for (const auto &[connected_chip_id, active_eth_cores] :
-                     this->get_ethernet_cores_grouped_by_connected_chips(chip_id)) {
-                    for (const auto &eth_core : active_eth_cores) {
-                        this->device_eth_routing_info_.at(chip_id).insert({eth_core, EthRouterMode::IDLE});
-                    }
+            }
+            // We want to also add the eth cores that are connected to other chips possibly outside the opened
+            // cluster.
+            const auto& soc_desc = get_soc_desc(chip_id);
+            for (const auto& eth_channel : cluster_desc_->get_active_eth_channels(chip_id)) {
+                auto eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
+                if (this->device_eth_routing_info_.at(chip_id).find(eth_core) ==
+                    this->device_eth_routing_info_.at(chip_id).end()) {
+                    this->device_eth_routing_info_.at(chip_id).insert({eth_core, EthRouterMode::IDLE});
                 }
             }
         }


### PR DESCRIPTION

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/20945)

### Problem description
Bring up changes needed for multi host control plane. In particular, adding support for big mesh, and general support for multihost on 6Us.

### What's changed
- distribute fabric init, mesh validation across multiple hosts
- added support multihost apis for 6U
- added HostRankId to IntermeshMeshTable 
- test changes

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes