### PR TITLE
Clang Tidy Light for PRs

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -158,6 +158,92 @@ jobs:
       runner: ${{ matrix.platform }}
       product: tt-metalium
 
+  docker-image:
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
+    uses: ./.github/workflows/build-docker-artifact.yaml
+    secrets: inherit
+    with:
+      distro: ubuntu
+      version: 22.04
+      architecture: amd64
+
+  # A lightweight ClangTidy scan.  It does not detect all issues, but is cheap
+  # enough to run during PRs without bringing infra to a grinding halt.
+  # A proper scan is run in Merge Gate to ensure only clean code lands.
+  clang-tidy-light:
+    needs: [docker-image]
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    container: ${{ needs.docker-image.outputs.ci-build-tag }}
+    permissions:
+      pull-requests: write
+      contents: write # to allow auto-closing conversations
+    steps:
+    - name: Change ownership of /github/home
+      run: sudo chown -R $(whoami) /github/home # Thanks GH...
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+        submodules: "recursive"
+    - name: Set safe directory for Git
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+    - name: Fetch base branch
+      run: |
+        git remote add upstream "https://github.com/${{ github.event.pull_request.base.repo.full_name }}"
+        git fetch --no-tags upstream "${{ github.event.pull_request.base.ref }}"
+    - name: Install clang-tidy
+      run: |
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y clang-tidy-17 python3.11 python3.11-venv python3.11-dev
+        sudo ln -s $(which clang-tidy-17) /usr/local/bin/clang-tidy
+        pip install pyyaml # Needed for clang-tidy-diff-17.py
+    - name: Prepare compile_commands.json
+      run: |
+        cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UNITY_BUILDS=OFF -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake
+    - name: 'Install jq'
+      uses: dcarbone/install-jq-action@v2
+    - name: Create results directory
+      run: |
+        mkdir clang-tidy-result
+    - name: Analyze
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # Find all touched files present in compile_commands.json
+        # This is not as simple as filtering non-code files, as some code (eg: Kernels) are C++ code that
+        # is not built at this level, and thus clang-tidy will be unable to process them.
+        PREFIX=$(pwd)
+        jq --arg prefix "$PREFIX/" -r '.[].file | sub("^" + $prefix; "")' build/compile_commands.json > relative_files_in_build.txt
+        git diff --name-only "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")..." > changed_files.txt
+        grep -F -f relative_files_in_build.txt changed_files.txt > common_files.txt || true
+
+        # Exit if there are no modified files known to CMake
+        [[ -s common_files.txt ]] || {
+          echo "No files to analyze"
+          exit 0
+        }
+
+        # Analyze the relevant diffs of the relevant files
+        git diff "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" -- $(cat common_files.txt) > filtered_changes.diff
+        clang-tidy-diff-17.py -p1 -path build  -export-fixes clang-tidy-result/fixes.yml -j$(nproc) < filtered_changes.diff
+
+        # Draw attention to this step (make it an error) if there are fixes to be addressed.
+        [[ -s clang-tidy-result/fixes.yml ]] && exit 42
+
+      timeout-minutes: 5
+    - name: Run clang-tidy-pr-comments action
+      if: ${{ !cancelled() }}
+      uses: platisd/clang-tidy-pr-comments@28cfb84edafa771c044bde7e4a2a3fae57463818 # v1.8.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        clang_tidy_fixes: clang-tidy-result/fixes.yml
+        request_changes: false # TODO: consider enabling this?
+        suggestions_per_comment: 10 # arbitrary limit toavoid GH API timeouts
+        python_path: python3 # Pip fails if the action attempts to install its own Python; Sidestep that.
+        auto_resolve_conversations: true # NOTE: only resolves when ALL are fixed.
+
   # GitHub has so many design limitations it's not even funny.
   # This job is purely so we can capture the essence of the workflow as a whole in our status checks.
   workflow-status:
@@ -171,13 +257,13 @@ jobs:
         contains(join(needs.*.result, ','), 'success') ||
         contains(join(needs.*.result, ','), 'failure')
       }}
-    needs: [asan-build, metalium-smoke-tests, ttnn-smoke-tests, build, metalium-examples]
+    needs: [asan-build, metalium-smoke-tests, ttnn-smoke-tests, build, metalium-examples, clang-tidy-light]
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
           required-jobs: "asan-build, build"
-          optional-jobs: "metalium-smoke-tests, ttnn-smoke-tests, metalium-examples"
+          optional-jobs: "metalium-smoke-tests, ttnn-smoke-tests, metalium-examples, clang-tidy-light"
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Devs are surprised by Clang Tidy failures when they thought their PR was done.
Worse, the feedback is very delayed due to the demand on our build infra.
Worse still is that when a PR gets evicted all subsequent jobs in the queue must get rebased and start over from scratch, placing even MORE demand on the build infra.

### What's changed
Added a lightweight version of Clang Tidy's scan that runs in PRs.  It doesn't detect everything, but what it does detect can be addressed _before_ attempting to merge.  Hopefully this detects enough of the issues that fewer jobs will get evicted from the MQ.
