### PR TITLE
#20867: Assign one go message slot per subdevice (#21300)

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/pgm_dispatch_golden.json
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/pgm_dispatch_golden.json
@@ -1,7 +1,7 @@
 {
   "context": {
-    "date": "2025-07-14T17:49:02+00:00",
-    "host_name": "tt-metal-ci-vm-161",
+    "date": "2025-07-29T20:18:54+00:00",
+    "host_name": "tt-metal-ci-vm-47",
     "executable": "./build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch",
     "num_cpus": 14,
     "mhz_per_cpu": 2300,
@@ -32,7 +32,7 @@
         "num_sharing": 1
       }
     ],
-    "load_avg": [9.1748,9.87354,10.3003],
+    "load_avg": [4.8833,6.53516,6.2002],
     "library_version": "v1.9.1",
     "library_build_type": "debug",
     "json_schema_version": 1
@@ -48,11 +48,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 28,
-      "real_time": 2.4883878392857146e+07,
-      "cpu_time": 2.8815642857140036e+04,
+      "real_time": 2.4892201892857142e+07,
+      "cpu_time": 2.4813464285717528e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.4883878392857146e-06
+      "IterationTime": 2.4892201892857145e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/512/manual_time",
@@ -64,11 +64,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 28,
-      "real_time": 2.4909258392857142e+07,
-      "cpu_time": 4.4636678571431861e+04,
+      "real_time": 2.4904945142857146e+07,
+      "cpu_time": 2.4839892857144085e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.4909258392857143e-06
+      "IterationTime": 2.4904945142857147e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/1024/manual_time",
@@ -80,11 +80,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 28,
-      "real_time": 2.5194027892857138e+07,
-      "cpu_time": 4.7751178571428121e+04,
+      "real_time": 2.5188858642857142e+07,
+      "cpu_time": 4.4212428571428172e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.5194027892857138e-06
+      "IterationTime": 2.5188858642857145e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/2048/manual_time",
@@ -96,11 +96,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 27,
-      "real_time": 2.5815937814814821e+07,
-      "cpu_time": 3.4837777777767616e+04,
+      "real_time": 2.5814234925925922e+07,
+      "cpu_time": 2.8615629629627594e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.5815937814814825e-06
+      "IterationTime": 2.5814234925925919e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/4096/manual_time",
@@ -112,11 +112,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 25,
-      "real_time": 2.7556996280000001e+07,
-      "cpu_time": 5.7657199999994191e+04,
+      "real_time": 2.7719673680000000e+07,
+      "cpu_time": 2.5022360000015455e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7556996280000001e-06
+      "IterationTime": 2.7719673680000001e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/8192/manual_time",
@@ -128,11 +128,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 23,
-      "real_time": 3.0153155478260860e+07,
-      "cpu_time": 2.9568391304340726e+04,
+      "real_time": 3.0173056304347824e+07,
+      "cpu_time": 2.9053478260871627e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0153155478260862e-06
+      "IterationTime": 3.0173056304347822e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/12288/manual_time",
@@ -144,11 +144,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.2820053333333328e+07,
-      "cpu_time": 3.3467523809531456e+04,
+      "real_time": 3.2850629238095231e+07,
+      "cpu_time": 2.5720904761901886e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.2820053333333331e-06
+      "IterationTime": 3.2850629238095229e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/256/manual_time",
@@ -160,11 +160,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 28,
-      "real_time": 2.4893738535714291e+07,
-      "cpu_time": 3.3019285714276848e+04,
+      "real_time": 2.4888467892857134e+07,
+      "cpu_time": 2.4699821428576997e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.4893738535714289e-06
+      "IterationTime": 2.4888467892857135e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/512/manual_time",
@@ -176,11 +176,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 28,
-      "real_time": 2.4897161821428567e+07,
-      "cpu_time": 2.8834642857157789e+04,
+      "real_time": 2.4934738714285713e+07,
+      "cpu_time": 2.5443321428556381e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.4897161821428569e-06
+      "IterationTime": 2.4934738714285717e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/1024/manual_time",
@@ -192,11 +192,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 28,
-      "real_time": 2.5187620607142854e+07,
-      "cpu_time": 3.3258928571422432e+04,
+      "real_time": 2.5180136464285713e+07,
+      "cpu_time": 2.3606249999990374e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.5187620607142850e-06
+      "IterationTime": 2.5180136464285712e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/2048/manual_time",
@@ -208,11 +208,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 27,
-      "real_time": 2.5807957259259265e+07,
-      "cpu_time": 2.7461407407383780e+04,
+      "real_time": 2.5808350370370369e+07,
+      "cpu_time": 2.4769888888870533e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.5807957259259264e-06
+      "IterationTime": 2.5808350370370368e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/4096/manual_time",
@@ -224,11 +224,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 25,
-      "real_time": 2.7578786159999996e+07,
-      "cpu_time": 2.4883479999999734e+04,
+      "real_time": 2.7735109239999995e+07,
+      "cpu_time": 2.5128320000007418e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7578786159999998e-06
+      "IterationTime": 2.7735109239999992e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/8192/manual_time",
@@ -240,11 +240,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 23,
-      "real_time": 3.0219190652173914e+07,
-      "cpu_time": 3.4420869565210880e+04,
+      "real_time": 3.0229338521739122e+07,
+      "cpu_time": 2.4142347826081888e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0219190652173913e-06
+      "IterationTime": 3.0229338521739122e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/12288/manual_time",
@@ -256,11 +256,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.2860583333333332e+07,
-      "cpu_time": 2.8787142857118688e+04,
+      "real_time": 3.2897981190476187e+07,
+      "cpu_time": 3.5524380952318374e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.2860583333333334e-06
+      "IterationTime": 3.2897981190476188e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/256/manual_time",
@@ -272,11 +272,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 26,
-      "real_time": 2.6804610038461540e+07,
-      "cpu_time": 2.6858000000018477e+04,
+      "real_time": 2.6820380423076928e+07,
+      "cpu_time": 2.8909692307689849e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.6804610038461538e-06
+      "IterationTime": 2.6820380423076928e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/512/manual_time",
@@ -288,11 +288,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 26,
-      "real_time": 2.6961797730769224e+07,
-      "cpu_time": 2.4998538461530072e+04,
+      "real_time": 2.6994243153846152e+07,
+      "cpu_time": 2.7422384615368635e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.6961797730769228e-06
+      "IterationTime": 2.6994243153846154e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/1024/manual_time",
@@ -304,11 +304,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 25,
-      "real_time": 2.7658732799999997e+07,
-      "cpu_time": 2.7819879999952944e+04,
+      "real_time": 2.7678226720000006e+07,
+      "cpu_time": 3.1293880000049514e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7658732799999997e-06
+      "IterationTime": 2.7678226720000001e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/2048/manual_time",
@@ -320,11 +320,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 23,
-      "real_time": 3.0664260608695641e+07,
-      "cpu_time": 2.9152173912967039e+04,
+      "real_time": 3.0686821739130430e+07,
+      "cpu_time": 3.0827043478285159e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0664260608695645e-06
+      "IterationTime": 3.0686821739130430e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/4096/manual_time",
@@ -336,11 +336,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.4384518899999999e+07,
-      "cpu_time": 3.0973500000008869e+04,
+      "real_time": 3.4244035500000000e+07,
+      "cpu_time": 2.9912900000006463e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.4384518900000004e-06
+      "IterationTime": 3.4244035500000006e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/8192/manual_time",
@@ -352,11 +352,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.1845659647058822e+07,
-      "cpu_time": 2.6830294117567464e+04,
+      "real_time": 4.1849496647058822e+07,
+      "cpu_time": 2.6508941176551976e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.1845659647058820e-06
+      "IterationTime": 4.1849496647058826e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/12288/manual_time",
@@ -368,11 +368,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 14,
-      "real_time": 4.9620794571428575e+07,
-      "cpu_time": 4.5538499999965767e+04,
+      "real_time": 4.9609079499999993e+07,
+      "cpu_time": 3.0762285714303060e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.9620794571428570e-06
+      "IterationTime": 4.9609079499999996e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/256/manual_time",
@@ -384,11 +384,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 25,
-      "real_time": 2.7646143639999997e+07,
-      "cpu_time": 3.4723200000001954e+04,
+      "real_time": 2.7687448639999997e+07,
+      "cpu_time": 4.3496400000009315e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7646143639999993e-06
+      "IterationTime": 2.7687448640000000e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/512/manual_time",
@@ -400,11 +400,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 25,
-      "real_time": 2.7824764799999997e+07,
-      "cpu_time": 2.4859999999975455e+04,
+      "real_time": 2.7819884999999996e+07,
+      "cpu_time": 2.7071279999972830e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7824764799999998e-06
+      "IterationTime": 2.7819884999999996e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/1024/manual_time",
@@ -416,11 +416,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 24,
-      "real_time": 2.9085197416666660e+07,
-      "cpu_time": 2.8657958333363116e+04,
+      "real_time": 2.9119778416666660e+07,
+      "cpu_time": 3.1619291666655041e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.9085197416666663e-06
+      "IterationTime": 2.9119778416666660e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/2048/manual_time",
@@ -431,12 +431,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 21,
-      "real_time": 3.2579420000000007e+07,
-      "cpu_time": 2.5924142857122879e+04,
+      "iterations": 22,
+      "real_time": 3.2544555181818176e+07,
+      "cpu_time": 3.4032409090914676e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.2579420000000009e-06
+      "IterationTime": 3.2544555181818175e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/4096/manual_time",
@@ -448,11 +448,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8655328888888896e+07,
-      "cpu_time": 3.9987055555536070e+04,
+      "real_time": 3.8648681333333328e+07,
+      "cpu_time": 3.2524999999949956e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8655328888888895e-06
+      "IterationTime": 3.8648681333333333e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/8192/manual_time",
@@ -464,11 +464,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 15,
-      "real_time": 4.7498873000000000e+07,
-      "cpu_time": 3.7664000000011314e+04,
+      "real_time": 4.7488901000000000e+07,
+      "cpu_time": 3.0352733333316450e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.7498872999999993e-06
+      "IterationTime": 4.7488900999999996e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/12288/manual_time",
@@ -480,11 +480,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.7854205916666657e+07,
-      "cpu_time": 3.7039999999895670e+04,
+      "real_time": 5.7871946000000000e+07,
+      "cpu_time": 5.7168916666701836e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.7854205916666653e-06
+      "IterationTime": 5.7871945999999993e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/256/manual_time",
@@ -496,11 +496,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 24,
-      "real_time": 2.9061124749999996e+07,
-      "cpu_time": 3.4218333333354189e+04,
+      "real_time": 2.9054254916666668e+07,
+      "cpu_time": 2.5633000000061893e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.9061124749999992e-06
+      "IterationTime": 2.9054254916666662e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/512/manual_time",
@@ -512,11 +512,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 24,
-      "real_time": 2.9058857333333340e+07,
-      "cpu_time": 3.0555833333334449e+04,
+      "real_time": 2.9057186166666668e+07,
+      "cpu_time": 2.7234083333382838e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.9058857333333335e-06
+      "IterationTime": 2.9057186166666663e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/1024/manual_time",
@@ -528,11 +528,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 23,
-      "real_time": 3.0673562347826093e+07,
-      "cpu_time": 3.2242391304316203e+04,
+      "real_time": 3.0701456043478262e+07,
+      "cpu_time": 2.5127391304287674e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0673562347826092e-06
+      "IterationTime": 3.0701456043478259e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/2048/manual_time",
@@ -544,11 +544,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.4827165299999997e+07,
-      "cpu_time": 2.7086650000018864e+04,
+      "real_time": 3.4820338300000004e+07,
+      "cpu_time": 2.5643349999882048e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.4827165299999997e-06
+      "IterationTime": 3.4820338300000004e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/4096/manual_time",
@@ -560,11 +560,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.1083860235294119e+07,
-      "cpu_time": 3.7231176470697843e+04,
+      "real_time": 4.1059299941176474e+07,
+      "cpu_time": 5.3848470588156808e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.1083860235294118e-06
+      "IterationTime": 4.1059299941176471e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/8192/manual_time",
@@ -576,11 +576,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 13,
-      "real_time": 5.3423405615384623e+07,
-      "cpu_time": 3.3453076922886394e+04,
+      "real_time": 5.3395166846153840e+07,
+      "cpu_time": 3.0723000000202424e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.3423405615384628e-06
+      "IterationTime": 5.3395166846153841e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/12288/manual_time",
@@ -592,11 +592,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.6254216090909094e+07,
-      "cpu_time": 3.3608181818129364e+04,
+      "real_time": 6.6243717454545453e+07,
+      "cpu_time": 2.6727272727294414e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.6254216090909087e-06
+      "IterationTime": 6.6243717454545458e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/256/manual_time",
@@ -608,11 +608,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 24,
-      "real_time": 2.9061408750000011e+07,
-      "cpu_time": 3.5973250000006134e+04,
+      "real_time": 2.9063589458333328e+07,
+      "cpu_time": 3.0195874999972006e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.9061408750000010e-06
+      "IterationTime": 2.9063589458333329e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/512/manual_time",
@@ -624,11 +624,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 24,
-      "real_time": 2.9061757541666672e+07,
-      "cpu_time": 3.2414166666624074e+04,
+      "real_time": 2.9056231125000004e+07,
+      "cpu_time": 2.5545416666735342e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.9061757541666670e-06
+      "IterationTime": 2.9056231125000003e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/1024/manual_time",
@@ -640,11 +640,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 23,
-      "real_time": 3.0670974695652176e+07,
-      "cpu_time": 3.2389130434689436e+04,
+      "real_time": 3.0720259086956523e+07,
+      "cpu_time": 2.8062043478194671e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0670974695652169e-06
+      "IterationTime": 3.0720259086956516e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/2048/manual_time",
@@ -656,11 +656,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.4833642450000003e+07,
-      "cpu_time": 3.2597000000045286e+04,
+      "real_time": 3.4822108199999996e+07,
+      "cpu_time": 2.6397500000108208e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.4833642450000002e-06
+      "IterationTime": 3.4822108199999997e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/4096/manual_time",
@@ -672,11 +672,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.1135111352941185e+07,
-      "cpu_time": 5.4451176470639868e+04,
+      "real_time": 4.1064494000000000e+07,
+      "cpu_time": 2.8350647058730639e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.1135111352941177e-06
+      "IterationTime": 4.1064493999999998e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/8192/manual_time",
@@ -688,11 +688,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 13,
-      "real_time": 5.3415879769230761e+07,
-      "cpu_time": 4.1529999999913620e+04,
+      "real_time": 5.3370792076923080e+07,
+      "cpu_time": 4.8606769230566177e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.3415879769230764e-06
+      "IterationTime": 5.3370792076923077e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/12288/manual_time",
@@ -704,11 +704,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.6155163909090906e+07,
-      "cpu_time": 4.9051909090991336e+04,
+      "real_time": 6.6496046090909094e+07,
+      "cpu_time": 2.9942727272666307e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.6155163909090908e-06
+      "IterationTime": 6.6496046090909086e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/256/manual_time",
@@ -720,11 +720,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1337269636363637e+07,
-      "cpu_time": 3.2663363636296275e+04,
+      "real_time": 3.1337900272727277e+07,
+      "cpu_time": 2.9330363636342390e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1337269636363634e-06
+      "IterationTime": 3.1337900272727280e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/512/manual_time",
@@ -736,11 +736,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1892428545454551e+07,
-      "cpu_time": 3.2950000000071937e+04,
+      "real_time": 3.1900840272727273e+07,
+      "cpu_time": 3.1274363636348633e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1892428545454555e-06
+      "IterationTime": 3.1900840272727272e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/1024/manual_time",
@@ -752,11 +752,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3373542190476190e+07,
-      "cpu_time": 3.4114285714198762e+04,
+      "real_time": 3.3387444523809522e+07,
+      "cpu_time": 2.8736285714156144e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.3373542190476194e-06
+      "IterationTime": 3.3387444523809520e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/2048/manual_time",
@@ -768,11 +768,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8681993388888881e+07,
-      "cpu_time": 2.9834944444257551e+04,
+      "real_time": 3.8677131222222216e+07,
+      "cpu_time": 3.0235555555554092e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8681993388888887e-06
+      "IterationTime": 3.8677131222222210e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/4096/manual_time",
@@ -784,11 +784,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.3940057937500000e+07,
-      "cpu_time": 3.1693499999985164e+04,
+      "real_time": 4.3704046187500000e+07,
+      "cpu_time": 3.0985687499818225e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.3940057937500002e-06
+      "IterationTime": 4.3704046187500004e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/8192/manual_time",
@@ -800,11 +800,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.6090117416666657e+07,
-      "cpu_time": 2.6250000000042444e+04,
+      "real_time": 5.6059656250000007e+07,
+      "cpu_time": 4.0812583333327268e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.6090117416666659e-06
+      "IterationTime": 5.6059656250000012e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/256/manual_time",
@@ -816,11 +816,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1610369863636363e+07,
-      "cpu_time": 2.5901818181850445e+04,
+      "real_time": 3.1601739999999996e+07,
+      "cpu_time": 2.5753863636427093e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1610369863636368e-06
+      "IterationTime": 3.1601739999999995e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/512/manual_time",
@@ -832,11 +832,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.2273292454545449e+07,
-      "cpu_time": 2.6578181818140674e+04,
+      "real_time": 3.2256880636363626e+07,
+      "cpu_time": 3.3940954545483044e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.2273292454545451e-06
+      "IterationTime": 3.2256880636363626e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/1024/manual_time",
@@ -848,11 +848,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3680105666666664e+07,
-      "cpu_time": 2.6137571428447041e+04,
+      "real_time": 3.3709069476190478e+07,
+      "cpu_time": 2.5877047619022029e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.3680105666666659e-06
+      "IterationTime": 3.3709069476190478e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/2048/manual_time",
@@ -864,11 +864,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8749957666666657e+07,
-      "cpu_time": 3.0201666666821817e+04,
+      "real_time": 3.8752573611111112e+07,
+      "cpu_time": 3.2739944444612789e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8749957666666652e-06
+      "IterationTime": 3.8752573611111110e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/4096/manual_time",
@@ -880,11 +880,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.4304180125000000e+07,
-      "cpu_time": 2.5434374999910859e+04,
+      "real_time": 4.4062764500000000e+07,
+      "cpu_time": 2.8619375000094038e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.4304180125000007e-06
+      "IterationTime": 4.4062764499999996e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/8192/manual_time",
@@ -896,11 +896,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.6872028250000000e+07,
-      "cpu_time": 2.8675833333361803e+04,
+      "real_time": 5.7190503083333336e+07,
+      "cpu_time": 3.6416666666797923e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.6872028249999999e-06
+      "IterationTime": 5.7190503083333335e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_8g/256/manual_time",
@@ -912,11 +912,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.8888390166666664e+07,
-      "cpu_time": 2.9701083333518360e+04,
+      "real_time": 5.8897010499999993e+07,
+      "cpu_time": 4.1311583333462448e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.8888390166666661e-06
+      "IterationTime": 5.8897010499999991e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_8g/512/manual_time",
@@ -928,11 +928,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.9092517916666657e+07,
-      "cpu_time": 2.6445499999934913e+04,
+      "real_time": 5.9149557833333336e+07,
+      "cpu_time": 2.9804333333179518e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.9092517916666662e-06
+      "IterationTime": 5.9149557833333332e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_8g/1024/manual_time",
@@ -944,11 +944,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 6.0057904916666664e+07,
-      "cpu_time": 2.9170916666506248e+04,
+      "real_time": 6.0188793583333336e+07,
+      "cpu_time": 6.2016666666645884e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.0057904916666663e-06
+      "IterationTime": 6.0188793583333337e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_8g/2048/manual_time",
@@ -960,11 +960,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.1842410545454532e+07,
-      "cpu_time": 2.6933636363938007e+04,
+      "real_time": 6.1907528545454532e+07,
+      "cpu_time": 9.6994454545231492e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.1842410545454537e-06
+      "IterationTime": 6.1907528545454540e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_8g/4096/manual_time",
@@ -976,11 +976,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.5655004454545446e+07,
-      "cpu_time": 3.5537272727284828e+04,
+      "real_time": 6.5645780272727259e+07,
+      "cpu_time": 6.0841909091441885e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.5655004454545449e-06
+      "IterationTime": 6.5645780272727258e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_8g/8192/manual_time",
@@ -992,11 +992,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 8,
-      "real_time": 8.6819026375000000e+07,
-      "cpu_time": 3.4832499999915002e+04,
+      "real_time": 8.7086591375000000e+07,
+      "cpu_time": 3.0306500000243374e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 8.6819026374999993e-06
+      "IterationTime": 8.7086591374999998e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb_8g/256/manual_time",
@@ -1008,11 +1008,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 6.0369204166666664e+07,
-      "cpu_time": 3.0471499999980744e+04,
+      "real_time": 6.0400949916666664e+07,
+      "cpu_time": 2.8819166666712208e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.0369204166666659e-06
+      "IterationTime": 6.0400949916666667e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb_8g/512/manual_time",
@@ -1024,11 +1024,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 6.0648541166666664e+07,
-      "cpu_time": 3.1337249999966825e+04,
+      "real_time": 6.0708644000000007e+07,
+      "cpu_time": 3.1266583333078303e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.0648541166666676e-06
+      "IterationTime": 6.0708644000000011e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb_8g/1024/manual_time",
@@ -1040,11 +1040,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.1424388727272719e+07,
-      "cpu_time": 3.6222545454413856e+04,
+      "real_time": 6.1572416727272719e+07,
+      "cpu_time": 3.8916272727492054e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.1424388727272720e-06
+      "IterationTime": 6.1572416727272715e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb_8g/2048/manual_time",
@@ -1056,11 +1056,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.3332580000000000e+07,
-      "cpu_time": 2.7450909091054531e+04,
+      "real_time": 6.3318903636363633e+07,
+      "cpu_time": 3.0508454545693810e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.3332579999999993e-06
+      "IterationTime": 6.3318903636363642e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb_8g/4096/manual_time",
@@ -1072,11 +1072,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 10,
-      "real_time": 6.7040876899999991e+07,
-      "cpu_time": 3.9802000000577209e+04,
+      "real_time": 6.6963786600000001e+07,
+      "cpu_time": 3.0679099999986192e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.7040876899999991e-06
+      "IterationTime": 6.6963786600000000e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb_8g/8192/manual_time",
@@ -1088,11 +1088,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 8,
-      "real_time": 9.0021835500000015e+07,
-      "cpu_time": 2.9285000000101034e+04,
+      "real_time": 9.0245778875000000e+07,
+      "cpu_time": 7.8613874999966531e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 9.0021835500000006e-06
+      "IterationTime": 9.0245778875000009e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/256/manual_time",
@@ -1104,11 +1104,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1313060863636363e+07,
-      "cpu_time": 2.8061500000120534e+04,
+      "real_time": 3.1333829681818176e+07,
+      "cpu_time": 4.6852681818295008e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1313060863636366e-06
+      "IterationTime": 3.1333829681818181e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/512/manual_time",
@@ -1120,11 +1120,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1823060090909090e+07,
-      "cpu_time": 2.6195454545397857e+04,
+      "real_time": 3.1850935409090914e+07,
+      "cpu_time": 3.3122272727064745e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1823060090909092e-06
+      "IterationTime": 3.1850935409090917e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/1024/manual_time",
@@ -1136,11 +1136,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3390756904761910e+07,
-      "cpu_time": 3.5234285713989892e+04,
+      "real_time": 3.3396644809523802e+07,
+      "cpu_time": 3.0062000000103104e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.3390756904761905e-06
+      "IterationTime": 3.3396644809523800e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/2048/manual_time",
@@ -1152,11 +1152,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8691494833333336e+07,
-      "cpu_time": 2.5420555555655257e+04,
+      "real_time": 3.8692367666666664e+07,
+      "cpu_time": 3.2531055555611805e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8691494833333337e-06
+      "IterationTime": 3.8692367666666665e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/4096/manual_time",
@@ -1168,11 +1168,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.3954257437500007e+07,
-      "cpu_time": 2.5722499999769610e+04,
+      "real_time": 4.3729421062499993e+07,
+      "cpu_time": 4.2665437499866952e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.3954257437500004e-06
+      "IterationTime": 4.3729421062499994e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/8192/manual_time",
@@ -1183,12 +1183,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 12,
-      "real_time": 5.6072303583333336e+07,
-      "cpu_time": 2.6861249999991327e+04,
+      "iterations": 13,
+      "real_time": 5.6045173538461536e+07,
+      "cpu_time": 6.1725307692046707e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.6072303583333334e-06
+      "IterationTime": 5.6045173538461538e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/256/manual_time",
@@ -1200,11 +1200,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1298071863636371e+07,
-      "cpu_time": 2.4899181818098401e+04,
+      "real_time": 3.1306541363636348e+07,
+      "cpu_time": 3.1741454545329940e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1298071863636364e-06
+      "IterationTime": 3.1306541363636346e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/512/manual_time",
@@ -1216,11 +1216,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1751117136363637e+07,
-      "cpu_time": 2.5284545454372743e+04,
+      "real_time": 3.1819227590909097e+07,
+      "cpu_time": 3.1438227272544013e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1751117136363635e-06
+      "IterationTime": 3.1819227590909096e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/1024/manual_time",
@@ -1232,11 +1232,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3293022714285720e+07,
-      "cpu_time": 2.4972857142794663e+04,
+      "real_time": 3.3287339238095239e+07,
+      "cpu_time": 2.9684761904780724e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.3293022714285719e-06
+      "IterationTime": 3.3287339238095237e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/2048/manual_time",
@@ -1248,11 +1248,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8677389833333336e+07,
-      "cpu_time": 2.5416666666839345e+04,
+      "real_time": 3.8693533222222231e+07,
+      "cpu_time": 4.4317944444729721e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8677389833333336e-06
+      "IterationTime": 3.8693533222222229e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/4096/manual_time",
@@ -1264,11 +1264,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.3767220500000000e+07,
-      "cpu_time": 2.8275687499856871e+04,
+      "real_time": 4.3511617375000007e+07,
+      "cpu_time": 3.1638812500123237e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.3767220500000001e-06
+      "IterationTime": 4.3511617375000005e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/8192/manual_time",
@@ -1279,12 +1279,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 12,
-      "real_time": 5.6111827333333321e+07,
-      "cpu_time": 3.5850166666998957e+04,
+      "iterations": 13,
+      "real_time": 5.5994466461538464e+07,
+      "cpu_time": 2.9622384615252555e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.6111827333333326e-06
+      "IterationTime": 5.5994466461538467e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/256/manual_time",
@@ -1296,11 +1296,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 14,
-      "real_time": 5.1332739714285709e+07,
-      "cpu_time": 3.3737928571245640e+04,
+      "real_time": 5.0650940571428575e+07,
+      "cpu_time": 2.9505785714129775e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.1332739714285709e-06
+      "IterationTime": 5.0650940571428580e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/512/manual_time",
@@ -1312,11 +1312,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 14,
-      "real_time": 5.1347847214285716e+07,
-      "cpu_time": 3.8987142857089500e+04,
+      "real_time": 5.1222990499999993e+07,
+      "cpu_time": 3.1362857142828001e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.1347847214285710e-06
+      "IterationTime": 5.1222990499999998e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/1024/manual_time",
@@ -1328,11 +1328,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 14,
-      "real_time": 5.1339036500000000e+07,
-      "cpu_time": 3.2947285714409903e+04,
+      "real_time": 5.1332460071428582e+07,
+      "cpu_time": 3.3730785714526843e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.1339036499999996e-06
+      "IterationTime": 5.1332460071428580e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/2048/manual_time",
@@ -1344,11 +1344,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 14,
-      "real_time": 5.1708546571428575e+07,
-      "cpu_time": 3.2747928571552620e+04,
+      "real_time": 5.1337560785714284e+07,
+      "cpu_time": 4.6071500000164997e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.1708546571428573e-06
+      "IterationTime": 5.1337560785714288e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/4096/manual_time",
@@ -1360,11 +1360,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 13,
-      "real_time": 5.3456419000000000e+07,
-      "cpu_time": 3.2270769230863676e+04,
+      "real_time": 5.3490397307692304e+07,
+      "cpu_time": 2.6368538461095064e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.3456419000000001e-06
+      "IterationTime": 5.3490397307692303e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/8192/manual_time",
@@ -1375,12 +1375,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 13,
-      "real_time": 5.5977836461538449e+07,
-      "cpu_time": 3.3030615384177509e+04,
+      "iterations": 12,
+      "real_time": 5.6616660500000000e+07,
+      "cpu_time": 4.5523916667159858e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.5977836461538451e-06
+      "IterationTime": 5.6616660499999990e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/256/manual_time",
@@ -1391,12 +1391,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 20,
-      "real_time": 3.5805884600000009e+07,
-      "cpu_time": 3.8585649999944850e+04,
+      "iterations": 18,
+      "real_time": 3.8209215888888888e+07,
+      "cpu_time": 2.5224888888983642e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5805884600000001e-06
+      "IterationTime": 3.8209215888888892e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/512/manual_time",
@@ -1407,12 +1407,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 20,
-      "real_time": 3.5893774699999996e+07,
-      "cpu_time": 3.0132999999921140e+04,
+      "iterations": 18,
+      "real_time": 3.8312205000000007e+07,
+      "cpu_time": 5.3924444444754095e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5893774699999988e-06
+      "IterationTime": 3.8312205000000009e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/1024/manual_time",
@@ -1423,12 +1423,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 19,
-      "real_time": 3.6066359947368421e+07,
-      "cpu_time": 2.7958421052544152e+04,
+      "iterations": 18,
+      "real_time": 3.8459749222222216e+07,
+      "cpu_time": 2.4121166666427976e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.6066359947368423e-06
+      "IterationTime": 3.8459749222222212e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/2048/manual_time",
@@ -1439,12 +1439,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 19,
-      "real_time": 3.6395909052631572e+07,
-      "cpu_time": 2.6587368420836665e+04,
+      "iterations": 18,
+      "real_time": 3.8833191222222231e+07,
+      "cpu_time": 2.6828944444427332e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.6395909052631581e-06
+      "IterationTime": 3.8833191222222236e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/4096/manual_time",
@@ -1455,12 +1455,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 19,
-      "real_time": 3.7123827842105277e+07,
-      "cpu_time": 2.3546421052488218e+04,
+      "iterations": 18,
+      "real_time": 3.9552758500000007e+07,
+      "cpu_time": 3.5378944444472734e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.7123827842105275e-06
+      "IterationTime": 3.9552758500000012e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/8192/manual_time",
@@ -1471,12 +1471,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 18,
-      "real_time": 3.8762999888888896e+07,
-      "cpu_time": 2.9761222222251461e+04,
+      "iterations": 17,
+      "real_time": 4.1242901588235304e+07,
+      "cpu_time": 5.6840000000005712e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8762999888888899e-06
+      "IterationTime": 4.1242901588235300e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_crta/256/manual_time",
@@ -1488,11 +1488,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1304064999999996e+07,
-      "cpu_time": 2.9232727272701904e+04,
+      "real_time": 3.1325595818181816e+07,
+      "cpu_time": 3.8143227272771888e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1304064999999996e-06
+      "IterationTime": 3.1325595818181823e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_crta/512/manual_time",
@@ -1504,11 +1504,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1795132136363637e+07,
-      "cpu_time": 5.9986363636193637e+04,
+      "real_time": 3.1836662545454547e+07,
+      "cpu_time": 5.5568727272646938e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1795132136363633e-06
+      "IterationTime": 3.1836662545454544e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_crta/1024/manual_time",
@@ -1520,11 +1520,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3312437285714287e+07,
-      "cpu_time": 3.2630952380787094e+04,
+      "real_time": 3.3300534857142858e+07,
+      "cpu_time": 3.2556476190577432e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.3312437285714290e-06
+      "IterationTime": 3.3300534857142853e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_crta/2048/manual_time",
@@ -1536,11 +1536,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8690045944444448e+07,
-      "cpu_time": 2.5029611111035720e+04,
+      "real_time": 3.8696373611111104e+07,
+      "cpu_time": 3.8750166666545738e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8690045944444442e-06
+      "IterationTime": 3.8696373611111101e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_crta/4096/manual_time",
@@ -1552,11 +1552,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.3788742187500000e+07,
-      "cpu_time": 2.8978187500250384e+04,
+      "real_time": 4.3510310312499993e+07,
+      "cpu_time": 3.0314312499779560e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.3788742187500002e-06
+      "IterationTime": 4.3510310312499992e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_crta/8192/manual_time",
@@ -1567,12 +1567,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 12,
-      "real_time": 5.6109580250000000e+07,
-      "cpu_time": 3.4741666666467572e+04,
+      "iterations": 13,
+      "real_time": 5.6002129307692297e+07,
+      "cpu_time": 3.6058384615409101e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.6109580250000007e-06
+      "IterationTime": 5.6002129307692299e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_128_crta/256/manual_time",
@@ -1584,11 +1584,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.2435558681818176e+07,
-      "cpu_time": 3.0673181818162800e+04,
+      "real_time": 3.2426711636363637e+07,
+      "cpu_time": 2.5102909091210469e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.2435558681818179e-06
+      "IterationTime": 3.2426711636363631e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_128_crta/512/manual_time",
@@ -1600,11 +1600,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.2965500523809522e+07,
-      "cpu_time": 3.2303809523982960e+04,
+      "real_time": 3.2962832571428571e+07,
+      "cpu_time": 2.9256666666453515e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.2965500523809522e-06
+      "IterationTime": 3.2962832571428570e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_128_crta/1024/manual_time",
@@ -1616,11 +1616,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.4562063899999991e+07,
-      "cpu_time": 2.7690000000291089e+04,
+      "real_time": 3.4554109549999997e+07,
+      "cpu_time": 3.2686000000126114e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.4562063899999993e-06
+      "IterationTime": 3.4554109549999996e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_128_crta/2048/manual_time",
@@ -1632,11 +1632,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9357560444444448e+07,
-      "cpu_time": 3.2706888888690679e+04,
+      "real_time": 3.9361983499999993e+07,
+      "cpu_time": 3.6138999999953587e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9357560444444448e-06
+      "IterationTime": 3.9361983499999990e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_128_crta/4096/manual_time",
@@ -1648,11 +1648,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.4877077875000000e+07,
-      "cpu_time": 3.3737937500166736e+04,
+      "real_time": 4.4808780250000007e+07,
+      "cpu_time": 5.4516687499450709e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.4877077875000000e-06
+      "IterationTime": 4.4808780250000000e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_128_crta/8192/manual_time",
@@ -1664,11 +1664,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.7297392333333336e+07,
-      "cpu_time": 2.7946666666167628e+04,
+      "real_time": 5.7227308416666664e+07,
+      "cpu_time": 3.3213583332525333e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.7297392333333336e-06
+      "IterationTime": 5.7227308416666664e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/256/manual_time",
@@ -1679,12 +1679,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 18,
-      "real_time": 3.8403748055555552e+07,
-      "cpu_time": 2.9122222221881580e+04,
+      "iterations": 17,
+      "real_time": 4.0830189294117652e+07,
+      "cpu_time": 4.2862411765340497e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8403748055555559e-06
+      "IterationTime": 4.0830189294117657e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/512/manual_time",
@@ -1695,12 +1695,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 18,
-      "real_time": 3.8616862277777776e+07,
-      "cpu_time": 3.3102222222364871e+04,
+      "iterations": 17,
+      "real_time": 4.1147203000000000e+07,
+      "cpu_time": 4.1227176470717008e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8616862277777769e-06
+      "IterationTime": 4.1147202999999993e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/1024/manual_time",
@@ -1711,12 +1711,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 18,
-      "real_time": 3.9374873444444440e+07,
-      "cpu_time": 4.3103944444548382e+04,
+      "iterations": 17,
+      "real_time": 4.1915969529411770e+07,
+      "cpu_time": 5.1488058823966800e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9374873444444439e-06
+      "IterationTime": 4.1915969529411770e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/2048/manual_time",
@@ -1727,12 +1727,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 17,
-      "real_time": 4.1391167470588244e+07,
-      "cpu_time": 2.7974764705618327e+04,
+      "iterations": 16,
+      "real_time": 4.3692432500000000e+07,
+      "cpu_time": 2.5336312499568692e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.1391167470588237e-06
+      "IterationTime": 4.3692432500000004e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/4096/manual_time",
@@ -1744,11 +1744,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 15,
-      "real_time": 4.6987590466666661e+07,
-      "cpu_time": 4.8076666666929676e+04,
+      "real_time": 4.7861593533333331e+07,
+      "cpu_time": 3.2175200000021203e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.6987590466666663e-06
+      "IterationTime": 4.7861593533333331e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/8192/manual_time",
@@ -1759,12 +1759,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 11,
-      "real_time": 6.6461751363636367e+07,
-      "cpu_time": 3.1345454544862150e+04,
+      "iterations": 10,
+      "real_time": 6.9062393999999985e+07,
+      "cpu_time": 2.7372899999988927e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.6461751363636359e-06
+      "IterationTime": 6.9062393999999990e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/256/manual_time",
@@ -1776,11 +1776,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 14,
-      "real_time": 4.9381299357142851e+07,
-      "cpu_time": 5.2424928570969445e+04,
+      "real_time": 4.8829710928571425e+07,
+      "cpu_time": 2.7259928571205754e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.9381299357142852e-06
+      "IterationTime": 4.8829710928571434e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/512/manual_time",
@@ -1792,11 +1792,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 14,
-      "real_time": 5.0141179571428560e+07,
-      "cpu_time": 2.5888571427807554e+04,
+      "real_time": 4.9431130857142858e+07,
+      "cpu_time": 2.4953499999266376e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.0141179571428561e-06
+      "IterationTime": 4.9431130857142852e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/1024/manual_time",
@@ -1808,11 +1808,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 14,
-      "real_time": 5.1428626285714284e+07,
-      "cpu_time": 4.8810714284895446e+04,
+      "real_time": 5.1256101000000000e+07,
+      "cpu_time": 2.6441499999561660e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.1428626285714295e-06
+      "IterationTime": 5.1256100999999995e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/2048/manual_time",
@@ -1824,11 +1824,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 13,
-      "real_time": 5.5258126076923087e+07,
-      "cpu_time": 5.7470769230751386e+04,
+      "real_time": 5.5490554846153848e+07,
+      "cpu_time": 2.6348384614913393e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.5258126076923082e-06
+      "IterationTime": 5.5490554846153845e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/4096/manual_time",
@@ -1840,11 +1840,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.1763408090909094e+07,
-      "cpu_time": 7.2142181817401841e+04,
+      "real_time": 6.1596967909090906e+07,
+      "cpu_time": 2.7434818181601175e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.1763408090909093e-06
+      "IterationTime": 6.1596967909090917e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/8192/manual_time",
@@ -1856,11 +1856,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 9,
-      "real_time": 7.5795948444444448e+07,
-      "cpu_time": 5.9176555555811530e+04,
+      "real_time": 7.5454335777777776e+07,
+      "cpu_time": 2.7532444445594389e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 7.5795948444444447e-06
+      "IterationTime": 7.5454335777777778e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/256/manual_time",
@@ -1872,11 +1872,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0147595014285715e+08,
-      "cpu_time": 7.0952714285762602e+04,
+      "real_time": 1.0138271042857143e+08,
+      "cpu_time": 3.0244142856921437e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0147595014285713e-05
+      "IterationTime": 1.0138271042857143e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/512/manual_time",
@@ -1888,11 +1888,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0180975657142857e+08,
-      "cpu_time": 3.0557142857950177e+04,
+      "real_time": 1.0180012428571428e+08,
+      "cpu_time": 3.6729999998945983e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0180975657142858e-05
+      "IterationTime": 1.0180012428571429e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/1024/manual_time",
@@ -1904,11 +1904,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0345694000000000e+08,
-      "cpu_time": 3.3472857142312154e+04,
+      "real_time": 1.0354507842857143e+08,
+      "cpu_time": 4.2280000000362503e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0345694000000000e-05
+      "IterationTime": 1.0354507842857142e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/2048/manual_time",
@@ -1920,11 +1920,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.0795937800000000e+08,
-      "cpu_time": 2.8621166668093185e+04,
+      "real_time": 1.0786699550000000e+08,
+      "cpu_time": 5.4515499999278436e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0795937800000000e-05
+      "IterationTime": 1.0786699550000002e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/4096/manual_time",
@@ -1936,11 +1936,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1483477633333333e+08,
-      "cpu_time": 9.7050000000820088e+04,
+      "real_time": 1.1482624216666667e+08,
+      "cpu_time": 4.4943333333454422e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1483477633333333e-05
+      "IterationTime": 1.1482624216666667e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/8192/manual_time",
@@ -1952,11 +1952,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.2758369140000001e+08,
-      "cpu_time": 3.7832000001003507e+04,
+      "real_time": 1.2754872580000000e+08,
+      "cpu_time": 5.3145999999060223e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2758369140000001e-05
+      "IterationTime": 1.2754872580000001e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_crta/256/manual_time",
@@ -1968,11 +1968,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1352272181818172e+07,
-      "cpu_time": 7.6846818181763869e+04,
+      "real_time": 3.1315225090909090e+07,
+      "cpu_time": 2.7318500000009491e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1352272181818168e-06
+      "IterationTime": 3.1315225090909089e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_crta/512/manual_time",
@@ -1984,11 +1984,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1865179136363637e+07,
-      "cpu_time": 7.5321409090763191e+04,
+      "real_time": 3.1847342727272734e+07,
+      "cpu_time": 3.2940909091197762e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1865179136363644e-06
+      "IterationTime": 3.1847342727272735e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_crta/1024/manual_time",
@@ -2000,11 +2000,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3406327238095239e+07,
-      "cpu_time": 5.3010285713959267e+04,
+      "real_time": 3.3393233857142851e+07,
+      "cpu_time": 2.5806571428466628e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.3406327238095238e-06
+      "IterationTime": 3.3393233857142846e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_crta/2048/manual_time",
@@ -2016,11 +2016,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8698000055555560e+07,
-      "cpu_time": 3.2998555556199943e+04,
+      "real_time": 3.8693210500000000e+07,
+      "cpu_time": 3.6014722222748533e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8698000055555559e-06
+      "IterationTime": 3.8693210500000003e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_crta/4096/manual_time",
@@ -2032,11 +2032,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.3961377375000000e+07,
-      "cpu_time": 3.7367500000051732e+04,
+      "real_time": 4.3718343562500000e+07,
+      "cpu_time": 3.0881499999857453e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.3961377375000003e-06
+      "IterationTime": 4.3718343562500000e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_crta/8192/manual_time",
@@ -2048,11 +2048,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.6080066666666664e+07,
-      "cpu_time": 3.7472499999561631e+04,
+      "real_time": 5.6028418416666664e+07,
+      "cpu_time": 3.5706666666375975e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.6080066666666664e-06
+      "IterationTime": 5.6028418416666670e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_crta/256/manual_time",
@@ -2064,11 +2064,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1556738636363637e+07,
-      "cpu_time": 3.5843636363805133e+04,
+      "real_time": 3.1536759681818176e+07,
+      "cpu_time": 2.9896636363637506e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1556738636363639e-06
+      "IterationTime": 3.1536759681818178e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_crta/512/manual_time",
@@ -2080,11 +2080,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.2141473636363637e+07,
-      "cpu_time": 2.8825545455064952e+04,
+      "real_time": 3.2104809636363637e+07,
+      "cpu_time": 2.5467772727242020e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.2141473636363634e-06
+      "IterationTime": 3.2104809636363637e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_crta/1024/manual_time",
@@ -2096,11 +2096,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3600102999999993e+07,
-      "cpu_time": 2.8799904761794573e+04,
+      "real_time": 3.3625686285714284e+07,
+      "cpu_time": 3.0658476190870671e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.3600103000000001e-06
+      "IterationTime": 3.3625686285714287e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_crta/2048/manual_time",
@@ -2112,11 +2112,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8718421777777784e+07,
-      "cpu_time": 3.1148888889257854e+04,
+      "real_time": 3.8709389944444433e+07,
+      "cpu_time": 2.6176777777682975e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8718421777777786e-06
+      "IterationTime": 3.8709389944444427e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_crta/4096/manual_time",
@@ -2128,11 +2128,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.4202860874999985e+07,
-      "cpu_time": 3.6188124999725347e+04,
+      "real_time": 4.3919995875000000e+07,
+      "cpu_time": 2.8304437499571122e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.4202860874999983e-06
+      "IterationTime": 4.3919995875000001e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_crta/8192/manual_time",
@@ -2144,11 +2144,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.6289752083333343e+07,
-      "cpu_time": 3.4515000000586348e+04,
+      "real_time": 5.6226498000000000e+07,
+      "cpu_time": 2.9247499999958865e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.6289752083333334e-06
+      "IterationTime": 5.6226498000000004e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_crta/256/manual_time",
@@ -2159,12 +2159,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 22,
-      "real_time": 3.2556292409090903e+07,
-      "cpu_time": 3.4101045454416511e+04,
+      "iterations": 21,
+      "real_time": 3.2617301904761903e+07,
+      "cpu_time": 4.8819238095293695e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.2556292409090904e-06
+      "IterationTime": 3.2617301904761906e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_crta/512/manual_time",
@@ -2176,11 +2176,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.2976265476190481e+07,
-      "cpu_time": 3.0476095237948659e+04,
+      "real_time": 3.2986515238095239e+07,
+      "cpu_time": 2.8768095238736652e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.2976265476190479e-06
+      "IterationTime": 3.2986515238095237e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_crta/1024/manual_time",
@@ -2192,11 +2192,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.4566151600000001e+07,
-      "cpu_time": 3.1146999999975833e+04,
+      "real_time": 3.4579847349999994e+07,
+      "cpu_time": 2.8816350000226976e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.4566151600000000e-06
+      "IterationTime": 3.4579847349999995e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_crta/2048/manual_time",
@@ -2208,11 +2208,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9362334111111112e+07,
-      "cpu_time": 3.0151666667027006e+04,
+      "real_time": 3.9360418666666672e+07,
+      "cpu_time": 3.1653222222871595e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9362334111111120e-06
+      "IterationTime": 3.9360418666666676e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_crta/4096/manual_time",
@@ -2224,11 +2224,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.5137553875000000e+07,
-      "cpu_time": 3.8637499999438776e+04,
+      "real_time": 4.4983336437499993e+07,
+      "cpu_time": 3.0270687500610904e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.5137553875000001e-06
+      "IterationTime": 4.4983336437499993e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_crta/8192/manual_time",
@@ -2240,11 +2240,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.7266217750000000e+07,
-      "cpu_time": 3.1025166666864836e+04,
+      "real_time": 5.7257084583333336e+07,
+      "cpu_time": 3.2879916666672674e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.7266217749999994e-06
+      "IterationTime": 5.7257084583333338e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/256/manual_time",
@@ -2256,11 +2256,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 25,
-      "real_time": 2.7486424439999994e+07,
-      "cpu_time": 2.9854480000039985e+04,
+      "real_time": 2.7653408640000004e+07,
+      "cpu_time": 2.5724120000063522e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7486424440000001e-06
+      "IterationTime": 2.7653408640000004e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/512/manual_time",
@@ -2272,11 +2272,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 25,
-      "real_time": 2.7675039680000000e+07,
-      "cpu_time": 3.0830399999786096e+04,
+      "real_time": 2.7694651920000006e+07,
+      "cpu_time": 2.4059360000023840e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7675039679999998e-06
+      "IterationTime": 2.7694651920000007e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/1024/manual_time",
@@ -2288,11 +2288,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 25,
-      "real_time": 2.7837206160000004e+07,
-      "cpu_time": 3.0028799999968214e+04,
+      "real_time": 2.7982135000000011e+07,
+      "cpu_time": 2.5178359999813438e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7837206160000004e-06
+      "IterationTime": 2.7982135000000013e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/2048/manual_time",
@@ -2304,11 +2304,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 24,
-      "real_time": 2.8668896125000000e+07,
-      "cpu_time": 3.0187083333762148e+04,
+      "real_time": 2.9061202916666672e+07,
+      "cpu_time": 2.6241250000206641e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.8668896125000002e-06
+      "IterationTime": 2.9061202916666675e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/4096/manual_time",
@@ -2320,11 +2320,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 23,
-      "real_time": 3.0247232739130434e+07,
-      "cpu_time": 2.9282608695246421e+04,
+      "real_time": 3.0298737739130426e+07,
+      "cpu_time": 2.4571260869675902e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0247232739130436e-06
+      "IterationTime": 3.0298737739130427e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/8192/manual_time",
@@ -2336,11 +2336,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.2766895285714287e+07,
-      "cpu_time": 2.9217142857381383e+04,
+      "real_time": 3.2869660095238090e+07,
+      "cpu_time": 2.3449142857213614e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.2766895285714288e-06
+      "IterationTime": 3.2869660095238084e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/256/manual_time",
@@ -2352,11 +2352,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 25,
-      "real_time": 2.7485982599999994e+07,
-      "cpu_time": 2.8508799999826806e+04,
+      "real_time": 2.7657870200000003e+07,
+      "cpu_time": 2.7334719999885237e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7485982599999994e-06
+      "IterationTime": 2.7657870200000002e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/512/manual_time",
@@ -2368,11 +2368,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 25,
-      "real_time": 2.7671905840000000e+07,
-      "cpu_time": 2.9286799999681534e+04,
+      "real_time": 2.7694331479999997e+07,
+      "cpu_time": 2.4273640000274099e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7671905840000001e-06
+      "IterationTime": 2.7694331479999997e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/1024/manual_time",
@@ -2384,11 +2384,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 25,
-      "real_time": 2.7837275480000000e+07,
-      "cpu_time": 2.9460000000085529e+04,
+      "real_time": 2.7983012960000005e+07,
+      "cpu_time": 2.3955999999998316e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7837275479999997e-06
+      "IterationTime": 2.7983012960000004e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/2048/manual_time",
@@ -2400,11 +2400,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 24,
-      "real_time": 2.9071018166666657e+07,
-      "cpu_time": 3.0935416666840374e+04,
+      "real_time": 2.9059524541666672e+07,
+      "cpu_time": 2.4367916666416058e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.9071018166666656e-06
+      "IterationTime": 2.9059524541666676e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/4096/manual_time",
@@ -2416,11 +2416,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 23,
-      "real_time": 3.0308427086956516e+07,
-      "cpu_time": 3.0510434782464152e+04,
+      "real_time": 3.0369445260869570e+07,
+      "cpu_time": 2.5573391304118082e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0308427086956518e-06
+      "IterationTime": 3.0369445260869569e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/8192/manual_time",
@@ -2432,11 +2432,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3106714285714287e+07,
-      "cpu_time": 2.9668047618867735e+04,
+      "real_time": 3.3182267952380948e+07,
+      "cpu_time": 2.7522952381429735e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.3106714285714284e-06
+      "IterationTime": 3.3182267952380948e-06
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/256/manual_time",
@@ -2448,11 +2448,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 9.6452451428571433e+07,
-      "cpu_time": 3.1853999997468109e+04,
+      "real_time": 9.6361016285714284e+07,
+      "cpu_time": 3.5468714283329711e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 9.6452451428571415e-06
+      "IterationTime": 9.6361016285714274e-06
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/512/manual_time",
@@ -2464,11 +2464,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 9.6886154714285731e+07,
-      "cpu_time": 3.6565714282232875e+04,
+      "real_time": 9.6781881428571433e+07,
+      "cpu_time": 2.8677428567951727e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 9.6886154714285722e-06
+      "IterationTime": 9.6781881428571435e-06
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/1024/manual_time",
@@ -2480,11 +2480,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 9.8551025142857149e+07,
-      "cpu_time": 3.7288571426025948e+04,
+      "real_time": 9.8440183999999985e+07,
+      "cpu_time": 2.8715571427743009e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 9.8551025142857139e-06
+      "IterationTime": 9.8440183999999999e-06
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/2048/manual_time",
@@ -2496,11 +2496,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0316530314285712e+08,
-      "cpu_time": 3.4631428572343531e+04,
+      "real_time": 1.0310912785714284e+08,
+      "cpu_time": 2.7686000001787241e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0316530314285714e-05
+      "IterationTime": 1.0310912785714285e-05
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/4096/manual_time",
@@ -2512,11 +2512,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.0895014383333333e+08,
-      "cpu_time": 4.0213500000163549e+04,
+      "real_time": 1.0877676516666669e+08,
+      "cpu_time": 3.3070166665538636e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0895014383333332e-05
+      "IterationTime": 1.0877676516666667e-05
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/8192/manual_time",
@@ -2528,11 +2528,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.2211488450000000e+08,
-      "cpu_time": 3.6743333329998983e+04,
+      "real_time": 1.2221235533333331e+08,
+      "cpu_time": 6.1976833331793081e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2211488450000001e-05
+      "IterationTime": 1.2221235533333331e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/256/manual_time",
@@ -2544,11 +2544,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0466645185714288e+08,
-      "cpu_time": 4.1416571426517679e+04,
+      "real_time": 1.0609567914285715e+08,
+      "cpu_time": 3.7935714289005773e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0466645185714287e-05
+      "IterationTime": 1.0609567914285716e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/512/manual_time",
@@ -2560,11 +2560,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0592315885714288e+08,
-      "cpu_time": 3.7151428569716569e+04,
+      "real_time": 1.0743208085714285e+08,
+      "cpu_time": 3.3641285714988306e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0592315885714287e-05
+      "IterationTime": 1.0743208085714287e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/1024/manual_time",
@@ -2576,11 +2576,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.0860456116666664e+08,
-      "cpu_time": 3.8110000000794265e+04,
+      "real_time": 1.1011154133333333e+08,
+      "cpu_time": 3.2434833334112529e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0860456116666664e-05
+      "IterationTime": 1.1011154133333335e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/2048/manual_time",
@@ -2592,11 +2592,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.2492647233333333e+08,
-      "cpu_time": 3.8308333335142677e+04,
+      "real_time": 1.2392876750000000e+08,
+      "cpu_time": 3.3454999998146675e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2492647233333333e-05
+      "IterationTime": 1.2392876749999999e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/4096/manual_time",
@@ -2608,11 +2608,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.7375641100000000e+08,
-      "cpu_time": 4.1009999996788334e+04,
+      "real_time": 1.7373006475000000e+08,
+      "cpu_time": 2.8775000004088724e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.7375641100000001e-05
+      "IterationTime": 1.7373006475000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/8192/manual_time",
@@ -2624,11 +2624,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 3,
-      "real_time": 2.7221030666666663e+08,
-      "cpu_time": 3.9313333331847389e+04,
+      "real_time": 2.7343089233333337e+08,
+      "cpu_time": 5.7776666665176890e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7221030666666664e-05
+      "IterationTime": 2.7343089233333337e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_rta_trace/256/manual_time",
@@ -2639,12 +2639,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 6,
-      "real_time": 1.2395146466666667e+08,
-      "cpu_time": 3.5424999997720384e+04,
+      "iterations": 5,
+      "real_time": 1.3934175859999999e+08,
+      "cpu_time": 3.6019999998870844e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2395146466666665e-05
+      "IterationTime": 1.3934175860000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_rta_trace/512/manual_time",
@@ -2655,12 +2655,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 6,
-      "real_time": 1.2513981516666664e+08,
-      "cpu_time": 3.9584999996122860e+04,
+      "iterations": 5,
+      "real_time": 1.4072436000000003e+08,
+      "cpu_time": 4.2530399997531276e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2513981516666666e-05
+      "IterationTime": 1.4072436000000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_rta_trace/1024/manual_time",
@@ -2672,11 +2672,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.2801846120000000e+08,
-      "cpu_time": 3.6856000002671863e+04,
+      "real_time": 1.4356670059999999e+08,
+      "cpu_time": 5.9365999999272390e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2801846120000000e-05
+      "IterationTime": 1.4356670060000000e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_rta_trace/2048/manual_time",
@@ -2688,11 +2688,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.4598639000000000e+08,
-      "cpu_time": 3.8185799996881542e+04,
+      "real_time": 1.5021266640000001e+08,
+      "cpu_time": 7.8180000002703309e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.4598638999999998e-05
+      "IterationTime": 1.5021266639999999e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_rta_trace/4096/manual_time",
@@ -2704,11 +2704,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.9496776150000000e+08,
-      "cpu_time": 3.9135000001522261e+04,
+      "real_time": 1.9595961250000003e+08,
+      "cpu_time": 5.3842249997160252e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.9496776149999998e-05
+      "IterationTime": 1.9595961250000002e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_rta_trace/8192/manual_time",
@@ -2720,11 +2720,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 2.9353013950000000e+08,
-      "cpu_time": 1.0313549999807493e+05,
+      "real_time": 2.9564689600000000e+08,
+      "cpu_time": 7.2959000007699622e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.9353013950000001e-05
+      "IterationTime": 2.9564689600000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_128_rta_trace/256/manual_time",
@@ -2735,12 +2735,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 6,
-      "real_time": 1.2558379599999999e+08,
-      "cpu_time": 7.1885000001733119e+04,
+      "iterations": 4,
+      "real_time": 1.6012347225000000e+08,
+      "cpu_time": 3.2837250003581175e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2558379600000000e-05
+      "IterationTime": 1.6012347224999999e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_128_rta_trace/512/manual_time",
@@ -2751,12 +2751,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 6,
-      "real_time": 1.2703990849999999e+08,
-      "cpu_time": 8.3613166665941200e+04,
+      "iterations": 4,
+      "real_time": 1.5780363675000000e+08,
+      "cpu_time": 3.3980250002230154e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2703990849999997e-05
+      "IterationTime": 1.5780363675000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_128_rta_trace/1024/manual_time",
@@ -2767,12 +2767,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 5,
-      "real_time": 1.3012868560000002e+08,
-      "cpu_time": 4.4161799996800255e+04,
+      "iterations": 4,
+      "real_time": 1.6586171575000000e+08,
+      "cpu_time": 4.4127500004265130e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.3012868560000002e-05
+      "IterationTime": 1.6586171575000000e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_128_rta_trace/2048/manual_time",
@@ -2783,12 +2783,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 4,
-      "real_time": 1.6049008274999997e+08,
-      "cpu_time": 8.8172499999927823e+04,
+      "iterations": 3,
+      "real_time": 2.0487747600000000e+08,
+      "cpu_time": 4.5823333332843205e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.6049008274999997e-05
+      "IterationTime": 2.0487747599999999e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_128_rta_trace/4096/manual_time",
@@ -2800,11 +2800,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 3,
-      "real_time": 2.0958260866666663e+08,
-      "cpu_time": 1.0074000000296715e+05,
+      "real_time": 2.5468642700000003e+08,
+      "cpu_time": 3.7336666669792372e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.0958260866666662e-05
+      "IterationTime": 2.5468642700000005e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_128_rta_trace/8192/manual_time",
@@ -2816,11 +2816,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 3.0809477050000000e+08,
-      "cpu_time": 8.8825500000666580e+04,
+      "real_time": 3.5398865900000000e+08,
+      "cpu_time": 7.8465499996127619e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0809477049999997e-05
+      "IterationTime": 3.5398865900000000e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_cb_trace/256/manual_time",
@@ -2831,12 +2831,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 7,
-      "real_time": 1.0751938885714285e+08,
-      "cpu_time": 1.0982000000175113e+05,
+      "iterations": 6,
+      "real_time": 1.0897220650000000e+08,
+      "cpu_time": 4.0701333333004186e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0751938885714286e-05
+      "IterationTime": 1.0897220650000000e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_cb_trace/512/manual_time",
@@ -2848,11 +2848,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.0881808966666667e+08,
-      "cpu_time": 2.7236666667818103e+04,
+      "real_time": 1.1035688483333333e+08,
+      "cpu_time": 5.8476666666251731e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0881808966666668e-05
+      "IterationTime": 1.1035688483333333e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_cb_trace/1024/manual_time",
@@ -2864,11 +2864,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1173212883333333e+08,
-      "cpu_time": 6.9014999998747357e+04,
+      "real_time": 1.1324363650000000e+08,
+      "cpu_time": 3.6608166662214593e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1173212883333333e-05
+      "IterationTime": 1.1324363650000000e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_cb_trace/2048/manual_time",
@@ -2879,12 +2879,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 5,
-      "real_time": 1.2782682940000001e+08,
-      "cpu_time": 1.0683180000228276e+05,
+      "iterations": 6,
+      "real_time": 1.2687886383333336e+08,
+      "cpu_time": 6.1886500001643675e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2782682940000000e-05
+      "IterationTime": 1.2687886383333335e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_cb_trace/4096/manual_time",
@@ -2896,11 +2896,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.7678185800000000e+08,
-      "cpu_time": 3.5022250003180488e+04,
+      "real_time": 1.7732599000000000e+08,
+      "cpu_time": 4.5745000001318200e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.7678185799999998e-05
+      "IterationTime": 1.7732599000000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_cb_trace/8192/manual_time",
@@ -2912,11 +2912,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 3,
-      "real_time": 2.7482459066666669e+08,
-      "cpu_time": 7.4033333334000417e+04,
+      "real_time": 2.7618393066666669e+08,
+      "cpu_time": 3.8486666672573243e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7482459066666668e-05
+      "IterationTime": 2.7618393066666674e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_32_cb_trace/256/manual_time",
@@ -2927,12 +2927,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 7,
-      "real_time": 1.0756220671428570e+08,
-      "cpu_time": 6.7939999999972715e+04,
+      "iterations": 6,
+      "real_time": 1.0951530266666667e+08,
+      "cpu_time": 5.7089666668730388e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0756220671428570e-05
+      "IterationTime": 1.0951530266666665e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_32_cb_trace/512/manual_time",
@@ -2944,11 +2944,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.0900317800000000e+08,
-      "cpu_time": 1.1326999999994313e+05,
+      "real_time": 1.1086583899999999e+08,
+      "cpu_time": 3.1306500000975269e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0900317799999999e-05
+      "IterationTime": 1.1086583899999998e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_32_cb_trace/1024/manual_time",
@@ -2960,11 +2960,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1183981800000000e+08,
-      "cpu_time": 4.1493500001858287e+04,
+      "real_time": 1.1383721950000001e+08,
+      "cpu_time": 4.6948499999643907e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1183981799999999e-05
+      "IterationTime": 1.1383721950000002e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_32_cb_trace/2048/manual_time",
@@ -2975,12 +2975,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 5,
-      "real_time": 1.2796905400000003e+08,
-      "cpu_time": 1.3547159999802714e+05,
+      "iterations": 6,
+      "real_time": 1.2694400383333333e+08,
+      "cpu_time": 3.1630166669553244e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2796905400000001e-05
+      "IterationTime": 1.2694400383333336e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_32_cb_trace/4096/manual_time",
@@ -2992,11 +2992,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.7702183750000000e+08,
-      "cpu_time": 1.1934249999967506e+05,
+      "real_time": 1.7755028275000000e+08,
+      "cpu_time": 6.5604750005832102e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.7702183749999999e-05
+      "IterationTime": 1.7755028275000002e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_32_cb_trace/8192/manual_time",
@@ -3008,11 +3008,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 3,
-      "real_time": 2.7501781000000006e+08,
-      "cpu_time": 7.9560666667551544e+04,
+      "real_time": 2.7622938666666669e+08,
+      "cpu_time": 5.5713333334021328e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7501781000000000e-05
+      "IterationTime": 2.7622938666666670e-05
     },
     {
       "name": "BM_pgm_dispatch/10000_kernel_all_cores_all_processors_32_cbs_trace/256/manual_time",
@@ -3024,11 +3024,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1502983416666667e+08,
-      "cpu_time": 4.5136666666204896e+04,
+      "real_time": 1.1540100816666664e+08,
+      "cpu_time": 5.5522000001436332e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1502983416666666e-05
+      "IterationTime": 1.1540100816666665e-05
     },
     {
       "name": "BM_pgm_dispatch/10000_kernel_all_cores_all_processors_32_cbs_trace/512/manual_time",
@@ -3040,11 +3040,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1504876000000000e+08,
-      "cpu_time": 3.7608333334067844e+04,
+      "real_time": 1.1541093466666667e+08,
+      "cpu_time": 4.8775000000963097e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1504876000000002e-05
+      "IterationTime": 1.1541093466666666e-05
     },
     {
       "name": "BM_pgm_dispatch/10000_kernel_all_cores_all_processors_32_cbs_trace/1024/manual_time",
@@ -3056,11 +3056,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1505655600000000e+08,
-      "cpu_time": 4.0178500000820350e+04,
+      "real_time": 1.1545785316666667e+08,
+      "cpu_time": 6.4411666670594052e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1505655599999999e-05
+      "IterationTime": 1.1545785316666667e-05
     },
     {
       "name": "BM_pgm_dispatch/10000_kernel_all_cores_all_processors_32_cbs_trace/2048/manual_time",
@@ -3072,11 +3072,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1511971083333333e+08,
-      "cpu_time": 3.6601833334278432e+04,
+      "real_time": 1.1550619000000000e+08,
+      "cpu_time": 4.6732166666174635e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1511971083333334e-05
+      "IterationTime": 1.1550618999999999e-05
     },
     {
       "name": "BM_pgm_dispatch/10000_kernel_all_cores_all_processors_32_cbs_trace/4096/manual_time",
@@ -3088,11 +3088,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1543584533333333e+08,
-      "cpu_time": 3.9220000000265522e+04,
+      "real_time": 1.1589404250000001e+08,
+      "cpu_time": 7.6092000000471671e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1543584533333335e-05
+      "IterationTime": 1.1589404250000001e-05
     },
     {
       "name": "BM_pgm_dispatch/10000_kernel_all_cores_all_processors_32_cbs_trace/8192/manual_time",
@@ -3104,11 +3104,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.5765007800000000e+08,
-      "cpu_time": 3.9572499993312245e+04,
+      "real_time": 1.5810557400000000e+08,
+      "cpu_time": 4.2952500002968460e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.5765007800000001e-05
+      "IterationTime": 1.5810557399999999e-05
     },
     {
       "name": "BM_pgm_dispatch/5000_kernel_all_cores_all_processors_32_cbs_trace/256/manual_time",
@@ -3120,11 +3120,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.4289722272727273e+07,
-      "cpu_time": 3.5262727273923454e+04,
+      "real_time": 6.4644007454545453e+07,
+      "cpu_time": 3.0462727272089815e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.4289722272727276e-06
+      "IterationTime": 6.4644007454545449e-06
     },
     {
       "name": "BM_pgm_dispatch/5000_kernel_all_cores_all_processors_32_cbs_trace/512/manual_time",
@@ -3136,11 +3136,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.4297879000000000e+07,
-      "cpu_time": 3.7149727272766206e+04,
+      "real_time": 6.4664059272727281e+07,
+      "cpu_time": 4.3711727272466305e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.4297879000000004e-06
+      "IterationTime": 6.4664059272727290e-06
     },
     {
       "name": "BM_pgm_dispatch/5000_kernel_all_cores_all_processors_32_cbs_trace/1024/manual_time",
@@ -3152,11 +3152,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.4318862818181805e+07,
-      "cpu_time": 3.2681818181985862e+04,
+      "real_time": 6.4685669272727273e+07,
+      "cpu_time": 2.8602090907270394e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.4318862818181803e-06
+      "IterationTime": 6.4685669272727262e-06
     },
     {
       "name": "BM_pgm_dispatch/5000_kernel_all_cores_all_processors_32_cbs_trace/2048/manual_time",
@@ -3168,11 +3168,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.4380087909090899e+07,
-      "cpu_time": 3.3895454544625121e+04,
+      "real_time": 6.4795312363636367e+07,
+      "cpu_time": 5.2309999998359752e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.4380087909090891e-06
+      "IterationTime": 6.4795312363636361e-06
     },
     {
       "name": "BM_pgm_dispatch/5000_kernel_all_cores_all_processors_32_cbs_trace/4096/manual_time",
@@ -3184,11 +3184,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.4727060636363633e+07,
-      "cpu_time": 3.5970909090627341e+04,
+      "real_time": 6.5159211363636352e+07,
+      "cpu_time": 4.8664272725318369e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.4727060636363635e-06
+      "IterationTime": 6.5159211363636357e-06
     },
     {
       "name": "BM_pgm_dispatch/5000_kernel_all_cores_all_processors_32_cbs_trace/8192/manual_time",
@@ -3200,11 +3200,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.0750604283333333e+08,
-      "cpu_time": 3.0728333333248276e+04,
+      "real_time": 1.0801896883333331e+08,
+      "cpu_time": 6.7356833331662827e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0750604283333333e-05
+      "IterationTime": 1.0801896883333330e-05
     },
     {
       "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/0/manual_time",
@@ -3216,11 +3216,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 28,
-      "real_time": 2.4880176428571433e+07,
-      "cpu_time": 2.6509535715035781e+04,
+      "real_time": 2.4894119535714280e+07,
+      "cpu_time": 2.8224607142135483e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.4880176428571435e-06
+      "IterationTime": 2.4894119535714282e-06
     },
     {
       "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/1000/manual_time",
@@ -3232,11 +3232,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 28,
-      "real_time": 2.4939170035714287e+07,
-      "cpu_time": 8.8762178571804325e+04,
+      "real_time": 2.4885972750000000e+07,
+      "cpu_time": 2.3407071428290950e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.4939170035714287e-06
+      "IterationTime": 2.4885972749999997e-06
     },
     {
       "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/2000/manual_time",
@@ -3248,11 +3248,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 25,
-      "real_time": 2.7992449799999990e+07,
-      "cpu_time": 4.4429600000057690e+04,
+      "real_time": 2.8436812000000004e+07,
+      "cpu_time": 2.6241199999503806e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7992449799999991e-06
+      "IterationTime": 2.8436812000000004e-06
     },
     {
       "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/3000/manual_time",
@@ -3264,11 +3264,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8174875166666657e+07,
-      "cpu_time": 6.4250555554836959e+04,
+      "real_time": 3.8496499888888888e+07,
+      "cpu_time": 3.8392777777100186e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8174875166666661e-06
+      "IterationTime": 3.8496499888888891e-06
     },
     {
       "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/4000/manual_time",
@@ -3280,11 +3280,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 14,
-      "real_time": 4.8327116357142858e+07,
-      "cpu_time": 2.4028571429214808e+04,
+      "real_time": 4.8646162857142866e+07,
+      "cpu_time": 2.8859071428704348e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.8327116357142854e-06
+      "IterationTime": 4.8646162857142864e-06
     },
     {
       "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/5000/manual_time",
@@ -3296,11 +3296,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.8535205250000000e+07,
-      "cpu_time": 4.7260583334226190e+04,
+      "real_time": 5.8838054166666664e+07,
+      "cpu_time": 4.2280083332476199e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.8535205249999998e-06
+      "IterationTime": 5.8838054166666662e-06
     },
     {
       "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/10000/manual_time",
@@ -3312,15 +3312,127 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.0929533200000000e+08,
-      "cpu_time": 1.1090883333508827e+05,
+      "real_time": 1.0962255750000001e+08,
+      "cpu_time": 1.0624016666819596e+05,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0929533199999999e-05
+      "IterationTime": 1.0962255750000001e-05
+    },
+    {
+      "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_left_processors_subdevices_trace/0/manual_time",
+      "family_index": 33,
+      "per_family_instance_index": 0,
+      "run_name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_left_processors_subdevices_trace/0/manual_time",
+      "run_type": "iteration",
+      "repetitions": 1,
+      "repetition_index": 0,
+      "threads": 1,
+      "iterations": 28,
+      "real_time": 2.4917392142857146e+07,
+      "cpu_time": 3.6366821429315416e+04,
+      "time_unit": "ns",
+      "Clock": 1.0000000000000000e+03,
+      "IterationTime": 2.4917392142857148e-06
+    },
+    {
+      "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_left_processors_subdevices_trace/1000/manual_time",
+      "family_index": 33,
+      "per_family_instance_index": 1,
+      "run_name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_left_processors_subdevices_trace/1000/manual_time",
+      "run_type": "iteration",
+      "repetitions": 1,
+      "repetition_index": 0,
+      "threads": 1,
+      "iterations": 28,
+      "real_time": 2.4894058142857138e+07,
+      "cpu_time": 2.8940035713885336e+04,
+      "time_unit": "ns",
+      "Clock": 1.0000000000000000e+03,
+      "IterationTime": 2.4894058142857139e-06
+    },
+    {
+      "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_left_processors_subdevices_trace/2000/manual_time",
+      "family_index": 33,
+      "per_family_instance_index": 2,
+      "run_name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_left_processors_subdevices_trace/2000/manual_time",
+      "run_type": "iteration",
+      "repetitions": 1,
+      "repetition_index": 0,
+      "threads": 1,
+      "iterations": 26,
+      "real_time": 2.7003694615384605e+07,
+      "cpu_time": 4.7985076923632383e+04,
+      "time_unit": "ns",
+      "Clock": 1.0000000000000000e+03,
+      "IterationTime": 2.7003694615384606e-06
+    },
+    {
+      "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_left_processors_subdevices_trace/3000/manual_time",
+      "family_index": 33,
+      "per_family_instance_index": 3,
+      "run_name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_left_processors_subdevices_trace/3000/manual_time",
+      "run_type": "iteration",
+      "repetitions": 1,
+      "repetition_index": 0,
+      "threads": 1,
+      "iterations": 19,
+      "real_time": 3.7033377052631587e+07,
+      "cpu_time": 3.0652105263434827e+04,
+      "time_unit": "ns",
+      "Clock": 1.0000000000000000e+03,
+      "IterationTime": 3.7033377052631588e-06
+    },
+    {
+      "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_left_processors_subdevices_trace/4000/manual_time",
+      "family_index": 33,
+      "per_family_instance_index": 4,
+      "run_name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_left_processors_subdevices_trace/4000/manual_time",
+      "run_type": "iteration",
+      "repetitions": 1,
+      "repetition_index": 0,
+      "threads": 1,
+      "iterations": 15,
+      "real_time": 4.7190159533333339e+07,
+      "cpu_time": 2.8654200000725417e+04,
+      "time_unit": "ns",
+      "Clock": 1.0000000000000000e+03,
+      "IterationTime": 4.7190159533333344e-06
+    },
+    {
+      "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_left_processors_subdevices_trace/5000/manual_time",
+      "family_index": 33,
+      "per_family_instance_index": 5,
+      "run_name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_left_processors_subdevices_trace/5000/manual_time",
+      "run_type": "iteration",
+      "repetitions": 1,
+      "repetition_index": 0,
+      "threads": 1,
+      "iterations": 12,
+      "real_time": 5.7366797333333321e+07,
+      "cpu_time": 5.0063333335496434e+04,
+      "time_unit": "ns",
+      "Clock": 1.0000000000000000e+03,
+      "IterationTime": 5.7366797333333326e-06
+    },
+    {
+      "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_left_processors_subdevices_trace/10000/manual_time",
+      "family_index": 33,
+      "per_family_instance_index": 6,
+      "run_name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_left_processors_subdevices_trace/10000/manual_time",
+      "run_type": "iteration",
+      "repetitions": 1,
+      "repetition_index": 0,
+      "threads": 1,
+      "iterations": 6,
+      "real_time": 1.0815294900000000e+08,
+      "cpu_time": 9.1371666670170263e+04,
+      "time_unit": "ns",
+      "Clock": 1.0000000000000000e+03,
+      "IterationTime": 1.0815294899999999e-05
     },
     {
       "name": "BM_pgm_dispatch/load_prefetcher_test/512/manual_time",
-      "family_index": 33,
+      "family_index": 34,
       "per_family_instance_index": 0,
       "run_name": "BM_pgm_dispatch/load_prefetcher_test/512/manual_time",
       "run_type": "iteration",
@@ -3328,15 +3440,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 5.5661048970000000e+09,
-      "cpu_time": 7.0620000002463712e+04,
+      "real_time": 5.5620984980000000e+09,
+      "cpu_time": 7.6070000005756810e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.8990129671874995e-06
+      "IterationTime": 2.8969263010416670e-06
     },
     {
       "name": "BM_pgm_dispatch/load_prefetcher_test/1024/manual_time",
-      "family_index": 33,
+      "family_index": 34,
       "per_family_instance_index": 1,
       "run_name": "BM_pgm_dispatch/load_prefetcher_test/1024/manual_time",
       "run_type": "iteration",
@@ -3344,15 +3456,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 3.9173599660000000e+09,
-      "cpu_time": 7.2719999991477380e+04,
+      "real_time": 3.9256019690000000e+09,
+      "cpu_time": 7.3401000008743722e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0604374734374996e-06
+      "IterationTime": 3.0668765382812501e-06
     },
     {
       "name": "BM_pgm_dispatch/load_prefetcher_test/2048/manual_time",
-      "family_index": 33,
+      "family_index": 34,
       "per_family_instance_index": 2,
       "run_name": "BM_pgm_dispatch/load_prefetcher_test/2048/manual_time",
       "run_type": "iteration",
@@ -3360,15 +3472,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 2.6840886390000000e+09,
-      "cpu_time": 9.3710999976792664e+04,
+      "real_time": 2.6786923330000000e+09,
+      "cpu_time": 6.7690999998148982e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.4858294012987015e-06
+      "IterationTime": 3.4788212116883113e-06
     },
     {
       "name": "BM_pgm_dispatch/load_prefetcher_test/4096/manual_time",
-      "family_index": 33,
+      "family_index": 34,
       "per_family_instance_index": 3,
       "run_name": "BM_pgm_dispatch/load_prefetcher_test/4096/manual_time",
       "run_type": "iteration",
@@ -3376,15 +3488,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.5836977890000000e+09,
-      "cpu_time": 4.6709999992344819e+04,
+      "real_time": 1.5774996630000000e+09,
+      "cpu_time": 7.1269999978085252e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.1135007506493499e-06
+      "IterationTime": 4.0974017220779220e-06
     },
     {
       "name": "BM_pgm_dispatch/load_prefetcher_test/8192/manual_time",
-      "family_index": 33,
+      "family_index": 34,
       "per_family_instance_index": 4,
       "run_name": "BM_pgm_dispatch/load_prefetcher_test/8192/manual_time",
       "run_type": "iteration",
@@ -3392,15 +3504,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.2056632970000000e+09,
-      "cpu_time": 7.0839999978034029e+04,
+      "real_time": 1.2018874460000000e+09,
+      "cpu_time": 6.5269999993233796e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.1828887025641032e-06
+      "IterationTime": 6.1635253641025643e-06
     },
     {
       "name": "BM_pgm_dispatch/load_prefetcher_test/12288/manual_time",
-      "family_index": 33,
+      "family_index": 34,
       "per_family_instance_index": 5,
       "run_name": "BM_pgm_dispatch/load_prefetcher_test/12288/manual_time",
       "run_type": "iteration",
@@ -3408,15 +3520,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 9.2614496300000000e+08,
-      "cpu_time": 6.4489999999750580e+04,
+      "real_time": 9.2940377400000000e+08,
+      "cpu_time": 6.1099999982161535e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 7.1241920230769240e-06
+      "IterationTime": 7.1492598000000002e-06
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/256/manual_time",
-      "family_index": 34,
+      "family_index": 35,
       "per_family_instance_index": 0,
       "run_name": "BM_pgm_dispatch/kernel_groups_4_shadow/256/manual_time",
       "run_type": "iteration",
@@ -3424,15 +3536,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 4.6951171100000000e+08,
-      "cpu_time": 5.8854500011307209e+04,
+      "real_time": 4.7859938900000000e+08,
+      "cpu_time": 9.2275500009009193e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.6951171100000004e-05
+      "IterationTime": 4.7859938900000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/512/manual_time",
-      "family_index": 34,
+      "family_index": 35,
       "per_family_instance_index": 1,
       "run_name": "BM_pgm_dispatch/kernel_groups_4_shadow/512/manual_time",
       "run_type": "iteration",
@@ -3440,15 +3552,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 4.7604925000000000e+08,
-      "cpu_time": 4.1814999988787349e+04,
+      "real_time": 4.8527555000000000e+08,
+      "cpu_time": 7.1860000019796644e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.7604924999999997e-05
+      "IterationTime": 4.8527554999999996e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/1024/manual_time",
-      "family_index": 34,
+      "family_index": 35,
       "per_family_instance_index": 2,
       "run_name": "BM_pgm_dispatch/kernel_groups_4_shadow/1024/manual_time",
       "run_type": "iteration",
@@ -3456,15 +3568,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 4.8908915750000000e+08,
-      "cpu_time": 4.3200000007459494e+04,
+      "real_time": 4.9813997000000000e+08,
+      "cpu_time": 8.7874499996587474e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.8908915750000000e-05
+      "IterationTime": 4.9813996999999993e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/2048/manual_time",
-      "family_index": 34,
+      "family_index": 35,
       "per_family_instance_index": 3,
       "run_name": "BM_pgm_dispatch/kernel_groups_4_shadow/2048/manual_time",
       "run_type": "iteration",
@@ -3472,15 +3584,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 5.2438413500000000e+08,
-      "cpu_time": 5.8850000016263948e+04,
+      "real_time": 5.2850054599999994e+08,
+      "cpu_time": 4.7450000010940130e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.2438413499999996e-05
+      "IterationTime": 5.2850054600000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/4096/manual_time",
-      "family_index": 34,
+      "family_index": 35,
       "per_family_instance_index": 4,
       "run_name": "BM_pgm_dispatch/kernel_groups_4_shadow/4096/manual_time",
       "run_type": "iteration",
@@ -3488,15 +3600,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 8.0039272200000000e+08,
-      "cpu_time": 6.7739999991545119e+04,
+      "real_time": 8.0622255200000000e+08,
+      "cpu_time": 6.0800999960974877e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 8.0039272200000005e-05
+      "IterationTime": 8.0622255199999996e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/8192/manual_time",
-      "family_index": 34,
+      "family_index": 35,
       "per_family_instance_index": 5,
       "run_name": "BM_pgm_dispatch/kernel_groups_4_shadow/8192/manual_time",
       "run_type": "iteration",
@@ -3504,15 +3616,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.4214700190000000e+09,
-      "cpu_time": 6.7029999996748302e+04,
+      "real_time": 1.4351456840000000e+09,
+      "cpu_time": 5.9789000033561024e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.4214700190000001e-04
+      "IterationTime": 1.4351456840000000e-04
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/256/manual_time",
-      "family_index": 35,
+      "family_index": 36,
       "per_family_instance_index": 0,
       "run_name": "BM_pgm_dispatch/kernel_groups_5_shadow/256/manual_time",
       "run_type": "iteration",
@@ -3520,15 +3632,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 5.6355384200000000e+08,
-      "cpu_time": 5.3519999994477985e+04,
+      "real_time": 5.7464394600000000e+08,
+      "cpu_time": 6.3119999992977682e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.6355384200000005e-05
+      "IterationTime": 5.7464394599999998e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/512/manual_time",
-      "family_index": 35,
+      "family_index": 36,
       "per_family_instance_index": 1,
       "run_name": "BM_pgm_dispatch/kernel_groups_5_shadow/512/manual_time",
       "run_type": "iteration",
@@ -3536,15 +3648,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 5.7112508400000000e+08,
-      "cpu_time": 4.5710999984294176e+04,
+      "real_time": 5.8234138300000000e+08,
+      "cpu_time": 7.0710999978018663e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.7112508399999994e-05
+      "IterationTime": 5.8234138300000004e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/1024/manual_time",
-      "family_index": 35,
+      "family_index": 36,
       "per_family_instance_index": 2,
       "run_name": "BM_pgm_dispatch/kernel_groups_5_shadow/1024/manual_time",
       "run_type": "iteration",
@@ -3552,15 +3664,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 5.8656288100000000e+08,
-      "cpu_time": 3.9082000000689732e+04,
+      "real_time": 5.9805866000000000e+08,
+      "cpu_time": 4.8268999989886652e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.8656288099999995e-05
+      "IterationTime": 5.9805865999999996e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/2048/manual_time",
-      "family_index": 35,
+      "family_index": 36,
       "per_family_instance_index": 3,
       "run_name": "BM_pgm_dispatch/kernel_groups_5_shadow/2048/manual_time",
       "run_type": "iteration",
@@ -3568,15 +3680,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 6.2989070900000000e+08,
-      "cpu_time": 4.3769999990672659e+04,
+      "real_time": 6.3739566300000000e+08,
+      "cpu_time": 4.6770000039941806e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.2989070899999999e-05
+      "IterationTime": 6.3739566299999997e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/4096/manual_time",
-      "family_index": 35,
+      "family_index": 36,
       "per_family_instance_index": 4,
       "run_name": "BM_pgm_dispatch/kernel_groups_5_shadow/4096/manual_time",
       "run_type": "iteration",
@@ -3584,15 +3696,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 9.2883005100000000e+08,
-      "cpu_time": 4.5679999999492793e+04,
+      "real_time": 9.3779535100000000e+08,
+      "cpu_time": 5.6760000006761402e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 9.2883005099999997e-05
+      "IterationTime": 9.3779535099999993e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/8192/manual_time",
-      "family_index": 35,
+      "family_index": 36,
       "per_family_instance_index": 5,
       "run_name": "BM_pgm_dispatch/kernel_groups_5_shadow/8192/manual_time",
       "run_type": "iteration",
@@ -3600,15 +3712,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.6514432550000000e+09,
-      "cpu_time": 8.5041000005503520e+04,
+      "real_time": 1.6618893070000000e+09,
+      "cpu_time": 5.5620000011913362e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.6514432549999999e-04
+      "IterationTime": 1.6618893069999998e-04
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/256/manual_time",
-      "family_index": 36,
+      "family_index": 37,
       "per_family_instance_index": 0,
       "run_name": "BM_pgm_dispatch/eth_dispatch/256/manual_time",
       "run_type": "iteration",
@@ -3616,15 +3728,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9250846444444448e+07,
-      "cpu_time": 2.5453333332987109e+04,
+      "real_time": 3.9132027777777776e+07,
+      "cpu_time": 2.5577222222257962e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9250846444444438e-06
+      "IterationTime": 3.9132027777777773e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/512/manual_time",
-      "family_index": 36,
+      "family_index": 37,
       "per_family_instance_index": 1,
       "run_name": "BM_pgm_dispatch/eth_dispatch/512/manual_time",
       "run_type": "iteration",
@@ -3632,15 +3744,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9244491833333343e+07,
-      "cpu_time": 2.9626111111408842e+04,
+      "real_time": 3.9136400555555552e+07,
+      "cpu_time": 3.1198333333451144e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9244491833333349e-06
+      "IterationTime": 3.9136400555555556e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/1024/manual_time",
-      "family_index": 36,
+      "family_index": 37,
       "per_family_instance_index": 2,
       "run_name": "BM_pgm_dispatch/eth_dispatch/1024/manual_time",
       "run_type": "iteration",
@@ -3648,15 +3760,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9267609555555552e+07,
-      "cpu_time": 3.4918888889339745e+04,
+      "real_time": 3.9141657277777776e+07,
+      "cpu_time": 3.3731111111971288e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9267609555555547e-06
+      "IterationTime": 3.9141657277777783e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/2048/manual_time",
-      "family_index": 36,
+      "family_index": 37,
       "per_family_instance_index": 3,
       "run_name": "BM_pgm_dispatch/eth_dispatch/2048/manual_time",
       "run_type": "iteration",
@@ -3664,15 +3776,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9252522833333343e+07,
-      "cpu_time": 3.2058388888521626e+04,
+      "real_time": 3.9138371666666664e+07,
+      "cpu_time": 3.3160722223455094e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9252522833333339e-06
+      "IterationTime": 3.9138371666666666e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/4096/manual_time",
-      "family_index": 36,
+      "family_index": 37,
       "per_family_instance_index": 4,
       "run_name": "BM_pgm_dispatch/eth_dispatch/4096/manual_time",
       "run_type": "iteration",
@@ -3680,15 +3792,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9268913999999985e+07,
-      "cpu_time": 2.4668888888375783e+04,
+      "real_time": 3.9133546111111119e+07,
+      "cpu_time": 2.7902777778384308e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9268913999999989e-06
+      "IterationTime": 3.9133546111111115e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/8192/manual_time",
-      "family_index": 36,
+      "family_index": 37,
       "per_family_instance_index": 5,
       "run_name": "BM_pgm_dispatch/eth_dispatch/8192/manual_time",
       "run_type": "iteration",
@@ -3696,31 +3808,31 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9247909666666664e+07,
-      "cpu_time": 2.4377777776862786e+04,
+      "real_time": 3.9150478388888881e+07,
+      "cpu_time": 3.4823166664131757e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9247909666666663e-06
+      "IterationTime": 3.9150478388888881e-06
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/256/manual_time",
-      "family_index": 37,
+      "family_index": 38,
       "per_family_instance_index": 0,
       "run_name": "BM_pgm_dispatch/tensix_eth_2/256/manual_time",
       "run_type": "iteration",
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 6,
-      "real_time": 1.2600905416666667e+08,
-      "cpu_time": 3.2413333334109968e+04,
+      "iterations": 5,
+      "real_time": 1.3457471519999999e+08,
+      "cpu_time": 4.1382000006251474e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2600905416666668e-05
+      "IterationTime": 1.3457471520000000e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/512/manual_time",
-      "family_index": 37,
+      "family_index": 38,
       "per_family_instance_index": 1,
       "run_name": "BM_pgm_dispatch/tensix_eth_2/512/manual_time",
       "run_type": "iteration",
@@ -3728,15 +3840,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.2647718300000000e+08,
-      "cpu_time": 2.9638000000886677e+04,
+      "real_time": 1.3647602359999999e+08,
+      "cpu_time": 3.6091999993459467e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2647718300000000e-05
+      "IterationTime": 1.3647602359999999e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/1024/manual_time",
-      "family_index": 37,
+      "family_index": 38,
       "per_family_instance_index": 2,
       "run_name": "BM_pgm_dispatch/tensix_eth_2/1024/manual_time",
       "run_type": "iteration",
@@ -3744,15 +3856,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.3040446859999999e+08,
-      "cpu_time": 2.7680400000917871e+04,
+      "real_time": 1.3967077520000002e+08,
+      "cpu_time": 5.9858399993117921e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.3040446859999999e-05
+      "IterationTime": 1.3967077520000002e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/2048/manual_time",
-      "family_index": 37,
+      "family_index": 38,
       "per_family_instance_index": 3,
       "run_name": "BM_pgm_dispatch/tensix_eth_2/2048/manual_time",
       "run_type": "iteration",
@@ -3760,15 +3872,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.4215715599999997e+08,
-      "cpu_time": 3.8233399999398898e+04,
+      "real_time": 1.4563553319999999e+08,
+      "cpu_time": 4.4812200007982028e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.4215715599999997e-05
+      "IterationTime": 1.4563553320000000e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/4096/manual_time",
-      "family_index": 37,
+      "family_index": 38,
       "per_family_instance_index": 4,
       "run_name": "BM_pgm_dispatch/tensix_eth_2/4096/manual_time",
       "run_type": "iteration",
@@ -3776,31 +3888,31 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.8750535100000000e+08,
-      "cpu_time": 5.0712499998439853e+04,
+      "real_time": 1.9131853350000000e+08,
+      "cpu_time": 7.3844999988637021e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.8750535100000000e-05
+      "IterationTime": 1.9131853350000001e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/8192/manual_time",
-      "family_index": 37,
+      "family_index": 38,
       "per_family_instance_index": 5,
       "run_name": "BM_pgm_dispatch/tensix_eth_2/8192/manual_time",
       "run_type": "iteration",
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 3,
-      "real_time": 2.7565202999999994e+08,
-      "cpu_time": 3.7689999999201973e+04,
+      "iterations": 2,
+      "real_time": 2.8106832700000000e+08,
+      "cpu_time": 3.8510999985419403e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7565202999999996e-05
+      "IterationTime": 2.8106832699999999e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/256/manual_time",
-      "family_index": 38,
+      "family_index": 39,
       "per_family_instance_index": 0,
       "run_name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/256/manual_time",
       "run_type": "iteration",
@@ -3808,15 +3920,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.0100027970000001e+09,
-      "cpu_time": 4.2070999995758029e+04,
+      "real_time": 1.0442509400000000e+09,
+      "cpu_time": 6.9950000010976510e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0100027970000001e-04
+      "IterationTime": 1.0442509399999999e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/512/manual_time",
-      "family_index": 38,
+      "family_index": 39,
       "per_family_instance_index": 1,
       "run_name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/512/manual_time",
       "run_type": "iteration",
@@ -3824,15 +3936,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.0184489250000000e+09,
-      "cpu_time": 5.1579999990281067e+04,
+      "real_time": 1.0525986199999999e+09,
+      "cpu_time": 7.5800999979946937e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0184489249999999e-04
+      "IterationTime": 1.0525986200000000e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/1024/manual_time",
-      "family_index": 38,
+      "family_index": 39,
       "per_family_instance_index": 2,
       "run_name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/1024/manual_time",
       "run_type": "iteration",
@@ -3840,15 +3952,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.0358318750000000e+09,
-      "cpu_time": 5.8449999983167800e+04,
+      "real_time": 1.0629309840000001e+09,
+      "cpu_time": 6.8809999959285051e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0358318750000001e-04
+      "IterationTime": 1.0629309840000002e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/2048/manual_time",
-      "family_index": 38,
+      "family_index": 39,
       "per_family_instance_index": 3,
       "run_name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/2048/manual_time",
       "run_type": "iteration",
@@ -3856,15 +3968,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.0659378500000001e+09,
-      "cpu_time": 9.0599999964524613e+04,
+      "real_time": 1.0936033960000000e+09,
+      "cpu_time": 6.9039000038628728e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0659378500000001e-04
+      "IterationTime": 1.0936033960000000e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/4096/manual_time",
-      "family_index": 38,
+      "family_index": 39,
       "per_family_instance_index": 4,
       "run_name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/4096/manual_time",
       "run_type": "iteration",
@@ -3872,15 +3984,15 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.1789919930000000e+09,
-      "cpu_time": 7.7219999980115972e+04,
+      "real_time": 1.2233552410000000e+09,
+      "cpu_time": 5.8780000017577549e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1789919929999998e-04
+      "IterationTime": 1.2233552410000000e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/8192/manual_time",
-      "family_index": 38,
+      "family_index": 39,
       "per_family_instance_index": 5,
       "run_name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/8192/manual_time",
       "run_type": "iteration",
@@ -3888,11 +4000,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.6306402270000000e+09,
-      "cpu_time": 5.8471000045301480e+04,
+      "real_time": 1.6801156270000000e+09,
+      "cpu_time": 6.5751000022373773e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.6306402270000001e-04
+      "IterationTime": 1.6801156269999999e-04
     }
   ]
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -629,6 +629,8 @@ int main(int argc, char** argv) {
             {"TO_MESH_ID", "0"},
             {"TO_DEV_ID", "0"},
             {"ROUTER_DIRECTION", "0"},
+            {"WORKER_MCAST_GRID", "0"},
+            {"NUM_WORKER_CORES_TO_MCAST", "0"},
             {"IS_D_VARIANT", "1"},
             {"IS_H_VARIANT", "1"},
         };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -43,6 +43,7 @@
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/math.hpp>
 #include "tt_metal/impl/dispatch/device_command.hpp"
+#include <tt-metalium/sub_device.hpp>
 
 constexpr uint32_t DEFAULT_ITERATIONS = 10000;
 constexpr uint32_t DEFAULT_WARMUP_ITERATIONS = 100;
@@ -76,6 +77,7 @@ struct TestInfo {
     uint32_t n_sems{0};
     uint32_t n_kgs{1};
     uint32_t n_cb_gs{1};
+    uint32_t n_subdevice_ranges{1};
     bool brisc_enabled{true};
     bool ncrisc_enabled{true};
     bool trisc_enabled{true};
@@ -87,6 +89,8 @@ struct TestInfo {
     bool dispatch_from_eth{false};
     bool use_all_cores{false};
     bool load_prefetcher{false};
+    // Use the entire leftmost column of cores.
+    bool use_left_cores{false};
 };
 
 std::tuple<uint32_t, uint32_t> get_core_count() {
@@ -130,6 +134,7 @@ void init(const std::vector<std::string>& input_args, TestInfo& info) {
             LogTest, " -ca: number of common runtime args multicast to all cores (default {}, max {})", 0, MAX_ARGS);
         log_info(LogTest, "  -S: number of semaphores (default {}, max {})", 0, NUM_SEMAPHORES);
         log_info(LogTest, " -kg: number of kernel groups (default 1)");
+        log_info(LogTest, " -sd: number of subdevices core ranges (default 1)");
         log_info(LogTest, "  -g: use a 4 byte global variable (additional spans");
         log_info(LogTest, " -rs: run \"slow\" kernels for exactly <n> cycles (default 0)");
         log_info(LogTest, " -rf: run \"fast\" kernels for exactly <n> cycles (default 0)");
@@ -167,6 +172,7 @@ void init(const std::vector<std::string>& input_args, TestInfo& info) {
     info.n_common_args = test_args::get_command_option_uint32(input_args, "-ca", 0);
     info.n_sems = test_args::get_command_option_uint32(input_args, "-S", 0);
     info.n_kgs = test_args::get_command_option_uint32(input_args, "-kg", 1);
+    info.n_subdevice_ranges = test_args::get_command_option_uint32(input_args, "-sd", 1);
     info.use_global = test_args::has_command_option(input_args, "-g");
     info.time_just_finish = test_args::has_command_option(input_args, "-f");
     info.fast_kernel_cycles = test_args::get_command_option_uint32(input_args, "-rf", 0);
@@ -220,13 +226,42 @@ void init(const std::vector<std::string>& input_args, TestInfo& info) {
 }
 
 void set_runtime_args(
-    tt_metal::Program& program, tt_metal::KernelHandle kernel_id, vector<uint32_t>& args, CoreRange kg) {
-    for (int core_idx_y = kg.start_coord.y; core_idx_y <= kg.end_coord.y; core_idx_y++) {
-        for (int core_idx_x = kg.start_coord.x; core_idx_x <= kg.end_coord.x; core_idx_x++) {
-            CoreCoord core = {(std::size_t)core_idx_x, (std::size_t)core_idx_y};
-            tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
+    tt_metal::Program& program, tt_metal::KernelHandle kernel_id, vector<uint32_t>& args, const CoreRangeSet& kgset) {
+    for (auto& kg : kgset.ranges()) {
+        for (int core_idx_y = kg.start_coord.y; core_idx_y <= kg.end_coord.y; core_idx_y++) {
+            for (int core_idx_x = kg.start_coord.x; core_idx_x <= kg.end_coord.x; core_idx_x++) {
+                CoreCoord core = {(std::size_t)core_idx_x, (std::size_t)core_idx_y};
+                tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
+            }
         }
     }
+}
+tt_metal::CoreRangeSet get_subdevice_core_range_set(const TestInfo& info, CoreRange all_core_range) {
+    std::set<CoreRange> core_range_set;
+    uint32_t total_core_x = all_core_range.end_coord.x - all_core_range.start_coord.x + 1;
+    if (info.n_subdevice_ranges > all_core_range.end_coord.x + 1) {
+        log_fatal(tt::LogTest, "Too many subdevice ranges for Worker core width");
+    }
+    if (info.n_subdevice_ranges > all_core_range.end_coord.y + 1) {
+        log_fatal(tt::LogTest, "Too many subdevice ranges for Worker core height");
+    }
+    // Construct/filter each column individually.
+    for (size_t i = 0; i < total_core_x; i++) {
+        uint32_t subdevice_subtract_amount = 0;
+        if (i >= total_core_x - info.n_subdevice_ranges) {
+            // First subdevice range is wide, remaining columns shrink by 1 each time.
+            uint32_t offset = i - (total_core_x - info.n_subdevice_ranges);
+            subdevice_subtract_amount = offset;
+        }
+
+        CoreRange column_core_range{
+            CoreCoord(all_core_range.start_coord.x + i, all_core_range.start_coord.y),
+            CoreCoord(all_core_range.start_coord.x + i, all_core_range.end_coord.y - subdevice_subtract_amount)};
+
+        core_range_set.insert(column_core_range);
+    }
+
+    return tt_metal::CoreRangeSet{core_range_set};
 }
 
 uint32_t get_num_kernels(const TestInfo& info) {
@@ -280,9 +315,15 @@ bool initialize_program(
     }
 
     // first kernel group is possibly wide, remaining kernel groups are 1 column each
-    CoreRange kg = {info.workers.start_coord, {info.workers.end_coord.x - info.n_kgs + 1, info.workers.end_coord.y}};
+    CoreRange total_kg = {
+        info.workers.start_coord, {info.workers.end_coord.x - info.n_kgs + 1, info.workers.end_coord.y}};
+    std::array<CoreRangeSet, NumHalProgrammableCoreTypes> core_ranges;
+    auto grid_size = mesh_device->compute_with_storage_grid_size();
+    CoreRange all_core_range{{0, 0}, {grid_size.x - 1, grid_size.y - 1}};
+    CoreRangeSet subdevice_core_ranges_set = get_subdevice_core_range_set(info, all_core_range);
     for (uint32_t i = 0; i < info.n_kgs; i++) {
         defines.insert(std::pair<std::string, std::string>(std::string("KG_") + std::to_string(i), ""));
+        CoreRangeSet kg = CoreRangeSet{total_kg}.intersection(subdevice_core_ranges_set);
 
         if (info.brisc_enabled) {
             auto dm0 = tt_metal::CreateKernel(
@@ -320,8 +361,8 @@ bool initialize_program(
             tt_metal::SetCommonRuntimeArgs(program, compute, common_args);
         }
 
-        kg.start_coord = {kg.end_coord.x + 1, kg.end_coord.y};
-        kg.end_coord = kg.start_coord;
+        total_kg.end_coord.x++;
+        total_kg.start_coord.x = total_kg.end_coord.x;
     }
 
     if (info.erisc_enabled) {
@@ -606,6 +647,7 @@ void log_test_configuration(const TestInfo& info) {
     }
 
     log_info(LogTest, "KGs: {}", info.n_kgs);
+    log_info(LogTest, "Subdevice core ranges: {}", info.n_subdevice_ranges);
     log_info(LogTest, "CBs: {}", info.n_cbs);
     log_info(LogTest, "UniqueRTArgs: {}", info.n_args);
     log_info(LogTest, "CommonRTArgs: {}", info.n_common_args);
@@ -627,6 +669,10 @@ static int pgm_dispatch(T& state, TestInfo info) {
         auto core_count = get_core_count();
         info.workers = CoreRange({0, 0}, {std::get<0>(core_count), std::get<1>(core_count)});
     }
+    if (info.use_left_cores) {
+        auto core_count = get_core_count();
+        info.workers = CoreRange({0, 0}, {0, std::get<1>(core_count)});
+    }
 
     log_test_configuration(info);
 
@@ -641,6 +687,18 @@ static int pgm_dispatch(T& state, TestInfo info) {
         mesh_device = MeshDevice::create_unit_mesh(
             device_id, DEFAULT_L1_SMALL_SIZE, 900 * 1024 * 1024, 1, DispatchCoreConfig{dispatch_core_type});
         auto& mesh_cq = mesh_device->mesh_command_queue(cq_id);
+
+        std::vector<tt_metal::SubDevice> sub_devices;
+        if (info.n_subdevice_ranges > 1) {
+            std::array<CoreRangeSet, NumHalProgrammableCoreTypes> core_ranges;
+            auto grid_size = mesh_device->compute_with_storage_grid_size();
+            CoreRange all_core_range{{0, 0}, {grid_size.x - 1, grid_size.y - 1}};
+            core_ranges[static_cast<size_t>(HalProgrammableCoreType::TENSIX)] =
+                get_subdevice_core_range_set(info, all_core_range);
+            sub_devices.push_back(tt_metal::SubDevice(core_ranges));
+            auto manager = mesh_device->create_sub_device_manager(sub_devices, 1024);
+            mesh_device->load_sub_device_manager(manager);
+        }
 
         // Declare program storage at function scope to ensure proper lifetime
         ProgramExecutor executor([]() {}, []() {}, 0);  // Initialize with placeholder
@@ -937,6 +995,20 @@ BENCHMARK_CAPTURE(
     BM_pgm_dispatch_vary_slow_cycles,
     256_bytes_brisc_only_all_processors_trace,
     TestInfo{.warmup_iterations = 5000, .kernel_size = 256, .ncrisc_enabled = false, .trisc_enabled = false, .use_trace = true, .use_all_cores = true})
+    ->Apply(KernelCycleArgs)
+    ->UseManualTime();
+BENCHMARK_CAPTURE(
+    BM_pgm_dispatch_vary_slow_cycles,
+    256_bytes_brisc_only_left_processors_subdevices_trace,
+    TestInfo{
+        .warmup_iterations = 5000,
+        .kernel_size = 256,
+        .n_subdevice_ranges = 6,
+        .ncrisc_enabled = false,
+        .trisc_enabled = false,
+        .use_trace = true,
+        // Use only the left column to allow for a single CoreRange in the kernel group.
+        .use_left_cores = true})
     ->Apply(KernelCycleArgs)
     ->UseManualTime();
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2166,6 +2166,8 @@ void configure_for_single_chip(
         {"TO_DEV_ID", "0"},
         {"ROUTER_DIRECTION", "0"},
         {"FABRIC_2D", "0"},
+        {"WORKER_MCAST_GRID", "0"},
+        {"NUM_WORKER_CORES_TO_MCAST", "0"},
     };
 
     CoreCoord phys_upstream_from_dispatch_core = split_prefetcher_g ? phys_prefetch_d_core : phys_prefetch_core_g;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -37,9 +37,10 @@ void kernel_main() {
     tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
 #endif
     uint64_t dispatch_addr = NOC_XY_ADDR(
-        NOC_X(mailboxes->go_message.master_x),
-        NOC_Y(mailboxes->go_message.master_y),
-        DISPATCH_MESSAGE_ADDR + NOC_STREAM_REG_SPACE_SIZE * mailboxes->go_message.dispatch_message_offset);
+        NOC_X(mailboxes->go_messages[mailboxes->go_message_index].master_x),
+        NOC_Y(mailboxes->go_messages[mailboxes->go_message_index].master_y),
+        DISPATCH_MESSAGE_ADDR +
+            NOC_STREAM_REG_SPACE_SIZE * mailboxes->go_messages[mailboxes->go_message_index].dispatch_message_offset);
     noc_fast_write_dw_inline<DM_DEDICATED_NOC>(
         noc_index,
         NCRISC_AT_CMD_BUF,

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -41,9 +41,9 @@ void MAIN {
         tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
 #endif
         uint64_t dispatch_addr = NOC_XY_ADDR(
-            NOC_X(mailboxes->go_message.master_x),
-            NOC_Y(mailboxes->go_message.master_y),
-            DISPATCH_MESSAGE_ADDR + NOC_STREAM_REG_SPACE_SIZE * mailboxes->go_message.dispatch_message_offset);
+            NOC_X(mailboxes->go_messages[mailboxes->go_message_index].master_x),
+            NOC_Y(mailboxes->go_messages[mailboxes->go_message_index].master_y),
+            DISPATCH_MESSAGE_ADDR + NOC_STREAM_REG_SPACE_SIZE * mailboxes->go_messages[mailboxes->go_message_index].dispatch_message_offset);
         noc_fast_write_dw_inline<DM_DEDICATED_NOC>(
                         noc_index,
                         NCRISC_AT_CMD_BUF,

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/api/tt-metalium/command_queue.hpp
+++ b/tt_metal/api/tt-metalium/command_queue.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -32,7 +32,10 @@ public:
     virtual void record_end() = 0;
 
     virtual void reset_worker_state(
-        bool reset_launch_msg_state, uint32_t num_sub_devices, const vector_aligned<uint32_t>& go_signal_noc_data) = 0;
+        bool reset_launch_msg_state,
+        uint32_t num_sub_devices,
+        const vector_aligned<uint32_t>& go_signal_noc_data,
+        const std::vector<std::pair<CoreRangeSet, uint32_t>>& core_go_message_mapping) = 0;
 
     virtual void set_go_signal_noc_data_and_dispatch_sems(
         uint32_t num_dispatch_sems, const vector_aligned<uint32_t>& noc_mcast_unicast_data) = 0;

--- a/tt_metal/api/tt-metalium/command_queue.hpp
+++ b/tt_metal/api/tt-metalium/command_queue.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -192,10 +192,9 @@ public:
     uint64_t get_dev_addr(CoreCoord virtual_core, HalL1MemAddrType addr_type) const;
     uint64_t get_dev_size(CoreCoord virtual_core, HalL1MemAddrType addr_type) const;
 
-    virtual uint8_t num_noc_mcast_txns(SubDeviceId sub_device_id) const = 0;
+    virtual bool has_noc_mcast_txns(SubDeviceId sub_device_id) const = 0;
     virtual uint8_t num_noc_unicast_txns(SubDeviceId sub_device_id) const = 0;
-    virtual uint8_t noc_data_start_index(
-        SubDeviceId sub_device_id, bool mcast_data = true, bool unicast_data = true) const = 0;
+    virtual uint8_t noc_data_start_index(SubDeviceId sub_device_id, bool unicast_data = true) const = 0;
 
     virtual SubDeviceManagerId get_active_sub_device_manager_id() const = 0;
     virtual SubDeviceManagerId get_default_sub_device_manager_id() const = 0;

--- a/tt_metal/api/tt-metalium/hal_types.hpp
+++ b/tt_metal/api/tt-metalium/hal_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -35,6 +35,7 @@ enum class HalL1MemAddrType : uint8_t {
     CORE_INFO,
     GO_MSG,
     LAUNCH_MSG_BUFFER_RD_PTR,
+    GO_MSG_INDEX,
     LOCAL,
     BANK_TO_NOC_SCRATCH,
     APP_SYNC_INFO,

--- a/tt_metal/api/tt-metalium/hal_types.hpp
+++ b/tt_metal/api/tt-metalium/hal_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -126,7 +126,10 @@ public:
     virtual void enqueue_wait_for_event(const MeshEvent& sync_event) = 0;
     virtual void finish(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
     virtual void reset_worker_state(
-        bool reset_launch_msg_state, uint32_t num_sub_devices, const vector_aligned<uint32_t>& go_signal_noc_data) = 0;
+        bool reset_launch_msg_state,
+        uint32_t num_sub_devices,
+        const vector_aligned<uint32_t>& go_signal_noc_data,
+        const std::vector<std::pair<CoreRangeSet, uint32_t>>& core_go_message_mapping) = 0;
     virtual void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) = 0;
     virtual void record_end() = 0;
     virtual void enqueue_trace(const MeshTraceId& trace_id, bool blocking) = 0;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -232,10 +232,9 @@ public:
     std::size_t num_program_cache_entries() override;
     HalProgrammableCoreType get_programmable_core_type(CoreCoord virtual_core) const override;
     HalMemType get_mem_type_of_core(CoreCoord virtual_core) const override;
-    uint8_t num_noc_mcast_txns(SubDeviceId sub_device_id) const override;
+    bool has_noc_mcast_txns(SubDeviceId sub_device_id) const override;
     uint8_t num_noc_unicast_txns(SubDeviceId sub_device_id) const override;
-    uint8_t noc_data_start_index(
-        SubDeviceId sub_device_id, bool mcast_data = true, bool unicast_data = true) const override;
+    uint8_t noc_data_start_index(SubDeviceId sub_device_id, bool unicast_data = true) const override;
     SubDeviceManagerId get_active_sub_device_manager_id() const override;
     SubDeviceManagerId get_default_sub_device_manager_id() const override;
     SubDeviceManagerId create_sub_device_manager(

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -769,7 +769,10 @@ void FDMeshCommandQueue::read_l1_data_from_completion_queue(MeshCoreDataReadDesc
 }
 
 void FDMeshCommandQueue::reset_worker_state(
-    bool reset_launch_msg_state, uint32_t num_sub_devices, const vector_aligned<uint32_t>& go_signal_noc_data) {
+    bool reset_launch_msg_state,
+    uint32_t num_sub_devices,
+    const vector_aligned<uint32_t>& go_signal_noc_data,
+    const std::vector<std::pair<CoreRangeSet, uint32_t>>& core_go_message_mapping) {
     for (auto device : mesh_device_->get_devices()) {
         TT_FATAL(!device->sysmem_manager().get_bypass_mode(), "Cannot reset worker state during trace capture");
     }
@@ -787,6 +790,10 @@ void FDMeshCommandQueue::reset_worker_state(
         program_dispatch::set_num_worker_sems_on_dispatch(mesh_device_, device->sysmem_manager(), id_, num_sub_devices);
         program_dispatch::set_go_signal_noc_data_on_dispatch(
             mesh_device_, go_signal_noc_data, device->sysmem_manager(), id_);
+        if (reset_launch_msg_state) {
+            program_dispatch::set_core_go_message_mapping_on_device(
+                device, core_go_message_mapping, device->sysmem_manager(), id_);
+        }
     }
     program_dispatch::reset_config_buf_mgrs_and_expected_workers(
         config_buffer_mgr_,

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -232,7 +232,8 @@ public:
     void reset_worker_state(
         bool reset_launch_msg_state,
         uint32_t num_sub_devices,
-        const vector_aligned<uint32_t>& go_signal_noc_data) override;
+        const vector_aligned<uint32_t>& go_signal_noc_data,
+        const std::vector<std::pair<CoreRangeSet, uint32_t>>& core_go_message_mapping) override;
     void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) override;
     void record_end() override;
     void enqueue_trace(const MeshTraceId& trace_id, bool blocking) override;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -966,16 +966,14 @@ HalMemType MeshDevice::get_mem_type_of_core(CoreCoord virtual_core) const {
 }
 
 // Methods for SubDevice Management
-uint8_t MeshDevice::num_noc_mcast_txns(SubDeviceId sub_device_id) const {
-    return sub_device_manager_tracker_->get_active_sub_device_manager()->num_noc_mcast_txns(sub_device_id);
+bool MeshDevice::has_noc_mcast_txns(SubDeviceId sub_device_id) const {
+    return sub_device_manager_tracker_->get_active_sub_device_manager()->has_noc_mcast_txns(sub_device_id);
 }
 uint8_t MeshDevice::num_noc_unicast_txns(SubDeviceId sub_device_id) const {
     return sub_device_manager_tracker_->get_active_sub_device_manager()->num_noc_unicast_txns(sub_device_id);
 }
-uint8_t MeshDevice::noc_data_start_index(SubDeviceId sub_device_id, bool mcast_data, bool unicast_data) const {
-    if (mcast_data) {
-        return sub_device_manager_tracker_->get_active_sub_device_manager()->noc_mcast_data_start_index(sub_device_id);
-    } else if (unicast_data) {
+uint8_t MeshDevice::noc_data_start_index(SubDeviceId sub_device_id, bool unicast_data) const {
+    if (unicast_data) {
         return sub_device_manager_tracker_->get_active_sub_device_manager()->noc_unicast_data_start_index(
             sub_device_id);
     } else {

--- a/tt_metal/distributed/mesh_workload_utils.cpp
+++ b/tt_metal/distributed/mesh_workload_utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -76,9 +76,10 @@ void write_go_signal(
         expected_num_workers_completed,
         *reinterpret_cast<uint32_t*>(&run_program_go_signal),
         MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(sub_device_index),
-        send_mcast ? device->num_noc_mcast_txns(sub_device_id) : 0,
+        (send_mcast && device->has_noc_mcast_txns(sub_device_id)) ? *sub_device_id
+                                                                  : CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET,
         send_unicasts ? device->num_virtual_eth_cores(sub_device_id) : 0,
-        device->noc_data_start_index(sub_device_id, send_mcast, send_unicasts), /* noc_data_start_idx */
+        device->noc_data_start_index(sub_device_id, send_unicasts), /* noc_data_start_idx */
         dispatcher_for_go_signal);
 
     TT_ASSERT(go_signal_cmd_sequence.size_bytes() == go_signal_cmd_sequence.write_offset_bytes());

--- a/tt_metal/distributed/mesh_workload_utils.cpp
+++ b/tt_metal/distributed/mesh_workload_utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -94,7 +94,8 @@ void SDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent&) {}
 void SDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId>) {}
 void SDMeshCommandQueue::finish_nolock(tt::stl::Span<const SubDeviceId>) {}
 
-void SDMeshCommandQueue::reset_worker_state(bool, uint32_t, const vector_aligned<uint32_t>&) {}
+void SDMeshCommandQueue::reset_worker_state(
+    bool, uint32_t, const vector_aligned<uint32_t>&, const std::vector<std::pair<CoreRangeSet, uint32_t>>&) {}
 
 void SDMeshCommandQueue::record_begin(const MeshTraceId&, const std::shared_ptr<MeshTraceDescriptor>&) {
     TT_THROW("Not supported for slow dispatch");

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -47,7 +47,8 @@ public:
     void reset_worker_state(
         bool reset_launch_msg_state,
         uint32_t num_sub_devices,
-        const vector_aligned<uint32_t>& go_signal_noc_data) override;
+        const vector_aligned<uint32_t>& go_signal_noc_data,
+        const std::vector<std::pair<CoreRangeSet, uint32_t>>& core_go_message_mapping) override;
     void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) override;
     void record_end() override;
     void enqueue_trace(const MeshTraceId& trace_id, bool blocking) override;

--- a/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -346,7 +346,7 @@ int main() {
 
     // Wait for all cores to be finished initializing before reporting initialization done.
     wait_ncrisc_trisc();
-    mailboxes->go_message.signal = RUN_MSG_DONE;
+    mailboxes->go_messages[0].signal = RUN_MSG_DONE;
 
     // Initialize the NoCs to a safe state
     // This ensures if we send any noc txns without running a kernel setup are valid
@@ -366,7 +366,7 @@ int main() {
         // before mcasting the launch message (as a hang workaround), which
         // ensures that the unicast data will also have been received.
         while (
-            ((go_message_signal = mailboxes->go_message.signal) != RUN_MSG_GO) &&
+            ((go_message_signal = mailboxes->go_messages[mailboxes->go_message_index].signal) != RUN_MSG_GO) &&
             !(mailboxes->launch[mailboxes->launch_msg_rd_ptr].kernel_config.preload & DISPATCH_ENABLE_FLAG_PRELOAD)) {
             invalidate_l1_cache();
             // While the go signal for kernel execution is not sent, check if the worker was signalled
@@ -376,12 +376,13 @@ int main() {
                 // Set the rd_ptr on workers to specified value
                 mailboxes->launch_msg_rd_ptr = 0;
                 if (go_message_signal == RUN_MSG_RESET_READ_PTR) {
+                    uint32_t go_message_index = mailboxes->go_message_index;
                     // Querying the noc_index is safe here, since the RUN_MSG_RESET_READ_PTR go signal is currently
                     // guaranteed to only be seen after a RUN_MSG_GO signal, which will set the noc_index to a valid
                     // value. For future proofing, the noc_index value is initialized to 0, to ensure an invalid NOC txn
                     // is not issued.
-                    uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_message);
-                    mailboxes->go_message.signal = RUN_MSG_DONE;
+                    uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_messages[go_message_index]);
+                    mailboxes->go_messages[go_message_index].signal = RUN_MSG_DONE;
                     // Notify dispatcher that this has been done
                     DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
                     notify_dispatch_core_done(dispatch_addr, noc_index);
@@ -512,7 +513,8 @@ int main() {
             }
 #endif
 
-            mailboxes->go_message.signal = RUN_MSG_DONE;
+            uint32_t go_message_index = mailboxes->go_message_index;
+            mailboxes->go_messages[go_message_index].signal = RUN_MSG_DONE;
 
             // Notify dispatcher core that tensix has completed running kernels, if the launch_msg was populated
             if (launch_msg_address->kernel_config.mode == DISPATCH_MODE_DEV) {
@@ -520,7 +522,7 @@ int main() {
                 // if a valid launch message is sent.
                 launch_msg_address->kernel_config.enables = 0;
                 launch_msg_address->kernel_config.preload = 0;
-                uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_message);
+                uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_messages[go_message_index]);
                 DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
                 // Only executed if watcher is enabled. Ensures that we don't report stale data due to invalid launch
                 // messages in the ring buffer. Must be executed before the atomic increment, as after that the launch

--- a/tt_metal/hw/firmware/src/tt-1xx/erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/erisc.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/firmware/src/tt-1xx/erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/erisc.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -108,7 +108,7 @@ void __attribute__((noinline)) Application(void) {
     mailboxes->launch_msg_rd_ptr = 0;  // Initialize the rdptr to 0
     while (routing_info->routing_enabled) {
         // FD: assume that no more host -> remote writes are pending
-        uint8_t go_message_signal = mailboxes->go_message.signal;
+        uint8_t go_message_signal = mailboxes->go_messages[0].signal;
         if (go_message_signal == RUN_MSG_GO) {
             // Only include this iteration in the device profile if the launch message is valid. This is because all
             // workers get a go signal regardless of whether they're running a kernel or not. We don't want to profile
@@ -133,11 +133,11 @@ void __attribute__((noinline)) Application(void) {
                 kernel_init();
                 WAYPOINT("D");
             }
-            mailboxes->go_message.signal = RUN_MSG_DONE;
+            mailboxes->go_messages[0].signal = RUN_MSG_DONE;
 
             if (launch_msg_address->kernel_config.mode == DISPATCH_MODE_DEV) {
                 launch_msg_address->kernel_config.enables = 0;
-                uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_message);
+                uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_messages[0]);
                 CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER();
                 internal_::notify_dispatch_core_done(dispatch_addr);
                 mailboxes->launch_msg_rd_ptr = (launch_msg_rd_ptr + 1) & (launch_msg_buffer_num_entries - 1);
@@ -148,8 +148,8 @@ void __attribute__((noinline)) Application(void) {
         } else if (go_message_signal == RUN_MSG_RESET_READ_PTR) {
             // Reset the launch message buffer read ptr
             mailboxes->launch_msg_rd_ptr = 0;
-            uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_message);
-            mailboxes->go_message.signal = RUN_MSG_DONE;
+            uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_messages[0]);
+            mailboxes->go_messages[0].signal = RUN_MSG_DONE;
             internal_::notify_dispatch_core_done(dispatch_addr);
         } else {
             internal_::risc_context_switch();

--- a/tt_metal/hw/firmware/src/tt-1xx/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/idle_erisc.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/firmware/src/tt-1xx/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/idle_erisc.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -132,7 +132,7 @@ int main() {
     deassert_all_reset();  // Bring all riscs on eth cores out of reset
     // Wait for all subordinate ERISCs to be ready before reporting the core is done initializing.
     wait_subordinate_eriscs(heartbeat);
-    mailboxes->go_message.signal = RUN_MSG_DONE;
+    mailboxes->go_messages[0].signal = RUN_MSG_DONE;
     mailboxes->launch_msg_rd_ptr = 0;  // Initialize the rdptr to 0
     // Cleanup profiler buffer incase we never get the go message
 
@@ -140,7 +140,7 @@ int main() {
         init_sync_registers();
         // Wait...
         WAYPOINT("GW");
-        while (mailboxes->go_message.signal != RUN_MSG_GO) {
+        while (mailboxes->go_messages[0].signal != RUN_MSG_GO) {
             invalidate_l1_cache();
             RISC_POST_HEARTBEAT(heartbeat);
         };
@@ -180,12 +180,12 @@ int main() {
 
             wait_subordinate_eriscs(heartbeat);
 
-            mailboxes->go_message.signal = RUN_MSG_DONE;
+            mailboxes->go_messages[0].signal = RUN_MSG_DONE;
 
             // Notify dispatcher core that it has completed
             if (launch_msg_address->kernel_config.mode == DISPATCH_MODE_DEV) {
                 launch_msg_address->kernel_config.enables = 0;
-                uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_message);
+                uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_messages[0]);
                 DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
                 CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER();
                 notify_dispatch_core_done(dispatch_addr, noc_index);

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -88,7 +88,7 @@
 // Hardcode below due to compiler bug that cannot statically resolve the expression see GH issue #19265
 #define MEM_MAILBOX_BASE 96  // (MEM_NCRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2) * 2)  // 2 nocs * 2 (B,NC)
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 12640
+#define MEM_MAILBOX_SIZE 12656
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_ZEROS_BASE ((MEM_MAILBOX_END + 31) & ~31)
 
@@ -166,7 +166,7 @@
 #define MEM_MAX_NUM_CONCURRENT_TRANSACTIONS 8
 #define MEM_ERISC_SYNC_INFO_SIZE (160 + 16 * MEM_MAX_NUM_CONCURRENT_TRANSACTIONS)
 #define MEM_ERISC_FABRIC_ROUTER_CONFIG_SIZE 2064
-#define MEM_ERISC_MAILBOX_SIZE 12576
+#define MEM_ERISC_MAILBOX_SIZE 12624
 #define MEM_ERISC_KERNEL_CONFIG_SIZE (25 * 1024)
 #define MEM_ERISC_BASE 0
 

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/inc/debug/assert.h
+++ b/tt_metal/hw/inc/debug/assert.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,7 +21,7 @@ void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type = DebugA
 #if defined(COMPILE_FOR_ERISC)
     // Update launch msg to show that we've exited. This is required so that the next run doesn't think there's a kernel
     // still running and try to make it exit.
-    volatile tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_message);
+    volatile tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
     go_message_ptr->signal = RUN_MSG_DONE;
 
     // This exits to base FW

--- a/tt_metal/hw/inc/debug/assert.h
+++ b/tt_metal/hw/inc/debug/assert.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -256,7 +256,7 @@ void __attribute__((noinline)) debug_sanitize_post_noc_addr_and_hang(
 #if defined(COMPILE_FOR_ERISC)
     // Update launch msg to show that we've exited. This is required so that the next run doesn't think there's a kernel
     // still running and try to make it exit.
-    volatile tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_message);
+    volatile tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
     go_message_ptr->signal = RUN_MSG_DONE;
 
     // For erisc, we can't hang the kernel/fw, because the core doesn't get restarted when a new

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -375,13 +375,18 @@ struct core_info_msg_t {
 };
 
 constexpr uint32_t launch_msg_buffer_num_entries = 8;
+// Equal to the maximum number of subdevices + 1. This allows all workers that aren't assigned to a subdevice to receive
+// a dummy entry.
+constexpr uint32_t go_message_num_entries = 9;
 struct mailboxes_t {
     struct ncrisc_halt_msg_t ncrisc_halt;
     struct subordinate_sync_msg_t subordinate_sync;
     volatile uint32_t launch_msg_rd_ptr;  // Volatile so this can be manually reset by host. TODO: remove volatile when
                                           // dispatch init moves to one-shot.
     struct launch_msg_t launch[launch_msg_buffer_num_entries];
-    volatile struct go_msg_t go_message;
+    volatile struct go_msg_t go_messages[go_message_num_entries];
+    uint32_t pads_1[3];
+    volatile uint32_t go_message_index;  // Index into go_messages to use. Always 0 on unicast cores.
     struct watcher_msg_t watcher;
     struct dprint_buf_msg_t dprint_buf;
     struct core_info_msg_t core_info;

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -78,8 +78,9 @@ uint32_t firmware_config_init(
 FORCE_INLINE
 void wait_for_go_message() {
     tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
+    uint32_t go_message_index = mailboxes->go_message_index;
 
-    while (mailboxes->go_message.signal != RUN_MSG_GO) {
+    while (mailboxes->go_messages[go_message_index].signal != RUN_MSG_GO) {
         invalidate_l1_cache();
     }
 }
@@ -117,8 +118,9 @@ FORCE_INLINE void notify_dispatch_core_done(uint64_t dispatch_addr, uint8_t noc_
 FORCE_INLINE
 bool is_message_go() {
     tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
+    uint32_t go_message_index = mailboxes->go_message_index;
 
-    return mailboxes->go_message.signal == RUN_MSG_GO;
+    return mailboxes->go_messages[go_message_index].signal == RUN_MSG_GO;
 }
 
 #define EARLY_RETURN_FOR_DEBUG \

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -76,7 +76,7 @@
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 12640
+#define MEM_MAILBOX_SIZE 12656
 // These are used in ncrisc-halt.S, asserted in ncrisc.cc to be valid
 #define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS MEM_MAILBOX_BASE + 4
 #define MEM_SUBORDINATE_RUN_MAILBOX_ADDRESS MEM_MAILBOX_BASE + 8

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -926,6 +926,8 @@ void MetalContext::initialize_firmware(
     uint32_t zero = 0;
     cluster_->write_core(
         &zero, sizeof(uint32_t), tt_cxy_pair(device_id, virtual_core), launch_msg_buffer_read_ptr_addr);
+    uint32_t go_message_index_addr = hal_->get_dev_addr(programmable_core_type, HalL1MemAddrType::GO_MSG_INDEX);
+    cluster_->write_core(&zero, sizeof(uint32_t), tt_cxy_pair(device_id, virtual_core), go_message_index_addr);
 }
 
 void MetalContext::initialize_and_launch_firmware(chip_id_t device_id) {

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -840,7 +840,16 @@ void WatcherDeviceReader::DumpLaunchMessage(CoreDescriptor& core, const mailboxe
             core.coord.str(),
             launch_msg->kernel_config.brisc_noc_id);
     }
-    DumpRunState(core, launch_msg, mbox_data->go_message.signal);
+    if (mbox_data->go_message_index < go_message_num_entries) {
+        DumpRunState(core, launch_msg, mbox_data->go_messages[mbox_data->go_message_index].signal);
+    } else {
+        LogRunningKernels(core, launch_msg);
+        TT_THROW(
+            "Watcher data corruption, unexpected go message index on core {}: {} (expected < {})",
+            core.coord.str(),
+            mbox_data->go_message_index,
+            go_message_num_entries);
+    }
 
     fprintf(f, "|");
     if (launch_msg->kernel_config.enables &

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -317,6 +317,21 @@ void Device::init_command_queue_device() {
         MetalContext::instance().get_cluster().write_core(
             &zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), launch_msg_buffer_read_ptr_addr);
     };
+    auto reset_go_message_index = [&](const CoreCoord& logical_core, const CoreType& core_type) {
+        CoreCoord virtual_core = MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+            id_, logical_core, core_type);
+        auto programmable_core_type = get_programmable_core_type(virtual_core);
+        uint32_t go_message_addr =
+            MetalContext::instance().hal().get_dev_addr(programmable_core_type, HalL1MemAddrType::GO_MSG);
+        uint32_t zero = 0;
+        MetalContext::instance().get_cluster().write_core(
+            &zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), go_message_addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(id_);
+        uint32_t go_message_index_addr =
+            MetalContext::instance().hal().get_dev_addr(programmable_core_type, HalL1MemAddrType::GO_MSG_INDEX);
+        MetalContext::instance().get_cluster().write_core(
+            &zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), go_message_index_addr);
+    };
     const auto& storage_only_cores = tt::get_logical_storage_cores(
         id_, num_hw_cqs_, MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config());
     auto storage_only_cores_set = std::unordered_set<CoreCoord>(storage_only_cores.begin(), storage_only_cores.end());
@@ -329,6 +344,7 @@ void Device::init_command_queue_device() {
             CoreCoord logical_core(x, y);
             if (!storage_only_cores_set.count(logical_core)) {
                 reset_launch_message_rd_ptr(logical_core, CoreType::WORKER);
+                reset_go_message_index(logical_core, CoreType::WORKER);
             }
         }
     }
@@ -693,18 +709,16 @@ void Device::mark_allocations_unsafe() { this->allocator()->mark_allocations_uns
 
 void Device::mark_allocations_safe() { this->allocator()->mark_allocations_safe(); }
 
-uint8_t Device::num_noc_mcast_txns(SubDeviceId sub_device_id) const {
-    return sub_device_manager_tracker_->get_active_sub_device_manager()->num_noc_mcast_txns(sub_device_id);
+bool Device::has_noc_mcast_txns(SubDeviceId sub_device_id) const {
+    return sub_device_manager_tracker_->get_active_sub_device_manager()->has_noc_mcast_txns(sub_device_id);
 }
 
 uint8_t Device::num_noc_unicast_txns(SubDeviceId sub_device_id) const {
     return sub_device_manager_tracker_->get_active_sub_device_manager()->num_noc_unicast_txns(sub_device_id);
 }
 
-uint8_t Device::noc_data_start_index(SubDeviceId sub_device_id, bool mcast_data, bool unicast_data) const {
-    if (mcast_data) {
-        return sub_device_manager_tracker_->get_active_sub_device_manager()->noc_mcast_data_start_index(sub_device_id);
-    } else if (unicast_data) {
+uint8_t Device::noc_data_start_index(SubDeviceId sub_device_id, bool unicast_data) const {
+    if (unicast_data) {
         return sub_device_manager_tracker_->get_active_sub_device_manager()->noc_unicast_data_start_index(
             sub_device_id);
     } else {

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -157,10 +157,9 @@ public:
     HalProgrammableCoreType get_programmable_core_type(CoreCoord virtual_core) const override;
     HalMemType get_mem_type_of_core(CoreCoord virtual_core) const override;
 
-    uint8_t num_noc_mcast_txns(SubDeviceId sub_device_id) const override;
+    bool has_noc_mcast_txns(SubDeviceId sub_device_id) const override;
     uint8_t num_noc_unicast_txns(SubDeviceId sub_device_id) const override;
-    uint8_t noc_data_start_index(
-        SubDeviceId sub_device_id, bool mcast_data = true, bool unicast_data = true) const override;
+    uint8_t noc_data_start_index(SubDeviceId sub_device_id, bool unicast_data = true) const override;
 
     SubDeviceManagerId get_active_sub_device_manager_id() const override;
     SubDeviceManagerId get_default_sub_device_manager_id() const override;

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -93,7 +93,7 @@ public:
         uint32_t wait_count,
         uint32_t go_signal,
         uint32_t wait_addr,
-        uint8_t num_mcast_txns,
+        uint8_t multicast_go_offset,
         uint8_t num_unicast_txns,
         uint8_t noc_data_start_index,
         DispatcherSelect dispatcher_type);

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -159,7 +159,10 @@ std::optional<uint32_t> HWCommandQueue::tid() const { return this->tid_; }
 SystemMemoryManager& HWCommandQueue::sysmem_manager() { return this->manager_; }
 
 void HWCommandQueue::reset_worker_state(
-    bool reset_launch_msg_state, uint32_t num_sub_devices, const vector_aligned<uint32_t>& go_signal_noc_data) {
+    bool reset_launch_msg_state,
+    uint32_t num_sub_devices,
+    const vector_aligned<uint32_t>& go_signal_noc_data,
+    const std::vector<std::pair<CoreRangeSet, uint32_t>>& core_go_message_mapping) {
     TT_FATAL(!this->manager_.get_bypass_mode(), "Cannot reset worker state during trace capture");
     cq_shared_state_->sub_device_cq_owner.clear();
     cq_shared_state_->sub_device_cq_owner.resize(num_sub_devices);
@@ -174,6 +177,9 @@ void HWCommandQueue::reset_worker_state(
         reset_launch_msg_state);
     program_dispatch::set_num_worker_sems_on_dispatch(device_, this->manager_, id_, num_sub_devices);
     program_dispatch::set_go_signal_noc_data_on_dispatch(device_, go_signal_noc_data, this->manager_, id_);
+    if (reset_launch_msg_state) {
+        program_dispatch::set_core_go_message_mapping_on_device(device_, core_go_message_mapping, this->manager_, id_);
+    }
     // expected_num_workers_completed is reset on the dispatcher, as part of this step - this must be reflected
     // on host, along with the config_buf_manager being reset, since we wait for all programs across SubDevices
     // to complete as part of resetting the worker state

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -65,7 +65,8 @@ public:
     void reset_worker_state(
         bool reset_launch_msg_state,
         uint32_t num_sub_devices,
-        const vector_aligned<uint32_t>& go_signal_noc_data) override;
+        const vector_aligned<uint32_t>& go_signal_noc_data,
+        const std::vector<std::pair<CoreRangeSet, uint32_t>>& core_go_message_mapping) override;
 
     void set_go_signal_noc_data_and_dispatch_sems(
         uint32_t num_dispatch_sems, const vector_aligned<uint32_t>& noc_mcast_unicast_data) override;

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -376,6 +376,12 @@ void DispatchKernel::CreateKernel() {
             .size();
     bool virtualize_num_eth_cores = num_virtual_active_eth_cores > num_physical_active_eth_cores;
 
+    const auto& compute_grid_size = device_->compute_with_storage_grid_size();
+    CoreRange device_worker_cores = CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1});
+    auto virtual_start = device_->virtual_core_from_logical_core(device_worker_cores.start_coord, CoreType::WORKER);
+    auto virtual_end = device_->virtual_core_from_logical_core(device_worker_cores.end_coord, CoreType::WORKER);
+    auto virtual_core_range = CoreRange(virtual_start, virtual_end);
+
     std::vector<uint32_t> compile_args = {};
 
     auto my_virtual_core = get_virtual_core_coord(logical_core_, GetCoreType());
@@ -474,6 +480,9 @@ void DispatchKernel::CreateKernel() {
         {"TO_MESH_ID", std::to_string(dependent_config_.to_mesh_id.value_or(0))},
         {"TO_DEV_ID", std::to_string(dependent_config_.to_dev_id.value_or(0))},
         {"ROUTER_DIRECTION", std::to_string(dependent_config_.router_direction.value_or(0))},
+        {"WORKER_MCAST_GRID",
+         std::to_string(device_->get_noc_multicast_encoding(noc_selection_.downstream_noc, virtual_core_range))},
+        {"NUM_WORKER_CORES_TO_MCAST", std::to_string(device_worker_cores.size())},
         {"IS_D_VARIANT", std::to_string(static_config_.is_d_variant.value())},
         {"IS_H_VARIANT", std::to_string(static_config_.is_h_variant.value())},
     };

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "dispatch_s.hpp"

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -229,6 +229,7 @@ enum CQDispatchCmdPackedWriteType {
     CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_LAUNCH = 0x2 << CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT,
     CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_SEMS = 0x3 << CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT,
     CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_EVENT = 0x4 << CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT,
+    CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_GO_MSG_INDEX = 0x5 << CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT,
 };
 
 struct CQDispatchWritePackedCmd {
@@ -326,9 +327,12 @@ struct CQDispatchSetUnicastOnlyCoresCmd {
     uint32_t num_unicast_only_cores;
 } __attribute__((packed));
 
+constexpr uint8_t CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET = 0xff;
+
 struct CQDispatchGoSignalMcastCmd {
     uint32_t go_signal;
-    uint8_t num_mcast_txns;
+    uint8_t multicast_go_offset;  // Index of the multicast go to write to. CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET - no
+                                  // multicast gos.
     uint8_t num_unicast_txns;
     uint8_t noc_data_start_index;
     uint32_t wait_count;

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -93,6 +93,9 @@ constexpr uint32_t router_direction = ROUTER_DIRECTION;
 
 constexpr bool is_2d_fabric = static_cast<bool>(FABRIC_2D);
 
+constexpr uint32_t worker_mcast_grid = WORKER_MCAST_GRID;
+constexpr uint32_t num_worker_cores_to_mcast = NUM_WORKER_CORES_TO_MCAST;
+
 constexpr uint32_t is_d_variant = IS_D_VARIANT;
 constexpr uint32_t is_h_variant = IS_H_VARIANT;
 
@@ -1000,36 +1003,36 @@ void process_go_signal_mcast_cmd() {
     // can guarantee that copying the go signal does not corrupt any other command fields, which is true (see
     // CQDispatchGoSignalMcastCmd).
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage = (volatile uint32_t tt_l1_ptr*)cmd_ptr;
-    *aligned_go_signal_storage = cmd->mcast.go_signal;
+    uint32_t go_signal_value = cmd->mcast.go_signal;
     uint8_t go_signal_noc_data_idx = cmd->mcast.noc_data_start_index;
-    if (cmd->mcast.num_mcast_txns > 0) {
+    uint32_t multicast_go_offset = cmd->mcast.multicast_go_offset;
+    uint32_t num_unicasts = cmd->mcast.num_unicast_txns;
+    uint32_t wait_count = cmd->mcast.wait_count;
+    if (multicast_go_offset != CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET) {
         // Setup registers before waiting for workers so only the NOC_CMD_CTRL register needs to be touched after.
         uint64_t dst_noc_addr_multicast =
-            get_noc_addr_helper(go_signal_noc_data[go_signal_noc_data_idx++], mcast_go_signal_addr);
-        uint32_t num_dests = go_signal_noc_data[go_signal_noc_data_idx++];
+            get_noc_addr_helper(worker_mcast_grid, mcast_go_signal_addr + sizeof(uint32_t) * multicast_go_offset);
+        uint32_t num_dests = num_worker_cores_to_mcast;
+        // Ensure the offset with respect to L1_ALIGNMENT is the same for the source and destination.
+        uint32_t storage_offset = multicast_go_offset % (L1_ALIGNMENT / sizeof(uint32_t));
+        aligned_go_signal_storage[storage_offset] = go_signal_value;
+
         cq_noc_async_write_init_state<CQ_NOC_SNDL, true>(
-            (uint32_t)aligned_go_signal_storage, dst_noc_addr_multicast, sizeof(uint32_t));
+            (uint32_t)&aligned_go_signal_storage[storage_offset], dst_noc_addr_multicast, sizeof(uint32_t));
         noc_nonposted_writes_acked[noc_index] += num_dests;
 
         while (!stream_wrap_ge(
-            NOC_STREAM_READ_REG(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX), cmd->mcast.wait_count)) {
+            NOC_STREAM_READ_REG(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX), wait_count)) {
         }
         cq_noc_async_write_with_state<CQ_NOC_sndl, CQ_NOC_wait>(0, 0, 0);
-        // Send GO signal to remaining destinations. Only the destination NOC needs to be modified.
-        for (uint32_t i = 1, num_mcasts = cmd->mcast.num_mcast_txns; i < num_mcasts; ++i) {
-            uint64_t dst = get_noc_addr_helper(go_signal_noc_data[go_signal_noc_data_idx++], mcast_go_signal_addr);
-            uint32_t num_dests = go_signal_noc_data[go_signal_noc_data_idx++];
-            cq_noc_async_write_with_state<CQ_NOC_sNdl>(0, dst, 0);
-            noc_nonposted_writes_acked[noc_index] += num_dests;
-        }
-        noc_nonposted_writes_num_issued[noc_index] += cmd->mcast.num_mcast_txns;
+        noc_nonposted_writes_num_issued[noc_index] += 1;
     } else {
         while (!stream_wrap_ge(
-            NOC_STREAM_READ_REG(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX), cmd->mcast.wait_count)) {
+            NOC_STREAM_READ_REG(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX), wait_count)) {
         }
     }
 
-    uint32_t num_unicasts = cmd->mcast.num_unicast_txns;
+    *aligned_go_signal_storage = go_signal_value;
     if constexpr (virtualize_unicast_cores) {
         // Issue #19729: Workaround to allow TT-Mesh Workload dispatch to target active ethernet cores.
         // This chip is virtualizing cores the go signal is unicasted to

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -40,6 +40,9 @@ constexpr uint32_t max_num_go_signal_noc_data_entries = MAX_NUM_GO_SIGNAL_NOC_DA
 constexpr uint32_t virtualize_unicast_cores = VIRTUALIZE_UNICAST_CORES;
 constexpr uint32_t num_virtual_unicast_cores = NUM_VIRTUAL_UNICAST_CORES;
 constexpr uint32_t num_physical_unicast_cores = NUM_PHYSICAL_UNICAST_CORES;
+
+constexpr uint32_t worker_mcast_grid = WORKER_MCAST_GRID;
+constexpr uint32_t num_worker_cores_to_mcast = NUM_WORKER_CORES_TO_MCAST;
 
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
 constexpr uint32_t dispatch_d_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y));
@@ -133,10 +136,10 @@ uint32_t stream_wrap_gt(uint32_t a, uint32_t b) {
 }
 
 FORCE_INLINE
-void wait_for_workers(volatile CQDispatchCmd tt_l1_ptr* cmd) {
+void wait_for_workers(uint32_t wait_count, uint32_t wait_stream) {
     volatile uint32_t* worker_sem =
-        (volatile uint32_t*)STREAM_REG_ADDR(cmd->mcast.wait_stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
-    while (stream_wrap_gt(cmd->mcast.wait_count, *worker_sem)) {
+        (volatile uint32_t*)STREAM_REG_ADDR(wait_stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
+    while (stream_wrap_gt(wait_count, *worker_sem)) {
     }
 }
 
@@ -212,33 +215,35 @@ void process_go_signal_mcast_cmd() {
     // can guarantee that copying the go signal does not corrupt any other command fields, which is true (see
     // CQDispatchGoSignalMcastCmd).
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage = (volatile uint32_t tt_l1_ptr*)cmd_ptr;
-    *aligned_go_signal_storage = cmd->mcast.go_signal;
+    uint32_t go_signal_value = cmd->mcast.go_signal;
     uint8_t go_signal_noc_data_idx = cmd->mcast.noc_data_start_index;
+    uint32_t multicast_go_offset = cmd->mcast.multicast_go_offset;
+    uint32_t num_unicasts = cmd->mcast.num_unicast_txns;
+    uint32_t wait_count = cmd->mcast.wait_count;
+    uint32_t wait_stream = cmd->mcast.wait_stream;
 
-    if (cmd->mcast.num_mcast_txns > 0) {
+    if (multicast_go_offset != CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET) {
         // Setup registers before waiting for workers so only the NOC_CMD_CTRL register needs to be touched after.
         uint64_t dst_noc_addr_multicast =
-            get_noc_addr_helper(go_signal_noc_data[go_signal_noc_data_idx++], mcast_go_signal_addr);
-        uint32_t num_dests = go_signal_noc_data[go_signal_noc_data_idx++];
+            get_noc_addr_helper(worker_mcast_grid, mcast_go_signal_addr + sizeof(uint32_t) * multicast_go_offset);
+        uint32_t num_dests = num_worker_cores_to_mcast;
+        // Ensure the offset with respect to L1_ALIGNMENT is the same for the source and destination.
+        uint32_t storage_offset = multicast_go_offset % (L1_ALIGNMENT / sizeof(uint32_t));
+        aligned_go_signal_storage[storage_offset] = go_signal_value;
+
         cq_noc_async_write_init_state<CQ_NOC_SNDL, true>(
-            (uint32_t)aligned_go_signal_storage, dst_noc_addr_multicast, sizeof(uint32_t));
+            (uint32_t)&aligned_go_signal_storage[storage_offset], dst_noc_addr_multicast, sizeof(uint32_t));
+
         noc_nonposted_writes_acked[noc_index] += num_dests;
 
-        wait_for_workers(cmd);
+        wait_for_workers(wait_count, wait_stream);
         cq_noc_async_write_with_state<CQ_NOC_sndl, CQ_NOC_wait>(0, 0, 0);
-        // Send GO signal to remaining destinations. Only the destination NOC needs to be modified.
-        for (uint32_t i = 1, num_mcasts = cmd->mcast.num_mcast_txns; i < num_mcasts; ++i) {
-            uint64_t dst = get_noc_addr_helper(go_signal_noc_data[go_signal_noc_data_idx++], mcast_go_signal_addr);
-            uint32_t num_dests = go_signal_noc_data[go_signal_noc_data_idx++];
-            cq_noc_async_write_with_state<CQ_NOC_sNdl>(0, dst, 0);
-            noc_nonposted_writes_acked[noc_index] += num_dests;
-        }
-        noc_nonposted_writes_num_issued[noc_index] += cmd->mcast.num_mcast_txns;
+        noc_nonposted_writes_num_issued[noc_index] += 1;
     } else {
-        wait_for_workers(cmd);
+        wait_for_workers(wait_count, wait_stream);
     }
 
-    uint32_t num_unicasts = cmd->mcast.num_unicast_txns;
+    *aligned_go_signal_storage = go_signal_value;
     if constexpr (virtualize_unicast_cores) {
         // Issue #19729: Workaround to allow TT-Mesh Workload dispatch to target active ethernet cores.
         // This chip is virtualizing cores the go signal is unicasted to

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -1627,9 +1627,7 @@ public:
         const ProgramTransferInfo& program_transfer_info,
         bool has_multicast_launch_cmds,
         bool has_unicast_launch_cmds) {
-        const auto& noc_data_start_idx =
-            device->noc_data_start_index(sub_device_id, has_multicast_launch_cmds, has_unicast_launch_cmds);
-        const auto& num_noc_mcast_txns = has_multicast_launch_cmds ? device->num_noc_mcast_txns(sub_device_id) : 0;
+        const auto& noc_data_start_idx = device->noc_data_start_index(sub_device_id, has_unicast_launch_cmds);
         const auto& num_noc_unicast_txns = has_unicast_launch_cmds ? device->num_noc_unicast_txns(sub_device_id) : 0;
         DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
         auto sub_device_index = *sub_device_id;
@@ -1662,7 +1660,7 @@ public:
             MetalContext::instance()
                 .dispatch_mem_map(constants.dispatch_core_type)
                 .get_dispatch_stream_index(sub_device_index),
-            num_noc_mcast_txns,
+            has_multicast_launch_cmds ? sub_device_index : CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET,
             num_noc_unicast_txns,
             noc_data_start_idx,
             dispatcher_for_go_signal);
@@ -2450,7 +2448,7 @@ void reset_worker_dispatch_state_on_device(
                 expected_num_workers_completed[i],
                 *reinterpret_cast<uint32_t*>(&reset_launch_message_read_ptr_go_signal),
                 MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(i),
-                device->num_noc_mcast_txns(sub_device_id),
+                device->has_noc_mcast_txns(sub_device_id) ? i : CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET,
                 device->num_noc_unicast_txns(sub_device_id),
                 device->noc_data_start_index(sub_device_id),
                 dispatcher_for_go_signal);
@@ -2576,6 +2574,112 @@ ExpectedNumWorkerUpdates get_expected_num_workers_completed_updates(
 
     return ExpectedNumWorkerUpdates{
         .previous = previous_expected_num_workers_completed, .current = num_workers, .wrapped = wrapped};
+}
+
+static_assert(
+    DispatchSettings::DISPATCH_MESSAGE_ENTRIES + 1 == go_message_num_entries,
+    "Max number of dispatch message entries + 1 must be equal to the number of go message entries");
+
+void set_core_go_message_mapping_on_device(
+    IDevice* device,
+    const std::vector<std::pair<CoreRangeSet, uint32_t>>& core_go_message_mapping,
+    SystemMemoryManager& manager,
+    uint8_t cq_id) {
+    tt::tt_metal::DeviceCommandCalculator calculator;
+    uint32_t go_msg_size =
+        MetalContext::instance().hal().get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
+    calculator.add_dispatch_write_linear<true, true>(go_msg_size);
+    calculator.add_dispatch_wait();
+
+    std::vector<std::pair<const void*, uint32_t>> data;
+    std::vector<CQDispatchWritePackedMulticastSubCmd> sub_cmds;
+    std::vector<std::pair<uint32_t, uint32_t>> payload;
+    auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
+    auto dispatch_core_type = dispatch_core_config.get_core_type();
+    uint32_t noc_index = k_dispatch_downstream_noc;
+    uint32_t max_prefetch_command_size =
+        MetalContext::instance().dispatch_mem_map(dispatch_core_type).max_prefetch_command_size();
+    uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(device);
+
+    for (size_t i = 0; i < core_go_message_mapping.size(); ++i) {
+        auto& [core_range_set, go_msg_offset] = core_go_message_mapping[i];
+        for (auto& core_range : core_range_set.ranges()) {
+            CoreCoord virtual_start = device->virtual_core_from_logical_core(core_range.start_coord, CoreType::WORKER);
+            CoreCoord virtual_end = device->virtual_core_from_logical_core(core_range.end_coord, CoreType::WORKER);
+            CoreRange core_range_virtual{virtual_start, virtual_end};
+            sub_cmds.emplace_back(CQDispatchWritePackedMulticastSubCmd{
+                .noc_xy_addr = device->get_noc_multicast_encoding(noc_index, core_range_virtual),
+                .num_mcast_dests = (uint32_t)core_range.size()});
+            data.emplace_back(&go_msg_offset, sizeof(uint32_t));
+        }
+    }
+    if (sub_cmds.size() > 0) {
+        calculator.insert_write_packed_payloads<CQDispatchWritePackedMulticastSubCmd>(
+            sub_cmds.size(), sizeof(uint32_t), max_prefetch_command_size, packed_write_max_unicast_sub_cmds, payload);
+    }
+
+    calculator.add_dispatch_wait();
+
+    const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
+    void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
+    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+
+    const auto& compute_grid_size = device->compute_with_storage_grid_size();
+
+    CoreRange all_core_range_logical{{0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}};
+    CoreCoord virtual_start =
+        device->virtual_core_from_logical_core(all_core_range_logical.start_coord, CoreType::WORKER);
+    CoreCoord virtual_end = device->virtual_core_from_logical_core(all_core_range_logical.end_coord, CoreType::WORKER);
+    CoreRange all_core_range_virtual{virtual_start, virtual_end};
+
+    // Write done to all indices on all tensix cores. All cores should already be idle at this point, but they may have
+    // garbage in the GO message entries they aren't using.
+    std::vector<uint32_t> go_data(go_message_num_entries, RUN_MSG_DONE);
+    TT_ASSERT(
+        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG) %
+            MetalContext::instance().hal().get_alignment(HalMemType::L1) ==
+        0);
+    command_sequence.add_dispatch_write_linear<true, true>(
+        all_core_range_logical.size(),
+        device->get_noc_multicast_encoding(noc_index, all_core_range_virtual),
+        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG),
+        go_msg_size,
+        go_data.data());
+    // Wait for previous writes before updating index.
+    command_sequence.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
+
+    // Write go index to all cores.
+    if (sub_cmds.size() > 0) {
+        TT_ASSERT(
+            MetalContext::instance().hal().get_dev_addr(
+                HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG_INDEX) %
+                MetalContext::instance().hal().get_alignment(HalMemType::L1) ==
+            0);
+        uint32_t go_msg_index_addr = MetalContext::instance().hal().get_dev_addr(
+            HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG_INDEX);
+        uint32_t go_msg_index_size = MetalContext::instance().hal().get_dev_size(
+            HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG_INDEX);
+        uint32_t curr_sub_cmd_idx = 0;
+        for (const auto& [num_sub_cmds_in_cmd, payload_sizeB] : payload) {
+            command_sequence.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(
+                CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_GO_MSG_INDEX,
+                num_sub_cmds_in_cmd,
+                go_msg_index_addr,
+                go_msg_index_size,
+                payload_sizeB,
+                sub_cmds,
+                data,
+                packed_write_max_unicast_sub_cmds,
+                curr_sub_cmd_idx);
+            curr_sub_cmd_idx += num_sub_cmds_in_cmd;
+        }
+    }
+    // Ensure go message index is received before writing out data for the next program.
+    command_sequence.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
+    TT_ASSERT(command_sequence.size_bytes() == command_sequence.write_offset_bytes());
+    manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
+    manager.fetch_queue_reserve_back(cq_id);
+    manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);
 }
 
 template uint32_t program_base_addr_on_core<ProgramImpl, IDevice*>(ProgramImpl&, IDevice*, HalProgrammableCoreType);

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -194,6 +194,12 @@ void reset_expected_num_workers_completed_on_device(
 //
 ExpectedNumWorkerUpdates get_expected_num_workers_completed_updates(
     uint32_t num_workers, uint32_t num_additional_workers);
+
+void set_core_go_message_mapping_on_device(
+    IDevice* device,
+    const std::vector<std::pair<CoreRangeSet, uint32_t>>& core_go_message_mapping,
+    SystemMemoryManager& manager,
+    uint8_t cq_id);
 
 }  // namespace program_dispatch
 

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -105,9 +105,9 @@ const SubDevice& SubDeviceManager::sub_device(SubDeviceId sub_device_id) const {
 
 const vector_aligned<uint32_t>& SubDeviceManager::noc_mcast_unicast_data() const { return noc_mcast_unicast_data_; }
 
-uint8_t SubDeviceManager::num_noc_mcast_txns(SubDeviceId sub_device_id) const {
+bool SubDeviceManager::has_noc_mcast_txns(SubDeviceId sub_device_id) const {
     auto sub_device_index = this->get_sub_device_index(sub_device_id);
-    return num_noc_mcast_txns_[sub_device_index];
+    return has_noc_mcast_txns_[sub_device_index];
 }
 
 uint8_t SubDeviceManager::num_noc_unicast_txns(SubDeviceId sub_device_id) const {
@@ -115,14 +115,13 @@ uint8_t SubDeviceManager::num_noc_unicast_txns(SubDeviceId sub_device_id) const 
     return num_noc_unicast_txns_[sub_device_index];
 }
 
-uint8_t SubDeviceManager::noc_mcast_data_start_index(SubDeviceId sub_device_id) const {
-    auto sub_device_index = this->get_sub_device_index(sub_device_id);
-    return noc_mcast_data_start_index_[sub_device_index];
-}
-
 uint8_t SubDeviceManager::noc_unicast_data_start_index(SubDeviceId sub_device_id) const {
     auto sub_device_index = this->get_sub_device_index(sub_device_id);
     return noc_unicast_data_start_index_[sub_device_index];
+}
+
+const std::vector<std::pair<CoreRangeSet, uint32_t>>& SubDeviceManager::get_core_go_message_mapping() const {
+    return core_go_message_mapping_;
 }
 
 const std::unique_ptr<Allocator>& SubDeviceManager::allocator(SubDeviceId sub_device_id) const {
@@ -324,27 +323,17 @@ void SubDeviceManager::populate_sub_allocators() {
 
 void SubDeviceManager::populate_noc_data() {
     uint32_t num_sub_devices = this->num_sub_devices();
-    num_noc_mcast_txns_.resize(num_sub_devices);
+    has_noc_mcast_txns_.resize(num_sub_devices);
     num_noc_unicast_txns_.resize(num_sub_devices);
-    noc_mcast_data_start_index_.resize(num_sub_devices);
     noc_unicast_data_start_index_.resize(num_sub_devices);
 
     NOC noc_index = MetalContext::instance().get_dispatch_query_manager().go_signal_noc();
     uint32_t idx = 0;
     for (uint32_t i = 0; i < num_sub_devices; ++i) {
-        const auto& tensix_cores = sub_devices_[i].cores(HalProgrammableCoreType::TENSIX).merge_ranges();
         const auto& eth_cores = sub_devices_[i].cores(HalProgrammableCoreType::ACTIVE_ETH);
 
-        noc_mcast_data_start_index_[i] = idx;
-        num_noc_mcast_txns_[i] = tensix_cores.size();
-        noc_mcast_unicast_data_.resize(idx + num_noc_mcast_txns_[i] * 2);
-        for (const auto& core_range : tensix_cores.ranges()) {
-            auto virtual_start = device_->virtual_core_from_logical_core(core_range.start_coord, CoreType::WORKER);
-            auto virtual_end = device_->virtual_core_from_logical_core(core_range.end_coord, CoreType::WORKER);
-            auto virtual_core_range = CoreRange(virtual_start, virtual_end);
-            noc_mcast_unicast_data_[idx++] = device_->get_noc_multicast_encoding(noc_index, virtual_core_range);
-            noc_mcast_unicast_data_[idx++] = core_range.size();
-        }
+        has_noc_mcast_txns_[i] = sub_devices_[i].has_core_type(HalProgrammableCoreType::TENSIX);
+
         noc_unicast_data_start_index_[i] = idx;
 
         // TODO: Precompute number of eth cores and resize once
@@ -362,6 +351,23 @@ void SubDeviceManager::populate_noc_data() {
             "NOC data entries {} exceeds maximum supported size {}",
             idx,
             DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES);
+    }
+
+    const auto& compute_grid_size = device_->compute_with_storage_grid_size();
+    CoreRange device_worker_cores = CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1});
+
+    std::vector<std::pair<CoreRangeSet, uint32_t>> core_go_message_mapping;
+    CoreRangeSet used_cores;
+    for (size_t i = 0; i < num_sub_devices; ++i) {
+        const auto& sub_device = sub_devices_[i];
+        const auto& tensix_cores = sub_device.cores(HalProgrammableCoreType::TENSIX);
+        used_cores = used_cores.merge(tensix_cores);
+        core_go_message_mapping_.emplace_back(tensix_cores, i);
+    }
+    CoreRangeSet all_core_set{device_worker_cores};
+    CoreRangeSet unused_cores = all_core_set.subtract(used_cores);
+    if (!unused_cores.empty()) {
+        core_go_message_mapping_.emplace_back(unused_cores, num_sub_devices);
     }
 }
 

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -367,7 +367,8 @@ void SubDeviceManager::populate_noc_data() {
     CoreRangeSet all_core_set{device_worker_cores};
     CoreRangeSet unused_cores = all_core_set.subtract(used_cores);
     if (!unused_cores.empty()) {
-        core_go_message_mapping_.emplace_back(unused_cores, num_sub_devices);
+        constexpr uint32_t unused_go_message_index = go_message_num_entries - 1;
+        core_go_message_mapping_.emplace_back(unused_cores, unused_go_message_index);
     }
 }
 

--- a/tt_metal/impl/sub_device/sub_device_manager.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/sub_device/sub_device_manager.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -50,10 +50,11 @@ public:
     const SubDevice& sub_device(SubDeviceId sub_device_id) const;
 
     const vector_aligned<uint32_t>& noc_mcast_unicast_data() const;
-    uint8_t num_noc_mcast_txns(SubDeviceId sub_device_id) const;
+    bool has_noc_mcast_txns(SubDeviceId sub_device_id) const;
     uint8_t num_noc_unicast_txns(SubDeviceId sub_device_id) const;
-    uint8_t noc_mcast_data_start_index(SubDeviceId sub_device_id) const;
     uint8_t noc_unicast_data_start_index(SubDeviceId sub_device_id) const;
+
+    const std::vector<std::pair<CoreRangeSet, uint32_t>>& get_core_go_message_mapping() const;
 
     const std::unique_ptr<Allocator>& allocator(SubDeviceId sub_device_id) const;
     std::unique_ptr<Allocator>& sub_device_allocator(SubDeviceId sub_device_id);
@@ -93,12 +94,12 @@ private:
 
     std::array<uint32_t, NumHalProgrammableCoreTypes> num_cores_{};
 
-    // mcast txn data followed by unicast txn data
     vector_aligned<uint32_t> noc_mcast_unicast_data_;
-    std::vector<uint8_t> num_noc_mcast_txns_;
+    std::vector<bool> has_noc_mcast_txns_;
     std::vector<uint8_t> num_noc_unicast_txns_;
-    std::vector<uint8_t> noc_mcast_data_start_index_;
     std::vector<uint8_t> noc_unicast_data_start_index_;
+
+    std::vector<std::pair<CoreRangeSet, uint32_t>> core_go_message_mapping_;
 
     std::unordered_map<distributed::MeshTraceId, std::shared_ptr<distributed::MeshTraceBuffer>> trace_buffer_pool_;
 

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -67,13 +67,20 @@ void SubDeviceManagerTracker::reset_sub_device_state(const std::unique_ptr<SubDe
         distributed::MeshDevice* mesh_device = dynamic_cast<distributed::MeshDevice*>(device_);
         for (uint8_t cq_id = 0; cq_id < mesh_device->num_hw_cqs(); ++cq_id) {
             mesh_device->mesh_command_queue(cq_id).reset_worker_state(
-                cq_id == 0, num_sub_devices, sub_device_manager->noc_mcast_unicast_data());
+                cq_id == 0,
+                num_sub_devices,
+                sub_device_manager->noc_mcast_unicast_data(),
+                sub_device_manager->get_core_go_message_mapping());
         }
     } else {
         for (uint8_t cq_id = 0; cq_id < device_->num_hw_cqs(); ++cq_id) {
             auto& hw_cq = device_->command_queue(cq_id);
             // Only need to reset launch messages once, so reset on cq 0
-            hw_cq.reset_worker_state(cq_id == 0, num_sub_devices, sub_device_manager->noc_mcast_unicast_data());
+            hw_cq.reset_worker_state(
+                cq_id == 0,
+                num_sub_devices,
+                sub_device_manager->noc_mcast_unicast_data(),
+                sub_device_manager->get_core_go_message_mapping());
         }
     }
     sub_device_manager->reset_sub_device_stall_group();

--- a/tt_metal/impl/trace/dispatch.cpp
+++ b/tt_metal/impl/trace/dispatch.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -44,7 +44,9 @@ HalCoreInfoType create_active_eth_mem_map() {
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] =
         tt::align(MEM_AERISC_MAP_END + MEM_ERISC_KERNEL_CONFIG_SIZE, max_alignment);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORE_INFO)] = GET_ETH_MAILBOX_ADDRESS_HOST(core_info);
-    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_ETH_MAILBOX_ADDRESS_HOST(go_message);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_ETH_MAILBOX_ADDRESS_HOST(go_messages);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG_INDEX)] =
+        GET_ETH_MAILBOX_ADDRESS_HOST(go_message_index);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] =
         GET_ETH_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BANK_TO_NOC_SCRATCH)] = MEM_AERISC_BANK_TO_NOC_SCRATCH;
@@ -74,7 +76,8 @@ HalCoreInfoType create_active_eth_mem_map() {
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = MEM_ERISC_KERNEL_CONFIG_SIZE;
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] =
         MEM_ERISC_MAX_SIZE - mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];
-    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t) * go_message_num_entries;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG_INDEX)] = sizeof(std::uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(std::uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BANK_TO_NOC_SCRATCH)] = MEM_AERISC_BANK_TO_NOC_SIZE;
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::APP_SYNC_INFO)] = MEM_ERISC_SYNC_INFO_SIZE;

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_idle_eth.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_idle_eth.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -44,7 +44,9 @@ HalCoreInfoType create_idle_eth_mem_map() {
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] =
         tt::align(MEM_AERISC_MAP_END + MEM_ERISC_KERNEL_CONFIG_SIZE, max_alignment);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORE_INFO)] = GET_IERISC_MAILBOX_ADDRESS_HOST(core_info);
-    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_IERISC_MAILBOX_ADDRESS_HOST(go_message);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_IERISC_MAILBOX_ADDRESS_HOST(go_messages);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG_INDEX)] =
+        GET_IERISC_MAILBOX_ADDRESS_HOST(go_message_index);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] =
         GET_IERISC_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BANK_TO_NOC_SCRATCH)] = MEM_IERISC_BANK_TO_NOC_SCRATCH;
@@ -62,7 +64,8 @@ HalCoreInfoType create_idle_eth_mem_map() {
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = MEM_ERISC_KERNEL_CONFIG_SIZE;
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] =
         MEM_ERISC_MAX_SIZE - mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];
-    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t) * go_message_num_entries;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG_INDEX)] = sizeof(std::uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(std::uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BANK_TO_NOC_SCRATCH)] = MEM_IERISC_BANK_TO_NOC_SIZE;
 

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -40,7 +40,9 @@ HalCoreInfoType create_tensix_mem_map() {
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = GET_MAILBOX_ADDRESS_HOST(profiler);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = MEM_MAP_END;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORE_INFO)] = GET_MAILBOX_ADDRESS_HOST(core_info);
-    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_MAILBOX_ADDRESS_HOST(go_message);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_MAILBOX_ADDRESS_HOST(go_messages);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG_INDEX)] =
+        GET_MAILBOX_ADDRESS_HOST(go_message_index);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] =
         GET_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LOCAL)] = MEM_LOCAL_BASE;
@@ -60,7 +62,8 @@ HalCoreInfoType create_tensix_mem_map() {
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
-    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t) * go_message_num_entries;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG_INDEX)] = sizeof(std::uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LOCAL)] =
         MEM_TRISC_LOCAL_SIZE;  // TRISC, BRISC, or NCRISC?

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_active_eth.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_active_eth.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -41,7 +41,9 @@ HalCoreInfoType create_active_eth_mem_map(bool is_base_routing_fw_enabled) {
         is_base_routing_fw_enabled ? eth_l1_mem::address_map::ROUTING_ENABLED_ERISC_L1_UNRESERVED_BASE
                                    : eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORE_INFO)] = GET_ETH_MAILBOX_ADDRESS_HOST(core_info);
-    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_ETH_MAILBOX_ADDRESS_HOST(go_message);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_ETH_MAILBOX_ADDRESS_HOST(go_messages);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG_INDEX)] =
+        GET_ETH_MAILBOX_ADDRESS_HOST(go_message_index);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] =
         GET_ETH_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BANK_TO_NOC_SCRATCH)] =
@@ -76,7 +78,8 @@ HalCoreInfoType create_active_eth_mem_map(bool is_base_routing_fw_enabled) {
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] =
         is_base_routing_fw_enabled ? eth_l1_mem::address_map::ROUTING_ENABLED_ERISC_L1_UNRESERVED_SIZE
                                    : eth_l1_mem::address_map::ERISC_L1_UNRESERVED_SIZE;
-    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t) * go_message_num_entries;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG_INDEX)] = sizeof(std::uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BANK_TO_NOC_SCRATCH)] =
         eth_l1_mem::address_map::ERISC_MEM_BANK_TO_NOC_SIZE;

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_idle_eth.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_idle_eth.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -44,7 +44,9 @@ HalCoreInfoType create_idle_eth_mem_map() {
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] =
         ((MEM_IERISC_MAP_END + L1_KERNEL_CONFIG_SIZE - 1) | (max_alignment - 1)) + 1;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORE_INFO)] = GET_IERISC_MAILBOX_ADDRESS_HOST(core_info);
-    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_IERISC_MAILBOX_ADDRESS_HOST(go_message);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_IERISC_MAILBOX_ADDRESS_HOST(go_messages);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG_INDEX)] =
+        GET_IERISC_MAILBOX_ADDRESS_HOST(go_message_index);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] =
         GET_IERISC_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BANK_TO_NOC_SCRATCH)] = MEM_IERISC_BANK_TO_NOC_SCRATCH;
@@ -63,7 +65,8 @@ HalCoreInfoType create_idle_eth_mem_map() {
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] =
         MEM_ETH_SIZE - mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];
     ;
-    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t) * go_message_num_entries;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG_INDEX)] = sizeof(std::uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(std::uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BANK_TO_NOC_SCRATCH)] = MEM_IERISC_BANK_TO_NOC_SIZE;
 

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -38,7 +38,9 @@ HalCoreInfoType create_tensix_mem_map() {
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = GET_MAILBOX_ADDRESS_HOST(profiler);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = MEM_MAP_END;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORE_INFO)] = GET_MAILBOX_ADDRESS_HOST(core_info);
-    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_MAILBOX_ADDRESS_HOST(go_message);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_MAILBOX_ADDRESS_HOST(go_messages);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG_INDEX)] =
+        GET_MAILBOX_ADDRESS_HOST(go_message_index);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] =
         GET_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LOCAL)] = MEM_LOCAL_BASE;
@@ -58,7 +60,8 @@ HalCoreInfoType create_tensix_mem_map() {
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
-    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t) * go_message_num_entries;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG_INDEX)] = sizeof(std::uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(std::uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LOCAL)] =
         MEM_TRISC_LOCAL_SIZE;  // TRISC, BRISC, or NCRISC?

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -135,6 +135,12 @@ void send_reset_go_signal(chip_id_t chip, const CoreCoord& virtual_core) {
     reset_msg.signal = RUN_MSG_RESET_READ_PTR_FROM_HOST;
     tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         &reset_msg, sizeof(go_msg_t), tt_cxy_pair(chip, virtual_core), go_signal_adrr);
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(chip);
+    uint32_t go_message_index_addr = tt_metal::MetalContext::instance().hal().get_dev_addr(
+        dispatch_core_type, tt_metal::HalL1MemAddrType::GO_MSG_INDEX);
+    uint32_t zero = 0;
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        &zero, sizeof(uint32_t), tt_cxy_pair(chip, virtual_core), go_message_index_addr);
 }
 
 void write_launch_msg_to_core(chip_id_t chip, const CoreCoord core, launch_msg_t *msg, go_msg_t *go_msg,  uint64_t base_addr, bool send_go) {


### PR DESCRIPTION
### Ticket
#20867

### Problem description
If there are multiple core ranges for a subdevice, sending GO to that subdevice will take multiple mcasts, slowing down the launch of the kernel on some cores.

### What's changed
We can assign a go message slot per subdevice. When the subdevice manager is loaded, we can set an index on each core so it knows which go message slot to look at. This allows us to use one mcast.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes