### PR TITLE
Remove HW % 32 == 0 Requirement for Bfloat8 Pool Testing

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -187,12 +187,6 @@ def run_max_pool(
     act_reshaped = act_permuted.reshape(act_shape)
 
     if dtype == ttnn.bfloat8_b:
-        if (in_h * in_w) % 32 != 0:
-            pytest.skip("For BFP8_B datatype, input height * width should be multiple of 32")
-        if shard_scheme == ttnn.TensorMemoryLayout.WIDTH_SHARDED and (in_c / max_cores) % 32 != 0:
-            pytest.skip("For BFP8_B datatype, input channels / max_cores should be multiple of 32")
-        if shard_scheme == ttnn.TensorMemoryLayout.BLOCK_SHARDED and (in_c / cores_x) % 32 != 0:
-            pytest.skip("For BFP8_B datatype, input channels / cores_x should be multiple of 32")
         ttact = ttnn.from_torch(act_reshaped, dtype, layout=ttnn.TILE_LAYOUT)
     else:
         ttact = ttnn.from_torch(act_reshaped, dtype)

--- a/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
@@ -61,6 +61,21 @@ parameters = {
             [1, 256, 20, 20, 8, 8, 6, 6, 0, 0, 1, 1, False],  # max rows per reduction multiple large kernel
             [1, 512, 20, 20, 8, 8, 6, 6, 0, 0, 1, 1, False],  # max rows per reduction multiple large kernel wide
             [1, 320, 48, 48, 36, 36, 1, 1, 0, 0, 1, 1, False],  # 3 reduction stages, multiple indexes per core, wide
+            [
+                1,
+                300,
+                45,
+                45,
+                36,
+                36,
+                1,
+                1,
+                0,
+                0,
+                1,
+                1,
+                False,
+            ],  # 3 reduction stages, multiple indexes per core, wide, non tile multiple for bfloat8
         ],
     },
     "test_run_max_pool": {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15108

### Problem description
An old bug report stated that Bfloat8 did not work unless HW % 32 == 0.

### What's changed
This issue no longer exists, it is unfortunately unclear what the fix was.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:

- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:

- [ ] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
(wormhole) 
(blackhole) 
- [x] New/Existing tests provide coverage for changes