### PR TITLE
[produce data] [skip ci] Remove redundant api calls

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -116,13 +116,6 @@ jobs:
           sleep 60
           echo "[Info] Workflow run attempt"
           gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }} | tee workflow.json
-      - name: Fetch workflow jobs data
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          ./infra/data_collection/github/download_cicd_logs_and_artifacts.sh --workflow-run-id ${{ steps.get-run-id-and-attempt.outputs.run-id }} --attempt-number ${{ steps.get-run-id-and-attempt.outputs.attempt-number }} --fetch-jobs-only
-          find generated/cicd/ -type f
       - name: Collect workflow artifact and job logs
         shell: bash
         env:

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -115,47 +115,14 @@ jobs:
           echo "Sleeping for 60 seconds for github to fully sync the workflow run before calling the API"
           sleep 60
           echo "[Info] Workflow run attempt"
-          gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}
-          gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }} > workflow.json
-          echo "[Info] Workflow run attempt jobs"
-          # Try the original --paginate approach first, fall back to manual pagination if it fails
-          set +e  # Disable exit on error
-          paginated_output=$(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}/jobs --paginate 2>&1)
-          paginate_exit_code=$?
-          set -e  # Re-enable exit on error
-
-          if [ $paginate_exit_code -eq 0 ]; then
-            echo "Successfully fetched jobs using --paginate"
-            echo "$paginated_output" | jq -s '{total_count: .[0].total_count, jobs: map(.jobs) | add}' > workflow_jobs.json
-          else
-            echo "--paginate failed (exit code: $paginate_exit_code), falling back to manual pagination"
-            echo "Error output: $paginated_output"
-            # Manual pagination to avoid 502 errors with --paginate
-            # Get first page to determine total count
-            first_page=$(gh api "/repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}/jobs?per_page=50&page=1")
-            total_count=$(echo "$first_page" | jq -r '.total_count')
-            echo "Total jobs: $total_count"
-
-            # Calculate total pages needed
-            per_page=50
-            total_pages=$(( (total_count + per_page - 1) / per_page ))
-            echo "Total pages: $total_pages"
-
-            # Initialize with first page
-            all_jobs=$(echo "$first_page" | jq -r '.jobs')
-
-            # Fetch remaining pages if any
-            for page in $(seq 2 $total_pages); do
-              echo "Fetching page $page of $total_pages"
-              page_data=$(gh api "/repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}/jobs?per_page=50&page=$page")
-              page_jobs=$(echo "$page_data" | jq -r '.jobs')
-              all_jobs=$(jq -s '.[0] + .[1]' <(echo "$all_jobs") <(echo "$page_jobs"))
-              sleep 5
-            done
-
-            # Create final JSON with total_count and combined jobs
-            echo "$all_jobs" | jq -s '{total_count: '$total_count', jobs: .[0]}' > workflow_jobs.json
-          fi
+          gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }} | tee workflow.json
+      - name: Fetch workflow jobs data
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./infra/data_collection/github/download_cicd_logs_and_artifacts.sh --workflow-run-id ${{ steps.get-run-id-and-attempt.outputs.run-id }} --attempt-number ${{ steps.get-run-id-and-attempt.outputs.attempt-number }} --fetch-jobs-only
+          find generated/cicd/ -type f
       - name: Collect workflow artifact and job logs
         shell: bash
         env:
@@ -195,7 +162,7 @@ jobs:
             path: |
               pipelinecopy_*.json
               workflow.json
-              workflow_jobs.json
+              workflow_jobs_${{ steps.get-run-id-and-attempt.outputs.run-id }}_${{ steps.get-run-id-and-attempt.outputs.attempt-number }}.json
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -155,7 +155,7 @@ jobs:
             path: |
               pipelinecopy_*.json
               workflow.json
-              workflow_jobs_${{ steps.get-run-id-and-attempt.outputs.run-id }}_${{ steps.get-run-id-and-attempt.outputs.attempt-number }}.json
+              workflow_jobs.json
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:

--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -32,7 +32,7 @@ get_jobs_with_pagination_fallback() {
     local workflow_run_id=$2
     local attempt_number=$3
 
-    local jobs_json_file="workflow_jobs_${workflow_run_id}_${attempt_number}.json"
+    local jobs_json_file="workflow_jobs.json"
 
     # Try the original --paginate approach first, fall back to manual pagination if it fails
     set +e  # Disable exit on error

--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -34,13 +34,6 @@ get_jobs_with_pagination_fallback() {
 
     local jobs_json_file="workflow_jobs_${workflow_run_id}_${attempt_number}.json"
 
-    # Check if the jobs JSON file already exists
-    if [[ -f "$jobs_json_file" ]]; then
-        echo "[info] Using existing $jobs_json_file"
-        cat "$jobs_json_file"
-        return 0
-    fi
-
     # Try the original --paginate approach first, fall back to manual pagination if it fails
     set +e  # Disable exit on error
     paginated_output=$(gh api /repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/jobs --paginate 2>&1)
@@ -113,9 +106,6 @@ download_logs_for_all_jobs() {
 }
 
 main() {
-    # Default: only fetch jobs if flag is set
-    fetch_jobs_only=false
-
     # Parse the arguments
     while [[ $# -gt 0 ]]; do
         case $1 in
@@ -130,9 +120,6 @@ main() {
             --repo)
                 repo=$2
                 shift
-                ;;
-            --fetch-jobs-only)
-                fetch_jobs_only=true
                 ;;
             *)
                 echo "Unknown option: $1"
@@ -153,11 +140,6 @@ main() {
     if [[ -z "$attempt_number" ]]; then
         echo "attempt_number is empty"
         exit 1
-    fi
-
-    if $fetch_jobs_only; then
-        get_jobs_with_pagination_fallback "$repo" "$workflow_run_id" "$attempt_number" > /dev/null
-        exit 0
     fi
 
     set_up_dirs "$workflow_run_id"


### PR DESCRIPTION
### Ticket
[Produce data pipeline gets all job data twice #24550](https://github.com/tenstorrent/tt-metal/issues/24550)

### Problem description
Code for fetching all jobs data was duplicated in _produce-data.yaml and download_cicd_logs_and_artifacts.sh

### What's changed
No duplicate API calls.
Jobs data is fetched once and json is generated within the script.

### Checklist
- [x] New/Existing tests provide coverage for changes

Tested by running:
- [x] [PR Gate #28542](https://github.com/tenstorrent/tt-metal/actions/runs/16201358400)
- [x] [[internal] Produce data for external analysis #124733](https://github.com/tenstorrent/tt-metal/actions/runs/16201582436) on main
- [x] [[internal] Produce data for external analysis #124725](https://github.com/tenstorrent/tt-metal/actions/runs/16201532748) with changes
- [x] Generated files are identical (excluding timestamp and trigger for the call itself)

