### PR TITLE
Migrate EnqueueProgram tests to use TT-Mesh APIs

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -49,6 +49,7 @@ jobs:
           {name: distributed_multiprocess, cmd: "./tests/tt_metal/multihost/run_multiprocess_socket_tests.sh"},
           {name: lightmetal, cmd: "./build/test/tt_metal/unit_tests_lightmetal"},
           {name: dispatch multicmd queue, cmd: "TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=MultiCommandQueue*Fixture.*"},
+          {name: dispatch multicmd queue, cmd: "TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshMultiCQ*Fixture.*"},
           {name: ttnn cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn},
           {name: ttnn ccl cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn_ccl},
           {name: ttnn ccl ops cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn_ccl_ops},

--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -116,7 +116,9 @@ jobs:
         run: |
           ./build/test/tt_metal/tt_fabric/test_system_health --system-topology TORUS_XY
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardFixture.*";
+          TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UnitMeshCQSingleCardFixture.*";
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardProgramFixture.*";
+          TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UnitMeshCQSingleCardProgramFixture.*";
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites";
           ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
           ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -13,9 +13,12 @@ test_suite_bh_single_pcie_metal_unit_tests() {
     ARCH_NAME=blackhole TT_METAL_SLOW_DISPATCH_MODE=1 ./tests/scripts/run_cpp_fd2_tests.sh
     # I wonder why we can't put these in the validation suite?
     ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=CommandQueueSingleCardProgramFixture.*
+    ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshCQSingleCardProgramFixture.*
     ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=CommandQueueProgramFixture.*
+    ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshCQProgramFixture.*
     ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=RandomProgramFixture.*
     ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=CommandQueueSingleCardBufferFixture.* # Tests EnqueueRead/EnqueueWrite Buffer from DRAM/L1
+
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_api --gtest_filter=*SimpleDram*:*SimpleL1* # Executable is dependent on arch (provided through GitHub CI workflow scripts)
 }
 
@@ -81,7 +84,9 @@ test_suite_wh_6u_metal_unit_tests() {
     echo "[upstream-tests] running WH 6U upstream metalium unit tests. Note that skips should be treated as failures"
     ./build/test/tt_metal/tt_fabric/test_system_health
     TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardFixture.*"
+    TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UntiMeshCQSingleCardFixture.*"
     TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardProgramFixture.*"
+    TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UnitMeshCQSingleCardProgramFixture.*"
     TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites"
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
 }

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -24,6 +24,8 @@ run_t3000_ttmetal_tests() {
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_eth --gtest_filter="DeviceFixture.ActiveEthKernelsInterleavedRingGatherAllChips" ; fail+=$?
   TT_METAL_ENABLE_REMOTE_CHIP=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCard*Fixture.*" ; fail+=$?
   TT_METAL_ENABLE_ERISC_IRAM=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueMultiDevice*Fixture.*" ; fail+=$?
+  TT_METAL_ENABLE_REMOTE_CHIP=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UnitMeshCQSingleDevice*Fixture.*" ; fail+=$?
+  TT_METAL_ENABLE_ERISC_IRAM=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UnitMeshCQMultiDevice*Fixture.*" ; fail+=$?
   ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter="DPrintFixture.*:WatcherFixture.*" ; fail+=$?
 
   # Programming examples

--- a/tests/scripts/tg/run_tg_unit_tests.sh
+++ b/tests/scripts/tg/run_tg_unit_tests.sh
@@ -63,9 +63,11 @@ run_tg_tests() {
   if [[ "$1" == "unit" ]]; then
     echo "LOG_METAL: running run_tg_unit_tests"
     TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_ENABLE_REMOTE_CHIP=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCard*Fixture.*"
+    TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_ENABLE_REMOTE_CHIP=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UnitMeshCQSingleCard*Fixture.*"
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_device --gtest_filter="GalaxyFixture.*:TGFixture.*"
     ./build/test/tt_metal/unit_tests_device --gtest_filter="GalaxyFixture.*:TGFixture.*"
     TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="MultiCommandQueueMultiDevice*Fixture.*"
+    TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UnitMeshMultiCQMultiDevice*Fixture.*"
 
   elif [[ "$1" == "fabric" ]]; then
     echo "LOG_FABRIC: running run_tg_fabric_tests"

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -24,7 +24,7 @@
 #include "llrt.hpp"
 
 namespace tt::tt_metal {
-
+// #22835: These Fixtures will be removed once tests are fully migrated, and replaced by UnitMeshCQFixtures
 class CommandQueueFixture : public DispatchFixture {
 protected:
     tt::tt_metal::IDevice* device_;
@@ -80,7 +80,7 @@ protected:
     void CreateDevice(const size_t trace_region_size) { this->create_device(trace_region_size); }
 };
 
-class UnitMeshCommandQueueFixture : public DispatchFixture {
+class UnitMeshCQFixture : public DispatchFixture {
 protected:
     void SetUp() override {
         if (!this->validate_dispatch_mode()) {
@@ -131,6 +131,10 @@ protected:
     std::vector<std::shared_ptr<distributed::MeshDevice>> devices_;
 };
 
+class UnitMeshCQProgramFixture : public UnitMeshCQFixture {};
+
+// #22835: These Fixtures will be removed once tests are fully migrated, and replaced by UnitMeshCQSingleCardFixture and
+// UnitMeshCQSingleCardProgramFixture
 class CommandQueueSingleCardFixture : virtual public DispatchFixture {
 protected:
     void SetUp() override {
@@ -198,6 +202,62 @@ protected:
     std::map<chip_id_t, tt::tt_metal::IDevice*> reserved_devices_;
 };
 
+class UnitMeshCQSingleCardFixture : virtual public DispatchFixture {
+protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
+    void SetUp() override {
+        if (!this->validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
+        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        this->create_devices();
+    }
+
+    void TearDown() override {
+        for (auto& device : devices_) {
+            device.reset();
+        }
+    }
+
+    bool validate_dispatch_mode() {
+        this->slow_dispatch_ = false;
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (slow_dispatch) {
+            log_info(tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
+            this->slow_dispatch_ = false;
+            return false;
+        }
+        return true;
+    }
+
+    void create_devices(std::size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
+        const auto& dispatch_core_config =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
+        const chip_id_t mmio_device_id = *tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids().begin();
+        std::vector<chip_id_t> chip_ids;
+        auto enable_remote_chip = getenv("TT_METAL_ENABLE_REMOTE_CHIP");
+        if (enable_remote_chip or
+            tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0) == BoardType::UBB) {
+            for (chip_id_t id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
+                chip_ids.push_back(id);
+            }
+        } else {
+            chip_ids.push_back(mmio_device_id);
+        }
+        auto reserved_devices = distributed::MeshDevice::create_unit_meshes(
+            chip_ids, DEFAULT_L1_SMALL_SIZE, trace_region_size, 1, dispatch_core_config);
+        for (const auto& [id, device] : reserved_devices) {
+            this->devices_.push_back(device);
+        }
+    }
+
+    std::vector<std::shared_ptr<distributed::MeshDevice>> devices_;
+};
+
+class UnitMeshCQSingleCardProgramFixture : virtual public UnitMeshCQSingleCardFixture {};
+
 class CommandQueueSingleCardBufferFixture : public CommandQueueSingleCardFixture {};
 
 class CommandQueueSingleCardTraceFixture : virtual public CommandQueueSingleCardFixture {
@@ -213,10 +273,7 @@ protected:
 
 class CommandQueueSingleCardProgramFixture : virtual public CommandQueueSingleCardFixture {};
 
-// Multi device command queue fixture. This fixture keeps the device open between test cases.
-// If the device should open closed/reopned for each test case then override the SetUpTestSuite and TearDownTestSuite
-// methods
-class UnitMeshCommandQueueMultiDeviceFixture : public DispatchFixture {
+class UnitMeshCQMultiDeviceFixture : public DispatchFixture {
 protected:
     void SetUp() override {
         this->slow_dispatch_ = false;
@@ -236,12 +293,10 @@ protected:
 
         std::vector<chip_id_t> chip_ids;
         for (chip_id_t id : tt::tt_metal::MetalContext::instance().get_cluster().all_chip_ids()) {
-            std::cout << "Adding chip ID: " << id << std::endl;
             chip_ids.push_back(id);
         }
 
-        const auto& dispatch_core_config =
-            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
+        auto dispatch_core_config = tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
         auto reserved_devices = distributed::MeshDevice::create_unit_meshes(
             chip_ids, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, dispatch_core_config);
         for (const auto& [id, device] : reserved_devices) {
@@ -259,6 +314,7 @@ protected:
     size_t num_devices_;
 };
 
+// #22835: These Fixtures will be removed once tests are fully migrated, and replaced by UnitMeshCQMultiDeviceFixtures
 class CommandQueueMultiDeviceFixture : public DispatchFixture {
 protected:
     void SetUp() override {
@@ -302,9 +358,9 @@ class CommandQueueMultiDeviceProgramFixture : public CommandQueueMultiDeviceFixt
 
 class CommandQueueMultiDeviceBufferFixture : public CommandQueueMultiDeviceFixture {};
 
-class DISABLED_CommandQueueMultiDeviceOnFabricFixture
-    : public CommandQueueMultiDeviceFixture,
-      public ::testing::WithParamInterface<tt::tt_fabric::FabricConfig> {
+class DISABLED_CQMultiDeviceOnFabricFixture
+    : public UnitMeshCQMultiDeviceFixture,
+      public ::testing::WithParamInterface<tt::tt_metal::FabricConfig> {
 private:
     bool original_fd_fabric_en_ = false;
     inline static ARCH arch_ = tt::ARCH::Invalid;
@@ -325,7 +381,7 @@ protected:
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(true);
         // This will force dispatch init to inherit the FabricConfig param
         tt::tt_fabric::SetFabricConfig(GetParam(), tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-        CommandQueueMultiDeviceFixture::SetUp();
+        UnitMeshCQMultiDeviceFixture::SetUp();
 
         if (::testing::Test::IsSkipped()) {
             tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
@@ -336,7 +392,7 @@ protected:
         if (::testing::Test::IsSkipped()) {
             return;
         }
-        CommandQueueMultiDeviceFixture::TearDown();
+        UnitMeshCQMultiDeviceFixture::TearDown();
         tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(original_fd_fabric_en_);
     }

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -360,7 +360,7 @@ class CommandQueueMultiDeviceBufferFixture : public CommandQueueMultiDeviceFixtu
 
 class DISABLED_CQMultiDeviceOnFabricFixture
     : public UnitMeshCQMultiDeviceFixture,
-      public ::testing::WithParamInterface<tt::tt_metal::FabricConfig> {
+      public ::testing::WithParamInterface<tt::tt_fabric::FabricConfig> {
 private:
     bool original_fd_fabric_en_ = false;
     inline static ARCH arch_ = tt::ARCH::Invalid;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1388,10 +1388,10 @@ TEST_F(UnitMeshCQFixture, TensixTestRuntimeArgsCorrectlySentSingleCore) {
 }
 
 auto CQFabricConfigsToTest = ::testing::Values(
-    tt::tt_metal::FabricConfig::FABRIC_1D,
-    tt::tt_metal::FabricConfig::FABRIC_1D_RING,
-    tt::tt_metal::FabricConfig::FABRIC_2D,
-    tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC);
+    tt::tt_fabric::FabricConfig::FABRIC_1D,
+    tt::tt_fabric::FabricConfig::FABRIC_1D_RING,
+    tt::tt_fabric::FabricConfig::FABRIC_2D,
+    tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
 
 INSTANTIATE_TEST_SUITE_P(CommandQueueMultiDevice, DISABLED_CQMultiDeviceOnFabricFixture, CQFabricConfigsToTest);
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -228,9 +228,14 @@ bool cb_config_successful(
     return pass;
 }
 
-void test_dummy_EnqueueProgram_with_runtime_args(IDevice* device, const CoreCoord& eth_core_coord) {
+void test_dummy_EnqueueProgram_with_runtime_args(
+    std::shared_ptr<distributed::MeshDevice> mesh_device, const CoreCoord& eth_core_coord) {
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program;
-    auto eth_noc_xy = device->ethernet_core_from_logical_core(eth_core_coord);
+    auto device = mesh_device->get_devices()[0];
+    auto eth_noc_xy = mesh_device->ethernet_core_from_logical_core(eth_core_coord);
 
     constexpr uint32_t num_runtime_args0 = 9;
     uint32_t rta_base0 = MetalContext::instance().hal().get_dev_addr(
@@ -248,9 +253,9 @@ void test_dummy_EnqueueProgram_with_runtime_args(IDevice* device, const CoreCoor
     vector<uint32_t> dummy_kernel0_args = {0, 1, 2, 3, 4, 5, 6, 7, 8};
     tt::tt_metal::SetRuntimeArgs(program, dummy_kernel0, eth_core_coord, dummy_kernel0_args);
 
-    tt::tt_metal::detail::CompileProgram(device, program);
-    auto& cq = device->command_queue();
-    EnqueueProgram(cq, program, false);
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    distributed::EnqueueMeshWorkload(cq, workload, false);
     Finish(cq);
 
     vector<uint32_t> dummy_kernel0_args_readback = tt::llrt::read_hex_vec_from_core(
@@ -380,20 +385,25 @@ bool test_dummy_EnqueueProgram_with_sems(
 }
 
 bool test_dummy_EnqueueProgram_with_runtime_args(
-    IDevice* device,
-    CommandQueue& cq,
+    std::shared_ptr<distributed::MeshDevice> mesh_device,
+    distributed::MeshCommandQueue& cq,
     const DummyProgramConfig& program_config,
     uint32_t num_runtime_args_dm0,
     uint32_t num_runtime_args_dm1,
     uint32_t num_runtime_args_compute,
     uint32_t num_iterations,
     bool do_checks = true) {
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+
+    auto device = mesh_device->get_devices()[0];
     Program program;
     bool pass = true;
 
     CoreRangeSet cr_set = program_config.cr_set;
 
-    uint32_t rta_base_dm0 = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    uint32_t rta_base_dm0 = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
     uint32_t rta_base_dm1 = rta_base_dm0 + num_runtime_args_dm0 * sizeof(uint32_t);
     uint32_t rta_base_compute = rta_base_dm1 + num_runtime_args_dm1 * sizeof(uint32_t);
     std::map<std::string, std::string> dm_defines0 = {
@@ -452,9 +462,9 @@ bool test_dummy_EnqueueProgram_with_runtime_args(
         }
     }
 
-    tt::tt_metal::detail::CompileProgram(device, program);
+    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
     for (uint32_t i = 0; i < num_iterations; i++) {
-        EnqueueProgram(cq, program, false);
+        distributed::EnqueueMeshWorkload(cq, workload, false);
     }
     Finish(cq);
 
@@ -490,12 +500,16 @@ bool test_dummy_EnqueueProgram_with_runtime_args(
 }
 
 bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
-    IDevice* device,
-    CommandQueue& cq,
+    std::shared_ptr<distributed::MeshDevice> mesh_device,
+    distributed::MeshCommandQueue& cq,
     const DummyProgramConfig& program_config,
     uint32_t num_runtime_args_for_cr0,
     uint32_t num_runtime_args_for_cr1,
     uint32_t num_iterations) {
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    auto device = mesh_device->get_devices()[0];
     Program program;
     bool pass = true;
 
@@ -504,7 +518,7 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
     CoreRangeSet cr_set = program_config.cr_set;
     constexpr uint32_t kCommonRTASeparation = 1024 * sizeof(uint32_t);
 
-    uint32_t rta_base_dm0 = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    uint32_t rta_base_dm0 = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
     uint32_t rta_base_dm1 = rta_base_dm0 + 2048 * sizeof(uint32_t);
     uint32_t rta_base_compute = rta_base_dm1 + 4096 * sizeof(uint32_t);
     // Copy max # runtime args in the kernel for simplicity
@@ -556,7 +570,10 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
 
     uint32_t idx = 0;
     constexpr uint32_t num_common_runtime_args = 13;
+    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+
     for (uint32_t iter = 0; iter < num_iterations; iter++) {
+        auto& program_ = workload.get_programs().at(device_range);
         SCOPED_TRACE(iter);
         dummy_cr0_args.clear();
         dummy_cr1_args.clear();
@@ -582,9 +599,9 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
                 continue;
             }
 
-            SetRuntimeArgs(program, dummy_kernel0, core_coord, dummy_cr0_args);
-            SetRuntimeArgs(program, dummy_kernel1, core_coord, dummy_cr0_args);
-            SetRuntimeArgs(program, dummy_compute_kernel, core_coord, dummy_cr0_args);
+            SetRuntimeArgs(program_, dummy_kernel0, core_coord, dummy_cr0_args);
+            SetRuntimeArgs(program_, dummy_kernel1, core_coord, dummy_cr0_args);
+            SetRuntimeArgs(program_, dummy_compute_kernel, core_coord, dummy_cr0_args);
         }
 
         first = true;
@@ -595,31 +612,31 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
                 continue;
             }
 
-            SetRuntimeArgs(program, dummy_kernel0, core_coord, dummy_cr1_args);
-            SetRuntimeArgs(program, dummy_kernel1, core_coord, dummy_cr1_args);
-            SetRuntimeArgs(program, dummy_compute_kernel, core_coord, dummy_cr1_args);
+            SetRuntimeArgs(program_, dummy_kernel0, core_coord, dummy_cr1_args);
+            SetRuntimeArgs(program_, dummy_kernel1, core_coord, dummy_cr1_args);
+            SetRuntimeArgs(program_, dummy_compute_kernel, core_coord, dummy_cr1_args);
         }
 
         if (iter == 0) {
-            SetCommonRuntimeArgs(program, dummy_kernel0, dummy_common_args);
-            SetCommonRuntimeArgs(program, dummy_kernel1, dummy_common_args);
-            SetCommonRuntimeArgs(program, dummy_compute_kernel, dummy_common_args);
+            SetCommonRuntimeArgs(program_, dummy_kernel0, dummy_common_args);
+            SetCommonRuntimeArgs(program_, dummy_kernel1, dummy_common_args);
+            SetCommonRuntimeArgs(program_, dummy_compute_kernel, dummy_common_args);
         } else {
             memcpy(
-                GetCommonRuntimeArgs(program, dummy_kernel0).rt_args_data,
+                GetCommonRuntimeArgs(program_, dummy_kernel0).rt_args_data,
                 dummy_common_args.data(),
                 dummy_common_args.size() * sizeof(uint32_t));
             memcpy(
-                GetCommonRuntimeArgs(program, dummy_kernel1).rt_args_data,
+                GetCommonRuntimeArgs(program_, dummy_kernel1).rt_args_data,
                 dummy_common_args.data(),
                 dummy_common_args.size() * sizeof(uint32_t));
             memcpy(
-                GetCommonRuntimeArgs(program, dummy_compute_kernel).rt_args_data,
+                GetCommonRuntimeArgs(program_, dummy_compute_kernel).rt_args_data,
                 dummy_common_args.data(),
                 dummy_common_args.size() * sizeof(uint32_t));
         }
 
-        EnqueueProgram(cq, program, false);
+        distributed::EnqueueMeshWorkload(cq, workload, false);
         Finish(cq);
 
         first = true;
@@ -893,12 +910,16 @@ IncrementKernelsSet create_increment_kernels(
 // Write unique and common RT args, increment in kernel, and verify correctness via readback.
 // Multiple program_configs may be provided to create multiple kernels on the same program.
 bool test_increment_runtime_args_sanity(
-    IDevice* device,
+    std::shared_ptr<distributed::MeshDevice> mesh_device,
     const std::vector<DummyProgramConfig>& program_configs,
     uint32_t num_unique_rt_args,
     uint32_t num_common_rt_args,
     const tt::RISCV& riscv,
     bool idle_eth = false) {
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    auto device = mesh_device->get_devices()[0];
     Program program;
     bool pass = true;
 
@@ -936,14 +957,15 @@ bool test_increment_runtime_args_sanity(
     }
 
     // Compile and Launch the Program now.
-    EnqueueProgram(device->command_queue(), program, false);
-    Finish(device->command_queue());
+    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+    Finish(mesh_device->mesh_command_queue());
 
     // Read all cores for all kernels
     constexpr uint32_t unique_arg_incr_val = 10;
     constexpr uint32_t common_arg_incr_val = 100;
     for (const auto& kernel_id : configured_kernels.kernel_handles) {
-        const auto& kernel = tt::tt_metal::detail::GetKernel(program, kernel_id);
+        const auto& kernel = tt::tt_metal::detail::GetKernel(workload.get_programs()[device_range], kernel_id);
 
         for (auto& core_range : kernel->logical_coreranges()) {
             for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
@@ -962,14 +984,14 @@ bool test_increment_runtime_args_sanity(
 }
 
 bool test_increment_runtime_args_sanity(
-    IDevice* device,
+    std::shared_ptr<distributed::MeshDevice> mesh_device,
     const DummyProgramConfig& program_config,
     uint32_t num_unique_rt_args,
     uint32_t num_common_rt_args,
     const tt::RISCV& riscv,
     bool idle_eth = false) {
     return test_increment_runtime_args_sanity(
-        device,
+        mesh_device,
         std::vector<DummyProgramConfig>{program_config},
         num_unique_rt_args,
         num_common_rt_args,
@@ -977,9 +999,13 @@ bool test_increment_runtime_args_sanity(
         idle_eth);
 }
 
-void test_my_coordinates(IDevice* device, tt::RISCV processor_class, size_t cq_id = 0, bool idle_eth = false) {
+void test_my_coordinates(
+    std::shared_ptr<distributed::MeshDevice> mesh_device,
+    tt::RISCV processor_class,
+    size_t cq_id = 0,
+    bool idle_eth = false) {
     const std::string k_kernel_path = "tests/tt_metal/tt_metal/test_kernels/misc/read_my_coordinates.cpp";
-
+    auto device = mesh_device->get_devices()[0];
     // All logical cores
     CoreRangeSet cr{CoreRange{{2, 2}, {6, 6}}};
     if (processor_class == tt::RISCV::ERISC) {
@@ -990,22 +1016,26 @@ void test_my_coordinates(IDevice* device, tt::RISCV processor_class, size_t cq_i
 
     uint32_t cb_addr = processor_class == tt::RISCV::ERISC
                            ? hal::get_erisc_l1_unreserved_base()
-                           : device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+                           : mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
     std::vector<uint32_t> compile_args{
         cb_addr,
     };
 
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = tt::tt_metal::CreateProgram();
     KernelHandle kernel =
         create_kernel(processor_class, program, CoreRangeSet{cr}, compile_args, k_kernel_path, idle_eth);
 
-    EnqueueProgram(device->command_queue(cq_id), program, false);
-    Finish(device->command_queue(cq_id));
+    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(cq_id), workload, false);
+    Finish(mesh_device->mesh_command_queue(cq_id));
 
     tt::tt_metal::verify_kernel_coordinates(processor_class, cr, device, tt::tt_metal::SubDeviceId{0}, cb_addr);
 }
 
-void test_basic_dispatch_functions(IDevice* device, int cq_id) {
+void test_basic_dispatch_functions(std::shared_ptr<distributed::MeshDevice> mesh_device, int cq_id) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
@@ -1015,6 +1045,8 @@ void test_basic_dispatch_functions(IDevice* device, int cq_id) {
     constexpr uint32_t k_LoopPerDev = 100;
 
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
+    auto device = mesh_device->get_devices()[0];
+    log_info(tt::LogTest, "Running On Device {} CQ{}", mesh_device->id(), cq_id);
 
     log_info(tt::LogTest, "Running On Device {} CQ{}", device->id(), cq_id);
 
@@ -1025,22 +1057,28 @@ void test_basic_dispatch_functions(IDevice* device, int cq_id) {
         src_data_1[i] = (device->id() + rand()) * 0xdeadbeef;
         src_data_2[i] = (device->id() + rand()) * 0xabcd1234;
     }
-    auto buffer = CreateBuffer(InterleavedBufferConfig{device, k_DataSize, k_PageSize, BufferType::L1});
-    auto dram_buffer = CreateBuffer(InterleavedBufferConfig{device, k_DataSize, k_PageSize, BufferType::DRAM});
-    auto& cq = device->command_queue(cq_id);
+    distributed::DeviceLocalBufferConfig l1_buffer_config{.page_size = k_PageSize, .buffer_type = BufferType::L1};
+    distributed::DeviceLocalBufferConfig dram_buffer_config{.page_size = k_PageSize, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig replicated_buffer_config{.size = k_DataSize};
+
+    auto buffer = distributed::MeshBuffer::create(replicated_buffer_config, l1_buffer_config, mesh_device.get());
+    auto dram_buffer = distributed::MeshBuffer::create(replicated_buffer_config, dram_buffer_config, mesh_device.get());
+
+    auto& cq = mesh_device->mesh_command_queue(cq_id);
+
     for (int iteration = 0; iteration < k_Iterations; ++iteration) {
         for (int i = 0; i < k_LoopPerDev; ++i) {
             EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(
-                device, cq, dummy_program_config, 24, 12, 15, k_LoopPerDev, false));
+                mesh_device, cq, dummy_program_config, 24, 12, 15, k_LoopPerDev, false));
 
             std::vector<uint32_t> dst_data;
             if (i & 1) {
-                EnqueueWriteBuffer(cq, *buffer, src_data_1, false);
-                EnqueueReadBuffer(cq, *buffer, dst_data, true);
+                distributed::EnqueueWriteMeshBuffer(cq, buffer, src_data_1, false);
+                distributed::ReadShard(cq, dst_data, buffer, distributed::MeshCoordinate{0, 0}, true);
                 EXPECT_EQ(src_data_1, dst_data);
             } else {
-                EnqueueWriteBuffer(cq, *dram_buffer, src_data_2, false);
-                EnqueueReadBuffer(cq, *dram_buffer, dst_data, true);
+                distributed::EnqueueWriteMeshBuffer(cq, dram_buffer, src_data_2, false);
+                distributed::ReadShard(cq, dst_data, dram_buffer, distributed::MeshCoordinate{0, 0}, true);
                 EXPECT_EQ(src_data_2, dst_data);
             }
         }
@@ -1049,18 +1087,18 @@ void test_basic_dispatch_functions(IDevice* device, int cq_id) {
     // non blocking fast data movement APIs
     for (int iteration = 0; iteration < k_Iterations; ++iteration) {
         for (int i = 0; i < k_LoopPerDev; ++i) {
-            EnqueueWriteBuffer(cq, *buffer, src_data_1, false);
+            distributed::EnqueueWriteMeshBuffer(cq, buffer, src_data_1, false);
         }
     }
 
     std::vector<uint32_t> dst_data;
     for (int iteration = 0; iteration < k_Iterations; ++iteration) {
         for (int i = 0; i < k_LoopPerDev; ++i) {
-            EnqueueReadBuffer(cq, *buffer, dst_data, false);
+            distributed::ReadShard(cq, dst_data, buffer, distributed::MeshCoordinate{0, 0}, true);
         }
     }
 
-    Finish(cq);
+    distributed::Finish(cq);
 }
 
 }  // namespace local_test_functions
@@ -1069,8 +1107,11 @@ namespace basic_tests {
 
 namespace compiler_workaround_hardware_bug_tests {
 
-TEST_F(CommandQueueSingleCardProgramFixture, TensixTestArbiterDoesNotHang) {
-    for (IDevice* device : devices_) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestArbiterDoesNotHang) {
+    for (auto device : devices_) {
+        distributed::MeshWorkload workload;
+        distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
+        distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         Program program;
 
         CoreRange cr({0, 0}, {0, 0});
@@ -1083,8 +1124,9 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestArbiterDoesNotHang) {
             cr_set,
             DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
 
-        EnqueueProgram(device->command_queue(), program, false);
-        Finish(device->command_queue());
+        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        distributed::EnqueueMeshWorkload(device->mesh_command_queue(), workload, false);
+        Finish(device->mesh_command_queue());
     }
 }
 }  // namespace compiler_workaround_hardware_bug_tests
@@ -1140,7 +1182,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCbRandomConfigCorrectlySentSi
     }
 }
 
-TEST_F(CommandQueueSingleCardProgramFixture, TensixTestMultiCBSharedAddressSpaceSentSingleCore) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCBSharedAddressSpaceSentSingleCore) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
@@ -1157,25 +1199,31 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestMultiCBSharedAddressSpace
         NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
     CoreCoord core_coord(0, 0);
 
-    for (IDevice* device : devices_) {
+    for (auto device : devices_) {
+        distributed::MeshWorkload workload;
+        distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
+        distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         Program program;
+
+        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        auto& program_ = workload.get_programs().at(device_range);
+
         CircularBufferConfig cb_config = CircularBufferConfig(cb_size, intermediate_and_out_data_format_spec)
                                              .set_page_size(intermediate_cb, single_tile_size)
                                              .set_page_size(out_cb, single_tile_size);
-        auto cb = CreateCircularBuffer(program, cr_set, cb_config);
+        auto cb = CreateCircularBuffer(program_, cr_set, cb_config);
 
-        local_test_functions::initialize_dummy_kernels(program, cr_set);
+        local_test_functions::initialize_dummy_kernels(program_, cr_set);
 
-        EnqueueProgram(device->command_queue(), program, false);
-
-        Finish(device->command_queue());
+        distributed::EnqueueMeshWorkload(device->mesh_command_queue(), workload, false);
+        Finish(device->mesh_command_queue());
 
         vector<uint32_t> cb_config_vector;
 
         tt::tt_metal::detail::ReadFromDeviceL1(
-            device,
+            device->get_devices()[0],
             core_coord,
-            program.get_cb_base_addr(device, core_coord, CoreType::WORKER),
+            program_.get_cb_base_addr(device->get_devices()[0], core_coord, CoreType::WORKER),
             cb_config_buffer_size,
             cb_config_vector);
         uint32_t cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
@@ -1222,31 +1270,36 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestSingleSemaphoreConfigCorrectlySent
     }
 }
 
-TEST_F(CommandQueueSingleCardProgramFixture, TensixTestAutoInsertedBlankBriscKernelInDeviceDispatchMode) {
-    for (IDevice* device : devices_) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestAutoInsertedBlankBriscKernelInDeviceDispatchMode) {
+    for (auto device : devices_) {
+        distributed::MeshWorkload workload;
+        distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
+        distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         Program program;
 
+        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        auto& program_ = workload.get_programs().at(device_range);
         CoreRange cr({0, 0}, {0, 0});
         CoreRangeSet cr_set({cr});
         // Add an NCRISC blank manually, but in compile program, the BRISC blank will be
         // added separately
         auto dummy_reader_kernel = CreateKernel(
-            program,
+            program_,
             "tt_metal/kernels/dataflow/blank.cpp",
             cr_set,
             DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
 
-        EnqueueProgram(device->command_queue(), program, false);
-        Finish(device->command_queue());
+        distributed::EnqueueMeshWorkload(device->mesh_command_queue(), workload, false);
+        Finish(device->mesh_command_queue());
     }
 }
 
 // Sanity test for setting and verifying common and unique runtime args to a single core, the simplest case.
-TEST_F(CommandQueueSingleCardProgramFixture, TensixIncrementRuntimeArgsSanitySingleCoreCompute) {
+TEST_F(UnitMeshCommandQueueFixture, TensixIncrementRuntimeArgsSanitySingleCoreCompute) {
     CoreRange cr0({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr0});
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    for (IDevice* device : devices_) {
+    for (auto device : devices_) {
         EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
             device, dummy_program_config, 8, 8, tt::RISCV::COMPUTE));
     }
@@ -1255,7 +1308,7 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixIncrementRuntimeArgsSanitySin
 // Test setting common runtime args across multiple kernel in the same program
 // This test will ensure a multicast (or unicast for eth) gets created for each time the
 // user calls SetCommonRuntimeArgs.
-TEST_F(CommandQueueSingleCardProgramFixture, TensixSetCommonRuntimeArgsMultipleCreateKernel) {
+TEST_F(UnitMeshCommandQueueFixture, TensixSetCommonRuntimeArgsMultipleCreateKernel) {
     const CoreRange core_range_0(CoreCoord(1, 1), CoreCoord(2, 2));
     const CoreRange core_range_1(CoreCoord(3, 3), CoreCoord(4, 4));
 
@@ -1267,15 +1320,15 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixSetCommonRuntimeArgsMultipleC
         {.cr_set = core_range_set_1},
     };
 
-    for (IDevice* device : devices_) {
+    for (auto device : devices_) {
         EXPECT_TRUE(
             local_test_functions::test_increment_runtime_args_sanity(device, configs, 8, 8, tt::RISCV::COMPUTE));
     }
 }
 
-TEST_F(CommandQueueSingleCardProgramFixture, ActiveEthEnqueueDummyProgram) {
+TEST_F(UnitMeshCommandQueueFixture, ActiveEthEnqueueDummyProgram) {
     for (const auto& device : devices_) {
-        for (const auto& eth_core : device->get_active_ethernet_cores(true)) {
+        for (const auto& eth_core : device->get_devices()[0]->get_active_ethernet_cores(true)) {
             local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(device, eth_core);
         }
     }
@@ -1283,9 +1336,9 @@ TEST_F(CommandQueueSingleCardProgramFixture, ActiveEthEnqueueDummyProgram) {
 
 // Sanity test for setting and verifying common and unique runtime args to single cores via ERISC. Some arch may return
 // 0 active eth cores, that's okay.
-TEST_F(CommandQueueSingleCardProgramFixture, ActiveEthIncrementRuntimeArgsSanitySingleCoreDataMovementErisc) {
-    for (IDevice* device : devices_) {
-        for (const auto& eth_core : device->get_active_ethernet_cores(true)) {
+TEST_F(UnitMeshCommandQueueFixture, ActiveEthIncrementRuntimeArgsSanitySingleCoreDataMovementErisc) {
+    for (auto device : devices_) {
+        for (const auto& eth_core : device->get_devices()[0]->get_active_ethernet_cores(true)) {
             CoreRange cr0(eth_core);
             CoreRangeSet cr_set({cr0});
             DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
@@ -1299,10 +1352,9 @@ TEST_F(CommandQueueSingleCardProgramFixture, ActiveEthIncrementRuntimeArgsSanity
 // Sanity test for setting and verifying common and unique runtime args to single cores via ERISC(IDLE). Some arch may
 // return 0 active eth cores, that's okay.
 // FIXME - Re-enable when FD-on-idle-eth is supported
-TEST_F(
-    CommandQueueSingleCardProgramFixture, DISABLED_ActiveEthIncrementRuntimeArgsSanitySingleCoreDataMovementEriscIdle) {
-    for (IDevice* device : devices_) {
-        for (const auto& eth_core : device->get_active_ethernet_cores(true)) {
+TEST_F(UnitMeshCommandQueueFixture, DISABLED_ActiveEthIncrementRuntimeArgsSanitySingleCoreDataMovementEriscIdle) {
+    for (auto device : devices_) {
+        for (const auto& eth_core : device->get_devices()[0]->get_active_ethernet_cores(true)) {
             CoreRange cr0(eth_core);
             CoreRangeSet cr_set({cr0});
             DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
@@ -1316,11 +1368,9 @@ TEST_F(
 // Sanity test for setting and verifying common and unique runtime args to single cores via inactive ERISC cores. Some
 // arch may return 0 active eth cores, that's okay.
 // FIXME - Re-enable when FD-on-idle-eth is supported
-TEST_F(
-    CommandQueueSingleCardProgramFixture,
-    DISABLED_IdleEthIncrementRuntimeArgsSanitySingleCoreDataMovementEriscInactive) {
-    for (IDevice* device : devices_) {
-        for (const auto& eth_core : device->get_inactive_ethernet_cores()) {
+TEST_F(UnitMeshCommandQueueFixture, DISABLED_IdleEthIncrementRuntimeArgsSanitySingleCoreDataMovementEriscInactive) {
+    for (auto device : devices_) {
+        for (const auto& eth_core : device->get_devices()[0]->get_inactive_ethernet_cores()) {
             CoreRange cr0(eth_core);
             CoreRangeSet cr_set({cr0});
             DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
@@ -1332,14 +1382,14 @@ TEST_F(
     }
 }
 
-TEST_F(CommandQueueSingleCardProgramFixture, TensixTestRuntimeArgsCorrectlySentSingleCore) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestRuntimeArgsCorrectlySentSingleCore) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    for (IDevice* device : devices_) {
+    for (auto& device : devices_) {
         EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(
-            device, device->command_queue(), dummy_program_config, 9, 12, 15, 1));
+            device, device->mesh_command_queue(), dummy_program_config, 9, 12, 15, 1));
     }
 }
 
@@ -1564,8 +1614,8 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestAllSemaphoreConfigsCorrectlySentMu
     }
 }
 
-TEST_F(CommandQueueSingleCardProgramFixture, TensixTestAllRuntimeArgsCorrectlySentMultiCore) {
-    for (IDevice* device : devices_) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestAllRuntimeArgsCorrectlySentMultiCore) {
+    for (auto device : devices_) {
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
 
         CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
@@ -1573,12 +1623,12 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestAllRuntimeArgsCorrectlySe
 
         DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
         EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(
-            device, device->command_queue(), dummy_program_config, 13, 17, 19, 1));
+            device, device->mesh_command_queue(), dummy_program_config, 13, 17, 19, 1));
     }
 }
 
-TEST_F(CommandQueueSingleCardProgramFixture, TensixTestAllRuntimeArgsCorrectlySentMultiCore_255_PerKernel) {
-    for (IDevice* device : devices_) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestAllRuntimeArgsCorrectlySentMultiCore_255_PerKernel) {
+    for (auto device : devices_) {
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
 
         CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
@@ -1586,12 +1636,12 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestAllRuntimeArgsCorrectlySe
 
         DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
         EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(
-            device, device->command_queue(), dummy_program_config, 255, 255, 255, 1));
+            device, device->mesh_command_queue(), dummy_program_config, 255, 255, 255, 1));
     }
 }
 
-TEST_F(CommandQueueSingleCardProgramFixture, TensixTestSendRuntimeArgsMultiCoreRange) {
-    for (IDevice* device : devices_) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestSendRuntimeArgsMultiCoreRange) {
+    for (auto device : devices_) {
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
 
         CoreRange cr0({0, 0}, {worker_grid_size.x - 1, 3});
@@ -1600,13 +1650,13 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestSendRuntimeArgsMultiCoreR
 
         DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
         EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
-            device, device->command_queue(), dummy_program_config, 12, 9, 2));
+            device, device->mesh_command_queue(), dummy_program_config, 12, 9, 2));
     }
 }
 
-TEST_F(CommandQueueSingleCardProgramFixture, TensixTestSendRuntimeArgsMultiNonOverlappingCoreRange) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestSendRuntimeArgsMultiNonOverlappingCoreRange) {
     // Core ranges get merged in kernel groups, this one does not
-    for (IDevice* device : devices_) {
+    for (auto device : devices_) {
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
 
         CoreRange cr0({0, 0}, {worker_grid_size.x - 1, 3});
@@ -1615,12 +1665,12 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestSendRuntimeArgsMultiNonOv
 
         DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
         EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
-            device, device->command_queue(), dummy_program_config, 9, 12, 2));
+            device, device->mesh_command_queue(), dummy_program_config, 9, 12, 2));
     }
 }
 
-TEST_F(CommandQueueSingleCardProgramFixture, TensixTestUpdateRuntimeArgsMultiCoreRange) {
-    for (IDevice* device : devices_) {
+TEST_F(UnitMeshCommandQueueFixture, TensixTestUpdateRuntimeArgsMultiCoreRange) {
+    for (auto device : devices_) {
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
 
         CoreRange cr0({0, 0}, {worker_grid_size.x - 1, 3});
@@ -1629,89 +1679,89 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestUpdateRuntimeArgsMultiCor
 
         DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
         EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
-            device, device->command_queue(), dummy_program_config, 9, 31, 10));
+            device, device->mesh_command_queue(), dummy_program_config, 9, 31, 10));
     }
 }
 
 // Sanity test for setting and verifying common and unique runtime args to multiple cores.
-TEST_F(CommandQueueSingleCardProgramFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute) {
+TEST_F(UnitMeshCommandQueueFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute) {
     CoreRange cr0({1, 1}, {2, 2});
     CoreRange cr1({3, 3}, {4, 4});
     CoreRangeSet cr_set(std::vector{cr0, cr1});
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    for (IDevice* device : devices_) {
+    for (auto device : devices_) {
         EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
             device, dummy_program_config, 16, 16, tt::RISCV::COMPUTE));
     }
 }
 
 // Max number of 255 unique RT args.
-TEST_F(CommandQueueSingleCardProgramFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute_255_UniqueArgs) {
+TEST_F(UnitMeshCommandQueueFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute_255_UniqueArgs) {
     CoreRange cr0({1, 1}, {2, 2});
     CoreRange cr1({3, 3}, {4, 4});
     CoreRangeSet cr_set(std::vector{cr0, cr1});
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    for (IDevice* device : devices_) {
+    for (auto device : devices_) {
         EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
             device, dummy_program_config, 255, 0, tt::RISCV::COMPUTE));
     }
 }
 
 // Max number of 255 common RT args.
-TEST_F(CommandQueueSingleCardProgramFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute_255_CommonArgs) {
+TEST_F(UnitMeshCommandQueueFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute_255_CommonArgs) {
     CoreRange cr0({1, 1}, {2, 2});
     CoreRange cr1({3, 3}, {4, 4});
     CoreRangeSet cr_set(std::vector{cr0, cr1});
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    for (IDevice* device : devices_) {
+    for (auto device : devices_) {
         EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
             device, dummy_program_config, 0, 255, tt::RISCV::COMPUTE));
     }
 }
 
 // Sanity test for setting and verifying common and unique runtime args to multiple cores via BRISC.
-TEST_F(CommandQueueSingleCardProgramFixture, TensixIncrementRuntimeArgsSanityMultiCoreDataMovementBrisc) {
+TEST_F(UnitMeshCommandQueueFixture, TensixIncrementRuntimeArgsSanityMultiCoreDataMovementBrisc) {
     CoreRange cr0({1, 1}, {2, 2});
     CoreRange cr1({3, 3}, {4, 4});
     CoreRangeSet cr_set(std::vector{cr0, cr1});
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    for (IDevice* device : devices_) {
+    for (auto device : devices_) {
         EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
             device, dummy_program_config, 16, 16, tt::RISCV::BRISC));
     }
 }
 
 // Sanity test for setting and verifying common and unique runtime args to multiple cores via NCRISC.
-TEST_F(CommandQueueSingleCardProgramFixture, TensixIncrementRuntimeArgsSanityMultiCoreDataMovementNcrisc) {
+TEST_F(UnitMeshCommandQueueFixture, TensixIncrementRuntimeArgsSanityMultiCoreDataMovementNcrisc) {
     CoreRange cr0({1, 1}, {2, 2});
     CoreRange cr1({3, 3}, {4, 4});
     CoreRangeSet cr_set(std::vector{cr0, cr1});
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    for (IDevice* device : devices_) {
+    for (auto device : devices_) {
         EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
             device, dummy_program_config, 16, 16, tt::RISCV::NCRISC));
     }
 }
 
 // Ensure the data movement core can access their own logical coordinate. Same binary enqueued to multiple cores.
-TEST_F(CommandQueueSingleCardProgramFixture, TestLogicalCoordinatesDataMovement) {
-    for (IDevice* device : devices_) {
+TEST_F(UnitMeshCommandQueueFixture, TestLogicalCoordinatesDataMovement) {
+    for (auto device : devices_) {
         local_test_functions::test_my_coordinates(device, tt::RISCV::BRISC);
         local_test_functions::test_my_coordinates(device, tt::RISCV::NCRISC);
     }
 }
 
 // Ensure the compute core can access their own logical coordinate. Same binary enqueued to multiple cores.
-TEST_F(CommandQueueSingleCardProgramFixture, TestLogicalCoordinatesCompute) {
-    for (IDevice* device : devices_) {
+TEST_F(UnitMeshCommandQueueFixture, TestLogicalCoordinatesCompute) {
+    for (auto device : devices_) {
         local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE);
     }
 }
 
 // Ensure the eth core can access their own logical coordinate. Same binary enqueued to multiple cores.
-TEST_F(CommandQueueSingleCardProgramFixture, TestLogicalCoordinatesEth) {
-    for (IDevice* device : devices_) {
-        if (!does_device_have_active_eth_cores(device)) {
+TEST_F(UnitMeshCommandQueueFixture, TestLogicalCoordinatesEth) {
+    for (auto device : devices_) {
+        if (!does_device_have_active_eth_cores(device->get_devices()[0])) {
             GTEST_SKIP() << "Skipping test because device " << device->id()
                          << " does not have any active ethernet cores";
         }
@@ -1720,305 +1770,306 @@ TEST_F(CommandQueueSingleCardProgramFixture, TestLogicalCoordinatesEth) {
 }
 
 // Ensure the data movement core can access their own logical coordinate. Same binary enqueued to multiple cores.
-TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TestLogicalCoordinatesDataMovement) {
-    for (IDevice* device : devices_) {
-        local_test_functions::test_my_coordinates(device, tt::RISCV::BRISC);
-        local_test_functions::test_my_coordinates(device, tt::RISCV::BRISC, 1);
-        local_test_functions::test_my_coordinates(device, tt::RISCV::NCRISC);
-        local_test_functions::test_my_coordinates(device, tt::RISCV::NCRISC, 1);
-    }
-}
+// TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TestLogicalCoordinatesDataMovement) {
+//     for (IDevice* device : devices_) {
+//         local_test_functions::test_my_coordinates(device, tt::RISCV::BRISC);
+//         local_test_functions::test_my_coordinates(device, tt::RISCV::BRISC, 1);
+//         local_test_functions::test_my_coordinates(device, tt::RISCV::NCRISC);
+//         local_test_functions::test_my_coordinates(device, tt::RISCV::NCRISC, 1);
+//     }
+// }
 
-// Ensure the compute core can access their own logical coordinate. Same binary enqueued to multiple cores.
-TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TestLogicalCoordinatesCompute) {
-    for (IDevice* device : devices_) {
-        local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE);
-        local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE, 1);
-    }
-}
+// // Ensure the compute core can access their own logical coordinate. Same binary enqueued to multiple cores.
+// TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TestLogicalCoordinatesCompute) {
+//     for (IDevice* device : devices_) {
+//         local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE);
+//         local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE, 1);
+//     }
+// }
 
-// Ensure the eth core can access their own logical coordinate. Same binary enqueued to multiple cores.
-TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TestLogicalCoordinatesEth) {
-    for (IDevice* device : devices_) {
-        if (!does_device_have_active_eth_cores(device)) {
-            GTEST_SKIP() << "Skipping test because device " << device->id()
-                         << " does not have any active ethernet cores";
-        }
-        local_test_functions::test_my_coordinates(device, tt::RISCV::ERISC, 0);
-        local_test_functions::test_my_coordinates(device, tt::RISCV::ERISC, 1);
-    }
-}
+// // Ensure the eth core can access their own logical coordinate. Same binary enqueued to multiple cores.
+// TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TestLogicalCoordinatesEth) {
+//     for (IDevice* device : devices_) {
+//         if (!does_device_have_active_eth_cores(device)) {
+//             GTEST_SKIP() << "Skipping test because device " << device->id()
+//                          << " does not have any active ethernet cores";
+//         }
+//         local_test_functions::test_my_coordinates(device, tt::RISCV::ERISC, 0);
+//         local_test_functions::test_my_coordinates(device, tt::RISCV::ERISC, 1);
+//     }
+// }
 
 }  // end namespace multicore_tests
 }  // namespace basic_tests
 
 namespace stress_tests {
 
-TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TensixTestRandomizedProgram) {
-    uint32_t NUM_PROGRAMS = 100;
-    uint32_t MAX_LOOP = 100;
-    uint32_t page_size = 1024;
+// TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TensixTestRandomizedProgram) {
+//     uint32_t NUM_PROGRAMS = 100;
+//     uint32_t MAX_LOOP = 100;
+//     uint32_t page_size = 1024;
 
-    if (this->arch_ == tt::ARCH::BLACKHOLE) {
-        GTEST_SKIP();  // Running on second CQ is hanging on CI
-    }
+//     if (this->arch_ == tt::ARCH::BLACKHOLE) {
+//         GTEST_SKIP();  // Running on second CQ is hanging on CI
+//     }
 
-    // Make random
-    auto random_seed = 0;  // (unsigned int)time(NULL);
-    uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
-    log_info(tt::LogTest, "Using Test Seed: {}", seed);
-    srand(seed);
+//     // Make random
+//     auto random_seed = 0;  // (unsigned int)time(NULL);
+//     uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
+//     log_info(tt::LogTest, "Using Test Seed: {}", seed);
+//     srand(seed);
 
-    CoreCoord worker_grid_size = this->device_->compute_with_storage_grid_size();
-    CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
-    CoreRangeSet cr_set({cr});
+//     CoreCoord worker_grid_size = this->device_->compute_with_storage_grid_size();
+//     CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+//     CoreRangeSet cr_set({cr});
 
-    log_info(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
+//     log_info(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
 
-    vector<Program> programs;
-    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-        programs.push_back(Program());
-        Program& program = programs.back();
+//     vector<Program> programs;
+//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+//         programs.push_back(Program());
+//         Program& program = programs.back();
 
-        std::map<std::string, std::string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
-        std::map<std::string, std::string> compute_defines = {{"COMPUTE", "1"}};
+//         std::map<string, string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
+//         std::map<string, string> compute_defines = {{"COMPUTE", "1"}};
 
-        // brisc
-        uint32_t BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS;
-        bool USE_MAX_RT_ARGS;
+//         // brisc
+//         uint32_t BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS;
+//         bool USE_MAX_RT_ARGS;
 
-        if (i == 0) {
-            // Ensures that we get at least one compilation with the max amount to
-            // ensure it compiles and runs
-            BRISC_OUTER_LOOP = MAX_LOOP;
-            BRISC_MIDDLE_LOOP = MAX_LOOP;
-            BRISC_INNER_LOOP = MAX_LOOP;
-            NUM_CBS = NUM_CIRCULAR_BUFFERS;
-            NUM_SEMS = NUM_SEMAPHORES;
-            USE_MAX_RT_ARGS = true;
-        } else {
-            BRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
-            BRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
-            BRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-            NUM_CBS = rand() % (NUM_CIRCULAR_BUFFERS) + 1;
-            NUM_SEMS = rand() % (NUM_SEMAPHORES) + 1;
-            USE_MAX_RT_ARGS = false;
-        }
+//         if (i == 0) {
+//             // Ensures that we get at least one compilation with the max amount to
+//             // ensure it compiles and runs
+//             BRISC_OUTER_LOOP = MAX_LOOP;
+//             BRISC_MIDDLE_LOOP = MAX_LOOP;
+//             BRISC_INNER_LOOP = MAX_LOOP;
+//             NUM_CBS = NUM_CIRCULAR_BUFFERS;
+//             NUM_SEMS = NUM_SEMAPHORES;
+//             USE_MAX_RT_ARGS = true;
+//         } else {
+//             BRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+//             BRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+//             BRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+//             NUM_CBS = rand() % (NUM_CIRCULAR_BUFFERS) + 1;
+//             NUM_SEMS = rand() % (NUM_SEMAPHORES) + 1;
+//             USE_MAX_RT_ARGS = false;
+//         }
 
-        log_debug(
-            tt::LogTest,
-            "Compiling program {}/{} w/ BRISC_OUTER_LOOP: {} BRISC_MIDDLE_LOOP: {} BRISC_INNER_LOOP: {} NUM_CBS: {} "
-            "NUM_SEMS: {} USE_MAX_RT_ARGS: {}",
-            i + 1,
-            NUM_PROGRAMS,
-            BRISC_OUTER_LOOP,
-            BRISC_MIDDLE_LOOP,
-            BRISC_INNER_LOOP,
-            NUM_CBS,
-            NUM_SEMS,
-            USE_MAX_RT_ARGS);
+//         log_debug(
+//             tt::LogTest,
+//             "Compiling program {}/{} w/ BRISC_OUTER_LOOP: {} BRISC_MIDDLE_LOOP: {} BRISC_INNER_LOOP: {} NUM_CBS: {} "
+//             "NUM_SEMS: {} USE_MAX_RT_ARGS: {}",
+//             i + 1,
+//             NUM_PROGRAMS,
+//             BRISC_OUTER_LOOP,
+//             BRISC_MIDDLE_LOOP,
+//             BRISC_INNER_LOOP,
+//             NUM_CBS,
+//             NUM_SEMS,
+//             USE_MAX_RT_ARGS);
 
-        for (uint32_t j = 0; j < NUM_CBS; j++) {
-            CircularBufferConfig cb_config = CircularBufferConfig(page_size * (j + 1), {{j, tt::DataFormat::Float16_b}})
-                                                 .set_page_size(j, page_size * (j + 1));
-            auto cb = CreateCircularBuffer(program, cr_set, cb_config);
-        }
+//         for (uint32_t j = 0; j < NUM_CBS; j++) {
+//             CircularBufferConfig cb_config = CircularBufferConfig(page_size * (j + 1), {{j,
+//             tt::DataFormat::Float16_b}})
+//                                                  .set_page_size(j, page_size * (j + 1));
+//             auto cb = CreateCircularBuffer(program, cr_set, cb_config);
+//         }
 
-        for (uint32_t j = 0; j < NUM_SEMS; j++) {
-            CreateSemaphore(program, cr_set, j + 1);
-        }
+//         for (uint32_t j = 0; j < NUM_SEMS; j++) {
+//             CreateSemaphore(program, cr_set, j + 1);
+//         }
 
-        auto [brisc_unique_rtargs, brisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
-        uint32_t num_brisc_unique_rtargs = brisc_unique_rtargs.size();
-        uint32_t num_brisc_common_rtargs = brisc_common_rtargs.size();
-        vector<uint32_t> brisc_compile_args = {
-            BRISC_OUTER_LOOP,
-            BRISC_MIDDLE_LOOP,
-            BRISC_INNER_LOOP,
-            NUM_CBS,
-            NUM_SEMS,
-            num_brisc_unique_rtargs,
-            num_brisc_common_rtargs,
-            page_size};
+//         auto [brisc_unique_rtargs, brisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
+//         uint32_t num_brisc_unique_rtargs = brisc_unique_rtargs.size();
+//         uint32_t num_brisc_common_rtargs = brisc_common_rtargs.size();
+//         vector<uint32_t> brisc_compile_args = {
+//             BRISC_OUTER_LOOP,
+//             BRISC_MIDDLE_LOOP,
+//             BRISC_INNER_LOOP,
+//             NUM_CBS,
+//             NUM_SEMS,
+//             num_brisc_unique_rtargs,
+//             num_brisc_common_rtargs,
+//             page_size};
 
-        // ncrisc
-        uint32_t NCRISC_OUTER_LOOP, NCRISC_MIDDLE_LOOP, NCRISC_INNER_LOOP;
-        if (i == 0) {
-            NCRISC_OUTER_LOOP = MAX_LOOP;
-            NCRISC_MIDDLE_LOOP = MAX_LOOP;
-            NCRISC_INNER_LOOP = MAX_LOOP;
-        } else {
-            NCRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
-            NCRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
-            NCRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-        }
+//         // ncrisc
+//         uint32_t NCRISC_OUTER_LOOP, NCRISC_MIDDLE_LOOP, NCRISC_INNER_LOOP;
+//         if (i == 0) {
+//             NCRISC_OUTER_LOOP = MAX_LOOP;
+//             NCRISC_MIDDLE_LOOP = MAX_LOOP;
+//             NCRISC_INNER_LOOP = MAX_LOOP;
+//         } else {
+//             NCRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+//             NCRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+//             NCRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+//         }
 
-        auto [ncrisc_unique_rtargs, ncrisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
-        uint32_t num_ncrisc_unique_rtargs = ncrisc_unique_rtargs.size();
-        uint32_t num_ncrisc_common_rtargs = ncrisc_common_rtargs.size();
-        vector<uint32_t> ncrisc_compile_args = {
-            NCRISC_OUTER_LOOP,
-            NCRISC_MIDDLE_LOOP,
-            NCRISC_INNER_LOOP,
-            NUM_CBS,
-            NUM_SEMS,
-            num_ncrisc_unique_rtargs,
-            num_ncrisc_common_rtargs,
-            page_size};
+//         auto [ncrisc_unique_rtargs, ncrisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
+//         uint32_t num_ncrisc_unique_rtargs = ncrisc_unique_rtargs.size();
+//         uint32_t num_ncrisc_common_rtargs = ncrisc_common_rtargs.size();
+//         vector<uint32_t> ncrisc_compile_args = {
+//             NCRISC_OUTER_LOOP,
+//             NCRISC_MIDDLE_LOOP,
+//             NCRISC_INNER_LOOP,
+//             NUM_CBS,
+//             NUM_SEMS,
+//             num_ncrisc_unique_rtargs,
+//             num_ncrisc_common_rtargs,
+//             page_size};
 
-        // trisc
-        uint32_t TRISC_OUTER_LOOP, TRISC_MIDDLE_LOOP, TRISC_INNER_LOOP;
-        if (i == 0) {
-            TRISC_OUTER_LOOP = MAX_LOOP;
-            TRISC_MIDDLE_LOOP = MAX_LOOP;
-            TRISC_INNER_LOOP = MAX_LOOP;
-        } else {
-            TRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
-            TRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
-            TRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-        }
+//         // trisc
+//         uint32_t TRISC_OUTER_LOOP, TRISC_MIDDLE_LOOP, TRISC_INNER_LOOP;
+//         if (i == 0) {
+//             TRISC_OUTER_LOOP = MAX_LOOP;
+//             TRISC_MIDDLE_LOOP = MAX_LOOP;
+//             TRISC_INNER_LOOP = MAX_LOOP;
+//         } else {
+//             TRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+//             TRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+//             TRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+//         }
 
-        auto [trisc_unique_rtargs, trisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
-        uint32_t num_trisc_unique_rtargs = trisc_unique_rtargs.size();
-        uint32_t num_trisc_common_rtargs = trisc_common_rtargs.size();
-        vector<uint32_t> trisc_compile_args = {
-            TRISC_OUTER_LOOP,
-            TRISC_MIDDLE_LOOP,
-            TRISC_INNER_LOOP,
-            NUM_CBS,
-            NUM_SEMS,
-            num_trisc_unique_rtargs,
-            num_trisc_common_rtargs,
-            page_size};
+//         auto [trisc_unique_rtargs, trisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
+//         uint32_t num_trisc_unique_rtargs = trisc_unique_rtargs.size();
+//         uint32_t num_trisc_common_rtargs = trisc_common_rtargs.size();
+//         vector<uint32_t> trisc_compile_args = {
+//             TRISC_OUTER_LOOP,
+//             TRISC_MIDDLE_LOOP,
+//             TRISC_INNER_LOOP,
+//             NUM_CBS,
+//             NUM_SEMS,
+//             num_trisc_unique_rtargs,
+//             num_trisc_common_rtargs,
+//             page_size};
 
-        bool at_least_one_kernel = false;
-        if (i == 0 or ((rand() % 2) == 0)) {
-            auto dummy_brisc_kernel = CreateKernel(
-                program,
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-                cr_set,
-                DataMovementConfig{
-                    .processor = DataMovementProcessor::RISCV_0,
-                    .noc = NOC::RISCV_0_default,
-                    .compile_args = brisc_compile_args,
-                    .defines = data_movement_defines});
-            SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
-            SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
-            at_least_one_kernel = true;
-        }
+//         bool at_least_one_kernel = false;
+//         if (i == 0 or ((rand() % 2) == 0)) {
+//             auto dummy_brisc_kernel = CreateKernel(
+//                 program,
+//                 "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+//                 cr_set,
+//                 DataMovementConfig{
+//                     .processor = DataMovementProcessor::RISCV_0,
+//                     .noc = NOC::RISCV_0_default,
+//                     .compile_args = brisc_compile_args,
+//                     .defines = data_movement_defines});
+//             SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
+//             SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
+//             at_least_one_kernel = true;
+//         }
 
-        if (i == 0 or ((rand() % 2) == 0)) {
-            auto dummy_ncrisc_kernel = CreateKernel(
-                program,
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-                cr_set,
-                DataMovementConfig{
-                    .processor = DataMovementProcessor::RISCV_1,
-                    .noc = NOC::RISCV_1_default,
-                    .compile_args = ncrisc_compile_args,
-                    .defines = data_movement_defines});
-            SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
-            SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
-            at_least_one_kernel = true;
-        }
+//         if (i == 0 or ((rand() % 2) == 0)) {
+//             auto dummy_ncrisc_kernel = CreateKernel(
+//                 program,
+//                 "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+//                 cr_set,
+//                 DataMovementConfig{
+//                     .processor = DataMovementProcessor::RISCV_1,
+//                     .noc = NOC::RISCV_1_default,
+//                     .compile_args = ncrisc_compile_args,
+//                     .defines = data_movement_defines});
+//             SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
+//             SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
+//             at_least_one_kernel = true;
+//         }
 
-        if (i == 0 or ((rand() % 2) == 0)) {
-            auto dummy_trisc_kernel = CreateKernel(
-                program,
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-                cr_set,
-                ComputeConfig{
-                    .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
-            SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
-            SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
-            at_least_one_kernel = true;
-        }
+//         if (i == 0 or ((rand() % 2) == 0)) {
+//             auto dummy_trisc_kernel = CreateKernel(
+//                 program,
+//                 "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+//                 cr_set,
+//                 ComputeConfig{
+//                     .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
+//             SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
+//             SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
+//             at_least_one_kernel = true;
+//         }
 
-        if (not at_least_one_kernel) {
-            uint32_t random_risc = rand() % 3 + 1;
-            if (random_risc == 1) {
-                auto dummy_brisc_kernel = CreateKernel(
-                    program,
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-                    cr_set,
-                    DataMovementConfig{
-                        .processor = DataMovementProcessor::RISCV_0,
-                        .noc = NOC::RISCV_0_default,
-                        .compile_args = brisc_compile_args,
-                        .defines = data_movement_defines});
-                SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
-                SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
-            } else if (random_risc == 2) {
-                auto dummy_ncrisc_kernel = CreateKernel(
-                    program,
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-                    cr_set,
-                    DataMovementConfig{
-                        .processor = DataMovementProcessor::RISCV_1,
-                        .noc = NOC::RISCV_1_default,
-                        .compile_args = ncrisc_compile_args,
-                        .defines = data_movement_defines});
-                SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
-                SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
-            } else if (random_risc == 3) {
-                auto dummy_trisc_kernel = CreateKernel(
-                    program,
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-                    cr_set,
-                    ComputeConfig{
-                        .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
-                SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
-                SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
-            } else {
-                TT_THROW("Invalid");
-            }
-        }
+//         if (not at_least_one_kernel) {
+//             uint32_t random_risc = rand() % 3 + 1;
+//             if (random_risc == 1) {
+//                 auto dummy_brisc_kernel = CreateKernel(
+//                     program,
+//                     "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+//                     cr_set,
+//                     DataMovementConfig{
+//                         .processor = DataMovementProcessor::RISCV_0,
+//                         .noc = NOC::RISCV_0_default,
+//                         .compile_args = brisc_compile_args,
+//                         .defines = data_movement_defines});
+//                 SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
+//                 SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
+//             } else if (random_risc == 2) {
+//                 auto dummy_ncrisc_kernel = CreateKernel(
+//                     program,
+//                     "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+//                     cr_set,
+//                     DataMovementConfig{
+//                         .processor = DataMovementProcessor::RISCV_1,
+//                         .noc = NOC::RISCV_1_default,
+//                         .compile_args = ncrisc_compile_args,
+//                         .defines = data_movement_defines});
+//                 SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
+//                 SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
+//             } else if (random_risc == 3) {
+//                 auto dummy_trisc_kernel = CreateKernel(
+//                     program,
+//                     "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+//                     cr_set,
+//                     ComputeConfig{
+//                         .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
+//                 SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
+//                 SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
+//             } else {
+//                 TT_THROW("Invalid");
+//             }
+//         }
 
-        tt::tt_metal::detail::CompileProgram(this->device_, program);
-    }
+//         tt::tt_metal::detail::CompileProgram(this->device_, program);
+//     }
 
-    for (uint8_t cq_id = 0; cq_id < this->device_->num_hw_cqs(); ++cq_id) {
-        log_info(tt::LogTest, "Running {} programs on cq {} for cache warmup.", programs.size(), (uint32_t)cq_id);
-        // This loop caches program and runs
-        for (Program& program : programs) {
-            EnqueueProgram(this->device_->command_queue(cq_id), program, false);
-        }
+//     for (uint8_t cq_id = 0; cq_id < this->device_->num_hw_cqs(); ++cq_id) {
+//         log_info(tt::LogTest, "Running {} programs on cq {} for cache warmup.", programs.size(), (uint32_t)cq_id);
+//         // This loop caches program and runs
+//         for (Program& program : programs) {
+//             EnqueueProgram(this->device_->command_queue(cq_id), program, false);
+//         }
 
-        // This loops assumes already cached
-        uint32_t NUM_ITERATIONS = 500;  // TODO(agrebenisan): Bump this to 5000, saw hangs for very large number of
-                                        // iterations, need to come back to that
+//         // This loops assumes already cached
+//         uint32_t NUM_ITERATIONS = 500;  // TODO(agrebenisan): Bump this to 5000, saw hangs for very large number of
+//                                         // iterations, need to come back to that
 
-        log_info(
-            tt::LogTest,
-            "Running {} programs on cq {} for {} iterations now.",
-            programs.size(),
-            (uint32_t)cq_id,
-            NUM_ITERATIONS);
-        for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
-            auto rng = std::default_random_engine{};
-            std::shuffle(std::begin(programs), std::end(programs), rng);
-            if (i % 10 == 0) {
-                log_debug(
-                    tt::LogTest,
-                    "Enqueuing {} programs on cq {} for iter: {}/{} now.",
-                    programs.size(),
-                    (uint32_t)cq_id,
-                    i + 1,
-                    NUM_ITERATIONS);
-            }
-            for (Program& program : programs) {
-                EnqueueProgram(this->device_->command_queue(cq_id), program, false);
-            }
-        }
+//         log_info(
+//             tt::LogTest,
+//             "Running {} programs on cq {} for {} iterations now.",
+//             programs.size(),
+//             (uint32_t)cq_id,
+//             NUM_ITERATIONS);
+//         for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
+//             auto rng = std::default_random_engine{};
+//             std::shuffle(std::begin(programs), std::end(programs), rng);
+//             if (i % 10 == 0) {
+//                 log_debug(
+//                     tt::LogTest,
+//                     "Enqueuing {} programs on cq {} for iter: {}/{} now.",
+//                     programs.size(),
+//                     (uint32_t)cq_id,
+//                     i + 1,
+//                     NUM_ITERATIONS);
+//             }
+//             for (Program& program : programs) {
+//                 EnqueueProgram(this->device_->command_queue(cq_id), program, false);
+//             }
+//         }
 
-        log_info(tt::LogTest, "Calling Finish.");
-        Finish(this->device_->command_queue(cq_id));
-    }
-}
+//         log_info(tt::LogTest, "Calling Finish.");
+//         Finish(this->device_->command_queue(cq_id));
+//     }
+// }
 
-TEST_F(CommandQueueSingleCardProgramFixture, DISABLED_TensixTestFillDispatchCoreBuffer) {
+TEST_F(UnitMeshCommandQueueFixture, DISABLED_TensixTestFillDispatchCoreBuffer) {
     uint32_t NUM_ITER = 100000;
-    for (IDevice* device : devices_) {
+    for (auto device : devices_) {
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
 
         CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
@@ -2027,446 +2078,452 @@ TEST_F(CommandQueueSingleCardProgramFixture, DISABLED_TensixTestFillDispatchCore
         DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
 
         EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(
-            device, device->command_queue(), dummy_program_config, 256, 256, 256, NUM_ITER));
+            device, device->mesh_command_queue(), dummy_program_config, 256, 256, 256, NUM_ITER));
     }
 }
 
-TEST_F(CommandQueueProgramFixture, TensixTestRandomizedProgram) {
-    uint32_t NUM_PROGRAMS = 100;
-    uint32_t MAX_LOOP = 100;
-    uint32_t page_size = 1024;
+// TEST_F(CommandQueueProgramFixture, TensixTestRandomizedProgram) {
+//     uint32_t NUM_PROGRAMS = 100;
+//     uint32_t MAX_LOOP = 100;
+//     uint32_t page_size = 1024;
 
-    // Make random
-    auto random_seed = 0;  // (unsigned int)time(NULL);
-    uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
-    log_info(tt::LogTest, "Using Test Seed: {}", seed);
-    srand(seed);
+//     // Make random
+//     auto random_seed = 0;  // (unsigned int)time(NULL);
+//     uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
+//     log_info(tt::LogTest, "Using Test Seed: {}", seed);
+//     srand(seed);
 
-    CoreCoord worker_grid_size = this->device_->compute_with_storage_grid_size();
-    CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
-    CoreRangeSet cr_set(cr);
+//     CoreCoord worker_grid_size = this->device_->compute_with_storage_grid_size();
+//     CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+//     CoreRangeSet cr_set(cr);
 
-    log_info(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
+//     log_info(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
 
-    vector<Program> programs;
-    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-        programs.push_back(Program());
-        Program& program = programs.back();
+//     vector<Program> programs;
+//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+//         programs.push_back(Program());
+//         Program& program = programs.back();
 
-        std::map<std::string, std::string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
-        std::map<std::string, std::string> compute_defines = {{"COMPUTE", "1"}};
+//         std::map<string, string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
+//         std::map<string, string> compute_defines = {{"COMPUTE", "1"}};
 
-        // brisc
-        uint32_t BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS;
-        bool USE_MAX_RT_ARGS;
+//         // brisc
+//         uint32_t BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS;
+//         bool USE_MAX_RT_ARGS;
 
-        if (i % 10 == 0) {
-            log_info(tt::LogTest, "Compiling program {} of {}", i + 1, NUM_PROGRAMS);
-        }
+//         if (i % 10 == 0) {
+//             log_info(tt::LogTest, "Compiling program {} of {}", i + 1, NUM_PROGRAMS);
+//         }
 
-        if (i == 0) {
-            // Ensures that we get at least one compilation with the max amount to
-            // ensure it compiles and runs
-            BRISC_OUTER_LOOP = MAX_LOOP;
-            BRISC_MIDDLE_LOOP = MAX_LOOP;
-            BRISC_INNER_LOOP = MAX_LOOP;
-            NUM_CBS = NUM_CIRCULAR_BUFFERS;
-            NUM_SEMS = NUM_SEMAPHORES;
-            USE_MAX_RT_ARGS = true;
-        } else {
-            BRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
-            BRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
-            BRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-            NUM_CBS = rand() % (NUM_CIRCULAR_BUFFERS) + 1;
-            NUM_SEMS = rand() % (NUM_SEMAPHORES) + 1;
-            USE_MAX_RT_ARGS = false;
-        }
+//         if (i == 0) {
+//             // Ensures that we get at least one compilation with the max amount to
+//             // ensure it compiles and runs
+//             BRISC_OUTER_LOOP = MAX_LOOP;
+//             BRISC_MIDDLE_LOOP = MAX_LOOP;
+//             BRISC_INNER_LOOP = MAX_LOOP;
+//             NUM_CBS = NUM_CIRCULAR_BUFFERS;
+//             NUM_SEMS = NUM_SEMAPHORES;
+//             USE_MAX_RT_ARGS = true;
+//         } else {
+//             BRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+//             BRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+//             BRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+//             NUM_CBS = rand() % (NUM_CIRCULAR_BUFFERS) + 1;
+//             NUM_SEMS = rand() % (NUM_SEMAPHORES) + 1;
+//             USE_MAX_RT_ARGS = false;
+//         }
 
-        log_debug(
-            tt::LogTest,
-            "Compiling program {}/{} w/ BRISC_OUTER_LOOP: {} BRISC_MIDDLE_LOOP: {} BRISC_INNER_LOOP: {} NUM_CBS: {} "
-            "NUM_SEMS: {} USE_MAX_RT_ARGS: {}",
-            i + 1,
-            NUM_PROGRAMS,
-            BRISC_OUTER_LOOP,
-            BRISC_MIDDLE_LOOP,
-            BRISC_INNER_LOOP,
-            NUM_CBS,
-            NUM_SEMS,
-            USE_MAX_RT_ARGS);
+//         log_debug(
+//             tt::LogTest,
+//             "Compiling program {}/{} w/ BRISC_OUTER_LOOP: {} BRISC_MIDDLE_LOOP: {} BRISC_INNER_LOOP: {} NUM_CBS: {} "
+//             "NUM_SEMS: {} USE_MAX_RT_ARGS: {}",
+//             i + 1,
+//             NUM_PROGRAMS,
+//             BRISC_OUTER_LOOP,
+//             BRISC_MIDDLE_LOOP,
+//             BRISC_INNER_LOOP,
+//             NUM_CBS,
+//             NUM_SEMS,
+//             USE_MAX_RT_ARGS);
 
-        for (uint32_t j = 0; j < NUM_CBS; j++) {
-            CircularBufferConfig cb_config = CircularBufferConfig(page_size * (j + 1), {{j, tt::DataFormat::Float16_b}})
-                                                 .set_page_size(j, page_size * (j + 1));
-            auto cb = CreateCircularBuffer(program, cr_set, cb_config);
-        }
+//         for (uint32_t j = 0; j < NUM_CBS; j++) {
+//             CircularBufferConfig cb_config = CircularBufferConfig(page_size * (j + 1), {{j,
+//             tt::DataFormat::Float16_b}})
+//                                                  .set_page_size(j, page_size * (j + 1));
+//             auto cb = CreateCircularBuffer(program, cr_set, cb_config);
+//         }
 
-        for (uint32_t j = 0; j < NUM_SEMS; j++) {
-            CreateSemaphore(program, cr_set, j + 1);
-        }
+//         for (uint32_t j = 0; j < NUM_SEMS; j++) {
+//             CreateSemaphore(program, cr_set, j + 1);
+//         }
 
-        auto [brisc_unique_rtargs, brisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
-        uint32_t num_brisc_unique_rtargs = brisc_unique_rtargs.size();
-        uint32_t num_brisc_common_rtargs = brisc_common_rtargs.size();
-        vector<uint32_t> brisc_compile_args = {
-            BRISC_OUTER_LOOP,
-            BRISC_MIDDLE_LOOP,
-            BRISC_INNER_LOOP,
-            NUM_CBS,
-            NUM_SEMS,
-            num_brisc_unique_rtargs,
-            num_brisc_common_rtargs,
-            page_size};
+//         auto [brisc_unique_rtargs, brisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
+//         uint32_t num_brisc_unique_rtargs = brisc_unique_rtargs.size();
+//         uint32_t num_brisc_common_rtargs = brisc_common_rtargs.size();
+//         vector<uint32_t> brisc_compile_args = {
+//             BRISC_OUTER_LOOP,
+//             BRISC_MIDDLE_LOOP,
+//             BRISC_INNER_LOOP,
+//             NUM_CBS,
+//             NUM_SEMS,
+//             num_brisc_unique_rtargs,
+//             num_brisc_common_rtargs,
+//             page_size};
 
-        // ncrisc
-        uint32_t NCRISC_OUTER_LOOP, NCRISC_MIDDLE_LOOP, NCRISC_INNER_LOOP;
-        if (i == 0) {
-            NCRISC_OUTER_LOOP = MAX_LOOP;
-            NCRISC_MIDDLE_LOOP = MAX_LOOP;
-            NCRISC_INNER_LOOP = MAX_LOOP;
-        } else {
-            NCRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
-            NCRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
-            NCRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-        }
+//         // ncrisc
+//         uint32_t NCRISC_OUTER_LOOP, NCRISC_MIDDLE_LOOP, NCRISC_INNER_LOOP;
+//         if (i == 0) {
+//             NCRISC_OUTER_LOOP = MAX_LOOP;
+//             NCRISC_MIDDLE_LOOP = MAX_LOOP;
+//             NCRISC_INNER_LOOP = MAX_LOOP;
+//         } else {
+//             NCRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+//             NCRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+//             NCRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+//         }
 
-        auto [ncrisc_unique_rtargs, ncrisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
-        uint32_t num_ncrisc_unique_rtargs = ncrisc_unique_rtargs.size();
-        uint32_t num_ncrisc_common_rtargs = ncrisc_common_rtargs.size();
-        vector<uint32_t> ncrisc_compile_args = {
-            NCRISC_OUTER_LOOP,
-            NCRISC_MIDDLE_LOOP,
-            NCRISC_INNER_LOOP,
-            NUM_CBS,
-            NUM_SEMS,
-            num_ncrisc_unique_rtargs,
-            num_ncrisc_common_rtargs,
-            page_size};
+//         auto [ncrisc_unique_rtargs, ncrisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
+//         uint32_t num_ncrisc_unique_rtargs = ncrisc_unique_rtargs.size();
+//         uint32_t num_ncrisc_common_rtargs = ncrisc_common_rtargs.size();
+//         vector<uint32_t> ncrisc_compile_args = {
+//             NCRISC_OUTER_LOOP,
+//             NCRISC_MIDDLE_LOOP,
+//             NCRISC_INNER_LOOP,
+//             NUM_CBS,
+//             NUM_SEMS,
+//             num_ncrisc_unique_rtargs,
+//             num_ncrisc_common_rtargs,
+//             page_size};
 
-        // trisc
-        uint32_t TRISC_OUTER_LOOP, TRISC_MIDDLE_LOOP, TRISC_INNER_LOOP;
-        if (i == 0) {
-            TRISC_OUTER_LOOP = MAX_LOOP;
-            TRISC_MIDDLE_LOOP = MAX_LOOP;
-            TRISC_INNER_LOOP = MAX_LOOP;
-        } else {
-            TRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
-            TRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
-            TRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-        }
+//         // trisc
+//         uint32_t TRISC_OUTER_LOOP, TRISC_MIDDLE_LOOP, TRISC_INNER_LOOP;
+//         if (i == 0) {
+//             TRISC_OUTER_LOOP = MAX_LOOP;
+//             TRISC_MIDDLE_LOOP = MAX_LOOP;
+//             TRISC_INNER_LOOP = MAX_LOOP;
+//         } else {
+//             TRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+//             TRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+//             TRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+//         }
 
-        auto [trisc_unique_rtargs, trisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
-        uint32_t num_trisc_unique_rtargs = trisc_unique_rtargs.size();
-        uint32_t num_trisc_common_rtargs = trisc_common_rtargs.size();
-        vector<uint32_t> trisc_compile_args = {
-            TRISC_OUTER_LOOP,
-            TRISC_MIDDLE_LOOP,
-            TRISC_INNER_LOOP,
-            NUM_CBS,
-            NUM_SEMS,
-            num_trisc_unique_rtargs,
-            num_trisc_common_rtargs,
-            page_size};
+//         auto [trisc_unique_rtargs, trisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
+//         uint32_t num_trisc_unique_rtargs = trisc_unique_rtargs.size();
+//         uint32_t num_trisc_common_rtargs = trisc_common_rtargs.size();
+//         vector<uint32_t> trisc_compile_args = {
+//             TRISC_OUTER_LOOP,
+//             TRISC_MIDDLE_LOOP,
+//             TRISC_INNER_LOOP,
+//             NUM_CBS,
+//             NUM_SEMS,
+//             num_trisc_unique_rtargs,
+//             num_trisc_common_rtargs,
+//             page_size};
 
-        bool at_least_one_kernel = false;
-        if (i == 0 or ((rand() % 2) == 0)) {
-            auto dummy_brisc_kernel = CreateKernel(
-                program,
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-                cr_set,
-                DataMovementConfig{
-                    .processor = DataMovementProcessor::RISCV_0,
-                    .noc = NOC::RISCV_0_default,
-                    .compile_args = brisc_compile_args,
-                    .defines = data_movement_defines});
-            SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
-            SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
-            at_least_one_kernel = true;
-        }
+//         bool at_least_one_kernel = false;
+//         if (i == 0 or ((rand() % 2) == 0)) {
+//             auto dummy_brisc_kernel = CreateKernel(
+//                 program,
+//                 "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+//                 cr_set,
+//                 DataMovementConfig{
+//                     .processor = DataMovementProcessor::RISCV_0,
+//                     .noc = NOC::RISCV_0_default,
+//                     .compile_args = brisc_compile_args,
+//                     .defines = data_movement_defines});
+//             SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
+//             SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
+//             at_least_one_kernel = true;
+//         }
 
-        if (i == 0 or ((rand() % 2) == 0)) {
-            auto dummy_ncrisc_kernel = CreateKernel(
-                program,
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-                cr_set,
-                DataMovementConfig{
-                    .processor = DataMovementProcessor::RISCV_1,
-                    .noc = NOC::RISCV_1_default,
-                    .compile_args = ncrisc_compile_args,
-                    .defines = data_movement_defines});
-            SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
-            SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
-            at_least_one_kernel = true;
-        }
+//         if (i == 0 or ((rand() % 2) == 0)) {
+//             auto dummy_ncrisc_kernel = CreateKernel(
+//                 program,
+//                 "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+//                 cr_set,
+//                 DataMovementConfig{
+//                     .processor = DataMovementProcessor::RISCV_1,
+//                     .noc = NOC::RISCV_1_default,
+//                     .compile_args = ncrisc_compile_args,
+//                     .defines = data_movement_defines});
+//             SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
+//             SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
+//             at_least_one_kernel = true;
+//         }
 
-        if (i == 0 or ((rand() % 2) == 0)) {
-            auto dummy_trisc_kernel = CreateKernel(
-                program,
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-                cr_set,
-                ComputeConfig{
-                    .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
-            SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
-            SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
-            at_least_one_kernel = true;
-        }
+//         if (i == 0 or ((rand() % 2) == 0)) {
+//             auto dummy_trisc_kernel = CreateKernel(
+//                 program,
+//                 "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+//                 cr_set,
+//                 ComputeConfig{
+//                     .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
+//             SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
+//             SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
+//             at_least_one_kernel = true;
+//         }
 
-        if (not at_least_one_kernel) {
-            uint32_t random_risc = rand() % 3 + 1;
-            if (random_risc == 1) {
-                auto dummy_brisc_kernel = CreateKernel(
-                    program,
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-                    cr_set,
-                    DataMovementConfig{
-                        .processor = DataMovementProcessor::RISCV_0,
-                        .noc = NOC::RISCV_0_default,
-                        .compile_args = brisc_compile_args,
-                        .defines = data_movement_defines});
-                SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
-                SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
-            } else if (random_risc == 2) {
-                auto dummy_ncrisc_kernel = CreateKernel(
-                    program,
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-                    cr_set,
-                    DataMovementConfig{
-                        .processor = DataMovementProcessor::RISCV_1,
-                        .noc = NOC::RISCV_1_default,
-                        .compile_args = ncrisc_compile_args,
-                        .defines = data_movement_defines});
-                SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
-                SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
-            } else if (random_risc == 3) {
-                auto dummy_trisc_kernel = CreateKernel(
-                    program,
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-                    cr_set,
-                    ComputeConfig{
-                        .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
-                SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
-                SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
-            } else {
-                TT_THROW("Invalid");
-            }
-        }
+//         if (not at_least_one_kernel) {
+//             uint32_t random_risc = rand() % 3 + 1;
+//             if (random_risc == 1) {
+//                 auto dummy_brisc_kernel = CreateKernel(
+//                     program,
+//                     "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+//                     cr_set,
+//                     DataMovementConfig{
+//                         .processor = DataMovementProcessor::RISCV_0,
+//                         .noc = NOC::RISCV_0_default,
+//                         .compile_args = brisc_compile_args,
+//                         .defines = data_movement_defines});
+//                 SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
+//                 SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
+//             } else if (random_risc == 2) {
+//                 auto dummy_ncrisc_kernel = CreateKernel(
+//                     program,
+//                     "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+//                     cr_set,
+//                     DataMovementConfig{
+//                         .processor = DataMovementProcessor::RISCV_1,
+//                         .noc = NOC::RISCV_1_default,
+//                         .compile_args = ncrisc_compile_args,
+//                         .defines = data_movement_defines});
+//                 SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
+//                 SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
+//             } else if (random_risc == 3) {
+//                 auto dummy_trisc_kernel = CreateKernel(
+//                     program,
+//                     "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+//                     cr_set,
+//                     ComputeConfig{
+//                         .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
+//                 SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
+//                 SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
+//             } else {
+//                 TT_THROW("Invalid");
+//             }
+//         }
 
-        tt::tt_metal::detail::CompileProgram(this->device_, program);
-    }
+//         tt::tt_metal::detail::CompileProgram(this->device_, program);
+//     }
 
-    log_info(tt::LogTest, "Running {} programs for cache warmup.", programs.size());
-    // This loop caches program and runs
-    for (Program& program : programs) {
-        EnqueueProgram(this->device_->command_queue(), program, false);
-    }
+//     log_info(tt::LogTest, "Running {} programs for cache warmup.", programs.size());
+//     // This loop caches program and runs
+//     for (Program& program : programs) {
+//         EnqueueProgram(this->device_->command_queue(), program, false);
+//     }
 
-    // This loops assumes already cached
-    uint32_t NUM_ITERATIONS = 500;  // TODO(agrebenisan): Bump this to 5000, saw hangs for very large number of
-                                    // iterations, need to come back to that
+//     // This loops assumes already cached
+//     uint32_t NUM_ITERATIONS = 500;  // TODO(agrebenisan): Bump this to 5000, saw hangs for very large number of
+//                                     // iterations, need to come back to that
 
-    log_info(tt::LogTest, "Running {} programs for {} iterations now.", programs.size(), NUM_ITERATIONS);
-    for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
-        auto rng = std::default_random_engine{};
-        std::shuffle(std::begin(programs), std::end(programs), rng);
-        if (i % 50 == 0) {
-            log_info(tt::LogTest, "Enqueuing {} programs for iter: {}/{} now.", programs.size(), i + 1, NUM_ITERATIONS);
-        }
-        for (Program& program : programs) {
-            EnqueueProgram(this->device_->command_queue(), program, false);
-        }
-    }
+//     log_info(tt::LogTest, "Running {} programs for {} iterations now.", programs.size(), NUM_ITERATIONS);
+//     for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
+//         auto rng = std::default_random_engine{};
+//         std::shuffle(std::begin(programs), std::end(programs), rng);
+//         if (i % 50 == 0) {
+//             log_info(tt::LogTest, "Enqueuing {} programs for iter: {}/{} now.", programs.size(), i + 1,
+//             NUM_ITERATIONS);
+//         }
+//         for (Program& program : programs) {
+//             EnqueueProgram(this->device_->command_queue(), program, false);
+//         }
+//     }
 
-    log_info(tt::LogTest, "Calling Finish.");
-    Finish(this->device_->command_queue());
-}
+//     log_info(tt::LogTest, "Calling Finish.");
+//     Finish(this->device_->command_queue());
+// }
 
-TEST_F(RandomProgramFixture, TensixTestSimplePrograms) {
-    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-        if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
-        }
-        Program program = CreateProgram();
-        this->create_kernel(program, CoreType::WORKER, true);
-        EnqueueProgram(device_->command_queue(), program, false);
-    }
+// TEST_F(RandomProgramFixture, TensixTestSimplePrograms) {
+//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+//         if (i % 10 == 0) {
+//             log_info(tt::LogTest, "Creating Program {}", i);
+//         }
+//         Program program = CreateProgram();
+//         this->create_kernel(program, CoreType::WORKER, true);
+//         EnqueueProgram(device_->command_queue(), program, false);
+//     }
 
-    Finish(device_->command_queue());
-}
+//     Finish(device_->command_queue());
+// }
 
-TEST_F(RandomProgramFixture, ActiveEthTestSimplePrograms) {
-    if (!does_device_have_active_eth_cores(device_)) {
-        GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet cores";
-    }
+// TEST_F(RandomProgramFixture, ActiveEthTestSimplePrograms) {
+//     if (!does_device_have_active_eth_cores(device_)) {
+//         GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet
+//         cores";
+//     }
 
-    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-        if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
-        }
-        Program program = CreateProgram();
-        this->create_kernel(program, CoreType::ETH, true);
-        EnqueueProgram(device_->command_queue(), program, false);
-    }
+//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+//         if (i % 10 == 0) {
+//             log_info(tt::LogTest, "Creating Program {}", i);
+//         }
+//         Program program = CreateProgram();
+//         this->create_kernel(program, CoreType::ETH, true);
+//         EnqueueProgram(device_->command_queue(), program, false);
+//     }
 
-    Finish(device_->command_queue());
-}
+//     Finish(device_->command_queue());
+// }
 
-TEST_F(RandomProgramFixture, TensixActiveEthTestSimplePrograms) {
-    if (!does_device_have_active_eth_cores(device_)) {
-        GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet cores";
-    }
+// TEST_F(RandomProgramFixture, TensixActiveEthTestSimplePrograms) {
+//     if (!does_device_have_active_eth_cores(device_)) {
+//         GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet
+//         cores";
+//     }
 
-    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-        if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
-        }
-        Program program = CreateProgram();
+//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+//         if (i % 10 == 0) {
+//             log_info(tt::LogTest, "Creating Program {}", i);
+//         }
+//         Program program = CreateProgram();
 
-        bool eth_kernel_added_to_program = false;
-        if (rand() % 2 == 0) {
-            this->create_kernel(program, CoreType::ETH, true);
-            eth_kernel_added_to_program = true;
-        }
-        if (rand() % 2 == 0 || !eth_kernel_added_to_program) {
-            this->create_kernel(program, CoreType::WORKER, true);
-        }
+//         bool eth_kernel_added_to_program = false;
+//         if (rand() % 2 == 0) {
+//             this->create_kernel(program, CoreType::ETH, true);
+//             eth_kernel_added_to_program = true;
+//         }
+//         if (rand() % 2 == 0 || !eth_kernel_added_to_program) {
+//             this->create_kernel(program, CoreType::WORKER, true);
+//         }
 
-        EnqueueProgram(device_->command_queue(), program, false);
-    }
+//         EnqueueProgram(device_->command_queue(), program, false);
+//     }
 
-    Finish(device_->command_queue());
-}
+//     Finish(device_->command_queue());
+// }
 
-TEST_F(RandomProgramFixture, TensixTestPrograms) {
-    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-        if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
-        }
-        Program program = CreateProgram();
-        this->create_kernel(program, CoreType::WORKER);
-        EnqueueProgram(device_->command_queue(), program, false);
-    }
+// TEST_F(RandomProgramFixture, TensixTestPrograms) {
+//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+//         if (i % 10 == 0) {
+//             log_info(tt::LogTest, "Creating Program {}", i);
+//         }
+//         Program program = CreateProgram();
+//         this->create_kernel(program, CoreType::WORKER);
+//         EnqueueProgram(device_->command_queue(), program, false);
+//     }
 
-    Finish(device_->command_queue());
-}
+//     Finish(device_->command_queue());
+// }
 
-TEST_F(RandomProgramFixture, ActiveEthTestPrograms) {
-    if (!does_device_have_active_eth_cores(device_)) {
-        GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet cores";
-    }
+// TEST_F(RandomProgramFixture, ActiveEthTestPrograms) {
+//     if (!does_device_have_active_eth_cores(device_)) {
+//         GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet
+//         cores";
+//     }
 
-    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-        if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
-        }
-        Program program = CreateProgram();
-        // Large eth kernels currently don't fit in the ring buffer, so we're reducing the max number of RTAs
-        // and the max kernel size to ensure that the kernel can fit in the ring buffer
-        KernelProperties kernel_properties;
-        kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-        kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
-        this->create_kernel(program, CoreType::ETH, false, kernel_properties);
-        EnqueueProgram(device_->command_queue(), program, false);
-    }
+//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+//         if (i % 10 == 0) {
+//             log_info(tt::LogTest, "Creating Program {}", i);
+//         }
+//         Program program = CreateProgram();
+//         // Large eth kernels currently don't fit in the ring buffer, so we're reducing the max number of RTAs
+//         // and the max kernel size to ensure that the kernel can fit in the ring buffer
+//         KernelProperties kernel_properties;
+//         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
+//         kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
+//         this->create_kernel(program, CoreType::ETH, false, kernel_properties);
+//         EnqueueProgram(device_->command_queue(), program, false);
+//     }
 
-    Finish(device_->command_queue());
-}
+//     Finish(device_->command_queue());
+// }
 
-TEST_F(RandomProgramFixture, TensixActiveEthTestPrograms) {
-    if (!does_device_have_active_eth_cores(device_)) {
-        GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet cores";
-    }
+// TEST_F(RandomProgramFixture, TensixActiveEthTestPrograms) {
+//     if (!does_device_have_active_eth_cores(device_)) {
+//         GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet
+//         cores";
+//     }
 
-    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-        if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
-        }
-        Program program = CreateProgram();
+//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+//         if (i % 10 == 0) {
+//             log_info(tt::LogTest, "Creating Program {}", i);
+//         }
+//         Program program = CreateProgram();
 
-        bool eth_kernel_added_to_program = false;
-        if (rand() % 2 == 0) {
-            // Large eth kernels currently don't fit in the ring buffer, so we're reducing the max number of RTAs
-            // and the max kernel size to ensure that the kernel can fit in the ring buffer
-            KernelProperties kernel_properties;
-            kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-            kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
-            kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
-            this->create_kernel(program, CoreType::ETH, false, kernel_properties);
-            eth_kernel_added_to_program = true;
-        }
-        if (rand() % 2 == 0 || !eth_kernel_added_to_program) {
-            KernelProperties kernel_properties;
-            kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
-            this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
-        }
+//         bool eth_kernel_added_to_program = false;
+//         if (rand() % 2 == 0) {
+//             // Large eth kernels currently don't fit in the ring buffer, so we're reducing the max number of RTAs
+//             // and the max kernel size to ensure that the kernel can fit in the ring buffer
+//             KernelProperties kernel_properties;
+//             kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
+//             kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
+//             kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
+//             this->create_kernel(program, CoreType::ETH, false, kernel_properties);
+//             eth_kernel_added_to_program = true;
+//         }
+//         if (rand() % 2 == 0 || !eth_kernel_added_to_program) {
+//             KernelProperties kernel_properties;
+//             kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
+//             this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
+//         }
 
-        EnqueueProgram(device_->command_queue(), program, false);
-    }
+//         EnqueueProgram(device_->command_queue(), program, false);
+//     }
 
-    Finish(device_->command_queue());
-}
+//     Finish(device_->command_queue());
+// }
 
-TEST_F(RandomProgramFixture, TensixTestAlternatingLargeAndSmallPrograms) {
-    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-        if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
-        }
-        Program program = CreateProgram();
+// TEST_F(RandomProgramFixture, TensixTestAlternatingLargeAndSmallPrograms) {
+//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+//         if (i % 10 == 0) {
+//             log_info(tt::LogTest, "Creating Program {}", i);
+//         }
+//         Program program = CreateProgram();
 
-        KernelProperties kernel_properties;
-        if (i % 2 == 0) {
-            kernel_properties = this->get_large_kernel_properties();
-        } else {
-            kernel_properties = this->get_small_kernel_properties();
-        }
+//         KernelProperties kernel_properties;
+//         if (i % 2 == 0) {
+//             kernel_properties = this->get_large_kernel_properties();
+//         } else {
+//             kernel_properties = this->get_small_kernel_properties();
+//         }
 
-        this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
-        EnqueueProgram(device_->command_queue(), program, false);
-    }
+//         this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
+//         EnqueueProgram(device_->command_queue(), program, false);
+//     }
 
-    Finish(device_->command_queue());
-}
+//     Finish(device_->command_queue());
+// }
 
-TEST_F(RandomProgramFixture, TensixTestLargeProgramFollowedBySmallPrograms) {
-    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-        if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
-        }
-        Program program = CreateProgram();
+// TEST_F(RandomProgramFixture, TensixTestLargeProgramFollowedBySmallPrograms) {
+//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+//         if (i % 10 == 0) {
+//             log_info(tt::LogTest, "Creating Program {}", i);
+//         }
+//         Program program = CreateProgram();
 
-        KernelProperties kernel_properties;
-        if (i == 0) {
-            kernel_properties = this->get_large_kernel_properties();
-        } else {
-            kernel_properties = this->get_small_kernel_properties();
-        }
+//         KernelProperties kernel_properties;
+//         if (i == 0) {
+//             kernel_properties = this->get_large_kernel_properties();
+//         } else {
+//             kernel_properties = this->get_small_kernel_properties();
+//         }
 
-        this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
-        EnqueueProgram(device_->command_queue(), program, false);
-    }
+//         this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
+//         EnqueueProgram(device_->command_queue(), program, false);
+//     }
 
-    Finish(device_->command_queue());
-}
+//     Finish(device_->command_queue());
+// }
 
-TEST_F(RandomProgramFixture, TensixTestLargeProgramInBetweenFiveSmallPrograms) {
-    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-        if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
-        }
-        Program program = CreateProgram();
+// TEST_F(RandomProgramFixture, TensixTestLargeProgramInBetweenFiveSmallPrograms) {
+//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+//         if (i % 10 == 0) {
+//             log_info(tt::LogTest, "Creating Program {}", i);
+//         }
+//         Program program = CreateProgram();
 
-        KernelProperties kernel_properties;
-        if (i % 6 == 0) {
-            kernel_properties = this->get_large_kernel_properties();
-        } else {
-            kernel_properties = this->get_small_kernel_properties();
-        }
+//         KernelProperties kernel_properties;
+//         if (i % 6 == 0) {
+//             kernel_properties = this->get_large_kernel_properties();
+//         } else {
+//             kernel_properties = this->get_small_kernel_properties();
+//         }
 
-        this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
-        EnqueueProgram(device_->command_queue(), program, false);
-    }
+//         this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
+//         EnqueueProgram(device_->command_queue(), program, false);
+//     }
 
-    Finish(device_->command_queue());
-}
+//     Finish(device_->command_queue());
+// }
 
 }  // namespace stress_tests
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1005,18 +1005,12 @@ void test_my_coordinates(
     size_t cq_id = 0,
     bool idle_eth = false) {
     const std::string k_kernel_path = "tests/tt_metal/tt_metal/test_kernels/misc/read_my_coordinates.cpp";
-    auto device = mesh_device->get_devices()[0];
     // All logical cores
     CoreRangeSet cr{CoreRange{{2, 2}, {6, 6}}};
-    if (processor_class == tt::RISCV::ERISC) {
-        const auto eth_cores =
-            idle_eth ? device->get_inactive_ethernet_cores() : device->get_active_ethernet_cores(true);
-        cr = CoreRangeSet{std::set<CoreRange>{eth_cores.begin(), eth_cores.end()}};
-    }
 
-    uint32_t cb_addr = processor_class == tt::RISCV::ERISC
-                           ? hal::get_erisc_l1_unreserved_base()
-                           : mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+    auto device = mesh_device->get_devices()[0];
+
+    uint32_t cb_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
     std::vector<uint32_t> compile_args{
         cb_addr,
     };
@@ -1107,8 +1101,8 @@ namespace basic_tests {
 
 namespace compiler_workaround_hardware_bug_tests {
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestArbiterDoesNotHang) {
-    for (auto device : devices_) {
+TEST_F(UnitMeshCQFixture, TensixTestArbiterDoesNotHang) {
+    for (const auto& device : devices_) {
         distributed::MeshWorkload workload;
         distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -1132,7 +1126,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestArbiterDoesNotHang) {
 }  // namespace compiler_workaround_hardware_bug_tests
 namespace single_core_tests {
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestSingleCbConfigCorrectlySentSingleCore) {
+TEST_F(UnitMeshCQFixture, TensixTestSingleCbConfigCorrectlySentSingleCore) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
@@ -1146,7 +1140,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestSingleCbConfigCorrectlySentSingleC
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCbSeqConfigCorrectlySentSingleCore) {
+TEST_F(UnitMeshCQFixture, TensixTestMultiCbSeqConfigCorrectlySentSingleCore) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
@@ -1164,7 +1158,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCbSeqConfigCorrectlySentSingl
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCbRandomConfigCorrectlySentSingleCore) {
+TEST_F(UnitMeshCQFixture, TensixTestMultiCbRandomConfigCorrectlySentSingleCore) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
@@ -1182,7 +1176,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCbRandomConfigCorrectlySentSi
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCBSharedAddressSpaceSentSingleCore) {
+TEST_F(UnitMeshCQFixture, TensixTestMultiCBSharedAddressSpaceSentSingleCore) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
@@ -1199,7 +1193,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCBSharedAddressSpaceSentSingl
         NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
     CoreCoord core_coord(0, 0);
 
-    for (auto device : devices_) {
+    for (const auto& device : devices_) {
         distributed::MeshWorkload workload;
         distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -1244,7 +1238,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCBSharedAddressSpaceSentSingl
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestSingleCbConfigCorrectlyUpdateSizeSentSingleCore) {
+TEST_F(UnitMeshCQFixture, TensixTestSingleCbConfigCorrectlyUpdateSizeSentSingleCore) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
@@ -1258,7 +1252,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestSingleCbConfigCorrectlyUpdateSizeS
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestSingleSemaphoreConfigCorrectlySentSingleCore) {
+TEST_F(UnitMeshCQFixture, TensixTestSingleSemaphoreConfigCorrectlySentSingleCore) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
@@ -1270,8 +1264,8 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestSingleSemaphoreConfigCorrectlySent
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestAutoInsertedBlankBriscKernelInDeviceDispatchMode) {
-    for (auto device : devices_) {
+TEST_F(UnitMeshCQFixture, TensixTestAutoInsertedBlankBriscKernelInDeviceDispatchMode) {
+    for (const auto& device : devices_) {
         distributed::MeshWorkload workload;
         distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -1295,11 +1289,11 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestAutoInsertedBlankBriscKernelInDevi
 }
 
 // Sanity test for setting and verifying common and unique runtime args to a single core, the simplest case.
-TEST_F(UnitMeshCommandQueueFixture, TensixIncrementRuntimeArgsSanitySingleCoreCompute) {
+TEST_F(UnitMeshCQFixture, TensixIncrementRuntimeArgsSanitySingleCoreCompute) {
     CoreRange cr0({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr0});
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    for (auto device : devices_) {
+    for (const auto& device : devices_) {
         EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
             device, dummy_program_config, 8, 8, tt::RISCV::COMPUTE));
     }
@@ -1308,7 +1302,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixIncrementRuntimeArgsSanitySingleCoreCo
 // Test setting common runtime args across multiple kernel in the same program
 // This test will ensure a multicast (or unicast for eth) gets created for each time the
 // user calls SetCommonRuntimeArgs.
-TEST_F(UnitMeshCommandQueueFixture, TensixSetCommonRuntimeArgsMultipleCreateKernel) {
+TEST_F(UnitMeshCQFixture, TensixSetCommonRuntimeArgsMultipleCreateKernel) {
     const CoreRange core_range_0(CoreCoord(1, 1), CoreCoord(2, 2));
     const CoreRange core_range_1(CoreCoord(3, 3), CoreCoord(4, 4));
 
@@ -1320,13 +1314,13 @@ TEST_F(UnitMeshCommandQueueFixture, TensixSetCommonRuntimeArgsMultipleCreateKern
         {.cr_set = core_range_set_1},
     };
 
-    for (auto device : devices_) {
+    for (const auto& device : devices_) {
         EXPECT_TRUE(
             local_test_functions::test_increment_runtime_args_sanity(device, configs, 8, 8, tt::RISCV::COMPUTE));
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, ActiveEthEnqueueDummyProgram) {
+TEST_F(UnitMeshCQFixture, ActiveEthEnqueueDummyProgram) {
     for (const auto& device : devices_) {
         for (const auto& eth_core : device->get_devices()[0]->get_active_ethernet_cores(true)) {
             local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(device, eth_core);
@@ -1336,8 +1330,8 @@ TEST_F(UnitMeshCommandQueueFixture, ActiveEthEnqueueDummyProgram) {
 
 // Sanity test for setting and verifying common and unique runtime args to single cores via ERISC. Some arch may return
 // 0 active eth cores, that's okay.
-TEST_F(UnitMeshCommandQueueFixture, ActiveEthIncrementRuntimeArgsSanitySingleCoreDataMovementErisc) {
-    for (auto device : devices_) {
+TEST_F(UnitMeshCQFixture, ActiveEthIncrementRuntimeArgsSanitySingleCoreDataMovementErisc) {
+    for (const auto& device : devices_) {
         for (const auto& eth_core : device->get_devices()[0]->get_active_ethernet_cores(true)) {
             CoreRange cr0(eth_core);
             CoreRangeSet cr_set({cr0});
@@ -1352,8 +1346,8 @@ TEST_F(UnitMeshCommandQueueFixture, ActiveEthIncrementRuntimeArgsSanitySingleCor
 // Sanity test for setting and verifying common and unique runtime args to single cores via ERISC(IDLE). Some arch may
 // return 0 active eth cores, that's okay.
 // FIXME - Re-enable when FD-on-idle-eth is supported
-TEST_F(UnitMeshCommandQueueFixture, DISABLED_ActiveEthIncrementRuntimeArgsSanitySingleCoreDataMovementEriscIdle) {
-    for (auto device : devices_) {
+TEST_F(UnitMeshCQFixture, DISABLED_ActiveEthIncrementRuntimeArgsSanitySingleCoreDataMovementEriscIdle) {
+    for (const auto& device : devices_) {
         for (const auto& eth_core : device->get_devices()[0]->get_active_ethernet_cores(true)) {
             CoreRange cr0(eth_core);
             CoreRangeSet cr_set({cr0});
@@ -1368,8 +1362,8 @@ TEST_F(UnitMeshCommandQueueFixture, DISABLED_ActiveEthIncrementRuntimeArgsSanity
 // Sanity test for setting and verifying common and unique runtime args to single cores via inactive ERISC cores. Some
 // arch may return 0 active eth cores, that's okay.
 // FIXME - Re-enable when FD-on-idle-eth is supported
-TEST_F(UnitMeshCommandQueueFixture, DISABLED_IdleEthIncrementRuntimeArgsSanitySingleCoreDataMovementEriscInactive) {
-    for (auto device : devices_) {
+TEST_F(UnitMeshCQFixture, DISABLED_IdleEthIncrementRuntimeArgsSanitySingleCoreDataMovementEriscInactive) {
+    for (const auto& device : devices_) {
         for (const auto& eth_core : device->get_devices()[0]->get_inactive_ethernet_cores()) {
             CoreRange cr0(eth_core);
             CoreRangeSet cr_set({cr0});
@@ -1382,7 +1376,7 @@ TEST_F(UnitMeshCommandQueueFixture, DISABLED_IdleEthIncrementRuntimeArgsSanitySi
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestRuntimeArgsCorrectlySentSingleCore) {
+TEST_F(UnitMeshCQFixture, TensixTestRuntimeArgsCorrectlySentSingleCore) {
     CoreRange cr({0, 0}, {0, 0});
     CoreRangeSet cr_set({cr});
 
@@ -1393,28 +1387,25 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestRuntimeArgsCorrectlySentSingleCore
     }
 }
 
-auto CommandQueueFabricConfigsToTest = ::testing::Values(
-    tt::tt_fabric::FabricConfig::FABRIC_1D,
-    tt::tt_fabric::FabricConfig::FABRIC_1D_RING,
-    tt::tt_fabric::FabricConfig::FABRIC_2D,
-    tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
+auto CQFabricConfigsToTest = ::testing::Values(
+    tt::tt_metal::FabricConfig::FABRIC_1D,
+    tt::tt_metal::FabricConfig::FABRIC_1D_RING,
+    tt::tt_metal::FabricConfig::FABRIC_2D,
+    tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC);
+
+INSTANTIATE_TEST_SUITE_P(CommandQueueMultiDevice, DISABLED_CQMultiDeviceOnFabricFixture, CQFabricConfigsToTest);
 
 INSTANTIATE_TEST_SUITE_P(
-    CommandQueueMultiDevice, DISABLED_CommandQueueMultiDeviceOnFabricFixture, CommandQueueFabricConfigsToTest);
+    MultiCommandQueueMultiDevice, DISABLED_MultiCQMultiDeviceOnFabricFixture, CQFabricConfigsToTest);
 
-INSTANTIATE_TEST_SUITE_P(
-    MultiCommandQueueMultiDevice,
-    DISABLED_MultiCommandQueueMultiDeviceOnFabricFixture,
-    CommandQueueFabricConfigsToTest);
-
-TEST_P(DISABLED_CommandQueueMultiDeviceOnFabricFixture, TensixTestBasicDispatchFunctions) {
-    for (IDevice* device : devices_) {
+TEST_P(DISABLED_CQMultiDeviceOnFabricFixture, TensixTestBasicDispatchFunctions) {
+    for (const auto& device : devices_) {
         local_test_functions::test_basic_dispatch_functions(device, 0);
     }
 }
 
-TEST_P(DISABLED_MultiCommandQueueMultiDeviceOnFabricFixture, TensixTestBasicDispatchFunctions) {
-    for (IDevice* device : devices_) {
+TEST_P(DISABLED_MultiCQMultiDeviceOnFabricFixture, TensixTestBasicDispatchFunctions) {
+    for (const auto& device : devices_) {
         for (int cq_id = 0; cq_id < device->num_hw_cqs(); ++cq_id) {
             local_test_functions::test_basic_dispatch_functions(device, cq_id);
         }
@@ -1424,7 +1415,7 @@ TEST_P(DISABLED_MultiCommandQueueMultiDeviceOnFabricFixture, TensixTestBasicDisp
 }  // end namespace single_core_tests
 
 namespace multicore_tests {
-TEST_F(UnitMeshCommandQueueFixture, TensixTestAllCbConfigsCorrectlySentMultiCore) {
+TEST_F(UnitMeshCQFixture, TensixTestAllCbConfigsCorrectlySentMultiCore) {
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
     std::vector<CBConfig> cb_config_vector(NUM_CIRCULAR_BUFFERS, cb_config);
@@ -1445,7 +1436,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestAllCbConfigsCorrectlySentMultiCore
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestAllCbConfigsCorrectlySentUpdateSizeMultiCore) {
+TEST_F(UnitMeshCQFixture, TensixTestAllCbConfigsCorrectlySentUpdateSizeMultiCore) {
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
     std::vector<CBConfig> cb_config_vector(NUM_CIRCULAR_BUFFERS, cb_config);
@@ -1466,7 +1457,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestAllCbConfigsCorrectlySentUpdateSiz
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCbConfigsCorrectlySentUpdateSizeMultiCore) {
+TEST_F(UnitMeshCQFixture, TensixTestMultiCbConfigsCorrectlySentUpdateSizeMultiCore) {
     CBConfig cb_config_0 = {.cb_id = 0, .num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
     CBConfig cb_config_1 = {.cb_id = 1, .num_pages = 2, .page_size = 4096, .data_format = tt::DataFormat::Float16_b};
     CBConfig cb_config_2 = {.cb_id = 2, .num_pages = 2, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
@@ -1487,7 +1478,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCbConfigsCorrectlySentUpdateS
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestAllCbConfigsCorrectlySentMultipleCoreRanges) {
+TEST_F(UnitMeshCQFixture, TensixTestAllCbConfigsCorrectlySentMultipleCoreRanges) {
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
     std::vector<CBConfig> cb_config_vector(NUM_CIRCULAR_BUFFERS, cb_config);
@@ -1511,7 +1502,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestAllCbConfigsCorrectlySentMultipleC
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestAllCbConfigsCorrectlySentUpdateSizeMultipleCoreRanges) {
+TEST_F(UnitMeshCQFixture, TensixTestAllCbConfigsCorrectlySentUpdateSizeMultipleCoreRanges) {
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
     std::vector<CBConfig> cb_config_vector(NUM_CIRCULAR_BUFFERS, cb_config);
@@ -1535,7 +1526,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestAllCbConfigsCorrectlySentUpdateSiz
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCbConfigsCorrectlySentUpdateSizeMultipleCoreRanges) {
+TEST_F(UnitMeshCQFixture, TensixTestMultiCbConfigsCorrectlySentUpdateSizeMultipleCoreRanges) {
     CBConfig cb_config_0 = {.cb_id = 0, .num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
     CBConfig cb_config_1 = {.cb_id = 1, .num_pages = 2, .page_size = 4096, .data_format = tt::DataFormat::Float16_b};
     CBConfig cb_config_2 = {.cb_id = 2, .num_pages = 2, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
@@ -1559,7 +1550,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestMultiCbConfigsCorrectlySentUpdateS
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestAllSemConfigsCorrectlySentMultiCore) {
+TEST_F(UnitMeshCQFixture, TensixTestAllSemConfigsCorrectlySentMultiCore) {
     for (const auto& device : devices_) {
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
 
@@ -1572,7 +1563,7 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestAllSemConfigsCorrectlySentMultiCor
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestAllSemaphoreConfigsCorrectlySentMultipleCoreRanges) {
+TEST_F(UnitMeshCQFixture, TensixTestAllSemaphoreConfigsCorrectlySentMultipleCoreRanges) {
     for (const auto& device : devices_) {
         CoreRange first_cr({0, 0}, {1, 1});
 
@@ -1614,8 +1605,8 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestAllSemaphoreConfigsCorrectlySentMu
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestAllRuntimeArgsCorrectlySentMultiCore) {
-    for (auto device : devices_) {
+TEST_F(UnitMeshCQFixture, TensixTestAllRuntimeArgsCorrectlySentMultiCore) {
+    for (const auto& device : devices_) {
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
 
         CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
@@ -1627,8 +1618,8 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestAllRuntimeArgsCorrectlySentMultiCo
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestAllRuntimeArgsCorrectlySentMultiCore_255_PerKernel) {
-    for (auto device : devices_) {
+TEST_F(UnitMeshCQFixture, TensixTestAllRuntimeArgsCorrectlySentMultiCore_255_PerKernel) {
+    for (const auto& device : devices_) {
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
 
         CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
@@ -1640,8 +1631,8 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestAllRuntimeArgsCorrectlySentMultiCo
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestSendRuntimeArgsMultiCoreRange) {
-    for (auto device : devices_) {
+TEST_F(UnitMeshCQFixture, TensixTestSendRuntimeArgsMultiCoreRange) {
+    for (const auto& device : devices_) {
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
 
         CoreRange cr0({0, 0}, {worker_grid_size.x - 1, 3});
@@ -1654,9 +1645,9 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestSendRuntimeArgsMultiCoreRange) {
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestSendRuntimeArgsMultiNonOverlappingCoreRange) {
+TEST_F(UnitMeshCQFixture, TensixTestSendRuntimeArgsMultiNonOverlappingCoreRange) {
     // Core ranges get merged in kernel groups, this one does not
-    for (auto device : devices_) {
+    for (const auto& device : devices_) {
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
 
         CoreRange cr0({0, 0}, {worker_grid_size.x - 1, 3});
@@ -1669,8 +1660,8 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestSendRuntimeArgsMultiNonOverlapping
     }
 }
 
-TEST_F(UnitMeshCommandQueueFixture, TensixTestUpdateRuntimeArgsMultiCoreRange) {
-    for (auto device : devices_) {
+TEST_F(UnitMeshCQFixture, TensixTestUpdateRuntimeArgsMultiCoreRange) {
+    for (const auto& device : devices_) {
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
 
         CoreRange cr0({0, 0}, {worker_grid_size.x - 1, 3});
@@ -1684,392 +1675,374 @@ TEST_F(UnitMeshCommandQueueFixture, TensixTestUpdateRuntimeArgsMultiCoreRange) {
 }
 
 // Sanity test for setting and verifying common and unique runtime args to multiple cores.
-TEST_F(UnitMeshCommandQueueFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute) {
+TEST_F(UnitMeshCQFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute) {
     CoreRange cr0({1, 1}, {2, 2});
     CoreRange cr1({3, 3}, {4, 4});
     CoreRangeSet cr_set(std::vector{cr0, cr1});
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    for (auto device : devices_) {
+    for (const auto& device : devices_) {
         EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
             device, dummy_program_config, 16, 16, tt::RISCV::COMPUTE));
     }
 }
 
 // Max number of 255 unique RT args.
-TEST_F(UnitMeshCommandQueueFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute_255_UniqueArgs) {
+TEST_F(UnitMeshCQFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute_255_UniqueArgs) {
     CoreRange cr0({1, 1}, {2, 2});
     CoreRange cr1({3, 3}, {4, 4});
     CoreRangeSet cr_set(std::vector{cr0, cr1});
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    for (auto device : devices_) {
+    for (const auto& device : devices_) {
         EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
             device, dummy_program_config, 255, 0, tt::RISCV::COMPUTE));
     }
 }
 
 // Max number of 255 common RT args.
-TEST_F(UnitMeshCommandQueueFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute_255_CommonArgs) {
+TEST_F(UnitMeshCQFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute_255_CommonArgs) {
     CoreRange cr0({1, 1}, {2, 2});
     CoreRange cr1({3, 3}, {4, 4});
     CoreRangeSet cr_set(std::vector{cr0, cr1});
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    for (auto device : devices_) {
+    for (const auto& device : devices_) {
         EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
             device, dummy_program_config, 0, 255, tt::RISCV::COMPUTE));
     }
 }
 
 // Sanity test for setting and verifying common and unique runtime args to multiple cores via BRISC.
-TEST_F(UnitMeshCommandQueueFixture, TensixIncrementRuntimeArgsSanityMultiCoreDataMovementBrisc) {
+TEST_F(UnitMeshCQFixture, TensixIncrementRuntimeArgsSanityMultiCoreDataMovementBrisc) {
     CoreRange cr0({1, 1}, {2, 2});
     CoreRange cr1({3, 3}, {4, 4});
     CoreRangeSet cr_set(std::vector{cr0, cr1});
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    for (auto device : devices_) {
+    for (const auto& device : devices_) {
         EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
             device, dummy_program_config, 16, 16, tt::RISCV::BRISC));
     }
 }
 
 // Sanity test for setting and verifying common and unique runtime args to multiple cores via NCRISC.
-TEST_F(UnitMeshCommandQueueFixture, TensixIncrementRuntimeArgsSanityMultiCoreDataMovementNcrisc) {
+TEST_F(UnitMeshCQFixture, TensixIncrementRuntimeArgsSanityMultiCoreDataMovementNcrisc) {
     CoreRange cr0({1, 1}, {2, 2});
     CoreRange cr1({3, 3}, {4, 4});
     CoreRangeSet cr_set(std::vector{cr0, cr1});
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    for (auto device : devices_) {
+    for (const auto& device : devices_) {
         EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
             device, dummy_program_config, 16, 16, tt::RISCV::NCRISC));
     }
 }
 
 // Ensure the data movement core can access their own logical coordinate. Same binary enqueued to multiple cores.
-TEST_F(UnitMeshCommandQueueFixture, TestLogicalCoordinatesDataMovement) {
-    for (auto device : devices_) {
+TEST_F(UnitMeshCQFixture, TestLogicalCoordinatesDataMovement) {
+    for (const auto& device : devices_) {
         local_test_functions::test_my_coordinates(device, tt::RISCV::BRISC);
         local_test_functions::test_my_coordinates(device, tt::RISCV::NCRISC);
     }
 }
 
 // Ensure the compute core can access their own logical coordinate. Same binary enqueued to multiple cores.
-TEST_F(UnitMeshCommandQueueFixture, TestLogicalCoordinatesCompute) {
-    for (auto device : devices_) {
+TEST_F(UnitMeshCQFixture, TestLogicalCoordinatesCompute) {
+    for (const auto& device : devices_) {
         local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE);
     }
 }
 
-// Ensure the eth core can access their own logical coordinate. Same binary enqueued to multiple cores.
-TEST_F(UnitMeshCommandQueueFixture, TestLogicalCoordinatesEth) {
-    for (auto device : devices_) {
-        if (!does_device_have_active_eth_cores(device->get_devices()[0])) {
-            GTEST_SKIP() << "Skipping test because device " << device->id()
-                         << " does not have any active ethernet cores";
-        }
-        local_test_functions::test_my_coordinates(device, tt::RISCV::ERISC);
+// Ensure the data movement core can access their own logical coordinate. Same binary enqueued to multiple cores.
+TEST_F(UnitMeshMultiCQSingleDeviceProgramFixture, TestLogicalCoordinatesDataMovement) {
+    for (const auto& device : devices_) {
+        local_test_functions::test_my_coordinates(device, tt::RISCV::BRISC);
+        local_test_functions::test_my_coordinates(device, tt::RISCV::BRISC, 1);
+        local_test_functions::test_my_coordinates(device, tt::RISCV::NCRISC);
+        local_test_functions::test_my_coordinates(device, tt::RISCV::NCRISC, 1);
     }
 }
 
-// Ensure the data movement core can access their own logical coordinate. Same binary enqueued to multiple cores.
-// TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TestLogicalCoordinatesDataMovement) {
-//     for (IDevice* device : devices_) {
-//         local_test_functions::test_my_coordinates(device, tt::RISCV::BRISC);
-//         local_test_functions::test_my_coordinates(device, tt::RISCV::BRISC, 1);
-//         local_test_functions::test_my_coordinates(device, tt::RISCV::NCRISC);
-//         local_test_functions::test_my_coordinates(device, tt::RISCV::NCRISC, 1);
-//     }
-// }
-
-// // Ensure the compute core can access their own logical coordinate. Same binary enqueued to multiple cores.
-// TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TestLogicalCoordinatesCompute) {
-//     for (IDevice* device : devices_) {
-//         local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE);
-//         local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE, 1);
-//     }
-// }
-
-// // Ensure the eth core can access their own logical coordinate. Same binary enqueued to multiple cores.
-// TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TestLogicalCoordinatesEth) {
-//     for (IDevice* device : devices_) {
-//         if (!does_device_have_active_eth_cores(device)) {
-//             GTEST_SKIP() << "Skipping test because device " << device->id()
-//                          << " does not have any active ethernet cores";
-//         }
-//         local_test_functions::test_my_coordinates(device, tt::RISCV::ERISC, 0);
-//         local_test_functions::test_my_coordinates(device, tt::RISCV::ERISC, 1);
-//     }
-// }
+// Ensure the compute core can access their own logical coordinate. Same binary enqueued to multiple cores.
+TEST_F(UnitMeshMultiCQSingleDeviceProgramFixture, TestLogicalCoordinatesCompute) {
+    for (const auto& device : devices_) {
+        local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE);
+        local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE, 1);
+    }
+}
 
 }  // end namespace multicore_tests
 }  // namespace basic_tests
 
 namespace stress_tests {
 
-// TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TensixTestRandomizedProgram) {
-//     uint32_t NUM_PROGRAMS = 100;
-//     uint32_t MAX_LOOP = 100;
-//     uint32_t page_size = 1024;
+TEST_F(UnitMeshMultiCQSingleDeviceProgramFixture, TensixTestRandomizedProgram) {
+    uint32_t NUM_PROGRAMS = 100;
+    uint32_t MAX_LOOP = 100;
+    uint32_t page_size = 1024;
 
-//     if (this->arch_ == tt::ARCH::BLACKHOLE) {
-//         GTEST_SKIP();  // Running on second CQ is hanging on CI
-//     }
+    if (this->arch_ == tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP();  // Running on second CQ is hanging on CI
+    }
 
-//     // Make random
-//     auto random_seed = 0;  // (unsigned int)time(NULL);
-//     uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
-//     log_info(tt::LogTest, "Using Test Seed: {}", seed);
-//     srand(seed);
+    // Make random
+    auto random_seed = 0;  // (unsigned int)time(NULL);
+    uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
+    log_info(tt::LogTest, "Using Test Seed: {}", seed);
+    srand(seed);
 
-//     CoreCoord worker_grid_size = this->device_->compute_with_storage_grid_size();
-//     CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
-//     CoreRangeSet cr_set({cr});
+    auto device = this->devices_.at(0);
 
-//     log_info(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
+    CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
+    CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+    CoreRangeSet cr_set({cr});
 
-//     vector<Program> programs;
-//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-//         programs.push_back(Program());
-//         Program& program = programs.back();
+    log_info(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
 
-//         std::map<string, string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
-//         std::map<string, string> compute_defines = {{"COMPUTE", "1"}};
+    vector<distributed::MeshWorkload> workloads;
+    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+        workloads.push_back(distributed::MeshWorkload());
+        distributed::MeshWorkload& workload = workloads.back();
+        distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
+        distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
 
-//         // brisc
-//         uint32_t BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS;
-//         bool USE_MAX_RT_ARGS;
+        Program program;
+        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        auto& program_ = workload.get_programs().at(device_range);
 
-//         if (i == 0) {
-//             // Ensures that we get at least one compilation with the max amount to
-//             // ensure it compiles and runs
-//             BRISC_OUTER_LOOP = MAX_LOOP;
-//             BRISC_MIDDLE_LOOP = MAX_LOOP;
-//             BRISC_INNER_LOOP = MAX_LOOP;
-//             NUM_CBS = NUM_CIRCULAR_BUFFERS;
-//             NUM_SEMS = NUM_SEMAPHORES;
-//             USE_MAX_RT_ARGS = true;
-//         } else {
-//             BRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
-//             BRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
-//             BRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-//             NUM_CBS = rand() % (NUM_CIRCULAR_BUFFERS) + 1;
-//             NUM_SEMS = rand() % (NUM_SEMAPHORES) + 1;
-//             USE_MAX_RT_ARGS = false;
-//         }
+        std::map<std::string, std::string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
+        std::map<std::string, std::string> compute_defines = {{"COMPUTE", "1"}};
 
-//         log_debug(
-//             tt::LogTest,
-//             "Compiling program {}/{} w/ BRISC_OUTER_LOOP: {} BRISC_MIDDLE_LOOP: {} BRISC_INNER_LOOP: {} NUM_CBS: {} "
-//             "NUM_SEMS: {} USE_MAX_RT_ARGS: {}",
-//             i + 1,
-//             NUM_PROGRAMS,
-//             BRISC_OUTER_LOOP,
-//             BRISC_MIDDLE_LOOP,
-//             BRISC_INNER_LOOP,
-//             NUM_CBS,
-//             NUM_SEMS,
-//             USE_MAX_RT_ARGS);
+        // brisc
+        uint32_t BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS;
+        bool USE_MAX_RT_ARGS;
 
-//         for (uint32_t j = 0; j < NUM_CBS; j++) {
-//             CircularBufferConfig cb_config = CircularBufferConfig(page_size * (j + 1), {{j,
-//             tt::DataFormat::Float16_b}})
-//                                                  .set_page_size(j, page_size * (j + 1));
-//             auto cb = CreateCircularBuffer(program, cr_set, cb_config);
-//         }
+        if (i == 0) {
+            // Ensures that we get at least one compilation with the max amount to
+            // ensure it compiles and runs
+            BRISC_OUTER_LOOP = MAX_LOOP;
+            BRISC_MIDDLE_LOOP = MAX_LOOP;
+            BRISC_INNER_LOOP = MAX_LOOP;
+            NUM_CBS = NUM_CIRCULAR_BUFFERS;
+            NUM_SEMS = NUM_SEMAPHORES;
+            USE_MAX_RT_ARGS = true;
+        } else {
+            BRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+            BRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+            BRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+            NUM_CBS = rand() % (NUM_CIRCULAR_BUFFERS) + 1;
+            NUM_SEMS = rand() % (NUM_SEMAPHORES) + 1;
+            USE_MAX_RT_ARGS = false;
+        }
 
-//         for (uint32_t j = 0; j < NUM_SEMS; j++) {
-//             CreateSemaphore(program, cr_set, j + 1);
-//         }
+        log_debug(
+            tt::LogTest,
+            "Compiling program {}/{} w/ BRISC_OUTER_LOOP: {} BRISC_MIDDLE_LOOP: {} BRISC_INNER_LOOP: {} NUM_CBS: {} "
+            "NUM_SEMS: {} USE_MAX_RT_ARGS: {}",
+            i + 1,
+            NUM_PROGRAMS,
+            BRISC_OUTER_LOOP,
+            BRISC_MIDDLE_LOOP,
+            BRISC_INNER_LOOP,
+            NUM_CBS,
+            NUM_SEMS,
+            USE_MAX_RT_ARGS);
 
-//         auto [brisc_unique_rtargs, brisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
-//         uint32_t num_brisc_unique_rtargs = brisc_unique_rtargs.size();
-//         uint32_t num_brisc_common_rtargs = brisc_common_rtargs.size();
-//         vector<uint32_t> brisc_compile_args = {
-//             BRISC_OUTER_LOOP,
-//             BRISC_MIDDLE_LOOP,
-//             BRISC_INNER_LOOP,
-//             NUM_CBS,
-//             NUM_SEMS,
-//             num_brisc_unique_rtargs,
-//             num_brisc_common_rtargs,
-//             page_size};
+        for (uint32_t j = 0; j < NUM_CBS; j++) {
+            CircularBufferConfig cb_config = CircularBufferConfig(page_size * (j + 1), {{j, tt::DataFormat::Float16_b}})
+                                                 .set_page_size(j, page_size * (j + 1));
+            auto cb = CreateCircularBuffer(program_, cr_set, cb_config);
+        }
 
-//         // ncrisc
-//         uint32_t NCRISC_OUTER_LOOP, NCRISC_MIDDLE_LOOP, NCRISC_INNER_LOOP;
-//         if (i == 0) {
-//             NCRISC_OUTER_LOOP = MAX_LOOP;
-//             NCRISC_MIDDLE_LOOP = MAX_LOOP;
-//             NCRISC_INNER_LOOP = MAX_LOOP;
-//         } else {
-//             NCRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
-//             NCRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
-//             NCRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-//         }
+        for (uint32_t j = 0; j < NUM_SEMS; j++) {
+            CreateSemaphore(program_, cr_set, j + 1);
+        }
 
-//         auto [ncrisc_unique_rtargs, ncrisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
-//         uint32_t num_ncrisc_unique_rtargs = ncrisc_unique_rtargs.size();
-//         uint32_t num_ncrisc_common_rtargs = ncrisc_common_rtargs.size();
-//         vector<uint32_t> ncrisc_compile_args = {
-//             NCRISC_OUTER_LOOP,
-//             NCRISC_MIDDLE_LOOP,
-//             NCRISC_INNER_LOOP,
-//             NUM_CBS,
-//             NUM_SEMS,
-//             num_ncrisc_unique_rtargs,
-//             num_ncrisc_common_rtargs,
-//             page_size};
+        auto [brisc_unique_rtargs, brisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
+        uint32_t num_brisc_unique_rtargs = brisc_unique_rtargs.size();
+        uint32_t num_brisc_common_rtargs = brisc_common_rtargs.size();
+        vector<uint32_t> brisc_compile_args = {
+            BRISC_OUTER_LOOP,
+            BRISC_MIDDLE_LOOP,
+            BRISC_INNER_LOOP,
+            NUM_CBS,
+            NUM_SEMS,
+            num_brisc_unique_rtargs,
+            num_brisc_common_rtargs,
+            page_size};
 
-//         // trisc
-//         uint32_t TRISC_OUTER_LOOP, TRISC_MIDDLE_LOOP, TRISC_INNER_LOOP;
-//         if (i == 0) {
-//             TRISC_OUTER_LOOP = MAX_LOOP;
-//             TRISC_MIDDLE_LOOP = MAX_LOOP;
-//             TRISC_INNER_LOOP = MAX_LOOP;
-//         } else {
-//             TRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
-//             TRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
-//             TRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-//         }
+        // ncrisc
+        uint32_t NCRISC_OUTER_LOOP, NCRISC_MIDDLE_LOOP, NCRISC_INNER_LOOP;
+        if (i == 0) {
+            NCRISC_OUTER_LOOP = MAX_LOOP;
+            NCRISC_MIDDLE_LOOP = MAX_LOOP;
+            NCRISC_INNER_LOOP = MAX_LOOP;
+        } else {
+            NCRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+            NCRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+            NCRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+        }
 
-//         auto [trisc_unique_rtargs, trisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
-//         uint32_t num_trisc_unique_rtargs = trisc_unique_rtargs.size();
-//         uint32_t num_trisc_common_rtargs = trisc_common_rtargs.size();
-//         vector<uint32_t> trisc_compile_args = {
-//             TRISC_OUTER_LOOP,
-//             TRISC_MIDDLE_LOOP,
-//             TRISC_INNER_LOOP,
-//             NUM_CBS,
-//             NUM_SEMS,
-//             num_trisc_unique_rtargs,
-//             num_trisc_common_rtargs,
-//             page_size};
+        auto [ncrisc_unique_rtargs, ncrisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
+        uint32_t num_ncrisc_unique_rtargs = ncrisc_unique_rtargs.size();
+        uint32_t num_ncrisc_common_rtargs = ncrisc_common_rtargs.size();
+        vector<uint32_t> ncrisc_compile_args = {
+            NCRISC_OUTER_LOOP,
+            NCRISC_MIDDLE_LOOP,
+            NCRISC_INNER_LOOP,
+            NUM_CBS,
+            NUM_SEMS,
+            num_ncrisc_unique_rtargs,
+            num_ncrisc_common_rtargs,
+            page_size};
 
-//         bool at_least_one_kernel = false;
-//         if (i == 0 or ((rand() % 2) == 0)) {
-//             auto dummy_brisc_kernel = CreateKernel(
-//                 program,
-//                 "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-//                 cr_set,
-//                 DataMovementConfig{
-//                     .processor = DataMovementProcessor::RISCV_0,
-//                     .noc = NOC::RISCV_0_default,
-//                     .compile_args = brisc_compile_args,
-//                     .defines = data_movement_defines});
-//             SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
-//             SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
-//             at_least_one_kernel = true;
-//         }
+        // trisc
+        uint32_t TRISC_OUTER_LOOP, TRISC_MIDDLE_LOOP, TRISC_INNER_LOOP;
+        if (i == 0) {
+            TRISC_OUTER_LOOP = MAX_LOOP;
+            TRISC_MIDDLE_LOOP = MAX_LOOP;
+            TRISC_INNER_LOOP = MAX_LOOP;
+        } else {
+            TRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+            TRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+            TRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+        }
 
-//         if (i == 0 or ((rand() % 2) == 0)) {
-//             auto dummy_ncrisc_kernel = CreateKernel(
-//                 program,
-//                 "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-//                 cr_set,
-//                 DataMovementConfig{
-//                     .processor = DataMovementProcessor::RISCV_1,
-//                     .noc = NOC::RISCV_1_default,
-//                     .compile_args = ncrisc_compile_args,
-//                     .defines = data_movement_defines});
-//             SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
-//             SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
-//             at_least_one_kernel = true;
-//         }
+        auto [trisc_unique_rtargs, trisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
+        uint32_t num_trisc_unique_rtargs = trisc_unique_rtargs.size();
+        uint32_t num_trisc_common_rtargs = trisc_common_rtargs.size();
+        vector<uint32_t> trisc_compile_args = {
+            TRISC_OUTER_LOOP,
+            TRISC_MIDDLE_LOOP,
+            TRISC_INNER_LOOP,
+            NUM_CBS,
+            NUM_SEMS,
+            num_trisc_unique_rtargs,
+            num_trisc_common_rtargs,
+            page_size};
 
-//         if (i == 0 or ((rand() % 2) == 0)) {
-//             auto dummy_trisc_kernel = CreateKernel(
-//                 program,
-//                 "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-//                 cr_set,
-//                 ComputeConfig{
-//                     .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
-//             SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
-//             SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
-//             at_least_one_kernel = true;
-//         }
+        bool at_least_one_kernel = false;
+        if (i == 0 or ((rand() % 2) == 0)) {
+            auto dummy_brisc_kernel = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+                cr_set,
+                DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_0,
+                    .noc = NOC::RISCV_0_default,
+                    .compile_args = brisc_compile_args,
+                    .defines = data_movement_defines});
+            SetRuntimeArgs(program_, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
+            SetCommonRuntimeArgs(program_, dummy_brisc_kernel, brisc_common_rtargs);
+            at_least_one_kernel = true;
+        }
 
-//         if (not at_least_one_kernel) {
-//             uint32_t random_risc = rand() % 3 + 1;
-//             if (random_risc == 1) {
-//                 auto dummy_brisc_kernel = CreateKernel(
-//                     program,
-//                     "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-//                     cr_set,
-//                     DataMovementConfig{
-//                         .processor = DataMovementProcessor::RISCV_0,
-//                         .noc = NOC::RISCV_0_default,
-//                         .compile_args = brisc_compile_args,
-//                         .defines = data_movement_defines});
-//                 SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
-//                 SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
-//             } else if (random_risc == 2) {
-//                 auto dummy_ncrisc_kernel = CreateKernel(
-//                     program,
-//                     "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-//                     cr_set,
-//                     DataMovementConfig{
-//                         .processor = DataMovementProcessor::RISCV_1,
-//                         .noc = NOC::RISCV_1_default,
-//                         .compile_args = ncrisc_compile_args,
-//                         .defines = data_movement_defines});
-//                 SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
-//                 SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
-//             } else if (random_risc == 3) {
-//                 auto dummy_trisc_kernel = CreateKernel(
-//                     program,
-//                     "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-//                     cr_set,
-//                     ComputeConfig{
-//                         .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
-//                 SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
-//                 SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
-//             } else {
-//                 TT_THROW("Invalid");
-//             }
-//         }
+        if (i == 0 or ((rand() % 2) == 0)) {
+            auto dummy_ncrisc_kernel = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+                cr_set,
+                DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_1,
+                    .noc = NOC::RISCV_1_default,
+                    .compile_args = ncrisc_compile_args,
+                    .defines = data_movement_defines});
+            SetRuntimeArgs(program_, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
+            SetCommonRuntimeArgs(program_, dummy_ncrisc_kernel, ncrisc_common_rtargs);
+            at_least_one_kernel = true;
+        }
 
-//         tt::tt_metal::detail::CompileProgram(this->device_, program);
-//     }
+        if (i == 0 or ((rand() % 2) == 0)) {
+            auto dummy_trisc_kernel = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+                cr_set,
+                ComputeConfig{
+                    .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
+            SetRuntimeArgs(program_, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
+            SetCommonRuntimeArgs(program_, dummy_trisc_kernel, trisc_common_rtargs);
+            at_least_one_kernel = true;
+        }
 
-//     for (uint8_t cq_id = 0; cq_id < this->device_->num_hw_cqs(); ++cq_id) {
-//         log_info(tt::LogTest, "Running {} programs on cq {} for cache warmup.", programs.size(), (uint32_t)cq_id);
-//         // This loop caches program and runs
-//         for (Program& program : programs) {
-//             EnqueueProgram(this->device_->command_queue(cq_id), program, false);
-//         }
+        if (not at_least_one_kernel) {
+            uint32_t random_risc = rand() % 3 + 1;
+            if (random_risc == 1) {
+                auto dummy_brisc_kernel = CreateKernel(
+                    program_,
+                    "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+                    cr_set,
+                    DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_0,
+                        .noc = NOC::RISCV_0_default,
+                        .compile_args = brisc_compile_args,
+                        .defines = data_movement_defines});
+                SetRuntimeArgs(program_, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
+                SetCommonRuntimeArgs(program_, dummy_brisc_kernel, brisc_common_rtargs);
+            } else if (random_risc == 2) {
+                auto dummy_ncrisc_kernel = CreateKernel(
+                    program_,
+                    "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+                    cr_set,
+                    DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_1,
+                        .noc = NOC::RISCV_1_default,
+                        .compile_args = ncrisc_compile_args,
+                        .defines = data_movement_defines});
+                SetRuntimeArgs(program_, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
+                SetCommonRuntimeArgs(program_, dummy_ncrisc_kernel, ncrisc_common_rtargs);
+            } else if (random_risc == 3) {
+                auto dummy_trisc_kernel = CreateKernel(
+                    program_,
+                    "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+                    cr_set,
+                    ComputeConfig{
+                        .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
+                SetRuntimeArgs(program_, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
+                SetCommonRuntimeArgs(program_, dummy_trisc_kernel, trisc_common_rtargs);
+            } else {
+                TT_THROW("Invalid");
+            }
+        }
+    }
 
-//         // This loops assumes already cached
-//         uint32_t NUM_ITERATIONS = 500;  // TODO(agrebenisan): Bump this to 5000, saw hangs for very large number of
-//                                         // iterations, need to come back to that
+    for (uint8_t cq_id = 0; cq_id < device->num_hw_cqs(); ++cq_id) {
+        log_info(tt::LogTest, "Running {} MeshWorkloads on cq {} for cache warmup.", workloads.size(), (uint32_t)cq_id);
+        // This loop caches program and runs
+        for (distributed::MeshWorkload& wl : workloads) {
+            distributed::EnqueueMeshWorkload(device->mesh_command_queue(), wl, false);
+        }
 
-//         log_info(
-//             tt::LogTest,
-//             "Running {} programs on cq {} for {} iterations now.",
-//             programs.size(),
-//             (uint32_t)cq_id,
-//             NUM_ITERATIONS);
-//         for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
-//             auto rng = std::default_random_engine{};
-//             std::shuffle(std::begin(programs), std::end(programs), rng);
-//             if (i % 10 == 0) {
-//                 log_debug(
-//                     tt::LogTest,
-//                     "Enqueuing {} programs on cq {} for iter: {}/{} now.",
-//                     programs.size(),
-//                     (uint32_t)cq_id,
-//                     i + 1,
-//                     NUM_ITERATIONS);
-//             }
-//             for (Program& program : programs) {
-//                 EnqueueProgram(this->device_->command_queue(cq_id), program, false);
-//             }
-//         }
+        // This loops assumes already cached
+        uint32_t NUM_ITERATIONS = 500;  // TODO(agrebenisan): Bump this to 5000, saw hangs for very large number of
+                                        // iterations, need to come back to that
 
-//         log_info(tt::LogTest, "Calling Finish.");
-//         Finish(this->device_->command_queue(cq_id));
-//     }
-// }
+        log_info(
+            tt::LogTest,
+            "Running {} programs on cq {} for {} iterations now.",
+            workloads.size(),
+            (uint32_t)cq_id,
+            NUM_ITERATIONS);
+        for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
+            auto rng = std::default_random_engine{};
+            std::shuffle(std::begin(workloads), std::end(workloads), rng);
+            if (i % 10 == 0) {
+                log_debug(
+                    tt::LogTest,
+                    "Enqueuing {} programs on cq {} for iter: {}/{} now.",
+                    workloads.size(),
+                    (uint32_t)cq_id,
+                    i + 1,
+                    NUM_ITERATIONS);
+            }
+            for (distributed::MeshWorkload& wl : workloads) {
+                EnqueueMeshWorkload(device->mesh_command_queue(), wl, false);
+            }
+        }
 
-TEST_F(UnitMeshCommandQueueFixture, DISABLED_TensixTestFillDispatchCoreBuffer) {
+        log_info(tt::LogTest, "Calling Finish.");
+        Finish(device->mesh_command_queue(cq_id));
+    }
+}
+
+TEST_F(UnitMeshCQFixture, DISABLED_TensixTestFillDispatchCoreBuffer) {
     uint32_t NUM_ITER = 100000;
-    for (auto device : devices_) {
+    for (const auto& device : devices_) {
         CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
 
         CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
@@ -2082,448 +2055,449 @@ TEST_F(UnitMeshCommandQueueFixture, DISABLED_TensixTestFillDispatchCoreBuffer) {
     }
 }
 
-// TEST_F(CommandQueueProgramFixture, TensixTestRandomizedProgram) {
-//     uint32_t NUM_PROGRAMS = 100;
-//     uint32_t MAX_LOOP = 100;
-//     uint32_t page_size = 1024;
+TEST_F(UnitMeshCQProgramFixture, TensixTestRandomizedProgram) {
+    uint32_t NUM_PROGRAMS = 100;
+    uint32_t MAX_LOOP = 100;
+    uint32_t page_size = 1024;
 
-//     // Make random
-//     auto random_seed = 0;  // (unsigned int)time(NULL);
-//     uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
-//     log_info(tt::LogTest, "Using Test Seed: {}", seed);
-//     srand(seed);
+    // Make random
+    auto random_seed = 0;  // (unsigned int)time(NULL);
+    uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
+    log_info(tt::LogTest, "Using Test Seed: {}", seed);
+    srand(seed);
 
-//     CoreCoord worker_grid_size = this->device_->compute_with_storage_grid_size();
-//     CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
-//     CoreRangeSet cr_set(cr);
+    auto device = this->devices_.at(0);
 
-//     log_info(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
+    CoreCoord worker_grid_size = device->compute_with_storage_grid_size();
+    CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+    CoreRangeSet cr_set(cr);
 
-//     vector<Program> programs;
-//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-//         programs.push_back(Program());
-//         Program& program = programs.back();
+    log_info(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
 
-//         std::map<string, string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
-//         std::map<string, string> compute_defines = {{"COMPUTE", "1"}};
+    vector<distributed::MeshWorkload> workloads;
+    distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+        workloads.push_back(distributed::MeshWorkload());
+        distributed::MeshWorkload& workload = workloads.back();
 
-//         // brisc
-//         uint32_t BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS;
-//         bool USE_MAX_RT_ARGS;
+        Program program;
+        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        auto& program_ = workload.get_programs().at(device_range);
 
-//         if (i % 10 == 0) {
-//             log_info(tt::LogTest, "Compiling program {} of {}", i + 1, NUM_PROGRAMS);
-//         }
+        std::map<std::string, std::string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
+        std::map<std::string, std::string> compute_defines = {{"COMPUTE", "1"}};
 
-//         if (i == 0) {
-//             // Ensures that we get at least one compilation with the max amount to
-//             // ensure it compiles and runs
-//             BRISC_OUTER_LOOP = MAX_LOOP;
-//             BRISC_MIDDLE_LOOP = MAX_LOOP;
-//             BRISC_INNER_LOOP = MAX_LOOP;
-//             NUM_CBS = NUM_CIRCULAR_BUFFERS;
-//             NUM_SEMS = NUM_SEMAPHORES;
-//             USE_MAX_RT_ARGS = true;
-//         } else {
-//             BRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
-//             BRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
-//             BRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-//             NUM_CBS = rand() % (NUM_CIRCULAR_BUFFERS) + 1;
-//             NUM_SEMS = rand() % (NUM_SEMAPHORES) + 1;
-//             USE_MAX_RT_ARGS = false;
-//         }
+        // brisc
+        uint32_t BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS;
+        bool USE_MAX_RT_ARGS;
 
-//         log_debug(
-//             tt::LogTest,
-//             "Compiling program {}/{} w/ BRISC_OUTER_LOOP: {} BRISC_MIDDLE_LOOP: {} BRISC_INNER_LOOP: {} NUM_CBS: {} "
-//             "NUM_SEMS: {} USE_MAX_RT_ARGS: {}",
-//             i + 1,
-//             NUM_PROGRAMS,
-//             BRISC_OUTER_LOOP,
-//             BRISC_MIDDLE_LOOP,
-//             BRISC_INNER_LOOP,
-//             NUM_CBS,
-//             NUM_SEMS,
-//             USE_MAX_RT_ARGS);
+        if (i % 10 == 0) {
+            log_info(tt::LogTest, "Compiling program {} of {}", i + 1, NUM_PROGRAMS);
+        }
 
-//         for (uint32_t j = 0; j < NUM_CBS; j++) {
-//             CircularBufferConfig cb_config = CircularBufferConfig(page_size * (j + 1), {{j,
-//             tt::DataFormat::Float16_b}})
-//                                                  .set_page_size(j, page_size * (j + 1));
-//             auto cb = CreateCircularBuffer(program, cr_set, cb_config);
-//         }
+        if (i == 0) {
+            // Ensures that we get at least one compilation with the max amount to
+            // ensure it compiles and runs
+            BRISC_OUTER_LOOP = MAX_LOOP;
+            BRISC_MIDDLE_LOOP = MAX_LOOP;
+            BRISC_INNER_LOOP = MAX_LOOP;
+            NUM_CBS = NUM_CIRCULAR_BUFFERS;
+            NUM_SEMS = NUM_SEMAPHORES;
+            USE_MAX_RT_ARGS = true;
+        } else {
+            BRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+            BRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+            BRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+            NUM_CBS = rand() % (NUM_CIRCULAR_BUFFERS) + 1;
+            NUM_SEMS = rand() % (NUM_SEMAPHORES) + 1;
+            USE_MAX_RT_ARGS = false;
+        }
 
-//         for (uint32_t j = 0; j < NUM_SEMS; j++) {
-//             CreateSemaphore(program, cr_set, j + 1);
-//         }
+        log_debug(
+            tt::LogTest,
+            "Compiling program {}/{} w/ BRISC_OUTER_LOOP: {} BRISC_MIDDLE_LOOP: {} BRISC_INNER_LOOP: {} NUM_CBS: {} "
+            "NUM_SEMS: {} USE_MAX_RT_ARGS: {}",
+            i + 1,
+            NUM_PROGRAMS,
+            BRISC_OUTER_LOOP,
+            BRISC_MIDDLE_LOOP,
+            BRISC_INNER_LOOP,
+            NUM_CBS,
+            NUM_SEMS,
+            USE_MAX_RT_ARGS);
 
-//         auto [brisc_unique_rtargs, brisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
-//         uint32_t num_brisc_unique_rtargs = brisc_unique_rtargs.size();
-//         uint32_t num_brisc_common_rtargs = brisc_common_rtargs.size();
-//         vector<uint32_t> brisc_compile_args = {
-//             BRISC_OUTER_LOOP,
-//             BRISC_MIDDLE_LOOP,
-//             BRISC_INNER_LOOP,
-//             NUM_CBS,
-//             NUM_SEMS,
-//             num_brisc_unique_rtargs,
-//             num_brisc_common_rtargs,
-//             page_size};
+        for (uint32_t j = 0; j < NUM_CBS; j++) {
+            CircularBufferConfig cb_config = CircularBufferConfig(page_size * (j + 1), {{j, tt::DataFormat::Float16_b}})
+                                                 .set_page_size(j, page_size * (j + 1));
+            auto cb = CreateCircularBuffer(program_, cr_set, cb_config);
+        }
 
-//         // ncrisc
-//         uint32_t NCRISC_OUTER_LOOP, NCRISC_MIDDLE_LOOP, NCRISC_INNER_LOOP;
-//         if (i == 0) {
-//             NCRISC_OUTER_LOOP = MAX_LOOP;
-//             NCRISC_MIDDLE_LOOP = MAX_LOOP;
-//             NCRISC_INNER_LOOP = MAX_LOOP;
-//         } else {
-//             NCRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
-//             NCRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
-//             NCRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-//         }
+        for (uint32_t j = 0; j < NUM_SEMS; j++) {
+            CreateSemaphore(program_, cr_set, j + 1);
+        }
 
-//         auto [ncrisc_unique_rtargs, ncrisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
-//         uint32_t num_ncrisc_unique_rtargs = ncrisc_unique_rtargs.size();
-//         uint32_t num_ncrisc_common_rtargs = ncrisc_common_rtargs.size();
-//         vector<uint32_t> ncrisc_compile_args = {
-//             NCRISC_OUTER_LOOP,
-//             NCRISC_MIDDLE_LOOP,
-//             NCRISC_INNER_LOOP,
-//             NUM_CBS,
-//             NUM_SEMS,
-//             num_ncrisc_unique_rtargs,
-//             num_ncrisc_common_rtargs,
-//             page_size};
+        auto [brisc_unique_rtargs, brisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
+        uint32_t num_brisc_unique_rtargs = brisc_unique_rtargs.size();
+        uint32_t num_brisc_common_rtargs = brisc_common_rtargs.size();
+        vector<uint32_t> brisc_compile_args = {
+            BRISC_OUTER_LOOP,
+            BRISC_MIDDLE_LOOP,
+            BRISC_INNER_LOOP,
+            NUM_CBS,
+            NUM_SEMS,
+            num_brisc_unique_rtargs,
+            num_brisc_common_rtargs,
+            page_size};
 
-//         // trisc
-//         uint32_t TRISC_OUTER_LOOP, TRISC_MIDDLE_LOOP, TRISC_INNER_LOOP;
-//         if (i == 0) {
-//             TRISC_OUTER_LOOP = MAX_LOOP;
-//             TRISC_MIDDLE_LOOP = MAX_LOOP;
-//             TRISC_INNER_LOOP = MAX_LOOP;
-//         } else {
-//             TRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
-//             TRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
-//             TRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-//         }
+        // ncrisc
+        uint32_t NCRISC_OUTER_LOOP, NCRISC_MIDDLE_LOOP, NCRISC_INNER_LOOP;
+        if (i == 0) {
+            NCRISC_OUTER_LOOP = MAX_LOOP;
+            NCRISC_MIDDLE_LOOP = MAX_LOOP;
+            NCRISC_INNER_LOOP = MAX_LOOP;
+        } else {
+            NCRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+            NCRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+            NCRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+        }
 
-//         auto [trisc_unique_rtargs, trisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
-//         uint32_t num_trisc_unique_rtargs = trisc_unique_rtargs.size();
-//         uint32_t num_trisc_common_rtargs = trisc_common_rtargs.size();
-//         vector<uint32_t> trisc_compile_args = {
-//             TRISC_OUTER_LOOP,
-//             TRISC_MIDDLE_LOOP,
-//             TRISC_INNER_LOOP,
-//             NUM_CBS,
-//             NUM_SEMS,
-//             num_trisc_unique_rtargs,
-//             num_trisc_common_rtargs,
-//             page_size};
+        auto [ncrisc_unique_rtargs, ncrisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
+        uint32_t num_ncrisc_unique_rtargs = ncrisc_unique_rtargs.size();
+        uint32_t num_ncrisc_common_rtargs = ncrisc_common_rtargs.size();
+        vector<uint32_t> ncrisc_compile_args = {
+            NCRISC_OUTER_LOOP,
+            NCRISC_MIDDLE_LOOP,
+            NCRISC_INNER_LOOP,
+            NUM_CBS,
+            NUM_SEMS,
+            num_ncrisc_unique_rtargs,
+            num_ncrisc_common_rtargs,
+            page_size};
 
-//         bool at_least_one_kernel = false;
-//         if (i == 0 or ((rand() % 2) == 0)) {
-//             auto dummy_brisc_kernel = CreateKernel(
-//                 program,
-//                 "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-//                 cr_set,
-//                 DataMovementConfig{
-//                     .processor = DataMovementProcessor::RISCV_0,
-//                     .noc = NOC::RISCV_0_default,
-//                     .compile_args = brisc_compile_args,
-//                     .defines = data_movement_defines});
-//             SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
-//             SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
-//             at_least_one_kernel = true;
-//         }
+        // trisc
+        uint32_t TRISC_OUTER_LOOP, TRISC_MIDDLE_LOOP, TRISC_INNER_LOOP;
+        if (i == 0) {
+            TRISC_OUTER_LOOP = MAX_LOOP;
+            TRISC_MIDDLE_LOOP = MAX_LOOP;
+            TRISC_INNER_LOOP = MAX_LOOP;
+        } else {
+            TRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+            TRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+            TRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+        }
 
-//         if (i == 0 or ((rand() % 2) == 0)) {
-//             auto dummy_ncrisc_kernel = CreateKernel(
-//                 program,
-//                 "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-//                 cr_set,
-//                 DataMovementConfig{
-//                     .processor = DataMovementProcessor::RISCV_1,
-//                     .noc = NOC::RISCV_1_default,
-//                     .compile_args = ncrisc_compile_args,
-//                     .defines = data_movement_defines});
-//             SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
-//             SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
-//             at_least_one_kernel = true;
-//         }
+        auto [trisc_unique_rtargs, trisc_common_rtargs] = create_runtime_args(USE_MAX_RT_ARGS);
+        uint32_t num_trisc_unique_rtargs = trisc_unique_rtargs.size();
+        uint32_t num_trisc_common_rtargs = trisc_common_rtargs.size();
+        vector<uint32_t> trisc_compile_args = {
+            TRISC_OUTER_LOOP,
+            TRISC_MIDDLE_LOOP,
+            TRISC_INNER_LOOP,
+            NUM_CBS,
+            NUM_SEMS,
+            num_trisc_unique_rtargs,
+            num_trisc_common_rtargs,
+            page_size};
 
-//         if (i == 0 or ((rand() % 2) == 0)) {
-//             auto dummy_trisc_kernel = CreateKernel(
-//                 program,
-//                 "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-//                 cr_set,
-//                 ComputeConfig{
-//                     .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
-//             SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
-//             SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
-//             at_least_one_kernel = true;
-//         }
+        bool at_least_one_kernel = false;
+        if (i == 0 or ((rand() % 2) == 0)) {
+            auto dummy_brisc_kernel = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+                cr_set,
+                DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_0,
+                    .noc = NOC::RISCV_0_default,
+                    .compile_args = brisc_compile_args,
+                    .defines = data_movement_defines});
+            SetRuntimeArgs(program_, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
+            SetCommonRuntimeArgs(program_, dummy_brisc_kernel, brisc_common_rtargs);
+            at_least_one_kernel = true;
+        }
 
-//         if (not at_least_one_kernel) {
-//             uint32_t random_risc = rand() % 3 + 1;
-//             if (random_risc == 1) {
-//                 auto dummy_brisc_kernel = CreateKernel(
-//                     program,
-//                     "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-//                     cr_set,
-//                     DataMovementConfig{
-//                         .processor = DataMovementProcessor::RISCV_0,
-//                         .noc = NOC::RISCV_0_default,
-//                         .compile_args = brisc_compile_args,
-//                         .defines = data_movement_defines});
-//                 SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
-//                 SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
-//             } else if (random_risc == 2) {
-//                 auto dummy_ncrisc_kernel = CreateKernel(
-//                     program,
-//                     "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-//                     cr_set,
-//                     DataMovementConfig{
-//                         .processor = DataMovementProcessor::RISCV_1,
-//                         .noc = NOC::RISCV_1_default,
-//                         .compile_args = ncrisc_compile_args,
-//                         .defines = data_movement_defines});
-//                 SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
-//                 SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
-//             } else if (random_risc == 3) {
-//                 auto dummy_trisc_kernel = CreateKernel(
-//                     program,
-//                     "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
-//                     cr_set,
-//                     ComputeConfig{
-//                         .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
-//                 SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
-//                 SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
-//             } else {
-//                 TT_THROW("Invalid");
-//             }
-//         }
+        if (i == 0 or ((rand() % 2) == 0)) {
+            auto dummy_ncrisc_kernel = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+                cr_set,
+                DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_1,
+                    .noc = NOC::RISCV_1_default,
+                    .compile_args = ncrisc_compile_args,
+                    .defines = data_movement_defines});
+            SetRuntimeArgs(program_, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
+            SetCommonRuntimeArgs(program_, dummy_ncrisc_kernel, ncrisc_common_rtargs);
+            at_least_one_kernel = true;
+        }
 
-//         tt::tt_metal::detail::CompileProgram(this->device_, program);
-//     }
+        if (i == 0 or ((rand() % 2) == 0)) {
+            auto dummy_trisc_kernel = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+                cr_set,
+                ComputeConfig{
+                    .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
+            SetRuntimeArgs(program_, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
+            SetCommonRuntimeArgs(program_, dummy_trisc_kernel, trisc_common_rtargs);
+            at_least_one_kernel = true;
+        }
 
-//     log_info(tt::LogTest, "Running {} programs for cache warmup.", programs.size());
-//     // This loop caches program and runs
-//     for (Program& program : programs) {
-//         EnqueueProgram(this->device_->command_queue(), program, false);
-//     }
+        if (not at_least_one_kernel) {
+            uint32_t random_risc = rand() % 3 + 1;
+            if (random_risc == 1) {
+                auto dummy_brisc_kernel = CreateKernel(
+                    program_,
+                    "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+                    cr_set,
+                    DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_0,
+                        .noc = NOC::RISCV_0_default,
+                        .compile_args = brisc_compile_args,
+                        .defines = data_movement_defines});
+                SetRuntimeArgs(program_, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
+                SetCommonRuntimeArgs(program_, dummy_brisc_kernel, brisc_common_rtargs);
+            } else if (random_risc == 2) {
+                auto dummy_ncrisc_kernel = CreateKernel(
+                    program_,
+                    "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+                    cr_set,
+                    DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_1,
+                        .noc = NOC::RISCV_1_default,
+                        .compile_args = ncrisc_compile_args,
+                        .defines = data_movement_defines});
+                SetRuntimeArgs(program_, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
+                SetCommonRuntimeArgs(program_, dummy_ncrisc_kernel, ncrisc_common_rtargs);
+            } else if (random_risc == 3) {
+                auto dummy_trisc_kernel = CreateKernel(
+                    program_,
+                    "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+                    cr_set,
+                    ComputeConfig{
+                        .math_approx_mode = false, .compile_args = trisc_compile_args, .defines = compute_defines});
+                SetRuntimeArgs(program_, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
+                SetCommonRuntimeArgs(program_, dummy_trisc_kernel, trisc_common_rtargs);
+            } else {
+                TT_THROW("Invalid");
+            }
+        }
+    }
 
-//     // This loops assumes already cached
-//     uint32_t NUM_ITERATIONS = 500;  // TODO(agrebenisan): Bump this to 5000, saw hangs for very large number of
-//                                     // iterations, need to come back to that
+    log_info(tt::LogTest, "Running {} programs for cache warmup.", workloads.size());
+    // This loop caches program and runs
+    for (distributed::MeshWorkload& wl : workloads) {
+        distributed::EnqueueMeshWorkload(device->mesh_command_queue(), wl, false);
+    }
 
-//     log_info(tt::LogTest, "Running {} programs for {} iterations now.", programs.size(), NUM_ITERATIONS);
-//     for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
-//         auto rng = std::default_random_engine{};
-//         std::shuffle(std::begin(programs), std::end(programs), rng);
-//         if (i % 50 == 0) {
-//             log_info(tt::LogTest, "Enqueuing {} programs for iter: {}/{} now.", programs.size(), i + 1,
-//             NUM_ITERATIONS);
-//         }
-//         for (Program& program : programs) {
-//             EnqueueProgram(this->device_->command_queue(), program, false);
-//         }
-//     }
+    // This loops assumes already cached
+    uint32_t NUM_ITERATIONS = 500;  // TODO(agrebenisan): Bump this to 5000, saw hangs for very large number of
+                                    // iterations, need to come back to that
 
-//     log_info(tt::LogTest, "Calling Finish.");
-//     Finish(this->device_->command_queue());
-// }
+    log_info(tt::LogTest, "Running {} programs for {} iterations now.", workloads.size(), NUM_ITERATIONS);
+    for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
+        auto rng = std::default_random_engine{};
+        std::shuffle(std::begin(workloads), std::end(workloads), rng);
+        if (i % 50 == 0) {
+            log_info(
+                tt::LogTest, "Enqueuing {} programs for iter: {}/{} now.", workloads.size(), i + 1, NUM_ITERATIONS);
+        }
+        for (distributed::MeshWorkload& wl : workloads) {
+            distributed::EnqueueMeshWorkload(device->mesh_command_queue(), wl, false);
+        }
+    }
 
-// TEST_F(RandomProgramFixture, TensixTestSimplePrograms) {
-//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-//         if (i % 10 == 0) {
-//             log_info(tt::LogTest, "Creating Program {}", i);
-//         }
-//         Program program = CreateProgram();
-//         this->create_kernel(program, CoreType::WORKER, true);
-//         EnqueueProgram(device_->command_queue(), program, false);
-//     }
+    log_info(tt::LogTest, "Calling Finish.");
+    Finish(device->mesh_command_queue());
+}
 
-//     Finish(device_->command_queue());
-// }
+TEST_F(RandomProgramFixture, TensixTestSimplePrograms) {
+    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+        if (i % 10 == 0) {
+            log_info(tt::LogTest, "Creating Program {}", i);
+        }
+        Program program = CreateProgram();
+        this->create_kernel(program, CoreType::WORKER, true);
+        EnqueueProgram(device_->command_queue(), program, false);
+    }
 
-// TEST_F(RandomProgramFixture, ActiveEthTestSimplePrograms) {
-//     if (!does_device_have_active_eth_cores(device_)) {
-//         GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet
-//         cores";
-//     }
+    Finish(device_->command_queue());
+}
 
-//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-//         if (i % 10 == 0) {
-//             log_info(tt::LogTest, "Creating Program {}", i);
-//         }
-//         Program program = CreateProgram();
-//         this->create_kernel(program, CoreType::ETH, true);
-//         EnqueueProgram(device_->command_queue(), program, false);
-//     }
+TEST_F(RandomProgramFixture, ActiveEthTestSimplePrograms) {
+    if (!does_device_have_active_eth_cores(device_)) {
+        GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet cores";
+    }
 
-//     Finish(device_->command_queue());
-// }
+    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+        if (i % 10 == 0) {
+            log_info(tt::LogTest, "Creating Program {}", i);
+        }
+        Program program = CreateProgram();
+        this->create_kernel(program, CoreType::ETH, true);
+        EnqueueProgram(device_->command_queue(), program, false);
+    }
 
-// TEST_F(RandomProgramFixture, TensixActiveEthTestSimplePrograms) {
-//     if (!does_device_have_active_eth_cores(device_)) {
-//         GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet
-//         cores";
-//     }
+    Finish(device_->command_queue());
+}
 
-//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-//         if (i % 10 == 0) {
-//             log_info(tt::LogTest, "Creating Program {}", i);
-//         }
-//         Program program = CreateProgram();
+TEST_F(RandomProgramFixture, TensixActiveEthTestSimplePrograms) {
+    if (!does_device_have_active_eth_cores(device_)) {
+        GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet cores";
+    }
 
-//         bool eth_kernel_added_to_program = false;
-//         if (rand() % 2 == 0) {
-//             this->create_kernel(program, CoreType::ETH, true);
-//             eth_kernel_added_to_program = true;
-//         }
-//         if (rand() % 2 == 0 || !eth_kernel_added_to_program) {
-//             this->create_kernel(program, CoreType::WORKER, true);
-//         }
+    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+        if (i % 10 == 0) {
+            log_info(tt::LogTest, "Creating Program {}", i);
+        }
+        Program program = CreateProgram();
 
-//         EnqueueProgram(device_->command_queue(), program, false);
-//     }
+        bool eth_kernel_added_to_program = false;
+        if (rand() % 2 == 0) {
+            this->create_kernel(program, CoreType::ETH, true);
+            eth_kernel_added_to_program = true;
+        }
+        if (rand() % 2 == 0 || !eth_kernel_added_to_program) {
+            this->create_kernel(program, CoreType::WORKER, true);
+        }
 
-//     Finish(device_->command_queue());
-// }
+        EnqueueProgram(device_->command_queue(), program, false);
+    }
 
-// TEST_F(RandomProgramFixture, TensixTestPrograms) {
-//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-//         if (i % 10 == 0) {
-//             log_info(tt::LogTest, "Creating Program {}", i);
-//         }
-//         Program program = CreateProgram();
-//         this->create_kernel(program, CoreType::WORKER);
-//         EnqueueProgram(device_->command_queue(), program, false);
-//     }
+    Finish(device_->command_queue());
+}
 
-//     Finish(device_->command_queue());
-// }
+TEST_F(RandomProgramFixture, TensixTestPrograms) {
+    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+        if (i % 10 == 0) {
+            log_info(tt::LogTest, "Creating Program {}", i);
+        }
+        Program program = CreateProgram();
+        this->create_kernel(program, CoreType::WORKER);
+        EnqueueProgram(device_->command_queue(), program, false);
+    }
 
-// TEST_F(RandomProgramFixture, ActiveEthTestPrograms) {
-//     if (!does_device_have_active_eth_cores(device_)) {
-//         GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet
-//         cores";
-//     }
+    Finish(device_->command_queue());
+}
 
-//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-//         if (i % 10 == 0) {
-//             log_info(tt::LogTest, "Creating Program {}", i);
-//         }
-//         Program program = CreateProgram();
-//         // Large eth kernels currently don't fit in the ring buffer, so we're reducing the max number of RTAs
-//         // and the max kernel size to ensure that the kernel can fit in the ring buffer
-//         KernelProperties kernel_properties;
-//         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-//         kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
-//         this->create_kernel(program, CoreType::ETH, false, kernel_properties);
-//         EnqueueProgram(device_->command_queue(), program, false);
-//     }
+TEST_F(RandomProgramFixture, ActiveEthTestPrograms) {
+    if (!does_device_have_active_eth_cores(device_)) {
+        GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet cores";
+    }
 
-//     Finish(device_->command_queue());
-// }
+    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+        if (i % 10 == 0) {
+            log_info(tt::LogTest, "Creating Program {}", i);
+        }
+        Program program = CreateProgram();
+        // Large eth kernels currently don't fit in the ring buffer, so we're reducing the max number of RTAs
+        // and the max kernel size to ensure that the kernel can fit in the ring buffer
+        KernelProperties kernel_properties;
+        kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
+        kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
+        this->create_kernel(program, CoreType::ETH, false, kernel_properties);
+        EnqueueProgram(device_->command_queue(), program, false);
+    }
 
-// TEST_F(RandomProgramFixture, TensixActiveEthTestPrograms) {
-//     if (!does_device_have_active_eth_cores(device_)) {
-//         GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet
-//         cores";
-//     }
+    Finish(device_->command_queue());
+}
 
-//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-//         if (i % 10 == 0) {
-//             log_info(tt::LogTest, "Creating Program {}", i);
-//         }
-//         Program program = CreateProgram();
+TEST_F(RandomProgramFixture, TensixActiveEthTestPrograms) {
+    if (!does_device_have_active_eth_cores(device_)) {
+        GTEST_SKIP() << "Skipping test because device " << device_->id() << " does not have any active ethernet cores";
+    }
 
-//         bool eth_kernel_added_to_program = false;
-//         if (rand() % 2 == 0) {
-//             // Large eth kernels currently don't fit in the ring buffer, so we're reducing the max number of RTAs
-//             // and the max kernel size to ensure that the kernel can fit in the ring buffer
-//             KernelProperties kernel_properties;
-//             kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-//             kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
-//             kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
-//             this->create_kernel(program, CoreType::ETH, false, kernel_properties);
-//             eth_kernel_added_to_program = true;
-//         }
-//         if (rand() % 2 == 0 || !eth_kernel_added_to_program) {
-//             KernelProperties kernel_properties;
-//             kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
-//             this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
-//         }
+    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+        if (i % 10 == 0) {
+            log_info(tt::LogTest, "Creating Program {}", i);
+        }
+        Program program = CreateProgram();
 
-//         EnqueueProgram(device_->command_queue(), program, false);
-//     }
+        bool eth_kernel_added_to_program = false;
+        if (rand() % 2 == 0) {
+            // Large eth kernels currently don't fit in the ring buffer, so we're reducing the max number of RTAs
+            // and the max kernel size to ensure that the kernel can fit in the ring buffer
+            KernelProperties kernel_properties;
+            kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
+            kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
+            kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
+            this->create_kernel(program, CoreType::ETH, false, kernel_properties);
+            eth_kernel_added_to_program = true;
+        }
+        if (rand() % 2 == 0 || !eth_kernel_added_to_program) {
+            KernelProperties kernel_properties;
+            kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
+            this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
+        }
 
-//     Finish(device_->command_queue());
-// }
+        EnqueueProgram(device_->command_queue(), program, false);
+    }
 
-// TEST_F(RandomProgramFixture, TensixTestAlternatingLargeAndSmallPrograms) {
-//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-//         if (i % 10 == 0) {
-//             log_info(tt::LogTest, "Creating Program {}", i);
-//         }
-//         Program program = CreateProgram();
+    Finish(device_->command_queue());
+}
 
-//         KernelProperties kernel_properties;
-//         if (i % 2 == 0) {
-//             kernel_properties = this->get_large_kernel_properties();
-//         } else {
-//             kernel_properties = this->get_small_kernel_properties();
-//         }
+TEST_F(RandomProgramFixture, TensixTestAlternatingLargeAndSmallPrograms) {
+    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+        if (i % 10 == 0) {
+            log_info(tt::LogTest, "Creating Program {}", i);
+        }
+        Program program = CreateProgram();
 
-//         this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
-//         EnqueueProgram(device_->command_queue(), program, false);
-//     }
+        KernelProperties kernel_properties;
+        if (i % 2 == 0) {
+            kernel_properties = this->get_large_kernel_properties();
+        } else {
+            kernel_properties = this->get_small_kernel_properties();
+        }
 
-//     Finish(device_->command_queue());
-// }
+        this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
+        EnqueueProgram(device_->command_queue(), program, false);
+    }
 
-// TEST_F(RandomProgramFixture, TensixTestLargeProgramFollowedBySmallPrograms) {
-//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-//         if (i % 10 == 0) {
-//             log_info(tt::LogTest, "Creating Program {}", i);
-//         }
-//         Program program = CreateProgram();
+    Finish(device_->command_queue());
+}
 
-//         KernelProperties kernel_properties;
-//         if (i == 0) {
-//             kernel_properties = this->get_large_kernel_properties();
-//         } else {
-//             kernel_properties = this->get_small_kernel_properties();
-//         }
+TEST_F(RandomProgramFixture, TensixTestLargeProgramFollowedBySmallPrograms) {
+    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+        if (i % 10 == 0) {
+            log_info(tt::LogTest, "Creating Program {}", i);
+        }
+        Program program = CreateProgram();
 
-//         this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
-//         EnqueueProgram(device_->command_queue(), program, false);
-//     }
+        KernelProperties kernel_properties;
+        if (i == 0) {
+            kernel_properties = this->get_large_kernel_properties();
+        } else {
+            kernel_properties = this->get_small_kernel_properties();
+        }
 
-//     Finish(device_->command_queue());
-// }
+        this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
+        EnqueueProgram(device_->command_queue(), program, false);
+    }
 
-// TEST_F(RandomProgramFixture, TensixTestLargeProgramInBetweenFiveSmallPrograms) {
-//     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-//         if (i % 10 == 0) {
-//             log_info(tt::LogTest, "Creating Program {}", i);
-//         }
-//         Program program = CreateProgram();
+    Finish(device_->command_queue());
+}
 
-//         KernelProperties kernel_properties;
-//         if (i % 6 == 0) {
-//             kernel_properties = this->get_large_kernel_properties();
-//         } else {
-//             kernel_properties = this->get_small_kernel_properties();
-//         }
+TEST_F(RandomProgramFixture, TensixTestLargeProgramInBetweenFiveSmallPrograms) {
+    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+        if (i % 10 == 0) {
+            log_info(tt::LogTest, "Creating Program {}", i);
+        }
+        Program program = CreateProgram();
 
-//         this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
-//         EnqueueProgram(device_->command_queue(), program, false);
-//     }
+        KernelProperties kernel_properties;
+        if (i % 6 == 0) {
+            kernel_properties = this->get_large_kernel_properties();
+        } else {
+            kernel_properties = this->get_small_kernel_properties();
+        }
 
-//     Finish(device_->command_queue());
-// }
+        this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
+        EnqueueProgram(device_->command_queue(), program, false);
+    }
+
+    Finish(device_->command_queue());
+}
 
 }  // namespace stress_tests
 

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -299,7 +299,7 @@ class MultiCommandQueueMultiDeviceBufferFixture : public MultiCommandQueueMultiD
 class MultiCommandQueueMultiDeviceEventFixture : public MultiCommandQueueMultiDeviceFixture {};
 
 class DISABLED_MultiCQMultiDeviceOnFabricFixture : public UnitMeshMultiCQMultiDeviceFixture,
-                                                   public ::testing::WithParamInterface<tt::tt_fabirc::FabricConfig> {
+                                                   public ::testing::WithParamInterface<tt::tt_fabric::FabricConfig> {
 private:
     // Save the result to reduce UMD calls
     inline static bool should_skip_ = false;

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -20,6 +20,8 @@
 
 namespace tt::tt_metal {
 
+// #22835: These Fixtures will be removed once tests are fully migrated, and replaced by
+// UnitMeshMultiCQSingleDeviceFixtures
 class MultiCommandQueueSingleDeviceFixture : public DispatchFixture {
 protected:
     void SetUp() override {
@@ -82,6 +84,87 @@ protected:
     uint8_t num_cqs_;
 };
 
+class UnitMeshMultiCQSingleDeviceFixture : public DispatchFixture {
+protected:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
+    void SetUp() override {
+        if (!this->validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
+
+        this->num_cqs_ = tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs();
+        if (this->num_cqs_ != 2) {
+            log_info(tt::LogTest, "This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
+            GTEST_SKIP();
+        }
+
+        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+
+        const chip_id_t device_id = 0;
+        const DispatchCoreType dispatch_core_type = this->get_dispatch_core_type();
+
+        this->create_devices();
+    }
+
+    void TearDown() override {
+        for (auto& device : devices_) {
+            device.reset();
+        }
+    }
+
+    bool validate_dispatch_mode() {
+        this->slow_dispatch_ = false;
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (slow_dispatch) {
+            log_info(tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
+            this->slow_dispatch_ = true;
+            return false;
+        }
+        return true;
+    }
+
+    DispatchCoreType get_dispatch_core_type() {
+        DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER;
+        if (this->arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() != 1) {
+            if (!tt::tt_metal::IsGalaxyCluster()) {
+                log_warning(
+                    tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in SetUp()");
+                dispatch_core_type = DispatchCoreType::ETH;
+            }
+        }
+        return dispatch_core_type;
+    }
+
+    void create_devices(std::size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
+        const auto& dispatch_core_config =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
+        const chip_id_t mmio_device_id = *tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids().begin();
+        std::vector<chip_id_t> chip_ids;
+        auto enable_remote_chip = getenv("TT_METAL_ENABLE_REMOTE_CHIP");
+        if (enable_remote_chip or
+            tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0) == BoardType::UBB) {
+            for (chip_id_t id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
+                chip_ids.push_back(id);
+            }
+        } else {
+            chip_ids.push_back(mmio_device_id);
+        }
+        auto reserved_devices = distributed::MeshDevice::create_unit_meshes(
+            chip_ids, DEFAULT_L1_SMALL_SIZE, trace_region_size, 2, dispatch_core_config);
+        for (const auto& [id, device] : reserved_devices) {
+            this->devices_.push_back(device);
+        }
+    }
+
+    std::vector<std::shared_ptr<distributed::MeshDevice>> devices_;
+    tt::ARCH arch_;
+    uint8_t num_cqs_;
+};
+
+class UnitMeshMultiCQSingleDeviceProgramFixture : public UnitMeshMultiCQSingleDeviceFixture {};
+
 class MultiCommandQueueSingleDeviceEventFixture : public MultiCommandQueueSingleDeviceFixture {};
 
 class MultiCommandQueueSingleDeviceBufferFixture : public MultiCommandQueueSingleDeviceFixture {};
@@ -113,6 +196,8 @@ protected:
     DispatchCoreType dispatch_core_type_;
 };
 
+// #22835: These Fixtures will be removed once tests are fully migrated, and replaced by
+// UnitMeshMultiCQMultiDeviceFixtures
 class MultiCommandQueueMultiDeviceFixture : public DispatchFixture {
 protected:
     void SetUp() override {
@@ -163,7 +248,7 @@ protected:
     std::map<chip_id_t, tt::tt_metal::IDevice*> reserved_devices_;
 };
 
-class UnitMeshMultiCommandQueueMultiDeviceFixture : public DispatchFixture {
+class UnitMeshMultiCQMultiDeviceFixture : public DispatchFixture {
 protected:
     void SetUp() override {
         this->slow_dispatch_ = false;
@@ -180,28 +265,26 @@ protected:
             GTEST_SKIP();
         }
 
-        const tt::ARCH arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-
-        DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER;
-        if (arch == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() != 1) {
-            if (!tt::tt_metal::IsGalaxyCluster()) {
-                log_warning(
-                    tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
-                dispatch_core_type = DispatchCoreType::ETH;
+        const auto& dispatch_core_config =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
+        const chip_id_t mmio_device_id = *tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids().begin();
+        std::vector<chip_id_t> chip_ids;
+        auto enable_remote_chip = getenv("TT_METAL_ENABLE_REMOTE_CHIP");
+        if (enable_remote_chip or
+            tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0) == BoardType::UBB) {
+            for (chip_id_t id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
+                chip_ids.push_back(id);
             }
-        }
-
-        std::vector<int> devices_to_open;
-        devices_to_open.reserve(tt::tt_metal::GetNumAvailableDevices());
-        for (int i = 0; i < tt::tt_metal::GetNumAvailableDevices(); ++i) {
-            devices_to_open.push_back(i);
+        } else {
+            chip_ids.push_back(mmio_device_id);
         }
         auto reserved_devices = distributed::MeshDevice::create_unit_meshes(
-            devices_to_open, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, num_cqs, dispatch_core_type);
+            chip_ids, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 2, dispatch_core_config);
         for (const auto& [id, device] : reserved_devices) {
-            devices_.push_back(device);
+            this->devices_.push_back(device);
         }
     }
+
     void TearDown() override {
         for (auto& device : devices_) {
             device.reset();
@@ -215,9 +298,8 @@ class MultiCommandQueueMultiDeviceBufferFixture : public MultiCommandQueueMultiD
 
 class MultiCommandQueueMultiDeviceEventFixture : public MultiCommandQueueMultiDeviceFixture {};
 
-class DISABLED_MultiCommandQueueMultiDeviceOnFabricFixture
-    : public MultiCommandQueueMultiDeviceFixture,
-      public ::testing::WithParamInterface<tt::tt_fabric::FabricConfig> {
+class DISABLED_MultiCQMultiDeviceOnFabricFixture : public UnitMeshMultiCQMultiDeviceFixture,
+                                                   public ::testing::WithParamInterface<tt::tt_metal::FabricConfig> {
 private:
     // Save the result to reduce UMD calls
     inline static bool should_skip_ = false;
@@ -236,7 +318,7 @@ protected:
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(true);
         // This will force dispatch init to inherit the FabricConfig param
         tt::tt_fabric::SetFabricConfig(GetParam(), tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
-        MultiCommandQueueMultiDeviceFixture::SetUp();
+        UnitMeshMultiCQMultiDeviceFixture::SetUp();
 
         if (::testing::Test::IsSkipped()) {
             tt::tt_fabric::SetFabricConfig(
@@ -245,8 +327,8 @@ protected:
     }
 
     void TearDown() override {
-        MultiCommandQueueMultiDeviceFixture::TearDown();
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
+        UnitMeshMultiCQMultiDeviceFixture::TearDown();
+        tt::tt_fabric::SetFabricConfig(FabricConfig::DISABLED);
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(original_fd_fabric_en_);
     }
 };

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -163,6 +163,54 @@ protected:
     std::map<chip_id_t, tt::tt_metal::IDevice*> reserved_devices_;
 };
 
+class UnitMeshMultiCommandQueueMultiDeviceFixture : public DispatchFixture {
+protected:
+    void SetUp() override {
+        this->slow_dispatch_ = false;
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (slow_dispatch) {
+            log_info(tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
+            this->slow_dispatch_ = true;
+            GTEST_SKIP();
+        }
+
+        auto num_cqs = tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs();
+        if (num_cqs != 2) {
+            log_info(tt::LogTest, "This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
+            GTEST_SKIP();
+        }
+
+        const tt::ARCH arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+
+        DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER;
+        if (arch == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() != 1) {
+            if (!tt::tt_metal::IsGalaxyCluster()) {
+                log_warning(
+                    tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
+                dispatch_core_type = DispatchCoreType::ETH;
+            }
+        }
+
+        std::vector<int> devices_to_open;
+        devices_to_open.reserve(tt::tt_metal::GetNumAvailableDevices());
+        for (int i = 0; i < tt::tt_metal::GetNumAvailableDevices(); ++i) {
+            devices_to_open.push_back(i);
+        }
+        auto reserved_devices = distributed::MeshDevice::create_unit_meshes(
+            devices_to_open, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, num_cqs, dispatch_core_type);
+        for (const auto& [id, device] : reserved_devices) {
+            devices_.push_back(device);
+        }
+    }
+    void TearDown() override {
+        for (auto& device : devices_) {
+            device.reset();
+        }
+    }
+
+    std::vector<std::shared_ptr<distributed::MeshDevice>> devices_;
+};
+
 class MultiCommandQueueMultiDeviceBufferFixture : public MultiCommandQueueMultiDeviceFixture {};
 
 class MultiCommandQueueMultiDeviceEventFixture : public MultiCommandQueueMultiDeviceFixture {};

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -299,7 +299,7 @@ class MultiCommandQueueMultiDeviceBufferFixture : public MultiCommandQueueMultiD
 class MultiCommandQueueMultiDeviceEventFixture : public MultiCommandQueueMultiDeviceFixture {};
 
 class DISABLED_MultiCQMultiDeviceOnFabricFixture : public UnitMeshMultiCQMultiDeviceFixture,
-                                                   public ::testing::WithParamInterface<tt::tt_metal::FabricConfig> {
+                                                   public ::testing::WithParamInterface<tt::tt_fabirc::FabricConfig> {
 private:
     // Save the result to reduce UMD calls
     inline static bool should_skip_ = false;
@@ -328,7 +328,7 @@ protected:
 
     void TearDown() override {
         UnitMeshMultiCQMultiDeviceFixture::TearDown();
-        tt::tt_fabric::SetFabricConfig(FabricConfig::DISABLED);
+        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
         tt::tt_metal::MetalContext::instance().rtoptions().set_fd_fabric(original_fd_fabric_en_);
     }
 };


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/22835)
### Problem description
Need to migrate more tests to use EnqueueMeshWorkload instead of EnqueueProgram. This is required to deprecate legacy CommandQueue APIs.

### What's changed
- Added `UnitMeshCQSingleCardFixture`, `UnitMeshCQSingleCardProgramFixture`, `UnitMeshCQMultiDeviceFixture`, `CQMultiDeviceOnFabricFixture` to `command_queue_fixture.hpp`
- Added `UnitMeshMultiCQSingleDeviceFixture`, `UnitMeshMultiCQSingleDeviceProgramFixture`, `UnitMeshMultiCQMultiDeviceFixture`, `MultiCQMultiDeviceOnFabricFixture` to `multi_command_queue_fixture.hpp`
- All above test fixtures use `MeshDevices` and parallel their legacy counterparts.
- Removed legacy `TestLogicalCoordinatesEth` tests as they are not compatible with `MeshDevices`
- Fixtures in `random_program_fixture.hpp` have not been migrated yet as they will be in an upcoming PR
- **Note:** Additional Fixtures will be used to replace legacy ones once migration is complete
### Checklist
- [x] [All Post-Commit Tests](https://github.com/tenstorrent/tt-metal/actions/runs/16288607427)
- [x] [T3K Unit Tests](https://github.com/tenstorrent/tt-metal/actions/runs/16283628321)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes