### PR TITLE
Use CIv2 P150b runners

### DIFF
--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -4,17 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       runner-label:
-        description: 'Valid inputs: ["P100", "P150"] (both cards), ["P100"] (P100 only), ["P150"] (P150 only)'
+        description: 'Valid inputs: ["P100", "P150b"] (both cards), ["P100"] (P100 only), ["P150b"] (P150 only)'
         required: false
         type: string
-        default: '["P100", "P150"]'
+        default: '["P100", "P150b"]'
   workflow_call:
     inputs:
       runner-label:
-        description: 'Valid inputs: ["P100", "P150"] (both cards), ["P100"] (P100 only), ["P150"] (P150 only)'
+        description: 'Valid inputs: ["P100", "P150b"] (both cards), ["P100"] (P100 only), ["P150b"] (P150 only)'
         required: false
         type: string
-        default: '["P100", "P150"]'
+        default: '["P100", "P150b"]'
   schedule:
     - cron: "0 */8 * * *"  # Every 8 hours at 0:00, 8:00, and 16:00 UTC
 
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
+        card_type: ["P100", "P150"]  # Cannot use P150b yet because CIv2 is using LFC and not MLPerf
     secrets: inherit
     with:
       runner-label: ${{ matrix.card_type }}
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
+        card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150b"]') }}
     with:
       arch: blackhole
       runner-label: ${{ matrix.card_type }}
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
+        card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150b"]') }}
     with:
       arch: blackhole
       runner-label: ${{ matrix.card_type }}
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
     with:
       arch: blackhole
-      runner-label: P150
+      runner-label: P150b
       timeout: 10
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -72,6 +72,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      civ2-matrix: ${{ steps.set-matrix.outputs.civ2-matrix }}
+      civ2-viommu-matrix: ${{ steps.set-matrix.outputs.civ2-viommu-matrix }}
     steps:
       - id: set-matrix
         run: |
@@ -80,10 +82,16 @@ jobs:
               echo "::warning::LLMBox tests are enabled but runner-label is not set to BH-LLMBox. Current value: ${{ inputs.runner-label }}"
             fi
             matrix='["BH-LLMBox"]'
+            civ2-matrix='["BH-LLMBox"]'
+            civ2-viommu-matrix='["BH-LLMBox"]'
           else
             matrix='["P100", "P150"]'
+            civ2-matrix='["P100", "P150b"]'
+            civ2-viommu-matrix='["P100", "P150b-viommu"]'
           fi
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
+          echo "civ2-matrix=$civ2-matrix" >> $GITHUB_OUTPUT
+          echo "civ2-viommu-matrix=$civ2-viommu-matrix" >> $GITHUB_OUTPUT
 
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
@@ -167,7 +175,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
     with:
       arch: blackhole
       runner-label: ${{ matrix.test-group }}
@@ -221,7 +229,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+        platform: ${{ fromJson(needs.generate-matrix.outputs.civ2-viommu-matrix) }}
     uses: ./.github/workflows/smoke.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
@@ -233,7 +241,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+        platform: ${{ fromJson(needs.generate-matrix.outputs.civ2-viommu-matrix) }}
     uses: ./.github/workflows/smoke.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -86,12 +86,12 @@ jobs:
             civ2-viommu-matrix='["BH-LLMBox"]'
           else
             matrix='["P100", "P150"]'
-            civ2-matrix='["P100", "P150b"]'
-            civ2-viommu-matrix='["P100", "P150b-viommu"]'
+            civ2_matrix='["P100", "P150b"]'
+            civ2_viommu_matrix='["P100", "P150b-viommu"]'
           fi
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
-          echo "civ2-matrix=$civ2-matrix" >> $GITHUB_OUTPUT
-          echo "civ2-viommu-matrix=$civ2-viommu-matrix" >> $GITHUB_OUTPUT
+          echo "civ2-matrix=$civ2_matrix" >> $GITHUB_OUTPUT
+          echo "civ2-viommu-matrix=$civ2_viommu_matrix" >> $GITHUB_OUTPUT
 
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -175,7 +175,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     with:
       arch: blackhole
       runner-label: ${{ matrix.test-group }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -82,8 +82,8 @@ jobs:
               echo "::warning::LLMBox tests are enabled but runner-label is not set to BH-LLMBox. Current value: ${{ inputs.runner-label }}"
             fi
             matrix='["BH-LLMBox"]'
-            civ2-matrix='["BH-LLMBox"]'
-            civ2-viommu-matrix='["BH-LLMBox"]'
+            civ2_matrix='["BH-LLMBox"]'
+            civ2_viommu_matrix='["BH-LLMBox"]'
           else
             matrix='["P100", "P150"]'
             civ2_matrix='["P100", "P150b"]'

--- a/.github/workflows/didt-tests.yaml
+++ b/.github/workflows/didt-tests.yaml
@@ -25,7 +25,11 @@ on:
 jobs:
   ttnn:
     name: didt tests ${{ inputs.arch }} ${{ inputs.runner-label }}
-    runs-on: ["in-service", "cloud-virtual-machine", "${{ inputs.runner-label }}"]
+    runs-on: >-
+      ${{
+        ((inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
+      }}
     container:
       image: ${{ inputs.docker-image }}
       env:

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -37,7 +37,7 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        (github.event.pull_request.head.repo.fork == true || inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -37,7 +37,7 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        (github.event.pull_request.head.repo.fork == true || inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -54,9 +54,11 @@ jobs:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
-    runs-on:
-      - ${{ inputs.runner-label }}
-      - "in-service"
+    runs-on: >-
+      ${{
+        ((inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
+      }}
     steps:
       - name: ⬇️  Setup Job
         uses: tenstorrent/tt-metal/.github/actions/setup-job@main

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -101,7 +101,7 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        (github.event.pull_request.head.repo.fork == true || inputs.runner-label == 'P150b') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
       }}
     container:


### PR DESCRIPTION
### Ticket
None

### Problem description
We have p150b runners in CIv2 that we aren't fully utilzing yet.

### What's changed
Switch some jobs from BH nightly and post commit to CIv2 P150b runners.

### Checklist
- [x] BH post commit: https://github.com/tenstorrent/tt-metal/actions/runs/16182487260
- [x] BH nightly: https://github.com/tenstorrent/tt-metal/actions/runs/16181089134
- [x] APC: https://github.com/tenstorrent/tt-metal/actions/runs/16181658105