### PR TITLE
Add methods in HAL to get read/write alignment

### DIFF
--- a/tt_metal/llrt/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal.cpp
@@ -85,6 +85,16 @@ void Hal::initialize_bh() {
     this->mem_alignments_[static_cast<std::size_t>(HalMemType::DRAM)] = DRAM_ALIGNMENT;
     this->mem_alignments_[static_cast<std::size_t>(HalMemType::HOST)] = PCIE_ALIGNMENT;
 
+    this->mem_read_alignments_.resize(static_cast<std::size_t>(HalMemType::COUNT));
+    this->mem_read_alignments_[static_cast<std::size_t>(HalMemType::L1)] = NOC_L1_READ_ALIGNMENT_BYTES;
+    this->mem_read_alignments_[static_cast<std::size_t>(HalMemType::DRAM)] = NOC_DRAM_READ_ALIGNMENT_BYTES;
+    this->mem_read_alignments_[static_cast<std::size_t>(HalMemType::HOST)] = NOC_PCIE_READ_ALIGNMENT_BYTES;
+
+    this->mem_write_alignments_.resize(static_cast<std::size_t>(HalMemType::COUNT));
+    this->mem_write_alignments_[static_cast<std::size_t>(HalMemType::L1)] = NOC_L1_WRITE_ALIGNMENT_BYTES;
+    this->mem_write_alignments_[static_cast<std::size_t>(HalMemType::DRAM)] = NOC_DRAM_WRITE_ALIGNMENT_BYTES;
+    this->mem_write_alignments_[static_cast<std::size_t>(HalMemType::HOST)] = NOC_PCIE_WRITE_ALIGNMENT_BYTES;
+
     this->mem_alignments_with_pcie_.resize(static_cast<std::size_t>(HalMemType::COUNT));
     this->mem_alignments_with_pcie_[static_cast<std::size_t>(HalMemType::L1)] = std::lcm(L1_ALIGNMENT, PCIE_ALIGNMENT);
     this->mem_alignments_with_pcie_[static_cast<std::size_t>(HalMemType::DRAM)] =

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -142,6 +142,8 @@ private:
     std::vector<DeviceAddr> dram_bases_;
     std::vector<uint32_t> dram_sizes_;
     std::vector<uint32_t> mem_alignments_;
+    std::vector<uint32_t> mem_read_alignments_;
+    std::vector<uint32_t> mem_write_alignments_;
     std::vector<uint32_t> mem_alignments_with_pcie_;
     uint32_t num_nocs_;
     uint32_t noc_addr_node_id_bits_;
@@ -268,6 +270,9 @@ public:
     uint32_t get_dev_size(HalDramMemAddrType addr_type) const;
 
     uint32_t get_alignment(HalMemType memory_type) const;
+    uint32_t get_read_alignment(HalMemType memory_type) const;
+    uint32_t get_write_alignment(HalMemType memory_type) const;
+
     // Returns an alignment that is aligned with PCIE and the given memory type
     uint32_t get_common_alignment_with_pcie(HalMemType memory_type) const;
 
@@ -385,6 +390,18 @@ inline uint32_t Hal::get_alignment(HalMemType memory_type) const {
     uint32_t index = utils::underlying_type<HalMemType>(memory_type);
     TT_ASSERT(index < this->mem_alignments_.size());
     return this->mem_alignments_[index];
+}
+
+inline uint32_t Hal::get_read_alignment(HalMemType memory_type) const {
+    uint32_t index = utils::underlying_type<HalMemType>(memory_type);
+    TT_ASSERT(index < this->mem_read_alignments_.size());
+    return this->mem_read_alignments_[index];
+}
+
+inline uint32_t Hal::get_write_alignment(HalMemType memory_type) const {
+    uint32_t index = utils::underlying_type<HalMemType>(memory_type);
+    TT_ASSERT(index < this->mem_write_alignments_.size());
+    return this->mem_write_alignments_[index];
 }
 
 inline uint32_t Hal::get_common_alignment_with_pcie(HalMemType memory_type) const {

--- a/tt_metal/llrt/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal.cpp
@@ -85,6 +85,16 @@ void Hal::initialize_wh(bool is_base_routing_fw_enabled) {
     this->mem_alignments_[static_cast<std::size_t>(HalMemType::DRAM)] = DRAM_ALIGNMENT;
     this->mem_alignments_[static_cast<std::size_t>(HalMemType::HOST)] = PCIE_ALIGNMENT;
 
+    this->mem_read_alignments_.resize(static_cast<std::size_t>(HalMemType::COUNT));
+    this->mem_read_alignments_[static_cast<std::size_t>(HalMemType::L1)] = NOC_L1_READ_ALIGNMENT_BYTES;
+    this->mem_read_alignments_[static_cast<std::size_t>(HalMemType::DRAM)] = NOC_DRAM_READ_ALIGNMENT_BYTES;
+    this->mem_read_alignments_[static_cast<std::size_t>(HalMemType::HOST)] = NOC_PCIE_READ_ALIGNMENT_BYTES;
+
+    this->mem_write_alignments_.resize(static_cast<std::size_t>(HalMemType::COUNT));
+    this->mem_write_alignments_[static_cast<std::size_t>(HalMemType::L1)] = NOC_L1_WRITE_ALIGNMENT_BYTES;
+    this->mem_write_alignments_[static_cast<std::size_t>(HalMemType::DRAM)] = NOC_DRAM_WRITE_ALIGNMENT_BYTES;
+    this->mem_write_alignments_[static_cast<std::size_t>(HalMemType::HOST)] = NOC_PCIE_WRITE_ALIGNMENT_BYTES;
+
     this->mem_alignments_with_pcie_.resize(static_cast<std::size_t>(HalMemType::COUNT));
     this->mem_alignments_with_pcie_[static_cast<std::size_t>(HalMemType::L1)] = std::lcm(L1_ALIGNMENT, PCIE_ALIGNMENT);
     this->mem_alignments_with_pcie_[static_cast<std::size_t>(HalMemType::DRAM)] =


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14807

### Problem description
Read and write alignments are different, but HAL only expose the max of the two as alignment.

### What's changed
Added new methods in HAL to get read/write alignment.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16182265182) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes