### PR TITLE
Remove incomplete check

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -229,8 +229,10 @@ jobs:
         git diff "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" -- $(cat common_files.txt) > filtered_changes.diff
         clang-tidy-diff-17.py -p1 -path build  -export-fixes clang-tidy-result/fixes.yml -j$(nproc) < filtered_changes.diff
 
-        # Draw attention to this step (make it an error) if there are fixes to be addressed.
-        [[ -s clang-tidy-result/fixes.yml ]] && exit 42
+        # TODO: Find a way to fail THIS step if there's some USEFUL issues detected.
+        #       For now disable it b/c it fails if it finds things in non-user code and/or NOLINT's.
+        # # Draw attention to this step (make it an error) if there are fixes to be addressed.
+        # [[ -s clang-tidy-result/fixes.yml ]] && exit 42
 
       timeout-minutes: 5
     - name: Run clang-tidy-pr-comments action


### PR DESCRIPTION
### Ticket
Follow-up to #24788

### Problem description
Either non-user warnings and/or NOLINTs cause the .yaml file to be written with content, even though there is nothing actionable.  This naive check would dutifully fail the step.  We need a better way to detect whether there's something to be addressed or not.

### What's changed
Removed the check.