### PR TITLE
#0: Fix alignment calc for sharded tensors

### DIFF
--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -578,8 +578,18 @@ const std::optional<BufferDistributionSpec>& Buffer::buffer_distribution_spec() 
     return this->buffer_distribution_spec_;
 }
 
-bool ShardSpec::operator==(const ShardSpec&) const = default;
-bool ShardSpec::operator!=(const ShardSpec&) const = default;
+bool ShardSpec::operator==(const ShardSpec& other) const {
+    if (this->grid != other.grid || this->orientation != other.orientation) {
+        return false;
+    }
+    auto this_shape = this->mode == ShardMode::LOGICAL ? this->physical_shard_shape : this->shape;
+    auto other_shape = other.mode == ShardMode::LOGICAL ? other.physical_shard_shape : other.shape;
+    if (this_shape != other_shape) {
+        return false;
+    }
+    return true;
+}
+bool ShardSpec::operator!=(const ShardSpec& other) const { return !(*this == other); }
 
 std::array<uint32_t, 2> ShardSpecBuffer::shape_in_pages() const {
     auto height_in_pages = page_shape[0] == 0 ? 0 : tensor_shard_spec.shape[0] / page_shape[0];

--- a/ttnn/core/tensor/layout/tensor_layout.cpp
+++ b/ttnn/core/tensor/layout/tensor_layout.cpp
@@ -47,23 +47,11 @@ Alignment legacyShapeToAlignment(
         const auto& shard_spec = memory_config.shard_spec().value();
         const auto shard_shape = shard_spec.physical_shard_shape.value_or(shard_spec.shape);
         if (page_config.get_layout() == Layout::ROW_MAJOR) {
-            if (memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-                return Alignment{shard_shape[0], 1};
-            } else if (memory_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
-                return Alignment{1, shard_shape[1]};
-            } else if (memory_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
-                return Alignment{shard_shape[0], shard_shape[1]};
-            }
+            return Alignment{shard_shape[0], shard_shape[1]};
         } else if (page_config.get_layout() == Layout::TILE) {
-            if (memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-                return Alignment{tt::round_up(shard_shape[0], constants::TILE_HEIGHT), constants::TILE_WIDTH};
-            } else if (memory_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
-                return Alignment{constants::TILE_HEIGHT, tt::round_up(shard_shape[1], constants::TILE_WIDTH)};
-            } else if (memory_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
-                return Alignment{
-                    tt::round_up(shard_shape[0], constants::TILE_HEIGHT),
-                    tt::round_up(shard_shape[1], constants::TILE_WIDTH)};
-            }
+            return Alignment{
+                tt::round_up(shard_shape[0], constants::TILE_HEIGHT),
+                tt::round_up(shard_shape[1], constants::TILE_WIDTH)};
         }
 
         return Alignment{};

--- a/ttnn/core/tensor/layout/tensor_layout.cpp
+++ b/ttnn/core/tensor/layout/tensor_layout.cpp
@@ -43,13 +43,29 @@ Alignment legacyShapeToAlignment(
             "Tensor with shape {} ({}) cannot be sharded because alignment will have rank greater than 2!",
             logical_shape,
             legacy_padded_shape);
+
+        const auto& shard_spec = memory_config.shard_spec().value();
+        const auto shard_shape = shard_spec.physical_shard_shape.value_or(shard_spec.shape);
         if (page_config.get_layout() == Layout::ROW_MAJOR) {
-            const auto& shard_spec = memory_config.shard_spec().value();
-            if (shard_spec.physical_shard_shape.has_value()) {
-                return Alignment{shard_spec.physical_shard_shape.value()[1]};
+            if (memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+                return Alignment{shard_shape[0], 1};
+            } else if (memory_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+                return Alignment{1, shard_shape[1]};
+            } else if (memory_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+                return Alignment{shard_shape[0], shard_shape[1]};
             }
-            return Alignment{shard_spec.shape[1]};
+        } else if (page_config.get_layout() == Layout::TILE) {
+            if (memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+                return Alignment{tt::round_up(shard_shape[0], constants::TILE_HEIGHT), constants::TILE_WIDTH};
+            } else if (memory_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+                return Alignment{constants::TILE_HEIGHT, tt::round_up(shard_shape[1], constants::TILE_WIDTH)};
+            } else if (memory_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+                return Alignment{
+                    tt::round_up(shard_shape[0], constants::TILE_HEIGHT),
+                    tt::round_up(shard_shape[1], constants::TILE_WIDTH)};
+            }
         }
+
         return Alignment{};
     }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -178,45 +178,21 @@ std::vector<TensorSpec> OptimizedConvNew::compute_output_specs(const std::vector
 
     auto output_layout = this->untilize_out ? Layout::ROW_MAJOR : Layout::TILE;
     if (this->memory_config.is_sharded()) {
-        if (this->memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-            uint32_t total_height_tiles = padded_output_shape.volume() / padded_output_shape[-1] / TILE_HEIGHT;
-            uint32_t num_cores = total_height_tiles / this->parallelization_config.per_core_out_matrix_height_ntile;
-            std::array<uint32_t, 2> shard_shape = {
-                this->parallelization_config.per_core_out_matrix_height_ntile * TILE_HEIGHT, padded_output_shape[-1]};
-            CoreRangeSet shard_grid =
-                tt::tt_metal::num_cores_to_corerangeset(num_cores, this->parallelization_config.grid_size, true);
-            auto shard_spec = ShardSpec{shard_grid, shard_shape, ShardOrientation::ROW_MAJOR};
-            auto mem_config = this->memory_config.with_shard_spec(shard_spec);
-            return {TensorSpec(
-                output_shape,
-                TensorLayout::fromPaddedShape(
-                    dtype, PageConfig(output_layout), mem_config, output_shape, padded_output_shape))};
-        } else if (this->memory_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
-            uint32_t total_height_tiles = padded_output_shape.volume() / padded_output_shape[-1] / TILE_HEIGHT;
-            std::array<uint32_t, 2> shard_shape = {
-                this->parallelization_config.per_core_out_matrix_height_ntile * TILE_HEIGHT,
-                this->parallelization_config.per_core_out_matrix_width_ntile * TILE_WIDTH};
-            auto shard_grid = this->memory_config.shard_spec().value().grid;
-            auto shard_spec = ShardSpec{shard_grid, shard_shape, this->memory_config.shard_spec().value().orientation};
-            auto mem_config = this->memory_config.with_shard_spec(shard_spec);
-            return {TensorSpec(
-                output_shape,
-                TensorLayout::fromPaddedShape(
-                    dtype, PageConfig(output_layout), mem_config, output_shape, padded_output_shape))};
-        } else if (this->memory_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
-            auto shard_grid = this->memory_config.shard_spec().value().grid;
-            auto shard_spec = ShardSpec{
-                shard_grid,
-                this->memory_config.shard_spec().value().shape,
-                this->memory_config.shard_spec().value().orientation};
-            auto mem_config = this->memory_config.with_shard_spec(shard_spec);
-            return {TensorSpec(
-                output_shape,
-                TensorLayout::fromPaddedShape(
-                    dtype, PageConfig(output_layout), mem_config, output_shape, padded_output_shape))};
-        } else {
-            TT_THROW("Unsupported shard scheme");
-        }
+        auto shard_grid = this->memory_config.shard_spec().value().grid;
+        std::array<uint32_t, 2> physical_shard_shape = {
+            this->parallelization_config.per_core_out_matrix_height_ntile * TILE_HEIGHT,
+            this->parallelization_config.per_core_out_matrix_width_ntile * TILE_WIDTH};
+        auto logical_shard_shape = this->memory_config.shard_spec().value().shape;
+        auto shard_spec = ShardSpec{
+            shard_grid,
+            logical_shard_shape,
+            physical_shard_shape,
+            this->memory_config.shard_spec().value().orientation};
+        auto mem_config = this->memory_config.with_shard_spec(shard_spec);
+        return {TensorSpec(
+            output_shape,
+            TensorLayout::fromPaddedShape(
+                dtype, PageConfig(output_layout), mem_config, output_shape, padded_output_shape))};
     }
     return {TensorSpec(
         output_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -47,7 +47,11 @@ void ConcatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) c
         if (in_ref.layout() == Layout::TILE and in_ref.logical_shape()[dim] != in_ref.padded_shape()[dim]) {
             warn_about_alignment = true;
         }
-        TT_FATAL(curr_shape == shape_first, "concat tensors differ in shape across non-concat dimensions.");
+        TT_FATAL(
+            curr_shape == shape_first,
+            "concat tensors differ in shape across non-concat dimensions. Got {} and {}",
+            in_ref,
+            first_input);
         TT_FATAL(in_ref.is_sharded() == shard_first, "All tensors must be sharded or all must be interleaved");
         if (shard_first) {
             TT_FATAL(in_ref.shard_spec().has_value(), "Sharded tensors must have a shard spec.");


### PR DESCRIPTION
### Ticket
#24425 

### Problem description
Conv2D uses physical sharding, which causes certain features or tests to fail.
Alignment is not correctly set for sharded tensors. 

### What's changed
- Switched Conv2D to logical sharding.
- Setting Alignment to the shard shape ensures that the physical shape is correctly calculated.
- Updated ShardSpec operator== to correctly compare logical and physical sharding. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes