### PR TITLE
Add multithread support for weight preparation on host.

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -28,6 +28,87 @@ using sliding_window::SlidingWindowConfig;
 
 namespace conv2d {
 
+/**
+ * Common 2D threading utility
+ * Parallelizes work across two dimensions with configurable thread counts
+ */
+class WeightLayoutThreader {
+private:
+    // Runtime flag to disable threading
+    static bool threading_enabled;
+
+    static uint32_t get_max_threads_per_dim() {
+        if (!threading_enabled) {
+            return 1;
+        }
+        uint32_t hw_concurrency = std::thread::hardware_concurrency();
+        // Do not use all hardware threads
+        return std::max(1u, static_cast<uint32_t>(std::sqrt(hw_concurrency - 1)));
+    }
+
+public:
+    struct ThreadConfig {
+        uint32_t out_threads, in_threads;
+        uint32_t out_per_thread, in_per_thread;
+        uint32_t out_total, in_total;
+    };
+
+    static ThreadConfig calculate_thread_config(uint32_t out_ch, uint32_t in_ch, int MIN_WORK_PER_THREAD = 16) {
+        uint32_t max_threads = get_max_threads_per_dim();
+        uint32_t out_threads = std::min(max_threads, std::max(1u, out_ch / MIN_WORK_PER_THREAD));
+        uint32_t in_threads = std::min(max_threads, std::max(1u, in_ch / MIN_WORK_PER_THREAD));
+
+        return {out_threads, in_threads, out_ch / out_threads, in_ch / in_threads, out_ch, in_ch};
+    }
+
+    template <typename Func>
+    static void parallel_for_channels(uint32_t out_ch, uint32_t in_ch, uint32_t min_work_per_thread, Func&& work_func) {
+        auto cfg = calculate_thread_config(out_ch, in_ch, min_work_per_thread);
+
+        if (cfg.out_threads == 1 && cfg.in_threads == 1) {
+            work_func(0, 0, 0, out_ch, 0, in_ch);
+            return;
+        }
+
+        std::vector<std::thread> threads;
+        std::exception_ptr exception_caught = nullptr;
+        threads.reserve(cfg.out_threads * cfg.in_threads);
+
+        for (uint32_t ot = 0; ot < cfg.out_threads; ++ot) {
+            uint32_t o_start = ot * cfg.out_per_thread;
+            uint32_t o_end = (ot == cfg.out_threads - 1) ? cfg.out_total : o_start + cfg.out_per_thread;
+
+            for (uint32_t it = 0; it < cfg.in_threads; ++it) {
+                uint32_t i_start = it * cfg.in_per_thread;
+                uint32_t i_end = (it == cfg.in_threads - 1) ? cfg.in_total : i_start + cfg.in_per_thread;
+
+                threads.emplace_back([=, &exception_caught, work_func = std::forward<Func>(work_func)] {
+                    try {
+                        work_func(ot, it, o_start, o_end, i_start, i_end);
+                    } catch (...) {
+                        // catch the first exception and store it
+                        if (!exception_caught) {
+                            exception_caught = std::current_exception();
+                        }
+                    }
+                });
+            }
+        }
+
+        // Wait for all threads to complete
+        for (auto& t : threads) {
+            t.join();
+        }
+
+        // Rethrow first exception if one was caught
+        if (exception_caught) {
+            std::rethrow_exception(exception_caught);
+        }
+    }
+};
+// Initialize static member
+bool WeightLayoutThreader::threading_enabled = true;
+
 template <typename T>
 static tt::tt_metal::HostBuffer create_host_buffer_for_conv_weight(
     tt::tt_metal::HostBuffer data, DataType output_dtype, const ttnn::Shape& output_shape) {
@@ -127,20 +208,28 @@ Tensor to_weight_special_padding_tile_layout(
             auto input_buffer = tt::tt_metal::host_buffer::get_as<T>(input_host_buffer);
 
             auto output_buffer = std::vector<T>(output_shape.volume());
-            for (auto r = 0; r < w_shape[2]; r++) {
-                for (auto s = 0; s < w_shape[3]; s++) {
-                    for (auto c = 0; c < w_shape[1]; c++) {
-                        for (auto k = 0; k < w_shape[0]; k++) {
-                            auto matrix_idx =
-                                k + c * weight_matrix_cols + s * w_shape[1] * weight_matrix_cols +
-                                r * ((w_shape[3] * w_shape[1]) + block_height_padding) * weight_matrix_cols;
-                            auto idx = k * w_shape[1] * w_shape[2] * w_shape[3] + c * w_shape[2] * w_shape[3] +
-                                       r * w_shape[3] + s;
-                            output_buffer[matrix_idx] = input_buffer[idx];
+
+            WeightLayoutThreader::parallel_for_channels(
+                w_shape[0],
+                w_shape[1],
+                16,  // Minimum work per thread
+                [&output_buffer, &input_buffer, &w_shape, &weight_matrix_cols, &block_height_padding](
+                    uint32_t out_t, uint32_t in_t, uint32_t k_start, uint32_t k_end, uint32_t c_start, uint32_t c_end) {
+                    for (auto r = 0; r < w_shape[2]; r++) {
+                        for (auto s = 0; s < w_shape[3]; s++) {
+                            for (auto c = c_start; c < c_end; c++) {
+                                for (auto k = k_start; k < k_end; k++) {
+                                    auto matrix_idx =
+                                        k + c * weight_matrix_cols + s * w_shape[1] * weight_matrix_cols +
+                                        r * ((w_shape[3] * w_shape[1]) + block_height_padding) * weight_matrix_cols;
+                                    auto idx = k * w_shape[1] * w_shape[2] * w_shape[3] + c * w_shape[2] * w_shape[3] +
+                                               r * w_shape[3] + s;
+                                    output_buffer[matrix_idx] = input_buffer[idx];
+                                }
+                            }
                         }
                     }
-                }
-            }
+                });
             return create_host_buffer_for_conv_weight<T>(
                 tt::tt_metal::HostBuffer(std::move(output_buffer)), output_dtype, output_shape);
         };
@@ -170,27 +259,38 @@ Tensor to_weight_tile_layout(
     }
     const ttnn::Shape output_shape{1, 1, weight_matrix_rows, weight_matrix_cols};
 
-    auto compute = [&w_shape, weight_matrix_cols, &output_shape, output_dtype](
-                       const tt::tt_metal::HostBuffer& input_host_buffer) {
-        auto input_buffer = tt::tt_metal::host_buffer::get_as<T>(input_host_buffer);
+    auto compute =
+        [&w_shape, weight_matrix_cols, &output_shape, output_dtype](const tt::tt_metal::HostBuffer& input_host_buffer) {
+            auto input_buffer = tt::tt_metal::host_buffer::get_as<T>(input_host_buffer);
 
-        auto output_buffer = std::vector<T>(output_shape.volume());
-        for (auto r = 0; r < w_shape[2]; r++) {
-            for (auto s = 0; s < w_shape[3]; s++) {
-                for (auto c = 0; c < w_shape[1]; c++) {
-                    for (auto k = 0; k < w_shape[0]; k++) {
-                        auto matrix_idx = k + c * weight_matrix_cols + s * w_shape[1] * weight_matrix_cols +
-                                          r * w_shape[3] * w_shape[1] * weight_matrix_cols;
-                        auto idx =
-                            k * w_shape[1] * w_shape[2] * w_shape[3] + c * w_shape[2] * w_shape[3] + r * w_shape[3] + s;
-                        output_buffer[matrix_idx] = input_buffer[idx];
+            auto output_buffer = std::vector<T>(output_shape.volume());
+            WeightLayoutThreader::parallel_for_channels(
+                w_shape[0],
+                w_shape[1],
+                16,  // Minimum work per thread
+                [&](uint32_t out_t,
+                    uint32_t in_t,
+                    uint32_t out_start,
+                    uint32_t out_end,
+                    uint32_t in_start,
+                    uint32_t in_end) {
+                    for (auto r = 0; r < w_shape[2]; r++) {
+                        for (auto s = 0; s < w_shape[3]; s++) {
+                            for (auto c = in_start; c < in_end; c++) {
+                                for (auto k = out_start; k < out_end; k++) {
+                                    auto matrix_idx = k + c * weight_matrix_cols + s * w_shape[1] * weight_matrix_cols +
+                                                      r * w_shape[3] * w_shape[1] * weight_matrix_cols;
+                                    auto idx = k * w_shape[1] * w_shape[2] * w_shape[3] + c * w_shape[2] * w_shape[3] +
+                                               r * w_shape[3] + s;
+                                    output_buffer[matrix_idx] = input_buffer[idx];
+                                }
+                            }
+                        }
                     }
-                }
-            }
-        }
-        return create_host_buffer_for_conv_weight<T>(
-            tt::tt_metal::HostBuffer(std::move(output_buffer)), output_dtype, output_shape);
-    };
+                });
+            return create_host_buffer_for_conv_weight<T>(
+                tt::tt_metal::HostBuffer(std::move(output_buffer)), output_dtype, output_shape);
+        };
 
     const TensorSpec output_spec(
         output_shape, tt::tt_metal::TensorLayout(output_dtype, tt::tt_metal::PageConfig(Layout::TILE), MemoryConfig{}));
@@ -273,47 +373,59 @@ Tensor to_weight_tile_layout_block_sharded(
         uint32_t height_stride_per_kernel_row =
             tt::round_up(conv_input_shard_width * (full_inner_dim ? kernel_h : 1) * kernel_w, constants::TILE_HEIGHT);
 
-        for (uint32_t ic = 0; ic < num_channel_shards; ic++) {
-            for (uint32_t r = 0; r < kernel_h; r++) {
-                for (uint32_t s = 0; s < kernel_w; s++) {
-                    for (uint32_t c_s = 0; c_s < conv_input_shard_width; c_s++) {
-                        for (uint32_t oc = 0; oc < num_channel_shards; oc++) {
-                            for (uint32_t k_s = 0; k_s < conv_output_shard_width; k_s++) {
-                                // Calculate matrix row index based on full_inner_dim flag
-                                uint32_t matrix_row;
-                                if (full_inner_dim) {
-                                    // When using full inner dim, layout is: [ic_shard][flattened_inner_dim]
-                                    // where flattened_inner_dim = r*kernel_w*conv_input_shard_width +
-                                    // s*conv_input_shard_width + c_s
-                                    uint32_t flattened_inner_idx =
-                                        r * kernel_w * conv_input_shard_width + s * conv_input_shard_width + c_s;
-                                    matrix_row = ic * weight_block_height_padded + flattened_inner_idx;
-                                } else {
-                                    // Original logic - slice by kernel height
-                                    matrix_row = ic * weight_block_height_padded + r * height_stride_per_kernel_row +
-                                                 s * conv_input_shard_width + c_s;
-                                }
+        WeightLayoutThreader::parallel_for_channels(
+            num_channel_shards,
+            num_channel_shards,
+            1,  // Minimum work per thread
+            [&](uint32_t out_t,
+                uint32_t in_t,
+                uint32_t out_start,
+                uint32_t out_end,
+                uint32_t in_start,
+                uint32_t in_end) {
+                for (uint32_t ic = in_start; ic < in_end; ic++) {
+                    for (uint32_t r = 0; r < kernel_h; r++) {
+                        for (uint32_t s = 0; s < kernel_w; s++) {
+                            for (uint32_t c_s = 0; c_s < conv_input_shard_width; c_s++) {
+                                for (uint32_t oc = out_start; oc < out_end; oc++) {
+                                    for (uint32_t k_s = 0; k_s < conv_output_shard_width; k_s++) {
+                                        // Calculate matrix row index based on full_inner_dim flag
+                                        uint32_t matrix_row;
+                                        if (full_inner_dim) {
+                                            // When using full inner dim, layout is: [ic_shard][flattened_inner_dim]
+                                            // where flattened_inner_dim = r*kernel_w*conv_input_shard_width +
+                                            // s*conv_input_shard_width + c_s
+                                            uint32_t flattened_inner_idx = r * kernel_w * conv_input_shard_width +
+                                                                           s * conv_input_shard_width + c_s;
+                                            matrix_row = ic * weight_block_height_padded + flattened_inner_idx;
+                                        } else {
+                                            // Original logic - slice by kernel height
+                                            matrix_row = ic * weight_block_height_padded +
+                                                         r * height_stride_per_kernel_row + s * conv_input_shard_width +
+                                                         c_s;
+                                        }
 
-                                uint32_t matrix_col = oc * conv_output_shard_width_padded + k_s;
-                                uint32_t matrix_idx = matrix_row * weight_matrix_cols + matrix_col;
+                                        uint32_t matrix_col = oc * conv_output_shard_width_padded + k_s;
+                                        uint32_t matrix_idx = matrix_row * weight_matrix_cols + matrix_col;
 
-                                // Calculate input tensor index [OC][IC][KH][KW]
-                                uint32_t input_oc = oc * conv_output_shard_width + k_s;
-                                uint32_t input_ic = ic * conv_input_shard_width + c_s;
-                                uint32_t idx = input_oc * w_shape[1] * w_shape[2] * w_shape[3] +
-                                               input_ic * w_shape[2] * w_shape[3] + r * w_shape[3] + s;
+                                        // Calculate input tensor index [OC][IC][KH][KW]
+                                        uint32_t input_oc = oc * conv_output_shard_width + k_s;
+                                        uint32_t input_ic = ic * conv_input_shard_width + c_s;
+                                        uint32_t idx = input_oc * w_shape[1] * w_shape[2] * w_shape[3] +
+                                                       input_ic * w_shape[2] * w_shape[3] + r * w_shape[3] + s;
 
-                                // Ensure we're within bounds before writing
-                                if (matrix_idx < output_buffer.size() && input_oc < w_shape[0] &&
-                                    input_ic < w_shape[1]) {
-                                    output_buffer[matrix_idx] = input_buffer[idx];
+                                        // Ensure we're within bounds before writing
+                                        if (matrix_idx < output_buffer.size() && input_oc < w_shape[0] &&
+                                            input_ic < w_shape[1]) {
+                                            output_buffer[matrix_idx] = input_buffer[idx];
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
-        }
+            });
 
         return create_host_buffer_for_conv_weight<T>(
             tt::tt_metal::HostBuffer(std::move(output_buffer)), output_dtype, output_shape);
@@ -479,22 +591,32 @@ static Tensor conv_depthwise_weight_bcast_helper(
         auto conv_weight_tensor_buffer = tt::tt_metal::host_buffer::get_as<T>(conv_weight_tensor_host_buffer);
         // Create a new buffer with the output shape
         auto output_buffer = std::vector<T>(output_weight_shape.volume());
-
-        // Copy the original weight tensor to the output tensor
-        for (int i = 0; i < output_weight_shape[0]; i++) {
-            for (int j = 0; j < output_weight_shape[1]; j++) {
-                for (int k = 0; k < output_weight_shape[2]; k++) {
-                    for (int l = 0; l < output_weight_shape[3]; l++) {
-                        auto value_flat_input_index = tt::tt_metal::compute_flat_indices(
-                            ttnn::SmallVector<int>{i, 0, k, l}, compute_strides(original_weight_shape));
-                        auto value = conv_weight_tensor_buffer[value_flat_input_index];
-                        auto output_flat_input_index = tt::tt_metal::compute_flat_indices(
-                            ttnn::SmallVector<int>{i, j, k, l}, compute_strides(output_weight_shape));
-                        output_buffer[output_flat_input_index] = value;
+        WeightLayoutThreader::parallel_for_channels(
+            output_weight_shape[0],
+            output_weight_shape[1],
+            16,  // Minimum work per thread
+            [&](uint32_t out_t,
+                uint32_t in_t,
+                uint32_t out_start,
+                uint32_t out_end,
+                uint32_t in_start,
+                uint32_t in_end) {
+                for (int i = out_start; i < out_end; i++) {
+                    for (int j = in_start; j < in_end; j++) {
+                        for (int k = 0; k < output_weight_shape[2]; k++) {
+                            for (int l = 0; l < output_weight_shape[3]; l++) {
+                                auto value_flat_input_index = tt::tt_metal::compute_flat_indices(
+                                    ttnn::SmallVector<int>{i, 0, k, l}, compute_strides(original_weight_shape));
+                                auto value = conv_weight_tensor_buffer[value_flat_input_index];
+                                auto output_flat_input_index = tt::tt_metal::compute_flat_indices(
+                                    ttnn::SmallVector<int>{i, j, k, l}, compute_strides(output_weight_shape));
+                                output_buffer[output_flat_input_index] = value;
+                            }
+                        }
                     }
                 }
-            }
-        }
+            });
+
         return tt::tt_metal::HostBuffer(std::move(output_buffer));
     };
     const TensorSpec output_spec(
@@ -619,32 +741,43 @@ static Tensor to_folded_weight_layout(const Tensor& conv_weight_tensor, std::arr
             std::vector<T> output_buffer(output_shape.volume(), T(0));
             int new_h = padded_kernel_h / stride[0];
             int new_w = padded_kernel_w / stride[1];
+            WeightLayoutThreader::parallel_for_channels(
+                out_channels,
+                in_channels,
+                16,  // Minimum work per thread
+                [&](uint32_t out_t,
+                    uint32_t in_t,
+                    uint32_t out_start,
+                    uint32_t out_end,
+                    uint32_t in_start,
+                    uint32_t in_end) {
+                    for (auto oc = out_start; oc < out_end; oc++) {
+                        for (auto ic = in_start; ic < in_end; ic++) {
+                            for (auto kh = 0; kh < kernel_h; kh++) {
+                                for (auto kw = 0; kw < kernel_w; kw++) {
+                                    uint32_t src_idx = ((((oc * in_channels + ic) * kernel_h) + kh) * kernel_w) + kw;
 
-            for (auto oc = 0; oc < out_channels; oc++) {
-                for (auto ic = 0; ic < in_channels; ic++) {
-                    for (auto kh = 0; kh < kernel_h; kh++) {
-                        for (auto kw = 0; kw < kernel_w; kw++) {
-                            uint32_t src_idx = ((((oc * in_channels + ic) * kernel_h) + kh) * kernel_w) + kw;
+                                    int sh = kh % stride[0];
+                                    int sw = kw % stride[1];
 
-                            int sh = kh % stride[0];
-                            int sw = kw % stride[1];
+                                    // Calculate new y,x coordinates
+                                    int y = kh / stride[0];
+                                    int x = kw / stride[1];
 
-                            // Calculate new y,x coordinates
-                            int y = kh / stride[0];
-                            int x = kw / stride[1];
+                                    // Calculate folded input channel index
+                                    int folded_ic_idx = (sh * stride[1] + sw) * in_channels + ic;
 
-                            // Calculate folded input channel index
-                            int folded_ic_idx = (sh * stride[1] + sw) * in_channels + ic;
+                                    // Calculate final destination index
+                                    int dst_idx = oc * in_channels * stride[0] * stride[1] * new_h * new_w +
+                                                  folded_ic_idx * new_h * new_w + y * new_w + x;
 
-                            // Calculate final destination index
-                            int dst_idx = oc * in_channels * stride[0] * stride[1] * new_h * new_w +
-                                          folded_ic_idx * new_h * new_w + y * new_w + x;
-
-                            output_buffer[dst_idx] = input_buffer[src_idx];
+                                    output_buffer[dst_idx] = input_buffer[src_idx];
+                                }
+                            }
                         }
                     }
-                }
-            }
+                });
+
             return tt::tt_metal::HostBuffer(std::move(output_buffer));
         });
         return Tensor(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -42,7 +42,8 @@ private:
             return 1;
         }
         uint32_t hw_concurrency = std::thread::hardware_concurrency();
-        // Do not use all hardware threads
+        // Use sqrt to balance 2D parallelization: total threads = out_threads × in_threads ≈ sqrt(hw_concurrency - 1)²
+        // This prevents oversubscription while maintaining good load distribution across both channel dimensions
         return std::max(1u, static_cast<uint32_t>(std::sqrt(hw_concurrency - 1)));
     }
 


### PR DESCRIPTION
### Problem description
Currently, weight preparation on the host is executed using a single thread.

### What's changed
This PR creates threading utility with following updates: 

- Utility distributes weight preparation among several thread based on availability of hardware threads. 
- To minimize changes to the existing logic, parallelism is applied only across input and output channels. This avoids parallelizing over height and width dimensions, which are typically small.
- Multi-threading can be disabled by making `threading_enabled` variable as false.

### Time consumed for release build(for test_conv_ws)

|  | main | this branch | Improvement
|--------|--------|--------|--------|
| WH | 2m48sec | 1m41sec | 40%

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17061675959)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17061686919) same as main
- [X] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17061678774)
- [X] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17061680875)
- [ ] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17061683210) same as main
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17061673588)