### PR TITLE
Remove unused rot matrix tensors from `tt_transformers`

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -18,12 +18,10 @@ from models.tt_transformers.tt.common import (
     calculate_hidden_dim,
     encode_prompt_hf,
     encode_prompt_instruct,
-    freqs_to_rotation_matrix,
     get_base_model_name,
     get_out_subblock_w,
     nearest_multiple,
     num_to_core_range_set,
-    precompute_freqs,
 )
 from models.tt_transformers.tt.load_checkpoints import (
     convert_hf_to_meta,
@@ -602,11 +600,6 @@ class ModelArgs:
         self.model_config["DECODERS_OPTIMIZATIONS"] = self.optimizations
         # Update memory layouts (Tile, except MLP)
         self.model_config.update({f"{key}_TILE": ttnn.TILE_LAYOUT for key in self.OP_KEYS if "LAYOUT" in key})
-
-        self.cos, self.sin = precompute_freqs(
-            self.head_dim, self.max_seq_len * 2, self.rope_theta, self.rope_scaling_factor, self.orig_context_len
-        )  # for prefill
-        self.rot_emb = freqs_to_rotation_matrix(self.cos, self.sin)  # for decode
 
         self.tokenizer = None if dummy_weights else self.create_tokenizer()
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24282

### Problem description
We are initializing unused tensors that could be quite large depending on the `max_seq_len` and were causing OOM on certain data-parallel runs.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [all post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16195995177)
- [x] [TG demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16193731203)
- [x] [T3K unit+demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16195991250)