### PR TITLE
changed BS shard creation in upsample test

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
@@ -70,10 +70,11 @@ def test_bilinear_interleaved_memory(
     allclose = torch.allclose(output_tensor, torch_result, atol=1e-1, rtol=1e-1)
     assert allclose
 
+
 @pytest.mark.parametrize(
     "input_shape",
     [
-        [1, 640, 16, 32],
+        [1, 640, 32, 32],
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn as nn
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.unit_tests.operations.pool.test_upsample import upsample_multicore_common
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
@@ -68,3 +69,35 @@ def test_bilinear_interleaved_memory(
     logger.info(pcc_message)
     allclose = torch.allclose(output_tensor, torch_result, atol=1e-1, rtol=1e-1)
     assert allclose
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        [1, 640, 16, 32],
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize("scale_h", [2])
+@pytest.mark.parametrize("scale_w", [2])
+@pytest.mark.parametrize(
+    "core_range",
+    [
+        [((0, 0), (4, 3))],
+    ],
+)
+def test_rectangle_core_grid_bs(device, input_shape, scale_h, scale_w, core_range):
+    (torch_result, output_tensor) = upsample_multicore_common(
+        device=device,
+        input_shape=input_shape,
+        scale_h=scale_h,
+        scale_w=scale_w,
+        shard_strategy=ttnn.ShardStrategy.BLOCK,
+        shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        core_range=core_range,
+    )
+    ## compare the results
+    torch_result = torch_result.permute(0, 2, 3, 1)
+
+    isequal = torch.equal(output_tensor, torch_result)
+
+    assert isequal

--- a/tests/ttnn/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_upsample.py
@@ -146,9 +146,9 @@ def upsample_multicore_common(
         )
         if shard_strategy == ttnn.ShardStrategy.BLOCK:
             if shard_orientation == ttnn.ShardOrientation.ROW_MAJOR:
-                ncores = (core_range[0][1][0] - core_range[0][0][0] + 1, core_range[0][1][1] - core_range[0][0][1] + 1)
-            elif shard_orientation == ttnn.ShardOrientation.COL_MAJOR:
                 ncores = (core_range[0][1][1] - core_range[0][0][1] + 1, core_range[0][1][0] - core_range[0][0][0] + 1)
+            elif shard_orientation == ttnn.ShardOrientation.COL_MAJOR:
+                ncores = (core_range[0][1][0] - core_range[0][0][0] + 1, core_range[0][1][1] - core_range[0][0][1] + 1)
         elif shard_strategy == ttnn.ShardStrategy.HEIGHT:
             ncores = shard_grid.num_cores()
         else:

--- a/tests/ttnn/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_upsample.py
@@ -147,8 +147,6 @@ def upsample_multicore_common(
         if shard_strategy == ttnn.ShardStrategy.BLOCK:
             if shard_orientation == ttnn.ShardOrientation.ROW_MAJOR:
                 ncores = (core_range[0][1][1] - core_range[0][0][1] + 1, core_range[0][1][0] - core_range[0][0][0] + 1)
-            elif shard_orientation == ttnn.ShardOrientation.COL_MAJOR:
-                ncores = (core_range[0][1][0] - core_range[0][0][0] + 1, core_range[0][1][1] - core_range[0][0][1] + 1)
         elif shard_strategy == ttnn.ShardStrategy.HEIGHT:
             ncores = shard_grid.num_cores()
         else:
@@ -484,3 +482,36 @@ def test_nearest_upsample_with_uneven_input_shards(
 
     assert allclose
     assert passing
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        [1, 640, 16, 32],
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize("scale_h", [2])
+@pytest.mark.parametrize("scale_w", [2])
+@pytest.mark.parametrize(
+    "core_range",
+    [
+        [((0, 0), (4, 3))],
+    ],
+)
+def test_rectangle_core_grid_bs(device, input_shape, scale_h, scale_w, core_range):
+    (torch_result, output_tensor) = upsample_multicore_common(
+        device=device,
+        input_shape=input_shape,
+        scale_h=scale_h,
+        scale_w=scale_w,
+        shard_strategy=ttnn.ShardStrategy.BLOCK,
+        shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        core_range=core_range,
+    )
+    ## compare the results
+    torch_result = torch_result.permute(0, 2, 3, 1)
+
+    isequal = torch.equal(output_tensor, torch_result)
+
+    assert isequal


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Creating Block Sharded input tensors with rectangular core grid (x!=y) would fail because `core_range` arg in 
`upsample_multicore_common` would sometimes be interpreted as both (x,y) when creating `shard_grid` and (y,x) when calculating shard shape.

Currently no pipelines fail because all BS test cases that have core_range in have square core_grid, not rectangular

### What's changed
Changed how the shard shape calculation is done ( `ncores` variable is used)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16195153399)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI  [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16195163248)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16197376453)