### PR TITLE
Correcting CCL core placement for full TG compatibility

### DIFF
--- a/models/demos/llama3_subdevices/tt/model_config.py
+++ b/models/demos/llama3_subdevices/tt/model_config.py
@@ -1559,7 +1559,8 @@ class TtModelArgs:
             )
 
             # Note PACKET_WORKER_CRS is 8 cores and it can NOT use any core in the following ranges:
-            # {2,8}-{3,8},{5,3}-{6,3}  (Reduce scatter ethernet worker cores),
+            # {2,8}-{3,8},{5,3}-{6,3}  (CCL cores in 6u),
+            # {3,3},{5,3}-{6,3}  (CCL cores in TG)
             # {1,0}-{2,0}, {1,4}-{2,5}, {1,9}-{2,9}, {5,0}-{6,2}, {5,4}-{6,7}, {5,9}-{6,9} (Matmul)
             # {0,0}-{0,9}, {4,0}-{4,9} (Prefetcher)
             # {3,6} (Matmul hop core)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_common.cpp
@@ -8,7 +8,8 @@ namespace llama_specific {
 
 CoreRangeSet get_custom_cores(uint32_t num_workers, bool row_wise) {
     CoreRangeSet worker_cores;
-    std::vector<CoreRange> desired_core_range = {CoreRange({5, 3}, {6, 3}), CoreRange({2, 8}, {3, 8})};
+    std::vector<CoreRange> desired_core_range = {
+        CoreRange({5, 3}, {6, 3}), num_workers == 4 ? CoreRange({2, 8}, {3, 8}) : CoreRange({3, 3}, {3, 3})};
     for (const auto& cr : desired_core_range) {
         auto cores = corerange_to_cores(cr, std::nullopt, row_wise);
         for (const auto& core : cores) {


### PR DESCRIPTION
### Ticket
Fixes broken CCL nightly test

### Problem description
Some unit tests and models restricted compute to the {6,6} core range, one of the dedicated CCL core for TG was outside this range, it was moved to core {3,3} from {2,8} in TG only which is slightly less ideal as the traffic is a tiny bit less well distributed but it should still be an improvement and does not clash

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16199097048
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] Full Llama suite: https://github.com/tenstorrent/tt-metal/actions/runs/16198934477
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes
