### PR TITLE
Fix TSAN error creating ethernet kernel

### DIFF
--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -503,22 +503,21 @@ void EthernetKernel::read_binaries(IDevice* device) {
         device->build_id(), erisc_core_type, dm_class_idx, erisc_id);
     // TODO: fix when active eth supports relo
     auto load_type = MetalContext::instance().hal().get_jit_build_config(erisc_core_type, erisc_id, 0).memory_load;
-    ll_api::memory const& binary_mem = llrt::get_risc_binary(
-        build_state.get_target_out_path(this->kernel_full_name_),
-        load_type);
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled() &&
-        this->config_.eth_mode != Eth::IDLE) {
-        // text_addr and some of span's addr point to IRAM base address.
-        // However it need to be placed L1 kernel base address for FW to copy it to IRAM then kick off
-        // The kernel can run with IRAM base address once it started.
-        const_cast<ll_api::memory&>(binary_mem)
-            .set_text_addr(tt::tt_metal::MetalContext::instance().hal().erisc_iram_relocate_dev_addr(
-                (uint64_t)binary_mem.get_text_addr()));
-        std::function<void(uint64_t& addr)> update_callback = [](uint64_t& addr) {
-            addr = tt::tt_metal::MetalContext::instance().hal().erisc_iram_relocate_dev_addr(addr);
-        };
-        const_cast<ll_api::memory&>(binary_mem).update_spans(update_callback);
-    }
+    const ll_api::memory& binary_mem = llrt::get_risc_binary(
+        build_state.get_target_out_path(this->kernel_full_name_), load_type, [this](ll_api::memory& binary_mem) {
+            if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled() &&
+                this->config_.eth_mode != Eth::IDLE) {
+                // text_addr and some of span's addr point to IRAM base address.
+                // However it need to be placed L1 kernel base address for FW to copy it to IRAM then kick off
+                // The kernel can run with IRAM base address once it started.
+                binary_mem.set_text_addr(tt::tt_metal::MetalContext::instance().hal().erisc_iram_relocate_dev_addr(
+                    (uint64_t)binary_mem.get_text_addr()));
+                std::function<void(uint64_t& addr)> update_callback = [](uint64_t& addr) {
+                    addr = tt::tt_metal::MetalContext::instance().hal().erisc_iram_relocate_dev_addr(addr);
+                };
+                binary_mem.update_spans(update_callback);
+            }
+        });
     binaries.push_back(&binary_mem);
     uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "ERISC={}, name={}, size={} (bytes)", erisc_id, this->name(), binary_size);

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -41,7 +41,8 @@ using std::uint16_t;
 using std::uint32_t;
 using std::uint64_t;
 
-const ll_api::memory& get_risc_binary(std::string_view path, ll_api::memory::Loading loading) {
+const ll_api::memory& get_risc_binary(
+    std::string_view path, ll_api::memory::Loading loading, std::function<void(ll_api::memory&)> update_callback) {
     static struct {
       std::unordered_map<std::string, std::unique_ptr<ll_api::memory const>> map;
       std::mutex mutex;
@@ -50,15 +51,19 @@ const ll_api::memory& get_risc_binary(std::string_view path, ll_api::memory::Loa
 
     std::unique_lock lock(cache.mutex);
     auto [slot, inserted] = cache.map.try_emplace(std::string(path));
-    ll_api::memory const* ptr = nullptr;
+    const ll_api::memory* ptr = nullptr;
     if (inserted) {
       // We're the first with PATH. Create and insert.
       lock.unlock();
-      ptr = new ll_api::memory(path, loading);
+      ll_api::memory* mutable_ptr = new ll_api::memory(path, loading);
+      if (update_callback) {
+          update_callback(*mutable_ptr);
+      }
 
       lock.lock();
       // maps have iterator stability, so SLOT is still valid.
-      slot->second = decltype(slot->second)(ptr);
+      slot->second = decltype(slot->second)(mutable_ptr);
+      ptr = mutable_ptr;
       // We can't wake just those waiting on this slot, so wake them
       // all. Should be a rare event anyway.
       cache.cvar.notify_all();

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -58,9 +58,11 @@ using WorkerCore = tt_cxy_pair;
 using WorkerCores = std::vector<WorkerCore>;
 
 // Return a reference to a potentially shared binary image.
-// The images are cached by path name.
+// The images are cached by path name only.
 const ll_api::memory& get_risc_binary(
-    std::string_view path, ll_api::memory::Loading loading = ll_api::memory::Loading::DISCRETE);
+    std::string_view path,
+    ll_api::memory::Loading loading = ll_api::memory::Loading::DISCRETE,
+    std::function<void(ll_api::memory&)> update_callback = nullptr);
 
 // TODO: try using "stop" method from device instead, it's the proper way of asserting reset
 


### PR DESCRIPTION
### Problem description
We get a TSAN error when doing EthernetKernel::read_binaries

### What's changed
Add a callback to get_risc_binary to do some initialization before returning the kernel. That way the initialization will only be done once and won't cause a TSAN error.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes