### PR TITLE
Revert Unet Perf Reduction

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -134,7 +134,7 @@ def test_unet_trace_perf(
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2350.0),)
+    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2400.0),)
 )
 def test_unet_trace_perf_multi_device(
     batch: int,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
A CI machine was showing instability in this test.

### What's changed
The offending machine has been taken offline, so the expected perf of this test has been reset.

### Checklist
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/16202464909 (in progress)