### PR TITLE
Profile dispatch cores after non-dispatch cores and make dispatch calls in profiler synchronous

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -222,7 +222,7 @@ def test_dispatch_cores():
     RISC_COUNT = 1
     ZONE_COUNT = 37
     REF_COUNT_DICT = {
-        "Tensix CQ Dispatch": [600, 1310, 2330],
+        "Tensix CQ Dispatch": [600, 760, 1310, 2330],
         "Tensix CQ Prefetch": [900, 1440, 3870, 5000],
         "dispatch_total_cq_cmd_op_time": [103],
         "dispatch_go_send_wait_time": [103],

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -222,8 +222,8 @@ def test_dispatch_cores():
     RISC_COUNT = 1
     ZONE_COUNT = 37
     REF_COUNT_DICT = {
-        "Tensix CQ Dispatch": [400, 600, 1000, 1290, 2000],
-        "Tensix CQ Prefetch": [400, 900, 1580, 4000],
+        "Tensix CQ Dispatch": [400, 1000, 1290, 2000],
+        "Tensix CQ Prefetch": [400, 800, 1000, 1580, 4000],
         "dispatch_total_cq_cmd_op_time": [103],
         "dispatch_go_send_wait_time": [103],
     }
@@ -293,7 +293,7 @@ def test_dispatch_cores():
 @skip_for_grayskull()
 def test_ethernet_dispatch_cores():
     REF_COUNT_DICT = {
-        "Ethernet CQ Dispatch": [322, 600, 1400, 1900, 2100],
+        "Ethernet CQ Dispatch": [322, 541, 1400, 1650, 1900, 2100],
         "Ethernet CQ Prefetch": [600, 2500],
     }
     devicesData = run_device_profiler_test(

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -222,8 +222,8 @@ def test_dispatch_cores():
     RISC_COUNT = 1
     ZONE_COUNT = 37
     REF_COUNT_DICT = {
-        "Tensix CQ Dispatch": [400, 1000, 1290, 2000],
-        "Tensix CQ Prefetch": [400, 800, 1000, 1580, 4000],
+        "Tensix CQ Dispatch": [600, 1310, 2330],
+        "Tensix CQ Prefetch": [900, 1440, 3870, 5000],
         "dispatch_total_cq_cmd_op_time": [103],
         "dispatch_go_send_wait_time": [103],
     }
@@ -240,9 +240,12 @@ def test_dispatch_cores():
                         if count - allowedRange <= readCount <= count + allowedRange:
                             res = True
                             break
-                    assert (
-                        res
-                    ), f"Wrong tensix dispatch zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
+                    print(
+                        f"Wrong tensix dispatch zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
+                    )
+                    # assert (
+                    #     res
+                    # ), f"Wrong tensix dispatch zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
 
         statTypesSet = set(statTypes)
         for statType in statTypes:
@@ -292,10 +295,7 @@ def test_dispatch_cores():
 @skip_for_blackhole()
 @skip_for_grayskull()
 def test_ethernet_dispatch_cores():
-    REF_COUNT_DICT = {
-        "Ethernet CQ Dispatch": [322, 541, 1400, 1650, 1900, 2100],
-        "Ethernet CQ Prefetch": [600, 2500],
-    }
+    REF_COUNT_DICT = {"Ethernet CQ Dispatch": [590, 1220, 1430, 1660, 2320], "Ethernet CQ Prefetch": []}
     devicesData = run_device_profiler_test(
         testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_with_ops",
         setupAutoExtract=True,
@@ -312,9 +312,12 @@ def test_ethernet_dispatch_cores():
                     if count - allowedRange < readCount < count + allowedRange:
                         res = True
                         break
-                assert (
-                    res
-                ), f"Wrong ethernet dispatch zone count, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
+                print(
+                    f"Wrong ethernet dispatch zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
+                )
+                # assert (
+                #     res
+                # ), f"Wrong ethernet dispatch zone count, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
 
     devicesData = run_device_profiler_test(
         testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_all_devices",
@@ -332,9 +335,12 @@ def test_ethernet_dispatch_cores():
                     if count - allowedRange < readCount < count + allowedRange:
                         res = True
                         break
-                assert (
-                    res
-                ), f"Wrong ethernet dispatch zone count, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
+                print(
+                    f"Wrong ethernet dispatch zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
+                )
+                # assert (
+                #     res
+                # ), f"Wrong ethernet dispatch zone count, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
 
 
 @skip_for_grayskull()

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -292,7 +292,7 @@ def test_dispatch_cores():
 @skip_for_blackhole()
 @skip_for_grayskull()
 def test_ethernet_dispatch_cores():
-    REF_COUNT_DICT = {"Ethernet CQ Dispatch": [590, 1220, 1430, 1660, 2320], "Ethernet CQ Prefetch": []}
+    REF_COUNT_DICT = {"Ethernet CQ Dispatch": [590, 1220, 1430, 1660, 2320], "Ethernet CQ Prefetch": [1180, 4630]}
     devicesData = run_device_profiler_test(
         testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_with_ops",
         setupAutoExtract=True,

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -240,12 +240,9 @@ def test_dispatch_cores():
                         if count - allowedRange <= readCount <= count + allowedRange:
                             res = True
                             break
-                    print(
-                        f"Wrong tensix dispatch zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
-                    )
-                    # assert (
-                    #     res
-                    # ), f"Wrong tensix dispatch zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
+                    assert (
+                        res
+                    ), f"Wrong tensix dispatch zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
 
         statTypesSet = set(statTypes)
         for statType in statTypes:
@@ -312,12 +309,9 @@ def test_ethernet_dispatch_cores():
                     if count - allowedRange < readCount < count + allowedRange:
                         res = True
                         break
-                print(
-                    f"Wrong ethernet dispatch zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
-                )
-                # assert (
-                #     res
-                # ), f"Wrong ethernet dispatch zone count, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
+                assert (
+                    res
+                ), f"Wrong ethernet dispatch zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
 
     devicesData = run_device_profiler_test(
         testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_all_devices",
@@ -335,12 +329,9 @@ def test_ethernet_dispatch_cores():
                     if count - allowedRange < readCount < count + allowedRange:
                         res = True
                         break
-                print(
-                    f"Wrong ethernet dispatch zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
-                )
-                # assert (
-                #     res
-                # ), f"Wrong ethernet dispatch zone count, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
+                assert (
+                    res
+                ), f"Wrong ethernet dispatch zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
 
 
 @skip_for_grayskull()

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1437,7 +1437,10 @@ void DeviceProfiler::dumpResults(
     // create nlohmann json log object
     nlohmann::ordered_json noc_trace_json_log = nlohmann::json::array();
 
+    // Dispatch cores must be added after non-dispatch cores as they must be profiled after non-dispatch cores in order
+    // to minimize the amount of dispatch data that is lost
     TT_ASSERT(doAllDispatchCoresComeAfterNonDispatchCores(device, virtual_cores));
+
     if (data_source == ProfilerDataBufferSource::DRAM) {
         readControlBuffers(device, virtual_cores, state);
 

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -354,8 +354,6 @@ bool onlyProfileDispatchCores(ProfilerDumpState state);
 
 bool isGalaxyMMIODevice(const IDevice* device);
 
-void waitForDeviceCommandsToFinish(IDevice* device);
-
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -787,8 +787,6 @@ void DumpDeviceProfileResults(
         }
     }
 
-    // Dispatch cores must be added after non-dispatch cores as they must be profiled after non-dispatch cores in order
-    // to minimize the amount of dispatch data that is lost
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_do_dispatch_cores()) {
         for (const CoreCoord& core :
              tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -773,14 +773,8 @@ void DumpDeviceProfileResults(
     const chip_id_t device_id = device->id();
     const uint8_t device_num_hw_cqs = device->num_hw_cqs();
     const auto& dispatch_core_config = get_dispatch_core_config();
-    if (onlyProfileDispatchCores(state)) {
-        for (const CoreCoord& core :
-             tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {
-            const CoreCoord curr_core =
-                device->virtual_core_from_logical_core(core, dispatch_core_config.get_core_type());
-            virtual_cores.push_back(curr_core);
-        }
-    } else {
+
+    if (!onlyProfileDispatchCores(state)) {
         for (const CoreCoord& core :
              tt::get_logical_compute_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {
             const CoreCoord curr_core = device->worker_core_from_logical_core(core);
@@ -788,6 +782,17 @@ void DumpDeviceProfileResults(
         }
         for (const CoreCoord& core : device->get_active_ethernet_cores(true)) {
             const CoreCoord curr_core = device->virtual_core_from_logical_core(core, CoreType::ETH);
+            virtual_cores.push_back(curr_core);
+        }
+    }
+
+    // Dispatch cores must be added after non-dispatch cores as they must be profiled after non-dispatch cores in order
+    // to minimize the amount of dispatch data that is lost
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_do_dispatch_cores()) {
+        for (const CoreCoord& core :
+             tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {
+            const CoreCoord curr_core =
+                device->virtual_core_from_logical_core(core, dispatch_core_config.get_core_type());
             virtual_cores.push_back(curr_core);
         }
     }

--- a/tt_metal/tools/profiler/device_post_proc_config.py
+++ b/tt_metal/tools/profiler/device_post_proc_config.py
@@ -302,8 +302,8 @@ class test_ethernet_dispatch_cores(default_setup):
         "Ethernet CQ Prefetch": {
             "across": "core",
             "type": "adjacent",
-            "start": {"risc": "ERISC", "zone_name": "KERNEL-MAIN-HD"},
-            "end": {"risc": "ERISC", "zone_name": "KERNEL-MAIN-HD"},
+            "start": {"risc": "ERISC", "zone_name": "CQ-PREFETCH"},
+            "end": {"risc": "ERISC", "zone_name": "CQ-PREFETCH"},
         },
     }
     detectOps = False


### PR DESCRIPTION
### Ticket
#24640 

A lot of profiling data for dispatch cores is not being picked up because profiling data for these cores is being dumped before profiling data for non-dispatch cores. This PR reverses the order so that profiling data for non-dispatch cores is dumped before data for dispatch cores, thus ensuring that most profiling data for dispatch cores is picked up.

This PR also makes profiler dispatch calls synchronous as it improves the readability of the profiler codebase.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/16228995550)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/16228235988)
- [x] [T3K Profiler] (https://github.com/tenstorrent/tt-metal/actions/runs/16228241129)
- [x] New/Existing tests provide coverage for changes