### PR TITLE
Remove redundant access specifiers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -185,7 +185,6 @@ Checks: >
   -readability-named-parameter,
   -readability-non-const-parameter,
   -readability-qualified-auto,
-  -readability-redundant-access-specifiers,
   -readability-redundant-control-flow,
   -readability-redundant-member-init,
   -readability-redundant-smartptr-get,

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -41,7 +41,6 @@ public:
         return true;
     }
 
-public:
     TTNNFixtureBase() : TTNNFixtureBase(DEFAULT_TRACE_REGION_SIZE, DEFAULT_L1_SMALL_SIZE) { }
 
     TTNNFixtureBase(int trace_region_size, int l1_small_size) :

--- a/tt_metal/api/tt-metalium/mesh_workload.hpp
+++ b/tt_metal/api/tt-metalium/mesh_workload.hpp
@@ -45,7 +45,6 @@ public:
 private:
     std::unique_ptr<MeshWorkloadImpl> pimpl_;
 
-private:
     friend void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking);
     friend FDMeshCommandQueue;
 };

--- a/tt_metal/llrt/tt_elffile.cpp
+++ b/tt_metal/llrt/tt_elffile.cpp
@@ -59,14 +59,12 @@ private:
     const std::string path_;
     ElfFile& owner_;
 
-private:
     class Weakener;
 
 public:
     Impl(ElfFile& owner, std::string_view path) : owner_(owner), path_(std::string(path)) {}
     ~Impl() = default;
 
-public:
     void LoadImage();
     void WeakenDataSymbols(std::span<std::string_view const> strong_names);
     void XIPify();
@@ -132,7 +130,6 @@ private:
         return symbol.st_shndx < GetShdrs().size() && GetSegmentIx(GetShdr(symbol.st_shndx)) > 0;
     }
 
-private:
     template <typename T = std::byte>
     [[nodiscard]] static T* ByteOffset(std::byte* base, size_t offset = 0) {
         return reinterpret_cast<T*>(base + offset);

--- a/tt_metal/llrt/tt_elffile.hpp
+++ b/tt_metal/llrt/tt_elffile.hpp
@@ -38,7 +38,6 @@ public:
             contents(contents), address(addr), lma(lma), membytes(membytes) {}
     };
 
-public:
     ElfFile() = default;
     ~ElfFile();
 
@@ -58,10 +57,8 @@ public:
         return *this;
     }
 
-public:
     std::vector<Segment> const& GetSegments() const { return segments_; }
 
-public:
     // Release the implementation data, leaving the segments and
     // contents. Use this, after processing, if the elf object is long-lived.
     void ReleaseImpl();

--- a/tt_metal/llrt/tt_memory.h
+++ b/tt_metal/llrt/tt_memory.h
@@ -37,7 +37,6 @@ public:
     memory();
     memory(std::string_view path, Loading loading);
 
-public:
     // These can be large objects, so ban copying ...
     memory(const memory&) = delete;
     memory& operator=(const memory&) = delete;
@@ -45,7 +44,6 @@ public:
     memory(memory&&) = default;
     memory& operator=(memory&&) = default;
 
-public:
     const std::vector<word_t>& data() const { return this->data_; }
 
     bool operator==(const memory& other) const;
@@ -60,7 +58,6 @@ public:
 
     size_t num_spans() const { return link_spans_.size(); }
 
-public:
     // Process spans in arg mem to fill data in *this (eg, from device)
     void fill_from_mem_template(
         const memory& mem_template,

--- a/tt_stl/tt_stl/slotmap.hpp
+++ b/tt_stl/tt_stl/slotmap.hpp
@@ -135,7 +135,6 @@ private:
         = default;
     };
 
-private:
     static constexpr index_type max_index = KeyT::max_index;
     static constexpr index_type invalid_index = std::numeric_limits<index_type>::max();
     std::vector<Slot> slots;

--- a/ttnn/api/ttnn/graph/graph_argument_serializer.hpp
+++ b/ttnn/api/ttnn/graph/graph_argument_serializer.hpp
@@ -35,7 +35,6 @@ private:
 
     void initialize();
 
-private:
     std::unordered_map<std::type_index, GraphArgumentSerializer::ConvertionFunction> map;
 };
 }  // namespace ttnn::graph

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -392,7 +392,6 @@ class RingReduceScatterBaseTensorSlicer : public LegacyCclTensorSlicer {
         TT_THROW("deprecated code path for ");
     }
 
-   public:
     std::vector<tt_xy_pair> get_worker_slice_shapes() const { return this->worker_slice_shapes; }
     uint32_t get_worker_slice_size_bytes(std::size_t worker_index) {
         TT_ASSERT(this->worker_slice_shapes.size() > worker_index, "Invalid worker index {} in `worker_slice_shapes` of size {}", worker_index, worker_slice_shapes.size());


### PR DESCRIPTION
### Ticket
Fixes #24867

### Problem description
Redundant things are redundant.

### What's changed
* Enabled the check
* Removed redundancy