### PR TITLE
Fix ttnn tensor tests with ASan

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/common_tensor_test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/common_tensor_test_utils.cpp
@@ -33,15 +33,13 @@ void test_tensor_on_device(
 
     const ttnn::QueueId io_cq = ttnn::DefaultQueueId;
 
-    const auto input_buf_size_bytes = layout.compute_packed_buffer_size_bytes(input_shape);
-    const auto host_buffer_datum_size_bytes = sizeof(uint32_t);
-    const auto input_buf_size = input_buf_size_bytes / host_buffer_datum_size_bytes;
+    const auto input_buf_size = layout.compute_packed_buffer_size_bytes(input_shape);
 
-    auto host_data = std::shared_ptr<void>(new uint32_t[input_buf_size], std::default_delete<uint32_t[]>());
-    auto* host_data_ptr = static_cast<uint32_t*>(host_data.get());
+    auto host_data = std::shared_ptr<void>(new uint8_t[input_buf_size], std::default_delete<uint8_t[]>());
+    auto* host_data_ptr = static_cast<uint8_t*>(host_data.get());
 
-    auto readback_data = std::shared_ptr<void>(new uint32_t[input_buf_size], std::default_delete<uint32_t[]>());
-    auto* readback_data_ptr = static_cast<uint32_t*>(readback_data.get());
+    auto readback_data = std::shared_ptr<void>(new uint8_t[input_buf_size], std::default_delete<uint8_t[]>());
+    auto* readback_data_ptr = static_cast<uint8_t*>(readback_data.get());
 
     const auto random_prime_number = 4051;
     for (int i = 0; i < input_buf_size; i++) {


### PR DESCRIPTION
### Ticket
Closes:
- https://github.com/tenstorrent/tt-metal/issues/24834
- https://github.com/tenstorrent/tt-metal/issues/24843
- https://github.com/tenstorrent/tt-metal/issues/24845

### Problem description
Some ttnn tensor tests are broken with ASan

### What's changed
- Switch to uint8_t for host vectors in test_tensor_on_device (https://github.com/tenstorrent/tt-metal/issues/24834)
- Add handling of non-uint32_t-aligned src addresses in memcpy_to_device (https://github.com/tenstorrent/tt-metal/issues/24843, https://github.com/tenstorrent/tt-metal/issues/24845)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/16229208206
  - Failure seem unrelated
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes