### PR TITLE
Remove Generic Pool HW % 32 == 0 Restriction

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
@@ -21,12 +21,6 @@ def randomize_tensor(tensor_map, tensor_shape):
         torch_tensor = tensor_map[tensor_shape]
     else:
         torch_tensor = torch.rand(tensor_shape, dtype=torch.bfloat16)
-    # torch_tensor = torch.zeros(tensor_shape, dtype=torch.bfloat16)
-    # for n in range(tensor_shape[0]):
-    #     for c in range(tensor_shape[1]):
-    #         for h in range(tensor_shape[2]):
-    #             for w in range(tensor_shape[3]):
-    #                 torch_tensor[n, c, h, w] = h * tensor_shape[3] + w
     return torch_tensor
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -187,12 +187,6 @@ def run_max_pool(
     act_reshaped = act_permuted.reshape(act_shape)
 
     if dtype == ttnn.bfloat8_b:
-        if (in_h * in_w) % 32 != 0:
-            pytest.skip("For BFP8_B datatype, input height * width should be multiple of 32")
-        if shard_scheme == ttnn.TensorMemoryLayout.WIDTH_SHARDED and (in_c / max_cores) % 32 != 0:
-            pytest.skip("For BFP8_B datatype, input channels / max_cores should be multiple of 32")
-        if shard_scheme == ttnn.TensorMemoryLayout.BLOCK_SHARDED and (in_c / cores_x) % 32 != 0:
-            pytest.skip("For BFP8_B datatype, input channels / cores_x should be multiple of 32")
         ttact = ttnn.from_torch(act_reshaped, dtype, layout=ttnn.TILE_LAYOUT)
     else:
         ttact = ttnn.from_torch(act_reshaped, dtype)

--- a/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
@@ -23,6 +23,7 @@ def tensor_map():
         [2, 32, 16, 16],
         [1, 512, 112, 32],
         [1, 320, 48, 48],
+        [1, 320, 47, 47],
     ),
 )
 @pytest.mark.parametrize(
@@ -79,6 +80,10 @@ def tensor_map():
     "use_program_cache",
     [True, False],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [ttnn.bfloat16, ttnn.bfloat8_b],
+)
 def test_avg_pool2d_post_commit(
     device,
     tensor_map,
@@ -91,12 +96,15 @@ def test_avg_pool2d_post_commit(
     divisor_override,
     count_include_pad,
     shard_scheme,
+    dtype,
 ):
     # we only want to test the largest kernel size with a specific input shape
     # to test otherwise untouched paths in the large kernel, other shapes run OOM
     # or will just slow the test down doing redundant work
-    if kernel_size == (36, 36) and input_shape != [1, 320, 48, 48]:
-        pytest.skip("Skipping only run shape [1, 320, 48, 48] with kernel size (36, 36)")
+    if kernel_size == (36, 36) and input_shape != [1, 320, 48, 48] and input_shape != [1, 320, 47, 47]:
+        pytest.skip("Skipping, only run shapes [1, 320, 48, 48] and [1, 320, 47, 47] with kernel size (36, 36)")
+    if dtype == ttnn.bfloat8_b and input_shape != [1, 320, 48, 48] and input_shape != [1, 320, 47, 47]:
+        pytest.skip("Skipping, only run shapes [1, 320, 48, 48] and [1, 320, 47, 47] with bfloat8_b dtype")
     run_avg_pool2d(
         device=device,
         tensor_map=tensor_map,
@@ -108,4 +116,5 @@ def test_avg_pool2d_post_commit(
         divisor_override=divisor_override,
         count_include_pad=count_include_pad,
         shard_scheme=shard_scheme,
+        dtype=dtype,
     )

--- a/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
@@ -61,6 +61,7 @@ parameters = {
             [1, 256, 20, 20, 8, 8, 6, 6, 0, 0, 1, 1, False],  # max rows per reduction multiple large kernel
             [1, 512, 20, 20, 8, 8, 6, 6, 0, 0, 1, 1, False],  # max rows per reduction multiple large kernel wide
             [1, 320, 48, 48, 36, 36, 1, 1, 0, 0, 1, 1, False],  # 3 reduction stages, multiple indexes per core, wide
+            [1, 320, 47, 47, 36, 36, 1, 1, 0, 0, 1, 1, False],  # non-tile multiple NHW, C
         ],
     },
     "test_run_max_pool": {

--- a/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
@@ -61,7 +61,7 @@ parameters = {
             [1, 256, 20, 20, 8, 8, 6, 6, 0, 0, 1, 1, False],  # max rows per reduction multiple large kernel
             [1, 512, 20, 20, 8, 8, 6, 6, 0, 0, 1, 1, False],  # max rows per reduction multiple large kernel wide
             [1, 320, 48, 48, 36, 36, 1, 1, 0, 0, 1, 1, False],  # 3 reduction stages, multiple indexes per core, wide
-            [1, 320, 47, 47, 36, 36, 1, 1, 0, 0, 1, 1, False],  # non-tile multiple NHW, C
+            [1, 320, 47, 47, 36, 36, 1, 1, 0, 0, 1, 1, False],  # non-tile multiple NHW
         ],
     },
     "test_run_max_pool": {

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -52,12 +52,12 @@ static Tensor pool2d_invoke(
         .ceil_mode = ceil_mode,
         .is_avg_pool = pool_type == Pool2DType::AVG_POOL2D,
     };
-    auto output_shape = sliding_window_config.get_output_shape();  // last dim/width is 0
+    auto output_shape = sliding_window_config.get_output_shape();
     auto input_tensor_sharded = input_tensor;
 
     // pool output is row major
     bool is_out_tiled = false;
-    bool is_in_tiled = input_tensor.dtype() == DataType::BFLOAT8_B;  // input tiled for bfp8_b
+    bool is_in_tiled = input_tensor.layout() == ttnn::TILE_LAYOUT;
 
     sliding_window::ParallelConfig parallel_config;
     MemoryConfig out_memory_config = input_tensor_sharded.memory_config();
@@ -85,7 +85,7 @@ static Tensor pool2d_invoke(
                 ShardOrientation::ROW_MAJOR,
                 false,
                 false,
-                false,
+                is_in_tiled,  // if input is tiled we need the shard width to be a tile multiple
                 0);
         } else {  // auto-sharding
             std::optional<sliding_window::ParallelConfig> sw_parallel_config =

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -86,7 +86,7 @@ static Tensor pool2d_invoke(
                 false,
                 false,
                 is_in_tiled,  // if input is tiled we need to choose num_cores_c to make the shard width to be a tile
-                              // multiple
+                              // multiple, it cannot be 16
                 0);
         } else {  // auto-sharding
             std::optional<sliding_window::ParallelConfig> sw_parallel_config =
@@ -124,12 +124,11 @@ static Tensor pool2d_invoke(
     // update the shard spec to match the output shape
     auto shard_spec = out_memory_config.shard_spec().value();
     uint32_t output_shard_width_padded =
-        input_tensor.dtype() == DataType::BFLOAT8_B
-            ? tt::round_up(channels / num_cores_c, tt::constants::TILE_WIDTH)
-            : tt::round_up(
-                  channels / num_cores_c *
-                      tt::datum_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype())),
-                  tt::constants::TILE_WIDTH);
+        is_out_tiled ? tt::round_up(channels / num_cores_c, tt::constants::TILE_WIDTH)
+                     : tt::round_up(
+                           channels / num_cores_c *
+                               tt::datum_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype())),
+                           tt::constants::TILE_WIDTH);
     uint32_t output_nhw = output_shape[0] * output_shape[1] * output_shape[2];
     uint32_t output_nhw_padded =
         tt::round_up(output_nhw, num_cores_nhw * (is_out_tiled ? tt::constants::TILE_HEIGHT : 1));

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -85,7 +85,8 @@ static Tensor pool2d_invoke(
                 ShardOrientation::ROW_MAJOR,
                 false,
                 false,
-                is_in_tiled,  // if input is tiled we need the shard width to be a tile multiple
+                is_in_tiled,  // if input is tiled we need to choose num_cores_c to make the shard width to be a tile
+                              // multiple
                 0);
         } else {  // auto-sharding
             std::optional<sliding_window::ParallelConfig> sw_parallel_config =

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -123,16 +123,13 @@ static Tensor pool2d_invoke(
 
     // update the shard spec to match the output shape
     auto shard_spec = out_memory_config.shard_spec().value();
-    uint32_t output_shard_width_padded =
-        is_out_tiled ? tt::round_up(channels / num_cores_c, tt::constants::TILE_WIDTH)
-                     : tt::round_up(
-                           channels / num_cores_c *
-                               tt::datum_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype())),
-                           tt::constants::TILE_WIDTH);
     uint32_t output_nhw = output_shape[0] * output_shape[1] * output_shape[2];
     uint32_t output_nhw_padded =
         tt::round_up(output_nhw, num_cores_nhw * (is_out_tiled ? tt::constants::TILE_HEIGHT : 1));
     uint32_t output_shard_height_padded = output_nhw_padded / num_cores_nhw;
+    uint32_t output_c = channels;
+    uint32_t output_c_padded = tt::round_up(output_c, num_cores_c * (is_out_tiled ? tt::constants::TILE_WIDTH : 1));
+    uint32_t output_shard_width_padded = output_c_padded / num_cores_c;
     log_debug(
         tt::LogOp,
         "output_nhw: {}, output_nhw_padded: {}, output_shard_height_padded: {}, output_shard_width_padded: {}",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15108

### Problem description
Previously there was an issue with Generic Pool parameterizations where HW % 32 != 0.

### What's changed
This problem no longer exists.  Unfortunately it is unclear what the solution was.  This PR removes the restriction and adds new test non-tile multiple HW parameterizations to the Generic Pool unit test.  The Average Pool unit test has also been updated to:
- alllow Bfloat8 testing
- raise the `atol` threshold from 0.0 to 0.35 for Bfloat8  and to 0.016 (the torch default) for Bfloat16
- lower the `rtol` threshold for all test cases from 0.02 to 0.01 (we cannot support the torch default of 0.0001 due to the use of Bfloat16 scalars)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/16312449266
failing on main this PR hits same error, unrelated to changes in this PR
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable):
https://github.com/tenstorrent/tt-metal/actions/runs/16312451705
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/16312454242
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
(wormhole) https://github.com/tenstorrent/tt-metal/actions/runs/16312457293
(blackhole) https://github.com/tenstorrent/tt-metal/actions/runs/16312459598
- [x] New/Existing tests provide coverage for changes