### PR TITLE
Rework BufferDistributionSpec API for providing core groups

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-logger/tt-logger.hpp>
-#include "core_coord.hpp"
 #include "gtest/gtest.h"
 
 #include "ttnn/tensor/tensor.hpp"

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt-logger/tt-logger.hpp>
+#include "core_coord.hpp"
 #include "gtest/gtest.h"
 
 #include "ttnn/tensor/tensor.hpp"
@@ -52,9 +54,7 @@ struct NDShardingCoreInfoParams {
 
     size_t expected_max_num_shards_per_core = 0;
     std::vector<size_t> expected_num_shards_per_core;
-    std::vector<CoreCoord> expected_cores_with_data;
-    BufferDistributionSpec::CoreGroup expected_core_group_1;
-    BufferDistributionSpec::CoreGroup expected_core_group_2;
+    BufferDistributionSpec::CoreGroups expected_groups;
 };
 struct NDShardingSqueezeRankParams {
     Shape tensor_shape_pages;
@@ -319,13 +319,12 @@ TEST_P(NDShardingCoreInfoTests, TestCoreInfo) {
         EXPECT_EQ(dspec.num_shards_per_core(i), params.expected_num_shards_per_core[i]);
     }
 
-    EXPECT_EQ(dspec.get_cores_with_data(), params.expected_cores_with_data);
-
-    auto [core_group_1, core_group_2] = dspec.get_core_groups_by_num_shards();
-    EXPECT_EQ(core_group_1.num_shards, params.expected_core_group_1.num_shards);
-    EXPECT_EQ(core_group_1.cores, params.expected_core_group_1.cores);
-    EXPECT_EQ(core_group_2.num_shards, params.expected_core_group_2.num_shards);
-    EXPECT_EQ(core_group_2.cores, params.expected_core_group_2.cores);
+    const auto& core_groups = dspec.core_groups();
+    EXPECT_EQ(core_groups.cores_with_data, params.expected_groups.cores_with_data);
+    EXPECT_EQ(core_groups.cores_in_group_1, params.expected_groups.cores_in_group_1);
+    EXPECT_EQ(core_groups.cores_in_group_2, params.expected_groups.cores_in_group_2);
+    EXPECT_EQ(core_groups.num_shards_per_core_in_group_1, params.expected_groups.num_shards_per_core_in_group_1);
+    EXPECT_EQ(core_groups.num_shards_per_core_in_group_2, params.expected_groups.num_shards_per_core_in_group_2);
 }
 
 class NDShardingSqueezeRankTests : public ::testing::TestWithParam<NDShardingSqueezeRankParams> {};
@@ -336,12 +335,12 @@ TEST_P(NDShardingSqueezeRankTests, TestSqueezeRank) {
     CoreRangeSet cores(CoreRange(CoreCoord{0, 0}, CoreCoord{6, 6}));
     BufferDistributionSpec dspec(
         params.tensor_shape_pages, params.shard_shape_pages, cores, ShardOrientation::ROW_MAJOR);
-    EXPECT_EQ(dspec.get_tensor_shape_in_pages(), params.expected_tensor_shape_pages);
-    EXPECT_EQ(dspec.get_shard_shape_in_pages(), params.expected_shard_shape_pages);
+    EXPECT_EQ(dspec.tensor_shape_in_pages(), params.expected_tensor_shape_pages);
+    EXPECT_EQ(dspec.shard_shape_in_pages(), params.expected_shard_shape_pages);
 
     if (params.tensor_shape_pages.rank() == params.shard_shape_pages.rank()) {
         auto expected_page_mapping =
-            detail::compute_page_mapping(params.tensor_shape_pages, params.shard_shape_pages, dspec.get_cores());
+            detail::compute_page_mapping(params.tensor_shape_pages, params.shard_shape_pages, dspec.cores());
         EXPECT_EQ(dspec.compute_page_mapping().core_host_page_indices, expected_page_mapping.core_host_page_indices);
     }
 }
@@ -919,9 +918,12 @@ INSTANTIATE_TEST_SUITE_P(
             .grid_size = CoreCoord{2, 2},
             .expected_max_num_shards_per_core = 2,
             .expected_num_shards_per_core = {2, 2, 2, 2},
-            .expected_cores_with_data = {CoreCoord{0, 0}, CoreCoord{1, 0}, CoreCoord{0, 1}, CoreCoord{1, 1}},
-            .expected_core_group_1 = {2, {CoreCoord{0, 0}, CoreCoord{1, 0}, CoreCoord{0, 1}, CoreCoord{1, 1}}},
-            .expected_core_group_2 = {},
+            .expected_groups =
+                {
+                    .cores_with_data = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                    .cores_in_group_1 = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                    .num_shards_per_core_in_group_1 = 2,
+                },
         },
         NDShardingCoreInfoParams{
             .shape_in_pages = Shape({3, 3, 3}),
@@ -929,9 +931,12 @@ INSTANTIATE_TEST_SUITE_P(
             .grid_size = CoreCoord{2, 2},
             .expected_max_num_shards_per_core = 2,
             .expected_num_shards_per_core = {2, 2, 2, 2},
-            .expected_cores_with_data = {CoreCoord{0, 0}, CoreCoord{1, 0}, CoreCoord{0, 1}, CoreCoord{1, 1}},
-            .expected_core_group_1 = {2, {CoreCoord{0, 0}, CoreCoord{1, 0}, CoreCoord{0, 1}, CoreCoord{1, 1}}},
-            .expected_core_group_2 = {},
+            .expected_groups =
+                {
+                    .cores_with_data = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                    .cores_in_group_1 = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                    .num_shards_per_core_in_group_1 = 2,
+                },
         },
         NDShardingCoreInfoParams{
             .shape_in_pages = Shape({0, 0, 0}),
@@ -939,9 +944,7 @@ INSTANTIATE_TEST_SUITE_P(
             .grid_size = CoreCoord{2, 2},
             .expected_max_num_shards_per_core = 0,
             .expected_num_shards_per_core = {0, 0, 0, 0},
-            .expected_cores_with_data = {},
-            .expected_core_group_1 = {},
-            .expected_core_group_2 = {},
+            .expected_groups = {},
         },
         NDShardingCoreInfoParams{
             .shape_in_pages = Shape({2, 2, 2}),
@@ -949,9 +952,12 @@ INSTANTIATE_TEST_SUITE_P(
             .grid_size = CoreCoord{2, 2},
             .expected_max_num_shards_per_core = 1,
             .expected_num_shards_per_core = {1, 0, 0, 0},
-            .expected_cores_with_data = {CoreCoord{0, 0}},
-            .expected_core_group_1 = {1, {CoreCoord{0, 0}}},
-            .expected_core_group_2 = {},
+            .expected_groups =
+                {
+                    .cores_with_data = CoreRangeSet(CoreRange({0, 0})),
+                    .cores_in_group_1 = CoreRangeSet(CoreRange({0, 0})),
+                    .num_shards_per_core_in_group_1 = 1,
+                },
         },
         NDShardingCoreInfoParams{
             .shape_in_pages = Shape({2, 2, 4}),
@@ -959,9 +965,12 @@ INSTANTIATE_TEST_SUITE_P(
             .grid_size = CoreCoord{2, 2},
             .expected_max_num_shards_per_core = 1,
             .expected_num_shards_per_core = {1, 1, 0, 0},
-            .expected_cores_with_data = {CoreCoord{0, 0}, CoreCoord{1, 0}},
-            .expected_core_group_1 = {1, {CoreCoord{0, 0}, CoreCoord{1, 0}}},
-            .expected_core_group_2 = {},
+            .expected_groups =
+                {
+                    .cores_with_data = CoreRangeSet(CoreRange({0, 0}, {1, 0})),
+                    .cores_in_group_1 = CoreRangeSet(CoreRange({0, 0}, {1, 0})),
+                    .num_shards_per_core_in_group_1 = 1,
+                },
         },
         NDShardingCoreInfoParams{
             .shape_in_pages = Shape({2, 6, 2}),
@@ -969,9 +978,14 @@ INSTANTIATE_TEST_SUITE_P(
             .grid_size = CoreCoord{2, 2},
             .expected_max_num_shards_per_core = 1,
             .expected_num_shards_per_core = {1, 1, 1, 0},
-            .expected_cores_with_data = {CoreCoord{0, 0}, CoreCoord{1, 0}, CoreCoord{0, 1}},
-            .expected_core_group_1 = {1, {CoreCoord{0, 0}, CoreCoord{1, 0}, CoreCoord{0, 1}}},
-            .expected_core_group_2 = {},
+            .expected_groups =
+                {
+                    .cores_with_data = CoreRangeSet(std::vector<CoreRange>{
+                        CoreRange({0, 0}, {1, 0}), CoreRange({0, 1})}),
+                    .cores_in_group_1 = CoreRangeSet(std::vector<CoreRange>{
+                        CoreRange({0, 0}, {1, 0}), CoreRange({0, 1})}),
+                    .num_shards_per_core_in_group_1 = 1,
+                },
         },
         NDShardingCoreInfoParams{
             .shape_in_pages = Shape({8, 2, 2}),
@@ -979,9 +993,12 @@ INSTANTIATE_TEST_SUITE_P(
             .grid_size = CoreCoord{2, 2},
             .expected_max_num_shards_per_core = 1,
             .expected_num_shards_per_core = {1, 1, 1, 1},
-            .expected_cores_with_data = {CoreCoord{0, 0}, CoreCoord{1, 0}, CoreCoord{0, 1}, CoreCoord{1, 1}},
-            .expected_core_group_1 = {1, {CoreCoord{0, 0}, CoreCoord{1, 0}, CoreCoord{0, 1}, CoreCoord{1, 1}}},
-            .expected_core_group_2 = {},
+            .expected_groups =
+                {
+                    .cores_with_data = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                    .cores_in_group_1 = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                    .num_shards_per_core_in_group_1 = 1,
+                },
         },
         NDShardingCoreInfoParams{
             .shape_in_pages = Shape({1, 1, 33}),
@@ -989,9 +1006,15 @@ INSTANTIATE_TEST_SUITE_P(
             .grid_size = CoreCoord{2, 2},
             .expected_max_num_shards_per_core = 5,
             .expected_num_shards_per_core = {5, 4, 4, 4},
-            .expected_cores_with_data = {CoreCoord{0, 0}, CoreCoord{1, 0}, CoreCoord{0, 1}, CoreCoord{1, 1}},
-            .expected_core_group_1 = {5, {CoreCoord{0, 0}}},
-            .expected_core_group_2 = {4, {CoreCoord{1, 0}, CoreCoord{0, 1}, CoreCoord{1, 1}}},
+            .expected_groups =
+                {
+                    .cores_with_data = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                    .cores_in_group_1 = CoreRangeSet(CoreRange({0, 0})),
+                    .cores_in_group_2 = CoreRangeSet(std::vector<CoreRange>{
+                        CoreRange({0, 1}, {1, 1}), CoreRange({1, 0})}),
+                    .num_shards_per_core_in_group_1 = 5,
+                    .num_shards_per_core_in_group_2 = 4,
+                },
         },
         NDShardingCoreInfoParams{
             .shape_in_pages = Shape({1, 35, 1}),
@@ -999,9 +1022,14 @@ INSTANTIATE_TEST_SUITE_P(
             .grid_size = CoreCoord{2, 2},
             .expected_max_num_shards_per_core = 5,
             .expected_num_shards_per_core = {5, 5, 4, 4},
-            .expected_cores_with_data = {CoreCoord{0, 0}, CoreCoord{1, 0}, CoreCoord{0, 1}, CoreCoord{1, 1}},
-            .expected_core_group_1 = {5, {CoreCoord{0, 0}, CoreCoord{1, 0}}},
-            .expected_core_group_2 = {4, {CoreCoord{0, 1}, CoreCoord{1, 1}}},
+            .expected_groups =
+                {
+                    .cores_with_data = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                    .cores_in_group_1 = CoreRangeSet(CoreRange({0, 0}, {1, 0})),
+                    .cores_in_group_2 = CoreRangeSet(CoreRange({0, 1}, {1, 1})),
+                    .num_shards_per_core_in_group_1 = 5,
+                    .num_shards_per_core_in_group_2 = 4,
+                },
         },
         NDShardingCoreInfoParams{
             .shape_in_pages = Shape({37, 1, 1}),
@@ -1009,9 +1037,15 @@ INSTANTIATE_TEST_SUITE_P(
             .grid_size = CoreCoord{2, 2},
             .expected_max_num_shards_per_core = 5,
             .expected_num_shards_per_core = {5, 5, 5, 4},
-            .expected_cores_with_data = {CoreCoord{0, 0}, CoreCoord{1, 0}, CoreCoord{0, 1}, CoreCoord{1, 1}},
-            .expected_core_group_1 = {5, {CoreCoord{0, 0}, CoreCoord{1, 0}, CoreCoord{0, 1}}},
-            .expected_core_group_2 = {4, {CoreCoord{1, 1}}},
+            .expected_groups =
+                {
+                    .cores_with_data = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                    .cores_in_group_1 = CoreRangeSet(std::vector<CoreRange>{
+                        CoreRange({0, 0}, {1, 0}), CoreRange({0, 1})}),
+                    .cores_in_group_2 = CoreRangeSet(CoreRange({1, 1})),
+                    .num_shards_per_core_in_group_1 = 5,
+                    .num_shards_per_core_in_group_2 = 4,
+                },
         }));
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
@@ -20,22 +20,22 @@ UncompressedBufferPageMapping compute_page_mapping(
 class BufferDistributionSpec {
 public:
     static BufferDistributionSpec from_shard_spec(
-        tt::tt_metal::Shape tensor_shape,
-        tt::tt_metal::Shape shard_shape,
-        tt::tt_metal::Shape2D page_shape,
+        Shape tensor_shape,
+        Shape shard_shape,
+        Shape2D page_shape,
         CoreRangeSet core_range_set,
         ShardOrientation shard_orientation,
         ShardDistributionStrategy shard_distribution_strategy = ShardDistributionStrategy::ROUND_ROBIN_1D);
 
     BufferDistributionSpec(
-        tt::tt_metal::Shape tensor_shape_in_pages,
-        tt::tt_metal::Shape shard_shape_in_pages,
+        Shape tensor_shape_in_pages,
+        Shape shard_shape_in_pages,
         CoreRangeSet core_range_set,
         ShardOrientation shard_orientation,
         ShardDistributionStrategy shard_distribution_strategy = ShardDistributionStrategy::ROUND_ROBIN_1D);
 
-    tt::tt_metal::Shape tensor_shape_in_pages() const { return tensor_shape_in_pages_; }
-    tt::tt_metal::Shape shard_shape_in_pages() const { return shard_shape_in_pages_; }
+    const Shape& tensor_shape_in_pages() const { return tensor_shape_in_pages_; }
+    const Shape& shard_shape_in_pages() const { return shard_shape_in_pages_; }
 
     size_t num_shards() const;
     size_t max_num_shards_per_core() const;
@@ -66,8 +66,8 @@ private:
         const CoreRangeSet& core_range_set, ShardDistributionStrategy shard_distribution_strategy);
     void init_precomputed_data();
 
-    tt::tt_metal::Shape tensor_shape_in_pages_;
-    tt::tt_metal::Shape shard_shape_in_pages_;
+    Shape tensor_shape_in_pages_;
+    Shape shard_shape_in_pages_;
     ShardOrientation shard_orientation_ = ShardOrientation::ROW_MAJOR;
 
     std::vector<CoreCoord> cores_;

--- a/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
@@ -56,6 +56,10 @@ public:
         size_t num_shards_per_core_in_group_2 = 0;
     };
     const CoreGroups& core_groups() const { return core_groups_; }
+    // CoreGroups represented as a tuple compatible with split_work_to_cores function.
+    // Returns: number of cores with data, cores with data, cores in group 1, cores in group 2,
+    // number of shards per core in group 1, number of shards per core in group 2.
+    std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> core_groups_tuple() const;
 
     UncompressedBufferPageMapping compute_page_mapping() const {
         return detail::compute_page_mapping(tensor_shape_in_pages_, shard_shape_in_pages_, cores_);

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -142,6 +142,8 @@ public:
 
     CoreRangeSet(const CoreRange& core_range);
 
+    CoreRangeSet(tt::stl::Span<const CoreCoord> core_coords);
+
     CoreRangeSet() = default;
 
     friend void swap(CoreRangeSet& first, CoreRangeSet& second);

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -179,6 +179,16 @@ CoreRangeSet::CoreRangeSet(const std::set<CoreRange>& core_ranges) : ranges_(cor
 
 CoreRangeSet::CoreRangeSet(const CoreRange& core_range) : ranges_{core_range} {}
 
+CoreRangeSet::CoreRangeSet(tt::stl::Span<const CoreCoord> core_coords) {
+    std::vector<CoreRange> core_ranges;
+    core_ranges.reserve(core_coords.size());
+    for (const auto& core_coord : core_coords) {
+        core_ranges.push_back(CoreRange(core_coord));
+    }
+    CoreRangeSet unmerged_set(std::move(core_ranges));
+    *this = unmerged_set.merge_ranges();
+}
+
 void swap(CoreRangeSet& first, CoreRangeSet& second) { std::swap(first.ranges_, second.ranges_); }
 
 CoreRangeSet::CoreRangeSet(const CoreRangeSet& other) { this->ranges_ = other.ranges_; }

--- a/tt_metal/impl/buffers/buffer_distribution_spec.cpp
+++ b/tt_metal/impl/buffers/buffer_distribution_spec.cpp
@@ -223,6 +223,18 @@ size_t BufferDistributionSpec::num_dev_pages_per_core(size_t core_idx) const {
     return num_shards_per_core(core_idx) * shard_volume_;
 }
 
+std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t>
+BufferDistributionSpec::core_groups_tuple() const {
+    return {
+        core_groups_.cores_with_data.num_cores(),
+        core_groups_.cores_with_data,
+        core_groups_.cores_in_group_1,
+        core_groups_.cores_in_group_2,
+        core_groups_.num_shards_per_core_in_group_1,
+        core_groups_.num_shards_per_core_in_group_2,
+    };
+}
+
 void BufferDistributionSpec::init_precomputed_data() {
     shard_volume_ = shard_shape_in_pages_.volume();
     if (tensor_shape_in_pages_.volume() != 0) {

--- a/tt_metal/impl/buffers/buffer_distribution_spec.cpp
+++ b/tt_metal/impl/buffers/buffer_distribution_spec.cpp
@@ -166,6 +166,8 @@ BufferDistributionSpec::BufferDistributionSpec(
     if (tensor_shape_in_pages_.volume() != 0) {
         TT_FATAL(cores_.size() != 0, "Can't distribute non zero volume tensor over an empty set of cores");
     }
+
+    init_precomputed_data();
 }
 
 std::vector<CoreCoord> BufferDistributionSpec::compute_core_list(
@@ -200,22 +202,9 @@ std::vector<CoreCoord> BufferDistributionSpec::compute_core_list(
         trimmed_core_grid, trimmed_core_grid.size(), shard_orientation_ == ShardOrientation::ROW_MAJOR);
 }
 
-size_t BufferDistributionSpec::num_shards() const {
-    if (tensor_shape_in_pages_.volume() == 0) {
-        return 0;
-    }
-    size_t num_shards = 1;
-    for (size_t i = 0; i < tensor_shape_in_pages_.size(); i++) {
-        num_shards *= (tensor_shape_in_pages_[i] + shard_shape_in_pages_[i] - 1) / shard_shape_in_pages_[i];
-    }
-    return num_shards;
-}
+size_t BufferDistributionSpec::num_shards() const { return num_shards_; }
 
 size_t BufferDistributionSpec::num_cores_with_data() const { return std::min(num_cores(), num_shards()); }
-
-std::vector<CoreCoord> BufferDistributionSpec::get_cores_with_data() const {
-    return std::vector<CoreCoord>(cores_.begin(), cores_.begin() + num_cores_with_data());
-}
 
 size_t BufferDistributionSpec::max_num_shards_per_core() const {
     if (cores_.size() == 0) {
@@ -224,40 +213,53 @@ size_t BufferDistributionSpec::max_num_shards_per_core() const {
     return (num_shards() + cores_.size() - 1) / cores_.size();
 }
 
-size_t BufferDistributionSpec::max_num_dev_pages_per_core() const {
-    return max_num_shards_per_core() * shard_shape_in_pages_.volume();
-}
+size_t BufferDistributionSpec::max_num_dev_pages_per_core() const { return max_num_shards_per_core() * shard_volume_; }
 
 size_t BufferDistributionSpec::num_shards_per_core(size_t core_idx) const {
-    auto num_shards = this->num_shards();
-    return num_shards / num_cores() + (core_idx < num_shards % num_cores() ? 1 : 0);
+    return num_shards() / num_cores() + (core_idx < num_shards() % num_cores() ? 1 : 0);
 }
 
 size_t BufferDistributionSpec::num_dev_pages_per_core(size_t core_idx) const {
-    return num_shards_per_core(core_idx) * shard_shape_in_pages_.volume();
+    return num_shards_per_core(core_idx) * shard_volume_;
 }
 
-std::pair<BufferDistributionSpec::CoreGroup, BufferDistributionSpec::CoreGroup>
-BufferDistributionSpec::get_core_groups_by_num_shards() const {
-    auto num_shards = this->num_shards();
-    if (num_shards == 0) {
-        return {CoreGroup{}, CoreGroup{}};
+void BufferDistributionSpec::init_precomputed_data() {
+    shard_volume_ = shard_shape_in_pages_.volume();
+    if (tensor_shape_in_pages_.volume() != 0) {
+        num_shards_ = 1;
+        for (size_t i = 0; i < tensor_shape_in_pages_.size(); i++) {
+            num_shards_ *= (tensor_shape_in_pages_[i] + shard_shape_in_pages_[i] - 1) / shard_shape_in_pages_[i];
+        }
     }
 
-    auto num_cores_with_more_shards = num_shards % num_cores();
-    if (num_cores_with_more_shards == 0) {
-        return {CoreGroup{num_shards / num_cores(), cores_}, CoreGroup{}};
-    }
+    cores_with_data_ = std::vector<CoreCoord>(cores_.begin(), cores_.begin() + num_cores_with_data());
 
-    std::vector<CoreCoord> cores_with_more_shards(cores_.begin(), cores_.begin() + num_cores_with_more_shards);
-    std::vector<CoreCoord> cores_with_less_shards;
-    if (num_shards / num_cores() != 0) {
-        cores_with_less_shards = std::vector<CoreCoord>(cores_.begin() + num_cores_with_more_shards, cores_.end());
+    if (num_shards() != 0) {
+        auto cores_with_data = CoreRangeSet(cores_with_data_);
+
+        auto num_cores_with_more_shards = num_shards() % num_cores();
+        if (num_cores_with_more_shards == 0) {
+            core_groups_ = CoreGroups{
+                .cores_with_data = cores_with_data,
+                .cores_in_group_1 = std::move(cores_with_data),
+                .num_shards_per_core_in_group_1 = num_shards() / num_cores(),
+            };
+        } else {
+            std::vector<CoreCoord> cores_with_more_shards(cores_.begin(), cores_.begin() + num_cores_with_more_shards);
+            std::vector<CoreCoord> cores_with_less_shards;
+            if (num_shards() / num_cores() != 0) {
+                cores_with_less_shards =
+                    std::vector<CoreCoord>(cores_.begin() + num_cores_with_more_shards, cores_.end());
+            }
+            core_groups_ = CoreGroups{
+                .cores_with_data = std::move(cores_with_data),
+                .cores_in_group_1 = CoreRangeSet(cores_with_more_shards),
+                .cores_in_group_2 = CoreRangeSet(cores_with_less_shards),
+                .num_shards_per_core_in_group_1 = num_shards() / num_cores() + 1,
+                .num_shards_per_core_in_group_2 = num_shards() / num_cores(),
+            };
+        }
     }
-    return {
-        CoreGroup{num_shards / num_cores() + 1, std::move(cores_with_more_shards)},
-        CoreGroup{num_shards / num_cores(), std::move(cores_with_less_shards)},
-    };
 }
 
 namespace detail {

--- a/ttnn/core/tensor/tensor_accessor_args.cpp
+++ b/ttnn/core/tensor/tensor_accessor_args.cpp
@@ -16,9 +16,9 @@ void append_sharded_args(
     TT_FATAL(buffer.buffer_distribution_spec(), "Buffer must have a buffer distribution spec");
 
     const auto& buffer_distribution_spec = buffer.buffer_distribution_spec().value();
-    const auto& tensor_shape = buffer_distribution_spec.get_tensor_shape_in_pages();
-    const auto& shard_shape = buffer_distribution_spec.get_shard_shape_in_pages();
-    const auto& bank_coords = buffer_distribution_spec.get_cores();
+    const auto& tensor_shape = buffer_distribution_spec.tensor_shape_in_pages();
+    const auto& shard_shape = buffer_distribution_spec.shard_shape_in_pages();
+    const auto& bank_coords = buffer_distribution_spec.cores();
 
     auto add_rank = args_config.test(tensor_accessor::ArgConfig::RuntimeRank) == is_runtime;
     auto add_num_banks = args_config.test(tensor_accessor::ArgConfig::RuntimeNumBanks) == is_runtime;


### PR DESCRIPTION
### Ticket

### Problem description
We need to rework BufferDistributionSpec API for providing core groups to make it usable for the OP developers.
Based on the feedback from @bbradelTT, we need to provide CoreRangeSets instead of vectors of cores to be compatible with the existing APIs and approaches.

### What's changed
Changed core groups API in BufferDistributionSpec to provide cores within each group and all cores together as CoreRangeSets
Calculate CoreGroups and some other data on BufferDistributionSpec creation to avoid recomputing it over and over again
Minor API renaming in BufferDistributionSpec for consistency
Added CoreRangeSet constructor from a span of CoreCoords
Updated the tests to use the new API

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16210433524)
- [x] New/Existing tests provide coverage for changes