### PR TITLE
#24912: Add DP Support for Yolov8s_World

### DIFF
--- a/models/demos/yolov8s_world/README.md
+++ b/models/demos/yolov8s_world/README.md
@@ -1,62 +1,106 @@
 # Yolov8s-World
+Demo showcasing Yolov8s-World running on `Wormhole - N150, N300` using ttnn.
 
-### Platforms:
+### Note:
 
-Wormhole N150, N300
+- On N300, Make sure to use `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` with the pytest.
 
-**Note:** On N300, make sure to use `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` with the pytest.
+- Or, make sure to set the following environment variable in the terminal:
+  ```
+  export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+  ```
+- To obtain the perf reports through profiler, please build with following command:
+  ```
+  ./build_metal.sh -p
+  ```
 
-Or, make sure to set the following environment variable in the terminal:
-```
-export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
-```
+## Introduction:
 
-To obtain the perf reports through profiler, please build with following command:
-```
-./build_metal.sh -p
-```
-### Introduction:
+The YOLO-World Model introduces an advanced, real-time Ultralytics YOLOv8-based approach for Open-Vocabulary Detection tasks. This innovation enables the detection of any object within an image based on descriptive texts. By significantly lowering computational demands while preserving competitive performance, YOLO-World emerges as a versatile tool for numerous vision-based applications. Resource link - [source](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/model.py)
 
-The YOLO-World Model introduces an advanced, real-time Ultralytics YOLOv8-based approach for Open-Vocabulary Detection tasks. This innovation enables the detection of any object within an image based on descriptive texts. By significantly lowering computational demands while preserving competitive performance, YOLO-World emerges as a versatile tool for numerous vision-based applications.
+## Details:
+The model picks up certain configs and weights from Ultralytics pretrained model. We've used weights available [here](https://docs.ultralytics.com/models/yolo-world/#available-models-supported-tasks-and-operating-modes) in YOLOv8s-world row.
 
-Resource link - [source](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/model.py)
+- The entry point to the `yolov8s_world` is `TtYOLOWorld` in - `models/demos/yolov8s_world/tt/ttnn_yolov8s_world.py`.
+- Batch Size : `1` (Single Device), `2` (Multi Device).
+- Supported Input Resolution : `(640, 640)` - (Height, Width).
+- Dataset used for evaluation : **COCO-2017**
 
-### Details:
-- The entry point to yolov8s_world model is TtYOLOWorld in `models/demos/yolov8s_world/tt/ttnn_yolov8s_world.py`.
-- The model picks up certain configs and weights from Ultralytics pretrained model. We've used weights available [here](https://docs.ultralytics.com/models/yolo-world/#available-models-supported-tasks-and-operating-modes) in YOLOv8s-world row.
-- Batch size :1
-- Supported Input Resolution - (640,640) (Height,Width)
-- Dataset used for evaluation - **coco-2017**
 
-### How to Run:
+## How to Run:
 
 Use the following command to run the model :
 ```
 pytest --disable-warnings models/demos/yolov8s_world/tests/pcc/test_ttnn_yolov8s_world.py::test_YoloModel
 ```
-### Performant Model with Trace+2CQ
-- end-2-end perf is 89 FPS
 
-Use the following command to run the performant Model with Trace+2CQs:
+### Model Performant with Trace+2CQ
 
-```
-pytest --disable-warnings models/demos/yolov8s_world/tests/perf/test_perf_yolov8s_world.py::test_perf_yolov8s_world
-```
+#### Single Device (BS=1) :
 
-### Performant Demo with Trace+2CQ
-Use the following command to run the performant Demo with Trace+2CQs:
+- For `640x640`, end-2-end perf is `90` FPS.
 
-```
-pytest --disable-warnings models/demos/yolov8s_world/demo/demo.py
-```
+  ```bash
+  pytest --disable-warnings models/demos/yolov8s_world/tests/perf/test_perf_yolov8s_world.py::test_perf_yolov8s_world
+  ```
+
+#### Multi Device (DP=2, N300) :
+
+- For `640x640`, end-2-end perf is `175` FPS.
+
+  ```bash
+  pytest --disable-warnings models/demos/yolov8s_world/tests/perf/test_perf_yolov8s_world.py::test_perf_yolov8s_world_dp
+  ```
+
+### Demo with Trace+2CQs
+
+##### Note: To test the demo with your own images, replace images with `models/demos/yolov8s_world/demo/images`.
+
+#### Single Device (BS=1) :
+
+#### Custom Images :
+
+- Use the following command to run the performant Demo:
+
+  ```
+  pytest --disable-warnings models/demos/yolov8s_world/demo/demo.py::test_demo
+  ```
+
+#### Dataset Images :
+
+- Use the following command to run the performant Demo:
+
+  ```
+  pytest --disable-warnings models/demos/yolov8s_world/demo/demo.py::test_demo_dataset
+  ```
+
+
+#### Multi Device (DP=2, N300) :
+
+#### Custom Images :
+
+- Use the following command to run the performant Demo:
+
+  ```
+  pytest --disable-warnings models/demos/yolov8s_world/demo/demo.py::test_demo_dp
+  ```
+
+#### Dataset Images :
+
+- Use the following command to run the performant Demo:
+
+  ```
+  pytest --disable-warnings models/demos/yolov8s_world/demo/demo.py::test_demo_dataset_dp
+  ```
 
 ### Performant evaluation with Trace+2CQ
-Use the following command to run the performant evaluation with Trace+2CQs:
 
-```
-pytest models/experimental/yolo_eval/evaluate.py::test_yolov8s_world[res0-device_params0-tt_model]
-```
+- Use the following command to run the performant evaluation with Trace+2CQs:
+
+  ```
+  pytest models/experimental/yolo_eval/evaluate.py::test_yolov8s_world[res0-device_params0-tt_model]
+  ```
 Note: The model is evaluated with 500 samples.
 
 ### Web Demo
-- Try the interactive web demo [instructions](https://github.com/tenstorrent/tt-metal/blob/main/models/demos/yolov8s_world/README.md)
+- Try the interactive web demo [instructions](https://github.com/tenstorrent/tt-metal/blob/main/models/demos/yolov8s_world/web_demo/README.md).

--- a/models/demos/yolov8s_world/common.py
+++ b/models/demos/yolov8s_world/common.py
@@ -9,6 +9,8 @@ import torch
 from models.demos.yolov8s_world.reference import yolov8s_world
 from models.demos.yolov8s_world.tt.ttnn_yolov8s_world_utils import attempt_load
 
+YOLOV8SWORLD_L1_SMALL_SIZE = 24576
+
 
 def load_torch_model(model_location_generator=None):
     if model_location_generator == None or "TT_GH_CI_INFRA" not in os.environ:

--- a/models/demos/yolov8s_world/demo/demo.py
+++ b/models/demos/yolov8s_world/demo/demo.py
@@ -2,64 +2,160 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
-from datetime import datetime
 
-import cv2
+import fiftyone
 import pytest
 import torch
 from loguru import logger
 
 import ttnn
-from models.demos.yolov8s_world.common import load_torch_model
-from models.demos.yolov8s_world.demo.demo_utils import LoadImages, load_coco_class_names, postprocess, preprocess
+from models.demos.yolov8s_world.common import YOLOV8SWORLD_L1_SMALL_SIZE, load_torch_model
+from models.demos.yolov8s_world.demo.demo_utils import (
+    LoadImages,
+    load_coco_class_names,
+    postprocess,
+    preprocess,
+    save_yolo_predictions_by_model,
+)
 from models.demos.yolov8s_world.reference import yolov8s_world
 from models.demos.yolov8s_world.runner.performant_runner import YOLOv8sWorldPerformantRunner
+from models.demos.yolov8s_world.tt.ttnn_yolov8s_world_utils import get_mesh_mappers
 from models.utility_functions import disable_persistent_kernel_cache
 
 
-def save_yolo_predictions_by_model(result, save_dir, image_path, model_name):
-    model_save_dir = os.path.join(save_dir, model_name)
-    os.makedirs(model_save_dir, exist_ok=True)
+def init_model_and_runner(
+    model_location_generator, device, model_type, use_weights_from_ultralytics, batch_size_per_device
+):
+    disable_persistent_kernel_cache()
 
-    image = cv2.imread(image_path)
-    image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+    num_devices = device.get_num_devices()
+    batch_size = batch_size_per_device * num_devices
 
-    if model_name == "torch_model":
-        bounding_box_color, label_color = (0, 255, 0), (0, 255, 0)
+    logger.info(f"Running with batch_size={batch_size} across {num_devices} devices")
+
+    inputs_mesh_mapper, weights_mesh_mapper, outputs_mesh_composer = get_mesh_mappers(device)
+
+    if use_weights_from_ultralytics:
+        model = load_torch_model(model_location_generator).model
     else:
-        bounding_box_color, label_color = (255, 0, 0), (255, 255, 0)
+        model = yolov8s_world.YOLOWorld().model
 
-    boxes = result["boxes"]["xyxy"]
-    scores = result["boxes"]["conf"]
-    classes = result["boxes"]["cls"]
-    names = result["names"]
+    logger.info("Inference [Torch] Model")
 
-    for box, score, cls in zip(boxes, scores, classes):
-        x1, y1, x2, y2 = map(int, box)
-        label = f"{names[int(cls)]} {score.item():.2f}"
-        cv2.rectangle(image, (x1, y1), (x2, y2), bounding_box_color, 3)
-        cv2.putText(image, label, (x1, y1 - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.5, label_color, 2)
+    performant_runner = None
+    if model_type == "tt_model":
+        performant_runner = YOLOv8sWorldPerformantRunner(
+            device,
+            batch_size,
+            ttnn.bfloat16,
+            ttnn.bfloat8_b,
+            resolution=(640, 640),
+            model_location_generator=model_location_generator,
+            inputs_mesh_mapper=inputs_mesh_mapper,
+            weights_mesh_mapper=weights_mesh_mapper,
+            outputs_mesh_composer=outputs_mesh_composer,
+        )
+        performant_runner._capture_yolov8s_world_trace_2cqs()
 
-    image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+    return model, performant_runner, outputs_mesh_composer, batch_size
 
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_name = f"prediction_{timestamp}.jpg"
-    output_path = os.path.join(model_save_dir, output_name)
 
-    cv2.imwrite(output_path, image)
+def process_images(dataset, res, batch_size):
+    torch_images, orig_images, paths_images = [], [], []
 
-    logger.info(f"Predictions saved to {output_path}")
+    for paths, im0s, _ in dataset:
+        assert len(im0s) == batch_size, f"Expected batch of size {batch_size}, but got {len(im0s)}"
+
+        paths_images.extend(paths)
+        orig_images.extend(im0s)
+
+        for idx, img in enumerate(im0s):
+            if img is None:
+                raise ValueError(f"Could not read image: {paths[idx]}")
+            tensor = preprocess([img], res=res)
+            torch_images.append(tensor)
+
+        if len(torch_images) >= batch_size:
+            break
+
+    torch_input_tensor = torch.cat(torch_images, dim=0)
+    return torch_input_tensor, orig_images, paths_images
+
+
+def run_inference_and_save(
+    model, runner, model_type, outputs_mesh_composer, im_tensor, orig_images, paths_images, save_dir, names
+):
+    if model_type == "torch_model":
+        preds = model(im_tensor)
+    else:
+        preds = runner.run(im_tensor)
+        preds[0] = ttnn.to_torch(preds[0], dtype=torch.float32, mesh_composer=outputs_mesh_composer)
+
+    results = postprocess(preds, im_tensor, orig_images, paths_images, names)
+
+    for result, image_path in zip(results, paths_images):
+        save_yolo_predictions_by_model(result, save_dir, image_path, model_type)
+
+
+def run_yolov8s_world_inference(
+    model_location_generator, device, model_type, use_weights_from_ultralytics, res, input_loc, batch_size_per_device
+):
+    model, runner, mesh_composer, batch_size = init_model_and_runner(
+        model_location_generator, device, model_type, use_weights_from_ultralytics, batch_size_per_device
+    )
+    dataset = LoadImages(path=os.path.abspath(input_loc), batch=batch_size)
+    im_tensor, orig_images, paths_images = process_images(dataset, res, batch_size)
+    names = load_coco_class_names()
+    save_dir = "models/demos/yolov8s_world/demo/runs"
+
+    run_inference_and_save(
+        model, runner, model_type, mesh_composer, im_tensor, orig_images, paths_images, save_dir, names
+    )
+
+    if runner:
+        runner.release()
+    logger.info("Inference done")
+
+
+def run_yolov8s_world_dataset_inference(
+    model_location_generator, device, model_type, use_weights_from_ultralytics, res, batch_size_per_device
+):
+    model, runner, mesh_composer, batch_size = init_model_and_runner(
+        model_location_generator, device, model_type, use_weights_from_ultralytics, batch_size_per_device
+    )
+
+    dataset = fiftyone.zoo.load_zoo_dataset("coco-2017", split="validation", max_samples=batch_size)
+    filepaths = [sample["filepath"] for sample in dataset]
+    image_loader = LoadImages(filepaths, batch=batch_size)
+    im_tensor, orig_images, paths_images = process_images(image_loader, res, batch_size)
+
+    with open(os.path.expanduser("~") + "/fiftyone/coco-2017/info.json") as f:
+        names = json.load(f)["classes"]
+
+    save_dir = "models/demos/yolov8s_world/demo/runs"
+    run_inference_and_save(
+        model, runner, model_type, mesh_composer, im_tensor, orig_images, paths_images, save_dir, names
+    )
+
+    if runner:
+        runner.release()
+    logger.info("Inference done")
 
 
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 24576, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
+    "device_params",
+    [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
+    indirect=True,
 )
 @pytest.mark.parametrize(
-    "source",
+    "input_loc, batch_size_per_device",
     [
-        ("models/demos/yolov8s_world/demo/images/bus.jpg"),
-        # ("models/demos/yolov8s_world/demo/images/elephants.jpg"), # Uncomment to run the demo with another image for the second example.
+        (
+            "models/demos/yolov8s/demo/images",
+            1,
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -70,57 +166,117 @@ def save_yolo_predictions_by_model(result, save_dir, image_path, model_name):
     ],
 )
 @pytest.mark.parametrize(
-    "use_pretrained_weight",
+    "use_weights_from_ultralytics",
     [True],
     ids=[
         "pretrained_weight_true",
     ],
 )
 @pytest.mark.parametrize("res", [(640, 640)])
-def test_demo(device, source, model_type, res, use_pretrained_weight, model_location_generator):
-    disable_persistent_kernel_cache()
+def test_demo(
+    model_location_generator, device, input_loc, batch_size_per_device, model_type, res, use_weights_from_ultralytics
+):
+    run_yolov8s_world_inference(
+        model_location_generator,
+        device,
+        model_type,
+        use_weights_from_ultralytics,
+        res,
+        input_loc,
+        batch_size_per_device,
+    )
 
-    if model_type == "torch_model":
-        if use_pretrained_weight:
-            model = load_torch_model(model_location_generator)
-        else:
-            model = yolov8s_world.YOLOWorld()
 
-        logger.info("Inferencing using Torch Model")
-    else:
-        yolov8s_world_trace_2cq = YOLOv8sWorldPerformantRunner(
-            device,
-            1,  # batch_size
-            ttnn.bfloat16,  # act_dtype
-            ttnn.bfloat8_b,  # weight_dtype
-            resolution=(640, 640),
-            model_location_generator=None,
-        )
-        yolov8s_world_trace_2cq._capture_yolov8s_world_trace_2cqs()
-        logger.info("Inferencing using ttnn Model")
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "model_type",
+    (
+        # "torch_model", # Uncomment to run the demo with torch model
+        "tt_model",
+    ),
+)
+@pytest.mark.parametrize(
+    "use_weights_from_ultralytics",
+    [True],
+)
+@pytest.mark.parametrize("res", [(640, 640)])
+def test_demo_dataset(model_location_generator, device, model_type, use_weights_from_ultralytics, res):
+    run_yolov8s_world_dataset_inference(
+        model_location_generator, device, model_type, use_weights_from_ultralytics, res, batch_size_per_device=1
+    )
 
-    save_dir = "models/demos/yolov8s_world/demo/runs"
 
-    dataset = LoadImages(path=source)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "input_loc, batch_size_per_device",
+    [
+        (
+            "models/demos/yolov8s_world/demo/images",
+            1,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        "tt_model",
+        # "torch_model", # Uncomment to run the demo with torch model.
+    ],
+)
+@pytest.mark.parametrize(
+    "use_weights_from_ultralytics",
+    [True],
+    ids=[
+        "pretrained_weight_true",
+    ],
+)
+@pytest.mark.parametrize("res", [(640, 640)])
+def test_demo_dp(
+    model_location_generator,
+    mesh_device,
+    input_loc,
+    batch_size_per_device,
+    model_type,
+    res,
+    use_weights_from_ultralytics,
+):
+    run_yolov8s_world_inference(
+        model_location_generator,
+        mesh_device,
+        model_type,
+        use_weights_from_ultralytics,
+        res,
+        input_loc,
+        batch_size_per_device,
+    )
 
-    model_save_dir = os.path.join(save_dir, model_type)
-    os.makedirs(model_save_dir, exist_ok=True)
 
-    names = load_coco_class_names()
-
-    for batch in dataset:
-        paths, im0s, s = batch
-
-        im = preprocess(im0s, res=res)
-
-        if model_type == "torch_model":
-            preds = model(im)
-        else:
-            preds = yolov8s_world_trace_2cq.run(im)
-            preds[0] = ttnn.to_torch(preds[0], dtype=torch.float32)
-
-        results = postprocess(preds, im, im0s, batch, names)[0]
-
-        save_yolo_predictions_by_model(results, save_dir, source, model_type)
-    yolov8s_world_trace_2cq.release()
-    logger.info("Inference done")
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "model_type",
+    (
+        # "torch_model", # Uncomment to run the demo with torch model
+        "tt_model",
+    ),
+)
+@pytest.mark.parametrize(
+    "use_weights_from_ultralytics",
+    [True],
+)
+@pytest.mark.parametrize("res", [(640, 640)])
+def test_demo_dataset_dp(model_location_generator, device, model_type, use_weights_from_ultralytics, res):
+    run_yolov8s_world_dataset_inference(
+        model_location_generator, device, model_type, use_weights_from_ultralytics, res, batch_size_per_device=1
+    )

--- a/models/demos/yolov8s_world/runner/performant_runner_infra.py
+++ b/models/demos/yolov8s_world/runner/performant_runner_infra.py
@@ -25,6 +25,9 @@ class YOLOv8sWorldPerformanceRunnerInfra:
         model_location_generator=None,
         resolution=(640, 640),
         torch_input_tensor=None,
+        inputs_mesh_mapper=None,
+        weights_mesh_mapper=None,
+        outputs_mesh_composer=None,
     ):
         torch.manual_seed(0)
         self.resolution = resolution
@@ -37,10 +40,14 @@ class YOLOv8sWorldPerformanceRunnerInfra:
         self.model_location_generator = model_location_generator
         self.torch_input_tensor = torch_input_tensor
 
-        self.torch_model = load_torch_model(model_location_generator)
-        self.torch_model = self.torch_model.model
+        self.num_devices = self.device.get_num_devices()
+        self.inputs_mesh_mapper = inputs_mesh_mapper
+        self.weights_mesh_mapper = weights_mesh_mapper
+        self.outputs_mesh_composer = outputs_mesh_composer
+
+        self.torch_model = load_torch_model(self.model_location_generator).model
         self.torch_input_tensor = (
-            torch.randn((1, 3, 640, 640), dtype=torch.float32)
+            torch.randn((batch_size, 3, 640, 640), dtype=torch.float32)
             if self.torch_input_tensor is None
             else self.torch_input_tensor
         )
@@ -70,24 +77,33 @@ class YOLOv8sWorldPerformanceRunnerInfra:
 
         self.torch_output_tensor = self.torch_model(self.torch_input_tensor)
 
-    def _setup_l1_sharded_input(self, device, torch_input_tensor=None):
+    def _setup_l1_sharded_input(self, device, torch_input_tensor=None, min_channels=16):
         if is_wormhole_b0():
             core_grid = ttnn.CoreGrid(y=8, x=8)
-        else:
-            exit("Unsupported device")
+        else:  # BH
+            core_grid = ttnn.CoreGrid(y=12, x=10)
 
-        num_devices = device.get_num_devices()
         torch_input_tensor = self.torch_input_tensor if torch_input_tensor is None else torch_input_tensor
         n, c, h, w = torch_input_tensor.shape
-        ## Converting from image based channels (3) to min channels (16)
-        if c == 3:
-            c = 16
+
+        if c < min_channels:
+            c = min_channels
+        elif c % min_channels != 0:
+            c = ((c // min_channels) + 1) * min_channels
+        n = n // self.num_devices if n // self.num_devices != 0 else n
+
         input_mem_config = ttnn.create_sharded_memory_config(
             [n, c, h, w],
             ttnn.CoreGrid(x=8, y=8),
             ttnn.ShardStrategy.HEIGHT,
         )
-        tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+        assert torch_input_tensor.ndim == 4, "Expected input tensor to have shape (BS, C, H, W)"
+
+        input_tensor = [torch_input_tensor[i].unsqueeze(0) for i in range(torch_input_tensor.shape[0])]
+        tt_inputs_host = ttnn.from_host_shards(
+            [ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT) for t in input_tensor], device.shape
+        )
 
         return tt_inputs_host, input_mem_config
 
@@ -116,7 +132,7 @@ class YOLOv8sWorldPerformanceRunnerInfra:
     def validate(self, output_tensor=None, torch_output_tensor=None):
         ttnn_output_tensor = self.output_tensor if output_tensor is None else output_tensor
         torch_output_tensor = self.torch_output_tensor if torch_output_tensor is None else torch_output_tensor
-        output_tensor = ttnn.to_torch(ttnn_output_tensor[0])
+        output_tensor = ttnn.to_torch(ttnn_output_tensor[0], mesh_composer=self.outputs_mesh_composer)
 
         self.pcc_passed, self.pcc_message = assert_with_pcc(self.torch_output_tensor[0], output_tensor, pcc=0.99)
 

--- a/models/demos/yolov8s_world/tests/pcc/test_ttnn_yolov8s_world.py
+++ b/models/demos/yolov8s_world/tests/pcc/test_ttnn_yolov8s_world.py
@@ -8,7 +8,7 @@ from loguru import logger
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
-from models.demos.yolov8s_world.common import load_torch_model
+from models.demos.yolov8s_world.common import YOLOV8SWORLD_L1_SMALL_SIZE, load_torch_model
 from models.demos.yolov8s_world.reference import yolov8s_world
 from models.demos.yolov8s_world.tt.ttnn_yolov8s_world import (
     TtC2f,
@@ -33,7 +33,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         True,
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("input_tensor", [(torch.rand((1, 3, 640, 640)))], ids=["input_tensor1"])
 @run_for_wormhole_b0()
 def test_Conv(device, input_tensor, use_pretrained_weight, reset_seeds, model_location_generator):
@@ -81,7 +81,7 @@ def test_Conv(device, input_tensor, use_pretrained_weight, reset_seeds, model_lo
         True,
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("input_tensor", [(torch.rand((1, 64, 160, 160)))], ids=["input_tensor1"])
 @run_for_wormhole_b0()
 def test_C2f(device, input_tensor, use_pretrained_weight, reset_seeds, model_location_generator):
@@ -134,7 +134,7 @@ def test_C2f(device, input_tensor, use_pretrained_weight, reset_seeds, model_loc
         True,
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("input_tensor", [(torch.rand((1, 512, 20, 20)))], ids=["input_tensor1"])
 @run_for_wormhole_b0()
 def test_SPPF(device, input_tensor, use_pretrained_weight, reset_seeds, model_location_generator):
@@ -179,7 +179,7 @@ def test_SPPF(device, input_tensor, use_pretrained_weight, reset_seeds, model_lo
         True,
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE}], indirect=True)
 @run_for_wormhole_b0()
 def test_MaxSigmoidAttnBlock(device, use_pretrained_weight, reset_seeds, model_location_generator):
     x = torch.randn(1, 128, 40, 40)
@@ -241,7 +241,7 @@ def test_MaxSigmoidAttnBlock(device, use_pretrained_weight, reset_seeds, model_l
         True,
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE}], indirect=True)
 @run_for_wormhole_b0()
 def test_C2fAttn(device, use_pretrained_weight, reset_seeds, model_location_generator):
     x = torch.randn(1, 768, 40, 40)
@@ -307,7 +307,7 @@ def test_C2fAttn(device, use_pretrained_weight, reset_seeds, model_location_gene
         True,
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE}], indirect=True)
 @run_for_wormhole_b0()
 def test_ImagePoolingAttn(device, use_pretrained_weight, reset_seeds, model_location_generator):
     x = [torch.randn(1, 128, 80, 80), torch.randn(1, 256, 40, 40), torch.randn(1, 512, 20, 20)]
@@ -371,7 +371,7 @@ def test_ImagePoolingAttn(device, use_pretrained_weight, reset_seeds, model_loca
         True,
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE}], indirect=True)
 @run_for_wormhole_b0()
 def test_ContrastiveHead(device, use_pretrained_weight, reset_seeds, model_location_generator):
     x = torch.randn(1, 512, 80, 80)
@@ -419,7 +419,7 @@ def test_ContrastiveHead(device, use_pretrained_weight, reset_seeds, model_locat
         True,
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE}], indirect=True)
 @run_for_wormhole_b0()
 def test_WorldDetect(device, use_pretrained_weight, reset_seeds, model_location_generator):
     x = [torch.randn(1, 128, 80, 80), torch.randn(1, 256, 40, 40), torch.randn(1, 512, 20, 20)]
@@ -545,7 +545,7 @@ def test_WorldDetect(device, use_pretrained_weight, reset_seeds, model_location_
         True,
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE}], indirect=True)
 @run_for_wormhole_b0()
 def test_WorldModel(device, use_pretrained_weight, reset_seeds, model_location_generator):
     x = torch.randn(1, 3, 640, 640)
@@ -614,7 +614,7 @@ def test_WorldModel(device, use_pretrained_weight, reset_seeds, model_location_g
         True,
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE}], indirect=True)
 @run_for_wormhole_b0()
 def test_YoloModel(device, use_pretrained_weight, reset_seeds, model_location_generator):
     x = torch.randn(1, 3, 640, 640)

--- a/models/demos/yolov8s_world/tests/perf/test_perf_yolov8s_world.py
+++ b/models/demos/yolov8s_world/tests/perf/test_perf_yolov8s_world.py
@@ -9,40 +9,32 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.demos.yolov8s_world.common import YOLOV8SWORLD_L1_SMALL_SIZE
 from models.demos.yolov8s_world.runner.performant_runner import YOLOv8sWorldPerformantRunner
+from models.demos.yolov8s_world.tt.ttnn_yolov8s_world_utils import get_mesh_mappers
 from models.perf.device_perf_utils import check_device_perf, prep_device_perf_report, run_device_perf
 from models.perf.perf_utils import prep_perf_report
 from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 
 
 def get_expected_times(name):
-    base = {"yolov8s_world": (183.7, 0.015)}
+    base = {"yolov8s_world": (183.7, 0.038)}
     return base[name]
 
 
-@run_for_wormhole_b0()
-@pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 79104, "trace_region_size": 23887872, "num_command_queues": 2}], indirect=True
-)
-@pytest.mark.parametrize(
-    "batch_size, act_dtype, weight_dtype",
-    ((1, ttnn.bfloat16, ttnn.bfloat8_b),),
-)
-@pytest.mark.parametrize(
-    "resolution",
-    [
-        (640, 640),
-    ],
-)
-@pytest.mark.models_performance_bare_metal
-def test_perf_yolov8s_world(
+def run_yolov8s_world_inference(
     device,
-    batch_size,
+    batch_size_per_device,
     act_dtype,
     weight_dtype,
     model_location_generator,
     resolution,
 ):
+    inputs_mesh_mapper, weights_mesh_mapper, outputs_mesh_composer = get_mesh_mappers(device)
+
+    num_devices = device.get_num_devices()
+    batch_size = batch_size_per_device * num_devices
+
     performant_runner = YOLOv8sWorldPerformantRunner(
         device,
         batch_size,
@@ -50,26 +42,31 @@ def test_perf_yolov8s_world(
         weight_dtype,
         resolution=resolution,
         model_location_generator=model_location_generator,
+        inputs_mesh_mapper=inputs_mesh_mapper,
+        weights_mesh_mapper=weights_mesh_mapper,
+        outputs_mesh_composer=outputs_mesh_composer,
     )
     performant_runner._capture_yolov8s_world_trace_2cqs()
-    input_shape = (1, 3, *resolution)
+
+    input_shape = (batch_size, 3, *resolution)
     torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
 
-    iterations = 32
     t0 = time.time()
-    for _ in range(iterations):
+    for _ in range(10):
         _ = performant_runner.run(torch_input_tensor)
     ttnn.synchronize_device(device)
     t1 = time.time()
 
     performant_runner.release()
+    inference_time = round((t1 - t0) / 10, 6)
 
-    inference_time = round((t1 - t0) / iterations, 6)
-    inference_and_compile_time = inference_time  # Don't care about compile time
+    inference_and_compile_time = inference_time
 
     logger.info(f"Compile time: {inference_and_compile_time - inference_time}")
     logger.info(f"Inference time: {inference_time}")
-    logger.info(f"Samples per second: {1 / inference_time * batch_size}")
+    logger.info(
+        f"Model: ttnn_yolov8s - batch_size: {batch_size}. One inference iteration time (sec): {inference_time}, FPS: {round(batch_size / inference_time)}"
+    )
 
     expected_compile_time, expected_inference_time = get_expected_times("yolov8s_world")
     prep_perf_report(
@@ -81,6 +78,76 @@ def test_perf_yolov8s_world(
         expected_inference_time=expected_inference_time,
         comments="",
         inference_time_cpu=0.0,
+    )
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE, "trace_region_size": 23887872, "num_command_queues": 2}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "batch_size_per_device, act_dtype, weight_dtype",
+    ((1, ttnn.bfloat16, ttnn.bfloat8_b),),
+)
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (640, 640),
+    ],
+)
+@pytest.mark.models_performance_bare_metal
+def test_perf_yolov8s_world(
+    device,
+    batch_size_per_device,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    resolution,
+):
+    run_yolov8s_world_inference(
+        device,
+        batch_size_per_device,
+        act_dtype,
+        weight_dtype,
+        model_location_generator,
+        resolution,
+    )
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE, "trace_region_size": 23887872, "num_command_queues": 2}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "batch_size_per_device, act_dtype, weight_dtype",
+    ((1, ttnn.bfloat16, ttnn.bfloat8_b),),
+)
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (640, 640),
+    ],
+)
+@pytest.mark.models_performance_bare_metal
+def test_perf_yolov8s_world_dp(
+    mesh_device,
+    batch_size_per_device,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    resolution,
+):
+    run_yolov8s_world_inference(
+        mesh_device,
+        batch_size_per_device,
+        act_dtype,
+        weight_dtype,
+        model_location_generator,
+        resolution,
     )
 
 

--- a/models/demos/yolov8s_world/web_demo/server/fast_api_yolov8s_world.py
+++ b/models/demos/yolov8s_world/web_demo/server/fast_api_yolov8s_world.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI, File, UploadFile
 from PIL import Image
 
 import ttnn
+from models.demos.yolov8s_world.common import YOLOV8SWORLD_L1_SMALL_SIZE
 from models.demos.yolov8s_world.runner.performant_runner import YOLOv8sWorldPerformantRunner
 from models.experimental.yolo_common.yolo_web_demo.yolo_evaluation_utils import postprocess
 
@@ -53,7 +54,7 @@ async def startup():
         device = ttnn.CreateDevice(
             device_id,
             dispatch_core_config=get_dispatch_core_config(),
-            l1_small_size=24576,
+            l1_small_size=YOLOV8SWORLD_L1_SMALL_SIZE,
             trace_region_size=3211264,
             num_command_queues=2,
         )
@@ -61,7 +62,9 @@ async def startup():
         model = YOLOv8sWorldPerformantRunner(device, 1)
     else:
         device_id = 0
-        device = ttnn.CreateDevice(device_id, l1_small_size=24576, trace_region_size=3211264, num_command_queues=2)
+        device = ttnn.CreateDevice(
+            device_id, l1_small_size=YOLOV8SWORLD_L1_SMALL_SIZE, trace_region_size=3211264, num_command_queues=2
+        )
         device.enable_program_cache()
         model = YOLOv8sWorldPerformantRunner(device, 1)
     model._capture_yolov8s_world_trace_2cqs()


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24912)

### Problem description
Add DataParallel support for Yolov8s_World model.

### What's changed
Added data parallel support for Yolov8s_World model to :
- Demo and
- e2e performant.
  - For 640x640 resolution,
    - Single Device : 90 FPS
    - Multi Device (N300) : 155 FPS
- ~Due to the issue reported in https://github.com/tenstorrent/tt-metal/issues/25718, FPS drops in multi-device~
  - Used ttnn.from_host_shards, during input tensor sharding and improved FPS
  - For 640x640 resolution,
    - Single Device : 90 FPS
    - Multi Device (N300) : 175 FPS

### Checklist
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/16642997754)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/16643012317/job/47097569077) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/16643004362/job/47097475359#step:22:628)
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16643000735/job/47097452133)
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/16643008369/job/47097473880)