### PR TITLE
Add logical left shift api

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -263,8 +263,21 @@ def test_binary_logical_int32_edge_cases(logical_op, device):
     ],
 )
 def test_binary_left_shift(device, ttnn_function, ttnn_dtype):
-    x_torch = torch.tensor([[99, 3, 100, 1, 72, 0, -100, 22, 12, 1000]], dtype=torch.int32)
-    y_torch = torch.tensor([[1, 2, 31, 4, 5, 0, -20, 1, -3, -25]], dtype=torch.int32)
+    # Test with regular values and extreme values for both int32 and uint32
+    if ttnn_dtype == ttnn.int32:
+        x_torch = torch.tensor(
+            [[99, 3, 100, 1, 72, 0, -100, 22, 12, 1000, 2147483647, -2147483648, -1, 1]], dtype=torch.int32
+        )  # Include int32 extremes
+
+    else:  # ttnn.uint32
+        # For uint32, test with values that represent the full uint32 range
+        # Note: 4294967295 (uint32 max) is represented as -1 in int32 two's complement
+        x_torch = torch.tensor(
+            [[99, 3, 100, 1, 72, 0, 22, 12, 1000, 0, -1, 2147483647, -2147483648]], dtype=torch.int32
+        )  # uint32 extremes as int32
+
+    y_torch = torch.tensor([[1, 2, 31, 4, 5, 0, -20, 1, -3, -25, 0, 1, 31, 30]], dtype=torch.int32)
+
     if ttnn_dtype == ttnn.uint32:  # Stimulate uint32 input
         x_uint32 = x_torch.to(torch.int64) & 0xFFFFFFFF
         y_uint32 = y_torch.to(torch.int64) & 0xFFFFFFFF

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -252,6 +252,7 @@ def test_binary_logical_int32_edge_cases(logical_op, device):
     "ttnn_function",
     [
         ttnn.bitwise_left_shift,
+        ttnn.logical_left_shift,
     ],
 )
 @pytest.mark.parametrize(
@@ -261,7 +262,7 @@ def test_binary_logical_int32_edge_cases(logical_op, device):
         ttnn.uint32,
     ],
 )
-def test_bitwise_left_shift(device, ttnn_function, ttnn_dtype):
+def test_binary_left_shift(device, ttnn_function, ttnn_dtype):
     x_torch = torch.tensor([[99, 3, 100, 1, 72, 0, -100, 22, 12, 1000]], dtype=torch.int32)
     y_torch = torch.tensor([[1, 2, 31, 4, 5, 0, -20, 1, -3, -25]], dtype=torch.int32)
     if ttnn_dtype == ttnn.uint32:  # Stimulate uint32 input

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -273,7 +273,7 @@ def test_binary_left_shift(device, ttnn_function, ttnn_dtype):
         # For uint32, test with values that represent the full uint32 range
         # Note: 4294967295 (uint32 max) is represented as -1 in int32 two's complement
         x_torch = torch.tensor(
-            [[99, 3, 100, 1, 72, 0, 22, 12, 1000, 0, -1, 2147483647, -2147483648]], dtype=torch.int32
+            [[99, 3, 100, 1, 72, 0, 5, 22, 12, 1000, 0, -1, 2147483647, -2147483648]], dtype=torch.int32
         )  # uint32 extremes as int32
 
     y_torch = torch.tensor([[1, 2, 31, 4, 5, 0, -20, 1, -3, -25, 0, 1, 31, 30]], dtype=torch.int32)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -496,6 +496,11 @@ struct ExecuteBitwiseRightShift {
         std::optional<bool> use_legacy = std::nullopt);
 };
 
+struct ExecuteLogicalLeftShift : ExecuteBitwiseLeftShift {
+    // Inherits all functionality from ExecuteBitwiseLeftShift
+    // but creates a distinct type for registration
+};
+
 }  // namespace binary
 }  // namespace operations
 
@@ -546,6 +551,8 @@ constexpr auto bitwise_or = ttnn::register_operation<"ttnn::bitwise_or", operati
 constexpr auto bitwise_xor = ttnn::register_operation<"ttnn::bitwise_xor", operations::binary::ExecuteBitwiseXor>();
 constexpr auto bitwise_left_shift =
     ttnn::register_operation<"ttnn::bitwise_left_shift", operations::binary::ExecuteBitwiseLeftShift>();
+constexpr auto logical_left_shift =
+    ttnn::register_operation<"ttnn::logical_left_shift", operations::binary::ExecuteLogicalLeftShift>();
 constexpr auto bitwise_right_shift =
     ttnn::register_operation<"ttnn::bitwise_right_shift", operations::binary::ExecuteBitwiseRightShift>();
 constexpr auto pow = ttnn::register_operation<"ttnn::pow", operations::binary::ExecutePower>();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -2155,7 +2155,7 @@ void py_module(py::module& module) {
         R"doc(Perform bitwise_left_shift operation on :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`. :attr:`input_tensor_b` has shift_bits which are integers within range (0, 31))doc",
         R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_and|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
         ". ",
-        R"doc(INT32)doc");
+        R"doc(INT32, UINT32)doc");
 
     detail::bind_bitwise_binary_ops_operation(
         module,
@@ -2163,7 +2163,15 @@ void py_module(py::module& module) {
         R"doc(Perform bitwise_right_shift operation on :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`. :attr:`input_tensor_b` has shift_bits which are integers within range (0, 31))doc",
         R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_and|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
         ". ",
-        R"doc(INT32)doc");
+        R"doc(INT32, UINT32)doc");
+
+    detail::bind_bitwise_binary_ops_operation(
+        module,
+        ttnn::logical_left_shift,
+        R"doc(Perform logical_left_shift operation on :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`. :attr:`input_tensor_b` has shift_bits which are integers within range (0, 31))doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \verb|logical_left_shift|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
+        ". ",
+        R"doc(INT32, UINT32)doc");
 
     detail::bind_logical_binary_ops_operation(
         module,
@@ -2171,7 +2179,7 @@ void py_module(py::module& module) {
         R"doc(Perform logical_right_shift operation on :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`. :attr:`input_tensor_b` has shift_bits which are integers within range (0, 31). Logical right shift fills vacated bits with zeros.)doc",
         R"doc(\mathrm{{output\_tensor}}_i = \verb|logical_right_shift|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
         ". ",
-        R"doc(INT32)doc");
+        R"doc(INT32, UINT32)doc");
 
     auto prim_module = module.def_submodule("prim", "Primitive binary operations");
 

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -404,6 +404,8 @@ def _golden_function_bitwise_left_shift(input_tensor_a, shift_amt, *args, **kwar
 
 ttnn.attach_golden_function(ttnn.bitwise_left_shift, golden_function=_golden_function_bitwise_left_shift)
 
+ttnn.attach_golden_function(ttnn.logical_left_shift, golden_function=_golden_function_bitwise_left_shift)
+
 
 def _golden_function_bitwise_right_shift(input_tensor_a, shift_amt, *args, **kwargs):
     import torch


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22862

### Problem description
logical left shift api missing

### What's changed
add logical left shift api and link with bitwise left shift as both perform similar operation

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes