### PR TITLE
#24891: Reinstate SDXL device perf test

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -103,7 +103,7 @@ jobs:
             # WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/yolov10/tests -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
             # WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/yolov7/tests/perf/test_perf.py -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
             WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/vit/demo/test_vit_device_perf.py -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
-            # WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
+            WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
             # WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/yolov6l/tests -m models_device_performance_bare_metal || FAILED=$((FAILED+1))
           fi
 


### PR DESCRIPTION
### Ticket
#24891 

### Problem description
SDXL test was removed from the device perf pipeline due to failure. Upon further investigation it was determined that the test passes and failure was due to HF issues.

### What's changed
Test added to the pipeline.

### Checklist
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/16261212363) CI passes