### PR TITLE
Bump expected unet device perf

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -39,7 +39,7 @@ def test_unet_model(batch, groups, device, iterations, reset_seeds):
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1430.0),),
+    ((1, 4, 1435.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_perf.py::test_unet_model"


### PR DESCRIPTION
### Ticket
#24889

### Problem description
Unet device perf is a bit better than the expected + margin.

### What's changed
Bump margin - I took the last 7-8 runs, most of them had 1435fps, one had 1433, and one 1437 (the one linked in the description). Setting to 1435fps.

### Checklist
Device perf pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/16217440376 - unet passed, yolo fails afterwards