### PR TITLE
Add item api for ttnn tensor

### DIFF
--- a/tests/ttnn/unit_tests/test_item.py
+++ b/tests/ttnn/unit_tests/test_item.py
@@ -16,14 +16,21 @@ import pytest
         (torch.tensor([3.14], dtype=torch.float32), ttnn.float32, "FLOAT32"),
         (torch.tensor([2.71], dtype=torch.bfloat16), ttnn.bfloat16, "BFLOAT16"),
         (torch.tensor([30000], dtype=torch.int16), ttnn.uint16, "UINT16"),
+        (torch.tensor([4294967295], dtype=torch.int64), ttnn.uint32, "UINT32"),
+        (torch.tensor([1.5], dtype=torch.float32), ttnn.bfloat8_b, "BFLOAT8_B"),
+        (torch.tensor([2.5], dtype=torch.float32), ttnn.bfloat4_b, "BFLOAT4_B"),
         (torch.tensor([200], dtype=torch.uint8), ttnn.uint8, "UINT8 edge case"),
         # Zero values
         (torch.tensor([0], dtype=torch.uint8), ttnn.uint8, "UINT8 zero"),
         (torch.tensor([0], dtype=torch.int32), ttnn.int32, "INT32 zero"),
         (torch.tensor([0.0], dtype=torch.float32), ttnn.float32, "FLOAT32 zero"),
+        (torch.tensor([0], dtype=torch.int64), ttnn.uint32, "UINT32 zero"),
+        (torch.tensor([0.0], dtype=torch.float32), ttnn.bfloat8_b, "BFLOAT8_B zero"),
+        (torch.tensor([0.0], dtype=torch.float32), ttnn.bfloat4_b, "BFLOAT4_B zero"),
         # Maximum values
         (torch.tensor([255], dtype=torch.uint8), ttnn.uint8, "UINT8 max"),
         (torch.tensor([2147483647], dtype=torch.int32), ttnn.int32, "INT32 max"),
+        (torch.tensor([4294967295], dtype=torch.int64), ttnn.uint32, "UINT32 max"),
         # Minimum values
         (torch.tensor([-2147483648], dtype=torch.int32), ttnn.int32, "INT32 min"),
         # Small float values
@@ -52,12 +59,18 @@ import pytest
         (torch.tensor([[[[30000]]]], dtype=torch.int16), ttnn.uint16, "4D UINT16"),
         (torch.tensor([[[[0.0]]]], dtype=torch.float32), ttnn.float32, "4D FLOAT32 zero"),
         (torch.tensor([[[[float("nan")]]]], dtype=torch.float32), ttnn.float32, "4D FLOAT32 nan"),
+        (torch.tensor([[[[1000000]]]], dtype=torch.int64), ttnn.uint32, "4D UINT32"),
+        (torch.tensor([[[[3.14]]]], dtype=torch.float32), ttnn.bfloat8_b, "4D BFLOAT8_B"),
+        (torch.tensor([[[[2.71]]]], dtype=torch.float32), ttnn.bfloat4_b, "4D BFLOAT4_B"),
     ],
 )
 def test_tensor_item_basic_types(device, torch_tensor, ttnn_dtype, description):
     """Test .item() with basic data types"""
 
     ttnn_tensor = ttnn.from_torch(torch_tensor, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    if ttnn_dtype == ttnn.bfloat8_b or ttnn_dtype == ttnn.bfloat4_b:
+        torch_tensor = ttnn.to_torch(ttnn_tensor)  # Torch does not support bfloat8_b and bfloat4_b
 
     original_value = torch_tensor.item()
     ttnn_value = ttnn_tensor.item()

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -267,6 +267,10 @@ public:
     // Size in bytes of a single element held in tensor
     uint32_t element_size() const;
 
+    // Extract the scalar value from a tensor containing exactly one element
+    // Returns a variant that can hold any of the supported data types
+    std::variant<float, bfloat16, int32_t, uint32_t, uint16_t, uint8_t> item() const;
+
     static constexpr auto attribute_names = std::forward_as_tuple("storage", "tensor_spec");
     auto attribute_values() const {
         return std::forward_as_tuple(

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -157,6 +157,9 @@ public:
     template <typename T>
     [[nodiscard]] std::vector<T> to_vector(ttnn::QueueId cq_id = ttnn::DefaultQueueId) const;
 
+    template <typename T>
+    [[nodiscard]] T item(ttnn::QueueId cq_id = ttnn::DefaultQueueId) const;
+
     [[nodiscard]] Tensor to_device(
         IDevice* target_device,
         const MemoryConfig& mem_config = MemoryConfig{},
@@ -266,10 +269,6 @@ public:
 
     // Size in bytes of a single element held in tensor
     uint32_t element_size() const;
-
-    // Extract the scalar value from a tensor containing exactly one element
-    // Returns a variant that can hold floating point or integer values
-    std::variant<double, int64_t> item() const;
 
     static constexpr auto attribute_names = std::forward_as_tuple("storage", "tensor_spec");
     auto attribute_values() const {

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -268,8 +268,8 @@ public:
     uint32_t element_size() const;
 
     // Extract the scalar value from a tensor containing exactly one element
-    // Returns a variant that can hold any of the supported data types
-    std::variant<float, bfloat16, int32_t, uint32_t, uint16_t, uint8_t> item() const;
+    // Returns a variant that can hold floating point or integer values
+    std::variant<double, int64_t> item() const;
 
     static constexpr auto attribute_names = std::forward_as_tuple("storage", "tensor_spec");
     auto attribute_values() const {

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -1068,16 +1068,7 @@ void pytensor_module(py::module& m_tensor) {
             "item",
             [](const Tensor& self) -> py::object {
                 auto result = self.item();
-                return std::visit(
-                    [](const auto& value) -> py::object {
-                        using T = std::decay_t<decltype(value)>;
-                        if constexpr (std::is_same_v<T, bfloat16>) {
-                            return py::cast(value.to_float());
-                        } else {
-                            return py::cast(value);
-                        }
-                    },
-                    result);
+                return std::visit([](const auto& value) -> py::object { return py::cast(value); }, result);
             },
             R"doc(
                  Extract the scalar value from a tensor containing exactly one element.

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -1067,8 +1067,17 @@ void pytensor_module(py::module& m_tensor) {
         .def(
             "item",
             [](const Tensor& self) -> py::object {
-                auto result = self.item();
-                return std::visit([](const auto& value) -> py::object { return py::cast(value); }, result);
+                switch (self.dtype()) {
+                    case DataType::FLOAT32: return py::cast(self.item<float>());
+                    case DataType::BFLOAT16: return py::cast(self.item<bfloat16>().to_float());
+                    case DataType::BFLOAT8_B:
+                    case DataType::BFLOAT4_B: return py::cast(self.item<float>());
+                    case DataType::INT32: return py::cast(self.item<int32_t>());
+                    case DataType::UINT32: return py::cast(self.item<uint32_t>());
+                    case DataType::UINT16: return py::cast(self.item<uint16_t>());
+                    case DataType::UINT8: return py::cast(self.item<uint8_t>());
+                    case DataType::INVALID: TT_THROW("Unsupported DataType");
+                }
             },
             R"doc(
                  Extract the scalar value from a tensor containing exactly one element.

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -1078,6 +1078,7 @@ void pytensor_module(py::module& m_tensor) {
                     case DataType::UINT8: return py::cast(self.item<uint8_t>());
                     case DataType::INVALID: TT_THROW("Unsupported DataType");
                 }
+                TT_THROW("Unreachable");
             },
             R"doc(
                  Extract the scalar value from a tensor containing exactly one element.

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -1070,11 +1070,10 @@ void pytensor_module(py::module& m_tensor) {
                 using namespace CMAKE_UNIQUE_NAMESPACE;
 
                 // Check if tensor has exactly one element
-                if (self.logical_shape().volume() != 1) {
-                    TT_THROW(
-                        "tensor.item() requires tensor to have exactly one element, but got {} elements",
-                        self.logical_shape().volume());
-                }
+                TT_FATAL(
+                    self.logical_shape().volume() == 1,
+                    "tensor.item() requires tensor to have exactly one element, but got {} elements",
+                    self.logical_shape().volume());
 
                 Tensor host_tensor = self.storage_type() == DEVICE_STORAGE_TYPE ? self.cpu() : self;
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24751

### Problem description
We dont have api for extract the scalar value from tensor as torch has .item()

### What's changed
Add .item() api for ttnn tensor

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/16218937750
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/16218937750
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes