### PR TITLE
Skip RoPE test for BH in MLA testing

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_deepseek_mla_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_deepseek_mla_ops.py
@@ -16,6 +16,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
 import ttnn
 from loguru import logger
 import pytest
+from models.utility_functions import skip_for_blackhole
 
 from models.demos.deepseek_v3.tt.rope import RotarySetup
 from models.demos.deepseek_v3.tt.rms_norm import RMSNorm
@@ -981,6 +982,7 @@ def test_prefill_matmuls(
     )
 
 
+@skip_for_blackhole("See GH Issue #24926.")
 @pytest.mark.parametrize(
     "shape, dtype, mem_config",
     [


### PR DESCRIPTION
### Ticket
- #24926

### Problem description
Decode RoPE for DeepSeekV3 shapes fails on BH APC

### What's changed
- Disable test for BH

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16219487461) CI with demo tests passes (if applicable)