### PR TITLE
Add uint32 support for logical_not

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -575,23 +575,6 @@ def test_unary_geglu_ttnn(input_shapes, dim, device):
     golden_tensor = golden_fn(in_data, dim)
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor])
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
-def test_unary_logical_not_ttnn(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    output_tensor = ttnn.logical_not_(input_tensor)
-    golden_function = ttnn.get_golden_function(ttnn.logical_not_)
-    golden_tensor = golden_function(in_data)
-
-    comp_pass = compare_pcc([input_tensor], [golden_tensor])
     assert comp_pass
 
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -486,16 +486,37 @@ def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_logical_not_ttnn(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype",
+    [
+        (torch.float32, ttnn.float32),
+        (torch.bfloat16, ttnn.bfloat16),
+    ],
+)
+def test_unary_logical_not_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+    num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
+    in_data = torch.linspace(-100, 100, num_elements, dtype=torch_dtype)
+    in_data[::5] = 0  # every 5th element is zero
+    in_data = in_data[:num_elements].reshape(input_shapes).nan_to_num(0.0)
+
+    input_tensor = ttnn.from_torch(
+        in_data,
+        dtype=ttnn_dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
     cq_id = 0
     ttnn.logical_not(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = torch.logical_not(in_data)
+    output_tensor = ttnn.to_torch(output_tensor, dtype=torch_dtype)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    golden_function = ttnn.get_golden_function(ttnn.logical_not)
+    golden_tensor = golden_function(in_data, device=device)
+
+    assert torch.equal(output_tensor, golden_tensor.to(torch_dtype))
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_uint32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_uint32.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        (torch.Size([])),
+        (torch.Size([1, 64])),
+        (torch.Size([1, 2, 32])),
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+        (torch.Size([1, 2, 32, 64, 125])),
+    ],
+)
+@pytest.mark.parametrize(
+    "low_a, high_a",
+    [
+        (0, 1000),
+        (1000, 1e5),
+        (1e5, 1e7),
+        (1e7, 1e9),
+        (4e9, 4294967295),  # large positive input
+        (0, 4294967295),  # full range
+    ],
+)
+def test_unary_logical_not_uint32(input_shapes, low_a, high_a, device):
+    if len(input_shapes) == 0:
+        torch_input_tensor = torch.randint(low=0, high=2**32, size=(), dtype=torch.int64)
+    else:
+        num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
+        torch_input_tensor = torch.linspace(low_a, high_a, num_elements, dtype=torch.int64)
+        torch_input_tensor[::5] = 0  # every 5th element is zero
+        corner_case = torch.tensor([4294967295])
+        torch_input_tensor[-2:] = corner_case
+        torch_input_tensor = torch_input_tensor[:num_elements].reshape(input_shapes)
+
+    golden_function = ttnn.get_golden_function(ttnn.logical_not)
+    torch_output_tensor = golden_function(torch_input_tensor, device=device)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    output_tensor = ttnn.logical_not(input_tensor)
+    output_tensor = ttnn.to_torch(output_tensor, dtype=torch.int64)
+
+    assert torch.equal(output_tensor, torch_output_tensor)
+
+
+height_sharded_memory_config = ttnn.create_sharded_memory_config(
+    [128, 160],
+    core_grid=ttnn.CoreRangeSet({ttnn.CoreRange((1, 0), (1, 6)), ttnn.CoreRange((3, 0), (3, 6))}),
+    strategy=ttnn.ShardStrategy.HEIGHT,
+    orientation=ttnn.ShardOrientation.COL_MAJOR,
+    use_height_and_width_as_shard_shape=True,
+)
+
+width_sharded_memory_config = ttnn.create_sharded_memory_config(
+    [2240, 32],
+    core_grid=ttnn.CoreRangeSet({ttnn.CoreRange((2, 2), (2, 3)), ttnn.CoreRange((0, 0), (0, 1))}),
+    strategy=ttnn.ShardStrategy.WIDTH,
+    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    use_height_and_width_as_shard_shape=True,
+)
+
+block_sharded_memory_config = ttnn.create_sharded_memory_config(
+    [320, 32],
+    core_grid=ttnn.CoreRangeSet({ttnn.CoreRange((1, 0), (4, 6))}),
+    strategy=ttnn.ShardStrategy.BLOCK,
+    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    use_height_and_width_as_shard_shape=True,
+)
+
+
+@pytest.mark.parametrize(
+    "a_shape",
+    [(torch.Size([5, 7, 64, 128]))],
+)
+@pytest.mark.parametrize(
+    "sharded_config",
+    [
+        height_sharded_memory_config,
+        width_sharded_memory_config,
+        block_sharded_memory_config,
+    ],
+)
+def test_unary_logical_not_uint32_sharded(a_shape, sharded_config, device):
+    num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
+    torch_input_tensor = torch.linspace(-100, 100, num_elements, dtype=torch.int32)
+    torch_input_tensor[::5] = 0  # every 5th element is zero
+    torch_input_tensor = torch_input_tensor[:num_elements].reshape(a_shape)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=sharded_config,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.logical_not)
+    torch_output_tensor = golden_function(torch_input_tensor, device=device)
+
+    output_tensor = ttnn.logical_not(input_tensor, memory_config=sharded_config)
+    output_tensor = ttnn.to_torch(output_tensor, dtype=torch.int32)
+
+    assert torch.equal(output_tensor, torch_output_tensor)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not_noti.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not_noti.h
@@ -1,15 +1,12 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpi.h"
 
-namespace ckernel {
-namespace sfpu {
+namespace ckernel::sfpu {
 
 template <typename V, typename T>
 inline void calculate_logical_not_unary() {
@@ -23,5 +20,4 @@ inline void calculate_logical_not_unary() {
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_logical_not_noti.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_logical_not_noti.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,16 +17,10 @@ inline void llk_math_eltwise_unary_sfpu_logical_not_unary_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::logical_not_unary, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, typename V, typename T>
 inline void llk_math_eltwise_unary_sfpu_logical_not_unary_op(uint dst_index) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_logical_not_unary<sfpi::vFloat, float>, dst_index, static_cast<int>(VectorMode::RC));
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_logical_not_unary_op_int32(uint dst_index) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_logical_not_unary<sfpi::vInt, int16_t>, dst_index, static_cast<int>(VectorMode::RC));
+        ckernel::sfpu::calculate_logical_not_unary<V, T>, dst_index, static_cast<int>(VectorMode::RC));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not_noti.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not_noti.h
@@ -1,17 +1,12 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
-
 #include "sfpi.h"
 
-namespace ckernel {
-namespace sfpu {
+namespace ckernel::sfpu {
 
 template <typename V, typename T>
 inline void calculate_logical_not_unary() {
@@ -25,5 +20,4 @@ inline void calculate_logical_not_unary() {
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_logical_not_noti.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_logical_not_noti.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,16 +16,11 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_logical_not_unary_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::logical_not_unary, APPROXIMATE>();
 }
-template <bool APPROXIMATE>
+
+template <bool APPROXIMATE, typename V, typename T>
 inline void llk_math_eltwise_unary_sfpu_logical_not_unary_op(uint dst_index) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_logical_not_unary<sfpi::vFloat, float>, dst_index, static_cast<int>(VectorMode::RC));
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_logical_not_unary_op_int32(uint dst_index) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_logical_not_unary<sfpi::vInt, int16_t>, dst_index, static_cast<int>(VectorMode::RC));
+        ckernel::sfpu::calculate_logical_not_unary<V, T>, dst_index, static_cast<int>(VectorMode::RC));
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/logical_not_noti.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/logical_not_noti.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -29,25 +29,15 @@ namespace ckernel {
  */
  // clang-format on
 ALWI void logical_not_unary_tile(uint32_t idst) {
-    MATH((llk_math_eltwise_unary_sfpu_logical_not_unary_op<APPROX>(idst)));
+    MATH((llk_math_eltwise_unary_sfpu_logical_not_unary_op<APPROX, sfpi::vFloat, float>(idst)));
 }
 
-// clang-format off
-/**
- * Performs element-wise computation of the logical not unary operation for int32 dtype on each element of a tile
- * in DST register at index tile_index. The DST register buffer must be in
- * acquired state via *acquire_dst* call. This call is blocking and is only
- * available on the compute engine.
- *
- * Return value: None
- *
- * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
- * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- */
-// clang-format on
 ALWI void logical_not_unary_tile_int32(uint32_t idst) {
-    MATH((llk_math_eltwise_unary_sfpu_logical_not_unary_op_int32<APPROX>(idst)));
+    MATH((llk_math_eltwise_unary_sfpu_logical_not_unary_op<APPROX, sfpi::vInt, int16_t>(idst)));
+}
+
+ALWI void logical_not_unary_tile_uint32(uint32_t idst) {
+    MATH((llk_math_eltwise_unary_sfpu_logical_not_unary_op<APPROX, sfpi::vUInt, uint16_t>(idst)));
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -398,6 +398,9 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
             if (input_dtype == DataType::INT32) {
                 op_init_and_name = {
                     "logical_not_unary_tile_init();", fmt::format("logical_not_unary_tile_int32({});", idst)};
+            } else if (input_dtype == DataType::UINT32) {
+                op_init_and_name = {
+                    "logical_not_unary_tile_init();", fmt::format("logical_not_unary_tile_uint32({});", idst)};
             } else {
                 op_init_and_name = {"logical_not_unary_tile_init();", fmt::format("logical_not_unary_tile({});", idst)};
             }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -1843,7 +1843,7 @@ void py_module(py::module& module) {
         ttnn::logical_not,
         R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{!input\_tensor_i}})doc",
         "",
-        R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, INT32, UINT32)doc");
     bind_unary_operation(
         module,
         ttnn::ltz,
@@ -2142,7 +2142,7 @@ void py_module(py::module& module) {
         ttnn::logical_not_,
         R"doc(Performs logical_not inplace function on :attr:`input_tensor`.)doc",
         "",
-        R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, INT32, UINT32)doc");
     bind_unary_composite(
         module,
         ttnn::normalize_global,


### PR DESCRIPTION
### Ticket
#24275

### Problem description
Current implementation for logical_not uses vFloat and vInt in its implementation
add support for uint32 dtype with vUInt

### What's changed
Added uint32 support for logical_not
Cleaned up float, int32, uint32 to single templated function.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16293358243) - PASSED (latest run: https://github.com/tenstorrent/tt-metal/actions/runs/16342220261 - same as main)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16221257095) - PASSED
- [x] [(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/16293344817) - same as main
- [x] New/Existing tests provide coverage for changes