### PR TITLE
Quick mesh device fix in Inspector

### DIFF
--- a/tt_metal/impl/debug/inspector.cpp
+++ b/tt_metal/impl/debug/inspector.cpp
@@ -185,7 +185,7 @@ void Inspector::mesh_device_created(
         auto* data = get_inspector_data();
         std::lock_guard<std::mutex> lock(data->mesh_devices_mutex);
         auto& mesh_device_data = data->mesh_devices_data[mesh_device->id()];
-        mesh_device_data.mesh_device = mesh_device->weak_from_this();
+        mesh_device_data.mesh_device = mesh_device;
         mesh_device_data.mesh_id = mesh_device->id();
         mesh_device_data.parent_mesh_id = parent_mesh_id;
         data->logger.log_mesh_device_created(mesh_device_data);

--- a/tt_metal/impl/debug/inspector_impl.cpp
+++ b/tt_metal/impl/debug/inspector_impl.cpp
@@ -214,7 +214,7 @@ void Logger::log_mesh_device_created(const MeshDeviceData& mesh_device_data) noe
             mesh_devices_ostream << "    parent_mesh_id: " << *mesh_device_data.parent_mesh_id << "\n";
         }
 
-        auto mesh_device = mesh_device_data.mesh_device.lock();
+        auto mesh_device = mesh_device_data.mesh_device;
         if (mesh_device) {
             mesh_devices_ostream << "    devices: [";
             bool first = true;

--- a/tt_metal/impl/debug/inspector_impl.hpp
+++ b/tt_metal/impl/debug/inspector_impl.hpp
@@ -58,7 +58,7 @@ struct ProgramData {
 };
 
 struct MeshDeviceData {
-    std::weak_ptr<const distributed::MeshDevice> mesh_device;
+    const distributed::MeshDevice* mesh_device;
     int mesh_id;
     std::optional<int> parent_mesh_id;
     bool initialized = false;


### PR DESCRIPTION
Removing usage of weak_ptr and using raw pointer. Problem, cannot dereference weak point of share pointer until constructor ends....