### PR TITLE
Adding Batched matmul support to the model

### DIFF
--- a/models/demos/llama3_subdevices/demo/text_demo_targets.json
+++ b/models/demos/llama3_subdevices/demo/text_demo_targets.json
@@ -3,7 +3,7 @@
         "4U": {
             "prefill_pcc": 0.9132907037883032,
             "decode_pcc": 0.9470088259102208,
-            "throughput": 58.4,
+            "throughput": 59.87,
             "absolute_margin": 1.0,
             "token_pos": 127
         }

--- a/models/demos/llama3_subdevices/tests/decoder_perf_targets_4u.json
+++ b/models/demos/llama3_subdevices/tests/decoder_perf_targets_4u.json
@@ -70,7 +70,7 @@
             "op_name": "ReduceScatter_FF3",
             "kernel_duration": 9456.963068181818,
             "op_to_op": 911.3131313131312,
-            "first_to_last_start": 723.1111111111111,
+            "first_to_last_start": 2042,
             "non-overlapped-dispatch-time": 7952.344444444445,
             "kernel_duration_relative_margin": 0.05,
             "op_to_op_duration_relative_margin": 0.2,

--- a/models/demos/llama3_subdevices/tests/decoder_perf_targets_4u.json
+++ b/models/demos/llama3_subdevices/tests/decoder_perf_targets_4u.json
@@ -100,17 +100,6 @@
             "dispatch_duration_relative_margin": 0.1
         },
         "Matmul_2": {
-            "op_name": "FF1_MM",
-            "kernel_duration": 9445.285827020201,
-            "op_to_op": 728.1616161616162,
-            "first_to_last_start": 2191.964646464646,
-            "non-overlapped-dispatch-time": 5524.777777777778,
-            "kernel_duration_relative_margin": 0.05,
-            "op_to_op_duration_relative_margin": 0.2,
-            "first_to_last_start_relative_margin": 0.2,
-            "dispatch_duration_relative_margin": 0.2
-        },
-        "Matmul_3": {
             "op_name": "FF2_MM",
             "kernel_duration": 14981.60827020202,
             "op_to_op": 726.8888888888888,
@@ -123,10 +112,10 @@
         },
         "Matmul_RS_0": {
             "op_name": "ReduceScatter_FF1_MM_FF3",
-            "kernel_duration": 11133.938194444445,
+            "kernel_duration": 20958.09375,
             "op_to_op": 768.6444444444444,
-            "first_to_last_start": 2314.777777777778,
-            "non-overlapped-dispatch-time": 23567.666666666668,
+            "first_to_last_start": 2338.777777777778,
+            "non-overlapped-dispatch-time": 18558.666666666668,
             "kernel_duration_relative_margin": 0.05,
             "op_to_op_duration_relative_margin": 0.2,
             "first_to_last_start_relative_margin": 0.2,

--- a/models/demos/llama3_subdevices/tests/decoder_perf_targets_6u.json
+++ b/models/demos/llama3_subdevices/tests/decoder_perf_targets_6u.json
@@ -67,17 +67,6 @@
       "dispatch_duration_relative_margin": 0.1
     },
     "Matmul_2": {
-      "op_name": "FF1_MM",
-      "kernel_duration": 8515.039583333333,
-      "op_to_op": 693.2888888888889,
-      "first_to_last_start": 1924.5111111111112,
-      "non-overlapped-dispatch-time": 4980.507936507936,
-      "kernel_duration_relative_margin": 0.05,
-      "op_to_op_duration_relative_margin": 0.2,
-      "first_to_last_start_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.1
-    },
-    "Matmul_3": {
       "op_name": "FF2_MM",
       "kernel_duration": 13973.23125,
       "op_to_op": 652.1777777777777,
@@ -123,12 +112,12 @@
     },
     "Matmul_RS_0": {
       "op_name": "Matmul_FF3_ReduceScatter_FF1",
-      "kernel_duration": 9292.354398148147,
-      "op_to_op": 980.7777777777778,
-      "first_to_last_start": 1914.9925925925927,
-      "non-overlapped-dispatch-time": 17432.341269841272,
+      "kernel_duration": 17497.70138888889,
+      "op_to_op": 723.4444444444445,
+      "first_to_last_start": 2007.5555555555557,
+      "non-overlapped-dispatch-time": 23457.444444444445,
       "kernel_duration_relative_margin": 0.05,
-      "op_to_op_duration_relative_margin": 0.3,
+      "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.3
     },

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -161,11 +161,7 @@ def merge_device_rows(df):
         missing_devices = []
         for device_id in device_ids:
             if not len(block_by_device[device_id]):
-                print(
-                    colored(
-                        f"Warning: Device {device_id} is missing operation {op_name} at index {global_index}", "yellow"
-                    )
-                )
+                logger.warning(f"Warning: Device {device_id} is missing operation {op_name} at index {global_index}")
                 continue
             if op_name is None:
                 op_name = block_by_device[device_id][0][0]
@@ -176,11 +172,8 @@ def merge_device_rows(df):
             blocks.append(block_by_device[device_id].pop(0))
 
         if missing_devices:
-            print(
-                colored(
-                    f"Warning: {op_name} at index {global_index} not present in CSV for {len(missing_devices)} devices {missing_devices} - do not trust data for this op or directly subsequent ops with the same name",
-                    "yellow",
-                )
+            logger.warning(
+                f"Warning: {op_name} at index {global_index} not present in CSV for {len(missing_devices)} devices {missing_devices} - do not trust data for this op or directly subsequent ops with the same name"
             )
 
         if not blocks:
@@ -215,7 +208,7 @@ def build_duration_dict(raw_dict, column_name):
     op_code_dict = {}
     for entry in raw_dict:
         if column_name not in entry:
-            print(f"Warning: {entry} does not have column {column_name}")
+            logger.warning(f"Warning: {entry} does not have column {column_name}")
         op_code = entry["OP CODE"]
         duration = entry[column_name]
         if op_code not in op_code_dict:
@@ -230,7 +223,7 @@ def build_duration_per_instance_dict(input_dict, num_layers):
         num_ops_with_op_code = len(input_dict[op_code])
         num_instances = num_ops_with_op_code // num_layers
         if num_ops_with_op_code % num_layers != 0:
-            print(f"Warning: {op_code} has {num_ops_with_op_code} ops, not a multiple of {num_layers} layers")
+            logger.warning(f"Warning: {op_code} has {num_ops_with_op_code} ops, not a multiple of {num_layers} layers")
             print_dict(input_dict, "input_dict")
             assert num_ops_with_op_code % num_layers == 0
         for iteration_id in range(num_layers):
@@ -272,10 +265,10 @@ def max_per_instance_dict(input_dict):
 
 def print_dict(input_dict, dict_name):
     # print dict as a readable python dict
-    print(f"\n{dict_name} = {{")
+    logger.info(f"\n{dict_name} = {{")
     for op_code_with_id in input_dict:
-        print(f'"{op_code_with_id}": {input_dict[op_code_with_id]},')
-    print("}")
+        logger.info(f'"{op_code_with_id}": {input_dict[op_code_with_id]},')
+    logger.info("}")
 
 
 def is_collective_op(op_code):
@@ -353,7 +346,7 @@ def verify_value_within_margin(value, target, margin, op_code_with_id, perf_type
 def add_benchmark_measurement(profiler, benchmark_data, step_name, op_name, value, prefix, measure_type, stats_type):
     name = f"{op_name}-{prefix}-{measure_type}-{stats_type}"
     benchmark_data.add_measurement(profiler, 0, step_name, name, value)
-    print(f"{name}: {value} ns")
+    logger.info(f"{name}: {value} ns")
 
 
 def load_perf_targets(galaxy_type):
@@ -521,7 +514,7 @@ def test_llama_TG_perf_device(
 
     all_passing = True
     # Verify decoder layer (mid layers)
-    print(f"Decoder layer")
+    logger.info(f"Decoder layer")
     for op_code_with_id in avg_kernel_duration_mid_layers_compilation.keys():
         if op_code_with_id in perf_targets["decoder"]:
             op_name = perf_targets["decoder"][op_code_with_id]["op_name"]
@@ -670,7 +663,7 @@ def test_llama_TG_perf_device(
             logger.info(f"Warning: {op_code_with_id} not found in perf_targets")
 
     # Verify model tail ops
-    print(f"Model tail ops")
+    logger.info(f"Model tail ops")
     for op_code_with_id in avg_kernel_duration_model_tail_compilation.keys():
         if op_code_with_id in perf_targets["model_tail"]:
             op_name = perf_targets["model_tail"][op_code_with_id]["op_name"]
@@ -766,9 +759,9 @@ def test_llama_TG_perf_device(
     # Estimated T/s/u is 1000000 / (80L-duration + ~2100 lmhead+sampling+embeddings + ~300 python-overhead
     tsu_estimate = 1000000 / ((e2e_estimate_80l + model_tail_e2e_estimate) / 1000 + 300)
 
-    print(f"80L e2e time estimate: {e2e_estimate_80l}")
-    print(f"Model tail e2e time estimate: {model_tail_e2e_estimate}")
-    print(f"80L T/s/u estimate: {tsu_estimate}")
+    logger.info(f"80L e2e time estimate: {e2e_estimate_80l}")
+    logger.info(f"Model tail e2e time estimate: {model_tail_e2e_estimate}")
+    logger.info(f"80L T/s/u estimate: {tsu_estimate}")
 
     benchmark_data.add_measurement(profiler, 0, step_name, "e2e_estimate_80l", e2e_estimate_80l)
     benchmark_data.add_measurement(profiler, 0, step_name, "tsu_estimate", tsu_estimate)
@@ -870,7 +863,7 @@ def test_llama_TG_perf_device_non_overlapped_dispatch(
         perf_targets["model_tail"]
     ), f"Expected {len(perf_targets['model_tail'])} operations in model tail, got {len(avg_dispatch_duration_model_tail)}. If the number or type of operations changed, expected times must be updated."
 
-    print("Decoder")
+    logger.info("Decoder")
     passing = True
     for op_code_with_id, avg_dispatch_duration in avg_dispatch_duration_mid_layers.items():
         if op_code_with_id in perf_targets["decoder"]:
@@ -919,7 +912,7 @@ def test_llama_TG_perf_device_non_overlapped_dispatch(
             passing = False
             logger.info(f"Warning: {op_code_with_id} not found in expected_times_dict")
 
-    print("Model tail")
+    logger.info("Model tail")
     all_passing = True
     for op_code_with_id, avg_dispatch_duration in avg_dispatch_duration_model_tail.items():
         if op_code_with_id in perf_targets["model_tail"]:

--- a/models/demos/llama3_subdevices/tt/llama_ccl.py
+++ b/models/demos/llama3_subdevices/tt/llama_ccl.py
@@ -644,6 +644,57 @@ class TT_CCL:
         self.gather_idx[cluster_axis] = (self.gather_idx[cluster_axis] + 1) % self.num_cbs
         return xqkv_reduced, q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD, v_heads_1BKD
 
+    def double_matmul_line_reduce_scatter(
+        self,
+        # Matmul
+        matmul_input,
+        matmul_weightA,
+        matmul_weightB,
+        # Matmul
+        compute_kernel_config=None,
+        dtype=None,
+        program_config=None,
+        memory_config=None,
+        global_cb=None,
+        sub_device_id=None,
+        # Reduce Scatter
+        dim=3,
+        num_links=1,
+        math_op=ttnn.ReduceType.Sum,
+        buffer_key=None,
+        RS_memory_config=None,
+        cluster_axis=1,
+        use_noc1_only=False,
+    ):
+        persistent_interim_buffer = self.reduce_scatter_buffers[cluster_axis][
+            self.reduce_scatter_buffer_idx[cluster_axis]
+        ]
+        w1_out, w3_out, ttnn_tensor_out = ttnn.experimental.llama_rs_matmul(
+            matmul_input,
+            matmul_weightA,
+            persistent_interim_buffer,
+            dim,
+            self.gather_semaphore_handles[cluster_axis][self.gather_idx[cluster_axis]],
+            cluster_axis,
+            self.mesh_device,
+            num_links,
+            self.worker_sub_device_id,
+            second_weight_tensor=matmul_weightB,
+            memory_config_rs=RS_memory_config,
+            compute_kernel_config=compute_kernel_config,
+            dtype=dtype,
+            program_config=program_config,
+            memory_config_mm=memory_config,
+            global_cb=global_cb,
+            topology=self.model_config["CCL_TOPOLOGY"],
+            use_noc1_only=use_noc1_only,
+        )
+        w1_out.deallocate(True)
+        self.gather_idx[cluster_axis] = (self.gather_idx[cluster_axis] + 1) % self.num_cbs
+        self.reduce_scatter_buffer_idx[cluster_axis] = (self.reduce_scatter_buffer_idx[cluster_axis] + 1) % self.num_cbs
+        # ttnn.synchronize_device(self.mesh_device, sub_device_ids=[self.worker_sub_device_id])
+        return ttnn_tensor_out, w3_out
+
     def matmul_line_reduce_scatter(
         self,
         # Matmul
@@ -673,7 +724,6 @@ class TT_CCL:
         w3_out, ttnn_tensor_out = ttnn.experimental.llama_rs_matmul(
             matmul_input,
             matmul_weight,
-            input_tensor_mesh,
             persistent_interim_buffer,
             dim,
             self.gather_semaphore_handles[cluster_axis][self.gather_idx[cluster_axis]],
@@ -681,12 +731,14 @@ class TT_CCL:
             self.mesh_device,
             num_links,
             self.worker_sub_device_id,
+            rs_tensor=input_tensor_mesh,
             memory_config_rs=RS_memory_config,
             compute_kernel_config=compute_kernel_config,
             dtype=dtype,
             program_config=program_config,
             memory_config_mm=memory_config,
             global_cb=global_cb,
+            second_weight_tensor=None,
             topology=self.model_config["CCL_TOPOLOGY"],
             use_noc1_only=use_noc1_only,
         )

--- a/models/demos/llama3_subdevices/tt/llama_mlp.py
+++ b/models/demos/llama3_subdevices/tt/llama_mlp.py
@@ -117,26 +117,13 @@ class TtLlamaMLP(LightweightModule):
         if mode == "prefill":
             return self.forward_prefill(x, mode)
 
-        pc_1 = self.model_config["FF1_3_TG_RING_PROGCFG"]
+        pc_1_3 = self.model_config["FF1_3_TG_RING_PROGCFG"]
         pc_2 = self.model_config["FF2_TG_RING_PROGCFG"]
-        pc_3 = self.model_config["FF1_3_TG_RING_PROGCFG"]
 
-        w1_out = ttnn.linear(
+        w1_out_reduced, w3_out = self.tt_ccl.double_matmul_line_reduce_scatter(
             x,
             self.w1,
-            compute_kernel_config=self.args.compute_kernel_config_lofi
-            if self.four_bit_mlp
-            else self.args.compute_kernel_config_hifi2,
-            dtype=ttnn.bfloat8_b,
-            program_config=pc_1,
-            memory_config=self.model_config["SHARDED_FF12_OUT_RING_MEMCFG"],
-            global_cb=self.prefetcher_setup.global_circular_buffer if self.model_config["USE_PREFETCHER"] else None,
-            sub_device_id=self.prefetcher_setup.worker_sub_device_id if mode == "decode" else None,
-        )
-        w1_out_reduced, w3_out = self.tt_ccl.matmul_line_reduce_scatter(
-            x,
             self.w3,
-            w1_out,
             cluster_axis=1,
             num_links=self.model_config["GALAXY_NUM_LINKS"],
             RS_memory_config=self.model_config["REDUCE_SCATTER_OUT_MEMCFG"],
@@ -144,24 +131,21 @@ class TtLlamaMLP(LightweightModule):
             if self.four_bit_mlp
             else self.args.compute_kernel_config_hifi2,
             dtype=ttnn.bfloat8_b,
-            program_config=pc_3,
+            program_config=pc_1_3,
             memory_config=self.model_config["SHARDED_FF12_OUT_RING_MEMCFG"],
             global_cb=self.prefetcher_setup.global_circular_buffer if self.model_config["USE_PREFETCHER"] else None,
             sub_device_id=self.prefetcher_setup.worker_sub_device_id if mode == "decode" else None,
             use_noc1_only=False,
         )
         ttnn.deallocate(x)
-        try:
-            w3_out_reduced = self.tt_ccl.line_reduce_scatter(
-                w3_out,
-                cluster_axis=1,
-                num_links=self.model_config["GALAXY_NUM_LINKS"],
-                memory_config=self.model_config["REDUCE_SCATTER_OUT_MEMCFG"],
-                use_noc1_only=False,
-            )
-        except Exception as e:
-            print(e)
-            self.tt_ccl.close()
+        w3_out_reduced = self.tt_ccl.line_reduce_scatter(
+            w3_out,
+            cluster_axis=1,
+            num_links=self.model_config["GALAXY_NUM_LINKS"],
+            memory_config=self.model_config["REDUCE_SCATTER_OUT_MEMCFG"],
+            use_noc1_only=False,
+        )
+        ttnn.deallocate(w3_out)
 
         ff1ff3 = ttnn.mul(
             w1_out_reduced,

--- a/models/demos/llama3_subdevices/tt/prefetcher_common.py
+++ b/models/demos/llama3_subdevices/tt/prefetcher_common.py
@@ -77,7 +77,7 @@ class TtLlamaPrefetcherSetup(LightweightModule):
             # This ensures that back to back matmuls (for eg. in MLP) can run
             # without stalling on the weight prefetch
             # To fit entire MLP we'd need ~742 * 1088 but using block-wise prefetching and 732 tiles this is sufficient for now
-            self.global_cb_size = 732 * 1088
+            self.global_cb_size = 728 * 1088
             self.sender_receiver_mapping = list(zip(self.all_sender_cores, self.all_receiver_cores))
             # self.global_circular_buffer = ttnn.create_global_circular_buffer(
             #     self.mesh_device, self.sender_receiver_mapping, self.global_cb_size

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rs_matmul_1d_gather_in0.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rs_matmul_1d_gather_in0.py
@@ -518,10 +518,9 @@ def run_multi_core_matmul_1d(
     worker_sub_device_id = ttnn.SubDeviceId(0)
     signpost("start")
     logger.info("Compiling model")
-    rs_out, matmul_out = ttnn.experimental.llama_rs_matmul(
+    rs_out_val, matmul_out_val = ttnn.experimental.llama_rs_matmul(
         in0_t,
         in1_t,
-        tt_input,
         tt_intermediate,
         dim,
         ccl_semaphore_handle,
@@ -529,6 +528,7 @@ def run_multi_core_matmul_1d(
         mesh_device,
         num_links,
         worker_sub_device_id,
+        rs_tensor=tt_input,
         program_config=program_config,
         memory_config_mm=output_sharded_mem_config,
         compute_kernel_config=compute_kernel_config,
@@ -543,7 +543,6 @@ def run_multi_core_matmul_1d(
         rs_out, matmul_out = ttnn.experimental.llama_rs_matmul(
             in0_t,
             in1_t,
-            tt_input,
             tt_intermediate,
             dim,
             ccl_semaphore_handle,
@@ -551,6 +550,7 @@ def run_multi_core_matmul_1d(
             mesh_device,
             num_links,
             worker_sub_device_id,
+            rs_tensor=tt_input,
             program_config=program_config,
             memory_config_mm=output_sharded_mem_config,
             compute_kernel_config=compute_kernel_config,
@@ -567,7 +567,6 @@ def run_multi_core_matmul_1d(
         rs_out, matmul_out = ttnn.experimental.llama_rs_matmul(
             in0_t,
             in1_t,
-            tt_input,
             tt_intermediate,
             dim,
             ccl_semaphore_handle,
@@ -575,6 +574,7 @@ def run_multi_core_matmul_1d(
             mesh_device,
             num_links,
             worker_sub_device_id,
+            rs_tensor=tt_input,
             program_config=program_config,
             memory_config_mm=output_sharded_mem_config,
             compute_kernel_config=compute_kernel_config,

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
@@ -279,9 +279,80 @@ void MatmulFusedOpSignaler::push_matmul_fused_op_rt_args(std::vector<uint32_t>& 
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[1]));
 }
 
+void MatmulFusedOpSignaler::init_llama_rs_cores_rs(const CoreRangeSet& rs_cores, tt::tt_metal::Program& program) {
+    // Copy the cores and create the semaphore and set the signaler type
+    TT_FATAL(
+        this->fused_op_type == MatmulFusedOpSignalerType::LLAMA_REDUCE_SCATTER,
+        "attempted to initialize signaler to llama rs which has a different type");
+    this->initialized_llama_reduce_scatter_part1 = true;
+    this->rs_cores = rs_cores;
+    auto rs_cores_superset = rs_cores.bounding_box();
+    this->rs_semaphore = tt::tt_metal::CreateSemaphore(program, rs_cores_superset, INVALID);
+}
+
+void MatmulFusedOpSignaler::init_llama_rs_cores_mm(
+    const CoreRangeSet& matmul_cores,
+    tt::tt_metal::Program& program,
+    const tt::tt_metal::IDevice* device,
+    int privilaged_index) {
+    // pick the privilaged core, record the number of matmul cores
+    TT_FATAL(initialized_llama_reduce_scatter_part1, "reduce scatter half needs to be initialized first");
+    auto cores = corerange_to_cores(matmul_cores);
+    TT_FATAL(cores.size() > privilaged_index, "Privilaged index is out of range of the matmul cores");
+    this->privilaged_core = cores.at(privilaged_index);
+    this->privilaged_core_physical = device->worker_core_from_logical_core(this->privilaged_core);
+    this->matmul_privilaged_semaphore = tt::tt_metal::CreateSemaphore(program, privilaged_core, 0);
+    this->matmul_semaphore_target = cores.size() - 1;
+}
+
+void MatmulFusedOpSignaler::push_llama_rs_rt_args_for_rs(std::vector<uint32_t>& out_rt_args) const {
+    out_rt_args.push_back(static_cast<uint32_t>(this->rs_semaphore));
+}
+
+void MatmulFusedOpSignaler::push_llama_rs_rt_args_for_mm(
+    std::vector<uint32_t>& out_rt_args,
+    CoreCoord current_core,
+    tt::tt_metal::NOC writer_noc,
+    const tt::tt_metal::IDevice* device) const {
+    out_rt_args.push_back(static_cast<uint32_t>(this->privilaged_core_physical.x));
+    out_rt_args.push_back(static_cast<uint32_t>(this->privilaged_core_physical.y));
+    out_rt_args.push_back(static_cast<uint32_t>(this->matmul_privilaged_semaphore));
+    if (current_core.x == this->privilaged_core.x && current_core.y == this->privilaged_core.y) {
+        out_rt_args.push_back(1);
+        out_rt_args.push_back(this->matmul_semaphore_target);
+        // coordinates of the bounding box
+        auto rs_cores_superset = this->rs_cores.bounding_box();
+        const CoreRange rs_cores_superset_physical = CoreRange(
+            device->worker_core_from_logical_core(rs_cores_superset.start_coord),
+            device->worker_core_from_logical_core(rs_cores_superset.end_coord));
+        if (writer_noc == NOC::NOC_1) {
+            out_rt_args.push_back(rs_cores_superset_physical.end_coord.x);
+            out_rt_args.push_back(rs_cores_superset_physical.end_coord.y);
+            out_rt_args.push_back(rs_cores_superset_physical.start_coord.x);
+            out_rt_args.push_back(rs_cores_superset_physical.start_coord.y);
+        } else {
+            out_rt_args.push_back(rs_cores_superset_physical.start_coord.x);
+            out_rt_args.push_back(rs_cores_superset_physical.start_coord.y);
+            out_rt_args.push_back(rs_cores_superset_physical.end_coord.x);
+            out_rt_args.push_back(rs_cores_superset_physical.end_coord.y);
+        }
+        // Size of the bounding box
+        uint32_t rs_cores_superset_size = (rs_cores_superset.end_coord.y - rs_cores_superset.start_coord.y + 1) *
+                                          (rs_cores_superset.end_coord.x - rs_cores_superset.start_coord.x + 1);
+        out_rt_args.push_back(rs_cores_superset_size);
+        out_rt_args.push_back(static_cast<uint32_t>(this->rs_semaphore));
+    } else {
+        out_rt_args.push_back(0);
+    }
+}
+
 bool MatmulFusedOpSignaler::is_all_gather() { return fused_op_type == MatmulFusedOpSignalerType::ALL_GATHER; }
 
 bool MatmulFusedOpSignaler::is_reduce_scatter() { return fused_op_type == MatmulFusedOpSignalerType::REDUCE_SCATTER; }
+
+bool MatmulFusedOpSignaler::is_llama_reduce_scatter() {
+    return fused_op_type == MatmulFusedOpSignalerType::LLAMA_REDUCE_SCATTER;
+}
 
 }  // namespace ccl
 }  // namespace experimental

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
@@ -82,7 +82,7 @@ struct ReduceScatterFusedOpSignaler {
     void push_reduce_scatter_fused_op_rt_args(std::vector<uint32_t>& out_rt_args);
 };
 
-enum class MatmulFusedOpSignalerType { ALL_GATHER, REDUCE_SCATTER, EMPTY };
+enum class MatmulFusedOpSignalerType { ALL_GATHER, REDUCE_SCATTER, EMPTY, LLAMA_REDUCE_SCATTER };
 
 // Used to propagate semaphore information from matmul to all_gather or reduce_scatter
 struct MatmulFusedOpSignaler {
@@ -109,8 +109,18 @@ struct MatmulFusedOpSignaler {
     std::vector<CoreCoord> matmul_worker_cores = {};
     uint32_t matmul_worker_sync_semaphore = 0;
 
+    /* Info for Llama Reduce Scatter*/
+    uint32_t matmul_privilaged_semaphore = 0;
+    uint32_t rs_semaphore = 0;
+    uint32_t matmul_semaphore_target = 0;
+    CoreRangeSet rs_cores;
+    CoreCoord privilaged_core;
+    CoreCoord privilaged_core_physical;
+
     bool initialized_all_gather = false;
     bool initialized_reduce_scatter = false;
+    bool initialized_llama_reduce_scatter_part1 = false;
+    bool initialized_llama_reduce_scatter = false;
     bool initialized_fused_op = false;
 
     MatmulFusedOpSignaler(MatmulFusedOpSignalerType signaler_type) { fused_op_type = signaler_type; }
@@ -130,6 +140,23 @@ struct MatmulFusedOpSignaler {
         const std::vector<uint32_t>& fused_op_receiver_signal_semaphores,
         FusedOpSignalerMode fused_op_signaler_mode);
 
+    void init_llama_rs_cores_rs(const CoreRangeSet& rs_reader_cores, tt::tt_metal::Program& program);
+    void init_llama_rs_cores_mm(
+        const CoreRangeSet& matmul_cores,
+        tt::tt_metal::Program& program,
+        const tt::tt_metal::IDevice* device,
+        int privilaged_index = 0);
+    // Get the rt values
+    // Write the semaphore ID
+    void push_llama_rs_rt_args_for_rs(std::vector<uint32_t>& out_rt_args) const;
+    // Is_privilaged, if yes: target_value, num_cores_to_signal, array_of_cores, if no: core_xy of signaler
+    // First core to run this is the privilaged core
+    void push_llama_rs_rt_args_for_mm(
+        std::vector<uint32_t>& out_rt_args,
+        CoreCoord current_core,
+        tt::tt_metal::NOC writer_noc,
+        const tt::tt_metal::IDevice* device) const;
+
     void init_fused_op(
         tt::tt_metal::Program& program,
         const tt::tt_metal::IDevice* device,
@@ -144,6 +171,7 @@ struct MatmulFusedOpSignaler {
 
     bool is_all_gather();
     bool is_reduce_scatter();
+    bool is_llama_reduce_scatter();
 
     void push_matmul_fused_op_rt_args(
         std::vector<uint32_t>& out_rt_args, uint32_t curr_worker_in0_idx, uint32_t curr_worker_in1_idx);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
@@ -36,6 +36,7 @@ void kernel_main() {
     constexpr uint32_t packet_worker_end_y = get_compile_time_arg_val(17);
     constexpr uint32_t num_sender_cores = get_compile_time_arg_val(18);
     constexpr uint32_t total_num_read_txns = get_compile_time_arg_val(19);
+    constexpr bool needs_signaler = get_compile_time_arg_val(20) == 1;
 
     // Derived compile-time constants
     constexpr uint32_t input_tensor_cores = input_shard_cores_per_device * num_devices;
@@ -66,6 +67,14 @@ void kernel_main() {
     uint32_t sender_shard_start = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t sender_shard_end = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t sender_total_num_pages = get_arg_val<uint32_t>(rt_arg_idx++);
+
+    // Get signal here
+    if constexpr (needs_signaler) {
+        uint32_t signaler_semaphore_address = get_semaphore(get_arg_val<uint32_t>(rt_arg_idx++));
+        volatile tt_l1_ptr uint32_t* signaler_semaphore_address_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signaler_semaphore_address);
+        noc_semaphore_wait(signaler_semaphore_address_ptr, 1);
+    }
 
     // Bank base addresses (compute once)
     const uint32_t bank_base_address = get_write_ptr(input_tensor_cb_id);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
@@ -49,24 +49,23 @@ void kernel_main() {
     size_t rt_arg_idx = 0;
 
     // Define all compile-time arguments at the beginning
-    constexpr uint32_t input_tensor_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t fabric_sender_cb_id = get_compile_time_arg_val(1);
-    constexpr uint32_t packet_header_cb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t fabric_receiver_cb_id = get_compile_time_arg_val(3);
-    constexpr uint32_t accumulator_cb_id = get_compile_time_arg_val(4);
-    constexpr uint32_t output_tensor_cb_id = get_compile_time_arg_val(5);
-    constexpr uint32_t chip_id = get_compile_time_arg_val(6);
-    constexpr uint32_t tiles_per_core_width = get_compile_time_arg_val(7);
-    constexpr uint32_t tiles_per_core_width_output = get_compile_time_arg_val(8);
-    constexpr uint32_t num_pages_per_packet = get_compile_time_arg_val(9);
-    constexpr uint32_t input_shard_cores_per_device = get_compile_time_arg_val(10);
-    constexpr uint32_t num_devices = get_compile_time_arg_val(11);
-    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(12);
-    constexpr uint32_t output_cores_per_device = get_compile_time_arg_val(13);
-    constexpr uint32_t packet_receiver_core_x = get_compile_time_arg_val(14);
-    constexpr uint32_t packet_receiver_core_y = get_compile_time_arg_val(15);
-    constexpr uint32_t num_packet_worker_cores = get_compile_time_arg_val(16);
-    constexpr bool ring_topology = (bool)get_compile_time_arg_val(17);
+    constexpr uint32_t fabric_sender_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t packet_header_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t fabric_receiver_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t accumulator_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t output_tensor_cb_id = get_compile_time_arg_val(4);
+    constexpr uint32_t chip_id = get_compile_time_arg_val(5);
+    constexpr uint32_t tiles_per_core_width = get_compile_time_arg_val(6);
+    constexpr uint32_t tiles_per_core_width_output = get_compile_time_arg_val(7);
+    constexpr uint32_t num_pages_per_packet = get_compile_time_arg_val(8);
+    constexpr uint32_t input_shard_cores_per_device = get_compile_time_arg_val(9);
+    constexpr uint32_t num_devices = get_compile_time_arg_val(10);
+    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(11);
+    constexpr uint32_t output_cores_per_device = get_compile_time_arg_val(12);
+    constexpr uint32_t packet_receiver_core_x = get_compile_time_arg_val(13);
+    constexpr uint32_t packet_receiver_core_y = get_compile_time_arg_val(14);
+    constexpr uint32_t num_packet_worker_cores = get_compile_time_arg_val(15);
+    constexpr bool ring_topology = (bool)get_compile_time_arg_val(16);
     // Derived compile-time constants
     constexpr uint32_t input_tensor_cores = input_shard_cores_per_device * num_devices;
     constexpr uint32_t num_packets_total_per_device =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.hpp
@@ -16,6 +16,7 @@
 #include "ttnn/global_semaphore.hpp"
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/fabric_edm_types.hpp>
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
 
 namespace ttnn::operations::experimental::ccl {
 
@@ -76,7 +77,8 @@ struct LlamaReduceScatterDeviceOperation {
             const ttnn::MeshCoordinate& mesh_coordinate,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value,
-            tt::tt_metal::Program& program);
+            tt::tt_metal::Program& program,
+            const std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& signaler);
         static void override_runtime_arguments_per_program(
             const shared_variables_t& shared_variables,
             tt::tt_metal::Program& program,
@@ -108,6 +110,9 @@ struct LlamaReduceScatterDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static std::tuple<CoreRangeSet, CoreRangeSet> get_rs_core_grids(
+        const LlamaReduceScatterDeviceOperation::operation_attributes_t& operation_attributes,
+        const LlamaReduceScatterDeviceOperation::tensor_args_t& tensor_args);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const ttnn::Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
@@ -303,7 +303,6 @@ std::tuple<CoreRangeSet, CoreRangeSet> LlamaReduceScatterDeviceOperation::get_rs
     uint32_t num_links = operation_attributes.num_links;
     const uint32_t num_devices = ring_size;
     auto intermediate_packet_buffer_grid = tensor_args.intermediate_packet_buffer.shard_spec().value().grid;
-    // UNCOMMENT this once we can allocate persistent buffers across all device lifetimes
     uint32_t ncores_input = (input_tensor_width + input_shard_width - 1) / input_shard_width;
     if (ncores_input % num_devices != 0) {
         ncores_input = ((ncores_input + num_devices - 1) / num_devices) * num_devices;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
@@ -27,24 +27,23 @@ void kernel_main() {
     size_t rt_arg_idx = 0;
 
     // Define all compile-time arguments at the beginning
-    constexpr uint32_t input_tensor_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t fabric_sender_cb_id = get_compile_time_arg_val(1);
-    constexpr uint32_t packet_header_cb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t fabric_receiver_cb_id = get_compile_time_arg_val(3);
-    constexpr uint32_t accumulator_cb_id = get_compile_time_arg_val(4);
+    constexpr uint32_t fabric_sender_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t packet_header_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t fabric_receiver_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t accumulator_cb_id = get_compile_time_arg_val(3);
     // constexpr uint32_t output_tensor_cb_id = get_compile_time_arg_val(5);
-    constexpr uint32_t chip_id = get_compile_time_arg_val(5);
-    constexpr uint32_t tiles_per_core_width = get_compile_time_arg_val(6);
-    constexpr uint32_t tiles_per_core_width_output = get_compile_time_arg_val(7);
-    constexpr uint32_t num_pages_per_packet = get_compile_time_arg_val(8);
-    constexpr uint32_t input_shard_cores_per_device = get_compile_time_arg_val(9);
-    constexpr uint32_t num_devices = get_compile_time_arg_val(10);
-    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(11);
-    constexpr uint32_t output_cores_per_device = get_compile_time_arg_val(12);
-    constexpr uint32_t packet_receiver_core_x = get_compile_time_arg_val(13);
-    constexpr uint32_t packet_receiver_core_y = get_compile_time_arg_val(14);
-    constexpr uint32_t num_packet_worker_cores = get_compile_time_arg_val(15);
-    constexpr bool RING_TOPOLOGY = get_compile_time_arg_val(16) == 0 ? false : true;
+    constexpr uint32_t chip_id = get_compile_time_arg_val(4);
+    constexpr uint32_t tiles_per_core_width = get_compile_time_arg_val(5);
+    constexpr uint32_t tiles_per_core_width_output = get_compile_time_arg_val(6);
+    constexpr uint32_t num_pages_per_packet = get_compile_time_arg_val(7);
+    constexpr uint32_t input_shard_cores_per_device = get_compile_time_arg_val(8);
+    constexpr uint32_t num_devices = get_compile_time_arg_val(9);
+    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(10);
+    constexpr uint32_t output_cores_per_device = get_compile_time_arg_val(11);
+    constexpr uint32_t packet_receiver_core_x = get_compile_time_arg_val(12);
+    constexpr uint32_t packet_receiver_core_y = get_compile_time_arg_val(13);
+    constexpr uint32_t num_packet_worker_cores = get_compile_time_arg_val(14);
+    constexpr bool RING_TOPOLOGY = get_compile_time_arg_val(15) == 0 ? false : true;
 
     // Derived compile-time constants
     constexpr uint32_t input_tensor_cores = input_shard_cores_per_device * num_devices;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
@@ -683,7 +683,6 @@ LlamaReduceScatterCreateHeadsDeviceOperation::LlamaReduceScatterCreateHeads::cre
     auto num_packet_worker_cores = packet_worker_cores.size();
 
     std::vector<uint32_t> writer_compile_time_args = {
-        input_tensor_cb_id,
         fabric_sender_cb_index,
         packet_header_cb_index,
         fabric_receiver_cb_index,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
@@ -20,15 +20,33 @@ Matmul_RS::program_factory_t Matmul_RS::select_program_factory(
 
 void Matmul_RS::validate_on_program_cache_hit(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    operation_attributes.matmul.validate(
-        {tensor_args.matmul.input_tensor, tensor_args.matmul.weight_tensor}, {std::nullopt}, {});
+    if (tensor_args.second_weight_tensor.has_value()) {
+        operation_attributes.matmul.validate(
+            {tensor_args.matmul.input_tensor,
+             tensor_args.matmul.weight_tensor,
+             tensor_args.second_weight_tensor.value()},
+            {std::nullopt},
+            {});
+    } else {
+        operation_attributes.matmul.validate(
+            {tensor_args.matmul.input_tensor, tensor_args.matmul.weight_tensor}, {std::nullopt}, {});
+    }
     operation_attributes.rs.validate_on_program_cache_hit(operation_attributes.rs_op, tensor_args.rs);
 }
 
 void Matmul_RS::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    operation_attributes.matmul.validate(
-        {tensor_args.matmul.input_tensor, tensor_args.matmul.weight_tensor}, {std::nullopt}, {});
+    if (tensor_args.second_weight_tensor.has_value()) {
+        operation_attributes.matmul.validate(
+            {tensor_args.matmul.input_tensor,
+             tensor_args.matmul.weight_tensor,
+             tensor_args.second_weight_tensor.value()},
+            {std::nullopt},
+            {});
+    } else {
+        operation_attributes.matmul.validate(
+            {tensor_args.matmul.input_tensor, tensor_args.matmul.weight_tensor}, {std::nullopt}, {});
+    }
     operation_attributes.rs.validate_on_program_cache_miss(operation_attributes.rs_op, tensor_args.rs);
 }
 
@@ -38,26 +56,37 @@ Matmul_RS::spec_return_value_t Matmul_RS::compute_output_specs(
     ttnn::TensorSpec reduce_scatter_output_spec =
         operation_attributes.rs.compute_output_specs(operation_attributes.rs_op, tensor_args.rs);
     // Matmul shape
-    ttnn::TensorSpec matmul_output_specs = operation_attributes.matmul.compute_output_specs(
-        {tensor_args.matmul.input_tensor, tensor_args.matmul.weight_tensor}, {})[0];
-
-    return {matmul_output_specs, reduce_scatter_output_spec};
+    if (tensor_args.second_weight_tensor.has_value()) {
+        auto matmul_output_specs = operation_attributes.matmul.compute_output_specs(
+            {tensor_args.matmul.input_tensor,
+             tensor_args.matmul.weight_tensor,
+             tensor_args.second_weight_tensor.value()},
+            {});
+        return {matmul_output_specs.at(0), matmul_output_specs.at(1), reduce_scatter_output_spec};
+    } else {
+        ttnn::TensorSpec matmul_output_specs = operation_attributes.matmul.compute_output_specs(
+            {tensor_args.matmul.input_tensor, tensor_args.matmul.weight_tensor}, {})[0];
+        return {matmul_output_specs, reduce_scatter_output_spec};
+    }
 }
 
 Matmul_RS::tensor_return_value_t Matmul_RS::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     // Matmul output tensor
-    Tensor matmul_output_tensor = operation_attributes.matmul.create_output_tensors(
-        {tensor_args.matmul.input_tensor, tensor_args.matmul.weight_tensor}, {})[0];
     Tensor rs_output_tensor = operation_attributes.rs.create_output_tensors(operation_attributes.rs_op, tensor_args.rs);
-
-    return {matmul_output_tensor, rs_output_tensor};
+    if (tensor_args.second_weight_tensor.has_value()) {
+        return {tensor_args.matmul_output_tensors.at(0), tensor_args.matmul_output_tensors.at(1), rs_output_tensor};
+    } else {
+        Tensor matmul_output_tensor = operation_attributes.matmul.create_output_tensors(
+            {tensor_args.matmul.input_tensor, tensor_args.matmul.weight_tensor}, {})[0];
+        return {matmul_output_tensor, rs_output_tensor};
+    }
 }
 
 std::tuple<Matmul_RS::operation_attributes_t, Matmul_RS::tensor_args_t> Matmul_RS::invoke(
     const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight_tensor,  // mm1 used
-    const ttnn::Tensor& rs_tensor,      // rs1
+    const ttnn::Tensor& weight_tensor,                   // mm1 used
+    const std::optional<const ttnn::Tensor>& rs_tensor,  // rs1
     ttnn::Tensor& intermediate_packet_buffer,
     const int32_t dim,
     const GlobalSemaphore& semaphore,
@@ -78,47 +107,117 @@ std::tuple<Matmul_RS::operation_attributes_t, Matmul_RS::tensor_args_t> Matmul_R
     const std::optional<const tt::tt_metal::Tile>& output_tile,                          // default std::nullopt
     const std::optional<Tensor>& optional_output_tensor,                                 // default std::nullopt
     tt::tt_fabric::Topology topology,
-    bool use_noc1_only) {
+    bool use_noc1_only,
+    const std::optional<const ttnn::Tensor>& second_weight_tensor) {
+    TT_FATAL(
+        rs_tensor.has_value() ^ second_weight_tensor.has_value(),
+        "Exactly one of rs_tensor or second_weight_tensor must have a value");
     LlamaReduceScatterDeviceOperation rs_struct{};
     std::optional<CoreCoord> user_core_coord;
     if (core_grid.has_value()) {
         user_core_coord = CoreCoord(core_grid->x, core_grid->y);
     }
-    bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(weight_tensor.logical_shape());
-    return {
-        operation_attributes_t{
-            rs_struct,
-            LlamaReduceScatterDeviceOperation::operation_attributes_t{
-                .dim = (dim < 0 ? uint32_t(rs_tensor.logical_shape().rank() + dim) : (uint32_t)dim),
-                .cross_device_semaphore = semaphore,
-                .subdevice_id = subdevice_id,
-                .cluster_axis = cluster_axis,
-                .output_mem_config = memory_config_rs,
-                .ring_devices = ring_devices,
-                .num_links = num_links,
-                .topology = topology,
-                .use_noc1_only = use_noc1_only},
-            operations::matmul::create_matmul_struct(
-                input_tensor,
-                weight_tensor,
-                /*parameters=*/
-                operations::matmul::Matmul{
-                    program_config,
-                    /*bcast_batch=*/std::nullopt,
-                    memory_config_mm.value_or(input_tensor.memory_config()),
-                    dtype.value_or(input_tensor.dtype()),
-                    compute_kernel_config,
-                    /*untilize_out=*/false,
-                    user_core_coord,
-                    ttnn::operations::matmul::get_fused_activation(activation),
-                    user_run_batched,
-                    transpose_a,
-                    transpose_b,
-                    output_tile,
-                    global_cb})},
-        tensor_args_t{
-            LlamaReduceScatterDeviceOperation::tensor_args_t{rs_tensor, intermediate_packet_buffer},
-            matmul_tensor_args_t{input_tensor, weight_tensor}}};
+
+    // bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(weight_tensor.logical_shape());
+    // return {
+    //     operation_attributes_t{
+    //         rs_struct,
+    //         LlamaReduceScatterDeviceOperation::operation_attributes_t{
+    //             .dim = (dim < 0 ? uint32_t(rs_tensor.logical_shape().rank() + dim) : (uint32_t)dim),
+    //             .cross_device_semaphore = semaphore,
+    //             .subdevice_id = subdevice_id,
+    //             .cluster_axis = cluster_axis,
+    //             .output_mem_config = memory_config_rs,
+    //             .ring_devices = ring_devices,
+    //             .num_links = num_links,
+    //             .topology = topology,
+    //             .use_noc1_only = use_noc1_only},
+    //         operations::matmul::create_matmul_struct(
+    //             input_tensor,
+    //             weight_tensor,
+    //             /*parameters=*/
+    //             operations::matmul::Matmul{
+    //                 program_config,
+    //                 /*bcast_batch=*/std::nullopt,
+    //                 memory_config_mm.value_or(input_tensor.memory_config()),
+    //                 dtype.value_or(input_tensor.dtype()),
+    //                 compute_kernel_config,
+    //                 /*untilize_out=*/false,
+    //                 user_core_coord,
+    //                 ttnn::operations::matmul::get_fused_activation(activation),
+    //                 user_run_batched,
+    //                 transpose_a,
+    //                 transpose_b,
+    //                 output_tile,
+    //                 global_cb})},
+    //     tensor_args_t{
+    //         LlamaReduceScatterDeviceOperation::tensor_args_t{rs_tensor, intermediate_packet_buffer},
+    //         matmul_tensor_args_t{input_tensor, weight_tensor}}};
+
+    bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(weight_tensor.get_logical_shape());
+    auto matmul_struct = operations::matmul::create_matmul_struct(
+        input_tensor,
+        weight_tensor,
+        /*parameters=*/
+        operations::matmul::Matmul{
+            program_config,
+            /*bcast_batch=*/std::nullopt,
+            memory_config_mm.value_or(input_tensor.memory_config()),
+            dtype.value_or(input_tensor.get_dtype()),
+            compute_kernel_config,
+            /*untilize_out=*/false,
+            user_core_coord,
+            ttnn::operations::matmul::get_fused_activation(activation),
+            user_run_batched,
+            transpose_a,
+            transpose_b,
+            output_tile,
+            global_cb});
+    if (second_weight_tensor.has_value()) {
+        std::vector<Tensor> matmul_output_tensors =
+            matmul_struct.create_output_tensors({input_tensor, weight_tensor, second_weight_tensor.value()}, {});
+        auto new_rs_tensor = matmul_output_tensors.at(0);
+        return {
+            operation_attributes_t{
+                rs_struct,
+                LlamaReduceScatterDeviceOperation::operation_attributes_t{
+                    .dim = (dim < 0 ? uint32_t(new_rs_tensor.get_logical_shape().rank() + dim) : (uint32_t)dim),
+                    .cross_device_semaphore = semaphore,
+                    .subdevice_id = subdevice_id,
+                    .cluster_axis = cluster_axis,
+                    .output_mem_config = memory_config_rs,
+                    .ring_devices = ring_devices,
+                    .num_links = num_links,
+                    .topology = topology,
+                    .use_noc1_only = use_noc1_only},
+                matmul_struct},
+            tensor_args_t{
+                LlamaReduceScatterDeviceOperation::tensor_args_t{new_rs_tensor, intermediate_packet_buffer},
+                matmul_tensor_args_t{input_tensor, weight_tensor},
+                matmul_output_tensors,
+                second_weight_tensor}};
+    } else {
+        auto new_rs_tensor = rs_tensor.value();
+        return {
+            operation_attributes_t{
+                rs_struct,
+                LlamaReduceScatterDeviceOperation::operation_attributes_t{
+                    .dim = (dim < 0 ? uint32_t(new_rs_tensor.get_logical_shape().rank() + dim) : (uint32_t)dim),
+                    .cross_device_semaphore = semaphore,
+                    .subdevice_id = subdevice_id,
+                    .cluster_axis = cluster_axis,
+                    .output_mem_config = memory_config_rs,
+                    .ring_devices = ring_devices,
+                    .num_links = num_links,
+                    .topology = topology,
+                    .use_noc1_only = use_noc1_only},
+                matmul_struct},
+            tensor_args_t{
+                LlamaReduceScatterDeviceOperation::tensor_args_t{new_rs_tensor, intermediate_packet_buffer},
+                matmul_tensor_args_t{input_tensor, weight_tensor},
+                {},
+                std::nullopt}};
+    }
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
@@ -118,43 +118,7 @@ std::tuple<Matmul_RS::operation_attributes_t, Matmul_RS::tensor_args_t> Matmul_R
         user_core_coord = CoreCoord(core_grid->x, core_grid->y);
     }
 
-    // bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(weight_tensor.logical_shape());
-    // return {
-    //     operation_attributes_t{
-    //         rs_struct,
-    //         LlamaReduceScatterDeviceOperation::operation_attributes_t{
-    //             .dim = (dim < 0 ? uint32_t(rs_tensor.logical_shape().rank() + dim) : (uint32_t)dim),
-    //             .cross_device_semaphore = semaphore,
-    //             .subdevice_id = subdevice_id,
-    //             .cluster_axis = cluster_axis,
-    //             .output_mem_config = memory_config_rs,
-    //             .ring_devices = ring_devices,
-    //             .num_links = num_links,
-    //             .topology = topology,
-    //             .use_noc1_only = use_noc1_only},
-    //         operations::matmul::create_matmul_struct(
-    //             input_tensor,
-    //             weight_tensor,
-    //             /*parameters=*/
-    //             operations::matmul::Matmul{
-    //                 program_config,
-    //                 /*bcast_batch=*/std::nullopt,
-    //                 memory_config_mm.value_or(input_tensor.memory_config()),
-    //                 dtype.value_or(input_tensor.dtype()),
-    //                 compute_kernel_config,
-    //                 /*untilize_out=*/false,
-    //                 user_core_coord,
-    //                 ttnn::operations::matmul::get_fused_activation(activation),
-    //                 user_run_batched,
-    //                 transpose_a,
-    //                 transpose_b,
-    //                 output_tile,
-    //                 global_cb})},
-    //     tensor_args_t{
-    //         LlamaReduceScatterDeviceOperation::tensor_args_t{rs_tensor, intermediate_packet_buffer},
-    //         matmul_tensor_args_t{input_tensor, weight_tensor}}};
-
-    bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(weight_tensor.get_logical_shape());
+    bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(weight_tensor.logical_shape());
     auto matmul_struct = operations::matmul::create_matmul_struct(
         input_tensor,
         weight_tensor,
@@ -163,7 +127,7 @@ std::tuple<Matmul_RS::operation_attributes_t, Matmul_RS::tensor_args_t> Matmul_R
             program_config,
             /*bcast_batch=*/std::nullopt,
             memory_config_mm.value_or(input_tensor.memory_config()),
-            dtype.value_or(input_tensor.get_dtype()),
+            dtype.value_or(input_tensor.dtype()),
             compute_kernel_config,
             /*untilize_out=*/false,
             user_core_coord,
@@ -181,7 +145,7 @@ std::tuple<Matmul_RS::operation_attributes_t, Matmul_RS::tensor_args_t> Matmul_R
             operation_attributes_t{
                 rs_struct,
                 LlamaReduceScatterDeviceOperation::operation_attributes_t{
-                    .dim = (dim < 0 ? uint32_t(new_rs_tensor.get_logical_shape().rank() + dim) : (uint32_t)dim),
+                    .dim = (dim < 0 ? uint32_t(new_rs_tensor.logical_shape().rank() + dim) : (uint32_t)dim),
                     .cross_device_semaphore = semaphore,
                     .subdevice_id = subdevice_id,
                     .cluster_axis = cluster_axis,
@@ -202,7 +166,7 @@ std::tuple<Matmul_RS::operation_attributes_t, Matmul_RS::tensor_args_t> Matmul_R
             operation_attributes_t{
                 rs_struct,
                 LlamaReduceScatterDeviceOperation::operation_attributes_t{
-                    .dim = (dim < 0 ? uint32_t(new_rs_tensor.get_logical_shape().rank() + dim) : (uint32_t)dim),
+                    .dim = (dim < 0 ? uint32_t(new_rs_tensor.logical_shape().rank() + dim) : (uint32_t)dim),
                     .cross_device_semaphore = semaphore,
                     .subdevice_id = subdevice_id,
                     .cluster_axis = cluster_axis,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.hpp
@@ -38,6 +38,8 @@ struct Matmul_RS {
     struct tensor_args_t {
         LlamaReduceScatterDeviceOperation::tensor_args_t rs;
         matmul_tensor_args_t matmul;
+        std::vector<Tensor> matmul_output_tensors;
+        const std::optional<const ttnn::Tensor> second_weight_tensor;
     };
     struct operation_attributes_t {
         LlamaReduceScatterDeviceOperation rs;
@@ -81,7 +83,7 @@ struct Matmul_RS {
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& weight_tensor,
-        const ttnn::Tensor& rs_tensor,
+        const std::optional<const ttnn::Tensor>& rs_tensor,
         ttnn::Tensor& intermediate_packet_buffer,
         int32_t dim,
         const GlobalSemaphore& semaphore,
@@ -102,7 +104,8 @@ struct Matmul_RS {
         const std::optional<const tt::tt_metal::Tile>& output_tile = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
         tt::tt_fabric::Topology topology = tt::tt_fabric::Topology::Linear,
-        bool use_noc1_only = false);
+        bool use_noc1_only = false,
+        const std::optional<const ttnn::Tensor>& second_weight_tensor = std::nullopt);
 };
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_program_factory.cpp
@@ -39,32 +39,65 @@ ttnn::device_operation::CachedProgram<Matmul_RS::Matmul_RS_PF::shared_variables_
     const tensor_args_t& tensor_args,
     std::vector<Tensor>& tensor_return_value) {
     tt::tt_metal::Program program{};
-    std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> empty_fused_op_signaler;
+
     tt::tt_metal::SubDeviceId sub_device_id = operation_attributes.rs_op.subdevice_id.value();
-    CoreRangeSet ccl_cores = llama_specific::get_custom_cores(operation_attributes.rs_op.num_links);
-    CoreRangeSet rs_cores = CoreRangeSet(std::set{::CoreRange{{1, 1}, {3, 2}}, ::CoreRange{{1, 3}, {2, 3}}});
-    rs_cores = rs_cores.merge(ccl_cores);
-    std::optional<CoreRangeSet> optional_core_range = rs_cores;
-    return {
-        std::move(program),
-        shared_variables_t{
-            LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at_program_processing(
-                operation_attributes.rs_op, mesh_coordinate, tensor_args.rs, tensor_return_value.at(1), program),
-            matmul::matmul_multi_core_reuse_mcast_1d_optimized_helper(
-                program,
-                tensor_args.matmul.input_tensor,
-                {tensor_args.matmul.weight_tensor},
-                std::nullopt /*bias*/,
-                {tensor_return_value.at(0)},
-                operation_attributes.matmul.bcast_batch.value(),
-                operation_attributes.matmul.compute_kernel_config.value(),
-                operation_attributes.matmul.program_config.value(),
-                operation_attributes.matmul.untilize_out,
-                empty_fused_op_signaler,
-                operation_attributes.matmul.global_cb,
-                sub_device_id /*sub_device_id*/,
-                tt::CBIndex::c_6 /*start cb index*/,
-                optional_core_range)}};
+    auto [part_cores, rs_cores] =
+        LlamaReduceScatterDeviceOperation::get_rs_core_grids(operation_attributes.rs_op, tensor_args.rs);
+    std::optional<CoreRangeSet> reduce_scatter_core_range = rs_cores;
+    if (tensor_args.second_weight_tensor.has_value()) {
+        ttnn::experimental::ccl::MatmulFusedOpSignaler base_signaler = ttnn::experimental::ccl::MatmulFusedOpSignaler(
+            ttnn::experimental::ccl::MatmulFusedOpSignalerType::LLAMA_REDUCE_SCATTER);
+        base_signaler.init_llama_rs_cores_rs(rs_cores, program);
+        std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> fused_op_signaler = base_signaler;
+        auto reduce_scatter_sv = LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at_program_processing(
+            operation_attributes.rs_op,
+            mesh_coordinate,
+            tensor_args.rs,
+            tensor_return_value.at(2),
+            program,
+            fused_op_signaler);
+        auto matmul_sv = matmul::matmul_multi_core_reuse_mcast_1d_optimized_helper(
+            program,
+            tensor_args.matmul.input_tensor,
+            {tensor_args.matmul.weight_tensor, tensor_args.second_weight_tensor.value()},
+            std::nullopt /*bias*/,
+            {tensor_return_value.at(0), tensor_return_value.at(1)},
+            operation_attributes.matmul.bcast_batch.value(),
+            operation_attributes.matmul.compute_kernel_config.value(),
+            operation_attributes.matmul.program_config.value(),
+            operation_attributes.matmul.untilize_out,
+            fused_op_signaler,
+            operation_attributes.matmul.global_cb,
+            sub_device_id /*sub_device_id*/,
+            tt::CBIndex::c_6 /*start cb index*/,
+            reduce_scatter_core_range);
+        return {std::move(program), shared_variables_t{reduce_scatter_sv, matmul_sv}};
+    } else {
+        std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> fused_op_signaler = std::nullopt;
+        auto reduce_scatter_sv = LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_at_program_processing(
+            operation_attributes.rs_op,
+            mesh_coordinate,
+            tensor_args.rs,
+            tensor_return_value.at(1),
+            program,
+            fused_op_signaler);
+        auto matmul_sv = matmul::matmul_multi_core_reuse_mcast_1d_optimized_helper(
+            program,
+            tensor_args.matmul.input_tensor,
+            {tensor_args.matmul.weight_tensor},
+            std::nullopt /*bias*/,
+            {tensor_return_value.at(0)},
+            operation_attributes.matmul.bcast_batch.value(),
+            operation_attributes.matmul.compute_kernel_config.value(),
+            operation_attributes.matmul.program_config.value(),
+            operation_attributes.matmul.untilize_out,
+            fused_op_signaler,
+            operation_attributes.matmul.global_cb,
+            sub_device_id /*sub_device_id*/,
+            tt::CBIndex::c_6 /*start cb index*/,
+            reduce_scatter_core_range);
+        return {std::move(program), shared_variables_t{reduce_scatter_sv, matmul_sv}};
+    }
 }
 
 void Matmul_RS::Matmul_RS_PF::override_runtime_arguments(
@@ -72,21 +105,42 @@ void Matmul_RS::Matmul_RS_PF::override_runtime_arguments(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     std::vector<Tensor>& tensor_return_value) {
-    for (auto& [range, program] : cached_workload.workload.get_programs()) {
-        const auto& shared_variables = cached_workload.shared_variables.at(range);
-        LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::override_runtime_arguments_per_program(
-            shared_variables.rs_shared_vars,
-            program,
-            operation_attributes.rs_op,
-            tensor_args.rs,
-            tensor_return_value.at(1));
-        reuse_mcast_1d_optimized_helpers::override_program_parameters(
-            shared_variables.matmul_shared_vars,
-            &operation_attributes.matmul,
-            program,
-            {tensor_args.matmul.input_tensor, tensor_args.matmul.weight_tensor},
-            {},
-            {tensor_return_value.at(0)});
+    if (tensor_args.second_weight_tensor.has_value()) {
+        for (auto& [range, program] : cached_workload.workload.get_programs()) {
+            const auto& shared_variables = cached_workload.shared_variables.at(range);
+            LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::override_runtime_arguments_per_program(
+                shared_variables.rs_shared_vars,
+                program,
+                operation_attributes.rs_op,
+                tensor_args.rs,
+                tensor_return_value.at(2));
+            reuse_mcast_1d_optimized_helpers::override_program_parameters(
+                shared_variables.matmul_shared_vars,
+                &operation_attributes.matmul,
+                program,
+                {tensor_args.matmul.input_tensor,
+                 tensor_args.matmul.weight_tensor,
+                 tensor_args.second_weight_tensor.value()},
+                {},
+                {tensor_return_value.at(0), tensor_return_value.at(1)});
+        }
+    } else {
+        for (auto& [range, program] : cached_workload.workload.get_programs()) {
+            const auto& shared_variables = cached_workload.shared_variables.at(range);
+            LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::override_runtime_arguments_per_program(
+                shared_variables.rs_shared_vars,
+                program,
+                operation_attributes.rs_op,
+                tensor_args.rs,
+                tensor_return_value.at(1));
+            reuse_mcast_1d_optimized_helpers::override_program_parameters(
+                shared_variables.matmul_shared_vars,
+                &operation_attributes.matmul,
+                program,
+                {tensor_args.matmul.input_tensor, tensor_args.matmul.weight_tensor},
+                {},
+                {tensor_return_value.at(0)});
+        }
     }
 }
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul.cpp
@@ -11,7 +11,6 @@ std::vector<ttnn::Tensor> ExecuteLlamaReduceScatterMatmul::invoke(
     QueueId queue_id,
     const ttnn::Tensor& input_tensor,               // mm0 used
     const ttnn::Tensor& weight_tensor,              // mm1 used
-    const ttnn::Tensor& rs_tensor,                  // rs1
     ttnn::Tensor& intermediate_packet_buffer,       // rs2
     int32_t dim,                                    // rs3
     const GlobalSemaphore& cross_device_semaphore,  // rs4
@@ -19,6 +18,8 @@ std::vector<ttnn::Tensor> ExecuteLlamaReduceScatterMatmul::invoke(
     const MeshDevice& mesh_device,                  // rs 6
     const uint32_t num_links,                       // rs 7 default 1
     const tt::tt_metal::SubDeviceId& subdevice_id,
+    const std::optional<const ttnn::Tensor>& second_weight_tensor,
+    const std::optional<const ttnn::Tensor>& rs_tensor,  // rs1
     tt::tt_fabric::Topology topology,
     const std::optional<ttnn::MemoryConfig>& memory_config_rs,  // rs 8 default std::nullopt
     const std::optional<ttnn::MemoryConfig>& memory_config_mm,  // mm4 used but default std::nullopt
@@ -61,7 +62,8 @@ std::vector<ttnn::Tensor> ExecuteLlamaReduceScatterMatmul::invoke(
         output_tile,
         optional_output_tensor,
         topology,
-        use_noc1_only);
+        use_noc1_only,
+        second_weight_tensor);
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul.hpp
@@ -17,7 +17,6 @@ struct ExecuteLlamaReduceScatterMatmul {
         QueueId queue_id,
         const ttnn::Tensor& input_tensor,               // mm0 used
         const ttnn::Tensor& weight_tensor,              // mm1 used
-        const ttnn::Tensor& rs_tensor,                  // rs1
         ttnn::Tensor& intermediate_packet_buffer,       // rs2
         int32_t dim,                                    // rs3
         const GlobalSemaphore& cross_device_semaphore,  // rs4
@@ -25,6 +24,8 @@ struct ExecuteLlamaReduceScatterMatmul {
         const MeshDevice& mesh_device,                  // rs 6
         uint32_t num_links,                             // rs 7 default 1
         const tt::tt_metal::SubDeviceId& subdevice_id,
+        const std::optional<const ttnn::Tensor>& second_weight_tensor = std::nullopt,
+        const std::optional<const ttnn::Tensor>& rs_tensor = std::nullopt,
         tt::tt_fabric::Topology topology = tt::tt_fabric::Topology::Linear,
         const std::optional<ttnn::MemoryConfig>& memory_config_rs = std::nullopt,  // rs 8 default std::nullopt
         const std::optional<ttnn::MemoryConfig>& memory_config_mm = std::nullopt,  // mm4 used but default std::nullopt

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul_pybind.cpp
@@ -53,7 +53,6 @@ void py_bind_rs_matmul(pybind11::module& module) {
             [](const decltype(ttnn::experimental::llama_rs_matmul)& self,
                const ttnn::Tensor& input_tensor,               // mm0 used
                const ttnn::Tensor& weight_tensor,              // mm1 used
-               const ttnn::Tensor& rs_tensor,                  // rs1
                ttnn::Tensor& intermediate_packet_buffer,       // rs2
                int32_t dim,                                    // rs3
                const GlobalSemaphore& cross_device_semaphore,  // rs4
@@ -61,6 +60,8 @@ void py_bind_rs_matmul(pybind11::module& module) {
                const MeshDevice& mesh_device,                  // rs 6
                const uint32_t num_links,                       // rs 7 default 1
                const tt::tt_metal::SubDeviceId& subdevice_id,
+               const std::optional<const ttnn::Tensor>& second_weight_tensor,
+               const std::optional<const ttnn::Tensor>& rs_tensor,  // rs1
                tt::tt_fabric::Topology topology,
                const std::optional<ttnn::MemoryConfig>& memory_config_rs,  // rs 8 default std::nullopt
                const std::optional<ttnn::MemoryConfig>& memory_config_mm,  // mm4 used but default std::nullopt
@@ -83,7 +84,6 @@ void py_bind_rs_matmul(pybind11::module& module) {
                     queue_id,
                     input_tensor,
                     weight_tensor,
-                    rs_tensor,
                     intermediate_packet_buffer,
                     dim,
                     cross_device_semaphore,
@@ -91,6 +91,8 @@ void py_bind_rs_matmul(pybind11::module& module) {
                     mesh_device,
                     num_links,
                     subdevice_id,
+                    second_weight_tensor,
+                    rs_tensor,
                     topology,
                     memory_config_rs,
                     memory_config_mm,
@@ -108,7 +110,6 @@ void py_bind_rs_matmul(pybind11::module& module) {
             },
             py::arg("input_tensor"),
             py::arg("weight_tensor"),
-            py::arg("rs_tensor"),
             py::arg("intermediate_packet_buffer"),
             py::arg("dim"),
             py::arg("cross_device_semaphore"),
@@ -117,6 +118,8 @@ void py_bind_rs_matmul(pybind11::module& module) {
             py::arg("num_links"),
             py::arg("subdevice_id"),
             py::kw_only(),
+            py::arg("second_weight_tensor") = std::nullopt,
+            py::arg("rs_tensor") = std::nullopt,
             py::arg("topology") = tt::tt_fabric::Topology::Linear,
             py::arg("memory_config_rs") = std::nullopt,
             py::arg("memory_config_mm") = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -51,15 +51,52 @@ void kernel_main() {
     constexpr uint32_t in1_shard_width_in_dram = get_compile_time_arg_val(10);
 
     uint32_t rt_args_idx = 0;
+    constexpr bool needs_signaler = get_compile_time_arg_val(15) == 1;
     uint32_t core_type = get_arg_val<uint32_t>(rt_args_idx++);
     if (core_type == (uint32_t)CORE_TYPE::IDLE_CORE || core_type == (uint32_t)CORE_TYPE::HOP_CORE) {
+        if constexpr (needs_signaler) {
+            const uint32_t pv_core_x = get_arg_val<uint32_t>(rt_args_idx++);
+            const uint32_t pv_core_y = get_arg_val<uint32_t>(rt_args_idx++);
+            const uint32_t pv_semaphore = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
+            volatile tt_l1_ptr uint32_t* pv_semaphore_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pv_semaphore);
+            const bool is_privilaged = get_arg_val<uint32_t>(rt_args_idx++) == 1;
+            if (is_privilaged) {
+                // Get parameters
+                const uint32_t target_sem_value = get_arg_val<uint32_t>(rt_args_idx++);
+                const uint32_t mc_sx = get_arg_val<uint32_t>(rt_args_idx++);
+                const uint32_t mc_sy = get_arg_val<uint32_t>(rt_args_idx++);
+                const uint32_t mc_ex = get_arg_val<uint32_t>(rt_args_idx++);
+                const uint32_t mc_ey = get_arg_val<uint32_t>(rt_args_idx++);
+                const uint32_t num_rs_semaphores = get_arg_val<uint32_t>(rt_args_idx++);
+                const uint32_t rs_semaphore = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
+                // Find the rs semaphore multicast address
+                const uint64_t rs_semaphore_address =
+                    get_noc_multicast_addr(mc_sx, mc_sy, mc_ex, mc_ey, 0) | rs_semaphore;
+                // Wait for privilage core to reach value
+                noc_semaphore_wait(pv_semaphore_ptr, target_sem_value);
+                // Set the memory address to 1 for broadcast to RS cores
+                noc_semaphore_set(pv_semaphore_ptr, 1);
+                // Broadcast to RS cores
+                noc_semaphore_set_multicast(pv_semaphore, rs_semaphore_address, num_rs_semaphores);
+            } else {
+                // Increment the privilage core semaphore by 1
+                noc_semaphore_inc(get_noc_addr(pv_core_x, pv_core_y, pv_semaphore), 1);
+            }
+        }
         return;
     }
     const uint32_t in1_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t ring_idx = get_arg_val<uint32_t>(rt_args_idx++);
-    const uint32_t dram_bank_id = get_arg_val<uint32_t>(rt_args_idx++);
-    const uint32_t vc = get_arg_val<uint32_t>(rt_args_idx++);
-    const uint32_t dram_read_offset = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t dram_bank_id = 0;
+    uint32_t vc = 0;
+    uint32_t dram_read_offset = 0;
+
+    if constexpr (in1_is_dram_interleaved || in1_is_dram_sharded) {
+        dram_bank_id = get_arg_val<uint32_t>(rt_args_idx++);
+        vc = get_arg_val<uint32_t>(rt_args_idx++);
+        dram_read_offset = get_arg_val<uint32_t>(rt_args_idx++);
+    }
 
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(11);
     constexpr uint32_t sync_cb = get_compile_time_arg_val(12);
@@ -146,6 +183,40 @@ void kernel_main() {
         experimental::remote_cb_pop_front(remote_cb_id, num_blocks);
         cb_pop_front(sync_cb, 1);
 #endif
+        // Signal Here
+        if constexpr (needs_signaler) {
+            if (b == 0) {
+                const uint32_t pv_core_x = get_arg_val<uint32_t>(rt_args_idx++);
+                const uint32_t pv_core_y = get_arg_val<uint32_t>(rt_args_idx++);
+                const uint32_t pv_semaphore = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
+                volatile tt_l1_ptr uint32_t* pv_semaphore_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pv_semaphore);
+                const bool is_privilaged = get_arg_val<uint32_t>(rt_args_idx++) == 1;
+                if (is_privilaged) {
+                    // Get parameters
+                    const uint32_t target_sem_value = get_arg_val<uint32_t>(rt_args_idx++);
+                    const uint32_t mc_sx = get_arg_val<uint32_t>(rt_args_idx++);
+                    const uint32_t mc_sy = get_arg_val<uint32_t>(rt_args_idx++);
+                    const uint32_t mc_ex = get_arg_val<uint32_t>(rt_args_idx++);
+                    const uint32_t mc_ey = get_arg_val<uint32_t>(rt_args_idx++);
+                    const uint32_t num_rs_semaphores = get_arg_val<uint32_t>(rt_args_idx++);
+                    const uint32_t rs_semaphore = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
+                    // Find the rs semaphore multicast address
+                    const uint64_t rs_semaphore_address =
+                        get_noc_multicast_addr(mc_sx, mc_sy, mc_ex, mc_ey, 0) | rs_semaphore;
+                    // Wait for privilage core to reach value
+                    noc_semaphore_wait(pv_semaphore_ptr, target_sem_value);
+                    // Set the memory address to 1 for broadcast to RS cores
+                    noc_semaphore_set(pv_semaphore_ptr, 1);
+                    // Broadcast to RS cores
+                    noc_semaphore_set_multicast(pv_semaphore, rs_semaphore_address, num_rs_semaphores);
+                } else {
+                    // Increment the privilage core semaphore by 1
+                    uint64_t sem_addr = get_noc_addr(pv_core_x, pv_core_y, pv_semaphore);
+                    noc_semaphore_inc(sem_addr, 1);
+                }
+            }
+        }
     }
 
 #ifdef ENABLE_GLOBAL_CB


### PR DESCRIPTION
### Description
Perf optimisation for TG llama:
FF1 Matmul + FF1 Reduce Scatter + FF3 Matmul are all merged together in this branch, which makes it possible to reuse the activation gathering from FF1 for FF3 MM.

Perf savings: 1.1 us

TG llama e2e perf: 71.58 t/s/u -> 72 t/s/u

Description of the algorithm:
The dataflow is that FF1 Matmul creates an output tensor, this tensor is the input to FF1 Reduce Scatter, In parallel FF3 Matmul creates an output tensor. The output of the OP is 3 tensors in the order: FF1 Matmul output, FF3 Matmul Output, FF1 Reduce Scatter Output. This requires the Reduce Scatter to wait for FF1 Matmul to complete before it starts reading the data requiring Semaphore logic.

In terms of resource sharing, the reduce scatter OP uses the core grid (1,1) to (3,3) (excluding (3,3) itself so 8 cores in total) to perform the reduction computation and cores (5,3),(6,3),(2,8),(3,8) to perform CCL. The remaining cores are used by matmul. Since Reduce Scatter must wait for Matmul to finish, all the matmul cores are used to compute FF1 Matmul and then once it is done, they are all re-used to run FF3 Matmul at the same time that Reduce Scatter runs.

The data input to the matmul comes from two places, the input comes from an input tensor and then the weights come from the prefetcher which feeds the data into a circular buffer which the matmul core uses. The function takes two weights tensors as input but it only uses them to extract tensor properties like shape, it does not grab the data from those tensors

The semaphore logic is as follows. We don't want any of the reduce scatter cores to start until all the matmul cores have finished FF1. In matmul we have a privileged core. The idea is the privileged core waits on a semaphore to reach the value equal to the number of matmul cores - 1. Then all the matmul cores increment this semaphore when they complete. Once this semaphore is done, it will multicast send a semaphore increment to all the reduce scatter cores. These cores wait on this semaphore and proceeds when it arrives ensuring the data is available in the FF1 Matmul output tensor

### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/25121)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16471799236) unrelated failures
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16492951688) running
- [ ] [TG 4U pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/16466437924) passing
- [ ] [TG 6U pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/16466447797) passing