### PR TITLE
#0: Migrate tt-train's `create_shape` to `ttnn::Shape` ctor.

### DIFF
--- a/tt-train/sources/examples/graph_capture/main.cpp
+++ b/tt-train/sources/examples/graph_capture/main.cpp
@@ -77,10 +77,10 @@ int main() {
     const size_t num_features = 784;
     auto* device = &ttml::autograd::ctx().get_device();
 
-    auto batch = ttml::autograd::create_tensor(
-        ttml::core::zeros(ttml::core::create_shape({batch_size, 1, 1, num_features}), device));
-    auto target = ttml::autograd::create_tensor(
-        ttml::core::zeros(ttml::core::create_shape({batch_size, 1, 1, num_targets}), device));
+    auto batch =
+        ttml::autograd::create_tensor(ttml::core::zeros(ttnn::Shape({batch_size, 1, 1, num_features}), device));
+    auto target =
+        ttml::autograd::create_tensor(ttml::core::zeros(ttnn::Shape({batch_size, 1, 1, num_targets}), device));
 
     auto model_params = ttml::modules::MultiLayerPerceptronParameters{
         .input_features = num_features, .hidden_features = {128}, .output_features = num_targets};

--- a/tt-train/sources/examples/linear_regression/main.cpp
+++ b/tt-train/sources/examples/linear_regression/main.cpp
@@ -58,9 +58,9 @@ int main() {
             }
 
             auto data_tensor = ttml::autograd::create_tensor(
-                ttml::core::from_vector(data, ttml::core::create_shape({batch_size, 1, 1, num_features}), device));
+                ttml::core::from_vector(data, ttnn::Shape({batch_size, 1, 1, num_features}), device));
             auto targets_tensor = ttml::autograd::create_tensor(
-                ttml::core::from_vector(targets, ttml::core::create_shape({batch_size, 1, 1, num_targets}), device));
+                ttml::core::from_vector(targets, ttnn::Shape({batch_size, 1, 1, num_targets}), device));
             return std::make_pair(data_tensor, targets_tensor);
         };
 

--- a/tt-train/sources/examples/mnist_mlp/main.cpp
+++ b/tt-train/sources/examples/mnist_mlp/main.cpp
@@ -190,7 +190,7 @@ int main(int argc, char **argv) {
             std::transform(data.begin(), data.end(), data.begin(), [](float pixel) { return pixel / 255.0F - 0.5F; });
 
             auto data_tensor = ttml::autograd::create_tensor(
-                ttml::core::from_vector(data, ttml::core::create_shape({batch_size, 1, 1, num_features}), device));
+                ttml::core::from_vector(data, ttnn::Shape({batch_size, 1, 1, num_features}), device));
 
             auto targets_tensor =
                 ttml::autograd::create_tensor(ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -273,8 +273,8 @@ void generate(
         }
     }
 
-    auto mask_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
-        mask, ttml::core::create_shape({1, 1, max_sequence_length, max_sequence_length}), device));
+    auto mask_tensor = ttml::autograd::create_tensor(
+        ttml::core::from_vector(mask, ttnn::Shape({1, 1, max_sequence_length, max_sequence_length}), device));
 
     // Prepare a padded buffer for the prompt
     std::vector<uint32_t> prompt_tokens_padded(max_sequence_length, pad_token_id);
@@ -300,10 +300,7 @@ void generate(
         }
         auto prompt_tokens_padded_size = static_cast<uint32_t>(prompt_tokens_padded.size());
         auto prompt_tensor = ttml::autograd::create_tensor(ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(
-            prompt_tokens_padded,
-            ttml::core::create_shape({1, 1, 1, prompt_tokens_padded_size}),
-            device,
-            ttnn::Layout::ROW_MAJOR));
+            prompt_tokens_padded, ttnn::Shape({1, 1, 1, prompt_tokens_padded_size}), device, ttnn::Layout::ROW_MAJOR));
 
         // Forward pass
         // 'output' shape is presumably [batch=1, 1, seq_len, vocab_size] or something similar
@@ -678,7 +675,7 @@ int main(int argc, char **argv) {
         }
     }
     cached_data.masks_tensor = ttml::autograd::create_tensor(
-        ttml::core::from_vector(mask, ttml::core::create_shape({1, 1, sequence_length, sequence_length}), device));
+        ttml::core::from_vector(mask, ttnn::Shape({1, 1, sequence_length, sequence_length}), device));
 
     std::function<BatchType(std::vector<DatasetSample> && samples)> collate_fn =
         [sequence_length, num_heads, device, &cached_data, &device_config](std::vector<DatasetSample> &&samples) {
@@ -706,14 +703,14 @@ int main(int argc, char **argv) {
                     auto data_tensor =
                         ttml::autograd::create_tensor(ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(
                             data,
-                            ttml::core::create_shape({batch_size, 1, 1, sequence_length}),
+                            ttnn::Shape({batch_size, 1, 1, sequence_length}),
                             device,
                             ttnn::Layout::ROW_MAJOR,
                             mapper.get()));
 
                     auto targets_tt_tensor = ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(
                         targets,
-                        ttml::core::create_shape({batch_size, sequence_length}),
+                        ttnn::Shape({batch_size, sequence_length}),
                         device,
                         ttnn::Layout::ROW_MAJOR,
                         mapper.get());
@@ -725,7 +722,7 @@ int main(int argc, char **argv) {
                 auto data_tensor =
                     ttml::autograd::create_tensor(ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(
                         data,
-                        ttml::core::create_shape({batch_size, 1, 1, sequence_length}),
+                        ttnn::Shape({batch_size, 1, 1, sequence_length}),
                         device,
                         ttnn::Layout::ROW_MAJOR,
                         mapper.get()));

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -227,10 +227,6 @@ bool is_tensor_initialized(const tt::tt_metal::Tensor& tensor) {
     return tensor.tensor_attributes != nullptr;
 }
 
-ttnn::Shape create_shape(const std::array<uint32_t, 4>& args) {
-    return ttnn::Shape{args};
-}
-
 void print_tensor_stats(const tt::tt_metal::Tensor& tensor, const std::string& name) {
     if (tensor.dtype() == ttnn::DataType::BFLOAT16 || tensor.dtype() == ttnn::DataType::FLOAT32) {
         print_tensor_stats_<float>(tensor, name);

--- a/tt-train/sources/ttml/core/tt_tensor_utils.hpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.hpp
@@ -46,8 +46,6 @@ template <class T = float>
 
 [[nodiscard]] bool is_tensor_initialized(const tt::tt_metal::Tensor& tensor);
 
-[[nodiscard]] ttnn::Shape create_shape(const std::array<uint32_t, 4>& args);
-
 template <class T = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
 [[nodiscard]] tt::tt_metal::Tensor from_xtensor(
     const xt::xarray<T>& buffer,

--- a/tt-train/sources/ttml/modules/distributed/linear.cpp
+++ b/tt-train/sources/ttml/modules/distributed/linear.cpp
@@ -53,7 +53,7 @@ void RowParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out_fe
             num_devices));
     }
 
-    auto weight_shape = core::create_shape({1, 1, out_features, in_features});
+    auto weight_shape = ttnn::Shape({1, 1, out_features, in_features});
 
     uint32_t rank = 4U;
     auto mesh_shape = device->shape();
@@ -65,7 +65,7 @@ void RowParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out_fe
         ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(weight, device, ttnn::Layout::TILE, mapper.get()));
 
     if (has_bias) {
-        auto bias_shape = core::create_shape({1, 1, 1, out_features});
+        auto bias_shape = ttnn::Shape({1, 1, 1, out_features});
         m_bias = ttml::autograd::create_tensor();
         init::uniform_init(m_bias, bias_shape, init::UniformRange{-init_k, init_k});
     }
@@ -103,7 +103,7 @@ void ColumnParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out
             num_devices));
     }
 
-    auto weight_shape = core::create_shape({1, 1, out_features, in_features});
+    auto weight_shape = ttnn::Shape({1, 1, out_features, in_features});
 
     uint32_t rank = 4U;
     auto mesh_shape = device->shape();
@@ -115,7 +115,7 @@ void ColumnParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out
         ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(weight, device, ttnn::Layout::TILE, mapper.get()));
 
     if (has_bias) {
-        auto bias_shape = core::create_shape({1, 1, 1, out_features});
+        auto bias_shape = ttnn::Shape({1, 1, 1, out_features});
         auto bias = init::uniform_init(bias_shape, init::UniformRange{-init_k, init_k});
         mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, rank - 1U);
         m_bias = autograd::create_tensor(

--- a/tt-train/sources/ttml/modules/embedding_module.cpp
+++ b/tt-train/sources/ttml/modules/embedding_module.cpp
@@ -17,8 +17,7 @@ namespace ttml::modules {
 void Embedding::initialize_tensors(uint32_t num_embeddings, uint32_t embedding_dim) {
     auto* device = &autograd::ctx().get_device();
     m_weight = autograd::create_tensor();
-    init::normal_init(
-        m_weight, core::create_shape({1, 1, num_embeddings, embedding_dim}), /* normal params */ {0.F, 1.F});
+    init::normal_init(m_weight, ttnn::Shape({1, 1, num_embeddings, embedding_dim}), /* normal params */ {0.F, 1.F});
 }
 
 Embedding::Embedding(uint32_t num_embeddings, uint32_t embedding_dim) {

--- a/tt-train/sources/ttml/modules/layer_norm_module.cpp
+++ b/tt-train/sources/ttml/modules/layer_norm_module.cpp
@@ -9,10 +9,8 @@
 namespace ttml::modules {
 
 void LayerNormLayer::initialize_tensors(uint32_t features) {
-    m_gamma =
-        autograd::create_tensor(core::ones(core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
-    m_beta =
-        autograd::create_tensor(core::zeros(core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+    m_gamma = autograd::create_tensor(core::ones(ttnn::Shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+    m_beta = autograd::create_tensor(core::zeros(ttnn::Shape({1, 1, 1, features}), &autograd::ctx().get_device()));
 }
 
 LayerNormLayer::LayerNormLayer(uint32_t features, bool use_composite_op) : m_use_composite_op(use_composite_op) {

--- a/tt-train/sources/ttml/modules/linear_module.cpp
+++ b/tt-train/sources/ttml/modules/linear_module.cpp
@@ -19,7 +19,7 @@ namespace ttml::modules {
 namespace {
 ttml::autograd::TensorPtr create_weight(uint32_t in_features, uint32_t out_features) {
     auto* device = &autograd::ctx().get_device();
-    auto weight_shape = core::create_shape({1, 1, out_features, in_features});
+    auto weight_shape = ttnn::Shape({1, 1, out_features, in_features});
     auto weight = ttml::autograd::create_tensor();
     const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
     init::uniform_init(weight, weight_shape, init::UniformRange{-init_k, init_k});
@@ -28,7 +28,7 @@ ttml::autograd::TensorPtr create_weight(uint32_t in_features, uint32_t out_featu
 ttml::autograd::TensorPtr create_bias(uint32_t in_features, uint32_t out_features) {
     const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
     auto* device = &ttml::autograd::ctx().get_device();
-    auto bias_shape = ttml::core::create_shape({1, 1, 1, out_features});
+    auto bias_shape = ttnn::Shape({1, 1, 1, out_features});
     auto bias = ttml::autograd::create_tensor();
     ttml::init::uniform_init(bias, bias_shape, ttml::init::UniformRange{-init_k, init_k});
     return bias;

--- a/tt-train/sources/ttml/modules/lora_linear_module.cpp
+++ b/tt-train/sources/ttml/modules/lora_linear_module.cpp
@@ -21,7 +21,7 @@ namespace ttml::modules {
 namespace {
 ttml::autograd::TensorPtr create_weight(uint32_t in_features, uint32_t out_features) {
     auto* device = &autograd::ctx().get_device();
-    auto weight_shape = core::create_shape({1, 1, out_features, in_features});
+    auto weight_shape = ttnn::Shape({1, 1, out_features, in_features});
     auto weight = ttml::autograd::create_tensor();
     const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
     init::uniform_init(weight, weight_shape, init::UniformRange{-init_k, init_k});
@@ -30,7 +30,7 @@ ttml::autograd::TensorPtr create_weight(uint32_t in_features, uint32_t out_featu
 
 ttml::autograd::TensorPtr create_lora_a(uint32_t rank, uint32_t out_features) {
     auto* device = &autograd::ctx().get_device();
-    auto weight_shape = core::create_shape({1, 1, out_features, rank});
+    auto weight_shape = ttnn::Shape({1, 1, out_features, rank});
     auto weight = ttml::autograd::create_tensor();
     init::constant_init(weight, weight_shape, 0.F);
     return weight;
@@ -38,7 +38,7 @@ ttml::autograd::TensorPtr create_lora_a(uint32_t rank, uint32_t out_features) {
 
 ttml::autograd::TensorPtr create_lora_b(uint32_t in_features, uint32_t rank) {
     auto* device = &autograd::ctx().get_device();
-    auto weight_shape = core::create_shape({1, 1, rank, in_features});
+    auto weight_shape = ttnn::Shape({1, 1, rank, in_features});
     auto weight = ttml::autograd::create_tensor();
     const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
     init::uniform_init(weight, weight_shape, init::UniformRange{-init_k, init_k});
@@ -48,7 +48,7 @@ ttml::autograd::TensorPtr create_lora_b(uint32_t in_features, uint32_t rank) {
 ttml::autograd::TensorPtr create_bias(uint32_t in_features, uint32_t out_features) {
     const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
     auto* device = &ttml::autograd::ctx().get_device();
-    auto bias_shape = ttml::core::create_shape({1, 1, 1, out_features});
+    auto bias_shape = ttnn::Shape({1, 1, 1, out_features});
     auto bias = ttml::autograd::create_tensor();
     ttml::init::uniform_init(bias, bias_shape, ttml::init::UniformRange{-init_k, init_k});
     return bias;

--- a/tt-train/sources/ttml/modules/positional_embeddings.cpp
+++ b/tt-train/sources/ttml/modules/positional_embeddings.cpp
@@ -30,7 +30,7 @@ autograd::AutocastTensor create_positional_embedding_tensor(uint32_t sequence_le
         }
     }
 
-    auto shape = core::create_shape({1, 1, sequence_length, embedding_dim});
+    auto shape = ttnn::Shape({1, 1, sequence_length, embedding_dim});
     auto* device = &autograd::ctx().get_device();
     auto tensor = core::from_vector(positional_embedding_data, shape, device);
     return autograd::AutocastTensor(tensor);
@@ -71,8 +71,7 @@ autograd::TensorPtr PositionalEmbedding::operator()(const autograd::TensorPtr& i
 void TrainablePositionalEmbedding::initialize_tensors(uint32_t sequence_length, uint32_t embedding_dim) {
     auto* device = &autograd::ctx().get_device();
     m_weight = autograd::create_tensor();
-    init::normal_init(
-        m_weight, core::create_shape({1, 1, sequence_length, embedding_dim}), /* normal params */ {0.F, 1.F});
+    init::normal_init(m_weight, ttnn::Shape({1, 1, sequence_length, embedding_dim}), /* normal params */ {0.F, 1.F});
 }
 
 TrainablePositionalEmbedding::TrainablePositionalEmbedding(const PositionalEmbeddingConfig& config) :

--- a/tt-train/sources/ttml/modules/rms_norm_module.cpp
+++ b/tt-train/sources/ttml/modules/rms_norm_module.cpp
@@ -10,8 +10,7 @@
 namespace ttml::modules {
 
 void RMSNormLayer::initialize_tensors(uint32_t features) {
-    m_gamma =
-        autograd::create_tensor(core::ones(core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+    m_gamma = autograd::create_tensor(core::ones(ttnn::Shape({1, 1, 1, features}), &autograd::ctx().get_device()));
 }
 
 RMSNormLayer::RMSNormLayer(uint32_t features, float epsilon, bool use_composite) :

--- a/tt-train/sources/ttml/ops/embedding_op.cpp
+++ b/tt-train/sources/ttml/ops/embedding_op.cpp
@@ -23,14 +23,14 @@ autograd::TensorPtr embedding_op(const autograd::TensorPtr& tensor, const autogr
     auto batch_size = embeddings_shape[0];
     auto sentence_size = embeddings_shape[1];
     auto embedding_dim = embeddings_shape[2];
-    embeddings = ttnn::reshape(embeddings, core::create_shape({batch_size, 1, sentence_size, embedding_dim}));
+    embeddings = ttnn::reshape(embeddings, ttnn::Shape({batch_size, 1, sentence_size, embedding_dim}));
     auto out = autograd::create_tensor(embeddings);
 
     autograd::GradFunction grad = [tensor, weight, out]() {
         auto out_grad = out->get_grad();
         auto tensor_shape = tensor->get_value().logical_shape();
         out_grad = ttnn::reshape(
-            out_grad, core::create_shape({1, 1, tensor_shape[0] * tensor_shape[-1], out_grad.logical_shape()[-1]}));
+            out_grad, ttnn::Shape({1, 1, tensor_shape[0] * tensor_shape[-1], out_grad.logical_shape()[-1]}));
         auto weight_grad = ttnn::embedding_bw(tensor->get_value(), weight->get_value(), out_grad);
         weight->add_grad(weight_grad);
     };

--- a/tt-train/sources/ttml/ops/layernorm_op.cpp
+++ b/tt-train/sources/ttml/ops/layernorm_op.cpp
@@ -24,7 +24,7 @@ autograd::TensorPtr layernorm(
     const autograd::TensorPtr& tensor, const autograd::TensorPtr& gamma, const autograd::TensorPtr& beta) {
     auto tensor_shape = tensor->get_value().logical_shape();
     auto mean = core::empty(
-        core::create_shape({tensor_shape[0], tensor_shape[1], tensor_shape[2], 1}),
+        ttnn::Shape({tensor_shape[0], tensor_shape[1], tensor_shape[2], 1}),
         &autograd::ctx().get_device(),
         tensor->get_value().memory_config());
     auto rstd = ttnn::empty_like(mean);
@@ -80,7 +80,7 @@ autograd::TensorPtr composite_layernorm(
     const autograd::TensorPtr& tensor, const autograd::TensorPtr& gamma, const autograd::TensorPtr& beta) {
     auto tensor_shape = tensor->get_value().logical_shape();
 
-    auto shape = core::create_shape({tensor_shape[0], tensor_shape[1], tensor_shape[2], 1});
+    auto shape = ttnn::Shape({tensor_shape[0], tensor_shape[1], tensor_shape[2], 1});
     auto mean = core::zeros(shape, &autograd::ctx().get_device(), tensor->get_value().dtype());
     ttnn::moreh_mean(
         tensor->get_value(),
@@ -138,7 +138,7 @@ autograd::TensorPtr composite_layernorm(
 
         // dnorm.mean(-1, keepdim=True)
         auto dnorm_shape = dtensor_normalized.logical_shape();
-        auto shape = core::create_shape({dnorm_shape[0], dnorm_shape[1], dnorm_shape[2], 1});
+        auto shape = ttnn::Shape({dnorm_shape[0], dnorm_shape[1], dnorm_shape[2], 1});
         auto dnorm_mean = core::zeros(shape, &autograd::ctx().get_device(), tensor->get_value().dtype());
         ttnn::moreh_mean(
             dtensor_normalized,

--- a/tt-train/sources/ttml/ops/losses.cpp
+++ b/tt-train/sources/ttml/ops/losses.cpp
@@ -33,7 +33,7 @@ autograd::TensorPtr mse_loss(
 autograd::TensorPtr cross_entropy_loss(
     const autograd::TensorPtr& prediction, const autograd::TensorPtr& target, ReduceType reduce) {
     auto loss = ttml::metal::cross_entropy_fw(prediction->get_value(), target->get_value());
-    auto shape = core::create_shape({1, 1, 1, 1});
+    auto shape = ttnn::Shape({1, 1, 1, 1});
     autograd::TensorPtr out = autograd::create_tensor(core::from_vector({0.F}, shape, &autograd::ctx().get_device()));
     ttnn::moreh_mean(
         loss,

--- a/tt-train/sources/ttml/ops/multi_head_utils.cpp
+++ b/tt-train/sources/ttml/ops/multi_head_utils.cpp
@@ -69,8 +69,7 @@ autograd::TensorPtr heads_fusion(const autograd::TensorPtr& x) {
         // (B, 1, S, E) -> (B, 1, E, S)
         auto grad_result = ttnn::transpose(grad_output, -2, -1);
         // (B, 1, E, S) -> (B, H, E/H, S)
-        grad_result =
-            ttnn::reshape(grad_result, core::create_shape({batch_size, num_heads, embedding_dim, sequence_length}));
+        grad_result = ttnn::reshape(grad_result, ttnn::Shape({batch_size, num_heads, embedding_dim, sequence_length}));
         // (B, H, E/H, S) -> (B, H, S, E/H)
         grad_result = ttnn::transpose(grad_result, -2, -1);
         x->add_grad(grad_result);

--- a/tt-train/sources/ttml/ops/unary_ops.cpp
+++ b/tt-train/sources/ttml/ops/unary_ops.cpp
@@ -107,7 +107,7 @@ autograd::TensorPtr log_softmax_moreh(const autograd::TensorPtr& tensor, int dim
 }
 
 autograd::TensorPtr mean(const autograd::TensorPtr& tensor) {
-    auto shape = core::create_shape({1, 1, 1, 1});
+    auto shape = ttnn::Shape({1, 1, 1, 1});
     autograd::TensorPtr out = autograd::create_tensor(core::from_vector({0.F}, shape, &autograd::ctx().get_device()));
     ttnn::moreh_mean(
         tensor->get_value(),
@@ -140,7 +140,7 @@ autograd::TensorPtr broadcast_batch(const autograd::TensorPtr& tensor, uint32_t 
         return tensor;
     }
     auto out = ttml::autograd::create_tensor();
-    auto repeats = core::create_shape({new_batch_dim, 1, 1, 1});
+    auto repeats = ttnn::Shape({new_batch_dim, 1, 1, 1});
     // currently assuming tensor came with shape: {1,X,Y,Z} and we want to get {B,X,Y,Z}
     out->set_value(ttnn::repeat(tensor->get_value(), repeats));
 

--- a/tt-train/sources/ttml/serialization/serialization.cpp
+++ b/tt-train/sources/ttml/serialization/serialization.cpp
@@ -105,7 +105,7 @@ void read_ttnn_tensor(MsgPackFile& file, std::string_view name, tt::tt_metal::Te
     tt::tt_metal::Layout layout{};
     tt::tt_metal::StorageType storage_type{};
 
-    auto shape = core::create_shape({1, 1, 1, 1});
+    auto shape = ttnn::Shape({1, 1, 1, 1});
     std::vector<uint8_t> bytes;
     file.get(std::string(name) + "/shape", bytes);
     from_bytes<ttnn::Shape>(bytes, shape);

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
@@ -27,7 +27,7 @@ tt::tt_metal::Tensor all_reduce(const tt::tt_metal::Tensor& tensor) {
         throw std::logic_error("All reduce supports only 4D tensors");
     }
 
-    auto reshaped_tensor = ttnn::reshape(tensor, core::create_shape({1, shape[0] * shape[1], shape[2], shape[3]}));
+    auto reshaped_tensor = ttnn::reshape(tensor, ttnn::Shape({1, shape[0] * shape[1], shape[2], shape[3]}));
     auto gathered_tensor = ttnn::all_gather(reshaped_tensor, 0);
 
     auto reduced_tensor = ttnn::moreh_sum(

--- a/tt-train/tests/autograd/autograd_tensor.cpp
+++ b/tt-train/tests/autograd/autograd_tensor.cpp
@@ -25,8 +25,8 @@ protected:
 };
 
 TEST_F(AutogradTensorTest, AutogradTensorFLOAT32) {
-    auto tensor = autograd::create_tensor(ttml::core::ones(
-        ttml::core::create_shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::FLOAT32));
+    auto tensor = autograd::create_tensor(
+        ttml::core::ones(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::FLOAT32));
     const auto& half_precision_tensor = tensor->get_value();
     const auto& full_precision_tensor = tensor->get_value(autograd::PreferredPrecision::FULL);
 
@@ -35,8 +35,8 @@ TEST_F(AutogradTensorTest, AutogradTensorFLOAT32) {
 }
 
 TEST_F(AutogradTensorTest, AutogradTensorBFLOAT16) {
-    auto tensor = autograd::create_tensor(ttml::core::ones(
-        ttml::core::create_shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::BFLOAT16));
+    auto tensor = autograd::create_tensor(
+        ttml::core::ones(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::BFLOAT16));
     const auto& half_precision_tensor = tensor->get_value();
     const auto& full_precision_tensor = tensor->get_value(autograd::PreferredPrecision::FULL);
 
@@ -45,8 +45,8 @@ TEST_F(AutogradTensorTest, AutogradTensorBFLOAT16) {
 }
 
 TEST_F(AutogradTensorTest, AutocastTensor) {
-    auto tt_tensor = ttml::core::ones(
-        ttml::core::create_shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::FLOAT32);
+    auto tt_tensor =
+        ttml::core::ones(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::FLOAT32);
     auto autocast_tensor = autograd::AutocastTensor(tt_tensor);
     const auto& half_precision_tensor = autocast_tensor.get_tensor();
     const auto& full_precision_tensor = autocast_tensor.get_tensor(autograd::PreferredPrecision::FULL);

--- a/tt-train/tests/autograd/autograd_test.cpp
+++ b/tt-train/tests/autograd/autograd_test.cpp
@@ -34,7 +34,7 @@ TEST_F(AutogradTest, TestSum) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data1 = {1.F, 2.F, 3.F, 4.F};
     std::vector<float> test_data2 = {4.F, 3.F, 2.F, 1.F};
-    auto shape = ttml::core::create_shape({1, 1, 1, 4});
+    auto shape = ttnn::Shape({1, 1, 1, 4});
     auto tensor1 = ttml::core::from_vector(test_data1, shape, device);
     auto tensor2 = ttml::core::from_vector(test_data2, shape, device);
 
@@ -63,7 +63,7 @@ TEST_F(AutogradTest, TestMul) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data1 = {1.F, 2.F, 3.F, 4.F};
     std::vector<float> test_data2 = {4.F, 3.F, 2.F, 1.F};
-    auto shape = ttml::core::create_shape({1, 1, 1, 4});
+    auto shape = ttnn::Shape({1, 1, 1, 4});
     auto tensor1 = ttml::core::from_vector(test_data1, shape, device);
     auto tensor2 = ttml::core::from_vector(test_data2, shape, device);
 
@@ -87,14 +87,14 @@ TEST_F(AutogradTest, BroadCastBatchTest) {
     using namespace ttml::ops;
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data1 = {1.F, 2.F, 3.F, 4.F};
-    auto shape = ttml::core::create_shape({1, 1, 1, 4});
+    auto shape = ttnn::Shape({1, 1, 1, 4});
     auto tensor1 = ttml::core::from_vector(test_data1, shape, device);
     auto t1 = ttml::autograd::create_tensor(tensor1);
     uint32_t new_batch = 4;
     auto res = ttml::ops::broadcast_batch(t1, new_batch);
     res->backward();
     auto t1_back = ttml::core::to_vector(t1->get_grad());
-    auto batch_shape = ttml::core::create_shape({4, 1, 1, 4});
+    auto batch_shape = ttnn::Shape({4, 1, 1, 4});
     auto new_shape = res->get_value().logical_shape();
     auto back_shape = t1->get_grad().logical_shape();
 

--- a/tt-train/tests/autograd/module_base_parameters_test.cpp
+++ b/tt-train/tests/autograd/module_base_parameters_test.cpp
@@ -93,8 +93,7 @@ TEST_F(ModuleBaseParametersTest, UnusedParametersInModuleSGD) {
     EXPECT_EQ(model_params.size(), 6);
     auto optimizer = ttml::optimizers::SGD(model_params, ttml::optimizers::SGDConfig{});
 
-    auto input_tensor =
-        ttml::autograd::create_tensor(ttml::core::zeros(ttml::core::create_shape({1, 1, 1, 784}), device));
+    auto input_tensor = ttml::autograd::create_tensor(ttml::core::zeros(ttnn::Shape({1, 1, 1, 784}), device));
     auto output = model(input_tensor);
     output->backward();
     optimizer.step();
@@ -109,8 +108,7 @@ TEST_F(ModuleBaseParametersTest, UnusedParametersInModuleAdamW) {
     EXPECT_EQ(model_params.size(), 6);
     auto optimizer = ttml::optimizers::AdamW(model_params, ttml::optimizers::AdamWConfig{});
 
-    auto input_tensor =
-        ttml::autograd::create_tensor(ttml::core::zeros(ttml::core::create_shape({1, 1, 1, 784}), device));
+    auto input_tensor = ttml::autograd::create_tensor(ttml::core::zeros(ttnn::Shape({1, 1, 1, 784}), device));
     auto output = model(input_tensor);
     output->backward();
     optimizer.step();

--- a/tt-train/tests/core/clip_grad_norm_test.cpp
+++ b/tt-train/tests/core/clip_grad_norm_test.cpp
@@ -53,7 +53,7 @@ TEST_F(ClipGradNormTest, ClipGradNorm_GENEROUS_TOLERANCE) {
 
     // Create tensors and set their gradients
     for (uint32_t i = 0; i < num_tensors; i++) {
-        auto tensor = autograd::create_tensor(core::zeros(core::create_shape({1U, 1U, 1U, tensor_size}), device));
+        auto tensor = autograd::create_tensor(core::zeros(ttnn::Shape({1U, 1U, 1U, tensor_size}), device));
         auto grad_tensor = core::from_xtensor(expected_grads[i], device);
         tensor->set_grad(grad_tensor);
         tensors.push_back(tensor);

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -27,7 +27,7 @@ TEST_F(TensorUtilsTest, TestFloatToFromTensorEven) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data = {1.F, 5.F, 10.F, 15.F};
 
-    auto shape = ttml::core::create_shape({1, 1, 1, 4});
+    auto shape = ttnn::Shape({1, 1, 1, 4});
     auto tensor = ttml::core::from_vector(test_data, shape, device);
 
     auto vec_back = ttml::core::to_vector(tensor);
@@ -43,7 +43,7 @@ TEST_F(TensorUtilsTest, TestFloatToFromTensorGPT2Tokenizer) {
     const size_t N = 50304;
     std::vector<float> test_data(N, 0.F);
 
-    auto shape = ttml::core::create_shape({1, 1, 1, N});
+    auto shape = ttnn::Shape({1, 1, 1, N});
     auto tensor = ttml::core::from_vector(test_data, shape, device);
 
     auto vec_back = ttml::core::to_vector(tensor);
@@ -58,7 +58,7 @@ TEST_F(TensorUtilsTest, TestFloatToFromTensorOdd) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data = {30.F, 20.F, 2.F};
 
-    auto shape = ttml::core::create_shape({1, 1, 1, 3});
+    auto shape = ttnn::Shape({1, 1, 1, 3});
     auto tensor = ttml::core::from_vector(test_data, shape, device);
 
     auto vec_back = ttml::core::to_vector(tensor);
@@ -73,7 +73,7 @@ TEST_F(TensorUtilsTest, TestUint32ToFromTensorEven) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<uint32_t> test_data = {1, 5, 10, 15};
 
-    auto shape = ttml::core::create_shape({1, 1, 1, 4});
+    auto shape = ttnn::Shape({1, 1, 1, 4});
     auto tensor = ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(test_data, shape, device);
 
     auto vec_back = ttml::core::to_vector<uint32_t>(tensor);
@@ -88,7 +88,7 @@ TEST_F(TensorUtilsTest, TestUint32ToFromTensorOdd) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<uint32_t> test_data = {30, 20, 2};
 
-    auto shape = ttml::core::create_shape({1, 1, 1, 3});
+    auto shape = ttnn::Shape({1, 1, 1, 3});
     auto tensor = ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(test_data, shape, device);
 
     auto vec_back = ttml::core::to_vector<uint32_t>(tensor);
@@ -108,7 +108,7 @@ TEST_F(TensorUtilsTest, TestUint32ToFromTensorLargeWithBatch) {
         test_data.push_back(i);
     }
 
-    auto shape = ttml::core::create_shape({batch_size, 1, 1, vec_size / batch_size});
+    auto shape = ttnn::Shape({batch_size, 1, 1, vec_size / batch_size});
     auto tensor = ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(test_data, shape, device);
     auto vec_back = ttml::core::to_vector<uint32_t>(tensor);
     ASSERT_EQ(vec_back.size(), test_data.size());
@@ -126,7 +126,7 @@ TEST_F(TensorUtilsTest, TestFloatToFromTensorLargeWithBatch) {
         test_data.push_back((float)i / 100.0F);
     }
 
-    auto shape = ttml::core::create_shape({batch_size, 1, 1, vec_size / batch_size});
+    auto shape = ttnn::Shape({batch_size, 1, 1, vec_size / batch_size});
     auto tensor = ttml::core::from_vector(test_data, shape, device);
     auto vec_back = ttml::core::to_vector(tensor);
     ASSERT_EQ(vec_back.size(), test_data.size());
@@ -143,7 +143,7 @@ TEST_F(TensorUtilsTest, TestToFromTensorLarge) {
         test_data.push_back((float)i / 100.0F);
     }
 
-    auto shape = ttml::core::create_shape({1, 1, 1, vec_size});
+    auto shape = ttnn::Shape({1, 1, 1, vec_size});
     auto tensor = ttml::core::from_vector(test_data, shape, device);
     auto vec_back = ttml::core::to_vector(tensor);
     ASSERT_EQ(vec_back.size(), test_data.size());
@@ -156,7 +156,7 @@ TEST_F(TensorUtilsTest, TestToFromTensorBatch) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data = {1.F, 5.F, 10.F, 15.F};
 
-    auto shape = ttml::core::create_shape({2, 1, 1, 2});
+    auto shape = ttnn::Shape({2, 1, 1, 2});
     auto tensor = ttml::core::from_vector(test_data, shape, device);
 
     auto vec_back = ttml::core::to_vector(tensor);
@@ -169,7 +169,7 @@ TEST_F(TensorUtilsTest, TestToFromTensorBatch) {
 
 TEST_F(TensorUtilsTest, TestOnes_0) {
     auto* device = &ttml::autograd::ctx().get_device();
-    auto shape = ttml::core::create_shape({1, 2, 3, 4});
+    auto shape = ttnn::Shape({1, 2, 3, 4});
     auto tensor = ttml::core::ones(shape, device);
     auto tensor_vec = ttml::core::to_vector(tensor);
     for (auto& val : tensor_vec) {
@@ -185,7 +185,7 @@ TEST_F(TensorUtilsTest, TestOnes_0) {
 
 TEST_F(TensorUtilsTest, TestOnes_1) {
     auto* device = &ttml::autograd::ctx().get_device();
-    auto shape = ttml::core::create_shape({1, 2, 3, 4});
+    auto shape = ttnn::Shape({1, 2, 3, 4});
     auto tensor_zeros = ttml::core::zeros(shape, device);
     auto tensor_ones = ttml::core::ones(tensor_zeros.logical_shape(), device);
     auto tensor_vec = ttml::core::to_vector(tensor_ones);
@@ -196,7 +196,7 @@ TEST_F(TensorUtilsTest, TestOnes_1) {
 
 TEST_F(TensorUtilsTest, TestZeros) {
     auto* device = &ttml::autograd::ctx().get_device();
-    auto shape = ttml::core::create_shape({1, 2, 3, 4});
+    auto shape = ttnn::Shape({1, 2, 3, 4});
     auto tensor = ttml::core::ones(shape, device);
 
     auto zeros_like_tensor = ttml::core::zeros_like(tensor);
@@ -212,14 +212,14 @@ TEST_F(TensorUtilsTest, TestIsInitialized) {
     tt::tt_metal::Tensor tensor;
     EXPECT_FALSE(ttml::core::is_tensor_initialized(tensor));
 
-    auto shape = ttml::core::create_shape({1, 2, 3, 4});
+    auto shape = ttnn::Shape({1, 2, 3, 4});
     tensor = ttml::core::zeros(shape, device);
     EXPECT_TRUE(ttml::core::is_tensor_initialized(tensor));
 }
 
 TEST_F(TensorUtilsTest, TestOnesLike) {
     auto* device = &ttml::autograd::ctx().get_device();
-    auto shape = ttml::core::create_shape({1, 2, 32, 321});
+    auto shape = ttnn::Shape({1, 2, 32, 321});
     auto tensor_zeros = ttml::core::zeros(shape, device);
     auto tensor_ones = ttml::core::ones_like(tensor_zeros);
     auto tensor_vec = ttml::core::to_vector(tensor_ones);
@@ -230,7 +230,7 @@ TEST_F(TensorUtilsTest, TestOnesLike) {
 
 TEST_F(TensorUtilsTest, TestZerosLike) {
     auto* device = &ttml::autograd::ctx().get_device();
-    auto shape = ttml::core::create_shape({1, 2, 31, 322});
+    auto shape = ttnn::Shape({1, 2, 31, 322});
     auto tensor_ones = ttml::core::ones(shape, device);
     auto tensor_zeros = ttml::core::zeros_like(tensor_ones);
     auto tensor_vec = ttml::core::to_vector(tensor_zeros);
@@ -243,7 +243,7 @@ TEST_F(TensorUtilsTest, TestFloatXtensor) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data = {30.F, 20.F, 2.F};
 
-    auto shape = ttml::core::create_shape({1, 1, 1, 3});
+    auto shape = ttnn::Shape({1, 1, 1, 3});
 
     xt::xarray<float> xtensor =
         ttml::core::span_to_xtensor_view(std::span<float>{test_data.data(), test_data.size()}, shape);
@@ -258,7 +258,7 @@ TEST_F(TensorUtilsTest, TestUint32XTensor) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<uint32_t> test_data = {30, 20, 2};
 
-    auto shape = ttml::core::create_shape({1, 1, 1, 3});
+    auto shape = ttnn::Shape({1, 1, 1, 3});
     xt::xarray<uint32_t> xtensor =
         ttml::core::span_to_xtensor_view(std::span<uint32_t>{test_data.data(), test_data.size()}, shape);
     auto tensor = ttml::core::from_xtensor<uint32_t, ttnn::DataType::UINT32>(xtensor, device);
@@ -272,7 +272,7 @@ TEST_F(TensorUtilsTest, TestBytesToFromTensor) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data = {1.F, 5.F, 10.F, 15.F};
 
-    auto shape = ttml::core::create_shape({1, 1, 1, 4});
+    auto shape = ttnn::Shape({1, 1, 1, 4});
     auto tensor = ttml::core::from_vector(test_data, shape, device);
 
     auto tensor2 = ttml::core::ones(shape, device);

--- a/tt-train/tests/model/linear_regression_ddp_test.cpp
+++ b/tt-train/tests/model/linear_regression_ddp_test.cpp
@@ -84,18 +84,10 @@ TEST_F(LinearRegressionDDPTest, Full) {
 
             const auto mapper = ttnn::distributed::replicate_tensor_to_mesh_mapper(*device);
             auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(
-                data,
-                ttml::core::create_shape({batch_size, 1, 1, num_features}),
-                device,
-                ttnn::Layout::TILE,
-                mapper.get()));
+                data, ttnn::Shape({batch_size, 1, 1, num_features}), device, ttnn::Layout::TILE, mapper.get()));
             auto targets_tensor =
                 ttml::autograd::create_tensor(ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(
-                    targets,
-                    ttml::core::create_shape({batch_size, 1, 1, num_targets}),
-                    device,
-                    ttnn::Layout::TILE,
-                    mapper.get()));
+                    targets, ttnn::Shape({batch_size, 1, 1, num_targets}), device, ttnn::Layout::TILE, mapper.get()));
 
             return std::make_pair(data_tensor, targets_tensor);
         };

--- a/tt-train/tests/model/linear_regression_full_test.cpp
+++ b/tt-train/tests/model/linear_regression_full_test.cpp
@@ -44,10 +44,10 @@ TEST_F(LinearRegressionFullTest, TestLinearRegressionFull) {
     }
 
     auto data_tensor = ttml::autograd::create_tensor(
-        ttml::core::from_vector(features, ttml::core::create_shape({batch_size, 1, 1, num_features}), device));
+        ttml::core::from_vector(features, ttnn::Shape({batch_size, 1, 1, num_features}), device));
 
-    auto targets_tensor = ttml::autograd::create_tensor(
-        ttml::core::from_vector(targets, ttml::core::create_shape({batch_size, 1, 1, 1}), device));
+    auto targets_tensor =
+        ttml::autograd::create_tensor(ttml::core::from_vector(targets, ttnn::Shape({batch_size, 1, 1, 1}), device));
 
     auto model = ttml::modules::LinearLayer(num_features, 1);
     auto optimizer = ttml::optimizers::SGD(model.parameters(), {0.01F, 0.0F});

--- a/tt-train/tests/model/nano_gpt_test.cpp
+++ b/tt-train/tests/model/nano_gpt_test.cpp
@@ -105,7 +105,7 @@ void train_test(bool use_moreh_adamw = false, bool memory_efficient = false) {
         }
     }
     cached_data.masks_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
-        mask, ttml::core::create_shape({config.batch_size, num_heads, sequence_length, sequence_length}), device));
+        mask, ttnn::Shape({config.batch_size, num_heads, sequence_length, sequence_length}), device));
 
     std::function<BatchType(std::vector<DatasetSample> && samples)> collate_fn =
         [sequence_length, num_heads, device, &cached_data](std::vector<DatasetSample> &&samples) {
@@ -127,7 +127,7 @@ void train_test(bool use_moreh_adamw = false, bool memory_efficient = false) {
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_timer - start_timer).count();
             fmt::print("dataloader host only step time {} ms\n", (double)duration / 1000.);
             auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(
-                data, ttml::core::create_shape({batch_size, 1, 1, sequence_length}), device, ttnn::Layout::ROW_MAJOR));
+                data, ttnn::Shape({batch_size, 1, 1, sequence_length}), device, ttnn::Layout::ROW_MAJOR));
             auto targets_tensor = ttml::autograd::create_tensor(ttml::core::from_vector<int32_t, ttnn::DataType::INT32>(
                 targets, ttnn::Shape({batch_size * sequence_length}), device));
             end_timer = std::chrono::high_resolution_clock::now();

--- a/tt-train/tests/model/weight_tying_test.cpp
+++ b/tt-train/tests/model/weight_tying_test.cpp
@@ -110,10 +110,10 @@ TEST_F(WeightTyingTest, ModelFC) {
 
     auto* device = &ttml::autograd::ctx().get_device();
     auto data_tensor = ttml::autograd::create_tensor(
-        ttml::core::from_vector(features, ttml::core::create_shape({batch_size, 1, 1, num_features}), device));
+        ttml::core::from_vector(features, ttnn::Shape({batch_size, 1, 1, num_features}), device));
 
     auto targets_tensor = ttml::autograd::create_tensor(
-        ttml::core::from_vector(targets, ttml::core::create_shape({batch_size, 1, 1, output_features}), device));
+        ttml::core::from_vector(targets, ttnn::Shape({batch_size, 1, 1, output_features}), device));
 
     auto optimizer_params = ttml::optimizers::AdamWConfig();
     optimizer_params.lr = 0.01F;

--- a/tt-train/tests/ops/embedding_op_test.cpp
+++ b/tt-train/tests/ops/embedding_op_test.cpp
@@ -30,7 +30,7 @@ TEST_F(EmbeddingOpTest, EmbeddingForwardBackward) {
     auto* device = &autograd::ctx().get_device();
     uint32_t num_embeddings = 32;
     uint32_t embedding_dim = 32;
-    auto weight_tensor = ttml::core::zeros(ttml::core::create_shape({1, 1, num_embeddings, embedding_dim}), device);
+    auto weight_tensor = ttml::core::zeros(ttnn::Shape({1, 1, num_embeddings, embedding_dim}), device);
     autograd::TensorPtr weight = autograd::create_tensor(weight_tensor);
 
     uint32_t batch_size = 1;
@@ -38,7 +38,7 @@ TEST_F(EmbeddingOpTest, EmbeddingForwardBackward) {
     std::vector<uint32_t> input_data((size_t)batch_size * sentence_size);
     std::iota(input_data.begin(), input_data.end(), 0U);
     auto input_tensor = ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(
-        input_data, ttml::core::create_shape({batch_size, 1, 1, sentence_size}), device, ttnn::Layout::ROW_MAJOR);
+        input_data, ttnn::Shape({batch_size, 1, 1, sentence_size}), device, ttnn::Layout::ROW_MAJOR);
     autograd::TensorPtr input = autograd::create_tensor(input_tensor);
 
     autograd::TensorPtr embeddings = ops::embedding_op(input, weight);
@@ -49,8 +49,8 @@ TEST_F(EmbeddingOpTest, EmbeddingForwardBackward) {
             target_vector[embedding_dim * i + j] = static_cast<float>(i);
         }
     }
-    auto target_tensor = autograd::create_tensor(ttml::core::from_vector(
-        target_vector, ttml::core::create_shape({batch_size, 1, sentence_size, embedding_dim}), device));
+    auto target_tensor = autograd::create_tensor(
+        ttml::core::from_vector(target_vector, ttnn::Shape({batch_size, 1, sentence_size, embedding_dim}), device));
     auto result = ttml::ops::mse_loss(embeddings, target_tensor);
     result->backward();
 
@@ -73,7 +73,7 @@ TEST_F(EmbeddingOpTest, EmbeddingNumEmbeddingsEmbeddingDimNotDivisibleBy32) {
     auto* device = &autograd::ctx().get_device();
     uint32_t num_embeddings = 13;
     uint32_t embedding_dim = 26;
-    auto weight_tensor = ttml::core::zeros(ttml::core::create_shape({1, 1, num_embeddings, embedding_dim}), device);
+    auto weight_tensor = ttml::core::zeros(ttnn::Shape({1, 1, num_embeddings, embedding_dim}), device);
     autograd::TensorPtr weight = autograd::create_tensor(weight_tensor);
 
     uint32_t batch_size = 1;
@@ -81,7 +81,7 @@ TEST_F(EmbeddingOpTest, EmbeddingNumEmbeddingsEmbeddingDimNotDivisibleBy32) {
     std::vector<uint32_t> input_data((size_t)batch_size * sentence_size);
     std::iota(input_data.begin(), input_data.end(), 0U);
     auto input_tensor = ttml::core::from_vector<uint32_t, DataType::UINT32>(
-        input_data, ttml::core::create_shape({batch_size, 1, 1, sentence_size}), device, Layout::ROW_MAJOR);
+        input_data, ttnn::Shape({batch_size, 1, 1, sentence_size}), device, Layout::ROW_MAJOR);
     autograd::TensorPtr input = autograd::create_tensor(input_tensor);
 
     EXPECT_NO_THROW(ops::embedding_op(input, weight));
@@ -94,7 +94,7 @@ TEST_F(EmbeddingOpTest, EmbeddingSentenceDimNotDivisibleBy32) {
     auto* device = &autograd::ctx().get_device();
     uint32_t num_embeddings = 32;
     uint32_t embedding_dim = 32;
-    auto weight_tensor = ttml::core::zeros(ttml::core::create_shape({1, 1, num_embeddings, embedding_dim}), device);
+    auto weight_tensor = ttml::core::zeros(ttnn::Shape({1, 1, num_embeddings, embedding_dim}), device);
     autograd::TensorPtr weight = autograd::create_tensor(weight_tensor);
 
     uint32_t batch_size = 1;
@@ -102,7 +102,7 @@ TEST_F(EmbeddingOpTest, EmbeddingSentenceDimNotDivisibleBy32) {
     std::vector<uint32_t> input_data((size_t)batch_size * sentence_size);
     std::iota(input_data.begin(), input_data.end(), 0U);
     auto input_tensor = ttml::core::from_vector<uint32_t, DataType::UINT32>(
-        input_data, ttml::core::create_shape({batch_size, 1, 1, sentence_size}), device, Layout::ROW_MAJOR);
+        input_data, ttnn::Shape({batch_size, 1, 1, sentence_size}), device, Layout::ROW_MAJOR);
     autograd::TensorPtr input = autograd::create_tensor(input_tensor);
 
     EXPECT_NO_THROW(ops::embedding_op(input, weight));
@@ -117,7 +117,7 @@ TEST_F(EmbeddingOpTest, EmbeddingSentenceDimNotDivisibleBy32) {
 //     auto* device = &autograd::ctx().get_device();
 //     uint32_t num_embeddings = 32;
 //     uint32_t embedding_dim = 32;
-//     auto weight_tensor = core::zeros(core::create_shape({1, 1, num_embeddings, embedding_dim}), device);
+//     auto weight_tensor = core::zeros(ttnn::Shape({1, 1, num_embeddings, embedding_dim}), device);
 //     autograd::TensorPtr weight = autograd::create_tensor(weight_tensor);
 
 //     uint32_t batch_size = 1;
@@ -125,7 +125,7 @@ TEST_F(EmbeddingOpTest, EmbeddingSentenceDimNotDivisibleBy32) {
 //     std::vector<uint32_t> input_data((size_t)batch_size * sentence_size);
 //     std::iota(input_data.begin(), input_data.end(), 0U);
 //     auto input_tensor =
-//         core::from_vector<uint32_t>(input_data, core::create_shape({batch_size, 1, 1, sentence_size}), device);
+//         core::from_vector<uint32_t>(input_data, ttnn::Shape({batch_size, 1, 1, sentence_size}), device);
 //     autograd::TensorPtr input = autograd::create_tensor(input_tensor);
 
 //     EXPECT_ANY_THROW(ops::embedding_op(input, weight));

--- a/tt-train/tests/ops/layer_norm_op_test.cpp
+++ b/tt-train/tests/ops/layer_norm_op_test.cpp
@@ -47,12 +47,10 @@ TEST_F(LayerNormOpTest, LayerNormOp_0) {
     }
 
     auto tensor = autograd::create_tensor(core::from_vector(
-        test_data, core::create_shape({batch_size, seq_len, heads, features}), &autograd::ctx().get_device()));
+        test_data, ttnn::Shape({batch_size, seq_len, heads, features}), &autograd::ctx().get_device()));
 
-    auto gamma =
-        autograd::create_tensor(core::ones(core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
-    auto beta =
-        autograd::create_tensor(core::zeros(core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+    auto gamma = autograd::create_tensor(core::ones(ttnn::Shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+    auto beta = autograd::create_tensor(core::zeros(ttnn::Shape({1, 1, 1, features}), &autograd::ctx().get_device()));
 
     auto result = ops::layernorm(tensor, gamma, beta);
 
@@ -87,12 +85,11 @@ TEST_F(LayerNormOpTest, LayerNormOp_backward) {
 
     std::vector<float> test_data{0.0, 1.0, 2.0};
     auto tensor = autograd::create_tensor(core::from_vector(
-        test_data, core::create_shape({batch_size, seq_len, heads, features}), &autograd::ctx().get_device()));
+        test_data, ttnn::Shape({batch_size, seq_len, heads, features}), &autograd::ctx().get_device()));
 
     auto gamma = autograd::create_tensor(
-        core::from_vector({1, 2, 3}, core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
-    auto beta =
-        autograd::create_tensor(core::zeros(core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+        core::from_vector({1, 2, 3}, ttnn::Shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+    auto beta = autograd::create_tensor(core::zeros(ttnn::Shape({1, 1, 1, features}), &autograd::ctx().get_device()));
 
     auto result = ops::layernorm(tensor, gamma, beta);
     auto target = autograd::create_tensor(core::zeros_like(tensor->get_value()));
@@ -135,12 +132,10 @@ TEST_F(LayerNormOpTest, CompositeLayerNormOp_0) {
     }
 
     auto tensor = autograd::create_tensor(core::from_vector(
-        test_data, core::create_shape({batch_size, seq_len, heads, features}), &autograd::ctx().get_device()));
+        test_data, ttnn::Shape({batch_size, seq_len, heads, features}), &autograd::ctx().get_device()));
 
-    auto gamma =
-        autograd::create_tensor(core::ones(core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
-    auto beta =
-        autograd::create_tensor(core::zeros(core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+    auto gamma = autograd::create_tensor(core::ones(ttnn::Shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+    auto beta = autograd::create_tensor(core::zeros(ttnn::Shape({1, 1, 1, features}), &autograd::ctx().get_device()));
 
     auto result = ops::composite_layernorm(tensor, gamma, beta);
 
@@ -175,12 +170,11 @@ TEST_F(LayerNormOpTest, CompositeLayerNormOp_backward) {
 
     std::vector<float> test_data{0.0, 1.0, 2.0};
     auto tensor = autograd::create_tensor(core::from_vector(
-        test_data, core::create_shape({batch_size, seq_len, heads, features}), &autograd::ctx().get_device()));
+        test_data, ttnn::Shape({batch_size, seq_len, heads, features}), &autograd::ctx().get_device()));
 
     auto gamma = autograd::create_tensor(
-        core::from_vector({1, 2, 3}, core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
-    auto beta =
-        autograd::create_tensor(core::zeros(core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+        core::from_vector({1, 2, 3}, ttnn::Shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+    auto beta = autograd::create_tensor(core::zeros(ttnn::Shape({1, 1, 1, features}), &autograd::ctx().get_device()));
 
     auto result = ops::composite_layernorm(tensor, gamma, beta);
     auto target = autograd::create_tensor(core::zeros_like(tensor->get_value()));

--- a/tt-train/tests/ops/linear_op_test.cpp
+++ b/tt-train/tests/ops/linear_op_test.cpp
@@ -56,16 +56,16 @@ bool compare_tensors_for_broken(const ttnn::Tensor& t1, const ttnn::Tensor& t2, 
 TEST_F(LinearOpTest, TTNNBackwardGoodShape) {
     auto* device = &ttml::autograd::ctx().get_device();
     auto tensor = ttml::autograd::create_tensor();
-    ttml::init::uniform_init(tensor, ttml::core::create_shape({64, 1, 256, 64}), ttml::init::UniformRange{-0.1F, 0.1F});
+    ttml::init::uniform_init(tensor, ttnn::Shape({64, 1, 256, 64}), ttml::init::UniformRange{-0.1F, 0.1F});
 
     auto weight = ttml::autograd::create_tensor();
-    ttml::init::uniform_init(weight, ttml::core::create_shape({1, 1, 64, 64}), ttml::init::UniformRange{-0.1F, 0.1F});
+    ttml::init::uniform_init(weight, ttnn::Shape({1, 1, 64, 64}), ttml::init::UniformRange{-0.1F, 0.1F});
 
     auto bias = ttml::autograd::create_tensor();
-    ttml::init::uniform_init(bias, ttml::core::create_shape({1, 1, 1, 64}), ttml::init::UniformRange{-0.1F, 0.1F});
+    ttml::init::uniform_init(bias, ttnn::Shape({1, 1, 1, 64}), ttml::init::UniformRange{-0.1F, 0.1F});
 
     auto out = ttml::autograd::create_tensor();
-    ttml::init::uniform_init(out, ttml::core::create_shape({64, 1, 256, 64}), ttml::init::UniformRange{-0.1F, 0.1F});
+    ttml::init::uniform_init(out, ttnn::Shape({64, 1, 256, 64}), ttml::init::UniformRange{-0.1F, 0.1F});
     out->set_grad(out->get_value());
 
     ttml::ops::ttnn_linear_backward(tensor, weight, bias, out);
@@ -90,15 +90,13 @@ void test_linear(uint32_t batch, uint32_t emb_dim) {
     std::cout << "dim: " << emb_dim << std::endl;
     auto* device = &ttml::autograd::ctx().get_device();
     auto tensor = ttml::autograd::create_tensor();
-    ttml::init::uniform_init(
-        tensor, ttml::core::create_shape({batch, 1, 1024, 768}), ttml::init::UniformRange{-0.1F, 0.1F});
+    ttml::init::uniform_init(tensor, ttnn::Shape({batch, 1, 1024, 768}), ttml::init::UniformRange{-0.1F, 0.1F});
 
     auto weight = ttml::autograd::create_tensor();
-    ttml::init::uniform_init(
-        weight, ttml::core::create_shape({1, 1, emb_dim, 768}), ttml::init::UniformRange{-0.1F, 0.1F});
+    ttml::init::uniform_init(weight, ttnn::Shape({1, 1, emb_dim, 768}), ttml::init::UniformRange{-0.1F, 0.1F});
 
     auto bias = ttml::autograd::create_tensor();
-    ttml::init::uniform_init(bias, ttml::core::create_shape({1, 1, 1, emb_dim}), ttml::init::UniformRange{-0.1F, 0.1F});
+    ttml::init::uniform_init(bias, ttnn::Shape({1, 1, 1, emb_dim}), ttml::init::UniformRange{-0.1F, 0.1F});
 
     ttml::ops::linear_op(tensor, weight, bias);
 }
@@ -113,19 +111,19 @@ TEST_F(LinearOpTest, TTNNLargeLinearOpWithBias) {
 // TEST_F(LinearOpTest, TTNNBackwardBadShape_BROKEN) {
 //     auto* device = &ttml::autograd::ctx().get_device();
 //     auto tensor = ttml::autograd::create_tensor();
-//     ttml::init::uniform_init(tensor, ttml::core::create_shape({128, 1, 1,
+//     ttml::init::uniform_init(tensor, ttnn::Shape({128, 1, 1,
 //     128}), ttml::init::UniformRange{-0.1F, 0.1F});
 
 //     auto weight = ttml::autograd::create_tensor();
-//     ttml::init::uniform_init(weight, ttml::core::create_shape({1, 1, 256,
+//     ttml::init::uniform_init(weight, ttnn::Shape({1, 1, 256,
 //     128}), ttml::init::UniformRange{-0.1F, 0.1F});
 
 //     auto bias = ttml::autograd::create_tensor();
-//     ttml::init::uniform_init(bias, ttml::core::create_shape({1, 1, 1, 256}),
+//     ttml::init::uniform_init(bias, ttnn::Shape({1, 1, 1, 256}),
 //     ttml::init::UniformRange{-0.1F, 0.1F});
 
 //     auto out = ttml::autograd::create_tensor();
-//     ttml::init::uniform_init(out, ttml::core::create_shape({128, 1, 1, 256}),
+//     ttml::init::uniform_init(out, ttnn::Shape({128, 1, 1, 256}),
 //     ttml::init::UniformRange{-0.1F, 0.1F}); out->set_grad(out->get_value());
 
 //     ttml::ops::ttnn_linear_backward(tensor, weight, bias, out);

--- a/tt-train/tests/ops/positional_embedding_test.cpp
+++ b/tt-train/tests/ops/positional_embedding_test.cpp
@@ -30,8 +30,7 @@ TEST_F(PositionalEmbeddingTest, NonTrainableEmbedding) {
     uint32_t sentence_size = 2;
     uint32_t embedding_dim = 4;
 
-    auto x =
-        autograd::create_tensor(core::zeros(core::create_shape({batch_size, 1, sentence_size, embedding_dim}), device));
+    auto x = autograd::create_tensor(core::zeros(ttnn::Shape({batch_size, 1, sentence_size, embedding_dim}), device));
     auto pos_emb = modules::PositionalEmbedding(modules::PositionalEmbeddingConfig{
         .embedding_dim = embedding_dim,
         .sequence_length = sentence_size,

--- a/tt-train/tests/ops/rmsnorm_op_test.cpp
+++ b/tt-train/tests/ops/rmsnorm_op_test.cpp
@@ -45,7 +45,7 @@ TEST_F(RMSNormOpTest, RMSNorm_Small_Forward) {
 
     xt::xarray<float> example_xtensor = {{{{1.F, 2.F, 3.F, 4.F, 1.F, 2.F, 3.F, 4.F}}}};
     auto example_tensor = autograd::create_tensor(core::from_xtensor(example_xtensor, &autograd::ctx().get_device()));
-    auto gamma = autograd::create_tensor(core::ones(core::create_shape({1, 1, 1, W}), &autograd::ctx().get_device()));
+    auto gamma = autograd::create_tensor(core::ones(ttnn::Shape({1, 1, 1, W}), &autograd::ctx().get_device()));
 
     auto result = ops::rmsnorm(example_tensor, gamma, 0.0078125F);
     auto result_xtensor = core::to_xtensor(result->get_value());
@@ -61,7 +61,7 @@ TEST_F(RMSNormOpTest, RMSNorm_Small_Backward) {
 
     xt::xarray<float> example_xtensor = {{{{1.F, 2.F, 3.F, 4.F, 1.F, 2.F, 3.F, 4.F}}}};
     auto example_tensor = autograd::create_tensor(core::from_xtensor(example_xtensor, &autograd::ctx().get_device()));
-    auto gamma = autograd::create_tensor(core::ones(core::create_shape({1, 1, 1, W}), &autograd::ctx().get_device()));
+    auto gamma = autograd::create_tensor(core::ones(ttnn::Shape({1, 1, 1, W}), &autograd::ctx().get_device()));
 
     auto result = ops::rmsnorm(example_tensor, gamma, 0.0078125F);
     auto result_xtensor = core::to_xtensor(result->get_value());
@@ -97,7 +97,7 @@ TEST_F(RMSNormOpTest, RMSNorm_Forward_Batch) {
     std::generate(a_xarray.begin(), a_xarray.end(), [cur = 0.0F]() mutable { return (cur++); });
 
     auto example_tensor = autograd::create_tensor(core::from_xtensor(a_xarray, &autograd::ctx().get_device()));
-    auto gamma = autograd::create_tensor(core::ones(core::create_shape({1, 1, 1, 5}), &autograd::ctx().get_device()));
+    auto gamma = autograd::create_tensor(core::ones(ttnn::Shape({1, 1, 1, 5}), &autograd::ctx().get_device()));
 
     auto result = ops::rmsnorm(example_tensor, gamma, 0.0078125F);
     auto result_xtensor = core::to_xtensor(result->get_value());
@@ -136,7 +136,7 @@ TEST_F(RMSNormOpTest, RMSNorm_Backward_Batch) {
     std::generate(a_xarray.begin(), a_xarray.end(), [cur = 0.0F]() mutable { return (cur++); });
 
     auto example_tensor = autograd::create_tensor(core::from_xtensor(a_xarray, &autograd::ctx().get_device()));
-    auto gamma = autograd::create_tensor(core::ones(core::create_shape({1, 1, 1, 5}), &autograd::ctx().get_device()));
+    auto gamma = autograd::create_tensor(core::ones(ttnn::Shape({1, 1, 1, 5}), &autograd::ctx().get_device()));
 
     auto result = ops::rmsnorm(example_tensor, gamma, 0.0078125F);
     auto result_xtensor = core::to_xtensor(result->get_value());
@@ -172,7 +172,7 @@ TEST_F(RMSNormOpTest, CompositeRMSNorm_Small_Forward) {
 
     xt::xarray<float> example_xtensor = {{{{1.F, 2.F, 3.F, 4.F, 1.F, 2.F, 3.F, 4.F}}}};
     auto example_tensor = autograd::create_tensor(core::from_xtensor(example_xtensor, &autograd::ctx().get_device()));
-    auto gamma = autograd::create_tensor(core::ones(core::create_shape({1, 1, 1, W}), &autograd::ctx().get_device()));
+    auto gamma = autograd::create_tensor(core::ones(ttnn::Shape({1, 1, 1, W}), &autograd::ctx().get_device()));
 
     auto result = ops::rmsnorm_composite(example_tensor, gamma, 0.0078125F);
     auto result_xtensor = core::to_xtensor(result->get_value());
@@ -188,7 +188,7 @@ TEST_F(RMSNormOpTest, CompositeRMSNorm_Small_Backward) {
 
     xt::xarray<float> example_xtensor = {{{{1.F, 2.F, 3.F, 4.F, 1.F, 2.F, 3.F, 4.F}}}};
     auto example_tensor = autograd::create_tensor(core::from_xtensor(example_xtensor, &autograd::ctx().get_device()));
-    auto gamma = autograd::create_tensor(core::ones(core::create_shape({1, 1, 1, W}), &autograd::ctx().get_device()));
+    auto gamma = autograd::create_tensor(core::ones(ttnn::Shape({1, 1, 1, W}), &autograd::ctx().get_device()));
 
     auto result = ops::rmsnorm_composite(example_tensor, gamma, 0.0078125F);
     auto result_xtensor = core::to_xtensor(result->get_value());
@@ -224,7 +224,7 @@ TEST_F(RMSNormOpTest, CompositeRMSNorm_Forward_Batch) {
     std::generate(a_xarray.begin(), a_xarray.end(), [cur = 0.0F]() mutable { return (cur++); });
 
     auto example_tensor = autograd::create_tensor(core::from_xtensor(a_xarray, &autograd::ctx().get_device()));
-    auto gamma = autograd::create_tensor(core::ones(core::create_shape({1, 1, 1, 5}), &autograd::ctx().get_device()));
+    auto gamma = autograd::create_tensor(core::ones(ttnn::Shape({1, 1, 1, 5}), &autograd::ctx().get_device()));
 
     auto result = ops::rmsnorm_composite(example_tensor, gamma, 0.0078125F);
     auto result_xtensor = core::to_xtensor(result->get_value());
@@ -263,7 +263,7 @@ TEST_F(RMSNormOpTest, CompositeRMSNorm_Backward_Batch) {
     std::generate(a_xarray.begin(), a_xarray.end(), [cur = 0.0F]() mutable { return (cur++); });
 
     auto example_tensor = autograd::create_tensor(core::from_xtensor(a_xarray, &autograd::ctx().get_device()));
-    auto gamma = autograd::create_tensor(core::ones(core::create_shape({1, 1, 1, 5}), &autograd::ctx().get_device()));
+    auto gamma = autograd::create_tensor(core::ones(ttnn::Shape({1, 1, 1, 5}), &autograd::ctx().get_device()));
 
     auto result = ops::rmsnorm_composite(example_tensor, gamma, 0.0078125F);
     auto result_xtensor = core::to_xtensor(result->get_value());

--- a/tt-train/tests/ops/unary_ops_test.cpp
+++ b/tt-train/tests/ops/unary_ops_test.cpp
@@ -29,7 +29,7 @@ protected:
 TEST_F(UnaryOpsTest, GlobalMean) {
     std::vector<float> test_data = {1.F, 2.F, 3.F, 4.F, 1.F, 2.F, 3.F, 4.F};
 
-    auto shape = core::create_shape({2, 1, 1, 4});
+    auto shape = ttnn::Shape({2, 1, 1, 4});
     auto tensor = core::from_vector(test_data, shape, &autograd::ctx().get_device());
 
     auto tensor_ptr = autograd::create_tensor(tensor);
@@ -51,7 +51,7 @@ TEST_F(UnaryOpsTest, GlobalMean) {
 TEST_F(UnaryOpsTest, LogSoftmax) {
     auto* device = &autograd::ctx().get_device();
     std::vector<float> test_data = {-0.1F, -0.2F, -0.3F, -0.4F, 0.F, -0.2F, -0.3F, -0.4F};
-    auto tensor = core::from_vector(test_data, core::create_shape({2, 1, 1, 4}), device);
+    auto tensor = core::from_vector(test_data, ttnn::Shape({2, 1, 1, 4}), device);
     auto tensor_ptr = autograd::create_tensor(tensor);
     auto result = log_softmax_moreh(tensor_ptr, 3);
     auto result_data = core::to_vector(result->get_value());

--- a/tt-train/tests/optimizers/adamw_test.cpp
+++ b/tt-train/tests/optimizers/adamw_test.cpp
@@ -45,10 +45,10 @@ TEST_F(AdamWFullTest, AdamWTest) {
     }
 
     auto data_tensor = ttml::autograd::create_tensor(
-        ttml::core::from_vector(features, ttml::core::create_shape({batch_size, 1, 1, num_features}), device));
+        ttml::core::from_vector(features, ttnn::Shape({batch_size, 1, 1, num_features}), device));
 
-    auto targets_tensor = ttml::autograd::create_tensor(
-        ttml::core::from_vector(targets, ttml::core::create_shape({batch_size, 1, 1, 1}), device));
+    auto targets_tensor =
+        ttml::autograd::create_tensor(ttml::core::from_vector(targets, ttnn::Shape({batch_size, 1, 1, 1}), device));
 
     auto model = ttml::modules::LinearLayer(num_features, 1);
     auto adamw_config = ttml::optimizers::AdamWConfig();

--- a/tt-train/tests/serialization/tensor_serializer_test.cpp
+++ b/tt-train/tests/serialization/tensor_serializer_test.cpp
@@ -42,7 +42,7 @@ protected:
 TEST_F(TensorFileTest, SerializeDeserializeTensor) {
     ttml::serialization::MsgPackFile serializer;
     auto* device = &ttml::autograd::ctx().get_device();
-    auto shape = ttml::core::create_shape({1, 2, 32, 321});
+    auto shape = ttnn::Shape({1, 2, 32, 321});
     auto tensor_zeros = ttml::core::zeros(shape, device);
     auto tensor_ones = ttml::core::ones(shape, device);
 

--- a/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
@@ -43,7 +43,7 @@ TEST_F(TrivialTnnFixedDistributedTest, TestCustomScatterDim0) {
     uint32_t size = 64U;
     std::vector<float> data(size);
     std::iota(data.begin(), data.end(), 0);
-    auto shape = ttml::core::create_shape({size, 1, 1, 1});
+    auto shape = ttnn::Shape({size, 1, 1, 1});
     auto tensor = ttml::core::from_vector(data, shape, device);
 
     auto scattered_tensor = ttml::ttnn_fixed::distributed::scatter(tensor, /* dim */ 0);
@@ -70,7 +70,7 @@ TEST_F(TrivialTnnFixedDistributedTest, TestCustomScatterDim1) {
     uint32_t size = 64U;
     std::vector<float> data(size);
     std::iota(data.begin(), data.end(), 0);
-    auto shape = ttml::core::create_shape({1, size, 1, 1});
+    auto shape = ttnn::Shape({1, size, 1, 1});
     auto tensor = ttml::core::from_vector(data, shape, device);
 
     auto scattered_tensor = ttml::ttnn_fixed::distributed::scatter(tensor, /* dim */ 1);
@@ -97,7 +97,7 @@ TEST_F(TrivialTnnFixedDistributedTest, TestCustomScatterDim2) {
     uint32_t size = 64U;
     std::vector<float> data(size);
     std::iota(data.begin(), data.end(), 0);
-    auto shape = ttml::core::create_shape({1, 1, size, 1});
+    auto shape = ttnn::Shape({1, 1, size, 1});
     auto tensor = ttml::core::from_vector(data, shape, device);
 
     auto scattered_tensor = ttml::ttnn_fixed::distributed::scatter(tensor, /* dim */ 2);
@@ -124,7 +124,7 @@ TEST_F(TrivialTnnFixedDistributedTest, TestCustomScatterDim3) {
     uint32_t size = 64U;
     std::vector<float> data(size);
     std::iota(data.begin(), data.end(), 0);
-    auto shape = ttml::core::create_shape({1, 1, 1, size});
+    auto shape = ttnn::Shape({1, 1, 1, size});
     auto tensor = ttml::core::from_vector(data, shape, device);
 
     auto scattered_tensor = ttml::ttnn_fixed::distributed::scatter(tensor, /* dim */ 3);

--- a/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
@@ -31,7 +31,7 @@ TEST_F(TrivialTnnFixedTest, TestMaxNegativeOne) {
     auto* device = &ttml::autograd::ctx().get_device();
 
     std::vector<float> data(24, -1.F);
-    auto shape = ttml::core::create_shape({1, 2, 3, 4});
+    auto shape = ttnn::Shape({1, 2, 3, 4});
     auto tensor = ttml::core::from_vector(data, shape, device);
     auto res = ttnn::max(tensor, /* dim */ 3, /* keepdim */ true);
     auto res_vector = ttml::core::to_vector(res);
@@ -48,7 +48,7 @@ TEST_F(TrivialTnnFixedTest, TestMaxNegativeOne) {
 TEST_F(TrivialTnnFixedTest, TestMaxNegativeBatch) {
     auto* device = &ttml::autograd::ctx().get_device();
 
-    auto shape = ttml::core::create_shape({4, 1, 1, 4});
+    auto shape = ttnn::Shape({4, 1, 1, 4});
     std::vector<float> data(16);
     for (int i = 0; i < 4; ++i) {
         for (int j = 0; j < 4; ++j) {
@@ -77,7 +77,7 @@ TEST_F(TrivialTnnFixedTest, TestStableSoftmax_0) {
     for (int i = 0; i < data.size(); ++i) {
         data[i] = 100.F + static_cast<float>(i);
     }
-    auto shape = ttml::core::create_shape({batch_size, 1, 1, features});
+    auto shape = ttnn::Shape({batch_size, 1, 1, features});
     auto tensor = ttml::core::from_vector(data, shape, device);
     auto tensor_data = ttml::core::to_vector(tensor);
     EXPECT_NEAR(tensor_data[0], 100.F, 1e-2);
@@ -98,7 +98,7 @@ TEST_F(TrivialTnnFixedTest, TestOriginalStableSoftmax_AllNegative) {
     for (int i = 0; i < data.size(); ++i) {
         data[i] = -100.F + static_cast<float>(i);
     }
-    auto shape = ttml::core::create_shape({batch_size, 1, 1, features});
+    auto shape = ttnn::Shape({batch_size, 1, 1, features});
     auto tensor = ttml::core::from_vector(data, shape, device);
     auto tensor_data = ttml::core::to_vector(tensor);
     EXPECT_NEAR(tensor_data[0], -100.F, 1e-2);
@@ -122,7 +122,7 @@ TEST_F(TrivialTnnFixedTest, TestStableSoftmax_2) {
     const size_t features = 10U;
     std::vector<float> data(batch_size * features, 0.F);
     data[0] = 1.0F;
-    auto shape = ttml::core::create_shape({batch_size, 1, 1, features});
+    auto shape = ttnn::Shape({batch_size, 1, 1, features});
     auto tensor = ttml::core::from_vector(data, shape, device);
     auto tensor_data = ttml::core::to_vector(tensor);
     EXPECT_NEAR(tensor_data[0], 1.F, 1e-2);
@@ -149,7 +149,7 @@ TEST_F(TrivialTnnFixedTest, TestSumOverBatch_0) {
     std::vector<float> data(batch_size * features);
     std::iota(data.begin(), data.end(), 0);
 
-    auto shape = ttml::core::create_shape({batch_size, 1, 1, features});
+    auto shape = ttnn::Shape({batch_size, 1, 1, features});
     auto tensor = ttml::core::from_vector(data, shape, device);
     auto tensor_shape = tensor.logical_shape();
     EXPECT_EQ(tensor_shape[0], batch_size);
@@ -178,7 +178,7 @@ TEST_F(TrivialTnnFixedTest, TestDivide) {
         rhs[i] = static_cast<float>(i + 1);
     }
 
-    auto shape = ttml::core::create_shape({batch_size, 1, 1, features});
+    auto shape = ttnn::Shape({batch_size, 1, 1, features});
     auto lhs_tensor = ttml::core::from_vector(lhs, shape, device);
     auto rhs_tensor = ttml::core::from_vector(rhs, shape, device);
 
@@ -210,7 +210,7 @@ TEST_F(TrivialTnnFixedTest, TestSumOverBatch_1) {
         value += step;
     }
 
-    auto shape = ttml::core::create_shape({batch_size, 1, 1, features});
+    auto shape = ttnn::Shape({batch_size, 1, 1, features});
     auto tensor = ttml::core::from_vector(data, shape, device);
     auto tensor_shape = tensor.logical_shape();
     EXPECT_EQ(tensor_shape[0], batch_size);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
[https://github.com/tenstorrent/tt-metal/commit/47a50f29e3d9a11dc58e9f33598dfbc721f1b486#diff-bccd76a148eae90d407f670[…]ef1b8b88632eb623aa153f76eR716](https://github.com/tenstorrent/tt-metal/commit/47a50f29e3d9a11dc58e9f33598dfbc721f1b486#diff-bccd76a148eae90d407f67054e181cce1b13846ef1b8b88632eb623aa153f76eR716) introduced a bug where `std::array<uint32_t, 4>` was binded to an initializer list with just 2 elements.

### What's changed
Remove `create_shape` helper in favor of `ttnn::Shape`, as it avoids this issue altogether.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16222431665)