### PR TITLE
Add stress test config to TT-Transformers. Add Llama8B stress test and Llama-70B perf test to Blackhole Quietbox CI

### DIFF
--- a/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
@@ -23,12 +23,12 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          # {
-          #   name: "llama3.1-8b quietbox data-parallel=4 performance",
-          #   arch: blackhole,
-          #   cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 4,
-          #   owner_id: U05RWH3QUPM # Salar Hosseini
-          #  },
+          {
+            name: "llama3.1-8b quietbox data-parallel=4 performance",
+            arch: blackhole,
+            cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 4,
+            owner_id: U05RWH3QUPM # Salar Hosseini
+           },
            {
             name: "llama3.1-8b quietbox data-parallel=4 stress",
             arch: blackhole,
@@ -36,7 +36,7 @@ jobs:
             owner_id: U03PUAKE719 # Miguel Tairum
            },
            {
-            name: "llama3.3-70b quietbox data-parallel=4 performance",
+            name: "llama3.3-70b batch-32 quietbox performance",
             arch: blackhole,
             cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32",
             owner_id: U03PUAKE719 # Miguel Tairum
@@ -78,7 +78,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.test-group.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e HF_TOKEN=${{ secrets.HUGGINGFACE_TOKEN }}
-            -v /localdev/blackhole_demos:/localdev/blackhole_demos
+            -v /localdev/blackhole_demos:/localdev/blackhole_demos:ro
           install_wheel: true
           run_args: |
             if [[ "${{ matrix.test-group.name }}" == *"llama"* ]]; then

--- a/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
@@ -32,7 +32,7 @@ jobs:
            {
             name: "llama3-8b quietbox data-parallel=4 stress",
             arch: blackhole,
-            cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel 4,
+            cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel 4 --max_generated_tokens 25000,
             owner_id: U03PUAKE719 # Miguel Tairum
            }      ]
     name: ${{ matrix.test-group.name }}

--- a/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
@@ -71,7 +71,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.test-group.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e HF_TOKEN=${{ secrets.HUGGINGFACE_TOKEN }}
-            -v /localdev/blackhole_demos:/localdev/blackhole_demos:ro
+            -v /localdev/blackhole_demos:/localdev/blackhole_demos
           install_wheel: true
           run_args: |
             if [[ "${{ matrix.test-group.name }}" == *"llama"* ]]; then

--- a/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
@@ -38,7 +38,7 @@ jobs:
            {
             name: "llama3.3-70b quietbox data-parallel=4 performance",
             arch: blackhole,
-            cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 4,
+            cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32",
             owner_id: U03PUAKE719 # Miguel Tairum
            }
         ]

--- a/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
@@ -24,17 +24,24 @@ jobs:
       matrix:
         test-group: [
           # {
-          #   name: "llama3-8b quietbox data-parallel=4 performance",
+          #   name: "llama3.1-8b quietbox data-parallel=4 performance",
           #   arch: blackhole,
           #   cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 4,
           #   owner_id: U05RWH3QUPM # Salar Hosseini
           #  },
            {
-            name: "llama3-8b quietbox data-parallel=4 stress",
+            name: "llama3.1-8b quietbox data-parallel=4 stress",
             arch: blackhole,
-            cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel 4 --max_generated_tokens 25000,
+            cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel 4 --max_generated_tokens 22000,
             owner_id: U03PUAKE719 # Miguel Tairum
-           }      ]
+           },
+           {
+            name: "llama3.3-70b quietbox data-parallel=4 performance",
+            arch: blackhole,
+            cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama3.3-70B-Instruct/ pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 4,
+            owner_id: U03PUAKE719 # Miguel Tairum
+           }
+        ]
     name: ${{ matrix.test-group.name }}
     runs-on: ["in-service", "${{ inputs.runner-label }}", "pipeline-perf"]
     steps:

--- a/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
@@ -28,8 +28,13 @@ jobs:
             arch: blackhole,
             cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 4,
             owner_id: U05RWH3QUPM # Salar Hosseini
-          }
-        ]
+           },
+           {
+            name: "llama3-8b quietbox data-parallel=4 stress",
+            arch: blackhole,
+            cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel 4,
+            owner_id: U03PUAKE719 # Miguel Tairum
+           }      ]
     name: ${{ matrix.test-group.name }}
     runs-on: ["in-service", "${{ inputs.runner-label }}", "pipeline-perf"]
     steps:

--- a/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
@@ -38,7 +38,7 @@ jobs:
            {
             name: "llama3.3-70b quietbox data-parallel=4 performance",
             arch: blackhole,
-            cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama3.3-70B-Instruct/ pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 4,
+            cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 4,
             owner_id: U03PUAKE719 # Miguel Tairum
            }
         ]

--- a/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
@@ -23,12 +23,12 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {
-            name: "llama3-8b quietbox data-parallel=4 performance",
-            arch: blackhole,
-            cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 4,
-            owner_id: U05RWH3QUPM # Salar Hosseini
-           },
+          # {
+          #   name: "llama3-8b quietbox data-parallel=4 performance",
+          #   arch: blackhole,
+          #   cmd:  LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 4,
+          #   owner_id: U05RWH3QUPM # Salar Hosseini
+          #  },
            {
             name: "llama3-8b quietbox data-parallel=4 stress",
             arch: blackhole,

--- a/models/tt_transformers/demo/conftest.py
+++ b/models/tt_transformers/demo/conftest.py
@@ -45,3 +45,10 @@ def pytest_addoption(parser):
         type=bool,
         help="Whether to compute top1 and top5 exact token matching accuracy",
     )
+    parser.addoption(
+        "--stress_test",
+        action="store",
+        default=False,
+        type=bool,
+        help="Run stress test (same decode iteration over a large number of iterations",
+    )

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -218,7 +218,7 @@ def prepare_generator_args(
 # optimization (ModelOptimizations): Optimization level to use for the model (performance or accuracy)
 # MESH_DEVICE (str): Fake device to use for testing (N150, N300, T3K, TG). Usage: `export MESH_DEVICE=N150`, will enable running a single-chip demo on a multi-chip system.
 @pytest.mark.parametrize(
-    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, ci_only, data_parallel, token_accuracy",
+    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, ci_only, data_parallel, token_accuracy, stress_test",
     [
         (  # Batch-1 run (Latency) - single user, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -234,6 +234,7 @@ def prepare_generator_args(
             False,  # ci_only
             1,
             False,  # token_accuracy
+            False,  # stress_test
         ),
         (  # Batch-32 run (Throughput) - 32 users, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -249,6 +250,7 @@ def prepare_generator_args(
             False,  # ci_only
             1,  # data_parallel
             False,  # token_accuracy
+            False,  # stress_test
         ),
         (  # Long-context 64k run - Single user, long prompt (may vary based on the model's tokenizer)
             "models/tt_transformers/demo/sample_prompts/input_data_long_64k.json",  # input_prompts
@@ -264,6 +266,7 @@ def prepare_generator_args(
             False,  # ci_only
             1,  # data_parallel
             False,  # token_accuracy
+            False,  # stress_test
         ),
         (  # Long-context 32k run - Single user, long prompt (may vary based on the model's tokenizer)
             "models/tt_transformers/demo/sample_prompts/input_data_long_32k.json",  # input_prompts
@@ -279,6 +282,7 @@ def prepare_generator_args(
             False,  # ci_only
             1,  # data_parallel
             False,  # token_accuracy
+            False,  # stress_test
         ),
         (  # Long-context 16k run - Single user, long prompt (may vary based on the model's tokenizer)
             "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json",  # input_prompts
@@ -294,6 +298,7 @@ def prepare_generator_args(
             False,  # ci_only
             1,  # data_parallel
             False,  # token_accuracy
+            False,  # stress_test
         ),
         (  # Batch-1 run (Reasoning) - single user, small prompt, long thinking time
             "models/tt_transformers/demo/input_data_questions_reasoning.json",  # input_prompts
@@ -312,6 +317,7 @@ def prepare_generator_args(
             False,  # ci_only
             1,  # data_parallel
             False,  # token_accuracy
+            False,  # stress_test
         ),
         (  # CI Batch-1 run - Measures the performance of a single user over 4096 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -327,6 +333,7 @@ def prepare_generator_args(
             True,  # ci_only
             1,  # data_parallel
             False,  # token_accuracy
+            False,  # stress_test
         ),
         (  # CI Batch-32 run - Measures the performance of a 32 users over 4096 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -342,6 +349,7 @@ def prepare_generator_args(
             True,  # ci_only
             1,  # data_parallel
             False,  # token_accuracy
+            False,  # stress_test
         ),
         (  # Batch-1 run (Latency) - single user, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -357,6 +365,7 @@ def prepare_generator_args(
             False,  # ci_only
             4,  # data_parallel
             False,  # token_accuracy
+            False,  # stress_test
         ),
         (  # Batch-1 run (Latency) - single user, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -372,6 +381,7 @@ def prepare_generator_args(
             False,  # ci_only
             8,  # data_parallel
             False,  # token_accuracy
+            False,  # stress_test
         ),
         (  # Batch-32 run (Throughput) - 32 users, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -387,6 +397,7 @@ def prepare_generator_args(
             False,  # ci_only
             4,  # data_parallel
             False,  # token_accuracy
+            False,  # stress_test
         ),
         (  # CI Batch-1 run - Measures the performance of a single user over 4096 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -402,6 +413,7 @@ def prepare_generator_args(
             True,  # ci_only
             4,  # data_parallel
             False,  # token_accuracy
+            False,  # stress_test
         ),
         (  # CI Batch-1 run - Measures the performance of a single user over 4096 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -417,6 +429,7 @@ def prepare_generator_args(
             True,  # ci_only
             8,  # data_parallel
             False,  # token_accuracy
+            False,  # stress_test
         ),
         (  # CI Batch-1 run - Measures the performance of a single user over 200 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -432,6 +445,7 @@ def prepare_generator_args(
             True,  # ci_only
             16,  # data_parallel
             False,  # token_accuracy
+            False,  # stress_test
         ),
         (  # CI Batch-1 run - Measures the performance of a single user over 200 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -447,8 +461,9 @@ def prepare_generator_args(
             True,  # ci_only
             32,  # data_parallel
             False,  # token_accuracy
+            False,  # stress_test
         ),
-        (  # CI stress test batch-1 run - Runs a short prefill (128) and exhaust the KV cache (128K), by running 50000 iterations
+        (  # CI stress test batch-1 run - Runs a short prefill (128) and loops the same iteration over 50000 times
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -462,6 +477,7 @@ def prepare_generator_args(
             True,  # ci_only
             1,  # data_parallel
             False,  # token_accuracy
+            True,  # stress_test
         ),
     ],
     ids=[
@@ -520,6 +536,7 @@ def test_demo_text(
     reset_seeds,
     request,
     token_accuracy,
+    stress_test,
 ):
     """
     Simple demo with limited dependence on reference code.
@@ -554,6 +571,10 @@ def test_demo_text(
     sampling_params = request.config.getoption("--sampling_params") or sampling_params
     json_config_file = request.config.getoption("--decoder_config_file")
     token_accuracy = request.config.getoption("--token_accuracy") or token_accuracy
+    stress_test = request.config.getoption("--stress_test") or stress_test
+
+    if stress_test and token_accuracy:
+        pytest.skip("Stress test cannot be run with token accuracy mode")
 
     if json_config_file:
         optimizations = parse_decoder_json(json_config_file)
@@ -781,7 +802,8 @@ def test_demo_text(
                 f"Iteration {iteration}: {1000*decode_iteration_time:.0f}ms @ {tokens_per_second_per_user:.1f} tok/s/user ({global_batch_size*tokens_per_second_per_user:.1f} tok/s throughput)"
             )
 
-            current_pos += 1
+            if not stress_test:  # During stress test runs we will iterate over the same position for X iterations
+                current_pos += 1
             # Save output token to print out later
             for user in range(global_batch_size):
                 user_tok = out_tok[user].item()

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -507,7 +507,7 @@ def prepare_generator_args(
     ],
     ids=["performance", "accuracy"],
 )
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 26000000, "num_command_queues": 1}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 28000000, "num_command_queues": 1}], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",
     [

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -252,7 +252,7 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
         ),
-        (  # Long-context 64k run - Single user, long prompt (may vary based on the model's tokenizer)
+        (  # long-context-64k run - Single user, long prompt (may vary based on the model's tokenizer)
             "models/tt_transformers/demo/sample_prompts/input_data_long_64k.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -268,7 +268,7 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
         ),
-        (  # Long-context 32k run - Single user, long prompt (may vary based on the model's tokenizer)
+        (  # Long-context-32k run - Single user, long prompt (may vary based on the model's tokenizer)
             "models/tt_transformers/demo/sample_prompts/input_data_long_32k.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -284,7 +284,7 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
         ),
-        (  # Long-context 16k run - Single user, long prompt (may vary based on the model's tokenizer)
+        (  # Long-context-16k run - Single user, long prompt (may vary based on the model's tokenizer)
             "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -300,7 +300,7 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
         ),
-        (  # Batch-1 run (Reasoning) - single user, small prompt, long thinking time
+        (  # reasoning-1 - single user, small prompt, long thinking time
             "models/tt_transformers/demo/input_data_questions_reasoning.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -319,7 +319,7 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
         ),
-        (  # CI Batch-1 run - Measures the performance of a single user over 4096 iterations
+        (  # ci-1 [CI-only] - Measures the performance of a single user over 4096 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -335,7 +335,7 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
         ),
-        (  # CI Batch-32 run - Measures the performance of a 32 users over 4096 iterations
+        (  # ci-32 [CI-only] - Measures the performance of 32 users over 4096 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -351,7 +351,7 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
         ),
-        (  # Batch-1 run (Latency) - single user, small prompt
+        (  # DP-4-b1 - single user, data-parallel=4, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -367,7 +367,7 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
         ),
-        (  # Batch-1 run (Latency) - single user, small prompt
+        (  # DP-8-b1 - single user, data-parallel=8, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -383,7 +383,7 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
         ),
-        (  # Batch-32 run (Throughput) - 32 users, small prompt
+        (  # DP-4-b32 - 32 users, data-parallel=4, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -399,7 +399,7 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
         ),
-        (  # CI Batch-1 run - Measures the performance of a single user over 4096 iterations
+        (  # ci-b1-DP-4 [CI-Only] - single user, data-parallel=4, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -415,7 +415,7 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
         ),
-        (  # CI Batch-1 run - Measures the performance of a single user over 4096 iterations
+        (  # ci-b1-DP-8 [CI-Only] - single user, data-parallel=8, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -431,7 +431,7 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
         ),
-        (  # CI Batch-1 run - Measures the performance of a single user over 200 iterations
+        (  # ci-b1-DP-16 [CI-Only] - single user, data-parallel=16, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -447,7 +447,7 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
         ),
-        (  # CI Batch-1 run - Measures the performance of a single user over 200 iterations
+        (  # ci-b1-DP-32 [CI-Only] - single user, data-parallel=32, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -463,7 +463,7 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
         ),
-        (  # CI stress test batch-1 run - Runs a short prefill (128) and loops the same iteration over 50000 times
+        (  # ci-stress-1 [CI-only] stress test - Runs a short prefill (128) and loops the same iteration over 50000 times
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -507,7 +507,7 @@ def prepare_generator_args(
     ],
     ids=["performance", "accuracy"],
 )
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 28000000, "num_command_queues": 1}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 30000000, "num_command_queues": 1}], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",
     [


### PR DESCRIPTION
### Tickets
- https://github.com/tenstorrent/tt-metal/issues/24042
- https://github.com/tenstorrent/tt-metal/issues/24849

### Problem description
- Adds a config to run TT-Transformers in stress mode. 
  - This will run prefill on the input prompts, and then just iterate decode over the same position for X number of steps. 

- Adds Llama-8B (DP=4) stress test to BH LLM-Box CI pipeline
- Adds LLama-70B (TP=4) test to BH LLM-Box CI pipeline

### Checklist
- [x] [Blackhole LLM-box demo CI](https://github.com/tenstorrent/tt-metal/actions/runs/16340808763)
- [x] [All-Post-Commit](https://github.com/tenstorrent/tt-metal/actions/runs/16340820146)
- [x] [Single-device Demo](https://github.com/tenstorrent/tt-metal/actions/runs/16340823343)
- [x] [T3K Demo](https://github.com/tenstorrent/tt-metal/actions/runs/16340827383)