### PR TITLE
[skip ci] Move Blackhole L2 tests to the official metal L2 tests workflow and run all single-card devices in L2 tests

### DIFF
--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -54,34 +54,6 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  ttnn-l2-tests:
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/tt-metal-l2-nightly-impl.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150b"]') }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.card_type }}
-      timeout: 120
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  didt-tests:
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/didt-tests.yaml
-    strategy:
-      fail-fast: false
-    with:
-      arch: blackhole
-      runner-label: P150b
-      timeout: 10
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   blackhole-llmbox-demo-tests:
     needs: build-artifact
     secrets: inherit

--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -24,7 +24,7 @@ on:
         default: 120
 
 jobs:
-  test:
+  tt-metal-l2-tests:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -3,20 +3,6 @@ name: "Nightly tt-metal L2 tests"
 on:
   workflow_dispatch:
     inputs:
-      arch:
-        required: true
-        type: choice
-        options:
-          - wormhole_b0
-          - blackhole
-      runner-label:
-        required: true
-        type: choice
-        options:
-          - N150
-          - N300
-          - P100
-          - P150b
       timeout:
         required: false
         type: number
@@ -37,9 +23,18 @@ jobs:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/tt-metal-l2-nightly-impl.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+          { arch: blackhole, runner-label: P100 },
+          { arch: blackhole, runner-label: P150b },
+        ]
     with:
-      arch: ${{ inputs.arch || 'wormhole_b0' }}
-      runner-label: ${{ inputs.runner-label || 'N150' }}
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
       timeout: ${{ (github.event_name == 'schedule' && 120) || fromJSON(inputs.timeout) }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
@@ -50,9 +45,16 @@ jobs:
     uses: ./.github/workflows/didt-tests.yaml
     strategy:
       fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+          { arch: blackhole, runner-label: P100 },
+          { arch: blackhole, runner-label: P150b },
+        ]
     with:
-      arch: ${{ inputs.arch || 'wormhole_b0' }}
-      runner-label: ${{ inputs.runner-label || 'N300' }}
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
       timeout: 10
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -19,7 +19,7 @@ jobs:
     with:
       build-wheel: true
       version: 22.04
-  test:
+  tt-metal-l2-tests:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/tt-metal-l2-nightly-impl.yaml


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-metal/issues/24935

### Problem description
We're running Metal L2 tests in two different locations (BH nightly for blackhole only, and official L2 which runs WH N150 only).
We should run all single card devices in the official L2 nightly workflow to avoid developers having to run multiple workflows to validate on L2 tests.

### What's changed
Move the blackhole L2 tests (l2+didt) out of Blackhole nightly and put them into official L2.
Fix official L2 flow to sweep over all single card types (n150/n300/p100/p150b) instead of providing only one card type to select and run.

### Checklist
- [x] Nightly L2: https://github.com/tenstorrent/tt-metal/actions/runs/16323776580