### PR TITLE
#23749: Correctly call Cluster destructor

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -237,6 +237,10 @@ MetalContext::MetalContext() {
     hal_ = std::make_unique<Hal>(get_platform_architecture(rtoptions_), is_base_routing_fw_enabled);
     cluster_ = std::make_unique<Cluster>(rtoptions_, *hal_);
     distributed_context_ = distributed::multihost::DistributedContext::get_current_world();
+
+    // We do need to call Cluster teardown at the end of the program, use atexit temporarily until we have clarity on
+    // how MetalContext lifetime will work through the API.
+    std::atexit([]() { MetalContext::instance().~MetalContext(); });
 }
 
 distributed::multihost::DistributedContext& MetalContext::get_distributed_context() {
@@ -245,6 +249,7 @@ distributed::multihost::DistributedContext& MetalContext::get_distributed_contex
 }
 
 MetalContext::~MetalContext() {
+    distributed_context_.reset();
     cluster_.reset();
     hal_.reset();
 }


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/23749
Cluster destructor wasn't being called. Workaround for now is to use atexit to do that, and we can investigate better options down the road (MetalContext owned by user and passed through API?)

https://github.com/tenstorrent/tt-metal/actions/runs/16301687404
https://github.com/tenstorrent/tt-metal/actions/runs/16301697216