### PR TITLE
Update code owners for TensorAccessor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@ tt_metal/hw/ckernels/ @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT
 tt_metal/hw/firmware/src/*erisc* @aliuTT @ubcheema
 tt_metal/hw/inc/ethernet/ @aliuTT @ubcheema
 tt_metal/hw/inc/wormhole/eth_l1_address_map.h @aliuTT @ubcheema
+tt_metal/hw/inc/accessor @tenstorrent/metalium-developers-ttnn-core
 tt_metal/hw/firmware/ @abhullar-tt @jbaumanTT @pgkeller @nathan-TT
 tt_metal/hw/toolchain/ @jbaumanTT @pgkeller @nathan-TT
 tt_metal/hw/**/CMakeLists.txt @tenstorrent/metalium-developers-infra @jbaumanTT @pgkeller @nathan-TT


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Making any changes to TensorAccessor requires approval from metal-runtime folks, even though ttnn-core team maintains it right now. 

### What's changed
Move tt_metal/hw/inc/accessor under @tenstorrent/metalium-developers-ttnn-core