### PR TITLE
Make routing specific to TG

### DIFF
--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -169,6 +169,11 @@ KernelHandle FDKernel::configure_kernel_variant(
         defines["FORCE_DPRINT_OFF"] = "1";
     }
     defines.insert(defines_in.begin(), defines_in.end());
+    if (MetalContext::instance().get_cluster().is_galaxy_cluster()) {
+        // TG specific fabric routing
+        // TODO: https://github.com/tenstorrent/tt-metal/issues/24413
+        defines["GALAXY_CLUSTER"] = "1";
+    }
 
     if (GetCoreType() == CoreType::WORKER) {
         return tt::tt_metal::CreateKernel(

--- a/tt_metal/impl/dispatch/kernels/cq_relay.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_relay.hpp
@@ -99,6 +99,7 @@ public:
             tt::tt_fabric::fabric_set_route(
                 (tt::tt_fabric::LowLatencyMeshPacketHeader*)packet_header_addr,
                 (eth_chan_directions)edm.direction,
+                0,  // branch forward
                 0,  // start hop
                 num_hops,
                 true);

--- a/tt_metal/impl/dispatch/kernels/cq_relay.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_relay.hpp
@@ -95,12 +95,22 @@ public:
                 to_mesh_id,
                 ew_dim);
 #else
+#if defined(GALAXY_CLUSTER)
             tt::tt_fabric::fabric_set_route(
                 (tt::tt_fabric::LowLatencyMeshPacketHeader*)packet_header_addr,
                 (eth_chan_directions)edm.direction,
                 0,  // start hop
                 num_hops,
                 true);
+#else
+            tt::tt_fabric::fabric_set_unicast_route(
+                (tt::tt_fabric::LowLatencyMeshPacketHeader*)packet_header_addr,
+                (eth_chan_directions)edm.direction,
+                my_dev_id,
+                to_dev_id,
+                to_mesh_id,
+                ew_dim);
+#endif
 #endif
         } else {
             auto header = reinterpret_cast<tt_l1_ptr PACKET_HEADER_TYPE*>(packet_header_addr);


### PR DESCRIPTION
### Ticket
None

### Problem description
2D Routing issues on T3K after 2D MCast support was added

### What's changed
Yet another workaround for TG. Make the routing logic specific for TG only. For T3K, use the normal path.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes