### PR TITLE
Add env var to force MetalContext re-init for upstream workaround

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -61,7 +61,7 @@ void MetalContext::initialize(
     size_t worker_l1_size,
     bool minimal) {
     // Workaround for galaxy and BH, need to always re-init
-    if (cluster_->is_galaxy_cluster() or cluster_->arch() == ARCH::BLACKHOLE) {
+    if (rtoptions_.get_force_context_reinit() or cluster_->is_galaxy_cluster() or cluster_->arch() == ARCH::BLACKHOLE) {
         force_reinit_ = true;
     }
     // Settings that affect FW build can also trigger a re-initialization

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -233,6 +233,10 @@ RunTimeOptions::RunTimeOptions() {
             this->disable_dma_ops = true;
         }
     }
+
+    if (getenv("TT_METAL_FORCE_REINIT")) {
+        force_context_reinit = true;
+    }
 }
 
 const std::string& RunTimeOptions::get_root_dir() const {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -185,6 +185,10 @@ class RunTimeOptions {
     // Force disables using DMA for reads and writes
     bool disable_dma_ops = false;
 
+    // Forces MetalContext re-init on Device creation. Workaround for upstream issues that require re-init each time.
+    // TODO: Once all of init is moved to MetalContext, investigate removing this option.
+    bool force_context_reinit = false;
+
 public:
     RunTimeOptions();
     RunTimeOptions(const RunTimeOptions&) = delete;
@@ -435,6 +439,8 @@ public:
 
     inline bool get_disable_dma_ops() const { return disable_dma_ops; }
     inline void set_disable_dma_ops(bool disable) { disable_dma_ops = disable; }
+
+    inline bool get_force_context_reinit() const { return force_context_reinit; }
 
 private:
     // Helper functions to parse feature-specific environment vaiables.

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -185,8 +185,8 @@ class RunTimeOptions {
     // Force disables using DMA for reads and writes
     bool disable_dma_ops = false;
 
-    // Forces MetalContext re-init on Device creation. Workaround for upstream issues that require re-init each time.
-    // TODO: Once all of init is moved to MetalContext, investigate removing this option.
+    // Forces MetalContext re-init on Device creation. Workaround for upstream issues that require re-init each time
+    // (#25048) TODO: Once all of init is moved to MetalContext, investigate removing this option.
     bool force_context_reinit = false;
 
 public:


### PR DESCRIPTION
Upstream SW has reported some issues w/ carried-over state. Give an env var to unblock upstream while we investigate further.

CI: https://github.com/tenstorrent/tt-metal/actions/runs/16278732695