### PR TITLE
Give multihost tests some owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -105,6 +105,7 @@ tests/tt_metal/tt_metal/sfpi/ @nathan-TT @pgkeller
 tests/tt_metal/tt_metal/test_kernels/sfpi/ @nathan-TT @pgkeller
 tests/tt_metal/tt_metal/data_movement @rtawfik01 @vvukomanovicTT @atatuzunerTT
 tests/tt_metal/tt_fabric/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT
+tests/tt_metal/multihost/ @tt-asaigal @tt-aho @aliuTT
 tests/tt_metal/tools/profiler/ @mo-tenstorrent @sagarwalTT
 
 # misc tests


### PR DESCRIPTION
### Ticket
None

### Problem description
These tests fell back to Metal Infra as owners, who are not the right owners.  Passing it to others who are more involved with that area of the code.

### What's changed
Called out owners.