### PR TITLE
2D Dynamic Fabric + Sockets on Nano-Exabox

### DIFF
--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -25,6 +25,7 @@ jobs:
         test-group: [
           { name: "t3k ttmetal tests", arch: wormhole_b0, cmd: run_t3000_ttmetal_tests, timeout: 35, owner_id: ULMEPM2MA}, #Sean Nijjar
           { name: "t3k ttnn tests", arch: wormhole_b0, cmd: run_t3000_ttnn_tests, timeout: 45, owner_id: UBHPP2NDP}, #Joseph Chu
+          { name: "t3k tt_metal multiprocess tests", arch: wormhole_b0, cmd: run_t3000_tt_metal_multiprocess_tests, timeout: 5, owner_id: U03NG0A5ND7}, #Aditya Saigal
           { name: "t3k falcon7b tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 30, owner_id: UBHPP2NDP}, #Joseph Chu
           { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 30, owner_id: U053W15B6JF}, #Djordje Ivanovic
           { name: "t3k llama3-small tests", arch: wormhole_b0, cmd: run_t3000_llama3-small_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -103,6 +103,22 @@ run_t3000_ttnn_tests() {
   fi
 }
 
+run_t3000_tt_metal_multiprocess_tests() {
+   # Record the start time
+  fail=0
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Running run_t3000_tt_metal_multiprocess_tests"
+  tt-run --mpi-args "--allow-run-as-root" --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/multi_host_fabric_tests
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_t3000_tt_metal_multiprocess_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
 run_t3000_falcon7b_tests() {
   # Record the start time
   fail=0

--- a/tests/tt_metal/distributed/config/1x2_multiprocess_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/1x2_multiprocess_rank_bindings.yaml
@@ -1,0 +1,22 @@
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    env_overrides:
+      TT_METAL_VISIBLE_DEVICES: "0"
+
+  - rank: 1
+    mesh_id: 1
+    env_overrides:
+      TT_METAL_VISIBLE_DEVICES: "3"
+
+  - rank: 2
+    mesh_id: 2
+    env_overrides:
+      TT_METAL_VISIBLE_DEVICES: "1"
+
+  - rank: 3
+    mesh_id: 3
+    env_overrides:
+      TT_METAL_VISIBLE_DEVICES: "2"
+
+mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x2_mesh_graph_descriptor.yaml"

--- a/tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml
@@ -1,0 +1,12 @@
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    env_overrides:
+      TT_METAL_VISIBLE_DEVICES: "0,1"
+
+  - rank: 1
+    mesh_id: 1
+    env_overrides:
+      TT_METAL_VISIBLE_DEVICES: "3,2"
+
+mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml"

--- a/tests/tt_metal/multihost/fabric_tests/CMakeLists.txt
+++ b/tests/tt_metal/multihost/fabric_tests/CMakeLists.txt
@@ -9,6 +9,8 @@ target_sources(
         main.cpp
         intermesh_routing.cpp
         intermesh_routing_test_utils.cpp
+        socket_send_recv.cpp
+        socket_send_recv_utils.cpp
 )
 
 target_include_directories(

--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing.cpp
@@ -6,23 +6,29 @@
 #include <gtest/gtest.h>
 #include <stdint.h>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <vector>
 
 #include "multihost_fabric_fixtures.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/fabric.hpp>
+
+#include <random>
+#include <algorithm>
 
 namespace tt::tt_fabric {
 namespace fabric_router_tests::multihost {
 
 // ========= Data-Movement Tests for 2 Host, 1 T3K bringup machine  =========
 
-TEST_F(InterMesh2x4Fabric2DFixture, RandomizedInterMeshUnicast) {
-    for (uint32_t i = 0; i < 500; i++) {
+TEST_F(IntermeshSplit2x2FabricFixture, RandomizedInterMeshUnicast) {
+    for (uint32_t i = 0; i < 100; i++) {
         multihost_utils::RandomizedInterMeshUnicast(this);
     }
 }
 
-TEST_F(InterMesh2x4Fabric2DFixture, MultiMeshEastMulticast) {
+TEST_F(IntermeshSplit2x2FabricFixture, MultiMeshEastMulticast_0) {
     std::vector<FabricNodeId> mcast_req_nodes = {
         FabricNodeId(MeshId{0}, 1), FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 3), FabricNodeId(MeshId{0}, 2)};
     std::vector<FabricNodeId> mcast_start_nodes = {FabricNodeId(MeshId{1}, 2), FabricNodeId(MeshId{1}, 0)};
@@ -30,47 +36,59 @@ TEST_F(InterMesh2x4Fabric2DFixture, MultiMeshEastMulticast) {
         McastRoutingInfo{.mcast_dir = RoutingDirection::E, .num_mcast_hops = 1}};
     std::vector<std::vector<FabricNodeId>> mcast_group_node_ids = {
         {FabricNodeId(MeshId{1}, 3)}, {FabricNodeId(MeshId{1}, 1)}};
-    for (uint32_t i = 0; i < 500; i++) {
+    for (uint32_t i = 0; i < 100; i++) {
         multihost_utils::InterMeshLineMcast(
             this, mcast_req_nodes[i % 4], mcast_start_nodes[i % 2], routing_info, mcast_group_node_ids[i % 2]);
     }
 }
 
-TEST_F(InterMesh2x4Fabric2DFixture, MultiMeshSouthMulticast) {
-    std::vector<FabricNodeId> mcast_req_nodes = {FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 1)};
-    std::vector<FabricNodeId> mcast_start_nodes = {FabricNodeId(MeshId{1}, 0), FabricNodeId(MeshId{1}, 1)};
+TEST_F(IntermeshSplit2x2FabricFixture, MultiMeshEastMulticast_1) {
+    std::vector<FabricNodeId> mcast_req_nodes = {
+        FabricNodeId(MeshId{1}, 1), FabricNodeId(MeshId{1}, 0), FabricNodeId(MeshId{1}, 3), FabricNodeId(MeshId{1}, 2)};
+    std::vector<FabricNodeId> mcast_start_nodes = {FabricNodeId(MeshId{0}, 3), FabricNodeId(MeshId{0}, 1)};
     std::vector<McastRoutingInfo> routing_info = {
-        McastRoutingInfo{.mcast_dir = RoutingDirection::S, .num_mcast_hops = 1}};
+        McastRoutingInfo{.mcast_dir = RoutingDirection::W, .num_mcast_hops = 1}};
     std::vector<std::vector<FabricNodeId>> mcast_group_node_ids = {
-        {FabricNodeId(MeshId{1}, 2)}, {FabricNodeId(MeshId{1}, 3)}};
-    for (uint32_t i = 0; i < 500; i++) {
+        {FabricNodeId(MeshId{0}, 2)}, {FabricNodeId(MeshId{0}, 0)}};
+    for (uint32_t i = 0; i < 100; i++) {
         multihost_utils::InterMeshLineMcast(
-            this, mcast_req_nodes[i % 2], mcast_start_nodes[i % 2], routing_info, mcast_group_node_ids[i % 2]);
+            this, mcast_req_nodes[i % 4], mcast_start_nodes[i % 2], routing_info, mcast_group_node_ids[i % 2], 1, 0);
     }
 }
 
-TEST_F(InterMesh2x4Fabric2DFixture, MultiMeshNorthMulticast) {
-    std::vector<FabricNodeId> mcast_req_nodes = {FabricNodeId(MeshId{0}, 3), FabricNodeId(MeshId{0}, 3)};
-    std::vector<FabricNodeId> mcast_start_nodes = {FabricNodeId(MeshId{1}, 2), FabricNodeId(MeshId{1}, 3)};
-    std::vector<McastRoutingInfo> routing_info = {
-        McastRoutingInfo{.mcast_dir = RoutingDirection::N, .num_mcast_hops = 1}};
-    std::vector<std::vector<FabricNodeId>> mcast_group_node_ids = {
-        {FabricNodeId(MeshId{1}, 0)}, {FabricNodeId(MeshId{1}, 1)}};
-    for (uint32_t i = 0; i < 500; i++) {
-        multihost_utils::InterMeshLineMcast(
-            this, mcast_req_nodes[i % 2], mcast_start_nodes[i % 2], routing_info, mcast_group_node_ids[i % 2]);
-    }
+// ========= Data-Movement Tests for Multi-Process Tests with 4 Ranks/Meshes =========
+
+TEST_F(InterMeshSplit1x2FabricFixture, MultiHopUnicast) {
+    // Route traffic between meshes that are not directily adjacent and require an intermediate mesh
+    auto distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
+
+    constexpr uint32_t num_iterations = 20;
+    auto run_send_recv = [&](uint32_t sender_rank, uint32_t recv_rank) {
+        for (int i = 0; i < num_iterations; i++) {
+            if (*(distributed_context->rank()) == sender_rank) {
+                multihost_utils::run_unicast_sender_step(this, tt::tt_metal::distributed::multihost::Rank{recv_rank});
+            } else if (*(distributed_context->rank()) == recv_rank) {
+                multihost_utils::run_unicast_recv_step(this, tt::tt_metal::distributed::multihost::Rank{sender_rank});
+            }
+        }
+    };
+    // Run send/recv on meshes that are diagonally opposite
+    run_send_recv(0, 3);
+    run_send_recv(1, 2);
+    run_send_recv(2, 1);
+    run_send_recv(3, 0);
+    distributed_context->barrier();
 }
 
 // ========= Data-Movement Tests for 2 Loudboxes with Intermesh Connections  =========
 
-TEST_F(InterMeshDual2x4Fabric2DFixture, RandomizedInterMeshUnicast) {
+TEST_F(InterMeshDual2x4FabricFixture, RandomizedInterMeshUnicast) {
     for (uint32_t i = 0; i < 500; i++) {
         multihost_utils::RandomizedInterMeshUnicast(this);
     }
 }
 
-TEST_F(InterMeshDual2x4Fabric2DFixture, MultiMesh_EW_Multicast) {
+TEST_F(InterMeshDual2x4FabricFixture, MultiMesh_EW_Multicast) {
     std::vector<FabricNodeId> mcast_req_nodes = {
         FabricNodeId(MeshId{0}, 1), FabricNodeId(MeshId{0}, 2), FabricNodeId(MeshId{0}, 5), FabricNodeId(MeshId{0}, 6)};
     std::vector<FabricNodeId> mcast_start_nodes = {
@@ -89,7 +107,7 @@ TEST_F(InterMeshDual2x4Fabric2DFixture, MultiMesh_EW_Multicast) {
     }
 }
 
-TEST_F(InterMeshDual2x4Fabric2DFixture, MultiMesh_EW_MultiHopMulticast) {
+TEST_F(InterMeshDual2x4FabricFixture, MultiMesh_EW_MultiHopMulticast) {
     std::vector<FabricNodeId> mcast_req_nodes = {
         FabricNodeId(MeshId{0}, 1), FabricNodeId(MeshId{0}, 2), FabricNodeId(MeshId{0}, 5), FabricNodeId(MeshId{0}, 6)};
     std::vector<FabricNodeId> mcast_start_nodes = {
@@ -116,7 +134,7 @@ TEST_F(InterMeshDual2x4Fabric2DFixture, MultiMesh_EW_MultiHopMulticast) {
     }
 }
 
-TEST_F(InterMeshDual2x4Fabric2DFixture, MultiMesh_EW_MulticastWithTurns) {
+TEST_F(InterMeshDual2x4FabricFixture, MultiMesh_EW_MulticastWithTurns) {
     std::vector<FabricNodeId> mcast_req_nodes = {
         FabricNodeId(MeshId{0}, 1), FabricNodeId(MeshId{0}, 2), FabricNodeId(MeshId{0}, 5), FabricNodeId(MeshId{0}, 6)};
     std::vector<FabricNodeId> mcast_start_nodes = {
@@ -133,6 +151,58 @@ TEST_F(InterMeshDual2x4Fabric2DFixture, MultiMesh_EW_MulticastWithTurns) {
         multihost_utils::InterMeshLineMcast(
             this, mcast_req_nodes[i % 4], mcast_start_nodes[i % 4], routing_info, mcast_group_node_ids[i % 4]);
     }
+}
+
+// ========= Data-Movement Tests for NanoExabox Machines  =========
+
+TEST_F(IntermeshNanoExaboxFabricFixture, RandomizedIntermeshUnicastBwd) {
+    auto distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
+
+    constexpr uint32_t sender_rank = 1;
+    constexpr uint32_t num_iterations = 100;
+
+    if (*(distributed_context->rank()) == sender_rank) {
+        std::vector<uint32_t> recv_node_ranks = {0, 2, 3, 4};
+        log_info(tt::LogTest, "{} rank starting unicast to all receivers", sender_rank);
+        for (uint32_t i = 0; i < num_iterations; i++) {
+            for (auto recv_rank : recv_node_ranks) {
+                multihost_utils::run_unicast_sender_step(this, tt::tt_metal::distributed::multihost::Rank{recv_rank});
+            }
+        }
+        log_info(tt::LogTest, "{} rank completed unicast to all receivers", sender_rank);
+    } else {
+        log_info(tt::LogTest, "{} rank processing unicasts", *(distributed_context->rank()));
+        for (uint32_t i = 0; i < num_iterations; i++) {
+            multihost_utils::run_unicast_recv_step(this, tt::tt_metal::distributed::multihost::Rank{sender_rank});
+        }
+        log_info(tt::LogTest, "{} rank done processing unicasts", *(distributed_context->rank()));
+    }
+    distributed_context->barrier();
+}
+
+TEST_F(IntermeshNanoExaboxFabricFixture, RandomizedIntermeshUnicastFwd) {
+    auto distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
+
+    constexpr uint32_t recv_rank = 1;
+    constexpr uint32_t num_iterations = 100;
+
+    if (*(distributed_context->rank()) == recv_rank) {
+        std::vector<uint32_t> sender_node_ranks = {0, 2, 3, 4};
+        log_info(tt::LogTest, "{} rank starting processing unicasts from all senders", recv_rank);
+        for (uint32_t i = 0; i < num_iterations; i++) {
+            for (auto sender_rank : sender_node_ranks) {
+                multihost_utils::run_unicast_recv_step(this, tt::tt_metal::distributed::multihost::Rank{sender_rank});
+            }
+        }
+        log_info(tt::LogTest, "{} rank completed processing unicasts from all senders", recv_rank);
+    } else {
+        log_info(tt::LogTest, "{} rank starting unicast to receiver", *(distributed_context->rank()));
+        for (uint32_t i = 0; i < num_iterations; i++) {
+            multihost_utils::run_unicast_sender_step(this, tt::tt_metal::distributed::multihost::Rank{recv_rank});
+        }
+        log_info(tt::LogTest, "{} rank completed unicast to receiver", *(distributed_context->rank()));
+    }
+    distributed_context->barrier();
 }
 
 }  // namespace fabric_router_tests::multihost

--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
@@ -3,12 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+
+#include <iostream>
 #include <random>
 #include <stdint.h>
 
 #include <tt-metalium/control_plane.hpp>
 #include <tt-metalium/device_pool.hpp>
 #include <tt-metalium/erisc_datamover_builder.hpp>
+#include <tt-metalium/fabric.hpp>
 #include <tt-metalium/fabric_host_interface.h>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -73,7 +76,7 @@ std::shared_ptr<tt_metal::Program> create_receiver_program(
     return recv_program;
 }
 
-void run_unicast_sender_step(BaseFabricFixture* fixture) {
+void run_unicast_sender_step(BaseFabricFixture* fixture, tt::tt_metal::distributed::multihost::Rank recv_host_rank) {
     // The following code runs on the sender host
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
@@ -93,8 +96,8 @@ void run_unicast_sender_step(BaseFabricFixture* fixture) {
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
     distributed_context->send(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&time_seed), sizeof(time_seed)),
-        tt::tt_metal::distributed::multihost::Rank{1},  // send to receiver host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange seed over tag 0
+        tt::tt_metal::distributed::multihost::Rank{recv_host_rank},  // send to receiver host
+        tt::tt_metal::distributed::multihost::Tag{0}                 // exchange seed over tag 0
     );
     // Randomly select a tx device
     auto random_dev = std::uniform_int_distribution<uint32_t>(0, devices.size() - 1)(global_rng);
@@ -112,54 +115,19 @@ void run_unicast_sender_step(BaseFabricFixture* fixture) {
     // Request randomized logical core from the receiver host
     distributed_context->recv(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&receiver_logical_core), sizeof(receiver_logical_core)),
-        tt::tt_metal::distributed::multihost::Rank{1},  // receive from receiver host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange logical core over tag 0
+        tt::tt_metal::distributed::multihost::Rank{recv_host_rank},  // receive from receiver host
+        tt::tt_metal::distributed::multihost::Tag{0}                 // exchange logical core over tag 0
     );
     FabricNodeId dst_fabric_node_id(MeshId{0}, 0);
     // Receive the randomized destination fabric node id from the receiver host
     distributed_context->recv(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&dst_fabric_node_id), sizeof(dst_fabric_node_id)),
-        tt::tt_metal::distributed::multihost::Rank{1},  // receive from receiver host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange fabric node id over tag 0
+        tt::tt_metal::distributed::multihost::Rank{recv_host_rank},  // receive from receiver host
+        tt::tt_metal::distributed::multihost::Tag{0}                 // exchange fabric node id over tag 0
     );
 
-    // Determine the port to use for intermesh routing
-    chip_id_t edge_chip = 0;
-    std::vector<chan_id_t> eth_chans;
-    if (control_plane.has_intermesh_links(src_physical_device_id)) {
-        // In this case, the src chip is an exit node. Choose an intermesh link to the destination mesh.
-        auto intermesh_routing_direction =
-            control_plane.get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id).value();
-        auto eth_cores_and_chans =
-            control_plane.get_active_fabric_eth_channels_in_direction(src_fabric_node_id, intermesh_routing_direction);
-        for (auto chan : eth_cores_and_chans) {
-            // Pin traffic to rouing plane 0 for T3K
-            if (control_plane.get_routing_plane_id(src_fabric_node_id, chan) == 0) {
-                eth_chans.push_back(chan);
-            }
-        }
-    } else {
-        // In this case, the src chip is not an exit node. Find a route to an exit node.
-        for (auto chip_id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
-            if (control_plane.has_intermesh_links(chip_id)) {
-                edge_chip = chip_id;
-                break;
-            }
-        }
-        auto edge_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(edge_chip);
-        eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_fabric_node_id, edge_fabric_node_id);
-    }
-
-    // Pick any port, for now pick the 1st one in the set
-    auto edm_port = *eth_chans.begin();
-
-    log_info(tt::LogTest, "Src MeshId {} ChipId {}", *(src_fabric_node_id.mesh_id), src_fabric_node_id.chip_id);
-    log_info(tt::LogTest, "Dst MeshId {} ChipId {}", *(dst_fabric_node_id.mesh_id), dst_fabric_node_id.chip_id);
-
-    auto edm_direction = control_plane.get_eth_chan_direction(src_fabric_node_id, edm_port);
-    CoreCoord edm_eth_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
-        src_physical_device_id, edm_port);
-    log_info(tt::LogTest, "Using edm port {} in direction {}", edm_port, edm_direction);
+    log_debug(tt::LogTest, "Src MeshId {} ChipId {}", *(src_fabric_node_id.mesh_id), src_fabric_node_id.chip_id);
+    log_debug(tt::LogTest, "Dst MeshId {} ChipId {}", *(dst_fabric_node_id.mesh_id), dst_fabric_node_id.chip_id);
 
     CoreCoord receiver_virtual_core = sender_device->worker_core_from_logical_core(receiver_logical_core);
     auto receiver_noc_encoding =
@@ -197,31 +165,8 @@ void run_unicast_sender_step(BaseFabricFixture* fixture) {
         dst_fabric_node_id.chip_id,
         *dst_fabric_node_id.mesh_id};
 
-    // append the EDM connection rt args
-    const auto sender_channel = edm_direction;
-    tt::tt_fabric::SenderWorkerAdapterSpec edm_connection = {
-        .edm_noc_x = edm_eth_core.x,
-        .edm_noc_y = edm_eth_core.y,
-        .edm_buffer_base_addr = edm_config.sender_channels_base_address[sender_channel],
-        .num_buffers_per_channel = edm_config.sender_channels_num_buffers[sender_channel],
-        .edm_l1_sem_addr = edm_config.sender_channels_local_flow_control_semaphore_address[sender_channel],
-        .edm_connection_handshake_addr = edm_config.sender_channels_connection_semaphore_address[sender_channel],
-        .edm_worker_location_info_addr = edm_config.sender_channels_worker_conn_info_base_address[sender_channel],
-        .buffer_size_bytes = edm_config.channel_buffer_size_bytes,
-        .buffer_index_semaphore_id = edm_config.sender_channels_buffer_index_semaphore_address[sender_channel],
-        .edm_direction = edm_direction};
-
-    auto worker_flow_control_semaphore_id = tt_metal::CreateSemaphore(sender_program, sender_logical_core, 0);
-    auto worker_teardown_semaphore_id = tt_metal::CreateSemaphore(sender_program, sender_logical_core, 0);
-    auto worker_buffer_index_semaphore_id = tt_metal::CreateSemaphore(sender_program, sender_logical_core, 0);
-
-    append_worker_to_fabric_edm_sender_rt_args(
-        edm_connection,
-        worker_flow_control_semaphore_id,
-        worker_teardown_semaphore_id,
-        worker_buffer_index_semaphore_id,
-        sender_runtime_args);
-
+    tt_fabric::append_fabric_connection_rt_args(
+        src_fabric_node_id, dst_fabric_node_id, 0, sender_program, {sender_logical_core}, sender_runtime_args);
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
     // Run sender program
@@ -247,23 +192,22 @@ void run_unicast_sender_step(BaseFabricFixture* fixture) {
     uint64_t receiver_bytes = 0;
     distributed_context->send(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&sender_bytes), sizeof(sender_bytes)),
-        tt::tt_metal::distributed::multihost::Rank{1},  // send to receiver host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange tests results over tag 0
+        tt::tt_metal::distributed::multihost::Rank{recv_host_rank},  // send to receiver host
+        tt::tt_metal::distributed::multihost::Tag{0}                 // exchange tests results over tag 0
     );
     // Request test results from the receiver host and ensure that they match
     distributed_context->recv(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&receiver_bytes), sizeof(receiver_bytes)),
-        tt::tt_metal::distributed::multihost::Rank{1},  // recv from receiver host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange tests results over tag 0
+        tt::tt_metal::distributed::multihost::Rank{recv_host_rank},  // recv from receiver host
+        tt::tt_metal::distributed::multihost::Tag{0}                 // exchange tests results over tag 0
     );
     EXPECT_EQ(sender_bytes, receiver_bytes);
 }
 
-void run_unicast_recv_step(BaseFabricFixture* fixture) {
+void run_unicast_recv_step(BaseFabricFixture* fixture, tt::tt_metal::distributed::multihost::Rank sender_host_rank) {
     // The following code runs on the receiver host
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
-
     constexpr uint32_t num_packets = 100;
     const auto& fabric_context = control_plane.get_fabric_context();
     const auto topology = fabric_context.get_fabric_topology();
@@ -275,8 +219,8 @@ void run_unicast_recv_step(BaseFabricFixture* fixture) {
     uint32_t time_seed = 0;
     distributed_context->recv(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&time_seed), sizeof(time_seed)),
-        tt::tt_metal::distributed::multihost::Rank{0},  // recv from sender host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange seed over tag 0
+        tt::tt_metal::distributed::multihost::Rank{sender_host_rank},  // recv from sender host
+        tt::tt_metal::distributed::multihost::Tag{0}                   // exchange seed over tag 0
     );
 
     // Randomly select an rx device
@@ -294,15 +238,15 @@ void run_unicast_recv_step(BaseFabricFixture* fixture) {
     // Send the randomized rx core to the sender host, so it can send packets to the correct destination
     distributed_context->send(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&receiver_logical_core), sizeof(receiver_logical_core)),
-        tt::tt_metal::distributed::multihost::Rank{0},  // send to sender host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange logical core over tag 0
+        tt::tt_metal::distributed::multihost::Rank{sender_host_rank},  // send to sender host
+        tt::tt_metal::distributed::multihost::Tag{0}                   // exchange logical core over tag 0
     );
 
     // Send the randomized rx fabric node id to the sender host, so it can send packets to the correct destination
     distributed_context->send(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&dst_fabric_node_id), sizeof(dst_fabric_node_id)),
-        tt::tt_metal::distributed::multihost::Rank{0},  // send to sender host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange fabric node id over tag 0
+        tt::tt_metal::distributed::multihost::Rank{sender_host_rank},  // send to sender host
+        tt::tt_metal::distributed::multihost::Tag{0}                   // exchange fabric node id over tag 0
     );
 
     // test parameters
@@ -311,12 +255,7 @@ void run_unicast_recv_step(BaseFabricFixture* fixture) {
 
     // Create the receiver program
     std::vector<uint32_t> compile_time_args = {
-        worker_mem_map.test_results_address,
-        worker_mem_map.test_results_size_bytes,
-        target_address,
-        0 /* mcast_mode */,
-        true,
-        fabric_config == tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC};
+        worker_mem_map.test_results_address, worker_mem_map.test_results_size_bytes, target_address, false};
 
     std::vector<uint32_t> receiver_runtime_args = {worker_mem_map.packet_payload_size_bytes, num_packets, time_seed};
 
@@ -343,14 +282,14 @@ void run_unicast_recv_step(BaseFabricFixture* fixture) {
     uint64_t sender_bytes = 0;
     distributed_context->recv(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&sender_bytes), sizeof(sender_bytes)),
-        tt::tt_metal::distributed::multihost::Rank{0},  // recv from sender host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange tests results over tag 0
+        tt::tt_metal::distributed::multihost::Rank{sender_host_rank},  // recv from sender host
+        tt::tt_metal::distributed::multihost::Tag{0}                   // exchange tests results over tag 0
     );
     // Send test results to the sender host
     distributed_context->send(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&receiver_bytes), sizeof(receiver_bytes)),
-        tt::tt_metal::distributed::multihost::Rank{0},  // send to sender host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange tests results over tag 0
+        tt::tt_metal::distributed::multihost::Rank{sender_host_rank},  // send to sender host
+        tt::tt_metal::distributed::multihost::Tag{0}                   // exchange tests results over tag 0
     );
     EXPECT_EQ(sender_bytes, receiver_bytes);
 }
@@ -360,7 +299,8 @@ void run_mcast_sender_step(
     FabricNodeId mcast_sender_node,
     FabricNodeId mcast_start_node,
     const std::vector<McastRoutingInfo>& mcast_routing_info,
-    const std::vector<FabricNodeId>& mcast_group_node_ids) {
+    const std::vector<FabricNodeId>& mcast_group_node_ids,
+    uint32_t recv_rank) {
     // The following code runs on the sender host
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
@@ -376,8 +316,8 @@ void run_mcast_sender_step(
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
     distributed_context->send(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&time_seed), sizeof(time_seed)),
-        tt::tt_metal::distributed::multihost::Rank{1},  // send to receiver host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange seed over tag 0
+        tt::tt_metal::distributed::multihost::Rank{recv_rank},  // send to receiver host
+        tt::tt_metal::distributed::multihost::Tag{0}            // exchange seed over tag 0
     );
     // Randomly select a mcast sender device
     auto sender_phys_id = control_plane.get_physical_chip_id_from_fabric_node_id(mcast_sender_node);
@@ -392,8 +332,8 @@ void run_mcast_sender_step(
     CoreCoord receiver_logical_core = {0, 0};
     distributed_context->recv(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&receiver_logical_core), sizeof(receiver_logical_core)),
-        tt::tt_metal::distributed::multihost::Rank{1},  // receive from receiver host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange logical core over tag 0
+        tt::tt_metal::distributed::multihost::Rank{recv_rank},  // receive from receiver host
+        tt::tt_metal::distributed::multihost::Tag{0}            // exchange logical core over tag 0
     );
 
     CoreCoord receiver_virtual_core = sender_device->worker_core_from_logical_core(receiver_logical_core);
@@ -430,73 +370,19 @@ void run_mcast_sender_step(
 
     std::vector<uint32_t> mcast_header_rtas(4, 0);
     for (const auto& routing_info : mcast_routing_info) {
-        mcast_header_rtas[static_cast<uint32_t>(
-            control_plane.routing_direction_to_eth_direction(routing_info.mcast_dir))] = routing_info.num_mcast_hops;
+        // Increment hop count to account for the mcast start node
+        mcast_header_rtas[static_cast<uint32_t>(control_plane.routing_direction_to_eth_direction(
+            routing_info.mcast_dir))] = routing_info.num_mcast_hops + 1;
     }
 
     sender_runtime_args.insert(sender_runtime_args.end(), mcast_header_rtas.begin(), mcast_header_rtas.end());
 
-    // Determine the port to use for intermesh routing
-    std::vector<chan_id_t> eth_chans;
-    chan_id_t edm_port;
-    if (control_plane.has_intermesh_links(sender_phys_id)) {
-        // In this case, the sender chip is an exit node. Choose an intermesh link to the mcast start mesh.
-        auto intermesh_routing_direction =
-            control_plane.get_forwarding_direction(mcast_sender_node, mcast_start_node).value();
-        auto eth_cores_and_chans =
-            control_plane.get_active_fabric_eth_channels_in_direction(mcast_sender_node, intermesh_routing_direction);
-        for (auto chan : eth_cores_and_chans) {
-            // Pin traffic to routing plane 0 for T3K
-            if (control_plane.get_routing_plane_id(mcast_sender_node, chan) == 0) {
-                eth_chans.push_back(chan);
-            }
-        }
-    } else {
-        // In this case, the sender chip is not an exit node. Find a route to an exit node.
-        chip_id_t edge_chip = 0;
-        for (auto chip_id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
-            if (control_plane.has_intermesh_links(chip_id)) {
-                edge_chip = chip_id;
-                break;
-            }
-        }
-        auto edge_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(edge_chip);
-        eth_chans = control_plane.get_forwarding_eth_chans_to_chip(mcast_sender_node, edge_fabric_node_id);
-    }
-    // Pick any port, for now pick the 1st one in the set
-    edm_port = *eth_chans.begin();
-    auto edm_direction = control_plane.get_eth_chan_direction(mcast_sender_node, edm_port);
-    CoreCoord edm_eth_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
-        sender_phys_id, edm_port);
-    log_info(tt::LogTest, "Using edm port {} in direction {}", edm_port, edm_direction);
-
-    const auto sender_channel = edm_direction;
-    tt::tt_fabric::SenderWorkerAdapterSpec edm_connection = {
-        .edm_noc_x = edm_eth_core.x,
-        .edm_noc_y = edm_eth_core.y,
-        .edm_buffer_base_addr = edm_config.sender_channels_base_address[sender_channel],
-        .num_buffers_per_channel = edm_config.sender_channels_num_buffers[sender_channel],
-        .edm_l1_sem_addr = edm_config.sender_channels_local_flow_control_semaphore_address[sender_channel],
-        .edm_connection_handshake_addr = edm_config.sender_channels_connection_semaphore_address[sender_channel],
-        .edm_worker_location_info_addr = edm_config.sender_channels_worker_conn_info_base_address[sender_channel],
-        .buffer_size_bytes = edm_config.channel_buffer_size_bytes,
-        .buffer_index_semaphore_id = edm_config.sender_channels_buffer_index_semaphore_address[sender_channel],
-        .edm_direction = edm_direction};
-
-    auto worker_flow_control_semaphore_id = tt_metal::CreateSemaphore(mcast_send_program, sender_logical_core, 0);
-    auto worker_teardown_semaphore_id = tt_metal::CreateSemaphore(mcast_send_program, sender_logical_core, 0);
-    auto worker_buffer_index_semaphore_id = tt_metal::CreateSemaphore(mcast_send_program, sender_logical_core, 0);
-
-    append_worker_to_fabric_edm_sender_rt_args(
-        edm_connection,
-        worker_flow_control_semaphore_id,
-        worker_teardown_semaphore_id,
-        worker_buffer_index_semaphore_id,
-        sender_runtime_args);
+    tt_fabric::append_fabric_connection_rt_args(
+        mcast_sender_node, mcast_start_node, 0, mcast_send_program, {sender_logical_core}, sender_runtime_args);
 
     tt_metal::SetRuntimeArgs(mcast_send_program, mcast_send_kernel, sender_logical_core, sender_runtime_args);
 
-    log_info(tt::LogTest, "Run Sender on: {}", sender_device->id());
+    log_debug(tt::LogTest, "Run Sender on: {}", sender_device->id());
     fixture->RunProgramNonblocking(sender_device, mcast_send_program);
     fixture->WaitForSingleProgramDone(sender_device, mcast_send_program);
 
@@ -515,23 +401,26 @@ void run_mcast_sender_step(
     // Send test results to the receiver host
     distributed_context->send(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&sender_bytes), sizeof(sender_bytes)),
-        tt::tt_metal::distributed::multihost::Rank{1},  // send to receiver host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange test results over tag 0
+        tt::tt_metal::distributed::multihost::Rank{recv_rank},  // send to receiver host
+        tt::tt_metal::distributed::multihost::Tag{0}            // exchange test results over tag 0
     );
     // Request test results from all devices on the receiver host and ensure that they match
     for (std::size_t recv_idx = 0; recv_idx < mcast_group_node_ids.size() + 1; recv_idx++) {
         uint64_t recv_bytes = 0;
         distributed_context->recv(
             tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&recv_bytes), sizeof(recv_bytes)),
-            tt::tt_metal::distributed::multihost::Rank{1},  // recv from receiver host
-            tt::tt_metal::distributed::multihost::Tag{0}    // exchange test results over tag 0
+            tt::tt_metal::distributed::multihost::Rank{recv_rank},  // recv from receiver host
+            tt::tt_metal::distributed::multihost::Tag{0}            // exchange test results over tag 0
         );
         EXPECT_EQ(sender_bytes, recv_bytes);
     }
 }
 
 void run_mcast_recv_step(
-    BaseFabricFixture* fixture, FabricNodeId mcast_start_node, const std::vector<FabricNodeId>& mcast_group_node_ids) {
+    BaseFabricFixture* fixture,
+    FabricNodeId mcast_start_node,
+    const std::vector<FabricNodeId>& mcast_group_node_ids,
+    uint32_t sender_rank) {
     // The following code runs on the receiver host
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
@@ -546,8 +435,8 @@ void run_mcast_recv_step(
     uint32_t time_seed = 0;
     distributed_context->recv(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&time_seed), sizeof(time_seed)),
-        tt::tt_metal::distributed::multihost::Rank{0},  // recv from sender host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange seed over tag 0
+        tt::tt_metal::distributed::multihost::Rank{sender_rank},  // recv from sender host
+        tt::tt_metal::distributed::multihost::Tag{0}              // exchange seed over tag 0
     );
     // Query the mcast start device
     auto mcast_start_phys_id = control_plane.get_physical_chip_id_from_fabric_node_id(mcast_start_node);
@@ -562,8 +451,8 @@ void run_mcast_recv_step(
     // Send the randomized receiver core to the sender host, so it can send packets to the correct destination
     distributed_context->send(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&receiver_logical_core), sizeof(receiver_logical_core)),
-        tt::tt_metal::distributed::multihost::Rank{0},  // send to sender host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange logical core over tag 0
+        tt::tt_metal::distributed::multihost::Rank{sender_rank},  // send to sender host
+        tt::tt_metal::distributed::multihost::Tag{0}              // exchange logical core over tag 0
     );
     // Query the mcast group devices
     std::vector<tt_metal::IDevice*> mcast_group_devices = {};
@@ -578,7 +467,7 @@ void run_mcast_recv_step(
 
     // Create the mcast receiver programs
     std::vector<uint32_t> compile_time_args = {
-        worker_mem_map.test_results_address, worker_mem_map.test_results_size_bytes, target_address};
+        worker_mem_map.test_results_address, worker_mem_map.test_results_size_bytes, target_address, false};
 
     std::vector<uint32_t> receiver_runtime_args = {worker_mem_map.packet_payload_size_bytes, num_packets, time_seed};
     std::unordered_map<tt_metal::IDevice*, std::shared_ptr<tt_metal::Program>> recv_programs;
@@ -590,7 +479,7 @@ void run_mcast_recv_step(
     }
     // Run the mcast receiver programs
     for (auto& [dev, recv_program] : recv_programs) {
-        log_info(tt::LogTest, "Run receiver on: {}", dev->id());
+        log_debug(tt::LogTest, "Run receiver on: {}", dev->id());
         fixture->RunProgramNonblocking(dev, *recv_program);
     }
 
@@ -602,8 +491,8 @@ void run_mcast_recv_step(
     uint64_t sender_bytes = 0;
     distributed_context->recv(
         tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&sender_bytes), sizeof(sender_bytes)),
-        tt::tt_metal::distributed::multihost::Rank{0},  // recv from sender host
-        tt::tt_metal::distributed::multihost::Tag{0}    // exchange tests results over tag 0
+        tt::tt_metal::distributed::multihost::Rank{sender_rank},  // recv from sender host
+        tt::tt_metal::distributed::multihost::Tag{0}              // exchange tests results over tag 0
     );
 
     for (auto& [dev, _] : recv_programs) {
@@ -622,8 +511,8 @@ void run_mcast_recv_step(
             ((uint64_t)receiver_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | receiver_status[TT_FABRIC_WORD_CNT_INDEX];
         distributed_context->send(
             tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&receiver_bytes), sizeof(receiver_bytes)),
-            tt::tt_metal::distributed::multihost::Rank{0},  // send to sender host
-            tt::tt_metal::distributed::multihost::Tag{0}    // exchange test results over tag 0
+            tt::tt_metal::distributed::multihost::Rank{sender_rank},  // send to sender host
+            tt::tt_metal::distributed::multihost::Tag{0}              // exchange test results over tag 0
         );
         EXPECT_EQ(sender_bytes, receiver_bytes);
     }
@@ -632,9 +521,9 @@ void run_mcast_recv_step(
 void RandomizedInterMeshUnicast(BaseFabricFixture* fixture) {
     auto distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
     if (*(distributed_context->rank()) == 0) {
-        run_unicast_sender_step(fixture);
+        run_unicast_sender_step(fixture, tt::tt_metal::distributed::multihost::Rank{1});
     } else {
-        run_unicast_recv_step(fixture);
+        run_unicast_recv_step(fixture, tt::tt_metal::distributed::multihost::Rank{0});
     }
 }
 
@@ -643,13 +532,16 @@ void InterMeshLineMcast(
     FabricNodeId mcast_sender_node,
     FabricNodeId mcast_start_node,
     const std::vector<McastRoutingInfo>& mcast_routing_info,
-    const std::vector<FabricNodeId>& mcast_group_node_ids) {
+    const std::vector<FabricNodeId>& mcast_group_node_ids,
+    uint32_t sender_rank,
+    uint32_t receiver_rank) {
     auto distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
 
-    if (*(distributed_context->rank()) == 0) {
-        run_mcast_sender_step(fixture, mcast_sender_node, mcast_start_node, mcast_routing_info, mcast_group_node_ids);
+    if (*(distributed_context->rank()) == sender_rank) {
+        run_mcast_sender_step(
+            fixture, mcast_sender_node, mcast_start_node, mcast_routing_info, mcast_group_node_ids, receiver_rank);
     } else {
-        run_mcast_recv_step(fixture, mcast_start_node, mcast_group_node_ids);
+        run_mcast_recv_step(fixture, mcast_start_node, mcast_group_node_ids, sender_rank);
     }
 }
 

--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.hpp
@@ -16,6 +16,10 @@ namespace fabric_router_tests {
 
 namespace multihost_utils {
 
+void run_unicast_sender_step(BaseFabricFixture* fixture, tt::tt_metal::distributed::multihost::Rank recv_host_rank);
+
+void run_unicast_recv_step(BaseFabricFixture* fixture, tt::tt_metal::distributed::multihost::Rank sender_host_rank);
+
 void RandomizedInterMeshUnicast(BaseFabricFixture* fixture);
 
 void InterMeshLineMcast(
@@ -23,7 +27,9 @@ void InterMeshLineMcast(
     FabricNodeId mcast_sender_node,
     FabricNodeId mcast_start_node,
     const std::vector<McastRoutingInfo>& mcast_routing_info,
-    const std::vector<FabricNodeId>& mcast_group_node_ids);
+    const std::vector<FabricNodeId>& mcast_group_node_ids,
+    uint32_t sender_rank = 0,
+    uint32_t receiver_rank = 1);
 
 std::map<FabricNodeId, chip_id_t> get_physical_chip_mapping_from_eth_coords_mapping(
     const std::vector<std::vector<eth_coord_t>>& mesh_graph_eth_coords, uint32_t local_mesh_id);

--- a/tests/tt_metal/multihost/fabric_tests/kernels/tt_fabric_2d_unicast_tx.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/kernels/tt_fabric_2d_unicast_tx.cpp
@@ -93,7 +93,6 @@ void kernel_main() {
     tt::tt_fabric::WorkerToFabricEdmSender bwd_fabric_connection;
 
     volatile tt_l1_ptr PACKET_HEADER_TYPE* fwd_packet_header;
-    volatile tt_l1_ptr PACKET_HEADER_TYPE* bwd_packet_header;
 
     fwd_fabric_connection =
         tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);

--- a/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
@@ -1,4 +1,3 @@
-
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -16,37 +15,81 @@
 namespace tt::tt_fabric {
 namespace fabric_router_tests {
 
+template <typename Fixture>
+void validate_and_setup_control_plane_config(Fixture* fixture) {
+    const char* mesh_id_str = std::getenv("TT_MESH_ID");
+    const char* host_rank_str = std::getenv("TT_HOST_RANK");
+    auto local_mesh_id = std::string(mesh_id_str);
+    auto local_host_rank = std::string(host_rank_str);
+
+    TT_FATAL(
+        local_mesh_id.size() and local_host_rank.size(),
+        "TT_MESH_ID and TT_HOST_RANK environment variables must be set for Multi-Host Fabric Tests.");
+
+    auto chip_to_eth_coord_mapping = multihost_utils::get_physical_chip_mapping_from_eth_coords_mapping(
+        fixture->get_eth_coord_mapping(), std::stoi(local_mesh_id));
+    tt::tt_metal::MetalContext::instance().set_custom_control_plane_mesh_graph(
+        fixture->get_path_to_mesh_graph_desc(), chip_to_eth_coord_mapping);
+    TT_FATAL(
+        tt::tt_metal::MetalContext::instance().get_control_plane().system_has_intermesh_links(),
+        "Multi-Host Routing tests require ethernet links to a remote host.");
+    TT_FATAL(
+        *(tt::tt_metal::MetalContext::instance().get_distributed_context().size()) > 1,
+        "Multi-Host Routing tests require multiple hosts in the system");
+}
+
+inline const std::vector<eth_coord_t>& get_eth_coords_for_t3k() {
+    static const std::vector<eth_coord_t> t3k_eth_coords = {
+        {0, 0, 0, 0, 0},
+        {0, 1, 0, 0, 0},
+        {0, 2, 0, 0, 0},
+        {0, 3, 0, 0, 0},
+        {0, 0, 1, 0, 0},
+        {0, 1, 1, 0, 0},
+        {0, 2, 1, 0, 0},
+        {0, 3, 1, 0, 0}};
+
+    return t3k_eth_coords;
+}
+
+inline const std::vector<std::vector<eth_coord_t>>& get_eth_coords_for_split_2x2_t3k() {
+    static const std::vector<std::vector<eth_coord_t>> t3k_2x2_eth_coords = {
+        {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}},
+        {{0, 2, 0, 0, 0}, {0, 3, 0, 0, 0}, {0, 2, 1, 0, 0}, {0, 3, 1, 0, 0}}};
+
+    return t3k_2x2_eth_coords;
+}
+
+inline const std::vector<std::vector<eth_coord_t>>& get_eth_coords_for_split_1x2_t3k() {
+    static const std::vector<std::vector<eth_coord_t>> t3k_1x2_eth_coords = {
+        {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}},
+        {{0, 2, 0, 0, 0}, {0, 3, 0, 0, 0}},
+        {{0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}},
+        {{0, 2, 1, 0, 0}, {0, 3, 1, 0, 0}}};
+
+    return t3k_1x2_eth_coords;
+}
+
+inline const std::vector<std::vector<eth_coord_t>>& get_eth_coords_for_dual_2x2_t3k() {
+    static const std::vector<std::vector<eth_coord_t>> t3k_2x2_eth_coords = {
+        {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}},
+        {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}}};
+
+    return t3k_2x2_eth_coords;
+}
+
+// Base fixture for Inter-Mesh Routing Fabric 2D tests.
 class InterMeshRoutingFabric2DFixture : public BaseFabricFixture {
 public:
     // This test fixture closes/opens devices on each test
     static void SetUpTestSuite() {}
     static void TearDownTestSuite() {}
-
     void SetUp() override {
         if (not system_supported()) {
             GTEST_SKIP() << "Skipping since this is not a supported system.";
         }
 
-        const char* mesh_id_str = std::getenv("TT_MESH_ID");
-        const char* host_rank_str = std::getenv("TT_HOST_RANK");
-        auto local_mesh_id = std::string(mesh_id_str);
-        auto local_host_rank = std::string(host_rank_str);
-
-        TT_FATAL(
-            local_mesh_id.size() and local_host_rank.size(),
-            "TT_MESH_ID and TT_HOST_RANK environment variables must be set for Multi-Host Fabric Tests.");
-
-        auto chip_to_eth_coord_mapping = multihost_utils::get_physical_chip_mapping_from_eth_coords_mapping(
-            get_eth_coord_mapping(), std::stoi(local_mesh_id));
-
-        tt::tt_metal::MetalContext::instance().set_custom_control_plane_mesh_graph(
-            get_path_to_mesh_graph_desc(), chip_to_eth_coord_mapping);
-        TT_FATAL(
-            tt::tt_metal::MetalContext::instance().get_control_plane().system_has_intermesh_links(),
-            "Multi-Host Routing tests require ethernet links to a remote host.");
-        TT_FATAL(
-            *(tt::tt_metal::MetalContext::instance().get_distributed_context().size()) > 1,
-            "Multi-Host Routing tests require multiple hosts in the system");
+        validate_and_setup_control_plane_config(this);
         this->DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
     }
 
@@ -61,58 +104,122 @@ public:
     virtual std::vector<std::vector<eth_coord_t>> get_eth_coord_mapping() = 0;
     // The derived fixture must infer if the current system is suitable for the requested
     // topology in the Mesh Graph, when implementing this function.
-    virtual bool system_supported() = 0;
+    bool system_supported() {
+        const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+        const auto& eth_coord_mapping = this->get_eth_coord_mapping();
+        return *(tt::tt_metal::MetalContext::instance().get_distributed_context().size()) == eth_coord_mapping.size() &&
+               cluster.user_exposed_chip_ids().size() == eth_coord_mapping[0].size();
+    }
 };
 
-class InterMesh2x4Fabric2DFixture : public InterMeshRoutingFabric2DFixture {
+// Base fixture for Multi-Host MeshDevice tests relying on Inter-Mesh Routing.
+class MultiMeshDeviceFabricFixture : public tt::tt_metal::GenericMeshDevice2DFabricFixture {
+public:
+    void SetUp() override {
+        if (not system_supported()) {
+            GTEST_SKIP() << "Skipping since this is not a supported system.";
+        }
+        validate_and_setup_control_plane_config(this);
+        tt::tt_metal::GenericMeshDevice2DFabricFixture::SetUp();
+    }
+
+    void TearDown() override {
+        if (system_supported()) {
+            tt::tt_metal::GenericMeshDevice2DFabricFixture::TearDown();
+        }
+    }
+
+    // Derived Classes (Fixtures specialized for topology/system) must define this
+    virtual std::string get_path_to_mesh_graph_desc() = 0;
+    virtual std::vector<std::vector<eth_coord_t>> get_eth_coord_mapping() = 0;
+    bool system_supported() {
+        const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+        const auto& eth_coord_mapping = this->get_eth_coord_mapping();
+        return *(tt::tt_metal::MetalContext::instance().get_distributed_context().size()) == eth_coord_mapping.size() &&
+               cluster.user_exposed_chip_ids().size() == eth_coord_mapping[0].size();
+    }
+};
+
+// Generic Fixture for Split 2x2 T3K systems using Fabric
+template <typename Fixture>
+class Split2x2FabricFixture : public Fixture {
 public:
     std::string get_path_to_mesh_graph_desc() override {
         return "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml";
     }
 
     std::vector<std::vector<eth_coord_t>> get_eth_coord_mapping() override {
-        return {
-            {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}},
-            {{0, 0, 0, 0, 0}, {0, 1, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 1, 1, 0, 0}}};
-    }
-
-    bool system_supported() override {
-        const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-        return cluster.user_exposed_chip_ids().size() == 4;
+        return get_eth_coords_for_split_2x2_t3k();
     }
 };
 
-class InterMeshDual2x4Fabric2DFixture : public InterMeshRoutingFabric2DFixture {
+// Generic Fixture for Split 1x2 T3K systems using Fabric
+template <typename Fixture>
+class Split1x2FabricFixture : public Fixture {
+    std::string get_path_to_mesh_graph_desc() override {
+        return "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x2_mesh_graph_descriptor.yaml";
+    }
+
+    std::vector<std::vector<eth_coord_t>> get_eth_coord_mapping() override {
+        return get_eth_coords_for_split_1x2_t3k();
+    }
+};
+
+// Generic Fixture for Dual 2x2 T3K systems using Fabric
+template <typename Fixture>
+class Dual2x2FabricFixture : public Fixture {
+public:
+    std::string get_path_to_mesh_graph_desc() override {
+        return "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml";
+    }
+
+    std::vector<std::vector<eth_coord_t>> get_eth_coord_mapping() override { return get_eth_coords_for_dual_2x2_t3k(); }
+};
+
+// Generic Fixture for Dual T3K systems using Fabric
+template <typename Fixture>
+class Dual2x4FabricFixture : public Fixture {
     std::string get_path_to_mesh_graph_desc() override {
         return "tests/tt_metal/tt_fabric/custom_mesh_descriptors/dual_t3k_mesh_graph_descriptor.yaml";
     }
 
     std::vector<std::vector<eth_coord_t>> get_eth_coord_mapping() override {
-        return {
-            {{0, 0, 0, 0, 0},
-             {0, 1, 0, 0, 0},
-             {0, 2, 0, 0, 0},
-             {0, 3, 0, 0, 0},
-             {0, 0, 1, 0, 0},
-             {0, 1, 1, 0, 0},
-             {0, 2, 1, 0, 0},
-             {0, 3, 1, 0, 0}},
-
-            {{0, 0, 0, 0, 0},
-             {0, 1, 0, 0, 0},
-             {0, 2, 0, 0, 0},
-             {0, 3, 0, 0, 0},
-             {0, 0, 1, 0, 0},
-             {0, 1, 1, 0, 0},
-             {0, 2, 1, 0, 0},
-             {0, 3, 1, 0, 0}}};
-    }
-
-    bool system_supported() override {
-        const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-        return cluster.user_exposed_chip_ids().size() == 8;
+        return {get_eth_coords_for_t3k(), get_eth_coords_for_t3k()};
     }
 };
+
+// Generic Fixture for Nano-Exabox systems using Fabric
+template <typename Fixture>
+class NanoExaboxFabricFixture : public Fixture {
+    std::string get_path_to_mesh_graph_desc() override {
+        return "tests/tt_metal/tt_fabric/custom_mesh_descriptors/nano_exabox_mesh_graph_descriptor.yaml";
+    }
+
+    std::vector<std::vector<eth_coord_t>> get_eth_coord_mapping() override {
+        return {
+            get_eth_coords_for_t3k(),
+            get_eth_coords_for_t3k(),
+            get_eth_coords_for_t3k(),
+            get_eth_coords_for_t3k(),
+            get_eth_coords_for_t3k()};
+    }
+};
+
+// Dedicated Fabric and Distributed Test Fixtures fir Multi-Host + Multi-Mesh Tests
+using IntermeshSplit2x2FabricFixture = Split2x2FabricFixture<InterMeshRoutingFabric2DFixture>;
+using MeshDeviceSplit2x2Fixture = Split2x2FabricFixture<MultiMeshDeviceFabricFixture>;
+
+using InterMeshSplit1x2FabricFixture = Split1x2FabricFixture<InterMeshRoutingFabric2DFixture>;
+using MeshDeviceSplit1x2Fixture = Split1x2FabricFixture<MultiMeshDeviceFabricFixture>;
+
+using IntermeshDual2x2FabricFixture = Dual2x2FabricFixture<InterMeshRoutingFabric2DFixture>;
+using MeshDeviceDual2x2Fixture = Dual2x2FabricFixture<MultiMeshDeviceFabricFixture>;
+
+using InterMeshDual2x4FabricFixture = Dual2x4FabricFixture<InterMeshRoutingFabric2DFixture>;
+using MeshDeviceDual2x4Fixture = Dual2x4FabricFixture<MultiMeshDeviceFabricFixture>;
+
+using IntermeshNanoExaboxFabricFixture = NanoExaboxFabricFixture<InterMeshRoutingFabric2DFixture>;
+using MeshDeviceNanoExaboxFixture = NanoExaboxFabricFixture<MultiMeshDeviceFabricFixture>;
 
 }  // namespace fabric_router_tests
 }  // namespace tt::tt_fabric

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv.cpp
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <gtest/gtest.h>
+#include <stdint.h>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
+#include "multihost_fabric_fixtures.hpp"
+#include "tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/fabric.hpp>
+
+#include <random>
+#include <algorithm>
+
+namespace tt::tt_fabric {
+namespace fabric_router_tests::multihost {
+
+using namespace multihost_utils;
+
+template <typename FixtureType>
+class MultiHostSocketTest : public FixtureType, public ::testing::WithParamInterface<SocketTestConfig> {
+public:
+    void RunTest() {
+        auto config = GetParam();
+
+        log_info(tt::LogTest, "Socket Test Variant: {} ", get_test_variant_name(config.variant));
+        log_info(tt::LogTest, "Socket Buffer Size: {} bytes", config.socket_fifo_size);
+        log_info(tt::LogTest, "Socket Page Size: {} bytes", config.socket_page_size);
+        log_info(tt::LogTest, "Data Size: {} bytes", config.data_size);
+        log_info(
+            tt::LogTest,
+            "Host Rank: {}",
+            *tt::tt_metal::distributed::multihost::DistributedContext::get_current_world()->rank());
+
+        // Call the appropriate test function based on variant
+        switch (config.variant) {
+            case TestVariant::SINGLE_CONN_BWD:
+                test_multi_mesh_single_conn_bwd(
+                    this->mesh_device_,
+                    config.socket_fifo_size,
+                    config.socket_page_size,
+                    config.data_size,
+                    config.system_config);
+                break;
+            case TestVariant::SINGLE_CONN_FWD:
+                test_multi_mesh_single_conn_fwd(
+                    this->mesh_device_,
+                    config.socket_fifo_size,
+                    config.socket_page_size,
+                    config.data_size,
+                    config.system_config);
+                break;
+            case TestVariant::MULTI_CONN_FWD:
+                test_multi_mesh_multi_conn_fwd(
+                    this->mesh_device_,
+                    config.socket_fifo_size,
+                    config.socket_page_size,
+                    config.data_size,
+                    config.system_config);
+                break;
+            case TestVariant::MULTI_CONN_BIDIR:
+                test_multi_mesh_multi_conn_bidirectional(
+                    this->mesh_device_,
+                    config.socket_fifo_size,
+                    config.socket_page_size,
+                    config.data_size,
+                    config.system_config);
+                break;
+        }
+    }
+};
+
+std::vector<SocketTestConfig> generate_socket_test_configs(SystemConfig system_config) {
+    std::vector<SocketTestConfig> configs;
+
+    std::vector<uint32_t> fifo_sizes = {1024, 2048, 4096, 512, 1024};
+    std::vector<uint32_t> page_sizes = {64, 256, 1088, 128, 128};
+    std::vector<uint32_t> data_sizes = {2048, 4096, 78336, 16384, 4096};
+    std::vector<TestVariant> variants = {
+        TestVariant::SINGLE_CONN_BWD,
+        TestVariant::SINGLE_CONN_FWD,
+        TestVariant::MULTI_CONN_FWD,
+        TestVariant::MULTI_CONN_BIDIR};
+
+    for (int config_idx = 0; config_idx < fifo_sizes.size(); ++config_idx) {
+        for (const auto& variant : variants) {
+            configs.push_back(
+                {.socket_fifo_size = fifo_sizes[config_idx],
+                 .socket_page_size = page_sizes[config_idx],
+                 .data_size = data_sizes[config_idx],
+                 .variant = variant,
+                 .system_config = system_config});
+        }
+    }
+    return configs;
+}
+
+template <typename ParamType>
+std::string generate_multihost_socket_test_name(const testing::TestParamInfo<ParamType>& info) {
+    return get_test_variant_name(info.param.variant) + "_" + get_system_config_name(info.param.system_config) + "_" +
+           std::to_string(info.param.socket_fifo_size) + "_" + std::to_string(info.param.socket_page_size) + "_" +
+           std::to_string(info.param.data_size);
+}
+
+using MultiHostSocketTestSplitT3K = MultiHostSocketTest<MeshDeviceSplit2x2Fixture>;
+using MultiHostSocketTestDualT3K = MultiHostSocketTest<MeshDeviceDual2x4Fixture>;
+using MultiHostSocketTestNanoExabox = MultiHostSocketTest<MeshDeviceNanoExaboxFixture>;
+
+TEST_P(MultiHostSocketTestSplitT3K, SocketTests) { RunTest(); }
+
+TEST_P(MultiHostSocketTestDualT3K, SocketTests) { RunTest(); }
+
+TEST_P(MultiHostSocketTestNanoExabox, SocketTests) { RunTest(); }
+
+INSTANTIATE_TEST_SUITE_P(
+    MultiHostSocketTestsSplitT3K,
+    MultiHostSocketTestSplitT3K,
+    ::testing::ValuesIn(generate_socket_test_configs(SystemConfig::SPLIT_T3K)),
+    generate_multihost_socket_test_name<MultiHostSocketTestSplitT3K::ParamType>);
+
+INSTANTIATE_TEST_SUITE_P(
+    MultiHostSocketTestsDualT3K,
+    MultiHostSocketTestDualT3K,
+    ::testing::ValuesIn(generate_socket_test_configs(SystemConfig::DUAL_T3K)),
+    generate_multihost_socket_test_name<MultiHostSocketTestDualT3K::ParamType>);
+
+INSTANTIATE_TEST_SUITE_P(
+    MultiHostSocketTestsNanoExabox,
+    MultiHostSocketTestNanoExabox,
+    ::testing::ValuesIn(generate_socket_test_configs(SystemConfig::NANO_EXABOX)),
+    generate_multihost_socket_test_name<MultiHostSocketTestDualT3K::ParamType>);
+
+TEST_F(MultiHostSocketTestNanoExabox, MultiContextSocketHandshake) {
+    std::vector<int> sender_node_ranks_ctx0 = {0, 2, 3, 4};
+    uint32_t recv_rank_ctx0 = 1;
+
+    std::vector<int> ctx1_ranks = sender_node_ranks_ctx0;
+    std::vector<int> sender_node_ranks_ctx1 = {0, 2, 3};
+    uint32_t recv_rank_ctx1 = 1;
+
+    auto distributed_ctx0 = tt_metal::distributed::multihost::DistributedContext::get_current_world();
+
+    std::unordered_map<uint32_t, tt_metal::distributed::MeshSocket> sockets_ctx0;
+    std::unordered_map<uint32_t, tt_metal::distributed::MeshSocket> sockets_ctx1;
+
+    auto socket_connection = tt_metal::distributed::SocketConnection{
+        .sender_core = {MeshCoordinate(0, 0), tt_metal::CoreCoord(0, 0)},
+        .receiver_core = {MeshCoordinate(0, 0), tt_metal::CoreCoord(0, 0)}};
+
+    auto socket_mem_config = tt_metal::distributed::SocketMemoryConfig{
+        .socket_storage_type = tt_metal::BufferType::L1,
+        .fifo_size = 1024,
+    };
+
+    // Initialize sockets in context0 namespace
+    if (*distributed_ctx0->rank() == recv_rank_ctx0) {
+        for (const auto& sender_rank : sender_node_ranks_ctx0) {
+            tt_metal::distributed::SocketConfig socket_config = {
+                .socket_connection_config = {socket_connection},
+                .socket_mem_config = socket_mem_config,
+                .sender_rank = tt_metal::distributed::multihost::Rank{sender_rank},
+                .receiver_rank = distributed_ctx0->rank(),
+                .distributed_context = distributed_ctx0};
+            sockets_ctx0.emplace(sender_rank, tt_metal::distributed::MeshSocket(mesh_device_, socket_config));
+        }
+    } else if (
+        std::find(sender_node_ranks_ctx0.begin(), sender_node_ranks_ctx0.end(), *distributed_ctx0->rank()) !=
+        sender_node_ranks_ctx0.end()) {
+        tt_metal::distributed::SocketConfig socket_config = {
+            .socket_connection_config = {socket_connection},
+            .socket_mem_config = socket_mem_config,
+            .sender_rank = distributed_ctx0->rank(),
+            .receiver_rank = tt_metal::distributed::multihost::Rank{recv_rank_ctx0},
+            .distributed_context = distributed_ctx0};
+        sockets_ctx0.emplace(recv_rank_ctx0, tt_metal::distributed::MeshSocket(mesh_device_, socket_config));
+    }
+    // Initialize sockets in context1 namespace
+    if (std::find(ctx1_ranks.begin(), ctx1_ranks.end(), *distributed_ctx0->rank()) != ctx1_ranks.end()) {
+        auto distributed_ctx1 = distributed_ctx0->create_sub_context(ctx1_ranks);
+        if (*distributed_ctx1->rank() == recv_rank_ctx1) {
+            for (const auto& sender_rank : sender_node_ranks_ctx1) {
+                tt_metal::distributed::SocketConfig socket_config = {
+                    .socket_connection_config = {socket_connection},
+                    .socket_mem_config = socket_mem_config,
+                    .sender_rank = tt_metal::distributed::multihost::Rank{sender_rank},
+                    .receiver_rank = distributed_ctx1->rank(),
+                    .distributed_context = distributed_ctx1};
+                sockets_ctx1.emplace(sender_rank, tt_metal::distributed::MeshSocket(mesh_device_, socket_config));
+            }
+        } else if (
+            std::find(sender_node_ranks_ctx1.begin(), sender_node_ranks_ctx1.end(), *distributed_ctx1->rank()) !=
+            sender_node_ranks_ctx1.end()) {
+            tt_metal::distributed::SocketConfig socket_config = {
+                .socket_connection_config = {socket_connection},
+                .socket_mem_config = socket_mem_config,
+                .sender_rank = distributed_ctx1->rank(),
+                .receiver_rank = tt_metal::distributed::multihost::Rank{recv_rank_ctx1},
+                .distributed_context = distributed_ctx1};
+            sockets_ctx1.emplace(recv_rank_ctx1, tt_metal::distributed::MeshSocket(mesh_device_, socket_config));
+        }
+    }
+}
+
+}  // namespace fabric_router_tests::multihost
+}  // namespace tt::tt_fabric

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
@@ -1,0 +1,524 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <stdint.h>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/fabric.hpp>
+
+#include <random>
+#include <algorithm>
+
+#include "tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.hpp"
+
+namespace tt::tt_fabric {
+namespace fabric_router_tests::multihost {
+
+namespace multihost_utils {
+
+std::string get_system_config_name(SystemConfig system_config) {
+    switch (system_config) {
+        case SystemConfig::SPLIT_T3K: return "SplitT3K";
+        case SystemConfig::DUAL_T3K: return "DualT3K";
+        case SystemConfig::NANO_EXABOX: return "NanoExabox";
+        default: return "Unknown";
+    }
+}
+
+std::string get_test_variant_name(TestVariant variant) {
+    switch (variant) {
+        case TestVariant::SINGLE_CONN_BWD: return "MultiMeshSingleConnectionBwd";
+        case TestVariant::SINGLE_CONN_FWD: return "MultiMeshSingleConnectionFwd";
+        case TestVariant::MULTI_CONN_FWD: return "MultiMeshMultiConnectionFwd";
+        case TestVariant::MULTI_CONN_BIDIR: return "MultiConnectionBidirectional";
+        default: return "Unknown";
+    }
+}
+
+void test_socket_send_recv(
+    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device_,
+    tt_metal::distributed::MeshSocket& socket,
+    uint32_t data_size,
+    uint32_t page_size,
+    uint32_t num_txns = 20) {
+    using namespace tt::tt_metal::distributed::multihost;
+    using namespace tt::tt_metal::distributed;
+    using namespace tt_metal;
+
+    auto fabric_max_packet_size = tt_fabric::get_tt_fabric_max_payload_size_bytes();
+    auto packet_header_size_bytes = tt_fabric::get_tt_fabric_packet_header_size_bytes();
+
+    auto distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
+    auto sender_rank = socket.get_config().sender_rank;
+    auto recv_rank = socket.get_config().receiver_rank;
+
+    auto sender_core = socket.get_config().socket_connection_config[0].sender_core.core_coord;
+    auto recv_core = socket.get_config().socket_connection_config[0].receiver_core.core_coord;
+
+    std::vector<uint32_t> src_vec(data_size / sizeof(uint32_t));
+
+    // Exchange seed between sender and receiver
+    uint32_t seed = 0;
+    if (distributed_context->rank() == sender_rank) {
+        seed = std::chrono::steady_clock::now().time_since_epoch().count();
+        distributed_context->send(
+            tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&seed), sizeof(seed)),
+            recv_rank,                                    // send to receiver host
+            tt::tt_metal::distributed::multihost::Tag{0}  // exchange seed over tag 0
+        );
+    } else {
+        distributed_context->recv(
+            tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&seed), sizeof(seed)),
+            sender_rank,                                  // recv from sender host
+            tt::tt_metal::distributed::multihost::Tag{0}  // exchange seed over tag 0
+        );
+    }
+
+    std::mt19937 gen(seed);
+    std::uniform_int_distribution<uint32_t> dis(0, UINT32_MAX);
+    std::generate(src_vec.begin(), src_vec.end(), [&]() { return dis(gen); });
+
+    const auto reserved_packet_header_CB_index = tt::CB::c_in0;
+
+    for (int i = 0; i < num_txns; i++) {
+        if (distributed_context->rank() == sender_rank) {
+            auto sender_data_shard_params =
+                ShardSpecBuffer(CoreRangeSet(sender_core), {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
+
+            const DeviceLocalBufferConfig sender_device_local_config{
+                .page_size = data_size,
+                .buffer_type = BufferType::L1,
+                .sharding_args = BufferShardingArgs(sender_data_shard_params, TensorMemoryLayout::HEIGHT_SHARDED),
+                .bottom_up = false};
+            const ReplicatedBufferConfig buffer_config{.size = data_size};
+
+            auto sender_data_buffer = MeshBuffer::create(buffer_config, sender_device_local_config, mesh_device_.get());
+            auto sender_mesh_workload = CreateMeshWorkload();
+
+            for (const auto& connection : socket.get_config().socket_connection_config) {
+                WriteShard(
+                    mesh_device_->mesh_command_queue(),
+                    sender_data_buffer,
+                    src_vec,
+                    connection.sender_core.device_coord);
+
+                auto sender_fabric_node_id =
+                    mesh_device_->get_device_fabric_node_id(connection.sender_core.device_coord);
+                auto recv_fabric_node_id =
+                    socket.get_fabric_node_id(SocketEndpoint::RECEIVER, connection.receiver_core.device_coord);
+
+                auto sender_program = CreateProgram();
+
+                auto sender_kernel = CreateKernel(
+                    sender_program,
+                    "tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp",
+                    sender_core,
+                    DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_0,
+                        .noc = NOC::RISCV_0_default,
+                        .compile_args =
+                            {static_cast<uint32_t>(socket.get_config_buffer()->address()),
+                             static_cast<uint32_t>(sender_data_buffer->address()),
+                             static_cast<uint32_t>(page_size),
+                             static_cast<uint32_t>(data_size)},
+                        .defines = {{"FABRIC_MAX_PACKET_SIZE", std::to_string(fabric_max_packet_size)}}});
+
+                tt::tt_metal::CircularBufferConfig sender_cb_reserved_packet_header_config =
+                    tt::tt_metal::CircularBufferConfig(
+                        2 * packet_header_size_bytes, {{reserved_packet_header_CB_index, tt::DataFormat::UInt32}})
+                        .set_page_size(reserved_packet_header_CB_index, packet_header_size_bytes);
+
+                auto sender_packet_header_CB_handle =
+                    CreateCircularBuffer(sender_program, sender_core, sender_cb_reserved_packet_header_config);
+
+                std::vector<uint32_t> sender_rtas;
+                tt_fabric::append_fabric_connection_rt_args(
+                    sender_fabric_node_id, recv_fabric_node_id, 0, sender_program, {sender_core}, sender_rtas);
+
+                tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_core, sender_rtas);
+                AddProgramToMeshWorkload(
+                    sender_mesh_workload,
+                    std::move(sender_program),
+                    MeshCoordinateRange(connection.sender_core.device_coord));
+            }
+            // Run workload performing Data Movement over the socket
+            EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), sender_mesh_workload, false);
+            Finish(mesh_device_->mesh_command_queue());
+        } else {
+            auto recv_virtual_coord = mesh_device_->worker_core_from_logical_core(recv_core);
+            auto recv_data_shard_params =
+                ShardSpecBuffer(CoreRangeSet(recv_core), {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
+
+            const DeviceLocalBufferConfig recv_device_local_config{
+                .page_size = data_size,
+                .buffer_type = BufferType::L1,
+                .sharding_args = BufferShardingArgs(recv_data_shard_params, TensorMemoryLayout::HEIGHT_SHARDED),
+                .bottom_up = false};
+
+            const ReplicatedBufferConfig buffer_config{.size = data_size};
+            auto recv_data_buffer = MeshBuffer::create(buffer_config, recv_device_local_config, mesh_device_.get());
+
+            auto recv_mesh_workload = CreateMeshWorkload();
+            for (const auto& connection : socket.get_config().socket_connection_config) {
+                auto sender_fabric_node_id =
+                    socket.get_fabric_node_id(SocketEndpoint::SENDER, connection.sender_core.device_coord);
+                auto recv_fabric_node_id =
+                    mesh_device_->get_device_fabric_node_id(connection.receiver_core.device_coord);
+
+                auto recv_program = CreateProgram();
+
+                auto recv_virtual_coord = recv_data_buffer->device()->worker_core_from_logical_core(recv_core);
+                auto output_virtual_coord = recv_data_buffer->device()->worker_core_from_logical_core(recv_core);
+
+                tt::tt_metal::CircularBufferConfig recv_cb_packet_header_config =
+                    tt::tt_metal::CircularBufferConfig(
+                        packet_header_size_bytes, {{reserved_packet_header_CB_index, tt::DataFormat::UInt32}})
+                        .set_page_size(tt::CB::c_in0, packet_header_size_bytes);
+
+                auto recv_packet_header_CB_handle =
+                    CreateCircularBuffer(recv_program, recv_core, recv_cb_packet_header_config);
+
+                KernelHandle recv_kernel = CreateKernel(
+                    recv_program,
+                    "tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_receiver_worker.cpp",
+                    recv_core,
+                    DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_0,
+                        .noc = NOC::RISCV_0_default,
+                        .compile_args = {
+                            static_cast<uint32_t>(socket.get_config_buffer()->address()),
+                            static_cast<uint32_t>(reserved_packet_header_CB_index),
+                            static_cast<uint32_t>(page_size),
+                            static_cast<uint32_t>(data_size),
+                            static_cast<uint32_t>(recv_virtual_coord.x),
+                            static_cast<uint32_t>(recv_virtual_coord.y),
+                            static_cast<uint32_t>(recv_data_buffer->address())}});
+
+                std::vector<uint32_t> recv_rtas;
+                tt_fabric::append_fabric_connection_rt_args(
+                    recv_fabric_node_id, sender_fabric_node_id, 0, recv_program, {recv_core}, recv_rtas);
+                tt_metal::SetRuntimeArgs(recv_program, recv_kernel, recv_core, recv_rtas);
+                AddProgramToMeshWorkload(
+                    recv_mesh_workload,
+                    std::move(recv_program),
+                    MeshCoordinateRange(connection.receiver_core.device_coord));
+            }
+            // Run receiver workload using the created socket
+            EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), recv_mesh_workload, false);
+            for (const auto& connection : socket.get_config().socket_connection_config) {
+                std::vector<uint32_t> recv_data_readback;
+                ReadShard(
+                    mesh_device_->mesh_command_queue(),
+                    recv_data_readback,
+                    recv_data_buffer,
+                    connection.receiver_core.device_coord);
+                EXPECT_EQ(src_vec, recv_data_readback);
+            }
+        }
+        // Increment the source vector for the next iteration
+        // This is to ensure that the data is different for each transaction
+        for (int i = 0; i < src_vec.size(); i++) {
+            src_vec[i]++;
+        }
+    }
+}
+
+std::vector<uint32_t> get_neighbor_host_ranks(SystemConfig system_config) {
+    std::vector<uint32_t> recv_ranks;
+
+    if (system_config == SystemConfig::NANO_EXABOX) {
+        // Nano-Exabox has 5 hosts. Sender ranks assignment is customized for a particular Rank File.
+        recv_ranks = {0, 2, 3, 4};
+    } else if (system_config == SystemConfig::SPLIT_T3K || system_config == SystemConfig::DUAL_T3K) {
+        // Only a single recv node is needed for the dual host configurations.
+        recv_ranks = {0};
+    } else {
+        TT_THROW("Unsupported system configuration for multi-mesh single connection test.");
+    }
+    return recv_ranks;
+}
+
+void test_multi_mesh_single_conn_bwd(
+    std::shared_ptr<tt_metal::distributed::MeshDevice> mesh_device,
+    uint32_t socket_fifo_size,
+    uint32_t socket_page_size,
+    uint32_t data_size,
+    SystemConfig system_config) {
+    using namespace tt::tt_metal::distributed::multihost;
+    using namespace tt::tt_metal::distributed;
+    using namespace tt_metal;
+
+    auto distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
+
+    auto sender_logical_coord = CoreCoord(0, 0);
+    auto recv_logical_coord = CoreCoord(0, 0);
+
+    SocketConnection socket_connection = {
+        .sender_core = {MeshCoordinate(0, 0), sender_logical_coord},
+        .receiver_core = {MeshCoordinate(0, 0), recv_logical_coord}};
+
+    SocketMemoryConfig socket_mem_config = {
+        .socket_storage_type = tt_metal::BufferType::L1,
+        .fifo_size = socket_fifo_size,
+    };
+
+    constexpr uint32_t sender_rank = 1;
+    constexpr uint32_t num_iterations = 50;
+
+    if (*distributed_context->rank() == sender_rank) {
+        std::unordered_map<uint32_t, MeshSocket> sockets;
+        std::vector<uint32_t> recv_node_ranks = get_neighbor_host_ranks(system_config);
+
+        for (const auto& recv_rank : recv_node_ranks) {
+            SocketConfig socket_config = {
+                .socket_connection_config = {socket_connection},
+                .socket_mem_config = socket_mem_config,
+                .sender_rank = distributed_context->rank(),
+                .receiver_rank = tt::tt_metal::distributed::multihost::Rank{recv_rank}};
+            sockets.emplace(recv_rank, MeshSocket(mesh_device, socket_config));
+        }
+
+        for (int i = 0; i < num_iterations; i++) {
+            for (auto& [recv_node, socket] : sockets) {
+                test_socket_send_recv(mesh_device, socket, data_size, socket_page_size);
+            }
+        }
+
+    } else {
+        SocketConfig socket_config = {
+            .socket_connection_config = {socket_connection},
+            .socket_mem_config = socket_mem_config,
+            .sender_rank = tt::tt_metal::distributed::multihost::Rank{sender_rank},
+            .receiver_rank = distributed_context->rank()};
+        auto socket = MeshSocket(mesh_device, socket_config);
+        for (int i = 0; i < num_iterations; i++) {
+            test_socket_send_recv(mesh_device, socket, data_size, socket_page_size);
+        }
+    }
+    distributed_context->barrier();
+}
+
+void test_multi_mesh_single_conn_fwd(
+    std::shared_ptr<tt_metal::distributed::MeshDevice> mesh_device,
+    uint32_t socket_fifo_size,
+    uint32_t socket_page_size,
+    uint32_t data_size,
+    SystemConfig system_config) {
+    using namespace tt::tt_metal::distributed::multihost;
+    using namespace tt::tt_metal::distributed;
+    using namespace tt_metal;
+
+    auto distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
+
+    auto sender_logical_coord = CoreCoord(0, 0);
+    auto recv_logical_coord = CoreCoord(0, 0);
+
+    SocketConnection socket_connection = {
+        .sender_core = {MeshCoordinate(0, 0), sender_logical_coord},
+        .receiver_core = {MeshCoordinate(0, 0), recv_logical_coord}};
+    SocketMemoryConfig socket_mem_config = {
+        .socket_storage_type = tt_metal::BufferType::L1,
+        .fifo_size = socket_fifo_size,
+    };
+
+    constexpr uint32_t recv_rank = 1;
+    constexpr uint32_t num_iterations = 50;
+
+    if (*distributed_context->rank() == recv_rank) {
+        std::unordered_map<uint32_t, MeshSocket> sockets;
+        std::vector<uint32_t> sender_node_ranks = get_neighbor_host_ranks(system_config);
+
+        for (const auto& sender_rank : sender_node_ranks) {
+            SocketConfig socket_config = {
+                .socket_connection_config = {socket_connection},
+                .socket_mem_config = socket_mem_config,
+                .sender_rank = tt::tt_metal::distributed::multihost::Rank{sender_rank},
+                .receiver_rank = distributed_context->rank()};
+            sockets.emplace(sender_rank, MeshSocket(mesh_device, socket_config));
+        }
+        for (int i = 0; i < num_iterations; i++) {
+            for (auto& [sender_node, socket] : sockets) {
+                test_socket_send_recv(mesh_device, socket, data_size, socket_page_size);
+            }
+        }
+    } else {
+        SocketConfig socket_config = {
+            .socket_connection_config = {socket_connection},
+            .socket_mem_config = socket_mem_config,
+            .sender_rank = distributed_context->rank(),
+            .receiver_rank = tt::tt_metal::distributed::multihost::Rank{recv_rank}};
+        auto socket = MeshSocket(mesh_device, socket_config);
+        for (int i = 0; i < num_iterations; i++) {
+            test_socket_send_recv(mesh_device, socket, data_size, socket_page_size);
+        }
+    }
+    distributed_context->barrier();
+}
+
+void test_multi_mesh_multi_conn_fwd(
+    std::shared_ptr<tt_metal::distributed::MeshDevice> mesh_device,
+    uint32_t socket_fifo_size,
+    uint32_t socket_page_size,
+    uint32_t data_size,
+    SystemConfig system_config) {
+    using namespace tt::tt_metal::distributed::multihost;
+    using namespace tt::tt_metal::distributed;
+    using namespace tt_metal;
+
+    auto distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
+    std::unordered_map<uint32_t, MeshSocket> sockets;
+    std::vector<SocketConnection> socket_connections;
+    auto sender_logical_core = CoreCoord(0, 0);
+    auto recv_logical_core = CoreCoord(0, 0);
+
+    for (const auto& coord : MeshCoordinateRange(mesh_device->shape())) {
+        socket_connections.push_back(
+            {.sender_core = {coord, sender_logical_core}, .receiver_core = {coord, recv_logical_core}});
+    }
+
+    SocketMemoryConfig socket_mem_config = {
+        .socket_storage_type = BufferType::L1,
+        .fifo_size = socket_fifo_size,
+    };
+    constexpr uint32_t recv_rank = 1;
+    constexpr uint32_t num_iterations = 50;
+
+    if (*distributed_context->rank() == recv_rank) {
+        std::unordered_map<uint32_t, MeshSocket> sockets;
+        std::vector<uint32_t> sender_node_ranks = get_neighbor_host_ranks(system_config);
+
+        for (const auto& sender_rank : sender_node_ranks) {
+            SocketConfig socket_config = {
+                .socket_connection_config = {socket_connections},
+                .socket_mem_config = socket_mem_config,
+                .sender_rank = tt::tt_metal::distributed::multihost::Rank{sender_rank},
+                .receiver_rank = distributed_context->rank()};
+            sockets.emplace(sender_rank, MeshSocket(mesh_device, socket_config));
+        }
+        for (int i = 0; i < num_iterations; i++) {
+            for (auto& [sender_node, socket] : sockets) {
+                test_socket_send_recv(mesh_device, socket, data_size, socket_page_size);
+            }
+        }
+    } else {
+        SocketConfig socket_config = {
+            .socket_connection_config = {socket_connections},
+            .socket_mem_config = socket_mem_config,
+            .sender_rank = distributed_context->rank(),
+            .receiver_rank = tt::tt_metal::distributed::multihost::Rank{recv_rank},
+        };
+        auto socket = MeshSocket(mesh_device, socket_config);
+        for (int i = 0; i < num_iterations; i++) {
+            test_socket_send_recv(mesh_device, socket, data_size, socket_page_size);
+        }
+    }
+    distributed_context->barrier();
+}
+
+void test_multi_mesh_multi_conn_bidirectional(
+    std::shared_ptr<tt_metal::distributed::MeshDevice> mesh_device,
+    uint32_t socket_fifo_size,
+    uint32_t socket_page_size,
+    uint32_t data_size,
+    SystemConfig system_config) {
+    using namespace tt::tt_metal::distributed::multihost;
+    using namespace tt::tt_metal::distributed;
+    using namespace tt_metal;
+
+    auto distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
+    std::unordered_map<uint32_t, MeshSocket> forward_sockets;
+    std::unordered_map<uint32_t, MeshSocket> backward_sockets;
+    std::vector<SocketConnection> socket_connections;
+    auto sender_logical_core = CoreCoord(0, 0);
+    auto recv_logical_core = CoreCoord(0, 0);
+
+    for (const auto& coord : MeshCoordinateRange(mesh_device->shape())) {
+        socket_connections.push_back(
+            {.sender_core = {coord, sender_logical_core}, .receiver_core = {coord, recv_logical_core}});
+    }
+
+    SocketMemoryConfig socket_mem_config = {
+        .socket_storage_type = BufferType::L1,
+        .fifo_size = socket_fifo_size,
+    };
+    constexpr uint32_t aggregator_rank = 1;
+    constexpr uint32_t num_iterations = 50;
+
+    if (*distributed_context->rank() == aggregator_rank) {
+        std::unordered_map<uint32_t, MeshSocket> forward_sockets;
+        std::unordered_map<uint32_t, MeshSocket> backward_sockets;
+        std::vector<uint32_t> compute_node_ranks = get_neighbor_host_ranks(system_config);
+
+        for (const auto& compute_rank : compute_node_ranks) {
+            SocketConfig forward_socket_config = {
+                .socket_connection_config = {socket_connections},
+                .socket_mem_config = socket_mem_config,
+                .sender_rank = tt::tt_metal::distributed::multihost::Rank{compute_rank},
+                .receiver_rank = distributed_context->rank()};
+            forward_sockets.emplace(compute_rank, MeshSocket(mesh_device, forward_socket_config));
+
+            SocketConfig backward_socket_config = {
+                .socket_connection_config = {socket_connections},
+                .socket_mem_config = socket_mem_config,
+                .sender_rank = distributed_context->rank(),
+                .receiver_rank = tt::tt_metal::distributed::multihost::Rank{compute_rank}};
+            backward_sockets.emplace(compute_rank, MeshSocket(mesh_device, backward_socket_config));
+        }
+        for (int i = 0; i < num_iterations; i++) {
+            for (auto& [compute_node, forward_socket] : forward_sockets) {
+                test_socket_send_recv(mesh_device, forward_socket, data_size, socket_page_size);
+            }
+            for (auto& [compute_node, backward_socket] : backward_sockets) {
+                test_socket_send_recv(mesh_device, backward_socket, data_size, socket_page_size);
+            }
+        }
+        for (int i = 0; i < num_iterations; i++) {
+            for (auto& [compute_node, forward_socket] : forward_sockets) {
+                test_socket_send_recv(mesh_device, forward_socket, data_size, socket_page_size);
+            }
+        }
+        for (int i = 0; i < num_iterations; i++) {
+            for (auto& [compute_node, backward_socket] : backward_sockets) {
+                test_socket_send_recv(mesh_device, backward_socket, data_size, socket_page_size);
+            }
+        }
+    } else {
+        SocketConfig forward_socket_config = {
+            .socket_connection_config = {socket_connections},
+            .socket_mem_config = socket_mem_config,
+            .sender_rank = distributed_context->rank(),
+            .receiver_rank = tt::tt_metal::distributed::multihost::Rank{aggregator_rank}};
+        auto forward_socket = MeshSocket(mesh_device, forward_socket_config);
+
+        SocketConfig backward_socket_config = {
+            .socket_connection_config = {socket_connections},
+            .socket_mem_config = socket_mem_config,
+            .sender_rank = tt::tt_metal::distributed::multihost::Rank{aggregator_rank},
+            .receiver_rank = distributed_context->rank()};
+        auto backward_socket = MeshSocket(mesh_device, backward_socket_config);
+        for (int i = 0; i < num_iterations; i++) {
+            test_socket_send_recv(mesh_device, forward_socket, data_size, socket_page_size);
+            test_socket_send_recv(mesh_device, backward_socket, data_size, socket_page_size);
+        }
+
+        for (int i = 0; i < num_iterations; i++) {
+            test_socket_send_recv(mesh_device, forward_socket, data_size, socket_page_size);
+        }
+        for (int i = 0; i < num_iterations; i++) {
+            test_socket_send_recv(mesh_device, backward_socket, data_size, socket_page_size);
+        }
+    }
+    distributed_context->barrier();
+}
+
+}  // namespace multihost_utils
+
+}  // namespace fabric_router_tests::multihost
+}  // namespace tt::tt_fabric

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.hpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <chrono>
+#include <gtest/gtest.h>
+#include <stdint.h>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/fabric.hpp>
+
+namespace tt::tt_fabric {
+namespace fabric_router_tests::multihost {
+
+namespace multihost_utils {
+
+// System Types currently supported for testing
+enum class SystemConfig { SPLIT_T3K, DUAL_T3K, NANO_EXABOX };
+
+// Socket Test Variants
+enum class TestVariant { SINGLE_CONN_BWD, SINGLE_CONN_FWD, MULTI_CONN_FWD, MULTI_CONN_BIDIR };
+
+std::string get_system_config_name(SystemConfig system_config);
+
+std::string get_test_variant_name(TestVariant variant);
+
+// Configuration for Multi-Host Socket Tests
+struct SocketTestConfig {
+    uint32_t socket_fifo_size;
+    uint32_t socket_page_size;
+    uint32_t data_size;
+    TestVariant variant;
+    SystemConfig system_config;
+};
+
+void test_multi_mesh_single_conn_bwd(
+    std::shared_ptr<tt_metal::distributed::MeshDevice> mesh_device,
+    uint32_t socket_fifo_size,
+    uint32_t socket_page_size,
+    uint32_t data_size,
+    SystemConfig system_config);
+
+void test_multi_mesh_single_conn_fwd(
+    std::shared_ptr<tt_metal::distributed::MeshDevice> mesh_device,
+    uint32_t socket_fifo_size,
+    uint32_t socket_page_size,
+    uint32_t data_size,
+    SystemConfig system_config);
+
+void test_multi_mesh_multi_conn_fwd(
+    std::shared_ptr<tt_metal::distributed::MeshDevice> mesh_device,
+    uint32_t socket_fifo_size,
+    uint32_t socket_page_size,
+    uint32_t data_size,
+    SystemConfig system_config);
+
+void test_multi_mesh_multi_conn_bidirectional(
+    std::shared_ptr<tt_metal::distributed::MeshDevice> mesh_device,
+    uint32_t socket_fifo_size,
+    uint32_t socket_page_size,
+    uint32_t data_size,
+    SystemConfig system_config);
+
+}  // namespace multihost_utils
+
+}  // namespace fabric_router_tests::multihost
+}  // namespace tt::tt_fabric

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/nano_exabox_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/nano_exabox_mesh_graph_descriptor.yaml
@@ -1,0 +1,68 @@
+ChipSpec: {
+  arch: wormhole_b0,
+  ethernet_ports: {
+    N: 2,
+    E: 2,
+    S: 2,
+    W: 2,
+  }
+}
+
+Board: [
+  { name: 2x4,
+    type: Mesh,
+    topology: [2, 4]}
+]
+
+Mesh: [
+{
+  id: 0,
+  board: 2x4,
+  device_topology: [2, 4],
+  host_topology: [1, 1],
+  host_ranks: [[0]]},
+{
+  id: 1,
+  board: 2x4,
+  device_topology: [2, 4],
+  host_topology: [1, 1],
+
+  host_ranks: [[0]]},
+{
+  id: 2,
+  board: 2x4,
+  device_topology: [2, 4],
+  host_topology: [1, 1],
+  host_ranks: [[0]]},
+{
+  id: 3,
+  board: 2x4,
+  device_topology: [2, 4],
+  host_topology: [1, 1],
+  host_ranks: [[0]]},
+{
+  id: 4,
+  board: 2x4,
+  device_topology: [2, 4],
+  host_topology: [1, 1],
+  host_ranks: [[0]]}
+]
+
+Graph: [
+  [[0, S2], [1, S4]],
+  [[0, S3], [1, S5]],
+  [[1, S4], [0, S2]],
+  [[1, S5], [0, S3]],
+  [[0, S4], [2, S4]],
+  [[0, S5], [2, S5]],
+  [[2, S4], [0, S4]],
+  [[2, S5], [0, S5]],
+  [[0, N4], [3, S4]],
+  [[0, N5], [3, S5]],
+  [[3, S4], [0, N4]],
+  [[3, S5], [0, N5]],
+  [[0, N2], [4, S4]],
+  [[0, N3], [4, S5]],
+  [[4, S4], [0, N2]],
+  [[4, S5], [0, N3]],
+]

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -97,6 +97,7 @@ protected:
         P150,
         N300,
         P300,
+        N300_2x2,
         T3000,
         TG,
     };
@@ -184,6 +185,7 @@ private:
             case MeshDeviceType::P150: return MeshShape(1, 1);
             case MeshDeviceType::N300:
             case MeshDeviceType::P300: return MeshShape(2, 1);
+            case MeshDeviceType::N300_2x2: return MeshShape(2, 2);
             case MeshDeviceType::T3000: return MeshShape(2, 4);
             case MeshDeviceType::TG: return MeshShape(4, 8);
             default: TT_FATAL(false, "Querying shape for unspecified Mesh Type.");
@@ -204,6 +206,12 @@ private:
                 switch (arch) {
                     case tt::ARCH::WORMHOLE_B0: return MeshDeviceType::N300;
                     case tt::ARCH::BLACKHOLE: return MeshDeviceType::P300;
+                    default: return std::nullopt;
+                }
+            }
+            case 4: {
+                switch (arch) {
+                    case tt::ARCH::WORMHOLE_B0: return MeshDeviceType::N300_2x2;
                     default: return std::nullopt;
                 }
             }
@@ -268,6 +276,12 @@ protected:
     T3000MeshDevice1DFabricFixture() :
         MeshDeviceFixtureBase(Config{
             .mesh_device_types = {MeshDeviceType::T3000}, .num_cqs = 1, .fabric_config = tt_fabric::FabricConfig::FABRIC_1D}) {}
+};
+
+class GenericMeshDevice2DFabricFixture : public MeshDeviceFixtureBase {
+protected:
+    GenericMeshDevice2DFabricFixture() :
+        MeshDeviceFixtureBase(Config{.num_cqs = 1, .fabric_config = tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC}) {}
 };
 
 class T3000MeshDevice2DFabricFixture : public MeshDeviceFixtureBase {

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -81,7 +81,11 @@ public:
     std::vector<chan_id_t> get_valid_eth_chans_on_routing_plane(
         FabricNodeId fabric_node_id, routing_plane_id_t routing_plane_id) const;
 
-    // Return path from device to device in the fabric
+    // Return path from device to device in the fabric.
+    // Constraints:
+    // - src_fabric_node_id must be local to the host on which this ControlPlane is running.
+    // - If dst_fabric_node_id is not local to the current host, the path will end at a local
+    // fabric node routing to the remote cluster.
     std::vector<std::pair<FabricNodeId, chan_id_t>> get_fabric_route(
         FabricNodeId src_fabric_node_id, FabricNodeId dst_fabric_node_id, chan_id_t src_chan_id) const;
 

--- a/tt_metal/api/tt-metalium/distributed_context.hpp
+++ b/tt_metal/api/tt-metalium/distributed_context.hpp
@@ -106,6 +106,7 @@ using Tag = tt::stl::StrongType<int, struct TagTag>;
 using Color = tt::stl::StrongType<int, struct ColorTag>;
 using Key = tt::stl::StrongType<int, struct KeyTag>;
 using Size = tt::stl::StrongType<int, struct SizeTag>;
+using DistributedContextId = tt::stl::StrongType<int, struct DistributedContextIdTag>;
 
 class DistributedException : public std::exception {
 public:
@@ -154,6 +155,9 @@ public:
     // Returns true if the distributed context has already been initialized
     static bool is_initialized();
 
+    // Returns a unique ID for this distributed context instance
+    DistributedContextId id() const;
+
     //--- Topology ------------------------------------------------------------
     [[nodiscard]] virtual Rank rank() const = 0;
     [[nodiscard]] virtual Size size() const = 0;
@@ -164,6 +168,8 @@ public:
 
     //--- Point-to-point (blocking) -----------------------------------------
     virtual void send(tt::stl::Span<std::byte> buffer, Rank dest, Tag tag) const = 0;
+
+    virtual void ssend(tt::stl::Span<std::byte> buffer, Rank dest, Tag tag) const = 0;
 
     virtual void recv(tt::stl::Span<std::byte> buffer, Rank source, Tag tag) const = 0;
 
@@ -239,5 +245,13 @@ public:
     virtual std::size_t snoop_incoming_msg_size(Rank source, Tag tag) const = 0;
 
     virtual ~DistributedContext() = default;
+
+protected:
+    // This function is used to generate a unique ID for each DistributedContext instance.
+    // It allows tracking which contexts are in use, and can be used for creating context specific resources.
+    // This function is not thread-safe.
+    static DistributedContextId generate_unique_id();
+    DistributedContextId id_{0};  // Unique identifier for the context
 };
+
 }  // namespace tt::tt_metal::distributed::multihost

--- a/tt_metal/api/tt-metalium/routing_table_generator.hpp
+++ b/tt_metal/api/tt-metalium/routing_table_generator.hpp
@@ -49,6 +49,9 @@ public:
     RoutingTable get_inter_mesh_table() const { return this->inter_mesh_table_; }
 
     void print_routing_tables() const;
+    // Return a list of all exit nodes, across all meshes that are connected to the requested
+    // MeshID.
+    const std::vector<FabricNodeId>& get_exit_nodes_routing_to_mesh(MeshId mesh_id) const;
 
     std::unique_ptr<MeshGraph> mesh_graph;
 
@@ -59,9 +62,10 @@ private:
 
     RoutingTable intra_mesh_table_;
     RoutingTable inter_mesh_table_;
+    std::unordered_map<MeshId, std::vector<FabricNodeId>> mesh_to_exit_nodes_;
 
     std::vector<std::vector<std::vector<std::pair<chip_id_t, MeshId>>>> get_paths_to_all_meshes(
-        MeshId src, const InterMeshConnectivity& inter_mesh_connectivity);
+        MeshId src, const InterMeshConnectivity& inter_mesh_connectivity) const;
     void generate_intramesh_routing_table(const IntraMeshConnectivity& intra_mesh_connectivity);
     // when generating intermesh routing table, we use the intramesh connectivity table to find the shortest path to
     // the exit chip

--- a/tt_metal/distributed/mesh_socket.cpp
+++ b/tt_metal/distributed/mesh_socket.cpp
@@ -10,14 +10,46 @@ using namespace tt::tt_metal::distributed::multihost;
 
 namespace tt::tt_metal::distributed {
 
+namespace {
+
+void point_to_point_barrier(
+    const std::vector<Rank>& ranks, std::shared_ptr<multihost::DistributedContext> distributed_context) {
+    TT_FATAL(ranks.size() == 2, "Point-to-point barrier requires exactly two ranks.");
+    TT_FATAL(ranks[0] != ranks[1], "Point-to-Point barrier cannot be used for synchronization within the same rank.");
+    TT_FATAL(
+        distributed_context->rank() == ranks[0] || distributed_context->rank() == ranks[1],
+        "Point-to-Point barrier for ranks {} and {} cannot be called on rank {}.",
+        *ranks[0],
+        *ranks[1],
+        *distributed_context->rank());
+
+    if (distributed_context->rank() == ranks[0]) {
+        int sync_msg = 1;
+        distributed_context->ssend(
+            tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&sync_msg), sizeof(sync_msg)), ranks[1], Tag{0});
+    } else {
+        int sync_msg = 0;
+        distributed_context->recv(
+            tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&sync_msg), sizeof(sync_msg)), ranks[0], Tag{0});
+        TT_FATAL(sync_msg == 1, "Received unexpected message during point-to-point barrier.");
+    }
+}
+
+}  // namespace
+
 MeshSocket::MeshSocket(const std::shared_ptr<MeshDevice>& device, const SocketConfig& config) : config_(config) {
     auto context = config.distributed_context ? config.distributed_context : DistributedContext::get_current_world();
-    TT_FATAL(
-        context->rank() == config.sender_rank || context->rank() == config.receiver_rank,
-        "Cannot create a socket on rank {} with sender rank {} and receiver rank {}.",
-        *context->rank(),
-        *config.sender_rank,
-        *config.receiver_rank);
+
+    if (!(context->rank() == config.sender_rank || context->rank() == config.receiver_rank)) {
+        log_warning(
+            LogMetal,
+            "Creating a null socket on host rank {} with sender rank {} and receiver rank {}.",
+            *context->rank(),
+            *config.sender_rank,
+            *config.receiver_rank);
+        return;
+    }
+
     TT_FATAL(
         config.sender_rank != config.receiver_rank,
         "{} must only be used for communication between different host ranks, not within the same rank.",
@@ -36,7 +68,7 @@ MeshSocket::MeshSocket(const std::shared_ptr<MeshDevice>& device, const SocketCo
 }
 
 void MeshSocket::connect_with_peer(std::shared_ptr<multihost::DistributedContext> context) {
-    auto local_endpoint_desc = generate_local_endpoint_descriptor(*this);
+    auto local_endpoint_desc = generate_local_endpoint_descriptor(*this, context->id());
     SocketPeerDescriptor remote_endpoint_desc;
     // Convention:
     //  - Sender Endpoint sends its descriptor first, then receives the peer's descriptor.
@@ -54,6 +86,7 @@ void MeshSocket::connect_with_peer(std::shared_ptr<multihost::DistributedContext
         fabric_node_id_map_ = generate_fabric_node_id_map(config_, remote_endpoint_desc, local_endpoint_desc);
     }
     write_socket_configs(config_buffer_, local_endpoint_desc, remote_endpoint_desc, socket_endpoint_type_);
+    point_to_point_barrier({config_.sender_rank, config_.receiver_rank}, context);
 }
 
 std::pair<MeshSocket, MeshSocket> MeshSocket::create_socket_pair(

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -128,13 +128,14 @@ void validate_remote_desc(const SocketPeerDescriptor& local_desc, const SocketPe
         "Mismatch in number of chip IDs during handshake.");
 }
 
-Tag generate_descriptor_exchange_tag() {
+Tag generate_descriptor_exchange_tag(Rank peer_rank, std::optional<DistributedContextId> context_id) {
     // Generate a unique id to tag the exchange of socket peer
     // descriptors between the sender and receiver.
     // This is used to ensure that the sender and receiver are
     // exchanging the correct descriptors.
-    static uint32_t exchange_tag = 0;
-    return Tag{++exchange_tag};
+    static std::unordered_map<DistributedContextId, std::unordered_map<Rank, uint32_t>> exchange_tags;
+    DistributedContextId unique_context_id = context_id.value_or(DistributedContext::get_current_world()->id());
+    return Tag{exchange_tags[unique_context_id][peer_rank]++};
 }
 }  // namespace
 
@@ -238,7 +239,6 @@ void write_socket_configs(
 
     if (is_sender) {
         std::vector<sender_socket_md> config_data(config_buffer->size() / sizeof(sender_socket_md), sender_socket_md());
-
         for (const auto& [device_coord, indexed_connections] : grouped_connections) {
             for (const auto& [conn_idx, connection] : indexed_connections) {
                 const auto& [sender_core, recv_core] = connection;
@@ -253,7 +253,9 @@ void write_socket_configs(
 
                 uint32_t idx = core_to_core_id.at(sender_core.core_coord);
                 auto& md = config_data[idx];
+                md.bytes_acked = 0;
                 md.write_ptr = peer_descriptor.data_buffer_address;
+                md.bytes_sent = 0;
                 md.downstream_fifo_addr = peer_descriptor.data_buffer_address;
                 md.downstream_fifo_total_size = config.socket_mem_config.fifo_size;
                 md.downstream_mesh_id = *downstream_mesh_id;
@@ -283,6 +285,8 @@ void write_socket_configs(
 
                 uint32_t idx = core_to_core_id.at(recv_core.core_coord);
                 auto& md = config_data[idx];
+                md.bytes_sent = 0;
+                md.bytes_acked = 0;
                 md.read_ptr = local_descriptor.data_buffer_address;
                 md.fifo_addr = local_descriptor.data_buffer_address;
                 md.fifo_total_size = config.socket_mem_config.fifo_size;
@@ -298,14 +302,17 @@ void write_socket_configs(
     }
 }
 
-SocketPeerDescriptor generate_local_endpoint_descriptor(const MeshSocket& socket_endpoint) {
+SocketPeerDescriptor generate_local_endpoint_descriptor(
+    const MeshSocket& socket_endpoint, std::optional<DistributedContextId> context_id) {
     const auto& config = socket_endpoint.get_config();
     bool is_sender = socket_endpoint.get_socket_endpoint_type() == SocketEndpoint::SENDER;
+
+    auto peer_rank = is_sender ? config.receiver_rank : config.sender_rank;
     SocketPeerDescriptor local_endpoint_desc = {
         .config = config,
         .config_buffer_address = socket_endpoint.get_config_buffer()->address(),
         .data_buffer_address = is_sender ? 0 : socket_endpoint.get_data_buffer()->address(),
-        .exchange_tag = generate_descriptor_exchange_tag()  // Unique tag for this exchange
+        .exchange_tag = generate_descriptor_exchange_tag(peer_rank, context_id)  // Unique tag for this exchange
     };
     auto device = socket_endpoint.get_config_buffer()->device();
     for (const auto& [sender_core, recv_core] : config.socket_connection_config) {

--- a/tt_metal/distributed/mesh_socket_utils.hpp
+++ b/tt_metal/distributed/mesh_socket_utils.hpp
@@ -43,7 +43,8 @@ void write_socket_configs(
     const SocketPeerDescriptor& peer_descriptor,
     SocketEndpoint socket_endpoint);
 
-SocketPeerDescriptor generate_local_endpoint_descriptor(const MeshSocket& socket_endpoint);
+SocketPeerDescriptor generate_local_endpoint_descriptor(
+    const MeshSocket& socket_endpoint, std::optional<multihost::DistributedContextId> context_id = std::nullopt);
 
 void forward_descriptor_to_peer(
     const SocketPeerDescriptor& desc,

--- a/tt_metal/distributed/multihost/distributed_context.cpp
+++ b/tt_metal/distributed/multihost/distributed_context.cpp
@@ -27,4 +27,12 @@ void DistributedContext::set_current_world(const ContextPtr& ctx) { ContextImpl:
 
 bool DistributedContext::is_initialized() { return ContextImpl::is_initialized(); }
 
+DistributedContextId DistributedContext::id() const { return id_; }
+
+/* -------------------- DistributedContext ID generation --------------------- */
+DistributedContextId DistributedContext::generate_unique_id() {
+    static std::size_t next_id = 0;
+    return DistributedContextId(next_id++);
+}
+
 }  // namespace tt::tt_metal::distributed::multihost

--- a/tt_metal/distributed/multihost/mpi_distributed_context.cpp
+++ b/tt_metal/distributed/multihost/mpi_distributed_context.cpp
@@ -207,12 +207,14 @@ MPIContext::MPIContext(MPI_Comm comm) : comm_(comm) {
     MPI_CHECK(MPI_Comm_group(comm_, &group_));
     MPI_CHECK(MPI_Comm_rank(comm_, &rank_));
     MPI_CHECK(MPI_Comm_size(comm_, &size_));
+    id_ = DistributedContext::generate_unique_id();
 }
 
 MPIContext::MPIContext(MPI_Comm comm, MPI_Group group) : comm_(comm), group_(group) {
     MPI_Comm_set_errhandler(comm_, MPI_ERRORS_RETURN);  // don't abort on error
     MPI_CHECK(MPI_Comm_rank(comm_, &rank_));
     MPI_CHECK(MPI_Comm_size(comm_, &size_));
+    id_ = DistributedContext::generate_unique_id();
 }
 
 Rank MPIContext::rank() const { return Rank(rank_); }
@@ -225,6 +227,11 @@ void MPIContext::barrier() const { MPI_CHECK(MPI_Barrier(comm_)); }
 void MPIContext::send(tt::stl::Span<std::byte> buf, Rank dest, Tag tag) const {
     check_size_fits_int(buf.size());
     MPI_CHECK(MPI_Send(buf.data(), static_cast<int>(buf.size()), MPI_CHAR, *dest, *tag, comm_));
+}
+
+void MPIContext::ssend(tt::stl::Span<std::byte> buf, Rank dest, Tag tag) const {
+    check_size_fits_int(buf.size());
+    MPI_CHECK(MPI_Ssend(buf.data(), static_cast<int>(buf.size()), MPI_CHAR, *dest, *tag, comm_));
 }
 
 void MPIContext::recv(tt::stl::Span<std::byte> buf, Rank src, Tag tag) const {

--- a/tt_metal/distributed/multihost/mpi_distributed_context.hpp
+++ b/tt_metal/distributed/multihost/mpi_distributed_context.hpp
@@ -72,6 +72,7 @@ public:
 
     /* ---------------- point‑to‑point ------------------- */
     void send(tt::stl::Span<std::byte> buf, Rank dest, Tag tag) const override;
+    void ssend(tt::stl::Span<std::byte> buf, Rank dest, Tag tag) const override;
     void recv(tt::stl::Span<std::byte> buf, Rank source, Tag tag) const override;
 
     [[nodiscard]] RequestPtr isend(tt::stl::Span<std::byte> buf, Rank dest, Tag tag) const override;

--- a/tt_metal/distributed/multihost/single_host_context.cpp
+++ b/tt_metal/distributed/multihost/single_host_context.cpp
@@ -11,7 +11,7 @@ namespace tt::tt_metal::distributed::multihost {
 // ---------------------------------------------------------------------
 //                           Context implementation
 // ---------------------------------------------------------------------
-SingleHostContext::SingleHostContext() : rank_(0), size_(1) {}
+SingleHostContext::SingleHostContext() : rank_(0), size_(1) { id_ = DistributedContext::generate_unique_id(); }
 
 void SingleHostContext::create(int argc, char** argv) { current_world_ = std::make_shared<SingleHostContext>(); }
 
@@ -46,6 +46,10 @@ void SingleHostContext::barrier() const {
 
 void SingleHostContext::send(tt::stl::Span<std::byte> buf, Rank dest, Tag tag) const {
     TT_THROW("method send is unsupported for single-host distributed contexts.");
+}
+
+void SingleHostContext::ssend(tt::stl::Span<std::byte> buf, Rank dest, Tag tag) const {
+    TT_THROW("method ssend is unsupported for single-host distributed contexts.");
 }
 
 void SingleHostContext::recv(tt::stl::Span<std::byte> buf, Rank source, Tag tag) const {

--- a/tt_metal/distributed/multihost/single_host_context.hpp
+++ b/tt_metal/distributed/multihost/single_host_context.hpp
@@ -38,6 +38,7 @@ public:
 
     /* ---------------- point‑to‑point ------------------- */
     void send(tt::stl::Span<std::byte> buf, Rank dest, Tag tag) const override;
+    void ssend(tt::stl::Span<std::byte> buf, Rank dest, Tag tag) const override;
     void recv(tt::stl::Span<std::byte> buf, Rank source, Tag tag) const override;
 
     [[nodiscard]] RequestPtr isend(tt::stl::Span<std::byte> buf, Rank dest, Tag tag) const override;

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <iostream>
 #include <magic_enum/magic_enum.hpp>
 #include <algorithm>
 #include <cstddef>
@@ -1164,16 +1165,51 @@ eth_chan_directions ControlPlane::get_eth_chan_direction(FabricNodeId fabric_nod
 
 std::vector<std::pair<FabricNodeId, chan_id_t>> ControlPlane::get_fabric_route(
     FabricNodeId src_fabric_node_id, FabricNodeId dst_fabric_node_id, chan_id_t src_chan_id) const {
+    // Query the mesh coord range owned by the current host
+    auto host_local_coord_range = this->get_coord_range(this->get_local_mesh_id_bindings()[0], MeshScope::LOCAL);
+    auto src_mesh_coord = this->routing_table_generator_->mesh_graph->chip_to_coordinate(
+        src_fabric_node_id.mesh_id, src_fabric_node_id.chip_id);
+    auto dst_mesh_coord = this->routing_table_generator_->mesh_graph->chip_to_coordinate(
+        dst_fabric_node_id.mesh_id, dst_fabric_node_id.chip_id);
+    // The src node is considered valid in this API if its owned by the current host. This requires the node to be in a
+    // mesh and coordinate range on this host.
+    bool valid_src =
+        this->is_local_mesh(src_fabric_node_id.mesh_id) and host_local_coord_range.contains(src_mesh_coord);
+    // Fabric Route will terminate at the exit node if the host does not own the destination node. i.e. dest is not on a
+    // mesh or coordinte range owned by the host.
+    bool end_route_at_exit_node =
+        !(this->is_local_mesh(dst_fabric_node_id.mesh_id) and host_local_coord_range.contains(dst_mesh_coord));
+
+    TT_FATAL(
+        valid_src,
+        "Cannot generate the fabric route between {} and {} on host {}, since M {} is not local to the host.",
+        src_fabric_node_id,
+        dst_fabric_node_id,
+        this->local_mesh_binding_.host_rank,
+        src_fabric_node_id.mesh_id);
+
+    std::vector<FabricNodeId> candidate_end_nodes;
+    if (end_route_at_exit_node) {
+        // If routing to a mesh remote to the host, we need to generate a path to a local exit node that can direct
+        // traffic to the remote mesh.
+        candidate_end_nodes = routing_table_generator_->get_exit_nodes_routing_to_mesh(dst_fabric_node_id.mesh_id);
+    } else {
+        // If routing to a mesh local to the host, we can route directly to the destination chip.
+        candidate_end_nodes.push_back(dst_fabric_node_id);
+    }
+
     std::vector<std::pair<FabricNodeId, chan_id_t>> route;
     int i = 0;
-    // Find any eth chan on the plane id
-    while (src_fabric_node_id != dst_fabric_node_id) {
+    while (std::find(candidate_end_nodes.begin(), candidate_end_nodes.end(), src_fabric_node_id) ==
+           candidate_end_nodes.end()) {
         i++;
         auto src_mesh_id = src_fabric_node_id.mesh_id;
         auto src_chip_id = src_fabric_node_id.chip_id;
         auto dst_mesh_id = dst_fabric_node_id.mesh_id;
         auto dst_chip_id = dst_fabric_node_id.chip_id;
         if (i >= tt::tt_fabric::MAX_MESH_SIZE * tt::tt_fabric::MAX_NUM_MESHES) {
+            log_warning(
+                tt::LogFabric, "Could not find a route between {} and {}", src_fabric_node_id, dst_fabric_node_id);
             return {};
         }
         chan_id_t next_chan_id = 0;
@@ -1186,6 +1222,8 @@ std::vector<std::pair<FabricNodeId, chan_id_t>> ControlPlane::get_fabric_route(
         }
         if (next_chan_id == eth_chan_magic_values::INVALID_DIRECTION) {
             // The complete route b/w src and dst not found, probably some eth cores are reserved along the path
+            log_warning(
+                tt::LogFabric, "Could not find a route between {} and {}", src_fabric_node_id, dst_fabric_node_id);
             return {};
         }
         if (src_chan_id != next_chan_id) {
@@ -1197,7 +1235,12 @@ std::vector<std::pair<FabricNodeId, chan_id_t>> ControlPlane::get_fabric_route(
             this->get_connected_mesh_chip_chan_ids(src_fabric_node_id, next_chan_id);
         route.push_back({src_fabric_node_id, src_chan_id});
     }
-
+    if (end_route_at_exit_node) {
+        // When routing to a remote mesh, append the exit node to the route.
+        route.push_back(
+            {src_fabric_node_id,
+             this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][*dst_fabric_node_id.mesh_id]});
+    }
     return route;
 }
 
@@ -1418,24 +1461,10 @@ void ControlPlane::write_fabric_connections_to_tensix_cores(MeshId mesh_id, chip
     const auto& connected_chips_and_eth_cores = cluster.get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
 
     size_t num_eth_endpoint = 0;
-    for (const auto& [connected_chip_id, eth_cores] : connected_chips_and_eth_cores) {
-        // iterate all physically connected ethernet cores
-        for (const auto& eth_core : eth_cores) {
-            auto eth_channel_id = soc_desc.logical_eth_core_to_chan_map.at(eth_core);
-            bool is_fabric_connected = false;
-            eth_chan_directions router_direction = eth_chan_directions::COUNT;
-            for (const auto& [direction, eth_chans] :
-                 this->router_port_directions_to_physical_eth_chan_map_.at(src_fabric_node_id)) {
-                // Check if the physically connected channel is part of fabric channel
-                if (std::find(eth_chans.begin(), eth_chans.end(), eth_channel_id) != eth_chans.end()) {
-                    is_fabric_connected = true;
-                    router_direction = this->routing_direction_to_eth_direction(direction);
-                    break;
-                }
-            }
-            if (!is_fabric_connected) {
-                continue;
-            }
+    for (const auto& [direction, eth_chans] :
+         this->router_port_directions_to_physical_eth_chan_map_.at(src_fabric_node_id)) {
+        for (auto eth_channel_id : eth_chans) {
+            eth_chan_directions router_direction = this->routing_direction_to_eth_direction(direction);
             if (num_eth_endpoint >= tt::tt_fabric::tensix_fabric_connections_l1_info_t::MAX_FABRIC_ENDPOINTS) {
                 log_warning(
                     tt::LogFabric,
@@ -1668,7 +1697,7 @@ void ControlPlane::initialize_intermesh_eth_links() {
             for (auto link : extract_intermesh_eth_links(config_data[0], chip_id)) {
                 // Find the CoreCoord for this channel
                 for (const auto& [core_coord, channel] : soc_desc.logical_eth_core_to_chan_map) {
-                    if (channel == link) {
+                    if (channel == link and this->is_intermesh_eth_link_trained(chip_id, core_coord)) {
                         intermesh_eth_links.push_back({core_coord, link});
                         break;
                     }
@@ -1732,8 +1761,6 @@ bool ControlPlane::is_intermesh_eth_link(chip_id_t chip_id, CoreCoord eth_core) 
 
 // TODO: Support Intramesh links through this API as well
 bool ControlPlane::is_intermesh_eth_link_trained(chip_id_t chip_id, CoreCoord eth_core) const {
-    TT_FATAL(
-        this->is_intermesh_eth_link(chip_id, eth_core), "Can only call {} on intermesh ethernet links.", __FUNCTION__);
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     auto remote_connections = cluster.get_ethernet_connections_to_remote_devices();
     const auto& soc_desc = cluster.get_soc_desc(chip_id);
@@ -1830,8 +1857,13 @@ std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(
             // responsible for querying this information.
             // Note: On UBB systems, intermesh links are already identified as active by UMD, so control
             // plane does not need to do this.
+            const auto& eth_routing_info = cluster.get_eth_routing_info(chip_id);
             auto intermesh_links = this->get_intermesh_eth_links(chip_id);
             for (const auto& [eth_coord, eth_chan] : intermesh_links) {
+                if (eth_routing_info.find(eth_coord) != eth_routing_info.end() and
+                    eth_routing_info.at(eth_coord) == EthRouterMode::FABRIC_ROUTER and skip_reserved_cores) {
+                    continue;
+                }
                 active_ethernet_cores.insert(eth_coord);
             }
         }
@@ -1865,10 +1897,6 @@ void ControlPlane::generate_local_intermesh_link_table() {
     for (const auto& chip_id : cluster.user_exposed_chip_ids()) {
         if (this->has_intermesh_links(chip_id)) {
             for (const auto& [eth_core, chan_id] : this->get_intermesh_eth_links(chip_id)) {
-                if (not this->is_intermesh_eth_link_trained(chip_id, eth_core)) {
-                    // Link is untrained/unusuable
-                    continue;
-                }
                 // TODO: remove below logic, should at very least be using UMD apis to get ids
                 // But all this data can be provided by UMD
                 tt_cxy_pair virtual_eth_core(
@@ -2061,8 +2089,8 @@ void ControlPlane::assign_intermesh_link_directions_to_remote_host(const FabricN
             }
         }
         if (intermesh_routing_direction != RoutingDirection::NONE) {
-            router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)[intermesh_routing_direction].push_back(
-                eth_chan);
+            auto& direction_to_channel_map = router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id);
+            direction_to_channel_map[intermesh_routing_direction].push_back(eth_chan);
         }
     }
     // Compute the number of intermesh links requsted by the user and ensure that they could be mapped to physical links

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -154,7 +154,7 @@ void RoutingTableGenerator::generate_intramesh_routing_table(const IntraMeshConn
 // Shortest Path
 // TODO: Put into mesh algorithms?
 std::vector<std::vector<std::vector<std::pair<chip_id_t, MeshId>>>> RoutingTableGenerator::get_paths_to_all_meshes(
-    MeshId src, const InterMeshConnectivity& inter_mesh_connectivity) {
+    MeshId src, const InterMeshConnectivity& inter_mesh_connectivity) const {
     // TODO: add more tests for this
     std::uint32_t num_meshes = inter_mesh_connectivity.size();
     // avoid vector<bool> specialization
@@ -299,6 +299,7 @@ void RoutingTableGenerator::generate_intermesh_routing_table(
                     //    }
                     //  }
                 }
+                mesh_to_exit_nodes_[dst_mesh_id].push_back(FabricNodeId(MeshId{src_mesh_id}, exit_chip_id));
             }
         }
     }
@@ -337,5 +338,13 @@ void RoutingTableGenerator::print_routing_tables() const {
         }
     }
     log_debug(tt::LogFabric, "{}", ss.str());
+}
+
+const std::vector<FabricNodeId>& RoutingTableGenerator::get_exit_nodes_routing_to_mesh(MeshId mesh_id) const {
+    auto it = this->mesh_to_exit_nodes_.find(mesh_id);
+    if (it != this->mesh_to_exit_nodes_.end()) {
+        return it->second;
+    }
+    TT_THROW("No exit nodes found for mesh_id {}", *mesh_id);
 }
 }  // namespace tt::tt_fabric

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1085,14 +1085,14 @@ void Cluster::reserve_ethernet_cores_for_tunneling() {
                     }
                 }
             }
-            // We want to also add the eth cores that are connected to other chips possibly outside the opened
-            // cluster.
+            // Mark all remaining ethernet cores as idle
             const auto& soc_desc = get_soc_desc(chip_id);
             for (const auto& eth_channel : cluster_desc_->get_active_eth_channels(chip_id)) {
                 auto eth_core = soc_desc.get_eth_core_for_channel(eth_channel, CoordSystem::LOGICAL);
-                if (this->device_eth_routing_info_.at(chip_id).find(eth_core) ==
-                    this->device_eth_routing_info_.at(chip_id).end()) {
-                    this->device_eth_routing_info_.at(chip_id).insert({eth_core, EthRouterMode::IDLE});
+                // Chip ID is guaranteed to be present in device_eth_routing_info_, since it was populated above
+                auto& routing_info = this->device_eth_routing_info_[chip_id];
+                if (routing_info.find(eth_core) == routing_info.end()) {
+                    routing_info.insert({eth_core, EthRouterMode::IDLE});
                 }
             }
         }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21159

### Problem description
- The Nano-Exabox system, displayed below, is to be used as a bringup machine for Fabric based Multi-Node training.
<img width="1057" height="805" alt="image" src="https://github.com/user-attachments/assets/05584aa9-4079-4210-b48e-fa3e223895fc" />

- This requires Fabric and `MeshSockets` to be brought up on this system.
- This PR adds:
  - Some remaining Control Plane support for generating routes to remote host meshes
  - Mesh Socket changes to support handshaking between more than 2 hosts
  - Multi-Process + Multi-Host Routing and Socket tests

### What's changed
- Changes in `ControlPlane::get_fabric_route` to generate a route to an appropriate exit node when the destination node is on a remote mesh
- `MeshSocket` changes to support rank specific tags, instead of globally unique tags. Without this, host to host handshaking will hang
-  `peer_to_peer_barrier` in `MeshSocket` to resolve a race condition when the receiver host is slower than the sender. Without this barrier, the receiver host can overwrite any notifications from the sender, causing a hang
- Intermesh Routing + Socket tests for Nano-Exabox
- Multi-process Intermesh Routing + Socket tests for CI

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes