### PR TITLE
#0: Fix dangling reference, remove stale TODOs

### DIFF
--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -74,7 +74,7 @@ struct MeshMapperConfig {
 std::ostream& operator<<(std::ostream& os, const MeshMapperConfig::Placement& placement);
 std::ostream& operator<<(std::ostream& os, const MeshMapperConfig& config);
 
-// Distributes a host tensor onto a multi-device configuration.
+// Mapper interface used for distributing a tensor onto a mesh.
 class TensorToMesh {
 public:
     ~TensorToMesh();
@@ -85,9 +85,9 @@ public:
 
     static TensorToMesh create(const MeshDevice& mesh_device, const MeshMapperConfig& config);
 
-    // Distributes a tensor onto a mesh.
-    // The input tensor is expected to be host-side tensor consisting of 1 device shard (i.e., distributed over 1x1
-    // mesh); the output tensor will be a host-side tensor distributed over a mesh of the same shape as the mesh device.
+    // Maps a tensor onto a mesh.
+    // The input tensor is expected to be host-side tensor consisting of 1 device shard (i.e., mapped to 1x1 mesh).
+    // The output tensor will be a host-side tensor mapped to a mesh of the same shape as the mesh device.
     Tensor operator()(const Tensor& tensor) const;
 
     // Overload that takes in a span of logical data; used in situations where the tensor object might not be
@@ -134,7 +134,7 @@ struct MeshComposerConfig {
 
 std::ostream& operator<<(std::ostream& os, const MeshComposerConfig& config);
 
-// Composer interface that aggregates a multi-device tensor into a host tensor.
+// Composer interface used for aggregating a tensor distributed over a mesh.
 class MeshToTensor {
 public:
     ~MeshToTensor();
@@ -145,12 +145,12 @@ public:
 
     static MeshToTensor create(const MeshDevice& mesh_device, const MeshComposerConfig& config);
 
-    // Composes multi-device tensor into a single tensor.
-    // The input tensor is expected to be distributed over a mesh of the same shape as the mesh device; the output
-    // tensor will be a host-side tensor consisting of 1 device shard (i.e., distributed over 1x1 mesh).
+    // Composes a tensor distributed over a mesh.
+    // The input tensor is expected to be distributed over a mesh of the same shape as the mesh device.
+    // The output tensor will be a host-side tensor consisting of 1 device shard (i.e., mapped to 1x1 mesh).
     Tensor compose(const Tensor& tensor) const;
 
-    // Overload that returns a pair of logical data composed of a multi-device tensor and its shape.
+    // Overload that returns a pair of logical data and its shape, composed from a tensor distributed over a mesh.
     template <typename T>
     std::pair<std::vector<T>, Shape> compose(const Tensor& tensor) const;
 

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -86,10 +86,8 @@ public:
     static TensorToMesh create(const MeshDevice& mesh_device, const MeshMapperConfig& config);
 
     // Distributes a tensor onto a mesh.
-    // The input tensor is expected to be a "single device" tensor with `HostStorage`; the output tensor will be a
-    // distributed tensor with `MultiDeviceHostStorage`.
-    // TODO: #15840 - eliminate the distinction between `HostStorage` and `MultiDeviceHostStorage`. This means possibly
-    // removing this API, and instead relying on the overload that accepts the span of logical data.
+    // The input tensor is expected to be host-side tensor consisting of 1 device shard (i.e., distributed over 1x1
+    // mesh); the output tensor will be a host-side tensor distributed over the shape specified in `MeshMapperConfig`.
     Tensor operator()(const Tensor& tensor) const;
 
     // Overload that takes in a span of logical data; used in situations where the tensor object might not be
@@ -148,10 +146,8 @@ public:
     static MeshToTensor create(const MeshDevice& mesh_device, const MeshComposerConfig& config);
 
     // Composes multi-device tensor into a single tensor.
-    // The input tensor is expected to be distributed over a mesh; the output tensor will be a "single device" tensor
-    // with `HostStorage`.
-    // TODO: #15840 - eliminate the distinction between `HostStorage` and `MultiDeviceHostStorage`. This means possibly
-    // removing this API, and instead relying on the overload that returns the vector of logical data.
+    // The input tensor is expected to be distributed over a mesh as specified in `MeshComposerConfig`; the output
+    // tensor will be a host-side tensor consisting of 1 device shard (i.e., distributed over 1x1 mesh).
     Tensor compose(const Tensor& tensor) const;
 
     // Overload that returns a pair of logical data composed of a multi-device tensor and its shape.

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -87,7 +87,7 @@ public:
 
     // Distributes a tensor onto a mesh.
     // The input tensor is expected to be host-side tensor consisting of 1 device shard (i.e., distributed over 1x1
-    // mesh); the output tensor will be a host-side tensor distributed over the shape specified in `MeshMapperConfig`.
+    // mesh); the output tensor will be a host-side tensor distributed over a mesh of the same shape as the mesh device.
     Tensor operator()(const Tensor& tensor) const;
 
     // Overload that takes in a span of logical data; used in situations where the tensor object might not be
@@ -146,7 +146,7 @@ public:
     static MeshToTensor create(const MeshDevice& mesh_device, const MeshComposerConfig& config);
 
     // Composes multi-device tensor into a single tensor.
-    // The input tensor is expected to be distributed over a mesh as specified in `MeshComposerConfig`; the output
+    // The input tensor is expected to be distributed over a mesh of the same shape as the mesh device; the output
     // tensor will be a host-side tensor consisting of 1 device shard (i.e., distributed over 1x1 mesh).
     Tensor compose(const Tensor& tensor) const;
 

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -243,11 +243,13 @@ public:
 
     // Returns device `Storage`.
     // Throws if the tensor is not on device.
-    const DeviceStorage& device_storage() const;
+    const DeviceStorage& device_storage() const&;
+    const DeviceStorage& device_storage() const&& = delete;  // prevents dangling reference to temporaries.
 
     // Returns host `Storage`.
     // Throws if the tensor is not on host.
-    const HostStorage& host_storage() const;
+    const HostStorage& host_storage() const&;
+    const HostStorage& host_storage() const&& = delete;  // prevents dangling reference to temporaries.
 
     // Returns device `MeshBuffer`.
     // Throws if the tensor is not allocated on a device.

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -395,7 +395,8 @@ public:
 
     template <typename T>
     std::pair<std::vector<T>, Shape> compose(const Tensor& tensor) const {
-        const auto& src_buffer = tensor.cpu().host_storage().buffer();
+        const auto cpu_tensor = tensor.cpu();
+        const auto& src_buffer = cpu_tensor.host_storage().buffer();
 
         auto remap_fn = get_remap_fn(distribution_mode_, &global_range_);
         auto dst_buffer = tt::tt_metal::DistributedHostBuffer::create(distribution_shape_);

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -814,13 +814,13 @@ const TensorSpec& Tensor::tensor_spec() const { return this->tensor_attributes->
 
 Buffer* Tensor::buffer() const { return device_storage().get_buffer(); }
 
-const DeviceStorage& Tensor::device_storage() const {
+const DeviceStorage& Tensor::device_storage() const& {
     const auto* device_storage = std::get_if<DeviceStorage>(&this->storage());
     TT_FATAL(device_storage != nullptr, "Expected Tensor with DeviceStorage, got {}", this->storage_type());
     return *device_storage;
 }
 
-const HostStorage& Tensor::host_storage() const {
+const HostStorage& Tensor::host_storage() const& {
     const auto* host_storage = std::get_if<HostStorage>(&this->storage());
     TT_FATAL(host_storage != nullptr, "Expected Tensor with HostStorage, got {}", this->storage_type());
     return *host_storage;


### PR DESCRIPTION
### Ticket
N/A

### Problem description
This is not safe `const auto& src_buffer = tensor.cpu().host_storage().buffer();`

### What's changed
Fix the problem by retaining ownership of `cpu_tensor` explicitly. 

Qualify `Tensor::host_storage` and `Tensor::device_storage` methods to prevent this sort of issues from happening at compile time.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16238817688) - pending
- [X] New/Existing tests provide coverage for changes (`./build_Release/test/ttnn/unit_tests_ttnn_tensor`)