### PR TITLE
Enable persistent kernel cache from binary side

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -15,7 +15,6 @@ from tt_metal.tools.profiler.process_device_log import import_log_run_stats
 import tt_metal.tools.profiler.device_post_proc_config as device_post_proc_config
 from tabulate import tabulate
 import pandas as pd
-from models.utility_functions import enable_persistent_kernel_cache, disable_persistent_kernel_cache
 
 from conftest import is_6u
 
@@ -549,8 +548,6 @@ def run_fabric_edm(
     logger.warning("removing file profile_log_device.csv")
     subprocess.run(["rm", "-rf", f"{os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv"])
 
-    enable_persistent_kernel_cache()
-
     use_direct_exec = get_direct_mode()
 
     # Create the args string for daemon
@@ -592,7 +589,6 @@ def run_fabric_edm(
         result = subprocess.run(cmd, shell=True, capture_output=False)
         rc = result.returncode
 
-    disable_persistent_kernel_cache()
     if rc != 0:
         # Handle exit codes differently for daemon vs direct execution
         if rc == 1:

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp"
+#include "persistent_kernel_cache.hpp"
 
 // Global state for daemon mode
 static bool daemon_running = true;
@@ -385,6 +386,7 @@ static void run_daemon_mode() {
 }
 
 int main(int argc, char** argv) {
+    tt::tt_metal::detail::EnablePersistentKernelCache();
     if (argc > 1 && std::string(argv[1]) == "daemon_mode") {
         run_daemon_mode();
         return 0;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22634

### Problem description
Persistent kernel cache has not been used due to
- bug, recently fixed https://github.com/tenstorrent/tt-metal/pull/24542
- enabling from python side, which was not effective due to different process

### What's changed
Call EnablePersistentCache() from c++ code.
Confirmed `GenerateBinaries()` is not called once the kernel is ready.

`pytest tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py` resutls (if kernel cache is available)

- T3K
145 sec -> 114 sec (-21.4%)
- 6U
717 sec -> 661 sec (-7.8%)


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes