### PR TITLE
Fix TG Failures caused by af50228

### DIFF
--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2013,7 +2013,18 @@ const IntermeshLinkTable& ControlPlane::get_local_intermesh_link_table() const {
 
 uint64_t ControlPlane::get_asic_id(chip_id_t chip_id) const { return chip_id_to_asic_id_.at(chip_id); }
 
-std::vector<MeshId> ControlPlane::get_local_mesh_id_bindings() const { return this->local_mesh_binding_.mesh_ids; }
+std::vector<MeshId> ControlPlane::get_local_mesh_id_bindings() const {
+    const auto& mesh_id_bindings = this->local_mesh_binding_.mesh_ids;
+    const auto& user_mesh_ids = this->get_user_physical_mesh_ids();
+    std::vector<MeshId> local_mesh_ids;
+    for (const auto& mesh_id : mesh_id_bindings) {
+        if (std::find(user_mesh_ids.begin(), user_mesh_ids.end(), mesh_id) != user_mesh_ids.end()) {
+            local_mesh_ids.push_back(mesh_id);
+        }
+    }
+    TT_FATAL(!local_mesh_ids.empty(), "No local mesh ids found");
+    return local_mesh_ids;
+}
 
 HostRankId ControlPlane::get_local_host_rank_id_binding() const { return this->local_mesh_binding_.host_rank; }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
TG Regression Tests are failing.

### What's changed
The TG systems are "special" because they feature N150 Wormhole cards that serve as MMIO devices which are "gateways" to the 32-chip mesh. In our software, these N150 cards should not be exposed to the users.

This is a fix to avoid the footgun of unintentionally accessing a non-user accessible mesh. The more sustainable approach is to make it impossible for these footguns to occur. However, this is outside scope of immediate fix to resolve TG-regression failures and intention is to deprecate TG support.

While `control_plane` sees all meshes as defined by the Mesh Graph Descriptor, only the user-accessible mesh should be used for binding processes onto.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/16259421782 
- [x] T3K Unit Tests: https://github.com/tenstorrent/tt-metal/actions/runs/16259427361
- [x] TG Unit Tests: https://github.com/tenstorrent/tt-metal/actions/runs/16258592873
- [x] TG Frequent: https://github.com/tenstorrent/tt-metal/actions/runs/16259919253

