### PR TITLE
Give MetalInfra a stake in the CMake files under test

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -100,6 +100,7 @@ tests/tt_metal/distributed/ @cfjchu @tt-asaigal @omilyutin-tt
 tests/tt_metal/distributed/**/CMakeLists.txt @cfjchu @tt-asaigal @omilyutin-tt @tenstorrent/metalium-developers-infra
 tests/tt_metal/microbenchmarks/ethernet/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT
 tests/tt_metal/tt_metal/ @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @nhuang-tt @tt-aho @cfjchu @omilyutin-tt
+tests/tt_metal/tt_metal/**/CMakeLists.txt @abhullar-tt @aagarwalTT @jbaumanTT @tt-asaigal @nhuang-tt @tt-aho @cfjchu @omilyutin-tt @tenstorrent/metalium-developers-infra
 tests/tt_metal/tt_metal/perf_microbenchmark/routing/ @ubcheema @aagarwalTT
 tests/tt_metal/tt_metal/sfpi/ @nathan-TT @pgkeller
 tests/tt_metal/tt_metal/test_kernels/sfpi/ @nathan-TT @pgkeller


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Metal Infra manages CMake cleanup and codeowners are, generally, uninterested in such things.  Prefer not to pester them with CMake changes.

### What's changed
Metal Infra now co-owns some CMake files under test/ (similar to other dirs).
Module owners can go about their business without involving Metal Infra, and Metal Infra can work on build improvements without interrupting the module owners.