### PR TITLE
#0: Make reshape at the end of Conv DRAM optional

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -775,6 +775,7 @@ def test_conv_dram(
         slice_config=ttnn.Conv2dSliceConfig(
             slice_type=slice_type,
             num_slices=num_slices,
+            reshape_output_to_2d=False if input_layout == ttnn.TILE_LAYOUT else True,
         ),
     )
 

--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -194,5 +194,6 @@ def test_conv_dram(
         slice_config=ttnn.Conv2dSliceConfig(
             slice_type=slice_type,
             num_slices=num_slices,
+            reshape_output_to_2d=False if input_layout == ttnn.TILE_LAYOUT else True,
         ),
     )

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -460,11 +460,11 @@ Result conv2d_DRAM(
     if (conv_config.deallocate_activation) {
         input_tensor_on_device.deallocate(true);
     }
-    const auto flattened_output_shape = flatten_4d_shape(dram_output_tensor.logical_shape());
-    const auto flattened_padded_output_shape = flatten_4d_shape(dram_output_tensor.padded_shape());
-
-    dram_output_tensor = ttnn::reshape(dram_output_tensor, flattened_output_shape, flattened_padded_output_shape);
-
+    if (dram_slice_config.reshape_output_to_2d) {
+        const auto flattened_output_shape = flatten_4d_shape(dram_output_tensor.logical_shape());
+        const auto flattened_padded_output_shape = flatten_4d_shape(dram_output_tensor.padded_shape());
+        dram_output_tensor = ttnn::reshape(dram_output_tensor, flattened_output_shape, flattened_padded_output_shape);
+    }
     return {dram_output_tensor, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};
 }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -382,10 +382,11 @@ void py_bind_conv2d(py::module& module) {
         | Conv2dSliceConfig determines how this slicing happens.
         )doc");
     py_conv_slice_config.def(
-        py::init<Conv2dSliceConfig::SliceType, uint32_t>(),
+        py::init<Conv2dSliceConfig::SliceType, uint32_t, bool>(),
         py::kw_only(),
         py::arg("slice_type"),
-        py::arg("num_slices"));
+        py::arg("num_slices"),
+        py::arg("reshape_output_to_2d") = false);
     py_conv_slice_config.def_readwrite(
         "slice_type",
         &Conv2dSliceConfig::slice_type,
@@ -402,6 +403,15 @@ void py_bind_conv2d(py::module& module) {
         | The output tensor is divided into num_slices slices along the slice_type dimension.
         | The corresponding input tensor needed to calculate that output is determined and sliced.
         | If the size of the slice dimension is not divisible by num_slices, then the last slice will be smaller than the rest.
+        )doc");
+    py_conv_slice_config.def_readwrite(
+        "reshape_output_to_2d",
+        &Conv2dSliceConfig::reshape_output_to_2d,
+        R"doc(
+        | Default True
+        | Controls if the output is reshaped to a flattened 2D Tensor to match the shapes of Conv2D L1 Sharded Tensors.
+        | Set to False for Conv2D DRAM Slicing to keep the output in the original 4D shape [N, H, W, C].
+        | For Tiled outputs, it is recommended to set this to False.
         )doc");
     py::enum_<Conv2dSliceConfig::SliceType>(py_conv_slice_config, "SliceTypeEnum")
         .value("SliceHeight", Conv2dSliceConfig::SliceType::HEIGHT)

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -144,6 +144,9 @@ struct Conv2dSliceConfig {
 
     // Number of slices that the output tensor should be divided into.
     uint32_t num_slices = 0;
+
+    // Reshape output tensor to 2D
+    bool reshape_output_to_2d = true;
 };
 
 // TODO: Accept parallelization


### PR DESCRIPTION
### Problem description
DRAM Slicing with Tiled Outputs causes the width to be rounded up to tile height. If the output is flattened to 2D, the output shape becomes incorrect. Plus this reshape has a significant impact on performance.

### What's changed
Added a new boolean flag to DRAM Slice Config to enable/disable the reshape to 2D. This is by default true to maintain compatibility with the existing API. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes