### PR TITLE
Fix DeepSeek MLA unit tests by removing triton jit decorators from reference

### DIFF
--- a/models/demos/deepseek_v3/reference/deepseek/kernel.py
+++ b/models/demos/deepseek_v3/reference/deepseek/kernel.py
@@ -9,7 +9,6 @@ import triton.language as tl
 from triton import Config
 
 
-@triton.jit
 def act_quant_kernel(x_ptr, y_ptr, s_ptr, BLOCK_SIZE: tl.constexpr):
     pid = tl.program_id(axis=0)
     offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
@@ -31,7 +30,6 @@ def act_quant(x: torch.Tensor, block_size: int = 128) -> Tuple[torch.Tensor, tor
     return y, s
 
 
-@triton.jit
 def weight_dequant_kernel(x_ptr, s_ptr, y_ptr, M, N, BLOCK_SIZE: tl.constexpr):
     pid_m = tl.program_id(axis=0)
     pid_n = tl.program_id(axis=1)
@@ -64,8 +62,6 @@ fp8_gemm_configs = [
 ]
 
 
-@triton.autotune(configs=fp8_gemm_configs, key=["N", "K"])
-@triton.jit
 def fp8_gemm_kernel(
     a_ptr,
     b_ptr,


### PR DESCRIPTION
### Problem description
DeepSeek MLA unit tests don't run

### What's changed
Remove triton jit decorators from reference code so it runs on CPU.