### PR TITLE
TTT : Fix Qwen2.5-7B vLLM issues 

### DIFF
--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -718,8 +718,7 @@ class Attention(LightweightModule):
             keys_BKSD, values_BKSD = kv_cache[0], kv_cache[1]
         else:
             keys_BKSD, values_BKSD = self.layer_past[0], self.layer_past[1]
-
-        k_heads_1KSD_8b = ttnn.typecast(k_heads_1KSD, dtype=self.kv_cache_dtype)
+        k_heads_1KSD_8b = ttnn.typecast(k_heads_1KSD, dtype=self.keys_BKSD.dtype)
         ttnn.deallocate(k_heads_1KSD)
 
         # sharding k_fill to deal with update_cache memory limitation
@@ -728,7 +727,7 @@ class Attention(LightweightModule):
         else:
             k_fill = k_heads_1KSD_8b
 
-        v_heads_1VSD_8b = ttnn.typecast(v_heads_1VSD, dtype=self.kv_cache_dtype)
+        v_heads_1VSD_8b = ttnn.typecast(v_heads_1VSD, dtype=values_BKSD.dtype)
 
         ttnn.deallocate(v_heads_1VSD)
 

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -718,7 +718,7 @@ class Attention(LightweightModule):
             keys_BKSD, values_BKSD = kv_cache[0], kv_cache[1]
         else:
             keys_BKSD, values_BKSD = self.layer_past[0], self.layer_past[1]
-        k_heads_1KSD_8b = ttnn.typecast(k_heads_1KSD, dtype=self.keys_BKSD.dtype)
+        k_heads_1KSD_8b = ttnn.typecast(k_heads_1KSD, dtype=keys_BKSD.dtype)
         ttnn.deallocate(k_heads_1KSD)
 
         # sharding k_fill to deal with update_cache memory limitation

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -569,7 +569,9 @@ class ModelArgs:
             max_prefill_chunk_size_div1024 = int(max_prefill_chunk_size_div1024)
         self.max_prefill_chunk_size = max_prefill_chunk_size_div1024 * 1024
 
-        if self.base_model_name in ["Llama-3.1-8B", "Llama-3.2-11B", "Mistral-7B"] and self.device_name == "N150":
+        if (self.base_model_name in ["Llama-3.1-8B", "Llama-3.2-11B", "Mistral-7B"] and self.device_name == "N150") or (
+            self.base_model_name in ["Qwen2.5-7B"] and self.device_name == "N300"
+        ):
             logger.info(f"Reducing prefill_len_cutoff to 512 for {self.model_name} on {self.device_name}")
             self.prefill_len_cutoff = 512
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24680
https://github.com/tenstorrent/tt-metal/issues/24098

### Problem description
self.kv_cache_dtype does not match kv cache dtype when kv cache is allocated through vllm 
Qwen2.5-7b goes boom after 512

### What's changed
typecast to kv_cache tensor instead of a pre-set self.kv_cache_dtype
change prefill_cutoff_len to 512 for qwen7b on n300

### Checklist
t3k demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/16265907664