### PR TITLE
Llama TG: Add support for higher sequence lengths on 6U

### DIFF
--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -373,6 +373,8 @@ def test_demo_text(
     # TODO: Remove this once all batch sizes are supported on TG
     if os.environ.get("MESH_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("Llama TG only supports batch-32")
+    if galaxy_type == "6U" and apc_test:
+        pytest.skip("Skipping test since there is no 6U machines dedicated for APC")
     if apc_test and not pcc_check:
         raise ValueError("APC test requires PCC check to be enabled")
     if pcc_check:

--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -189,7 +189,7 @@ def create_tt_model(
 # optimization (LlamaOptimizations): Optimization level to use for the model (performance or accuracy)
 # MESH_DEVICE (str): Fake device to use for testing (N150, N300, T3K, TG). Usage: `export MESH_DEVICE=N150`, will enable running a single-chip demo on a multi-chip system.
 @pytest.mark.parametrize(
-    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, ci_only, pcc_check, num_layers, print_outputs",
+    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, apc_test, pcc_check, num_layers, print_outputs",
     [
         (  # Batch-32 run (Throughput) - 32 users, small prompt
             "models/demos/llama3_subdevices/demo/input_data_questions_prefill_128.json",  # input_prompts

--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_prefill_ccl_ops_TG.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_prefill_ccl_ops_TG.py
@@ -15,7 +15,6 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_gather_TG_post_commit import 
 )
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from tracy import signpost
-from tests.ttnn.unit_tests.operations.ccl.test_llama_prefill_ccl_ops import padded_shape
 
 NUM_BUFFERS = 16
 
@@ -26,7 +25,6 @@ def run_ag_with_trace(
     input_tensor,
     dim,
     persistent_output_tensor,
-    persistent_intermediate_buffer,
     num_links,
     cluster_axis,
     output_mem_config,
@@ -44,8 +42,7 @@ def run_ag_with_trace(
         input_tensor,
         dim=dim,
         cluster_axis=cluster_axis,
-        persistent_intermediate_buffer=persistent_intermediate_buffer,
-        multi_device_global_semaphore=[ccl_semaphore_handles[NUM_BUFFERS - 1], ccl_semaphore_handles[NUM_BUFFERS - 2]],
+        multi_device_global_semaphore=ccl_semaphore_handles[NUM_BUFFERS - 1],
         persistent_output_buffer=persistent_output_tensor,
         num_links=num_links,
         memory_config=output_mem_config,
@@ -65,11 +62,7 @@ def run_ag_with_trace(
                 input_tensor,
                 dim=dim,
                 cluster_axis=cluster_axis,
-                persistent_intermediate_buffer=persistent_intermediate_buffer,
-                multi_device_global_semaphore=[
-                    ccl_semaphore_handles[(2 * i) % NUM_BUFFERS],
-                    ccl_semaphore_handles[(2 * i + 1) % NUM_BUFFERS],
-                ],
+                multi_device_global_semaphore=ccl_semaphore_handles[i % NUM_BUFFERS],
                 persistent_output_buffer=persistent_output_tensor,
                 num_links=num_links,
                 memory_config=output_mem_config,
@@ -194,16 +187,6 @@ def run_all_gather_on_TG(
         mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
 
-    ttnn_persistent_intermediate_tensor = ttnn.from_torch(
-        torch.zeros(padded_shape(per_chip_output_shape, tile, num_devices, num_links, input_dtype)),
-        tile=ttnn.Tile(tile),
-        dtype=input_dtype,
-        device=mesh_device,
-        layout=layout,
-        memory_config=output_mem_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-    )
-
     sub_device_stall_group = []
     compute_grid_size = mesh_device.compute_with_storage_grid_size()
     ccl_sub_device_crs = ttnn.CoreRangeSet(
@@ -225,14 +208,12 @@ def run_all_gather_on_TG(
         for _ in range(NUM_BUFFERS)
     ]
     try:
-        # ttnn.visualize_mesh_device(mesh_device, tensor=ttnn_tensor)
         if trace_mode:
             ttnn_tensor_out = run_ag_with_trace(
                 input_tensor=ttnn_tensor,
                 dim=dim,
                 cluster_axis=cluster_axis,
                 mesh_device=mesh_device,
-                persistent_intermediate_buffer=ttnn_persistent_intermediate_tensor,
                 persistent_output_tensor=ttnn_persistent_output_tensor,
                 num_links=num_links,
                 output_mem_config=output_mem_config,
@@ -253,7 +234,6 @@ def run_all_gather_on_TG(
                     dim=dim,
                     cluster_axis=cluster_axis,
                     # mesh_device=mesh_device,
-                    persistent_intermediate_buffer=ttnn_persistent_intermediate_tensor,
                     persistent_output_buffer=ttnn_persistent_output_tensor,
                     multi_device_global_semaphore=ccl_semaphore_handles[i % NUM_BUFFERS],
                     num_links=num_links,
@@ -285,8 +265,6 @@ def run_all_gather_on_TG(
             persistent_tensor.buffer_address() == output_tensor.buffer_address()
         ), "Persistent tensor address mismatch"
 
-    # Repeat the input tensor to represent the fact that the full concatenated input tensor lives across every
-    # device in the line
     repeat_factor = [1] * len(output_golden.shape)
     repeat_factor[dim] = num_devices
     output_golden[:, :, :, :] = full_input_tensor_unfractured.repeat(repeat_factor)
@@ -411,7 +389,6 @@ def run_reduce_scatter_on_TG(
     warmup_iters: int = 0,
     cluster_axis: int = 0,
     trace_mode=False,
-    # New all-gather-async and persistent fabric params
 ):
     per_reduce_scatter_output_shape = list(per_chip_input_shape)
     per_reduce_scatter_output_shape[dim] *= num_devices
@@ -514,7 +491,7 @@ def run_reduce_scatter_on_TG(
             mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         ),
         ttnn.from_torch(
-            torch.zeros(padded_shape(per_chip_input_shape, tile, num_devices, num_links, input_dtype)),
+            torch.zeros(per_chip_output_shape),
             tile=ttnn.Tile(tile),
             dtype=input_dtype,
             device=mesh_device,
@@ -596,27 +573,17 @@ def run_reduce_scatter_on_TG(
     assert passed, f"FAILED: {output}"
 
 
-# Enumerate the post-commit cases explicitly
 @skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("seq_len", [128, 4096, 8192], ids=["128_seq", "4k_seq", "8k_seq"])
 @pytest.mark.parametrize(
-    "num_devices, num_links, per_chip_output_shape, dim, layout, input_dtype, cluster_axis, replication_factor",
+    "num_devices, num_links, width, dim, layout, input_dtype, cluster_axis, replication_factor",
     [
-        # 128 seq len
-        (8, 4, [1, 1, 128, 256 * 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 0, 4),
-        (4, 4, [1, 1, 128, 320 * 4], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
-        (4, 4, [1, 1, 128, 896 * 4], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
-        (4, 2, [1, 1, 128, 32 * 4], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, 1, 8),
-        # 4k seq len
-        (8, 4, [1, 1, 4096, 256 * 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 0, 4),
-        (4, 4, [1, 1, 4096, 320 * 4], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
-        (4, 4, [1, 1, 4096, 896 * 4], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
-        (4, 4, [1, 1, 4096, 32 * 4], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, 1, 8),
-        # 8k seq len
-        (8, 4, [1, 1, 8192, 256 * 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 0, 4),
-        (4, 4, [1, 1, 8192, 320 * 4], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
-        (4, 4, [1, 1, 8192, 896 * 4], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
-        (4, 4, [1, 1, 8192, 32 * 4], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, 1, 8),
+        (8, 4, 256, 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 0, 4),
+        (4, 4, 320, 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
+        (4, 4, 896, 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
+        (4, 4, 32, 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, 1, 8),
     ],
+    ids=["sh-256w", "sh-320w", "sh-896w", "sh-32w"],
 )
 @pytest.mark.parametrize(
     "buffer_type",
@@ -634,9 +601,10 @@ def run_reduce_scatter_on_TG(
 def test_all_gather_TG(
     mesh_device,
     num_devices,
-    per_chip_output_shape,
-    dim,
     num_links,
+    seq_len,
+    width,
+    dim,
     input_dtype,
     layout,
     buffer_type,
@@ -647,6 +615,8 @@ def test_all_gather_TG(
     warmup_iters,
     trace_mode,
 ):
+    per_chip_output_shape = [1, 1, seq_len, width * num_devices]
+
     run_all_gather_on_TG(
         mesh_device,
         num_devices,
@@ -666,24 +636,16 @@ def test_all_gather_TG(
     )
 
 
-# Enumerate the post-commit cases explicitly
 @skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("seq_len", [128, 4096, 8192], ids=["128_seq", "4k_seq", "8k_seq"])
 @pytest.mark.parametrize(
-    "num_devices, num_links, rs_input_shape, dim, layout, input_dtype, cluster_axis, replication_factor",
+    "num_devices, num_links, width, dim, layout, input_dtype, cluster_axis, replication_factor",
     [
-        # 128 seq len
-        (8, 4, [1, 1, 128, 2048], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 0, 4),
-        (4, 2, [1, 1, 128, 1280], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
-        (4, 4, [1, 1, 128, 3584], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
-        # 4k seq len
-        (8, 4, [1, 1, 4096, 2048], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 0, 4),
-        (4, 4, [1, 1, 4096, 1280], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
-        (4, 4, [1, 1, 4096, 3584], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
-        # 8k seq len
-        (8, 4, [1, 1, 8192, 2048], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 0, 4),
-        (4, 4, [1, 1, 8192, 1280], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
-        (4, 4, [1, 1, 8192, 3584], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
+        (8, 4, 2048, 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 0, 4),
+        (4, 4, 1280, 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
+        (4, 4, 3584, 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, 1, 8),
     ],
+    ids=["sh-2048w", "sh-1280w", "sh-3584w"],
 )
 @pytest.mark.parametrize(
     "buffer_type",
@@ -701,9 +663,10 @@ def test_all_gather_TG(
 def test_reduce_scatter_TG(
     mesh_device,
     num_devices,
-    rs_input_shape,
-    dim,
     num_links,
+    seq_len,
+    width,
+    dim,
     input_dtype,
     layout,
     buffer_type,
@@ -714,6 +677,8 @@ def test_reduce_scatter_TG(
     warmup_iters,
     trace_mode,
 ):
+    rs_input_shape = [1, 1, seq_len, width]
+
     run_reduce_scatter_on_TG(
         mesh_device,
         num_devices,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -32,7 +32,7 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
 
 ttnn::Tensor ExecuteAllGatherAsync::invoke(
     const ttnn::Tensor& input_tensor,
-    ttnn::Tensor& persistent_output_buffer,
+    const std::optional<ttnn::Tensor>& persistent_output_buffer,
     const int32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
     const uint32_t num_links,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
@@ -24,7 +24,7 @@ struct ExecuteAllGatherAsync {
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        ttnn::Tensor& persistent_output_buffer,
+        const std::optional<ttnn::Tensor>& persistent_output_buffer,
         int32_t dim,
         const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
         uint32_t num_links = 1,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.cpp
@@ -72,10 +72,11 @@ void bind_all_gather_async(pybind11::module& module, const ccl_operation_t& oper
             py::arg("subdevice_id") = std::nullopt,
             py::arg("use_optimal_ccl_for_llama") = false},
 
+        // ring
         ttnn::pybind_overload_t{
             [](const ccl_operation_t& self,
                const ttnn::Tensor& input_tensor,
-               ttnn::Tensor& persistent_output_buffer,
+               const std::optional<ttnn::Tensor>& persistent_output_buffer,
                const int32_t dim,
                const GlobalSemaphoreArg& multi_device_global_semaphore,
                const uint32_t num_links,
@@ -108,6 +109,7 @@ void bind_all_gather_async(pybind11::module& module, const ccl_operation_t& oper
             py::arg("cluster_axis") = std::nullopt,
             py::arg("use_optimal_ccl_for_llama") = false},
 
+        // line
         ttnn::pybind_overload_t{
             [](const ccl_operation_t& self,
                const ttnn::Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -291,7 +291,7 @@ tt::tt_metal::operation::ProgramWithCallbacks AllGatherAsync::create_program_at(
                 output_tensors[0],
                 this->dim,
                 this->num_links,
-                this->ring_size,
+                target_ring_size,
                 device_index,
                 this->topology,
                 this->semaphore.at(0),
@@ -385,7 +385,7 @@ Tensor all_gather_async_impl(
 
 Tensor all_gather_async_impl(
     const Tensor& input_tensor,
-    Tensor& persistent_output_buffer,
+    const std::optional<ttnn::Tensor>& persistent_output_buffer,
     const uint32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
     const uint32_t num_links,
@@ -399,6 +399,10 @@ Tensor all_gather_async_impl(
         std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr,
         "all_gather_async op is only supported for Fast Dispatch");
     uint32_t num_devices = devices.size();
+    uint32_t ring_size = num_devices;
+    if (cluster_axis.has_value()) {
+        ring_size = (cluster_axis.value() == 0) ? 8 : 4;
+    }
     TT_FATAL(num_devices > 1, "all_gather_async op will only work for num_devices > 1, but has {}", num_devices);
     ttnn::ccl::Topology ccl_topology = topology;
 
@@ -419,7 +423,7 @@ Tensor all_gather_async_impl(
                    devices,
                    dim,
                    num_links,
-                   num_devices,
+                   ring_size,
                    memory_config.value_or(input_tensor.memory_config()),
                    ccl_topology,
                    multi_device_global_semaphore,
@@ -447,7 +451,8 @@ Tensor all_gather_async_impl(
     const auto& mesh_view = mesh_device.get_view();
     TT_FATAL(
         mesh_view.is_mesh_2d(), "all-gather invoked with cluster_axis API on >2D mesh, which is currently unsupported");
-    std::size_t num_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
+    // std::size_t num_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
+    std::size_t num_devices = (cluster_axis == 0) ? 8 : 4;
 
     int32_t rank = input_tensor.logical_shape().rank();
 
@@ -508,7 +513,7 @@ Tensor all_gather_async(
 
 Tensor all_gather_async(
     const Tensor& input_tensor,
-    Tensor& persistent_output_buffer,
+    const std::optional<ttnn::Tensor>& persistent_output_buffer,
     const uint32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
     const uint32_t num_links,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -180,7 +180,7 @@ Tensor all_gather_async(
 
 Tensor all_gather_async(
     const Tensor& input_tensor,
-    Tensor& persistent_output_buffer,
+    const std::optional<ttnn::Tensor>& persistent_output_buffer,
     uint32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
     uint32_t num_links = 1,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.hpp
@@ -163,8 +163,7 @@ namespace ccl {
 
 Tensor reduce_scatter_minimal_async(
     const Tensor& input_tensor,
-    Tensor& persistent_intermediate_buffer,
-    Tensor& persistent_output_buffer,
+    const std::optional<std::vector<ttnn::Tensor>>& persistent_output_buffers,
     uint32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
     uint32_t num_links = 1,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -12,8 +12,7 @@ namespace ttnn::operations::experimental::ccl {
 
 ttnn::Tensor ExecuteReduceScatterMinimalAsync::invoke(
     const ttnn::Tensor& input_tensor,
-    ttnn::Tensor& persistent_intermediate_buffer,
-    ttnn::Tensor& persistent_output_buffer,
+    const std::optional<std::vector<ttnn::Tensor>>& persistent_output_buffers,
     const int32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
     const uint32_t num_links,
@@ -23,8 +22,7 @@ ttnn::Tensor ExecuteReduceScatterMinimalAsync::invoke(
     std::optional<uint32_t> cluster_axis) {
     return ttnn::operations::experimental::ccl::reduce_scatter_minimal_async(
         input_tensor,
-        persistent_intermediate_buffer,
-        persistent_output_buffer,
+        persistent_output_buffers,
         dim,
         multi_device_global_semaphore,
         num_links,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.hpp
@@ -14,8 +14,7 @@ namespace operations::experimental::ccl {
 struct ExecuteReduceScatterMinimalAsync {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        ttnn::Tensor& persistent_intermediate_buffer,
-        ttnn::Tensor& persistent_output_buffer,
+        const std::optional<std::vector<ttnn::Tensor>>& persistent_output_buffers,
         int32_t dim,
         const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
         uint32_t num_links = 1,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async_pybind.cpp
@@ -28,8 +28,7 @@ void bind_reduce_scatter_minimal_async(pybind11::module& module, const ccl_opera
         ttnn::pybind_overload_t{
             [](const ccl_operation_t& self,
                const ttnn::Tensor& input_tensor,
-               ttnn::Tensor& persistent_intermediate_buffer,
-               ttnn::Tensor& persistent_output_buffer,
+               const std::optional<std::vector<ttnn::Tensor>>& persistent_output_buffers,
                const int32_t dim,
                const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
                const uint32_t num_links,
@@ -39,8 +38,7 @@ void bind_reduce_scatter_minimal_async(pybind11::module& module, const ccl_opera
                std::optional<uint32_t> cluster_axis) -> ttnn::Tensor {
                 return self(
                     input_tensor,
-                    persistent_intermediate_buffer,
-                    persistent_output_buffer,
+                    persistent_output_buffers,
                     dim,
                     multi_device_global_semaphore,
                     num_links,
@@ -50,8 +48,7 @@ void bind_reduce_scatter_minimal_async(pybind11::module& module, const ccl_opera
                     cluster_axis);
             },
             py::arg("input_tensor"),
-            py::arg("persistent_intermediate_buffer"),
-            py::arg("persistent_output_buffer"),
+            py::arg("persistent_output_buffers") = std::nullopt,
             py::arg("dim"),
             py::arg("multi_device_global_semaphore"),
             py::kw_only(),


### PR DESCRIPTION
### Problem description
Current ring implementation of ccl ops expected preallocated persistent buffers, so it could only be used for sequence lengths up to 8k. 

### What's changed
- Added support for optional persistent output tensors in ring implementation of  `AllGatherAsync` and `ReduceScatterMinimalAsync` ops 
- Changed `llama_ccl` to support seqlens that don't have preallocated buffers

Tested on `glx6u-04` for seqlens 16k, 32k, 64k and 128k.
[TG pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/16295774247)
### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes