### PR TITLE
reenable cache for test_split

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_split.py
+++ b/tests/ttnn/unit_tests/operations/test_split.py
@@ -26,9 +26,6 @@ dims = [0, 1, 2, 3, 4]
 @pytest.mark.parametrize("chunksize", chunksize_list)
 @pytest.mark.parametrize("dim", dims)
 def test_split(device, layout, dtype, shape, chunksize, dim):
-    # https://github.com/tenstorrent/tt-metal/issues/23237
-    device.disable_and_clear_program_cache()
-
     if dim > len(shape) - 1:
         pytest.skip("dim greater than rank")
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23237)

### Problem description
This test was failing with cache enabled, @amorrisonTT already did a fix and cache can be reenabled for this

### What's changed
[Describe the approach used to solve the problem.
Summarize the changes made and its impact.
](https://github.com/tenstorrent/tt-metal/pull/24667/files)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes