### PR TITLE
Add query_op_constraint tests for unary and binary pointwise ops.

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -203,7 +203,8 @@ class EltwiseUnaryOpIfTest : public TTNNFixtureWithDevice,
 TEST_P(EltwiseUnaryOpIfTest, UnaryRelu) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    // TODO: Enable BH when ready (#25088)
+    if (board_type != BoardType::N300) {
         GTEST_SKIP();
     }
 
@@ -226,7 +227,7 @@ TEST_P(EltwiseUnaryOpIfTest, UnaryRelu) {
 TEST_P(EltwiseUnaryOpIfTest, Sqrt) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    if (board_type != BoardType::N300) {
         GTEST_SKIP();
     }
 
@@ -249,7 +250,7 @@ TEST_P(EltwiseUnaryOpIfTest, Sqrt) {
 TEST_P(EltwiseUnaryOpIfTest, Sigmoid) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    if (board_type != BoardType::N300) {
         GTEST_SKIP();
     }
 
@@ -280,7 +281,7 @@ TEST_P(EltwiseUnaryOpIfTest, Sigmoid) {
 TEST_P(EltwiseUnaryOpIfTest, ClampScalar) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    if (board_type != BoardType::N300) {
         GTEST_SKIP();
     }
 
@@ -307,7 +308,7 @@ TEST_P(EltwiseUnaryOpIfTest, ClampScalar) {
 TEST_P(EltwiseUnaryOpIfTest, Reciprocal) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    if (board_type != BoardType::N300) {
         GTEST_SKIP();
     }
 
@@ -330,7 +331,7 @@ TEST_P(EltwiseUnaryOpIfTest, Reciprocal) {
 TEST_P(EltwiseUnaryOpIfTest, Sin) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    if (board_type != BoardType::N300) {
         GTEST_SKIP();
     }
 
@@ -353,7 +354,7 @@ TEST_P(EltwiseUnaryOpIfTest, Sin) {
 TEST_P(EltwiseUnaryOpIfTest, Cos) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    if (board_type != BoardType::N300) {
         GTEST_SKIP();
     }
 
@@ -407,7 +408,7 @@ TEST_P(SoftmaxOpIfTest, Softmax) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const auto& dim_arg = std::get<int>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    if (board_type != BoardType::N300) {
         GTEST_SKIP();
     }
 
@@ -461,7 +462,7 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryAdd) {
     const auto& input_spec_a = std::get<0>(GetParam());
     const auto& input_spec_b = std::get<1>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    if (board_type != BoardType::N300) {
         GTEST_SKIP();
     }
 
@@ -529,7 +530,7 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryMul) {
     const auto& input_spec_a = std::get<0>(GetParam());
     const auto& input_spec_b = std::get<1>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    if (board_type != BoardType::N300) {
         GTEST_SKIP();
     }
 
@@ -563,7 +564,7 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryMax) {
     const auto& input_spec_a = std::get<0>(GetParam());
     const auto& input_spec_b = std::get<1>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    if (board_type != BoardType::N300) {
         GTEST_SKIP();
     }
 
@@ -597,7 +598,7 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryMin) {
     const auto& input_spec_a = std::get<0>(GetParam());
     const auto& input_spec_b = std::get<1>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    if (board_type != BoardType::N300) {
         GTEST_SKIP();
     }
 

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -200,9 +200,9 @@ class EltwiseUnaryOpIfTest : public TTNNFixtureWithDevice,
 TEST_P(EltwiseUnaryOpIfTest, UnaryRelu) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-        GTEST_SKIP();
-    }
+    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    //    GTEST_SKIP ();
+    //}
 
     // Run the test
     {
@@ -210,6 +210,129 @@ TEST_P(EltwiseUnaryOpIfTest, UnaryRelu) {
         const auto& output_spec = input_spec;
         auto query = ttnn::graph::query_op_constraints(
             ttnn::relu, device, input_spec, output_spec.tensor_layout().get_memory_config());
+
+        EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
+        // Ensure some real usage is reported
+        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 1024);
+        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 1024);
+        ASSERT_TRUE(query.output_tensor_spec.has_value());
+        EXPECT_EQ(query.output_tensor_spec.value(), input_spec);
+    }
+}
+
+TEST_P(EltwiseUnaryOpIfTest, Sqrt) {
+    const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
+    const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
+    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    //    GTEST_SKIP ();
+    //}
+
+    // Run the test
+    {
+        tt::tt_metal::IDevice* device = device_;
+        const auto& output_spec = input_spec;
+        auto query = ttnn::graph::query_op_constraints(
+            ttnn::sqrt, device, input_spec, output_spec.tensor_layout().get_memory_config());
+
+        EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
+        // Ensure some real usage is reported
+        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 1024);
+        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 1024);
+        ASSERT_TRUE(query.output_tensor_spec.has_value());
+        EXPECT_EQ(query.output_tensor_spec.value(), input_spec);
+    }
+}
+
+TEST_P(EltwiseUnaryOpIfTest, Sigmoid) {
+    const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
+    const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
+    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    //    GTEST_SKIP ();
+    //}
+
+    // Run the test
+    {
+        tt::tt_metal::IDevice* device = device_;
+        const auto& output_spec = input_spec;
+        // Add default parameters
+        int32_t vectorMode = static_cast<int32_t>(::ttnn::operations::unary::VecMode::RC);
+        bool approximateMode = false;
+        auto query = ttnn::graph::query_op_constraints(
+            ttnn::sigmoid,
+            device,
+            input_spec,
+            vectorMode,
+            approximateMode,
+            output_spec.tensor_layout().get_memory_config());
+
+        EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
+        // Ensure some real usage is reported
+        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 1024);
+        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 1024);
+        ASSERT_TRUE(query.output_tensor_spec.has_value());
+        EXPECT_EQ(query.output_tensor_spec.value(), input_spec);
+    }
+}
+
+TEST_P(EltwiseUnaryOpIfTest, Reciprocal) {
+    const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
+    const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
+    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    //    GTEST_SKIP ();
+    //}
+
+    // Run the test
+    {
+        tt::tt_metal::IDevice* device = device_;
+        const auto& output_spec = input_spec;
+        auto query = ttnn::graph::query_op_constraints(
+            ttnn::reciprocal, device, input_spec, output_spec.tensor_layout().get_memory_config());
+
+        EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
+        // Ensure some real usage is reported
+        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 1024);
+        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 1024);
+        ASSERT_TRUE(query.output_tensor_spec.has_value());
+        EXPECT_EQ(query.output_tensor_spec.value(), input_spec);
+    }
+}
+
+TEST_P(EltwiseUnaryOpIfTest, Sin) {
+    const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
+    const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
+    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    //    GTEST_SKIP ();
+    //}
+
+    // Run the test
+    {
+        tt::tt_metal::IDevice* device = device_;
+        const auto& output_spec = input_spec;
+        auto query = ttnn::graph::query_op_constraints(
+            ttnn::sin, device, input_spec, output_spec.tensor_layout().get_memory_config());
+
+        EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
+        // Ensure some real usage is reported
+        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 1024);
+        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 1024);
+        ASSERT_TRUE(query.output_tensor_spec.has_value());
+        EXPECT_EQ(query.output_tensor_spec.value(), input_spec);
+    }
+}
+
+TEST_P(EltwiseUnaryOpIfTest, Cos) {
+    const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
+    const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
+    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    //    GTEST_SKIP ();
+    //}
+
+    // Run the test
+    {
+        tt::tt_metal::IDevice* device = device_;
+        const auto& output_spec = input_spec;
+        auto query = ttnn::graph::query_op_constraints(
+            ttnn::cos, device, input_spec, output_spec.tensor_layout().get_memory_config());
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
         // Ensure some real usage is reported
@@ -308,9 +431,9 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryAdd) {
     const auto& input_spec_a = std::get<0>(GetParam());
     const auto& input_spec_b = std::get<1>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-        GTEST_SKIP();
-    }
+    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    //    GTEST_SKIP();
+    //}
 
     // Run the test
     {
@@ -320,6 +443,74 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryAdd) {
 
         auto query = ttnn::graph::query_op_constraints(
             ttnn::add,
+            device,
+            input_spec_a,
+            input_spec_b,
+            output_spec.data_type(),
+            output_spec.tensor_layout().get_memory_config(),
+            std::nullopt,
+            none,
+            none,
+            none,
+            false);
+
+        EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
+        // Ensure some real usage is reported
+        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 1024);
+        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 1024);
+    }
+}
+
+TEST_P(EltwiseBinaryOpIfTest, BinarySubtract) {  //----------- TEMP ---------------
+    const auto& input_spec_a = std::get<0>(GetParam());
+    const auto& input_spec_b = std::get<1>(GetParam());
+    const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
+    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    //     GTEST_SKIP();
+    // }
+
+    // Run the test
+    {
+        tt::tt_metal::IDevice* device = device_;
+        const auto& output_spec = input_spec_a;
+        constexpr tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> none{};
+
+        auto query = ttnn::graph::query_op_constraints(
+            ttnn::subtract,
+            device,
+            input_spec_a,
+            input_spec_b,
+            output_spec.data_type(),
+            output_spec.tensor_layout().get_memory_config(),
+            std::nullopt,
+            none,
+            none,
+            none,
+            false);
+
+        EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
+        // Ensure some real usage is reported
+        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 1024);
+        EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 1024);
+    }
+}
+
+TEST_P(EltwiseBinaryOpIfTest, BinaryMul) {  //----------- TEMP ---------------
+    const auto& input_spec_a = std::get<0>(GetParam());
+    const auto& input_spec_b = std::get<1>(GetParam());
+    const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
+    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+    //     GTEST_SKIP();
+    // }
+
+    // Run the test
+    {
+        tt::tt_metal::IDevice* device = device_;
+        const auto& output_spec = input_spec_a;
+        constexpr tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> none{};
+
+        auto query = ttnn::graph::query_op_constraints(
+            ttnn::multiply,
             device,
             input_spec_a,
             input_spec_b,

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -30,6 +30,7 @@
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/eltwise/unary/unary_composite.hpp"
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "ttnn/operations/functions.hpp"
 #include "ttnn/operations/matmul/device/matmul_op.hpp"
@@ -202,9 +203,9 @@ class EltwiseUnaryOpIfTest : public TTNNFixtureWithDevice,
 TEST_P(EltwiseUnaryOpIfTest, UnaryRelu) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-    //    GTEST_SKIP ();
-    //}
+    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+        GTEST_SKIP();
+    }
 
     // Run the test
     {
@@ -225,9 +226,9 @@ TEST_P(EltwiseUnaryOpIfTest, UnaryRelu) {
 TEST_P(EltwiseUnaryOpIfTest, Sqrt) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-    //    GTEST_SKIP ();
-    //}
+    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+        GTEST_SKIP();
+    }
 
     // Run the test
     {
@@ -248,9 +249,9 @@ TEST_P(EltwiseUnaryOpIfTest, Sqrt) {
 TEST_P(EltwiseUnaryOpIfTest, Sigmoid) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-    //    GTEST_SKIP ();
-    //}
+    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+        GTEST_SKIP();
+    }
 
     // Run the test
     {
@@ -279,9 +280,9 @@ TEST_P(EltwiseUnaryOpIfTest, Sigmoid) {
 TEST_P(EltwiseUnaryOpIfTest, ClampScalar) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-    //    GTEST_SKIP ();
-    //}
+    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+        GTEST_SKIP();
+    }
 
     // Run the test
     {
@@ -306,9 +307,9 @@ TEST_P(EltwiseUnaryOpIfTest, ClampScalar) {
 TEST_P(EltwiseUnaryOpIfTest, Reciprocal) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-    //    GTEST_SKIP ();
-    //}
+    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+        GTEST_SKIP();
+    }
 
     // Run the test
     {
@@ -329,9 +330,9 @@ TEST_P(EltwiseUnaryOpIfTest, Reciprocal) {
 TEST_P(EltwiseUnaryOpIfTest, Sin) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-    //    GTEST_SKIP ();
-    //}
+    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+        GTEST_SKIP();
+    }
 
     // Run the test
     {
@@ -352,9 +353,9 @@ TEST_P(EltwiseUnaryOpIfTest, Sin) {
 TEST_P(EltwiseUnaryOpIfTest, Cos) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-    //    GTEST_SKIP ();
-    //}
+    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+        GTEST_SKIP();
+    }
 
     // Run the test
     {
@@ -460,9 +461,9 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryAdd) {
     const auto& input_spec_a = std::get<0>(GetParam());
     const auto& input_spec_b = std::get<1>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-    //    GTEST_SKIP();
-    //}
+    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+        GTEST_SKIP();
+    }
 
     // Run the test
     {
@@ -490,13 +491,13 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryAdd) {
     }
 }
 
-TEST_P(EltwiseBinaryOpIfTest, BinarySubtract) {  //----------- TEMP ---------------
+TEST_P(EltwiseBinaryOpIfTest, BinarySubtract) {
     const auto& input_spec_a = std::get<0>(GetParam());
     const auto& input_spec_b = std::get<1>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-    //     GTEST_SKIP();
-    // }
+    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+        GTEST_SKIP();
+    }
 
     // Run the test
     {
@@ -524,13 +525,13 @@ TEST_P(EltwiseBinaryOpIfTest, BinarySubtract) {  //----------- TEMP ------------
     }
 }
 
-TEST_P(EltwiseBinaryOpIfTest, BinaryMul) {  //----------- TEMP ---------------
+TEST_P(EltwiseBinaryOpIfTest, BinaryMul) {
     const auto& input_spec_a = std::get<0>(GetParam());
     const auto& input_spec_b = std::get<1>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-    //     GTEST_SKIP();
-    // }
+    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+        GTEST_SKIP();
+    }
 
     // Run the test
     {
@@ -558,13 +559,13 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryMul) {  //----------- TEMP ---------------
     }
 }
 
-TEST_P(EltwiseBinaryOpIfTest, BinaryMax) {  //----------- TEMP ---------------
+TEST_P(EltwiseBinaryOpIfTest, BinaryMax) {
     const auto& input_spec_a = std::get<0>(GetParam());
     const auto& input_spec_b = std::get<1>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-    //     GTEST_SKIP();
-    // }
+    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+        GTEST_SKIP();
+    }
 
     // Run the test
     {
@@ -592,13 +593,13 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryMax) {  //----------- TEMP ---------------
     }
 }
 
-TEST_P(EltwiseBinaryOpIfTest, BinaryMin) {  //----------- TEMP ---------------
+TEST_P(EltwiseBinaryOpIfTest, BinaryMin) {
     const auto& input_spec_a = std::get<0>(GetParam());
     const auto& input_spec_b = std::get<1>(GetParam());
     const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
-    // if (board_type != BoardType::N300 && board_type != BoardType::E150) {
-    //     GTEST_SKIP();
-    // }
+    if (board_type != BoardType::N300 && board_type != BoardType::E150) {
+        GTEST_SKIP();
+    }
 
     // Run the test
     {


### PR DESCRIPTION
### Ticket
Issue tenstorrent/tt-mlir#3987

### Problem description
Adding query_op_constraints unit tests on metal for all ops used in OpModel.

### What's changed
Added tests for most unary and binary eltwise ops. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes