### PR TITLE
Improve accuracy of pow function with new implementation

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -13,131 +13,14 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-// Helper function for _sfpu_binary_power_
-// This function convert a float32 to int32, given that in >= 0.0f.
-sfpi_inline sfpi::vInt _float_to_int32_positive_(sfpi::vFloat in) {
-    sfpi::vInt result;
-    sfpi::vInt exp = exexp(in);  // extract exponent
-    v_if(exp < 0) { result = 0; }
-    v_elseif(exp > 30)  // overflow occurs above this range
-    {
-        // set to int32 max value in case of overflow
-        result = std::numeric_limits<int32_t>::max();
-    }
-    v_else {
-        // extract mantissa
-        sfpi::vInt man = exman8(in);
-        // shift the mantissa by (23-exponent) to the right
-        sfpi::vInt shift = exp - 23;  // 23 is number of mantissa in float32
-        man = shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
-
-        result = man;
-    }
-    v_endif;
-    return result;
-}
-
-sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow) {
-    // Normalize base to calculation range
-    sfpi::vFloat x = setsgn(base, 0);  // set base as positive
-    x = sfpi::setexp(x, 127);          // set exp to exp bias (put base in range of 1-2)
-
-    // 3rd order polynomial approx - determined using rminimax over [1,2]
-    sfpi::vFloat series_result = x * (x * (x * 0x2.44734p-4f - 0xd.e712ap-4f) + 0x2.4f5388p+0f) - 0x1.952992p+0f;
-
-    // Convert exponent to float
-    sfpi::vInt exp = sfpi::exexp(base);
-    v_if(exp < 0) { exp = sfpi::setsgn(~exp + 1, 1); }
-    v_endif;
-    sfpi::vFloat expf = sfpi::int32_to_float(exp, 0);
-
-    // De-normalize to original range
-    const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;        // 1.4426950408889634f;
-    sfpi::vFloat log2_result = expf + series_result * vConst1Ln2;  // exp correction: ln(1+x) + exp*ln(2)
-
-    sfpi::vFloat zff = pow * log2_result;
-    const sfpi::vFloat low_threshold = sfpi::vConstFloatPrgm1;
-    v_if(zff < low_threshold) {  // -126.99999237060546875
-        zff = low_threshold;
-    }
-    v_endif;
-
-    zff = addexp(zff, 23);                                                 // * 2**23 (Mn)
-    sfpi::vInt z = _float_to_int32_positive_(zff + sfpi::vFloat(0x3f800000));  // (bias + x * log2(a)) * N_m
-
-    sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));
-    sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));
-
-    sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
-    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif);
-    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif);
-    d2 = d1 * d2;
-    zif = _float_to_int32_positive_(d2 * d3);
-
-    // zii |= zif; // restore exponent
-    zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));
-
-    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(zii);
-
-    // Check valid base range
-    sfpi::vInt pow_int =
-        sfpi::float_to_int16(pow, 0);  // int16 should be plenty, since large powers will approach 0/Inf
-    sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
-
-    v_if(base == 0.f && pow < 0.f) {  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
-        y = std::numeric_limits<float>::quiet_NaN();
-    }
-    v_endif
-
-    v_if(base < 0.0f) {  // negative base
-        // Check for integer power
-        v_if(pow_rounded == pow) {
-            // if pow is odd integer, set result to negative
-            v_if(pow_int & 0x1) {
-                // if negative base and negative pow then x**y = -(abs(x))**(abs(y))
-                // `sign` will be used at the end
-                y = setsgn(y, 1);
-            }
-            v_endif;
-        }
-        v_else {
-            // multiplication by NaN gives NaN.
-            // Since we are going to multiply the result by `sign` to handle negative bases, we also use
-            // `sign` to handle NaN results
-            y = std::numeric_limits<float>::quiet_NaN();
-        }
-        v_endif;
-    }
-    v_endif;
-
-    return y;
-}  // namespace ckernel
-
 template <bool APPROXIMATION_MODE, BinaryOp BINOP, int ITERATIONS = 8>
 inline void calculate_sfpu_binary(const uint dst_offset) {
-    if constexpr (BINOP == BinaryOp::POW) {
-        for (int d = 0; d < ITERATIONS; d++) {
-            constexpr uint dst_tile_size = 32;
-            sfpi::vFloat in0 = sfpi::dst_reg[0];
-            sfpi::vFloat in1 = sfpi::dst_reg[dst_offset * dst_tile_size];
-            sfpi::vFloat result = _sfpu_binary_power_(in0, in1);
-
-            sfpi::dst_reg[0] = result;
-            sfpi::dst_reg++;
-        }
-    } else {
-        _calculate_sfpu_binary_<APPROXIMATION_MODE, BINOP, ITERATIONS>(dst_offset);
-    }
+    _calculate_sfpu_binary_<APPROXIMATION_MODE, BINOP, ITERATIONS>(dst_offset);
 }
 
 template <bool APPROXIMATION_MODE /*unused*/, BinaryOp BINOP>
 inline void sfpu_binary_init() {
-    if constexpr (BINOP == BinaryOp::POW) {
-        sfpi::vConstFloatPrgm0 = 1.442695f;
-        sfpi::vConstFloatPrgm1 = -127.0f;
-    } else {
-        _sfpu_binary_init_<APPROXIMATION_MODE, BINOP>();
-    }
+    _sfpu_binary_init_<APPROXIMATION_MODE, BINOP>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -13,7 +13,9 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-inline sfpi::vInt _float_to_int32_fast_(sfpi::vFloat in) {
+// Helper function for _sfpu_binary_power_
+// This function convert a float32 to int32, given that in >= 0.0f.
+sfpi_inline sfpi::vInt _float_to_int32_positive_(sfpi::vFloat in) {
     sfpi::vInt result;
     sfpi::vInt exp = exexp(in);  // extract exponent
     v_if(exp < 0) { result = 0; }
@@ -61,7 +63,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow
     v_endif;
 
     zff = addexp(zff, 23);                                                 // * 2**23 (Mn)
-    sfpi::vInt z = _float_to_int32_fast_(zff + sfpi::vFloat(0x3f800000));  // (bias + x * log2(a)) * N_m
+    sfpi::vInt z = _float_to_int32_positive_(zff + sfpi::vFloat(0x3f800000));  // (bias + x * log2(a)) * N_m
 
     sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));
     sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));
@@ -70,7 +72,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow
     sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif);
     sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif);
     d2 = d1 * d2;
-    zif = _float_to_int32_fast_(d2 * d3);
+    zif = _float_to_int32_positive_(d2 * d3);
 
     // zii |= zif; // restore exponent
     zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -13,14 +13,129 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
+inline sfpi::vInt _float_to_int32_fast_(sfpi::vFloat in) {
+    sfpi::vInt result;
+    sfpi::vInt exp = exexp(in);  // extract exponent
+    v_if(exp < 0) { result = 0; }
+    v_elseif(exp > 30)  // overflow occurs above this range
+    {
+        // set to int32 max value in case of overflow
+        result = std::numeric_limits<int32_t>::max();
+    }
+    v_else {
+        // extract mantissa
+        sfpi::vInt man = exman8(in);
+        // shift the mantissa by (23-exponent) to the right
+        sfpi::vInt shift = exp - 23;  // 23 is number of mantissa in float32
+        man = shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
+
+        result = man;
+    }
+    v_endif;
+    return result;
+}
+
+sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow) {
+    // Normalize base to calculation range
+    sfpi::vFloat x = setsgn(base, 0);  // set base as positive
+    x = sfpi::setexp(x, 127);          // set exp to exp bias (put base in range of 1-2)
+
+    // 3rd order polynomial approx - determined using rminimax over [1,2]
+    sfpi::vFloat series_result = x * (x * (x * 0x2.44734p-4f - 0xd.e712ap-4f) + 0x2.4f5388p+0f) - 0x1.952992p+0f;
+
+    // Convert exponent to float
+    sfpi::vInt exp = sfpi::exexp(base);
+    v_if(exp < 0) { exp = sfpi::setsgn(~exp + 1, 1); }
+    v_endif;
+    sfpi::vFloat expf = sfpi::int32_to_float(exp, 0);
+
+    // De-normalize to original range
+    const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;        // 1.4426950408889634f;
+    sfpi::vFloat log2_result = expf + series_result * vConst1Ln2;  // exp correction: ln(1+x) + exp*ln(2)
+
+    sfpi::vFloat zff = pow * log2_result;
+    const sfpi::vFloat low_threshold = sfpi::vConstFloatPrgm1;
+    v_if(zff < low_threshold) {  // -126.99999237060546875
+        zff = low_threshold;
+    }
+    v_endif;
+
+    zff = addexp(zff, 23);                                                 // * 2**23 (Mn)
+    sfpi::vInt z = _float_to_int32_fast_(zff + sfpi::vFloat(0x3f800000));  // (bias + x * log2(a)) * N_m
+
+    sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));
+    sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));
+
+    sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
+    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif);
+    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif);
+    d2 = d1 * d2;
+    zif = _float_to_int32_fast_(d2 * d3);
+
+    // zii |= zif; // restore exponent
+    zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));
+
+    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(zii);
+
+    // Check valid base range
+    sfpi::vInt pow_int =
+        sfpi::float_to_int16(pow, 0);  // int16 should be plenty, since large powers will approach 0/Inf
+    sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
+
+    v_if(base == 0.f && pow < 0.f) {  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
+        y = std::numeric_limits<float>::quiet_NaN();
+    }
+    v_endif
+
+    v_if(base < 0.0f) {  // negative base
+        // Check for integer power
+        v_if(pow_rounded == pow) {
+            // if pow is odd integer, set result to negative
+            v_if(pow_int & 0x1) {
+                // if negative base and negative pow then x**y = -(abs(x))**(abs(y))
+                // `sign` will be used at the end
+                y = setsgn(y, 1);
+            }
+            v_endif;
+        }
+        v_else {
+            // multiplication by NaN gives NaN.
+            // Since we are going to multiply the result by `sign` to handle negative bases, we also use
+            // `sign` to handle NaN results
+            y = std::numeric_limits<float>::quiet_NaN();
+        }
+        v_endif;
+    }
+    v_endif;
+
+    return y;
+}  // namespace ckernel
+
 template <bool APPROXIMATION_MODE, BinaryOp BINOP, int ITERATIONS = 8>
 inline void calculate_sfpu_binary(const uint dst_offset) {
-    _calculate_sfpu_binary_<APPROXIMATION_MODE, BINOP, ITERATIONS>(dst_offset);
+    if constexpr (BINOP == BinaryOp::POW) {
+        for (int d = 0; d < ITERATIONS; d++) {
+            constexpr uint dst_tile_size = 32;
+            sfpi::vFloat in0 = sfpi::dst_reg[0];
+            sfpi::vFloat in1 = sfpi::dst_reg[dst_offset * dst_tile_size];
+            sfpi::vFloat result = _sfpu_binary_power_(in0, in1);
+
+            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg++;
+        }
+    } else {
+        _calculate_sfpu_binary_<APPROXIMATION_MODE, BINOP, ITERATIONS>(dst_offset);
+    }
 }
 
 template <bool APPROXIMATION_MODE /*unused*/, BinaryOp BINOP>
 inline void sfpu_binary_init() {
-    _sfpu_binary_init_<APPROXIMATION_MODE, BINOP>();
+    if constexpr (BINOP == BinaryOp::POW) {
+        sfpi::vConstFloatPrgm0 = 1.442695f;
+        sfpi::vConstFloatPrgm1 = -127.0f;
+    } else {
+        _sfpu_binary_init_<APPROXIMATION_MODE, BINOP>();
+    }
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -14,7 +14,8 @@ namespace ckernel {
 namespace sfpu {
 
 // Helper function for _sfpu_binary_power_
-// This function convert a float32 to int32, given that in >= 0.0f.
+// This function is based _float32_to_int32_, but expects a positive input, which allows us to optimize
+// away several lines (and make it faster)
 sfpi_inline sfpi::vInt _float_to_int32_positive_(sfpi::vFloat in) {
     sfpi::vInt result;
     sfpi::vInt exp = exexp(in);  // extract exponent

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -13,14 +13,130 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
+inline sfpi::vInt _float_to_int32_fast_(sfpi::vFloat in) {
+    sfpi::vInt result;
+    sfpi::vInt exp = exexp(in);  // extract exponent
+    v_if(exp < 0) { result = 0; }
+    v_elseif(exp > 30)  // overflow occurs above this range
+    {
+        // set to int32 max value in case of overflow
+        result = std::numeric_limits<int32_t>::max();
+    }
+    v_else {
+        // extract mantissa
+        sfpi::vInt man = exman8(in);
+        // shift the mantissa by (23-exponent) to the right
+        sfpi::vInt shift = exp - 23;  // 23 is number of mantissa in float32
+        man = shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
+
+        result = man;
+    }
+    v_endif;
+    return result;
+}
+
+sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow) {
+    // Normalize base to calculation range
+    sfpi::vFloat x = setsgn(base, 0);  // set base as positive
+    x = sfpi::setexp(x, 127);          // set exp to exp bias (put base in range of 1-2)
+
+    // 3rd order polynomial approx - determined using rminimax over [1,2]
+    sfpi::vFloat series_result = x * (x * (x * 0x2.44734p-4f - 0xd.e712ap-4f) + 0x2.4f5388p+0f) - 0x1.952992p+0f;
+
+    // Convert exponent to float
+    sfpi::vInt exp = sfpi::exexp(base);
+    v_if(exp < 0) { exp = sfpi::setsgn(~exp + 1, 1); }
+    v_endif;
+    sfpi::vFloat expf = sfpi::int32_to_float(exp, 0);
+
+    // De-normalize to original range
+    const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;        // 1.4426950408889634f;
+    sfpi::vFloat log2_result = expf + series_result * vConst1Ln2;  // exp correction: ln(1+x) + exp*ln(2)
+
+    sfpi::vFloat zff = pow * log2_result;
+    const sfpi::vFloat low_threshold = sfpi::vConstFloatPrgm1;
+    v_if(zff < low_threshold)  // -126.99999237060546875
+    {
+        zff = low_threshold;
+    }
+    v_endif;
+
+    zff = addexp(zff, 23);                                                 // * 2**23 (Mn)
+    sfpi::vInt z = _float_to_int32_fast_(zff + sfpi::vFloat(0x3f800000));  // (bias + x * log2(a)) * N_m
+
+    sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));
+    sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));
+
+    sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
+    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif);
+    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif);
+    d2 = d1 * d2;
+    zif = _float_to_int32_fast_(d2 * d3);
+
+    // zii |= zif; // restore exponent
+    zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));
+
+    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(zii);
+
+    // Check valid base range
+    sfpi::vInt pow_int =
+        sfpi::float_to_int16(pow, 0);  // int16 should be plenty, since large powers will approach 0/Inf
+    sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
+
+    v_if(base == 0.f && pow < 0.f) {
+        y = std::numeric_limits<float>::quiet_NaN();  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
+    }
+    v_endif
+
+    v_if(base < 0.0f) {  // negative base
+        // Check for integer power
+        v_if(pow_rounded == pow) {
+            // if pow is odd integer, set result to negative
+            v_if(pow_int & 0x1) {
+                // if negative base and negative pow then x**y = -(abs(x))**(abs(y))
+                // `sign` will be used at the end
+                y = setsgn(y, 1);
+            }
+            v_endif;
+        }
+        v_else {
+            // multiplication by NaN gives NaN.
+            // Since we are going to multiply the result by `sign` to handle negative bases, we also use
+            // `sign` to handle NaN results
+            y = std::numeric_limits<float>::quiet_NaN();
+        }
+        v_endif;
+    }
+    v_endif;
+
+    return y;
+}  // namespace ckernel
+
 template <bool APPROXIMATION_MODE, BinaryOp BINOP, int ITERATIONS = 8>
 inline void calculate_sfpu_binary(const uint dst_offset) {
-    _calculate_sfpu_binary_<APPROXIMATION_MODE, BINOP, ITERATIONS>(dst_offset);
+    if constexpr (BINOP == BinaryOp::POW) {
+        for (int d = 0; d < ITERATIONS; d++) {
+            constexpr uint dst_tile_size = 32;
+            sfpi::vFloat in0 = sfpi::dst_reg[0];
+            sfpi::vFloat in1 = sfpi::dst_reg[dst_offset * dst_tile_size];
+            sfpi::vFloat result = _sfpu_binary_power_(in0, in1);
+
+            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg++;
+        }
+    } else {
+        _calculate_sfpu_binary_<APPROXIMATION_MODE, BINOP, ITERATIONS>(dst_offset);
+    }
 }
 
 template <bool APPROXIMATION_MODE /*unused*/, BinaryOp BINOP>
 inline void sfpu_binary_init() {
-    _sfpu_binary_init_<APPROXIMATION_MODE, BINOP>();
+    if constexpr (BINOP == BinaryOp::POW) {
+        sfpi::vConstFloatPrgm0 = 1.442695f;
+        sfpi::vConstFloatPrgm1 = -127.0f;
+    } else {
+        _sfpu_binary_init_<APPROXIMATION_MODE, BINOP>();
+    }
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -13,7 +13,9 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-inline sfpi::vInt _float_to_int32_fast_(sfpi::vFloat in) {
+// Helper function for _sfpu_binary_power_
+// This function convert a float32 to int32, given that in >= 0.0f.
+sfpi_inline sfpi::vInt _float_to_int32_positive_(sfpi::vFloat in) {
     sfpi::vInt result;
     sfpi::vInt exp = exexp(in);  // extract exponent
     v_if(exp < 0) { result = 0; }
@@ -62,7 +64,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow
     v_endif;
 
     zff = addexp(zff, 23);                                                 // * 2**23 (Mn)
-    sfpi::vInt z = _float_to_int32_fast_(zff + sfpi::vFloat(0x3f800000));  // (bias + x * log2(a)) * N_m
+    sfpi::vInt z = _float_to_int32_positive_(zff + sfpi::vFloat(0x3f800000));  // (bias + x * log2(a)) * N_m
 
     sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));
     sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));
@@ -71,7 +73,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow
     sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif);
     sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560) + zif);
     d2 = d1 * d2;
-    zif = _float_to_int32_fast_(d2 * d3);
+    zif = _float_to_int32_positive_(d2 * d3);
 
     // zii |= zif; // restore exponent
     zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));
@@ -119,7 +121,8 @@ inline void calculate_sfpu_binary(const uint dst_offset) {
             constexpr uint dst_tile_size = 32;
             sfpi::vFloat in0 = sfpi::dst_reg[0];
             sfpi::vFloat in1 = sfpi::dst_reg[dst_offset * dst_tile_size];
-            sfpi::vFloat result = _sfpu_binary_power_(in0, in1);
+            sfpi::vFloat result = 0.f;
+            result = _sfpu_binary_power_(in0, in1);
 
             sfpi::dst_reg[0] = result;
             sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -122,12 +122,12 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow
     sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
 
     // Division by 0 when base is 0 and pow is negative => set to NaN
-    v_if((base == 0.f || base == -0.f) && pow < 0.f) {
+    v_if((base == 0.f) && pow < 0.f) {
         y = sfpi::vConstFloatPrgm2;  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
     }
-    v_endif
+    v_endblock;
 
-    v_if(base < -0.0f) {  // negative base
+    v_if(base < 0.0f) {  // negative base
         // Check for integer power
         v_if(pow_rounded == pow) {
             // if pow is odd integer, set result to negative

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -29,7 +29,7 @@ sfpi_inline sfpi::vInt _float_to_int32_positive_(sfpi::vFloat in) {
         sfpi::vInt man = exman8(in);
         // shift the mantissa by (23-exponent) to the right
         sfpi::vInt shift = exp - 23;  // 23 is number of mantissa in float32
-        man = shft(sfpi::reinterpret<sfpi::vUInt>(man), shift);
+        man = sfpi::reinterpret<sfpi::vInt>(shft(sfpi::reinterpret<sfpi::vUInt>(man), shift));
 
         result = man;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -72,8 +72,8 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow
 
     // Step 1: Compute log2(base)
     // Normalize base to calculation range
-    sfpi::vFloat x = setsgn(base, 0);  // set base as positive
-    x = sfpi::setexp(x, 127);          // set exp to exp bias (put base in range of 1-2)
+    sfpi::vFloat absbase = setsgn(base, 0);       // set base as positive
+    sfpi::vFloat x = sfpi::setexp(absbase, 127);  // set exp to exp bias (put base in range of 1-2)
 
     // 3rd order polynomial approx - determined using rminimax over [1,2]
     sfpi::vFloat series_result = x * (x * (x * 0x2.44734p-4f - 0xd.e712ap-4f) + 0x2.4f5388p+0f) - 0x1.952992p+0f;
@@ -122,7 +122,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow
     sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
 
     // Division by 0 when base is 0 and pow is negative => set to NaN
-    v_if((base == 0.f) && pow < 0.f) {
+    v_if((absbase == 0.f) && pow < 0.f) {
         y = sfpi::vConstFloatPrgm2;  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
     }
     v_endif;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 // Helper function for _sfpu_binary_power_
-// This function is based _float32_to_int32_, but expects a positive input, which allows us to optimize
+// This function is based on _float32_to_int32_, but expects a positive input, which allows us to optimize
 // away several lines (and make it faster)
 sfpi_inline sfpi::vInt _float_to_int32_positive_(sfpi::vFloat in) {
     sfpi::vInt result;
@@ -89,7 +89,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow
     sfpi::vFloat log2_result = expf + series_result * vConst1Ln2;  // exp correction: ln(1+x) + exp*ln(2)
 
     // Step 2: Compute base**pow = 2**(pow * log2(base))
-    // If (base, exponent) => (0, +inf) or (base, exponent) => (N, -inf) then ooutput should be 0
+    // If (base, exponent) => (0, +inf) or (base, exponent) => (N, -inf) then output should be 0
     // However, intermediary values can overflow, which leads to output increasing again instead of
     // staying at 0.
     // This overflows happens when zff < -127. Therefore, we clamp zff to -127.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -125,7 +125,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow
     v_if((base == 0.f) && pow < 0.f) {
         y = sfpi::vConstFloatPrgm2;  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
     }
-    v_endblock;
+    v_endif;
 
     v_if(base < 0.0f) {  // negative base
         // Check for integer power
@@ -133,15 +133,11 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow
             // if pow is odd integer, set result to negative
             v_if(pow_int & 0x1) {
                 // if negative base and negative pow then x**y = -(abs(x))**(abs(y))
-                // `sign` will be used at the end
                 y = setsgn(y, 1);
             }
             v_endif;
         }
         v_else {
-            // multiplication by NaN gives NaN.
-            // Since we are going to multiply the result by `sign` to handle negative bases, we also use
-            // `sign` to handle NaN results
             y = sfpi::vConstFloatPrgm2;  // = NaN
         }
         v_endif;


### PR DESCRIPTION
### Ticket
#23529

### Problem description

As reported by issues #23529 and #19821 the current implementation of the `pow()` for `(tensor, tensor)` is not accurate enough.

For instance, `pow(9, 2) ~= 78` instead of `81` for bfloat16 inputs.

### What's changed

This PR replaces the current implementation by a more accurate implementation. 

This implementation follows that of `power_21f` from [Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]](https://www.researchgate.net/publication/361844431_Simple_Multiple_Precision_Algorithms_for_Exponential_Functions_Tips_Tricks_IEEE_Signal_Processing_Magazine_394_130-137) paper from 2022 by Moroz et al. 

#### Accuracy improvement

Based on our testing, the new function is more accurate than the old one by a factor of 5. 

Notably, `pow21f(9, 2) = 80.5` which brings it only 1 ULP away from 81.
(Note: 1 ULP can be further reduce to a perfect result by properly rounding the result to bf16 https://github.com/tenstorrent/tt-llk/issues/494 )

##### For bfloat16:
| x | y | torch | ttnn.pow (current) | tttn.pow (proposed) |
| - | - | - | - | - |
| 9 | 2 | 81 | 78.0 | 80.5 |
| 100000 | 1.7984 | 9.6050e+08 | 9.0178e+08 | 9.6050e+08 | 
| 5 | 3 | 125 | 122 | 124.5 | 

##### ULP error (lower is better):
| x | y | ttnn.pow (current) | ttnn.pow (proposed) |
| - | - | - | - |
| 9 | 2 | 6 | 1 |
| 100000 | 1.7984 | 12 | 0 |
| 5 | 3 | 6 | 1 |

##### For float32:
| x | y | torch | ttnn.pow (current) | tttn.pow (proposed) |
| - | - | - | - | - |
| 9 | 2 | 81 | 78.192 | 80.819 |
| 100000 | 1.7984 | 9.8175e+08 | 9.2114e+08 | 9.6050e+08 | 
| 5 | 3 | 125 | 122.36 | 124.5 | 


For `y = a**x`, with a in `{2, 3, 10}`, the `pow_21f` function is always under 2 ULP of error (goal should be < 5 ULP error): 

 
<img width="250" height="200" alt="pow2-bfloat16" src="https://github.com/user-attachments/assets/3a47aa49-e685-4bf2-b7e8-557bf4f20809" />
<img width="250" height="200" alt="pow3-bfloat16" src="https://github.com/user-attachments/assets/41c3bf2f-0bcb-4231-b2dc-06f794c9bf1d" />
<img width="250" height="200" alt="pow10-bfloat16" src="https://github.com/user-attachments/assets/02080e89-8be3-4f99-91e0-69004b8e46ff" />




To ascertain the accuracy of a larger range of input, I've exhaustively tested it on every possible pair of bfloat16 inputs. 

The following heat maps show the matching accuracy results for the current `pow` function, and the proposed `pow`. 
Purple inputs = non-finite results (NaN or infinity). Darker = better. 

<img width="350" height="357" alt="pow" src="https://github.com/user-attachments/assets/4313d8c8-3298-4288-aded-648288e9300e" /> <img width="350" height="357" alt="pow21f" src="https://github.com/user-attachments/assets/45d0cc8d-3ec4-42a7-8afd-deb9c66153a1" />


To mitigate the file size overhead (i.e 4 billions possible inputs would mean several gigabytes of data), I've grouped results: a single data point represents 128x128 values (i.e. values are grouped by mantissa). This is why there is a square pattern.
The value is the *maximum* error in ULP among all 128x128 results. 


#### Execution time overhead

The execution time has been measured with a tracy, and by looping 100'000 times on the LLK:
```
for (size_t i = 0; i < 100000; i++) {
    result = _sfpu_binary_power_(in0, in1);
}
```

As shown on the table, the proposed approximation not only improves accuracy but is also 4% faster than the current implementation. 

For a `512x512` tensor in L1 memory:

_Wormhole_:
 
| . | Execution Time [ns] | Throughput [GElem/s] | Perf vs. current |
| - | - | - | - |
| `ttnn.pow` | 12675| 20.7 | N/A |
| this | 12160 | 21.6 | +4% |


### Future work

Implementation on Blackhole is blocked by what seems to be a compiler bug that leads to nonsensical results: https://github.com/tenstorrent/tt-metal/issues/25647

Also, due to a rounding issue, some bfloat16 results are rounded down rather than rounded to the nearest number.
For instance, `pow(9, 2) = 8.0819`, but gets truncated down to `80.5` for bfloat16 rather than to the nearest 81 (which would have been a perfect result): https://github.com/tenstorrent/tt-llk/issues/494

Note: I've left `_float_to_int32_positive_` in `ckernel_sfpu_binary.h` because it's only used for this `pow` implementation. But it could also be moved to the file that contains other conversion ops.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/16373371298
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [X] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/16374899678
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/16374911867
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [X] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main): https://github.com/tenstorrent/tt-metal/actions/runs/16374527296
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes
