### PR TITLE
Revert "[skip ci] [Shift Left] ttnn tensor unit tests"

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -52,6 +52,7 @@ jobs:
           {name: ttnn cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn},
           {name: ttnn ccl cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn_ccl},
           {name: ttnn ccl ops cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn_ccl_ops},
+          {name: ttnn tensor cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn_tensor},
         ]
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     container:

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -87,7 +87,6 @@ target_link_libraries(
     PRIVATE
         TTNN::Test::Smoke
         TTNN::Test::Basic
-        TTNN::Test::Basic::Tensor
         TTNN::Test::Slow
 )
 
@@ -153,11 +152,9 @@ setup_ttnn_test_target(unit_tests_ttnn_accessor)
 
 # unit_tests_ttnn_tensor
 
-add_library(unit_tests_ttnn_tensor_lib OBJECT)
-add_library(TTNN::Test::Basic::Tensor ALIAS unit_tests_ttnn_tensor_lib)
-TT_ENABLE_UNITY_BUILD(unit_tests_ttnn_tensor_lib)
+add_executable(unit_tests_ttnn_tensor)
 target_sources(
-    unit_tests_ttnn_tensor_lib
+    unit_tests_ttnn_tensor
     PRIVATE
         tensor/common_tensor_test_utils.cpp
         tensor/test_create_tensor.cpp
@@ -174,11 +171,8 @@ target_sources(
         tensor/test_xtensor_adapter.cpp
         tensor/test_xtensor_conversion.cpp
 )
-setup_ttnn_test_target(unit_tests_ttnn_tensor_lib)
-target_link_libraries(unit_tests_ttnn_tensor_lib PRIVATE xtensor)
-
-add_executable(unit_tests_ttnn_tensor)
-target_link_libraries(unit_tests_ttnn_tensor PRIVATE TTNN::Test::Basic::Tensor)
+setup_ttnn_test_target(unit_tests_ttnn_tensor)
+target_link_libraries(unit_tests_ttnn_tensor PRIVATE xtensor)
 
 # test_ccl_multi_cq_multi_device
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -42,8 +42,6 @@ class IDevice;
 
 namespace {
 
-namespace CMAKE_UNIQUE_NAMESPACE {
-
 void run_create_tensor_test(tt::tt_metal::distributed::MeshDevice* device, const ttnn::Shape& input_shape) {
     MemoryConfig mem_cfg = MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
 
@@ -83,26 +81,25 @@ struct CreateTensorParams {
     ttnn::Shape shape;
 };
 
-}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 class CreateTensorTest : public ttnn::TTNNFixtureWithDevice,
-                         public ::testing::WithParamInterface<CMAKE_UNIQUE_NAMESPACE::CreateTensorParams> {};
+                         public ::testing::WithParamInterface<CreateTensorParams> {};
 
 TEST_P(CreateTensorTest, Tile) {
-    CMAKE_UNIQUE_NAMESPACE::CreateTensorParams params = GetParam();
-    CMAKE_UNIQUE_NAMESPACE::run_create_tensor_test(device_, params.shape);
+    CreateTensorParams params = GetParam();
+    run_create_tensor_test(device_, params.shape);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     CreateTensorTestWithShape,
     CreateTensorTest,
     ::testing::Values(
-        CMAKE_UNIQUE_NAMESPACE::CreateTensorParams{.shape = ttnn::Shape({1, 1, 32, 32})},
-        CMAKE_UNIQUE_NAMESPACE::CreateTensorParams{.shape = ttnn::Shape({2, 1, 32, 32})},
-        CMAKE_UNIQUE_NAMESPACE::CreateTensorParams{.shape = ttnn::Shape({0, 0, 0, 0})},
-        CMAKE_UNIQUE_NAMESPACE::CreateTensorParams{.shape = ttnn::Shape({0, 1, 32, 32})},
-        CMAKE_UNIQUE_NAMESPACE::CreateTensorParams{.shape = ttnn::Shape({0})}));
+        CreateTensorParams{.shape = ttnn::Shape({1, 1, 32, 32})},
+        CreateTensorParams{.shape = ttnn::Shape({2, 1, 32, 32})},
+        CreateTensorParams{.shape = ttnn::Shape({0, 0, 0, 0})},
+        CreateTensorParams{.shape = ttnn::Shape({0, 1, 32, 32})},
+        CreateTensorParams{.shape = ttnn::Shape({0})}));
 
 std::ostream& operator<<(std::ostream& os, const tt::tt_metal::DataType& value) {
     os << magic_enum::enum_name(value);

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_with_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_with_layout.cpp
@@ -20,9 +20,6 @@
 #include "ttnn_test_fixtures.hpp"
 
 namespace {
-
-namespace CMAKE_UNIQUE_NAMESPACE {
-
 struct Inputs {
     ttnn::Shape shape;
     TensorLayout layout;
@@ -37,42 +34,42 @@ struct CreateTensorParams {
     Expected expected;
 };
 
-const tt::tt_metal::MemoryConfig DefaultMemoryConfig{
-    tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM, std::nullopt};
-
-}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 class CreateTensorWithLayoutTest : public ttnn::TTNNFixtureWithDevice,
-                                   public ::testing::WithParamInterface<CMAKE_UNIQUE_NAMESPACE::CreateTensorParams> {};
+                                   public ::testing::WithParamInterface<CreateTensorParams> {};
 
 TEST_P(CreateTensorWithLayoutTest, Tile) {
-    CMAKE_UNIQUE_NAMESPACE::CreateTensorParams params = GetParam();
+    CreateTensorParams params = GetParam();
 
     auto tensor = tt::tt_metal::create_device_tensor(TensorSpec(params.inputs.shape, params.inputs.layout), device_);
     EXPECT_EQ(tensor.padded_shape(), params.expected.padded_shape);
     EXPECT_EQ(tensor.logical_shape(), params.inputs.shape);
 }
 
+namespace {
+const tt::tt_metal::MemoryConfig DefaultMemoryConfig{
+    tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM, std::nullopt};
+}
+
 INSTANTIATE_TEST_SUITE_P(
     CreateTensorWithLayoutTestWithShape,
     CreateTensorWithLayoutTest,
     ::testing::Values(
-        CMAKE_UNIQUE_NAMESPACE::CreateTensorParams{
-            CMAKE_UNIQUE_NAMESPACE::Inputs{
+        CreateTensorParams{
+            Inputs{
                 .shape = ttnn::Shape({1, 1, 32, 32}),
-                .layout = TensorLayout(DataType::BFLOAT16, Layout::TILE, CMAKE_UNIQUE_NAMESPACE::DefaultMemoryConfig)},
-            CMAKE_UNIQUE_NAMESPACE::Expected{.padded_shape = ttnn::Shape({1, 1, 32, 32})}},
+                .layout = TensorLayout(DataType::BFLOAT16, Layout::TILE, DefaultMemoryConfig)},
+            Expected{.padded_shape = ttnn::Shape({1, 1, 32, 32})}},
 
-        CMAKE_UNIQUE_NAMESPACE::CreateTensorParams{
-            CMAKE_UNIQUE_NAMESPACE::Inputs{
+        CreateTensorParams{
+            Inputs{
                 .shape = ttnn::Shape({1, 1, 16, 10}),
-                .layout = TensorLayout(DataType::BFLOAT16, Layout::TILE, CMAKE_UNIQUE_NAMESPACE::DefaultMemoryConfig)},
-            CMAKE_UNIQUE_NAMESPACE::Expected{.padded_shape = ttnn::Shape({1, 1, 32, 32})}},
+                .layout = TensorLayout(DataType::BFLOAT16, Layout::TILE, DefaultMemoryConfig)},
+            Expected{.padded_shape = ttnn::Shape({1, 1, 32, 32})}},
 
-        CMAKE_UNIQUE_NAMESPACE::CreateTensorParams{
-            CMAKE_UNIQUE_NAMESPACE::Inputs{
+        CreateTensorParams{
+            Inputs{
                 .shape = ttnn::Shape({1, 1, 16, 10}),
-                .layout =
-                    TensorLayout(DataType::BFLOAT16, Layout::ROW_MAJOR, CMAKE_UNIQUE_NAMESPACE::DefaultMemoryConfig)},
-            CMAKE_UNIQUE_NAMESPACE::Expected{.padded_shape = ttnn::Shape({1, 1, 16, 10})}}));
+                .layout = TensorLayout(DataType::BFLOAT16, Layout::ROW_MAJOR, DefaultMemoryConfig)},
+            Expected{.padded_shape = ttnn::Shape({1, 1, 16, 10})}}));

--- a/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
@@ -214,7 +214,7 @@ TEST(PartitionTest, DimensionOutofRange) {
 TEST(PartitionTest, EmptyInput) {
     std::vector<xt::xarray<int>> input;
     EXPECT_NO_THROW(concat(input, 0));
-    EXPECT_TRUE(concat(input, 0).data().empty());
+    EXPECT_TRUE(xt::allclose(concat(input, 0).expr(), xt::xarray<int>{}));
 }
 
 TEST(PartitionTest, ChunkDoesNotAccessData) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
@@ -352,8 +352,8 @@ TEST_P(NDShardingSqueezeRankTests, TestSqueezeRank) {
     EXPECT_EQ(dspec.shard_shape_in_pages(), params.expected_shard_shape_pages);
 
     if (params.tensor_shape_pages.rank() == params.shard_shape_pages.rank()) {
-        auto expected_page_mapping = tt::tt_metal::detail::compute_page_mapping(
-            params.tensor_shape_pages, params.shard_shape_pages, dspec.cores());
+        auto expected_page_mapping =
+            detail::compute_page_mapping(params.tensor_shape_pages, params.shard_shape_pages, dspec.cores());
         EXPECT_EQ(dspec.compute_page_mapping().core_host_page_indices, expected_page_mapping.core_host_page_indices);
     }
 }

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
@@ -18,15 +18,6 @@
 #include <vector>
 
 namespace ttnn {
-
-namespace CMAKE_UNIQUE_NAMESPACE {
-
-TensorSpec get_tensor_spec(const ttnn::Shape& shape, DataType dtype) {
-    return TensorSpec(shape, TensorLayout(dtype, Layout::ROW_MAJOR, MemoryConfig{}));
-}
-
-}  // namespace CMAKE_UNIQUE_NAMESPACE
-
 namespace {
 
 using ::testing::ElementsAre;
@@ -37,14 +28,18 @@ using ::tt::tt_metal::distributed::test::utils::TemporaryFile;
 
 using namespace tt::tt_metal;
 
+TensorSpec get_tensor_spec(const ttnn::Shape& shape, DataType dtype) {
+    return TensorSpec(shape, TensorLayout(dtype, Layout::ROW_MAJOR, MemoryConfig{}));
+}
+
 using TensorSerializationFlatbufferTest = GenericMeshDeviceFixture;
 
 TEST_F(TensorSerializationFlatbufferTest, ReplicatedTensorRoundtrip) {
     TemporaryFile test_file("flatbuffer.bin");
     std::vector<float> test_data{1.0f, 2.5f, -3.7f, 42.0f, -0.5f, 100.0f};
 
-    Tensor original_tensor = Tensor::from_vector(
-        test_data, CMAKE_UNIQUE_NAMESPACE::get_tensor_spec(ttnn::Shape{1, 2, 3, 1}, DataType::FLOAT32));
+    Tensor original_tensor =
+        Tensor::from_vector(test_data, get_tensor_spec(ttnn::Shape{1, 2, 3, 1}, DataType::FLOAT32));
 
     ASSERT_TRUE(original_tensor.storage_type() == StorageType::HOST);
 
@@ -64,8 +59,7 @@ TEST_F(TensorSerializationFlatbufferTest, ReplicatedTensorDifferentDataTypes) {
     {
         TemporaryFile test_file("uint32.bin");
         std::vector<uint32_t> test_data{1, 2, 3, 4, 5, 6};
-        Tensor original_tensor = Tensor::from_vector(
-            test_data, CMAKE_UNIQUE_NAMESPACE::get_tensor_spec(ttnn::Shape{2, 3}, DataType::UINT32));
+        Tensor original_tensor = Tensor::from_vector(test_data, get_tensor_spec(ttnn::Shape{2, 3}, DataType::UINT32));
 
         dump_tensor_flatbuffer(test_file.string(), original_tensor);
         Tensor loaded_tensor = load_tensor_flatbuffer(test_file.string());
@@ -77,8 +71,7 @@ TEST_F(TensorSerializationFlatbufferTest, ReplicatedTensorDifferentDataTypes) {
     {
         TemporaryFile test_file("bfloat16.bin");
         std::vector<bfloat16> test_data{bfloat16(1.5f), bfloat16(2.5f), bfloat16(-3.5f), bfloat16(4.5f)};
-        Tensor original_tensor = Tensor::from_vector(
-            test_data, CMAKE_UNIQUE_NAMESPACE::get_tensor_spec(ttnn::Shape{1, 4}, DataType::BFLOAT16));
+        Tensor original_tensor = Tensor::from_vector(test_data, get_tensor_spec(ttnn::Shape{1, 4}, DataType::BFLOAT16));
 
         dump_tensor_flatbuffer(test_file.string(), original_tensor);
         Tensor loaded_tensor = load_tensor_flatbuffer(test_file.string());
@@ -104,8 +97,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard1DTensorRoundtrip) {
     }
 
     Tensor input_tensor = Tensor::from_vector(
-        test_data,
-        CMAKE_UNIQUE_NAMESPACE::get_tensor_spec(ttnn::Shape{1, num_devices, kNumElements, 1}, DataType::FLOAT32));
+        test_data, get_tensor_spec(ttnn::Shape{1, num_devices, kNumElements, 1}, DataType::FLOAT32));
 
     auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*mesh_device_, 1);
     Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);
@@ -146,8 +138,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard2DTensorRoundtrip) {
     }
 
     Tensor input_tensor = Tensor::from_vector(
-        test_data,
-        CMAKE_UNIQUE_NAMESPACE::get_tensor_spec(ttnn::Shape{1, kNumRows, kNumCols, kNumElements}, DataType::FLOAT32));
+        test_data, get_tensor_spec(ttnn::Shape{1, kNumRows, kNumCols, kNumElements}, DataType::FLOAT32));
 
     auto mapper = ttnn::distributed::create_mesh_mapper(
         *mesh_device_,
@@ -192,8 +183,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard1DFewerShardsThanDevicesRoun
     }
 
     Tensor input_tensor = Tensor::from_vector(
-        test_data,
-        CMAKE_UNIQUE_NAMESPACE::get_tensor_spec(ttnn::Shape{1, num_devices - 1, kNumElements, 1}, DataType::FLOAT32));
+        test_data, get_tensor_spec(ttnn::Shape{1, num_devices - 1, kNumElements, 1}, DataType::FLOAT32));
 
     auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*mesh_device_, 1);
     Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);
@@ -235,8 +225,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, Shard2x3SubmeshRoundtrip) {
     }
 
     Tensor input_tensor = Tensor::from_vector(
-        test_data,
-        CMAKE_UNIQUE_NAMESPACE::get_tensor_spec(ttnn::Shape{1, kNumRows, kNumCols, kNumElements}, DataType::FLOAT32));
+        test_data, get_tensor_spec(ttnn::Shape{1, kNumRows, kNumCols, kNumElements}, DataType::FLOAT32));
 
     auto mapper = ttnn::distributed::create_mesh_mapper(
         *mesh_device_,
@@ -285,8 +274,7 @@ TEST_F(TensorSerializationFlatbufferT3000Test, PartiallyReplicatedRoundtrip) {
     }
 
     Tensor input_tensor = Tensor::from_vector(
-        test_data,
-        CMAKE_UNIQUE_NAMESPACE::get_tensor_spec(ttnn::Shape{1, kNumRows, kNumCols, kNumElements}, DataType::FLOAT32));
+        test_data, get_tensor_spec(ttnn::Shape{1, kNumRows, kNumCols, kNumElements}, DataType::FLOAT32));
 
     auto mapper = ttnn::distributed::create_mesh_mapper(
         *mesh_device_,

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -180,77 +180,35 @@ target_sources(
             impl/dispatch/kernels/packet_queue.hpp
             impl/dispatch/kernels/packet_queue_ctrl.hpp
             include/compute_kernel_api.h
-            include/compute_kernel_api/add_int_sfpu.h
             include/compute_kernel_api/bcast.h
-            include/compute_kernel_api/binary_bitwise_sfpu.h
-            include/compute_kernel_api/binary_max_min.h
-            include/compute_kernel_api/binary_shift.h
             include/compute_kernel_api/blank.h
             include/compute_kernel_api/cb_api.h
             include/compute_kernel_api/common.h
             include/compute_kernel_api/common_globals.h
             include/compute_kernel_api/compute_kernel_hw_startup.h
-            include/compute_kernel_api/copy_dest_values.h
-            include/compute_kernel_api/cumsum.h
             include/compute_kernel_api/eltwise_binary.h
-            include/compute_kernel_api/eltwise_binary_sfpu.h
-            include/compute_kernel_api/eltwise_unary/binop_with_scalar.h
-            include/compute_kernel_api/eltwise_unary/bitwise_and.h
-            include/compute_kernel_api/eltwise_unary/bitwise_not.h
-            include/compute_kernel_api/eltwise_unary/bitwise_or.h
-            include/compute_kernel_api/eltwise_unary/bitwise_xor.h
             include/compute_kernel_api/eltwise_unary/comp.h
-            include/compute_kernel_api/eltwise_unary/dropout.h
             include/compute_kernel_api/eltwise_unary/eltwise_unary.h
-            include/compute_kernel_api/eltwise_unary/elu.h
-            include/compute_kernel_api/eltwise_unary/erf_erfc.h
-            include/compute_kernel_api/eltwise_unary/erfinv.h
             include/compute_kernel_api/eltwise_unary/exp.h
-            include/compute_kernel_api/eltwise_unary/fill.h
-            include/compute_kernel_api/eltwise_unary/fmod.h
-            include/compute_kernel_api/eltwise_unary/gelu.h
-            include/compute_kernel_api/eltwise_unary/i0.h
-            include/compute_kernel_api/eltwise_unary/i1.h
-            include/compute_kernel_api/eltwise_unary/identity.h
-            include/compute_kernel_api/eltwise_unary/isinf_isnan.h
-            include/compute_kernel_api/eltwise_unary/left_shift.h
-            include/compute_kernel_api/eltwise_unary/log1p.h
-            include/compute_kernel_api/eltwise_unary/logical_not_noti.h
             include/compute_kernel_api/eltwise_unary/negative.h
-            include/compute_kernel_api/eltwise_unary/prelu.h
-            include/compute_kernel_api/eltwise_unary/rand.h
             include/compute_kernel_api/eltwise_unary/recip.h
             include/compute_kernel_api/eltwise_unary/relu.h
-            include/compute_kernel_api/eltwise_unary/remainder.h
-            include/compute_kernel_api/eltwise_unary/reverseops.h
-            include/compute_kernel_api/eltwise_unary/right_shift.h
-            include/compute_kernel_api/eltwise_unary/rounding.h
-            include/compute_kernel_api/eltwise_unary/sfpu_int_sum.h
             include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
-            include/compute_kernel_api/eltwise_unary/softplus.h
             include/compute_kernel_api/eltwise_unary/sqrt.h
-            include/compute_kernel_api/eltwise_unary/trigonometry.h
-            include/compute_kernel_api/eltwise_unary/typecast.h
-            include/compute_kernel_api/gcd.h
-            include/compute_kernel_api/layernorm.h
-            include/compute_kernel_api/lcm.h
             include/compute_kernel_api/mask.h
             include/compute_kernel_api/matmul.h
-            include/compute_kernel_api/mul_int_sfpu.h
             include/compute_kernel_api/pack.h
             include/compute_kernel_api/pack_untilize.h
-            include/compute_kernel_api/quantization.h
             include/compute_kernel_api/reconfig_data_format.h
             include/compute_kernel_api/reduce.h
             include/compute_kernel_api/reg_api.h
-            include/compute_kernel_api/reshuffle.h
             include/compute_kernel_api/softmax.h
-            include/compute_kernel_api/sub_int_sfpu.h
             include/compute_kernel_api/tile_move_copy.h
             include/compute_kernel_api/tilize.h
             include/compute_kernel_api/transpose_wh.h
-            include/compute_kernel_api/transpose_wh_dest.h
             include/compute_kernel_api/untilize.h
+            include/compute_kernel_api/eltwise_binary.h
+            include/compute_kernel_api/tile_move_copy.h
             soc_descriptors/blackhole_140_arch.yaml
             soc_descriptors/wormhole_b0_80_arch.yaml
             third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel.h

--- a/ttnn/test/CMakeLists.txt
+++ b/ttnn/test/CMakeLists.txt
@@ -11,11 +11,6 @@ install(TARGETS tt-nn-validation-smoke RUNTIME COMPONENT ttnn-validation)
 # Basic
 add_executable(tt-nn-validation-basic)
 
-target_link_libraries(
-    tt-nn-validation-basic
-    PRIVATE
-        TTNN::Test::Basic
-        TTNN::Test::Basic::Tensor
-)
+target_link_libraries(tt-nn-validation-basic PRIVATE TTNN::Test::Basic)
 
 install(TARGETS tt-nn-validation-basic RUNTIME COMPONENT ttnn-validation)


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#24620

Breaking all post commit gcc build
https://github.com/tenstorrent/tt-metal/actions/runs/16269431270/job/45937909936#step:10:1115

```
In file included from /work/build/tests/ttnn/unit_tests/gtests/CMakeFiles/unit_tests_ttnn_tensor_lib.dir/Unity/unity_1_cxx.cxx:7:
/work/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp:94:7: error: 'NDShardingTests' has a base 'testing::WithParamInterface<std::tuple<{anonymous}::NDShardingParams, tt::tt_metal::BufferType, tt::tt_metal::ShardOrientation> >' whose type uses the anonymous namespace [-Werror=subobject-linkage]
   94 | class NDShardingTests
      |       ^~~~~~~~~~~~~~~
/work/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp:166:7: error: 'LegacyToNdShardingTests' has a base 'testing::TestWithParam<{anonymous}::LegacyToNdShardingParams>' whose type uses the anonymous namespace [-Werror=subobject-linkage]
  166 | class LegacyToNdShardingTests : public ::testing::TestWithParam<LegacyToNdShardingParams> {};
      |       ^~~~~~~~~~~~~~~~~~~~~~~
/work/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp:188:7: error: 'NdToLegacyShardingTests' has a base 'testing::TestWithParam<{anonymous}::NdToLegacyShardingParams>' whose type uses the anonymous namespace [-Werror=subobject-linkage]
  188 | class NdToLegacyShardingTests : public ::testing::TestWithParam<NdToLegacyShardingParams> {};
```