### PR TITLE
[skip ci] Remove silent catch for model validation failures and always drop duplicate test names

### DIFF
--- a/infra/data_collection/cicd.py
+++ b/infra/data_collection/cicd.py
@@ -78,16 +78,12 @@ def create_cicd_json_for_data_analysis(
 
         logger.info(f"Found {len(tests)} tests for job {github_job_id}")
 
-        try:
-            job = pydantic_models.Job(
-                **raw_job,
-                tt_smi_version=github_job_id_to_smi_versions.get(github_job_id),
-                tests=tests,
-            )
-        except ValueError as e:
-            logger.warning(f"Skipping insert for job {github_job_id}, model validation failed: {e}")
-        else:
-            jobs.append(job)
+        job = pydantic_models.Job(
+            **raw_job,
+            tt_smi_version=github_job_id_to_smi_versions.get(github_job_id),
+            tests=tests,
+        )
+        jobs.append(job)
 
     pipeline = pydantic_models.Pipeline(
         **raw_pipeline,

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -379,6 +379,7 @@ def deduplicate_tests_by_name(tests):
         else:
             # Multiple tests with same name, apply deduplication logic
             # First, try to find one with elapsed time > 0
+            logger.warning(f"Found {len(test_list)} tests with the same name: {test_name}. Will deduplicate.")
             test_with_elapsed_time = None
             for test in test_list:
                 if test.test_end_ts != test.test_start_ts:

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -270,8 +270,14 @@ def get_pydantic_test_from_testcase_(testcase, default_timestamp=datetime.now(),
                 test_start_ts = datetime.fromisoformat(properties["start_timestamp"])
                 test_end_ts = datetime.fromisoformat(properties["end_timestamp"])
             else:
-                test_start_ts = default_timestamp
-                test_end_ts = default_timestamp
+                # Check if there's a time attribute in the testcase
+                if "time" in testcase.attrib:
+                    pytest_elapsed_time = float(testcase.attrib["time"])
+                    test_start_ts = default_timestamp
+                    test_end_ts = default_timestamp + timedelta(seconds=pytest_elapsed_time)
+                else:
+                    test_start_ts = default_timestamp
+                    test_end_ts = default_timestamp
         else:
             test_start_ts = default_timestamp
             # gtest stores elapsed time for the test in the time attribute
@@ -350,6 +356,42 @@ def is_valid_testcase_(testcase):
         return True
 
 
+def deduplicate_tests_by_name(tests):
+    """
+    Deduplicate tests based on test_case_name.
+    If there are multiple tests with the same name:
+    - Take the first one with elapsed time > 0 (test_end_ts != test_start_ts)
+    - If they all have 0 elapsed time, take the first instance
+    """
+    test_name_to_tests = {}
+
+    for test in tests:
+        test_name = test.test_case_name
+        if test_name not in test_name_to_tests:
+            test_name_to_tests[test_name] = []
+        test_name_to_tests[test_name].append(test)
+
+    deduplicated_tests = []
+    for test_name, test_list in test_name_to_tests.items():
+        if len(test_list) == 1:
+            # Only one test with this name, keep it
+            deduplicated_tests.append(test_list[0])
+        else:
+            # Multiple tests with same name, apply deduplication logic
+            # First, try to find one with elapsed time > 0
+            test_with_elapsed_time = None
+            for test in test_list:
+                if test.test_end_ts != test.test_start_ts:
+                    test_with_elapsed_time = test
+                    break
+
+            # If found one with elapsed time > 0, use it; otherwise use the first one
+            selected_test = test_with_elapsed_time if test_with_elapsed_time else test_list[0]
+            deduplicated_tests.append(selected_test)
+
+    return deduplicated_tests
+
+
 def get_tests_from_test_report_path(test_report_path):
     report_root_tree = junit_xml_utils.get_xml_file_root_element_tree(test_report_path)
 
@@ -367,7 +409,7 @@ def get_tests_from_test_report_path(test_report_path):
                     default_timestamp=default_timestamp, is_pytest=False, testsuite_name=None, testcase=testcase
                 )
                 tests.append(pyd_test_info)
-        return tests
+        return deduplicate_tests_by_name(tests)
 
     is_pytest = junit_xml_utils.is_pytest_junit_xml(report_root)
     is_gtest = junit_xml_utils.is_gtest_xml(report_root)
@@ -389,7 +431,7 @@ def get_tests_from_test_report_path(test_report_path):
                 if is_valid_testcase_(testcase):
                     tests.append(get_pydantic_test(testcase))
 
-        return tests
+        return deduplicate_tests_by_name(tests)
     else:
         logger.warning("XML is not pytest junit or gtest format, or no tests were found in the XML, skipping for now")
         return []

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -356,9 +356,9 @@ def is_valid_testcase_(testcase):
         return True
 
 
-def deduplicate_tests_by_name(tests):
+def deduplicate_tests_by_full_name(tests):
     """
-    Deduplicate tests based on test_case_name.
+    Deduplicate tests based on full_test_name.
     If there are multiple tests with the same name:
     - Take the first one with elapsed time > 0 (test_end_ts != test_start_ts)
     - If they all have 0 elapsed time, take the first instance
@@ -366,7 +366,7 @@ def deduplicate_tests_by_name(tests):
     test_name_to_tests = {}
 
     for test in tests:
-        test_name = test.test_case_name
+        test_name = test.full_test_name
         if test_name not in test_name_to_tests:
             test_name_to_tests[test_name] = []
         test_name_to_tests[test_name].append(test)
@@ -379,7 +379,7 @@ def deduplicate_tests_by_name(tests):
         else:
             # Multiple tests with same name, apply deduplication logic
             # First, try to find one with elapsed time > 0
-            logger.warning(f"Found {len(test_list)} tests with the same name: {test_name}. Will deduplicate.")
+            logger.warning(f"Found {len(test_list)} tests with the same full_test_name: {test_name}. Will deduplicate.")
             test_with_elapsed_time = None
             for test in test_list:
                 if test.test_end_ts != test.test_start_ts:
@@ -410,7 +410,7 @@ def get_tests_from_test_report_path(test_report_path):
                     default_timestamp=default_timestamp, is_pytest=False, testsuite_name=None, testcase=testcase
                 )
                 tests.append(pyd_test_info)
-        return deduplicate_tests_by_name(tests)
+        return deduplicate_tests_by_full_name(tests)
 
     is_pytest = junit_xml_utils.is_pytest_junit_xml(report_root)
     is_gtest = junit_xml_utils.is_gtest_xml(report_root)
@@ -432,7 +432,7 @@ def get_tests_from_test_report_path(test_report_path):
                 if is_valid_testcase_(testcase):
                     tests.append(get_pydantic_test(testcase))
 
-        return deduplicate_tests_by_name(tests)
+        return deduplicate_tests_by_full_name(tests)
     else:
         logger.warning("XML is not pytest junit or gtest format, or no tests were found in the XML, skipping for now")
         return []

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -239,9 +239,19 @@ def test_create_pipeline_json_for_gtest_testcases(workflow_run_gh_environment):
             # check that there are failing pytests stored in the pydantic testcase list
             assert len([x for x in job.tests if not x.success]) > 0
             assert job.job_status == JobStatus.failure
-
-    # fails validation, job is expected be skipped
-    assert len([x for x in pipeline.jobs if x.github_job_id == 37190219113]) == 0
+        # job has two tests with the same full_test_name, should be deduplicated
+        if job.github_job_id == 37190219113:
+            assert (
+                len(
+                    [
+                        x
+                        for x in job.tests
+                        if x.full_test_name
+                        == "tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp::N300DeviceFixture::EthValidatePhysicalCoreConversion"
+                    ]
+                )
+                == 1
+            )
 
 
 def test_empty_gtest_xml(workflow_run_gh_environment):


### PR DESCRIPTION
### Ticket
None

### Problem description
Model validation fails for specific TG llama pipeline test (https://github.com/tenstorrent/tt-metal/actions/runs/16268716885/job/45931059950).

This is because the pytest XML file contains two instances of the same test case name (one for test failure, one for test teardown error).
Currently it fails model validation but skips the job and moves onto the next (pipeline passes, which a false positive).

### What's changed

- Remove the try-except block that catches the model validation failure: now when validation fails the pipeline will flip to red and notify on slack
- Handle duplicate test case name entries: when we encounter multiple test cases with the same name, take the first one that has a non-zero elapsed time, otherwise if the elapsed times are all zero just take the first instance and drop the rest.

### Checklist
- [x] Produce data pipeline on original test case: https://github.com/tenstorrent/tt-metal/actions/runs/16276710507/job/45957261241

cc @roseli-TT @subinleeTT