### PR TITLE
AGMM Bug Fix

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/multi_core/all_gather_matmul_async_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/multi_core/all_gather_matmul_async_op_multi_core.cpp
@@ -107,6 +107,24 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_matmul_async_multi_core
                     matmul_fused_op_signaler);
                 matmul_override_runtime_arguments_callback =
                     matmul_program_with_callbacks->override_runtime_arguments_callback;
+            } else if (std::is_same_v<
+                           ProgramConfigType,
+                           operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                matmul_program_with_callbacks = operations::matmul::matmul_multi_core_reuse_mcast_1d_optimized_helper(
+                    program,
+                    all_gather_output_tensor,
+                    {weight_tensor},
+                    bias,
+                    {matmul_output_tensor},
+                    bcast_batch,
+                    compute_kernel_config,
+                    config,
+                    untilize_out,
+                    matmul_fused_op_signaler,
+                    std::nullopt,
+                    std::nullopt);
+                matmul_override_runtime_arguments_callback =
+                    matmul_program_with_callbacks->override_runtime_arguments_callback;
             } else {
                 TT_THROW("Unsupported MatmulProgramConfig type. Needs to be 1D or 2D Multicast.");
             }
@@ -169,7 +187,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_matmul_async_multi_core
                     program,
                     {input_tensors[0]}, /* input tensor */
                     optional_input_tensors,
-                    {output_tensors[1]} /* all gather output tensor */
+                    {output_tensors[0]} /* all gather output tensor */
                 );
             }
         };


### PR DESCRIPTION
### Problem description
- Fused AGMM did not support `MatmulMultiCoreReuseMultiCast1DProgramConfig`
- Fused AGMM had a program cache bug (we forgot to update the value when we removed the intermediate buffer from the AGMM implementation)
- Both of these fixes are required for the legacy CCLs -> fabric CCLs model port

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/16334694745
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16334705414
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16334710397
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). https://github.com/tenstorrent/tt-metal/actions/runs/16334716989
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/16282143656
- [x] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work https://github.com/tenstorrent/tt-metal/actions/runs/16282159793
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes