### PR TITLE
#24425, 22626: Cleanup and document tensor alignment

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1768,13 +1768,6 @@ def test_binary_sharded_invalid_spec(
             ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (0, 1))}),
         ],
         [
-            torch.Size([64, 33]),
-            torch.Size([64, 33]),
-            ttnn.ShardStrategy.HEIGHT,
-            [32, 64],
-            ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (0, 1))}),
-        ],
-        [
             torch.Size([64, 4 * 32]),
             torch.Size([64, 4 * 32]),
             ttnn.ShardStrategy.WIDTH,

--- a/ttnn/api/ttnn/tensor/layout/page_config.hpp
+++ b/ttnn/api/ttnn/tensor/layout/page_config.hpp
@@ -84,6 +84,11 @@ public:
     PageConfig(Layout layout);
     PageConfig(Layout layout, const std::optional<Tile>& tile);
 
+    // Alignment is applied to the tensor shape, to guarantee that it is divisible by page size.
+    // For tile layout, the page size is the tile size, so alignment is also equal to the tile size.
+    // For row major layout, the page size is the width of the tensor, or the width of the shard (for sharded tensors).
+    // So for row major tensors, alignment is either [1] for interleaved tensors or shard width for sharded tensors.
+    // Note: alignment rules are different for logical sharding.
     Alignment create_default_alignment(DataType dtype, const MemoryConfig& memory_config) const;
     void validate_alignment(const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config) const;
 

--- a/ttnn/api/ttnn/tensor/layout/tensor_layout.hpp
+++ b/ttnn/api/ttnn/tensor/layout/tensor_layout.hpp
@@ -23,7 +23,11 @@ using Strides = std::vector<size_t>;
 // shape) And provides information required to physically lay out the tensor in memory
 class TensorLayout {
 public:
-    TensorLayout(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config);
+    TensorLayout(
+        DataType dtype,
+        const PageConfig& page_config,
+        const MemoryConfig& memory_config,
+        const Alignment& alignment = {});
 
     // static method makes it easy to find and remove all of its usages in the codebase - thats why it is not a
     // constructor
@@ -93,10 +97,6 @@ public:
         DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment);
 
 private:
-    // Private to not expose alignment parameter to the public API
-    TensorLayout(
-        DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment);
-
     void initialize_alignment();
 
     DataType dtype_ = DataType::BFLOAT16;

--- a/ttnn/core/tensor/layout/page_config.cpp
+++ b/ttnn/core/tensor/layout/page_config.cpp
@@ -158,11 +158,7 @@ Alignment RowMajorPageConfig::create_default_alignment(DataType dtype, const Mem
             return shard_spec.physical_shard_shape.has_value() ? Alignment(shard_spec.physical_shard_shape.value())
                                                                : Alignment({shard_spec.shape[1]});
         }
-        // TODO: Investigate why we need guard against HEIGHT_SHARDED and merge logic with LOGICAL sharding
-        if (shard_spec.mode == ShardMode::PHYSICAL &&
-            memory_config.memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED) {
-            return Alignment({shard_spec.shape[1]});
-        }
+        return Alignment({shard_spec.shape[1]});
     } else if (memory_config.nd_shard_spec().has_value()) {
         const auto& nd_shard_spec = *memory_config.nd_shard_spec();
         return Alignment({nd_shard_spec.shard_shape[-1]});

--- a/ttnn/core/tensor/layout/tensor_layout.cpp
+++ b/ttnn/core/tensor/layout/tensor_layout.cpp
@@ -126,10 +126,6 @@ void validate_shard_spec(const TensorLayout& tensor_layout) {
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
-TensorLayout::TensorLayout(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config) :
-    TensorLayout(dtype, page_config, memory_config, {}) {}
-
-// Private
 TensorLayout::TensorLayout(
     DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment) :
     dtype_(dtype), page_config_(page_config), memory_config_(memory_config), alignment_(alignment) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24425
https://github.com/tenstorrent/tt-metal/issues/22626

### Problem description
Currently Tensor alignment is confusing, and often misunderstood. We need to simplify it and provide an explanation of what it does.

### What's changed
Removed special handling in alignment calculation for height sharded Tensors
Added a comment explaining how default alignment is calculated
Made TensorLayout constructor with explicit alignment public, to avoid forcing users to use deprecated fromPaddedShape method.

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/16278180308)
- [x] New/Existing tests provide coverage for changes