### PR TITLE
#0: Distribute shards in 2D mesh in snake order

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_device_view.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_view.cpp
@@ -56,13 +56,13 @@ TEST(MeshDeviceViewTest, GetRingCoordinatesDonut) {
 }
 
 TEST(MeshDeviceViewTest, GetLineCoordinatesLineTooBig) {
-    EXPECT_ANY_THROW((void)MeshDeviceView::get_line_coordinates(
-        /*length*/ 10, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0)));
+    EXPECT_ANY_THROW((void)MeshDeviceView::get_snake_coordinates(
+        /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0), /*length*/ 10));
 }
 
 TEST(MeshDeviceViewTest, GetLineCoordinatesWithShorterLine) {
-    auto line_coords =
-        MeshDeviceView::get_line_coordinates(/*length*/ 3, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0));
+    auto line_coords = MeshDeviceView::get_snake_coordinates(
+        /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0), /*length*/ 3);
     ASSERT_THAT(line_coords, SizeIs(3));
     EXPECT_EQ(line_coords[0], MeshCoordinate(0, 0));
     EXPECT_EQ(line_coords[1], MeshCoordinate(0, 1));
@@ -70,8 +70,8 @@ TEST(MeshDeviceViewTest, GetLineCoordinatesWithShorterLine) {
 }
 
 TEST(MeshDeviceViewTest, GetLineCoordinates2x2) {
-    auto line_coords =
-        MeshDeviceView::get_line_coordinates(/*length*/ 4, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0));
+    auto line_coords = MeshDeviceView::get_snake_coordinates(
+        /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0), /*length*/ 4);
     ASSERT_THAT(line_coords, SizeIs(4));
     EXPECT_EQ(line_coords[0], MeshCoordinate(0, 0));
     EXPECT_EQ(line_coords[1], MeshCoordinate(0, 1));
@@ -80,16 +80,16 @@ TEST(MeshDeviceViewTest, GetLineCoordinates2x2) {
 }
 
 TEST(MeshDeviceViewTest, GetLineCoordinates2x2WithOffset) {
-    auto line_coords =
-        MeshDeviceView::get_line_coordinates(/*length*/ 2, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(1, 0));
+    auto line_coords = MeshDeviceView::get_snake_coordinates(
+        /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(1, 0), /*length*/ 2);
     ASSERT_THAT(line_coords, SizeIs(2));
     EXPECT_EQ(line_coords[0], MeshCoordinate(1, 0));
     EXPECT_EQ(line_coords[1], MeshCoordinate(1, 1));
 }
 
 TEST(MeshDeviceViewTest, GetLineCoordinates3x3) {
-    auto line_coords =
-        MeshDeviceView::get_line_coordinates(/*length*/ 9, /*mesh_shape*/ Shape2D(3, 3), /*mesh_offset*/ Shape2D(0, 0));
+    auto line_coords = MeshDeviceView::get_snake_coordinates(
+        /*mesh_shape*/ Shape2D(3, 3), /*mesh_offset*/ Shape2D(0, 0), /*length*/ 9);
     ASSERT_THAT(line_coords, SizeIs(9));
     EXPECT_EQ(line_coords[0], MeshCoordinate(0, 0));
     EXPECT_EQ(line_coords[1], MeshCoordinate(0, 1));
@@ -103,8 +103,8 @@ TEST(MeshDeviceViewTest, GetLineCoordinates3x3) {
 }
 
 TEST(MeshDeviceViewTest, GetLineCoordinates3x3WithOffset) {
-    auto line_coords =
-        MeshDeviceView::get_line_coordinates(/*length*/ 5, /*mesh_shape*/ Shape2D(3, 3), /*mesh_offset*/ Shape2D(1, 1));
+    auto line_coords = MeshDeviceView::get_snake_coordinates(
+        /*mesh_shape*/ Shape2D(3, 3), /*mesh_offset*/ Shape2D(1, 1), /*length*/ 5);
     ASSERT_THAT(line_coords, SizeIs(5));
     EXPECT_EQ(line_coords[0], MeshCoordinate(1, 1));
     EXPECT_EQ(line_coords[1], MeshCoordinate(1, 2));

--- a/tt_metal/api/tt-metalium/mesh_device_view.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device_view.hpp
@@ -85,22 +85,37 @@ public:
     [[nodiscard]] DeviceViews get_row_views() const;
     [[nodiscard]] DeviceViews get_column_views() const;
 
-    // These utility methods linearize the set of devices in a mesh into a line or ring.
-    // Linearizing a mesh into a line asserts the condition that device[i-1] is connected to device[i].
-    // Linearizing a mesh into a ring asserts the condition that device[i-1] is connected to device[i] and device[0] is
-    // connected to device[-1].
+    // These utility methods linearize the set of devices in a mesh using either a snake- or ring-based iteration
+    // patterns:
     //
-    // Given a starting coordinate, get the coordinates of a line of devices where device[i-1] is connected to device[i]
-    // The current support only provides left-to-right and right-to-left snaking of the line.
+    // 1. Linearizing a mesh using a snake pattern asserts the condition that device[i-1] is connected to device[i];
+    //    that is, "line" topology. For example, for 3x3 mesh:
     //
-    // Important: these utilities currently only support 2D meshes.
-    // TODO: #17477 - Remove the methods that assume 2D mesh.
-    [[nodiscard]] static std::vector<MeshCoordinate> get_line_coordinates(
-        size_t length, const Shape2D& mesh_shape, const Shape2D& mesh_offset);
+    //    0 1 2
+    //    5 4 3
+    //    6 7 8
+    //
+    // 2. Linearizing a mesh using a ring pattern asserts the condition that device[i-1] is connected to device[i] and
+    //    device[0] is connected to device[-1], resulting in "ring" topology. The line is formed by iterating over the
+    //    edges of 2D mesh, for example:
+    //
+    //    0 1 2
+    //    7   3
+    //    6 5 4
+    //
+    //    The coordinate in the middle is skipped, to preserve ring connectivity.
+    //
+    // Important: these utility methods currently only support 2D meshes.
+    // TODO: #17477 - Remove the methods that assume 2D mesh, or update them to support ND. Ideally, lower them to
+    // `mesh_coord.hpp` infra.
+    [[nodiscard]] static std::vector<MeshCoordinate> get_snake_coordinates(
+        const Shape2D& mesh_shape,
+        const std::optional<Shape2D>& mesh_offset = std::nullopt,
+        std::optional<size_t> length = std::nullopt);
+    [[nodiscard]] std::vector<IDevice*> get_snake_devices() const;
     [[nodiscard]] static std::vector<MeshCoordinate> get_ring_coordinates(
         const Shape2D& ring_shape, const Shape2D& mesh_shape);
     [[nodiscard]] std::vector<IDevice*> get_ring_devices() const;
-    [[nodiscard]] std::vector<IDevice*> get_line_devices() const;
 
     // Distributed mesh support
     // Returns the offset of this host's portion of the mesh within the global distributed mesh.

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -475,7 +475,7 @@ std::vector<IDevice*> MeshDevice::get_row_major_devices(const MeshShape& new_sha
     // From an MxN mesh, we can always reduce rank to a 1xM*N Line mesh.
     // However, going from a Line mesh to an MxN mesh is not always possible.
     if (new_shape.is_line_topology()) {
-        return view_->get_line_devices();
+        return view_->get_snake_devices();
     }
 
     auto new_physical_device_ids = SystemMesh::instance().get_mapped_physical_device_ids(new_shape);

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -156,7 +156,7 @@ std::vector<int> SystemMesh::Impl::get_mapped_physical_device_ids(
 
         auto line_length = shape.mesh_size();
         for (const auto& logical_coordinate :
-             MeshDeviceView::get_line_coordinates(line_length, system_mesh_2d, system_offset_2d)) {
+             MeshDeviceView::get_snake_coordinates(system_mesh_2d, system_offset_2d, line_length)) {
             physical_device_ids.push_back(get_maybe_remote_device_id(logical_coordinate));
         }
         return extract_locals(physical_device_ids);

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -66,7 +66,7 @@ struct MeshMapperConfig {
     tt::stl::SmallVector<Placement> placements;
 
     // If provided, the sharding will be performed according to this shape, but re-mapped to the mesh device shape in
-    // either row-major order, or preserving the original coordinates (if the shape fits within the mesh device
+    // either snake order, or preserving the original coordinates (if the shape fits within the mesh device
     // entirely).
     std::optional<ttnn::MeshShape> mesh_shape_override = std::nullopt;
 };
@@ -127,7 +127,7 @@ struct MeshComposerConfig {
     tt::stl::SmallVector<int> dims;
 
     // If provided, the concatenation will be performed according to this shape, but re-mapped to the mesh device shape
-    // in either row-major order, or preserving the original coordinates (if the shape fits within the mesh device
+    // in either snake order, or preserving the original coordinates (if the shape fits within the mesh device
     // entirely).
     std::optional<ttnn::MeshShape> mesh_shape_override = std::nullopt;
 };


### PR DESCRIPTION
### Ticket
N/A

### Problem description
When sharding data across 2D mesh, we default to using row major iteration. This breaks physical connectivity of neighboring shards.

### What's changed
Instead of row-major distribution, form a "snake" and following the fully connected ordering. E.g. for 3x3 mesh:
```ascii
0 1 2
5 4 3
6 7 8
```

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [X] New/Existing tests provide coverage for changes