### PR TITLE
Preallocate buffers for Falcon and Mixtral CCLs

### DIFF
--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -571,6 +571,7 @@ def run_falcon_demo_kv(
 @pytest.mark.parametrize("perf_mode", (False,))  # Option to measure perf using max seq length (with invalid outputs)
 @pytest.mark.parametrize("greedy_sampling", (False,))
 @pytest.mark.parametrize("max_seq_len", (128,))
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_demo(
     perf_mode,
     greedy_sampling,

--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -216,6 +216,7 @@ def run_falcon_demo_kv(
     prefill_ids, num_users, num_input_tokens = preprocess_and_validate_inputs(
         input_prompts, tokenizer, max_seq_len, perf_mode
     )
+    actual_seq_len = prefill_ids.shape[1]
     profiler.end(f"tokenizing_inputs")
 
     # Update model_config for prefill
@@ -240,6 +241,7 @@ def run_falcon_demo_kv(
         model_config,
         tt_cache_path,
         use_global_cos_sin_cache,
+        actual_seq_len,
     )  # single layer only used for compile
     logger.info("Moved weights (single layer) to devices!")
 
@@ -347,6 +349,7 @@ def run_falcon_demo_kv(
         model_config,
         tt_cache_path,
         use_global_cos_sin_cache,
+        actual_seq_len,
     )
     logger.info("Moved weights (all layers) to device!")
     profiler.end(f"moving_to_device")

--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -574,7 +574,7 @@ def run_falcon_demo_kv(
 @pytest.mark.parametrize("perf_mode", (False,))  # Option to measure perf using max seq length (with invalid outputs)
 @pytest.mark.parametrize("greedy_sampling", (False,))
 @pytest.mark.parametrize("max_seq_len", (128,))
-@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_demo(
     perf_mode,
     greedy_sampling,

--- a/models/demos/t3000/falcon40b/tests/test_demo.py
+++ b/models/demos/t3000/falcon40b/tests/test_demo.py
@@ -11,6 +11,7 @@ from models.demos.t3000.falcon40b.tt.model_config import model_config_entries
 
 
 @pytest.mark.parametrize("max_seq_len", (128,))
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_demo_generate_reference_output(
     max_seq_len, model_location_generator, get_tt_cache_path, t3k_mesh_device, is_ci_env
 ):
@@ -41,6 +42,7 @@ def test_demo_generate_reference_output(
 
 
 @pytest.mark.parametrize("max_seq_len", (128,))
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_demo(
     max_seq_len,
     model_location_generator,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
@@ -9,6 +9,7 @@ from loguru import logger
 import ttnn
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
 from models.demos.t3000.falcon40b.tt.falcon_attention import TtFalconAttention
+from models.demos.t3000.falcon40b.tt.falcon_ccl import TT_CCL
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config
 from models.utility_functions import nearest_32, skip_for_grayskull
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
@@ -220,8 +221,10 @@ def run_test_FalconAttention_inference(
     )
 
     # TT hardware execution -------------------------------------------------------------
+    tt_ccl = TT_CCL(mesh_device)
     tt_FalconAttention_model = TtFalconAttention(
         mesh_device,
+        tt_ccl,
         state_dict,
         base_url,
         layer_num,
@@ -294,6 +297,8 @@ def run_test_FalconAttention_inference(
 
         does_pass = does_pass and does_pass2
 
+    tt_ccl.close()
+
     if does_pass:
         logger.info("Falcon Attention output Passed!")
     else:
@@ -328,6 +333,7 @@ def run_test_FalconAttention_inference(
     ],
     ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"],
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_FalconAttention_inference(
     num_devices,
     model_version,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
@@ -221,7 +221,7 @@ def run_test_FalconAttention_inference(
     )
 
     # TT hardware execution -------------------------------------------------------------
-    tt_ccl = TT_CCL(mesh_device)
+    tt_ccl = TT_CCL(mesh_device, model_config, seq_len)
     tt_FalconAttention_model = TtFalconAttention(
         mesh_device,
         tt_ccl,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
@@ -333,7 +333,7 @@ def run_test_FalconAttention_inference(
     ],
     ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"],
 )
-@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_FalconAttention_inference(
     num_devices,
     model_version,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
@@ -167,6 +167,7 @@ def run_test_FalconCausalLM_inference(
         model_config,
         tt_cache_path,
         use_global_cos_sin_cache=use_global_cos_sin_cache,
+        seq_len=seq_len,
     )
 
     # TODO: Generate embeddings and attention_mask on device
@@ -308,6 +309,7 @@ def run_test_FalconCausalLM_inference(
     ],
     ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"],
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_FalconCausalLM_inference(
     num_devices,
     model_version,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM
+from models.demos.t3000.falcon40b.tt.falcon_ccl import TT_CCL
 from models.demos.t3000.falcon40b.tt.falcon_decoder import TtFalconDecoderLayer
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config
 from models.demos.t3000.falcon40b.tt.model_utils import generate_layernorm_persistent_tensors
@@ -229,8 +230,10 @@ def run_test_FalconDecoder_inference(
     )
 
     # TT hardware execution =================================================================
+    tt_ccl = TT_CCL(mesh_device)
     tt_FalconDecoder_model = TtFalconDecoderLayer(
         mesh_device,
+        tt_ccl,
         state_dict,
         base_url,
         layer_num,
@@ -304,6 +307,8 @@ def run_test_FalconDecoder_inference(
 
         does_pass = does_pass and does_pass2
 
+    tt_ccl.close()
+
     if does_pass:
         logger.info("Falcon Decoder output Passed!")
     else:
@@ -348,6 +353,7 @@ def run_test_FalconDecoder_inference(
     ],
     ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"],
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_FalconDecoder_inference(
     num_devices,
     model_version,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
@@ -230,7 +230,7 @@ def run_test_FalconDecoder_inference(
     )
 
     # TT hardware execution =================================================================
-    tt_ccl = TT_CCL(mesh_device)
+    tt_ccl = TT_CCL(mesh_device, model_config, seq_len)
     tt_FalconDecoder_model = TtFalconDecoderLayer(
         mesh_device,
         tt_ccl,
@@ -353,7 +353,7 @@ def run_test_FalconDecoder_inference(
     ],
     ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"],
 )
-@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_FalconDecoder_inference(
     num_devices,
     model_version,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -119,6 +119,7 @@ def run_test_FalconCausalLM_end_to_end(
         model_config,
         tt_cache_path,
         use_global_cos_sin_cache,
+        seq_len=seq_len,
     )
     ttnn.synchronize_device(mesh_device)
     profiler.end("TtFalcon_model_setup")
@@ -430,6 +431,7 @@ def run_test_FalconCausalLM_end_to_end(
         ),
     ),
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_FalconCausalLM_end_to_end_with_program_cache(
     num_devices,
     model_version,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -431,7 +431,7 @@ def run_test_FalconCausalLM_end_to_end(
         ),
     ),
 )
-@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_FalconCausalLM_end_to_end_with_program_cache(
     num_devices,
     model_version,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
@@ -64,7 +64,7 @@ def run_test_FalconMLP_inference(
     pytorch_out = pytorch_FalconMLP_model(mlp_input)
     # TT hardware execution -------------------------------------------------------------
 
-    tt_ccl = TT_CCL(mesh_device)
+    tt_ccl = TT_CCL(mesh_device, model_config, seq_len)
     tt_FalconMLP_model = TtFalconMLP(
         mesh_device,
         tt_ccl,
@@ -132,7 +132,7 @@ def run_test_FalconMLP_inference(
     ],
     ids=("BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"),
 )
-@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_FalconMLP_inference(
     num_devices,
     model_version,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model.py
@@ -306,6 +306,7 @@ def run_test_FalconModel_inference(
     ],
     ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"],
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_FalconModel_inference(
     num_devices,
     model_version,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model.py
@@ -166,6 +166,7 @@ def run_test_FalconModel_inference(
         model_config,
         tt_cache_path,
         use_global_cos_sin_cache=use_global_cos_sin_cache,
+        seq_len=seq_len,
     )
     ttnn.synchronize_device(mesh_device)
 
@@ -306,7 +307,7 @@ def run_test_FalconModel_inference(
     ],
     ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"],
 )
-@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_FalconModel_inference(
     num_devices,
     model_version,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_prefill_determinism.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_prefill_determinism.py
@@ -253,6 +253,7 @@ def run_test_falcon_prefill_end_to_end_determinism(
         "BFLOAT16-DRAM",
     ),
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_falcon_prefill_end_to_end_determinism(
     generate_weights,
     enable_program_cache,

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -96,6 +96,7 @@ def run_test_FalconCausalLM_end_to_end(
         model_config,
         tt_cache_path,
         use_global_cos_sin_cache,
+        seq_len,
     )
     ttnn.synchronize_device(mesh_device)
     profiler.end("TtFalcon_model_setup")
@@ -335,6 +336,7 @@ def run_test_FalconCausalLM_end_to_end(
     ("tiiuae/falcon-40b-instruct",),
     ids=["falcon_40b"],
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_perf_bare_metal(
     num_devices,
     model_version,
@@ -406,6 +408,7 @@ def test_perf_bare_metal(
     ("tiiuae/falcon-40b-instruct",),
     ids=["falcon_40b"],
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_device_perf_bare_metal(
     num_devices,
     model_version,

--- a/models/demos/t3000/falcon40b/tests/test_perplexity_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perplexity_falcon.py
@@ -272,6 +272,7 @@ def test_perplexity_huggingface(
         "decode_2048",
     ],
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_perplexity(
     llm_mode,
     batch_size,

--- a/models/demos/t3000/falcon40b/tt/falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_attention.py
@@ -367,6 +367,7 @@ class TtFalconAttention:
         )
         attn_output = ttnn.experimental.all_gather_async(
             attn_output,
+            persistent_output_buffer=self.tt_ccl.ag_output_pbs["ATTN_FWD_PREFILL_AG"],
             dim=3,
             multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
@@ -586,6 +587,7 @@ class TtFalconAttention:
         )
         attn_output = ttnn.experimental.all_gather_async(
             attn_output,
+            persistent_output_buffer=self.tt_ccl.ag_output_pbs["ATTN_FWD_DECODE_AG"],
             dim=3,
             multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],

--- a/models/demos/t3000/falcon40b/tt/falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_attention.py
@@ -116,6 +116,7 @@ class TtFalconAttention:
     def __init__(
         self,
         mesh_device,
+        tt_ccl,
         state_dict,
         base_url,
         layer_num,
@@ -133,6 +134,7 @@ class TtFalconAttention:
         self.max_position_embeddings = max_position_embeddings
         self.num_devices = mesh_device.get_num_devices()
         self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
         self.state_dict = state_dict
         self.model_config = model_config
         self.num_heads_per_device = self.num_heads // mesh_device.get_num_devices()
@@ -363,11 +365,13 @@ class TtFalconAttention:
             attn_output,
             memory_config=self.model_config["CONCAT_HEADS_OUTPUT_MEMCFG"],
         )
-        attn_output = ttnn.all_gather(
+        attn_output = ttnn.experimental.all_gather_async(
             attn_output,
             dim=3,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
             memory_config=self.model_config["DEFAULT_MEMCFG"],
+            subdevice_id=self.tt_ccl.worker_sub_device_id,
         )
         attn_output = falcon_prefill_matmul(
             attn_output,
@@ -580,19 +584,13 @@ class TtFalconAttention:
             attn_output,
             memory_config=self.model_config["CONCAT_HEADS_OUTPUT_MEMCFG"],
         )
-        attn_output = ttnn.sharded_to_interleaved(
-            attn_output,
-            memory_config=self.model_config["DEFAULT_MEMCFG"],
-        )
-        attn_output = ttnn.all_gather(
+        attn_output = ttnn.experimental.all_gather_async(
             attn_output,
             dim=3,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-            memory_config=self.model_config["DEFAULT_MEMCFG"],
-        )
-        attn_output = ttnn.interleaved_to_sharded(
-            attn_output,
-            self.model_config["ATTN_ALL_GATHER_OUTPUT_MEMCFG"],
+            memory_config=self.model_config["ATTN_ALL_GATHER_OUTPUT_MEMCFG"],
+            subdevice_id=self.tt_ccl.worker_sub_device_id,
         )
         attn_output = ttnn.matmul(
             attn_output,

--- a/models/demos/t3000/falcon40b/tt/falcon_causallm.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_causallm.py
@@ -24,6 +24,7 @@ class TtFalconCausalLM(TtFalconModelShared):
         model_config,
         tt_cache_path,
         use_global_cos_sin_cache,
+        seq_len: Optional[int] = None,
     ):
         assert base_url == "", "base_url should be empty at the root of the model!"
 
@@ -37,6 +38,7 @@ class TtFalconCausalLM(TtFalconModelShared):
             model_config=model_config,
             tt_cache_path=tt_cache_path,
             use_global_cos_sin_cache=use_global_cos_sin_cache,
+            seq_len=seq_len,
         )
         self.model_config = model_config
         self.mesh_device = mesh_device
@@ -168,6 +170,5 @@ class TtFalconCausalLM(TtFalconModelShared):
             dtype=self.model_config["LM_HEAD_MM_OUTPUT_DTYPE"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
         )
-        hidden_states.deallocate(True)
 
         return lm_logits, presents

--- a/models/demos/t3000/falcon40b/tt/falcon_ccl.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_ccl.py
@@ -35,12 +35,13 @@ class TT_CCL:
         self.rs_semaphore_handles = [[], []]
 
         self.model_config = model_config
+        self.default_dtype = model_config["DEFAULT_DTYPE"]
 
         self.ag_output_pbs = {}
         self.rs_output_pbs = {}
         self.rs_intermediate_pbs = {}
 
-        self.seq_len = 32  # TODO: Why is the falcon demo dim 2 seq_len hardcoded to 32?
+        self.seq_len = seq_len
 
         self.create_persistent_buffers()
 
@@ -99,29 +100,29 @@ class TT_CCL:
         self.ag_output_pbs["DECODER_FWD_PREFILL_AG"] = self.create_persistent_buffer(
             shape=[1, 1, self.seq_len, 8192],
             mem_config=self.model_config["DEFAULT_MEMCFG"],
-            dtype=ttnn.DataType.BFLOAT8_B,
+            dtype=self.default_dtype,
         )
         self.ag_output_pbs["ATTN_FWD_PREFILL_AG"] = self.create_persistent_buffer(
             shape=[1, 1, self.seq_len, 8192],
             mem_config=self.model_config["DEFAULT_MEMCFG"],
-            dtype=ttnn.DataType.BFLOAT8_B,
+            dtype=self.default_dtype,
         )
 
         self.rs_intermediate_pbs["MLP_FWD_PREFILL_RS"] = self.create_persistent_buffer(
             shape=[1, 1, self.seq_len, 8192],
             mem_config=self.model_config["DEFAULT_MEMCFG"],
-            dtype=ttnn.DataType.BFLOAT8_B,
+            dtype=self.default_dtype,
         )
         self.rs_output_pbs["MLP_FWD_PREFILL_RS"] = self.create_persistent_buffer(
             shape=[1, 1, self.seq_len, 1024],
             mem_config=self.model_config["DEFAULT_MEMCFG"],
-            dtype=ttnn.DataType.BFLOAT8_B,
+            dtype=self.default_dtype,
         )
 
         self.ag_output_pbs["MODEL_FWD_PREFILL_AG"] = self.create_persistent_buffer(
             shape=[1, 1, self.seq_len, 8192],
             mem_config=self.model_config["DEFAULT_MEMCFG"],
-            dtype=ttnn.DataType.BFLOAT8_B,
+            dtype=self.default_dtype,
         )
 
         # decode
@@ -138,25 +139,25 @@ class TT_CCL:
         self.ag_output_pbs["DECODER_FWD_DECODE_AG"] = self.create_persistent_buffer(
             shape=[1, 1, 32, 8192],
             mem_config=mem_config,
-            dtype=ttnn.DataType.BFLOAT8_B,
+            dtype=self.default_dtype,
         )
 
         self.ag_output_pbs["ATTN_FWD_DECODE_AG"] = self.create_persistent_buffer(
             shape=[1, 1, 32, 8192],
             mem_config=mem_config,
-            dtype=ttnn.DataType.BFLOAT8_B,
+            dtype=self.default_dtype,
         )
 
         self.ag_output_pbs["MODEL_FWD_DECODE_AG"] = self.create_persistent_buffer(
             shape=[1, 1, 32, 8192],
             mem_config=mem_config,
-            dtype=ttnn.DataType.BFLOAT8_B,
+            dtype=self.default_dtype,
         )
 
         self.rs_intermediate_pbs["MLP_FWD_DECODE_RS"] = self.create_persistent_buffer(
             shape=[1, 1, 32, 8192],
             mem_config=mem_config,
-            dtype=ttnn.DataType.BFLOAT8_B,
+            dtype=self.default_dtype,
             distributed=True,
         )
         shard_shape = [32, 32]
@@ -172,7 +173,7 @@ class TT_CCL:
         self.rs_output_pbs["MLP_FWD_DECODE_RS"] = self.create_persistent_buffer(
             shape=[1, 1, 32, 1024],
             mem_config=mem_config,
-            dtype=ttnn.DataType.BFLOAT8_B,
+            dtype=self.default_dtype,
             distributed=True,
         )
 

--- a/models/demos/t3000/falcon40b/tt/falcon_ccl.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_ccl.py
@@ -140,7 +140,6 @@ class TT_CCL:
             mem_config=mem_config,
             dtype=ttnn.DataType.BFLOAT8_B,
         )
-        print("DECODER_FWD_DECODE_AG mem_cfg: ", self.ag_output_pbs["DECODER_FWD_DECODE_AG"].memory_config())
 
         self.ag_output_pbs["ATTN_FWD_DECODE_AG"] = self.create_persistent_buffer(
             shape=[1, 1, 32, 8192],

--- a/models/demos/t3000/falcon40b/tt/falcon_ccl.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_ccl.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+
+
+class TT_CCL:
+    def __init__(
+        self,
+        mesh_device,
+    ):
+        self.mesh_device = mesh_device
+        self.worker_sub_device_id = ttnn.SubDeviceId(0)
+        self.sub_device_crs = ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(
+                        self.mesh_device.compute_with_storage_grid_size().x - 1,
+                        self.mesh_device.compute_with_storage_grid_size().y - 1,
+                    ),
+                )
+            }
+        )
+
+        self.ag_semaphores_idx = 0
+        self.ag_semaphore_handles = [[], []]
+
+        self.rs_semaphores_idx = 0
+        self.rs_semaphore_handles = [[], []]
+
+        for i in range(2):
+            for _ in range(2):
+                self.ag_semaphore_handles[i].append(
+                    ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0)
+                )
+            for _ in range(3):
+                self.rs_semaphore_handles[i].append(
+                    ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0)
+                )
+
+        worker_sub_device = ttnn.SubDevice([self.sub_device_crs])
+        sub_device_manager = self.mesh_device.create_sub_device_manager([worker_sub_device], 0)
+        self.mesh_device.load_sub_device_manager(sub_device_manager)
+        self.mesh_device.set_sub_device_stall_group([self.worker_sub_device_id])
+
+    def get_and_cycle_ag_semaphore_handles(self):
+        current_idx = self.ag_semaphores_idx
+        self.ag_semaphores_idx = (self.ag_semaphores_idx + 1) % 2
+        return self.ag_semaphore_handles[current_idx]
+
+    def get_and_cycle_rs_semaphore_handles(self):
+        current_idx = self.rs_semaphores_idx
+        self.rs_semaphores_idx = (self.rs_semaphores_idx + 1) % 2
+        return self.rs_semaphore_handles[current_idx]
+
+    def close(self):
+        self.mesh_device.reset_sub_device_stall_group()

--- a/models/demos/t3000/falcon40b/tt/falcon_ccl.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_ccl.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import torch
+
 import ttnn
 
 
@@ -9,6 +11,8 @@ class TT_CCL:
     def __init__(
         self,
         mesh_device,
+        model_config,
+        seq_len,  # if seq_len is not None, it will be used to set the size of the prefill persistent buffers
     ):
         self.mesh_device = mesh_device
         self.worker_sub_device_id = ttnn.SubDeviceId(0)
@@ -29,6 +33,16 @@ class TT_CCL:
 
         self.rs_semaphores_idx = 0
         self.rs_semaphore_handles = [[], []]
+
+        self.model_config = model_config
+
+        self.ag_output_pbs = {}
+        self.rs_output_pbs = {}
+        self.rs_intermediate_pbs = {}
+
+        self.seq_len = 32  # TODO: Why is the falcon demo dim 2 seq_len hardcoded to 32?
+
+        self.create_persistent_buffers()
 
         for i in range(2):
             for _ in range(2):
@@ -54,6 +68,114 @@ class TT_CCL:
         current_idx = self.rs_semaphores_idx
         self.rs_semaphores_idx = (self.rs_semaphores_idx + 1) % 2
         return self.rs_semaphore_handles[current_idx]
+
+    def create_persistent_buffer(self, shape, mem_config, dtype, distributed=False):
+        if distributed:
+            shape[3] *= self.mesh_device.get_num_devices()
+            cluster_shape = list(self.mesh_device.shape)
+            mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=(None, 3), mesh_shape=cluster_shape)
+        else:
+            mesh_mapper = ttnn.ReplicateTensorToMesh(self.mesh_device)
+        return ttnn.from_torch(
+            torch.zeros(shape),
+            device=self.mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=dtype,
+            memory_config=mem_config,
+            mesh_mapper=mesh_mapper,
+        )
+
+    def create_persistent_buffers(self):
+        shard_spec_32_cores_grid = ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(7, 3),
+                ),
+            }
+        )
+
+        # prefill
+        self.ag_output_pbs["DECODER_FWD_PREFILL_AG"] = self.create_persistent_buffer(
+            shape=[1, 1, self.seq_len, 8192],
+            mem_config=self.model_config["DEFAULT_MEMCFG"],
+            dtype=ttnn.DataType.BFLOAT8_B,
+        )
+        self.ag_output_pbs["ATTN_FWD_PREFILL_AG"] = self.create_persistent_buffer(
+            shape=[1, 1, self.seq_len, 8192],
+            mem_config=self.model_config["DEFAULT_MEMCFG"],
+            dtype=ttnn.DataType.BFLOAT8_B,
+        )
+
+        self.rs_intermediate_pbs["MLP_FWD_PREFILL_RS"] = self.create_persistent_buffer(
+            shape=[1, 1, self.seq_len, 8192],
+            mem_config=self.model_config["DEFAULT_MEMCFG"],
+            dtype=ttnn.DataType.BFLOAT8_B,
+        )
+        self.rs_output_pbs["MLP_FWD_PREFILL_RS"] = self.create_persistent_buffer(
+            shape=[1, 1, self.seq_len, 1024],
+            mem_config=self.model_config["DEFAULT_MEMCFG"],
+            dtype=ttnn.DataType.BFLOAT8_B,
+        )
+
+        self.ag_output_pbs["MODEL_FWD_PREFILL_AG"] = self.create_persistent_buffer(
+            shape=[1, 1, self.seq_len, 8192],
+            mem_config=self.model_config["DEFAULT_MEMCFG"],
+            dtype=ttnn.DataType.BFLOAT8_B,
+        )
+
+        # decode
+        shard_shape = [32, 256]
+        mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                shard_spec_32_cores_grid,
+                shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+        self.ag_output_pbs["DECODER_FWD_DECODE_AG"] = self.create_persistent_buffer(
+            shape=[1, 1, 32, 8192],
+            mem_config=mem_config,
+            dtype=ttnn.DataType.BFLOAT8_B,
+        )
+        print("DECODER_FWD_DECODE_AG mem_cfg: ", self.ag_output_pbs["DECODER_FWD_DECODE_AG"].memory_config())
+
+        self.ag_output_pbs["ATTN_FWD_DECODE_AG"] = self.create_persistent_buffer(
+            shape=[1, 1, 32, 8192],
+            mem_config=mem_config,
+            dtype=ttnn.DataType.BFLOAT8_B,
+        )
+
+        self.ag_output_pbs["MODEL_FWD_DECODE_AG"] = self.create_persistent_buffer(
+            shape=[1, 1, 32, 8192],
+            mem_config=mem_config,
+            dtype=ttnn.DataType.BFLOAT8_B,
+        )
+
+        self.rs_intermediate_pbs["MLP_FWD_DECODE_RS"] = self.create_persistent_buffer(
+            shape=[1, 1, 32, 8192],
+            mem_config=mem_config,
+            dtype=ttnn.DataType.BFLOAT8_B,
+            distributed=True,
+        )
+        shard_shape = [32, 32]
+        mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                shard_spec_32_cores_grid,
+                shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+        self.rs_output_pbs["MLP_FWD_DECODE_RS"] = self.create_persistent_buffer(
+            shape=[1, 1, 32, 1024],
+            mem_config=mem_config,
+            dtype=ttnn.DataType.BFLOAT8_B,
+            distributed=True,
+        )
 
     def close(self):
         self.mesh_device.reset_sub_device_stall_group()

--- a/models/demos/t3000/falcon40b/tt/falcon_ccl.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_ccl.py
@@ -70,13 +70,8 @@ class TT_CCL:
         self.rs_semaphores_idx = (self.rs_semaphores_idx + 1) % 2
         return self.rs_semaphore_handles[current_idx]
 
-    def create_persistent_buffer(self, shape, mem_config, dtype, distributed=False):
-        if distributed:
-            shape[3] *= self.mesh_device.get_num_devices()
-            cluster_shape = list(self.mesh_device.shape)
-            mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=(None, 3), mesh_shape=cluster_shape)
-        else:
-            mesh_mapper = ttnn.ReplicateTensorToMesh(self.mesh_device)
+    def create_persistent_buffer(self, shape, mem_config, dtype):
+        mesh_mapper = ttnn.ReplicateTensorToMesh(self.mesh_device)
         return ttnn.from_torch(
             torch.zeros(shape),
             device=self.mesh_device,

--- a/models/demos/t3000/falcon40b/tt/falcon_ccl.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_ccl.py
@@ -100,7 +100,7 @@ class TT_CCL:
         self.ag_output_pbs["DECODER_FWD_PREFILL_AG"] = self.create_persistent_buffer(
             shape=[1, 1, self.seq_len, 8192],
             mem_config=self.model_config["DEFAULT_MEMCFG"],
-            dtype=self.default_dtype,
+            dtype=self.model_config["BFP8_DTYPE"],
         )
         self.ag_output_pbs["ATTN_FWD_PREFILL_AG"] = self.create_persistent_buffer(
             shape=[1, 1, self.seq_len, 8192],
@@ -122,7 +122,7 @@ class TT_CCL:
         self.ag_output_pbs["MODEL_FWD_PREFILL_AG"] = self.create_persistent_buffer(
             shape=[1, 1, self.seq_len, 8192],
             mem_config=self.model_config["DEFAULT_MEMCFG"],
-            dtype=self.default_dtype,
+            dtype=self.model_config["BFP8_DTYPE"],
         )
 
         # decode

--- a/models/demos/t3000/falcon40b/tt/falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_decoder.py
@@ -307,7 +307,7 @@ class TtFalconDecoderLayer:
         assert not output_attentions
 
         replicated_hidden_states = ttnn.experimental.all_gather_async(
-            replicated_hidden_states,
+            hidden_states,
             dim=3,
             multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],

--- a/models/demos/t3000/falcon40b/tt/falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_decoder.py
@@ -17,6 +17,7 @@ class TtFalconDecoderLayer:
     def __init__(
         self,
         mesh_device,
+        tt_ccl,
         state_dict,
         base_url,
         layer_num,
@@ -32,6 +33,7 @@ class TtFalconDecoderLayer:
         self.state_dict = state_dict
         self.base_url = base_url
         self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
         self.layer_num = layer_num
         self.max_position_embeddings = max_position_embeddings
         self.model_config = model_config
@@ -42,6 +44,7 @@ class TtFalconDecoderLayer:
 
         self.self_attn = TtFalconAttention(
             mesh_device=mesh_device,
+            tt_ccl=self.tt_ccl,
             state_dict=state_dict,
             base_url=base_url,
             layer_num=layer_num,
@@ -54,6 +57,7 @@ class TtFalconDecoderLayer:
 
         self.mlp = TtFalconMLP(
             mesh_device=mesh_device,
+            tt_ccl=self.tt_ccl,
             state_dict=state_dict,
             base_url=base_url,
             layer_num=layer_num,
@@ -207,11 +211,13 @@ class TtFalconDecoderLayer:
                 replicated_hidden_states, self.model_config["BFP8_DTYPE"], memory_config=ttnn.DRAM_MEMORY_CONFIG
             )
 
-        replicated_hidden_states = ttnn.all_gather(
+        replicated_hidden_states = ttnn.experimental.all_gather_async(
             replicated_hidden_states,
             dim=3,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
             memory_config=self.model_config["DEFAULT_MEMCFG"],
+            subdevice_id=self.tt_ccl.worker_sub_device_id,
         )
 
         if self.model_config["LN_INPUT_DTYPE"] != self.model_config["BFP8_DTYPE"]:
@@ -300,22 +306,14 @@ class TtFalconDecoderLayer:
 
         assert not output_attentions
 
-        replicated_hidden_states = ttnn.sharded_to_interleaved(
-            hidden_states,
-            memory_config=self.model_config["DEFAULT_MEMCFG"],
-        )
-
-        replicated_hidden_states = ttnn.all_gather(
+        replicated_hidden_states = ttnn.experimental.all_gather_async(
             replicated_hidden_states,
             dim=3,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-            memory_config=self.model_config["DEFAULT_MEMCFG"],
+            memory_config=self.model_config["DECODER_ALL_GATHER_OUTPUT_MEMCFG"],
+            subdevice_id=self.tt_ccl.worker_sub_device_id,
         )
-        replicated_hidden_states = ttnn.interleaved_to_sharded(
-            replicated_hidden_states,
-            self.model_config["DECODER_ALL_GATHER_OUTPUT_MEMCFG"],
-        )
-
         attn_ln_output = ttnn.layer_norm(
             replicated_hidden_states,
             epsilon=self.layernorm_eps,

--- a/models/demos/t3000/falcon40b/tt/falcon_model.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_model.py
@@ -47,7 +47,6 @@ class TtFalconModelShared:
         self.num_layers = num_layers
         self.hidden_size = config.hidden_size
         self.num_devices = mesh_device.get_num_devices()
-        self.seq_len = seq_len
         self.ln_output_tensors_dict = {
             "final_layernorm": dict(),
             "mlp_layernorm": dict(),

--- a/models/demos/t3000/falcon40b/tt/falcon_model.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_model.py
@@ -10,6 +10,7 @@ from tqdm import tqdm
 
 import ttnn
 from models.demos.t3000.falcon40b.tt.falcon_attention import generate_cos_sin_cache
+from models.demos.t3000.falcon40b.tt.falcon_ccl import TT_CCL
 from models.demos.t3000.falcon40b.tt.falcon_decoder import TtFalconDecoderLayer
 from models.demos.t3000.falcon40b.tt.falcon_embeddings import TtFalconEmbeddings
 from models.demos.t3000.falcon40b.tt.model_utils import generate_layernorm_persistent_tensors, partial_layernorm
@@ -36,6 +37,7 @@ class TtFalconModelShared:
         # NOTE: Once we make embeddings run on device, pass in state dict
         # instead of model itself
         self.mesh_device = mesh_device
+        self.tt_ccl = TT_CCL(self.mesh_device)
         self.state_dict = state_dict
         self.base_url = base_url
         self.config = config
@@ -74,6 +76,7 @@ class TtFalconModelShared:
         self.layers = [
             TtFalconDecoderLayer(
                 mesh_device=mesh_device,
+                tt_ccl=self.tt_ccl,
                 state_dict=state_dict,
                 base_url=f"{base_url}.h",
                 layer_num=layer_num,
@@ -308,11 +311,13 @@ class TtFalconModelShared:
                 layer_output, self.model_config["BFP8_DTYPE"], memory_config=ttnn.DRAM_MEMORY_CONFIG
             )
 
-        layer_output = ttnn.all_gather(
+        layer_output = ttnn.experimental.all_gather_async(
             layer_output,
             dim=3,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
             memory_config=self.model_config["DEFAULT_MEMCFG"],
+            subdevice_id=self.tt_ccl.worker_sub_device_id,
         )
 
         if self.model_config["LN_INPUT_DTYPE"] != self.model_config["BFP8_DTYPE"]:
@@ -361,19 +366,13 @@ class TtFalconModelShared:
             presents += layer_output[1:]
             layer_output = layer_output[0]
 
-        layer_output = ttnn.sharded_to_interleaved(
-            layer_output,
-            memory_config=self.model_config["DEFAULT_MEMCFG"],
-        )
-        layer_output = ttnn.all_gather(
+        layer_output = ttnn.experimental.all_gather_async(
             layer_output,
             dim=3,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-            memory_config=self.model_config["DEFAULT_MEMCFG"],
-        )
-        layer_output = ttnn.interleaved_to_sharded(
-            layer_output,
-            self.model_config["FINAL_ALL_GATHER_OUTPUT_MEMCFG"],
+            memory_config=self.model_config["FINAL_ALL_GATHER_OUTPUT_MEMCFG"],
+            subdevice_id=self.tt_ccl.worker_sub_device_id,
         )
 
         # apply final norm layer

--- a/models/demos/t3000/falcon40b/tt/falcon_model.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_model.py
@@ -404,6 +404,7 @@ class TtFalconModel(TtFalconModelShared):
         model_config,
         tt_cache_path,
         use_global_cos_sin_cache,
+        seq_len,
     ):
         super().__init__(
             mesh_device=mesh_device,
@@ -415,6 +416,7 @@ class TtFalconModel(TtFalconModelShared):
             model_config=model_config,
             tt_cache_path=tt_cache_path,
             use_global_cos_sin_cache=use_global_cos_sin_cache,
+            seq_len=seq_len,
         )
 
     def __call__(

--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -34,6 +34,7 @@ from models.utility_functions import is_wormhole_b0
     ],
 )
 @pytest.mark.parametrize("mesh_device", (1, 2, 3, 4, 5, 6, 7, 8), indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_demo_multichip(
     perf_mode,  # Option to measure perf using max seq length (with invalid outputs) and expected perf (t/s)
     max_seq_len,

--- a/models/demos/t3000/mixtral8x7b/demo/demo.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo.py
@@ -128,6 +128,7 @@ def run_mixtral_demo(user_input, batch_size, mesh_device, instruct_mode, is_ci_e
 
     cache_attention(
         mesh_device,
+        tt_model.tt_ccl,
         state_dict,
         model_args,
         current_rot_mat,
@@ -264,6 +265,7 @@ def run_mixtral_demo(user_input, batch_size, mesh_device, instruct_mode, is_ci_e
     ],
     ids=["general", "instruct"],
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_mixtral8x7b_demo(t3k_mesh_device, input_prompts, instruct_weights, is_ci_env):
     if is_ci_env and instruct_weights == True:
         pytest.skip("CI demo test only runs general weights to reduce CI pipeline load (both are supported)")

--- a/models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py
@@ -228,6 +228,7 @@ def run_mixtral_demo(user_input, batch_size, mesh_device, instruct_mode, test_pr
     profiler.start("cache_attention")
     cache_attention(
         mesh_device,
+        tt_model.tt_ccl,
         state_dict,
         model_args,
         current_rot_mat,
@@ -485,6 +486,7 @@ def run_mixtral_demo(user_input, batch_size, mesh_device, instruct_mode, test_pr
         "32k-instruct",
     ],
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_mixtral8x7b_demo(t3k_mesh_device, input_prompts, instruct_weights, prefill_len, is_ci_env):
     if is_ci_env and instruct_weights == False:
         pytest.skip("CI demo test only runs instruct weights with max prefill length of 32k to reduce CI pipeline load")

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
@@ -1,18 +1,21 @@
 # SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import pytest
 import torch
 from loguru import logger
 
 import ttnn
 from models.demos.t3000.mixtral8x7b.reference.model import Attention, precompute_freqs_cis
 from models.demos.t3000.mixtral8x7b.tt.mixtral_attention import TtMixtralAttention
+from models.demos.t3000.mixtral8x7b.tt.mixtral_ccl import TT_CCL
 from models.demos.t3000.mixtral8x7b.tt.mixtral_common import get_single_rot_mat, prepare_inputs_ttnn
 from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
 from models.utility_functions import comp_allclose, comp_pcc
 from ttnn import ConcatMeshToTensor
 
 
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_mixtral_attention_inference(t3k_mesh_device, reset_seeds):
     pcc = 0.99
     dtype = ttnn.bfloat8_b
@@ -29,6 +32,7 @@ def test_mixtral_attention_inference(t3k_mesh_device, reset_seeds):
     reference_model = Attention(args=model_args)
     reference_model.load_state_dict(partial_state_dict)
 
+    tt_ccl = TT_CCL(t3k_mesh_device)
     tt_model = TtMixtralAttention(t3k_mesh_device, state_dict, args=model_args, layer_num=0, dtype=dtype)
 
     current_rot_mat, rot_matrix = get_single_rot_mat(
@@ -78,6 +82,8 @@ def test_mixtral_attention_inference(t3k_mesh_device, reset_seeds):
 
         # Update rotation matrix for next iteration
         current_rot_mat = ttnn.linear(rot_matrix, current_rot_mat)
+
+    tt_ccl.close()
 
     if all_tests_pass:
         logger.info("Mixtral Attention output Passed!")

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
@@ -33,7 +33,7 @@ def test_mixtral_attention_inference(t3k_mesh_device, reset_seeds):
     reference_model.load_state_dict(partial_state_dict)
 
     tt_ccl = TT_CCL(t3k_mesh_device)
-    tt_model = TtMixtralAttention(t3k_mesh_device, state_dict, args=model_args, layer_num=0, dtype=dtype)
+    tt_model = TtMixtralAttention(t3k_mesh_device, tt_ccl, state_dict, args=model_args, layer_num=0, dtype=dtype)
 
     current_rot_mat, rot_matrix = get_single_rot_mat(
         model_args.head_dim,

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention_prefill.py
@@ -8,6 +8,7 @@ from loguru import logger
 import ttnn
 from models.demos.t3000.mixtral8x7b.reference.model import Attention, precompute_freqs_cis
 from models.demos.t3000.mixtral8x7b.tt.mixtral_attention import TtMixtralAttention
+from models.demos.t3000.mixtral8x7b.tt.mixtral_ccl import TT_CCL
 from models.demos.t3000.mixtral8x7b.tt.mixtral_common import (
     get_prefill_rot_mat,
     get_rot_transformation_mat,
@@ -29,6 +30,7 @@ from ttnn import ConcatMeshToTensor, ReplicateTensorToMesh
     ),
 )
 @torch.no_grad()
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_mixtral_attention_inference(t3k_mesh_device, reset_seeds, seq_len):
     pcc = 0.99
     dtype = ttnn.bfloat8_b
@@ -57,7 +59,8 @@ def test_mixtral_attention_inference(t3k_mesh_device, reset_seeds, seq_len):
     )
 
     # Load ttnn model
-    tt_model = TtMixtralAttention(t3k_mesh_device, state_dict, args=model_args, layer_num=0, dtype=dtype)
+    tt_ccl = TT_CCL(t3k_mesh_device)
+    tt_model = TtMixtralAttention(t3k_mesh_device, tt_ccl, state_dict, args=model_args, layer_num=0, dtype=dtype)
 
     generation_start_pos = 0
     generation_length = 3
@@ -126,6 +129,8 @@ def test_mixtral_attention_inference(t3k_mesh_device, reset_seeds, seq_len):
             else:
                 logger.warning(f"{current_cache} Failed! PCC value is lower than {pcc}")
                 all_tests_pass = False
+
+    tt_ccl.close()
 
     if all_tests_pass:
         logger.info("Mixtral Attention output Passed!")

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.t3000.mixtral8x7b.reference.model import TransformerBlock, precompute_freqs_cis
+from models.demos.t3000.mixtral8x7b.tt.mixtral_ccl import TT_CCL
 from models.demos.t3000.mixtral8x7b.tt.mixtral_common import get_single_rot_mat, prepare_inputs_ttnn
 from models.demos.t3000.mixtral8x7b.tt.mixtral_decoder import TtTransformerBlock
 from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
@@ -21,6 +22,7 @@ from ttnn import ConcatMeshToTensor
         16,
     ),
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_mixtral_decoder_inference(t3k_mesh_device, reset_seeds, batch):
     """
     b: batch
@@ -47,8 +49,10 @@ def test_mixtral_decoder_inference(t3k_mesh_device, reset_seeds, batch):
     reference_model.load_state_dict(partial_state_dict)
 
     # Initialize TT model
+    tt_ccl = TT_CCL(t3k_mesh_device)
     tt_model = TtTransformerBlock(
         mesh_device=t3k_mesh_device,
+        tt_ccl=tt_ccl,
         state_dict=state_dict,
         args=model_args,
         layer_num=0,
@@ -104,6 +108,8 @@ def test_mixtral_decoder_inference(t3k_mesh_device, reset_seeds, batch):
             all_tests_pass = False
 
         current_rot_mat = ttnn.linear(rot_matrix, current_rot_mat)
+
+    tt_ccl.close()
 
     if all_tests_pass:
         logger.info(f"All {generation_length} Mistral decode iterations Passed!")

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder_prefill.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.t3000.mixtral8x7b.reference.model import RMSNorm, TransformerBlock, precompute_freqs_cis
+from models.demos.t3000.mixtral8x7b.tt.mixtral_ccl import TT_CCL
 from models.demos.t3000.mixtral8x7b.tt.mixtral_common import (
     get_prefill_rot_mat,
     get_rot_transformation_mat,
@@ -28,6 +29,7 @@ from ttnn import ConcatMeshToTensor, ReplicateTensorToMesh
         1024 * 32,
     ),
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_mixtral_decoder_inference(t3k_mesh_device, reset_seeds, seq_len):
     """
     b: batch
@@ -59,8 +61,10 @@ def test_mixtral_decoder_inference(t3k_mesh_device, reset_seeds, seq_len):
     )
 
     # Initialize TT model
+    tt_ccl = TT_CCL(t3k_mesh_device)
     tt_model = TtTransformerBlock(
         mesh_device=t3k_mesh_device,
+        tt_ccl=tt_ccl,
         state_dict=state_dict,
         args=model_args,
         layer_num=0,
@@ -116,6 +120,8 @@ def test_mixtral_decoder_inference(t3k_mesh_device, reset_seeds, seq_len):
         else:
             logger.warning("Mistral Decoder Block Failed!")
             all_tests_pass = False
+
+    tt_ccl.close()
 
     if all_tests_pass:
         logger.info(f"All {generation_length} Mistral decode iterations Passed!")

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
@@ -33,6 +33,7 @@ class Emb(torch.nn.Module):
         32,
     ),
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_mixtral_model_inference(t3k_mesh_device, reset_seeds, batch):
     valid_pcc = 0.964
     dtype = ttnn.bfloat8_b

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model_prefill.py
@@ -40,6 +40,7 @@ class Emb(torch.nn.Module):
         1024 * 32,
     ),
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_mixtral_model_inference_CI(t3k_mesh_device, reset_seeds, seq_len, is_ci_env):
     # Set additional Mistral flag for CI
     if is_ci_env:

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model_prefill.py
@@ -40,7 +40,7 @@ class Emb(torch.nn.Module):
         1024 * 32,
     ),
 )
-@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_mixtral_model_inference_CI(t3k_mesh_device, reset_seeds, seq_len, is_ci_env):
     # Set additional Mistral flag for CI
     if is_ci_env:

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import pytest
 import torch
 from loguru import logger
 
 import ttnn
 from models.demos.t3000.mixtral8x7b.reference.model import FeedForward
 from models.demos.t3000.mixtral8x7b.reference.moe import MoeLayer
+from models.demos.t3000.mixtral8x7b.tt.mixtral_ccl import TT_CCL
 from models.demos.t3000.mixtral8x7b.tt.mixtral_mlp import TtMixtralMLP
 from models.demos.t3000.mixtral8x7b.tt.mixtral_moe import TtMoeLayer
 from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
@@ -14,6 +16,7 @@ from models.utility_functions import comp_allclose, comp_pcc
 from ttnn import ConcatMeshToTensor, ReplicateTensorToMesh
 
 
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_mixtral_moe_inference(t3k_mesh_device, reset_seeds):
     pcc = 0.99
     iterations = 1
@@ -50,8 +53,10 @@ def test_mixtral_moe_inference(t3k_mesh_device, reset_seeds):
         },
     )
 
+    tt_ccl = TT_CCL(t3k_mesh_device)
     tt_model = TtMoeLayer(
         mesh_device=t3k_mesh_device,
+        tt_ccl=tt_ccl,
         state_dict=state_dict,
         experts=experts,
         args=model_args,
@@ -99,6 +104,8 @@ def test_mixtral_moe_inference(t3k_mesh_device, reset_seeds):
         else:
             logger.warning("Mistral MOE Failed!")
             all_tests_pass = False
+
+    tt_ccl.close()
 
     if all_tests_pass:
         logger.info(f"All {iterations} Mistral MOE iterations Passed!")

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe_prefill.py
@@ -8,6 +8,7 @@ from loguru import logger
 import ttnn
 from models.demos.t3000.mixtral8x7b.reference.model import FeedForward
 from models.demos.t3000.mixtral8x7b.reference.moe import MoeLayer
+from models.demos.t3000.mixtral8x7b.tt.mixtral_ccl import TT_CCL
 from models.demos.t3000.mixtral8x7b.tt.mixtral_mlp import TtMixtralMLP
 from models.demos.t3000.mixtral8x7b.tt.mixtral_moe import TtMoeLayer
 from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
@@ -24,6 +25,7 @@ from ttnn import ConcatMeshToTensor, ReplicateTensorToMesh
         1024 * 32,
     ),
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_mixtral_moe_inference(t3k_mesh_device, reset_seeds, seq_len):
     pcc = 0.99
     iterations = 1
@@ -62,8 +64,10 @@ def test_mixtral_moe_inference(t3k_mesh_device, reset_seeds, seq_len):
         },
     )
 
+    tt_ccl = TT_CCL(t3k_mesh_device)
     tt_model = TtMoeLayer(
         mesh_device=t3k_mesh_device,
+        tt_ccl=tt_ccl,
         state_dict=state_dict,
         experts=experts,
         args=model_args,
@@ -105,6 +109,8 @@ def test_mixtral_moe_inference(t3k_mesh_device, reset_seeds, seq_len):
         else:
             logger.warning("Mistral MOE Failed!")
             all_tests_pass = False
+
+    tt_ccl.close()
 
     if all_tests_pass:
         logger.info(f"All {iterations} Mistral MOE iterations Passed!")

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
@@ -40,6 +40,7 @@ class Emb(torch.nn.Module):
         (2048, 150, 0.085),
     ),
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_mixtral_model_perf(
     t3k_mesh_device,
     generation_start_pos,

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perplexity.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perplexity.py
@@ -33,6 +33,7 @@ class Emb(torch.nn.Module):
 
 
 @torch.no_grad()
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def run_test_perplexity(
     mesh_device,
     batch_size,

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
@@ -1,17 +1,20 @@
 # SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import pytest
 import torch
 from loguru import logger
 
 import ttnn
 from models.common.rmsnorm import RMSNorm as TtRMSNorm
 from models.demos.t3000.mixtral8x7b.reference.model import RMSNorm as RefRMSNorm
+from models.demos.t3000.mixtral8x7b.tt.mixtral_ccl import TT_CCL
 from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
 from models.utility_functions import comp_allclose, comp_pcc
 from ttnn import ConcatMeshToTensor, ReplicateTensorToMesh
 
 
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_mixtral_rms_norm_inference(t3k_mesh_device, reset_seeds):
     dtype = ttnn.bfloat16
 
@@ -23,8 +26,10 @@ def test_mixtral_rms_norm_inference(t3k_mesh_device, reset_seeds):
     reference_model = RefRMSNorm(dim=model_args.dim)
     reference_model.load_state_dict(partial_state_dict)
 
+    tt_ccl = TT_CCL(t3k_mesh_device)
     tt_model = TtRMSNorm(
         device=t3k_mesh_device,
+        tt_ccl=tt_ccl,
         dim=model_args.dim,
         state_dict=state_dict,
         layer_num=0,
@@ -50,6 +55,8 @@ def test_mixtral_rms_norm_inference(t3k_mesh_device, reset_seeds):
 
     logger.info(comp_allclose(reference_output, tt_output_torch))
     logger.info(pcc_message)
+
+    tt_ccl.close()
 
     if passing:
         logger.info("Mixtral_rms_norm Passed!")

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_topk.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_topk.py
@@ -38,6 +38,7 @@ class Emb(torch.nn.Module):
         # "256seqlen"
     ),
 )
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_mixtral_model_inference(t3k_mesh_device, reset_seeds, iterations, expected_top1, expected_top5):
     # TODO Currently topk test is supporting decode-only mode. Add prefill support.
 

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
@@ -271,13 +271,6 @@ class TtMixtralAttention(LightweightModule):
         )
         attn_output_11BH.deallocate(True)
         # All gather
-        dim = 2
-        ag_output_shape = list(dense_out_11BH.shape)
-        ag_output_shape[dim] *= self.mesh_device.get_num_devices()
-        # print("ATTN_FWD_DECODE_AG")
-        # print(ag_output_shape)
-        # print(dense_out_11BH.dtype)
-        # print(dense_out_11BH.memory_config())
         dense_outputs_11BH = ttnn.experimental.all_gather_async(
             dense_out_11BH,
             persistent_output_buffer=self.tt_ccl.ag_output_pbs["ATTN_FWD_DECODE_AG"],
@@ -427,12 +420,7 @@ class TtMixtralAttention(LightweightModule):
         dim = 1
         ag_output_shape = list(output_11SH.shape)
         ag_output_shape[dim] *= self.mesh_device.get_num_devices()
-        print("ATTN_FWD_PREFILL_AG")
-        print(ag_output_shape)
-        print(output_11SH.dtype)
-        print(output_11SH.memory_config())
         output_buffer = self.tt_ccl.ag_output_pbs[("ATTN_FWD_PREFILL_AG", tuple(ag_output_shape))]
-        breakpoint()
 
         output_11BH_gathered = ttnn.experimental.all_gather_async(
             output_11SH,

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
@@ -418,10 +418,10 @@ class TtMixtralAttention(LightweightModule):
         output_11BH_gathered = ttnn.experimental.all_gather_async(
             output_11SH,
             dim=1,
-            multi_device_global_semaphore=self.multi_device_global_semaphore_handles[:2],
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
             num_links=1,
             memory_config=output_11SH.memory_config(),
-            subdevice_id=self.worker_sub_device_id,
+            subdevice_id=self.tt_ccl.worker_sub_device_id,
         )
         output_11SH.deallocate(True)
         output_11BH_reduced = ttnn.experimental.fast_reduce_nc(

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_ccl.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_ccl.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+
+
+class TT_CCL:
+    def __init__(
+        self,
+        mesh_device,
+    ):
+        self.mesh_device = mesh_device
+        self.worker_sub_device_id = ttnn.SubDeviceId(0)
+        self.sub_device_crs = ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(
+                        self.mesh_device.compute_with_storage_grid_size().x - 1,
+                        self.mesh_device.compute_with_storage_grid_size().y - 1,
+                    ),
+                )
+            }
+        )
+
+        self.ag_semaphores_idx = 0
+        self.ag_semaphore_handles = [[], []]
+
+        self.rs_semaphores_idx = 0
+        self.rs_semaphore_handles = [[], []]
+
+        for i in range(2):
+            for _ in range(2):
+                self.ag_semaphore_handles[i].append(
+                    ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0)
+                )
+            for _ in range(3):
+                self.rs_semaphore_handles[i].append(
+                    ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0)
+                )
+
+        worker_sub_device = ttnn.SubDevice([self.sub_device_crs])
+        sub_device_manager = self.mesh_device.create_sub_device_manager([worker_sub_device], 0)
+        self.mesh_device.load_sub_device_manager(sub_device_manager)
+        self.mesh_device.set_sub_device_stall_group([self.worker_sub_device_id])
+
+    def get_and_cycle_ag_semaphore_handles(self):
+        current_idx = self.ag_semaphores_idx
+        self.ag_semaphores_idx = (self.ag_semaphores_idx + 1) % 2
+        return self.ag_semaphore_handles[current_idx]
+
+    def get_and_cycle_rs_semaphore_handles(self):
+        current_idx = self.rs_semaphores_idx
+        self.rs_semaphores_idx = (self.rs_semaphores_idx + 1) % 2
+        return self.rs_semaphore_handles[current_idx]
+
+    def close(self):
+        self.mesh_device.reset_sub_device_stall_group()

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_ccl.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_ccl.py
@@ -118,7 +118,7 @@ class TT_CCL:
         )
 
         self.ag_output_pbs["MOE_FWD_DECODE_AG"] = self.create_persistent_buffer(
-            shape=[1, 8, 32, 4096],
+            shape=[1, 1, 256, 4096],
             mem_config=ttnn.L1_MEMORY_CONFIG,
             dtype=ttnn.DataType.BFLOAT8_B,
         )

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_ccl.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_ccl.py
@@ -67,13 +67,8 @@ class TT_CCL:
         self.rs_semaphores_idx = (self.rs_semaphores_idx + 1) % 2
         return self.rs_semaphore_handles[current_idx]
 
-    def create_persistent_buffer(self, shape, mem_config, dtype, distributed=False):
-        if distributed:
-            shape[3] *= self.mesh_device.get_num_devices()
-            cluster_shape = list(self.mesh_device.shape)
-            mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=(None, 3), mesh_shape=cluster_shape)
-        else:
-            mesh_mapper = ttnn.ReplicateTensorToMesh(self.mesh_device)
+    def create_persistent_buffer(self, shape, mem_config, dtype):
+        mesh_mapper = ttnn.ReplicateTensorToMesh(self.mesh_device)
         return ttnn.from_torch(
             torch.zeros(shape),
             device=self.mesh_device,

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_common.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_common.py
@@ -214,7 +214,7 @@ def sample(logits: torch.Tensor, temperature: float, top_p: float):
     return next_token
 
 
-def cache_attention(mesh_device, state_dict, model_args, current_rot_mat, rot_matrix, dtype):
+def cache_attention(mesh_device, tt_ccl, state_dict, model_args, current_rot_mat, rot_matrix, dtype):
     from models.demos.t3000.mixtral8x7b.tt.mixtral_attention import TtMixtralAttention
 
     logger.info(f"Caching attention...")
@@ -230,6 +230,7 @@ def cache_attention(mesh_device, state_dict, model_args, current_rot_mat, rot_ma
 
     tt_attn = TtMixtralAttention(
         mesh_device,
+        tt_ccl,
         state_dict,
         model_args,
         layer_num=0,

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_decoder.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_decoder.py
@@ -13,6 +13,7 @@ class TtTransformerBlock(LightweightModule):
     def __init__(
         self,
         mesh_device,
+        tt_ccl,
         state_dict,
         args,
         layer_num,
@@ -22,12 +23,14 @@ class TtTransformerBlock(LightweightModule):
 
         self.state_dict = state_dict
         self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
 
         self.args = args
 
         self.layer_num = layer_num
         self.attention = TtMixtralAttention(
             mesh_device=mesh_device,
+            tt_ccl=self.tt_ccl,
             state_dict=state_dict,
             args=args,
             layer_num=layer_num,
@@ -36,6 +39,7 @@ class TtTransformerBlock(LightweightModule):
 
         self.feed_forward = TtMoeLayer(
             mesh_device=mesh_device,
+            tt_ccl=self.tt_ccl,
             state_dict=state_dict,
             experts=TtMixtralMLP(
                 mesh_device=mesh_device,
@@ -54,6 +58,7 @@ class TtTransformerBlock(LightweightModule):
         )
         self.attention_norm = RMSNorm(
             device=mesh_device,
+            tt_ccl=self.tt_ccl,
             dim=args.dim,
             state_dict=state_dict,
             layer_num=layer_num,
@@ -63,6 +68,7 @@ class TtTransformerBlock(LightweightModule):
 
         self.ffn_norm = RMSNorm(
             device=mesh_device,
+            tt_ccl=self.tt_ccl,
             dim=args.dim,
             state_dict=state_dict,
             layer_num=layer_num,

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
@@ -7,6 +7,7 @@ import torch
 import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.rmsnorm import RMSNorm
+from models.demos.t3000.mixtral8x7b.tt.mixtral_ccl import TT_CCL
 from models.demos.t3000.mixtral8x7b.tt.mixtral_common import get_single_rot_mat_multi_pos, get_single_rot_mat_torch
 from models.demos.t3000.mixtral8x7b.tt.mixtral_decoder import TtTransformerBlock
 
@@ -22,9 +23,12 @@ class TtTransformer(LightweightModule):
         self.rotary_on_host = rotary_on_host
         assert self.vocab_size > 0
 
+        self.tt_ccl = TT_CCL(self.mesh_device)
+
         self.layers = [
             TtTransformerBlock(
                 mesh_device=mesh_device,
+                tt_ccl=self.tt_ccl,
                 state_dict=state_dict,
                 args=args,
                 dtype=dtype,
@@ -34,6 +38,7 @@ class TtTransformer(LightweightModule):
         ]
         self.norm = RMSNorm(
             device=mesh_device,
+            tt_ccl=self.tt_ccl,
             dim=args.dim,
             state_dict=state_dict,
             layer_num=None,

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
@@ -23,7 +23,7 @@ class TtTransformer(LightweightModule):
         self.rotary_on_host = rotary_on_host
         assert self.vocab_size > 0
 
-        self.tt_ccl = TT_CCL(self.mesh_device)
+        self.tt_ccl = TT_CCL(self.mesh_device, self.model_config, None)
 
         self.layers = [
             TtTransformerBlock(

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
@@ -135,13 +135,10 @@ class TtMoeLayer(LightweightModule):
             dim = 1
             ag_output_shape = list(results_11BH.shape)
             ag_output_shape[dim] *= self.mesh_device.get_num_devices()
-            # print("MOE_FWD_PREFILL_AG")
-            # print(ag_output_shape)
-            # print(results_11BH.dtype)
-            # print(results_11BH.memory_config())
+            output_buffer = self.tt_ccl.ag_output_pbs[("ATTN_FWD_PREFILL_AG", tuple(ag_output_shape))]
             output_11BH_gathered = ttnn.experimental.all_gather_async(
                 results_11BH,
-                persistent_output_buffer=self.tt_ccl.ag_output_pbs["MOE_FWD_PREFILL_AG"],
+                persistent_output_buffer=output_buffer,
                 dim=1,
                 multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
                 num_links=1,
@@ -155,13 +152,6 @@ class TtMoeLayer(LightweightModule):
             )
             # output_11BH_gathered.deallocate(True)
         else:  # Decode mode
-            dim = 1
-            ag_output_shape = list(results_11BH.shape)
-            ag_output_shape[dim] *= self.mesh_device.get_num_devices()
-            # print("MOE_FWD_DECODE_AG")
-            # print(ag_output_shape)
-            # print(results_11BH.dtype)
-            # print(results_11BH.memory_config())
             output_11BH_gathered = ttnn.experimental.all_gather_async(
                 results_11BH,
                 persistent_output_buffer=self.tt_ccl.ag_output_pbs["MOE_FWD_DECODE_AG"],

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
@@ -10,9 +10,10 @@ from ttnn import ReplicateTensorToMesh, ShardTensorToMesh
 
 
 class TtMoeLayer(LightweightModule):
-    def __init__(self, mesh_device, state_dict, experts, args, layer_num, dtype):
+    def __init__(self, mesh_device, tt_ccl, state_dict, experts, args, layer_num, dtype):
         super().__init__()
         self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
         self.experts = experts
         self.args = args
         self.dtype = dtype
@@ -131,7 +132,13 @@ class TtMoeLayer(LightweightModule):
 
         # All gather
         if mode == "prefill":
-            output_11BH_gathered = ttnn.all_gather(results_11BH, dim=1, num_links=1)
+            output_11BH_gathered = ttnn.experimental.all_gather_async(
+                results_11BH,
+                dim=1,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
+                num_links=1,
+                subdevice_id=self.tt_ccl.worker_sub_device_id,
+            )
             results_11BH.deallocate(True)
             # Sum reduction
             output_11BH_reduced = ttnn.experimental.fast_reduce_nc(
@@ -139,7 +146,13 @@ class TtMoeLayer(LightweightModule):
             )
             output_11BH_gathered.deallocate(True)
         else:  # Decode mode
-            output_11BH_gathered = ttnn.all_gather(results_11BH, dim=2, num_links=1)
+            output_11BH_gathered = ttnn.experimental.all_gather_async(
+                results_11BH,
+                dim=2,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
+                num_links=1,
+                subdevice_id=self.tt_ccl.worker_sub_device_id,
+            )
             results_11BH.deallocate(True)
             # Reduction
             output_11BH_reduced = ttnn.matmul(

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_async.py
@@ -1,0 +1,526 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import math
+from loguru import logger
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from tests.ttnn.unit_tests.operations.ccl.test_all_gather import is_unsupported_case
+from models.utility_functions import skip_for_grayskull, skip_for_blackhole
+
+from ttnn import ShardTensorToMesh, ConcatMeshToTensor
+
+
+def create_global_semaphores(t3k_mesh_device, num_devices, cores, initial_value):
+    # create global semaphore handles
+    ccl_semaphore_handles = [ttnn.create_global_semaphore(t3k_mesh_device, cores, initial_value) for _ in range(2)]
+    return ccl_semaphore_handles
+
+
+def run_all_gather_impl(
+    t3k_mesh_device,
+    num_devices,
+    ag_output_shape,
+    dim,
+    num_links,
+    ag_input_dtype,
+    layout,
+    mem_config_input,
+    mem_config_ag,
+    all_gather_topology,
+    num_iters=1,
+    enable_trace=True,
+):
+    torch.manual_seed(0)
+
+    tile = (32, 32)
+
+    # Skip unsupported cases
+    (is_known_failure, message) = is_unsupported_case(
+        ag_output_shape, dim, mem_config_ag, num_devices, num_links, ag_input_dtype, layout, tile
+    )
+    if is_known_failure:
+        pytest.skip(f"Skipping unsupported case {message}.")
+
+    if num_iters < 1:
+        pytest.fail("num_iters must be >= 1")
+
+    ##### All gather setup #####
+    compute_grid_size = t3k_mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice(
+        [
+            ccl_sub_device_crs,
+        ]
+    )
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+
+    sub_device_manager = t3k_mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    t3k_mesh_device.load_sub_device_manager(sub_device_manager)
+    t3k_mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+    # create global semaphore handles
+    ccl_semaphore_handles = [
+        create_global_semaphores(t3k_mesh_device, num_devices, ccl_sub_device_crs, 0) for _ in range(num_iters)
+    ]
+
+    ### Create persistent output buffers
+    logger.info("Creating persistent buffers")
+    persistent_output_buffers = [
+        ttnn.from_torch(
+            torch.zeros(ag_output_shape),
+            device=t3k_mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ag_input_dtype,
+            memory_config=mem_config_ag,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(t3k_mesh_device),
+        )
+        for _ in range(num_iters)
+    ]
+
+    logger.info("Done creating persistent buffers")
+
+    ##### All gather input setup #####
+    logger.info(f"All gather output shape: {ag_output_shape}")
+    logger.info(f"All gather dim: {dim}")
+
+    input_tensor_mesh_list = []
+    ag_output_tensor_goldens_list = []
+
+    for i in range(num_iters):
+        ag_output_tensor = torch.rand(ag_output_shape).bfloat16()
+        ag_output_tensor_goldens_list.append(ag_output_tensor)
+
+        input_tensor_mesh = ttnn.from_torch(
+            ag_output_tensor,
+            device=t3k_mesh_device,
+            layout=layout,
+            dtype=ag_input_dtype,
+            memory_config=mem_config_input,
+            mesh_mapper=ttnn.ShardTensorToMesh(t3k_mesh_device, dim=dim),
+        )
+
+        input_tensor_mesh_list.append(input_tensor_mesh)
+
+    ##### Perform the TT ops #####
+    tt_all_gather_out_tensor_list = []
+
+    def run_op(i):
+        tt_all_gather_out_tensor = ttnn.experimental.all_gather_async(
+            input_tensor_mesh_list[i],
+            persistent_output_buffer=persistent_output_buffers[i],
+            dim=dim,
+            multi_device_global_semaphore=ccl_semaphore_handles[i],
+            num_links=num_links,
+            memory_config=mem_config_ag,
+            topology=all_gather_topology,
+            subdevice_id=worker_sub_device_id,
+        )
+
+        return tt_all_gather_out_tensor
+
+    if enable_trace:
+        # Compile the op
+        tt_all_gather_out_tensor = run_op(0)
+        ttnn.synchronize_device(t3k_mesh_device, sub_device_ids=sub_device_stall_group)
+        logger.info(f"Done compiling Op")
+
+        # Capture the trace
+        trace_id = ttnn.begin_trace_capture(t3k_mesh_device, cq_id=0)
+        tt_all_gather_out_tensor = run_op(0)
+        ttnn.end_trace_capture(t3k_mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(t3k_mesh_device, sub_device_ids=sub_device_stall_group)
+        logger.info(f"Done capturing trace")
+
+        # Execute trace
+        for i in range(num_iters):
+            ttnn.execute_trace(t3k_mesh_device, trace_id, cq_id=0, blocking=False)
+            ttnn.synchronize_device(t3k_mesh_device, sub_device_ids=sub_device_stall_group)
+            tt_all_gather_out_tensor_list.append(tt_all_gather_out_tensor)
+        logger.info(f"Done executing trace")
+    else:
+        for i in range(num_iters):
+            tt_all_gather_out_tensor = run_op(i)
+            tt_all_gather_out_tensor_list.append(tt_all_gather_out_tensor)
+
+            logger.info(f"Waiting for op")
+            ttnn.synchronize_device(t3k_mesh_device, sub_device_ids=sub_device_stall_group)
+            logger.info(f"Done op")
+
+            logger.info(f"Done iteration {i}")
+
+    for i in range(num_iters):
+        tt_ag_out_tensor = tt_all_gather_out_tensor_list[i]
+        torch_ag_out_tensor = ag_output_tensor_goldens_list[i if not enable_trace else 0]
+
+        tt_ag_out = ttnn.from_device(tt_ag_out_tensor)
+        tt_ag_out = ttnn.to_torch(tt_ag_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
+        tt_ag_out = tt_ag_out[:, :, :, 0 : torch_ag_out_tensor.shape[3]]
+        eq, output = comp_pcc(tt_ag_out, torch_ag_out_tensor, 1)
+        logger.info(f"{output}, iteration {i}")
+        assert eq, f"{i} FAILED ag: {output}"
+
+    t3k_mesh_device.reset_sub_device_stall_group()
+    t3k_mesh_device.clear_loaded_sub_device_manager()
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, ag_output_shape, dim, layout, ag_input_dtype",
+    [
+        (8, 1, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config_input, mem_config_ag",
+    [
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace,num_iters",
+    [
+        (True, 10),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
+)
+def test_all_gather_async_interleaved_to_interleaved(
+    t3k_mesh_device,
+    num_devices,
+    ag_output_shape,
+    dim,
+    num_links,
+    ag_input_dtype,
+    layout,
+    mem_config_input,
+    mem_config_ag,
+    enable_trace,
+    all_gather_topology,
+    num_iters,
+):
+    if t3k_mesh_device.get_num_devices() != 8:
+        pytest.skip("Not T3K!")
+
+    run_all_gather_impl(
+        t3k_mesh_device,
+        num_devices,
+        ag_output_shape,
+        dim,
+        num_links,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+    )
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, layout, ag_input_dtype",
+    [
+        (8, 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize(
+    "ag_output_shape, dim, input_shard_shape, input_shard_grid, input_mem_layout, output_shard_shape, output_shard_grid, output_mem_layout",
+    [
+        (
+            [1, 1, 32, 3072],
+            3,
+            (32, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            (32, 512),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            [1, 1, 384, 1024],
+            3,
+            (64, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            (64, 1024),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+        (
+            [1, 1, 384, 3072],
+            3,
+            (64, 384),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            (384, 512),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace,num_iters",
+    [
+        (True, 10),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
+)
+def test_all_gather_async_sharded_to_sharded(
+    t3k_mesh_device,
+    num_devices,
+    num_links,
+    layout,
+    ag_input_dtype,
+    ag_output_shape,
+    dim,
+    input_shard_shape,
+    input_shard_grid,
+    input_mem_layout,
+    output_shard_shape,
+    output_shard_grid,
+    output_mem_layout,
+    enable_trace,
+    all_gather_topology,
+    num_iters,
+):
+    if t3k_mesh_device.get_num_devices() != 8:
+        pytest.skip("Not T3K!")
+
+    input_shard_spec = ttnn.ShardSpec(
+        input_shard_grid,
+        input_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_shard_spec = ttnn.ShardSpec(
+        output_shard_grid,
+        output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    mem_config_input = ttnn.MemoryConfig(
+        input_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=input_shard_spec
+    )
+    mem_config_ag = ttnn.MemoryConfig(output_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=output_shard_spec)
+
+    run_all_gather_impl(
+        t3k_mesh_device,
+        num_devices,
+        ag_output_shape,
+        dim,
+        num_links,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+    )
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, layout, ag_input_dtype",
+    [
+        (8, 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize(
+    "ag_output_shape, dim, input_shard_shape, input_shard_grid, input_mem_layout",
+    [
+        (
+            [1, 1, 32, 3072],
+            3,
+            (32, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            [1, 1, 384, 1024],
+            3,
+            (64, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace,num_iters",
+    [
+        (True, 10),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
+)
+def test_all_gather_async_sharded_to_interleaved(
+    t3k_mesh_device,
+    num_devices,
+    num_links,
+    layout,
+    ag_input_dtype,
+    ag_output_shape,
+    dim,
+    input_shard_shape,
+    input_shard_grid,
+    input_mem_layout,
+    enable_trace,
+    all_gather_topology,
+    num_iters,
+):
+    if t3k_mesh_device.get_num_devices() != 8:
+        pytest.skip("Not T3K!")
+
+    input_shard_spec = ttnn.ShardSpec(
+        input_shard_grid,
+        input_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    mem_config_input = ttnn.MemoryConfig(
+        input_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=input_shard_spec
+    )
+    mem_config_ag = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+    run_all_gather_impl(
+        t3k_mesh_device,
+        num_devices,
+        ag_output_shape,
+        dim,
+        num_links,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+    )
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, layout, ag_input_dtype",
+    [
+        (8, 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize(
+    "ag_output_shape, dim, output_shard_shape, output_shard_grid, output_mem_layout",
+    [
+        (
+            [1, 1, 32, 3072],
+            3,
+            (32, 512),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            [1, 1, 384, 1024],
+            3,
+            (64, 1024),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace,num_iters",
+    [
+        (True, 10),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
+)
+def test_all_gather_async_interleaved_to_sharded(
+    t3k_mesh_device,
+    num_devices,
+    num_links,
+    layout,
+    ag_input_dtype,
+    ag_output_shape,
+    dim,
+    output_shard_shape,
+    output_shard_grid,
+    output_mem_layout,
+    enable_trace,
+    all_gather_topology,
+    num_iters,
+):
+    if t3k_mesh_device.get_num_devices() != 8:
+        pytest.skip("Not T3K!")
+
+    output_shard_spec = ttnn.ShardSpec(
+        output_shard_grid,
+        output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    mem_config_input = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    mem_config_ag = ttnn.MemoryConfig(output_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=output_shard_spec)
+
+    run_all_gather_impl(
+        t3k_mesh_device,
+        num_devices,
+        ag_output_shape,
+        dim,
+        num_links,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+    )

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_reduce_scatter.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_reduce_scatter.py
@@ -9,6 +9,7 @@ from loguru import logger
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
 from tests.ttnn.unit_tests.operations.ccl.test_all_gather import is_unsupported_case
+from models.utility_functions import skip_for_grayskull, skip_for_blackhole
 
 from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 
@@ -33,10 +34,15 @@ def run_reduce_scatter_impl(
     num_iters=1,
     enable_trace=True,
     ones_tensor=False,
+    mem_config_intermediate=None,
 ):
     torch.manual_seed(0)
 
     tile = (32, 32)
+
+    # Set the default config
+    if mem_config_intermediate is None:
+        mem_config_intermediate = mem_config_rs
 
     ##### Fabric setup #####
     compute_grid_size = t3k_mesh_device.compute_with_storage_grid_size()
@@ -71,7 +77,7 @@ def run_reduce_scatter_impl(
             device=t3k_mesh_device,
             layout=ttnn.TILE_LAYOUT,
             dtype=rs_input_dtype,
-            memory_config=mem_config_rs,
+            memory_config=mem_config_intermediate,
             mesh_mapper=ttnn.ReplicateTensorToMesh(t3k_mesh_device),
         )
         for _ in range(num_iters)
@@ -202,6 +208,8 @@ def run_reduce_scatter_impl(
     t3k_mesh_device.clear_loaded_sub_device_manager()
 
 
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@skip_for_blackhole("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
     "num_devices, num_links, rs_input_shape, dim, layout, rs_input_dtype",
     [
@@ -277,6 +285,9 @@ def test_reduce_scatter_async(
     ones_tensor,
     rs_topology,
 ):
+    if t3k_mesh_device.get_num_devices() != 8:
+        pytest.skip("Not T3K!")
+
     run_reduce_scatter_impl(
         t3k_mesh_device,
         num_devices,
@@ -291,4 +302,358 @@ def test_reduce_scatter_async(
         enable_trace=enable_trace,
         num_iters=num_iters,
         ones_tensor=ones_tensor,
+    )
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, layout, rs_input_dtype",
+    [
+        (8, 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize(
+    "rs_input_shape, dim, input_shard_shape, input_shard_grid, input_mem_layout, intermediate_shard_shape, intermediate_shard_grid, intermediate_mem_layout, output_shard_shape, output_shard_grid, output_mem_layout",
+    [
+        (
+            [1, 1, 32, 3072],
+            3,
+            (32, 512),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            (32, 512),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            (32, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            [4, 1, 384, 1024],
+            3,
+            (256, 1024),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            (64, 1024),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            (256, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+        (
+            [4, 1, 384, 3072],
+            3,
+            (256, 3072),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            (384, 512),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            (1536, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace, num_iters",
+    [
+        (True, 10),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "ones_tensor",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "device_params, rs_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 90112}, ttnn.Topology.Ring),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring"],
+)
+def test_reduce_scatter_async_sharded_to_sharded(
+    t3k_mesh_device,
+    num_devices,
+    num_links,
+    rs_input_dtype,
+    layout,
+    rs_input_shape,
+    dim,
+    input_shard_shape,
+    input_shard_grid,
+    input_mem_layout,
+    intermediate_shard_shape,
+    intermediate_shard_grid,
+    intermediate_mem_layout,
+    output_shard_shape,
+    output_shard_grid,
+    output_mem_layout,
+    enable_trace,
+    num_iters,
+    ones_tensor,
+    rs_topology,
+):
+    if t3k_mesh_device.get_num_devices() != 8:
+        pytest.skip("Not T3K!")
+
+    input_shard_spec = ttnn.ShardSpec(
+        input_shard_grid,
+        input_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    intermediate_shard_spec = ttnn.ShardSpec(
+        intermediate_shard_grid,
+        intermediate_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_shard_spec = ttnn.ShardSpec(
+        output_shard_grid,
+        output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    mem_config_input = ttnn.MemoryConfig(
+        input_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=input_shard_spec
+    )
+    mem_config_intermediate = ttnn.MemoryConfig(
+        intermediate_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=intermediate_shard_spec
+    )
+    mem_config_rs = ttnn.MemoryConfig(output_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=output_shard_spec)
+
+    run_reduce_scatter_impl(
+        t3k_mesh_device,
+        num_devices,
+        rs_input_shape,
+        dim,
+        num_links,
+        rs_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_rs,
+        rs_topology=rs_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        ones_tensor=ones_tensor,
+        mem_config_intermediate=mem_config_intermediate,
+    )
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, layout, rs_input_dtype",
+    [
+        (8, 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize(
+    "rs_input_shape, dim, intermediate_shard_shape, intermediate_shard_grid, intermediate_mem_layout, output_shard_shape, output_shard_grid, output_mem_layout",
+    [
+        (
+            [4, 1, 256, 3072],
+            3,
+            (256, 512),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            (1024, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            [4, 1, 384, 1024],
+            3,
+            (64, 1024),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            (256, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace, num_iters",
+    [
+        (True, 10),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "ones_tensor",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "device_params, rs_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 90112}, ttnn.Topology.Ring),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring"],
+)
+def test_reduce_scatter_async_interleaved_to_sharded(
+    t3k_mesh_device,
+    num_devices,
+    num_links,
+    rs_input_dtype,
+    layout,
+    rs_input_shape,
+    dim,
+    intermediate_shard_shape,
+    intermediate_shard_grid,
+    intermediate_mem_layout,
+    output_shard_shape,
+    output_shard_grid,
+    output_mem_layout,
+    enable_trace,
+    num_iters,
+    ones_tensor,
+    rs_topology,
+):
+    if t3k_mesh_device.get_num_devices() != 8:
+        pytest.skip("Not T3K!")
+
+    intermediate_shard_spec = ttnn.ShardSpec(
+        intermediate_shard_grid,
+        intermediate_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_shard_spec = ttnn.ShardSpec(
+        output_shard_grid,
+        output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    mem_config_input = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    mem_config_intermediate = ttnn.MemoryConfig(
+        intermediate_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=intermediate_shard_spec
+    )
+    mem_config_rs = ttnn.MemoryConfig(output_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=output_shard_spec)
+
+    run_reduce_scatter_impl(
+        t3k_mesh_device,
+        num_devices,
+        rs_input_shape,
+        dim,
+        num_links,
+        rs_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_rs,
+        rs_topology=rs_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        ones_tensor=ones_tensor,
+        mem_config_intermediate=mem_config_intermediate,
+    )
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, layout, rs_input_dtype",
+    [
+        (8, 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize(
+    "rs_input_shape, dim, input_shard_shape, input_shard_grid, input_mem_layout",
+    [
+        (
+            [4, 1, 256, 3072],
+            3,
+            (1024, 512),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            [4, 1, 384, 1024],
+            3,
+            (256, 1024),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace, num_iters",
+    [
+        (True, 10),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "ones_tensor",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "device_params, rs_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 90112}, ttnn.Topology.Ring),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring"],
+)
+def test_reduce_scatter_async_sharded_to_interleaved(
+    t3k_mesh_device,
+    num_devices,
+    num_links,
+    rs_input_dtype,
+    layout,
+    rs_input_shape,
+    dim,
+    input_shard_shape,
+    input_shard_grid,
+    input_mem_layout,
+    enable_trace,
+    num_iters,
+    ones_tensor,
+    rs_topology,
+):
+    if t3k_mesh_device.get_num_devices() != 8:
+        pytest.skip("Not T3K!")
+
+    input_shard_spec = ttnn.ShardSpec(
+        input_shard_grid,
+        input_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    mem_config_input = ttnn.MemoryConfig(
+        input_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=input_shard_spec
+    )
+    mem_config_intermediate = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    mem_config_rs = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+    run_reduce_scatter_impl(
+        t3k_mesh_device,
+        num_devices,
+        rs_input_shape,
+        dim,
+        num_links,
+        rs_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_rs,
+        rs_topology=rs_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        ones_tensor=ones_tensor,
+        mem_config_intermediate=mem_config_intermediate,
     )

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.cpp
@@ -56,6 +56,7 @@ uint32_t EriscDatamoverConfig::compute_buffer_size(
     return buffer_size;
 }
 
+// TODO: #24600
 CCLOpConfig::CCLOpConfig(
     std::vector<Tensor>& input_tensors, const std::vector<Tensor>& output_tensors, Topology topology) :
     input_tensors(&input_tensors),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -32,7 +32,7 @@ void AllGatherAsync::validate_with_output_tensors(
             input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
             input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
             input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
-        "Unsupported memory layout {}.",
+        "Unsupported input tensor memory layout {}.",
         input_tensor.memory_config().memory_layout());
 
     if (output_tensors.size() > 0 and output_tensors[0].has_value()) {
@@ -62,6 +62,14 @@ void AllGatherAsync::validate_with_output_tensors(
             "Error, Output tensor memory config should be same as output_mem_config but has {}",
             output_tensor.value().memory_config());
 
+        TT_FATAL(
+            output_tensor.value().memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED ||
+                output_tensor.value().memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
+                output_tensor.value().memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+                output_tensor.value().memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
+            "Unsupported output tensor memory layout {}.",
+            output_tensor.value().memory_config().memory_layout());
+
         // check the output tensor size
         auto output_shape = output_tensor.value().padded_shape();
         auto input_shape = input_tensor.padded_shape();
@@ -87,11 +95,33 @@ void AllGatherAsync::validate_with_output_tensors(
             }
         }
 
-        // check memory layout
-        TT_FATAL(
-            output_tensor.value().memory_config().memory_layout() == input_tensor.memory_config().memory_layout(),
-            "Error, Output tensor memory layout should be same as input tensor memory layout but has {}",
-            output_tensor.value().memory_config().memory_layout());
+        if (layout == tt::tt_metal::Layout::TILE && semaphore.size() == 2) {
+            // Checks specific to the MINIMAL_DEFAULT case
+
+            // Don't support output DRAM block sharding
+            if (output_tensor.value().memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+                TT_FATAL(
+                    output_tensor.value().memory_config().buffer_type() == BufferType::L1,
+                    "We don't support output DRAM block sharding");
+            }
+        } else {
+            // Checks specific to cases that are not MINIMAL_DEFAULT
+
+            TT_FATAL(
+                output_tensor.value().memory_config().memory_layout() == input_tensor.memory_config().memory_layout(),
+                "Error, Output tensor memory layout should be same as input tensor memory layout but has {}",
+                output_tensor.value().memory_config().memory_layout());
+        }
+    }
+
+    // Checks specific to the MINIMAL_DEFAULT case
+    if (layout == tt::tt_metal::Layout::TILE && semaphore.size() == 2) {
+        // Don't support input DRAM block sharding
+        if (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+            TT_FATAL(
+                input_tensor.memory_config().buffer_type() == BufferType::L1,
+                "We don't support input DRAM block sharding");
+        }
     }
 }
 
@@ -138,15 +168,10 @@ AllGatherAsyncVersion AllGatherAsync::select_version(const Tensor& input_tensor)
     log_trace(tt::LogOp, "[select_version] input_shard_num_cores: {}", input_shard_num_cores);
     log_trace(tt::LogOp, "[select_version] output_shard_num_cores: {}", output_shard_num_cores);
 
-    // Check for minimal interleaved case
-    if (input_tensor_buffer_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED &&
-        input_tensor_page_layout == tt::tt_metal::Layout::TILE && semaphore.size() == 2) {
-        return AllGatherAsyncVersion::MINIMAL_INTERLEAVED;
-    }
-
     log_trace(tt::LogOp, "[select_version] input_is_sharded: {}", input_is_sharded);
     log_trace(tt::LogOp, "[select_version] output_is_sharded: {}", output_is_sharded);
 
+    // Check for minimal sharded case
     if (input_is_sharded && output_is_sharded) {
         // Check for llama post binary mult+silu case
         if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1 && input_tensor_shape[2] == 32 &&
@@ -193,6 +218,14 @@ AllGatherAsyncVersion AllGatherAsync::select_version(const Tensor& input_tensor)
             return AllGatherAsyncVersion::LLAMA_MINIMAL_SHARDED;
         }
     }
+
+    // Check for default minimal case
+    // Note: Since default minimal implementation also supports sharding,
+    // should check for the special llama sharding case first before falling back to this implementation
+    if (input_tensor_page_layout == tt::tt_metal::Layout::TILE && semaphore.size() == 2) {
+        return AllGatherAsyncVersion::MINIMAL_DEFAULT;
+    }
+
     log_trace(tt::LogOp, "Using generic implementation");
     return AllGatherAsyncVersion::GENERIC;
 }
@@ -246,23 +279,6 @@ tt::tt_metal::operation::ProgramWithCallbacks AllGatherAsync::create_program_at(
     log_trace(tt::LogOp, "version: {}", static_cast<uint32_t>(version));
 
     switch (version) {
-        case AllGatherAsyncVersion::MINIMAL_INTERLEAVED: {
-            log_trace(
-                tt::LogOp, "Detected all gather specialized shape. all_gather_async_minimal_interleaved is called");
-            return all_gather_async_minimal_interleaved(
-                input_tensors[0],
-                target_device,
-                forward_device,
-                backward_device,
-                output_tensors[0],
-                this->dim,
-                this->num_links,
-                target_ring_size,
-                device_index,
-                this->topology,
-                this->semaphore,
-                this->sub_device_id);
-        }
         case AllGatherAsyncVersion::LLAMA_MINIMAL_SHARDED:
             log_trace(tt::LogOp, "Detected all gather specialized shape. all_gather_async_llama_sharded is called");
             return all_gather_async_llama_sharded(
@@ -279,6 +295,22 @@ tt::tt_metal::operation::ProgramWithCallbacks AllGatherAsync::create_program_at(
                 this->semaphore.at(0),
                 this->sub_device_id,
                 this->use_optimal_ccl_for_llama);
+
+        case AllGatherAsyncVersion::MINIMAL_DEFAULT:
+            log_trace(tt::LogOp, "Detected all gather specialized shape. all_gather_async_minimal_default is called");
+            return all_gather_async_minimal_default(
+                input_tensors[0],
+                target_device,
+                forward_device,
+                backward_device,
+                output_tensors[0],
+                this->dim,
+                this->num_links,
+                target_ring_size,
+                device_index,
+                this->topology,
+                this->semaphore,
+                this->sub_device_id);
 
         case AllGatherAsyncVersion::GENERIC:
         default:

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -28,7 +28,7 @@ using ccl::EriscDatamoverBuilder;
 enum class AllGatherAsyncVersion {
     GENERIC = 0,
     LLAMA_MINIMAL_SHARDED = 1,
-    MINIMAL_INTERLEAVED = 2,
+    MINIMAL_DEFAULT = 2,
 };
 
 struct AllGatherAsync {
@@ -120,7 +120,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_multi_core_with_w
     ccl::Topology topology,
     GlobalSemaphore semaphore,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id);
-tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleaved(
+tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default(
     const Tensor& input_tensor,
     IDevice* target_device,
     std::optional<IDevice*> forward_device,
@@ -133,7 +133,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
     ccl::Topology topology,
     const std::vector<GlobalSemaphore>& semaphore,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id);
-tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleaved_helper(
+tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_helper(
     tt::tt_metal::Program& program,
     const Tensor& input_tensor,
     IDevice* target_device,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -13,6 +13,7 @@
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 #include "ttnn/operations/math.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
@@ -36,7 +37,7 @@ namespace ttnn {
 
 using namespace ccl;
 
-tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleaved(
+tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default(
     const Tensor& input_tensor,
     IDevice* sender_device,
     std::optional<IDevice*> forward_device,
@@ -51,7 +52,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
     tt::tt_metal::Program program{};
     std::optional<experimental::ccl::AllGatherFusedOpSignaler> empty_fused_op_signaler;
-    return all_gather_async_minimal_interleaved_helper(
+    return all_gather_async_minimal_default_helper(
         program,
         input_tensor,
         sender_device,
@@ -68,7 +69,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         empty_fused_op_signaler);
 }
 
-tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleaved_helper(
+tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_helper(
     tt::tt_metal::Program& program,
     const Tensor& input_tensor,
     IDevice* sender_device,
@@ -120,9 +121,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
     }
 
     // Get OP Config, topology config
-    std::vector<Tensor> input_tensors = {input_tensor};
-    std::vector<Tensor> output_tensors = {output_tensor};
-    const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, topology);
+    uint32_t page_size = input_tensor.buffer()->page_size();
     auto [num_targets_forward, num_targets_backward, dynamic_alternate] =
         ccl::get_forward_backward_configuration(ring_size, ring_index, topology);
     TT_FATAL(
@@ -146,7 +145,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
 
     // L1 Scratch CB Creation
     const size_t packet_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
-    uint32_t l1_scratch_cb_page_size_bytes = op_config.get_page_size();
+    uint32_t l1_scratch_cb_page_size_bytes = page_size;
 
     // scatter-write currently only supports 2 distinct noc addresses
     uint32_t max_target_noc_addresses_per_packet = 2;
@@ -193,40 +192,58 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
     auto reserved_packet_header_backward_CB_handle =
         CreateCircularBuffer(program, sender_backward_core_ranges, cb_reserved_packet_header_backward_config);
 
+    bool input_is_sharded = input_tensor.is_sharded();
+    bool output_is_sharded = output_tensor.is_sharded();
+
+    std::map<std::string, std::string> reader_compute_defines;
+    std::map<std::string, std::string> writer_compute_defines;
+
+    if (input_is_sharded) {
+        reader_compute_defines["INPUT_IS_SHARDED"] = "1";
+    }
+    if (output_is_sharded) {
+        reader_compute_defines["OUTPUT_IS_SHARDED"] = "1";
+        writer_compute_defines["OUTPUT_IS_SHARDED"] = "1";
+    }
+
     // KERNEL CREATION
     // Forward Direction
     // Reader
-    auto sender_reader_forward_kernel_config = tt::tt_metal::ReaderDataMovementConfig{};
-    sender_reader_forward_kernel_config.compile_args = {
+    std::vector<uint32_t> sender_reader_forward_compile_args = {
         ring_index,                                        // my_chip_id
         static_cast<uint32_t>(input_tensor_buffer_type),   // input_buffer_type
         static_cast<uint32_t>(output_tensor_buffer_type),  // output_buffer_type
         sender_forward_cb_index,                           // cb_forward_id
         num_tiles_to_write_per_packet,                     // num_tiles_to_write_per_packet
-        op_config.get_page_size(),                         // tensor0_page_size
+        page_size,                                         // tensor0_page_size
         num_targets_forward,                               // num_slices_forward_direction
         num_targets_backward,                              // num_slices_backward_direction
         static_cast<uint32_t>(topology),                   // topology
         1,                                                 // direction
         fuse_op,                                           // fused op
     };
+    if (input_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(input_tensor, sender_reader_forward_compile_args);
+    }
+    if (output_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(output_tensor, sender_reader_forward_compile_args);
+    }
     auto worker_sender_reader_forward_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/"
-        "interleaved_reader.cpp",
+        "minimal_default_reader.cpp",
         sender_forward_core_ranges,
-        sender_reader_forward_kernel_config);
+        tt::tt_metal::ReaderDataMovementConfig(sender_reader_forward_compile_args, reader_compute_defines));
 
     // Writer
-    auto sender_writer_forward_kernel_config = tt::tt_metal::WriterDataMovementConfig{};
-    sender_writer_forward_kernel_config.compile_args = {
+    std::vector<uint32_t> sender_writer_forward_compile_args = {
         ring_index,                                        // my_chip_id
         reserved_packet_header_forward_CB_index,           // reserved_packet_header_cb_id
         num_packet_headers_storable,                       // num_packet_headers_storable
         static_cast<uint32_t>(output_tensor_buffer_type),  // output_buffer_type
         sender_forward_cb_index,                           // cb_forward_id
         num_tiles_to_write_per_packet,                     // num_tiles_to_write_per_packet
-        op_config.get_page_size(),                         // tensor0_page_size
+        page_size,                                         // tensor0_page_size
         num_targets_forward,                               // num_targets_forward_direction
         num_targets_backward,                              // num_targets_backward_direction
         dynamic_alternate,                                 // alternate
@@ -234,46 +251,53 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         static_cast<uint32_t>(topology),                   // topology
         1,                                                 // direction
     };
+    if (output_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(output_tensor, sender_writer_forward_compile_args);
+    }
     auto worker_sender_writer_forward_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/"
-        "interleaved_writer.cpp",
+        "minimal_default_writer.cpp",
         sender_forward_core_ranges,
-        sender_writer_forward_kernel_config);
+        tt::tt_metal::WriterDataMovementConfig(sender_writer_forward_compile_args, writer_compute_defines));
 
     // Backward Direction
     // Reader
-    auto sender_reader_backward_kernel_config = tt::tt_metal::ReaderDataMovementConfig{};
-    sender_reader_backward_kernel_config.compile_args = {
+    std::vector<uint32_t> sender_reader_backward_compile_args = {
         ring_index,                                        // my_chip_id
         static_cast<uint32_t>(input_tensor_buffer_type),   // input_buffer_type
         static_cast<uint32_t>(output_tensor_buffer_type),  // output_buffer_type
         sender_backward_cb_index,                          // cb_forward_id
         num_tiles_to_write_per_packet,                     // num_tiles_to_write_per_packet
-        op_config.get_page_size(),                         // tensor0_page_size
+        page_size,                                         // tensor0_page_size
         num_targets_forward,                               // num_slices_forward_direction
         num_targets_backward,                              // num_slices_backward_direction
         static_cast<uint32_t>(topology),                   // topology
         0,                                                 // direction
         fuse_op,                                           // fused op
     };
+    if (input_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(input_tensor, sender_reader_backward_compile_args);
+    }
+    if (output_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(output_tensor, sender_reader_backward_compile_args);
+    }
     auto worker_sender_reader_backward_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/"
-        "interleaved_reader.cpp",
+        "minimal_default_reader.cpp",
         sender_backward_core_ranges,
-        sender_reader_backward_kernel_config);
+        tt::tt_metal::ReaderDataMovementConfig(sender_reader_backward_compile_args, reader_compute_defines));
 
     // Writer
-    auto sender_writer_backward_kernel_config = tt::tt_metal::WriterDataMovementConfig{};
-    sender_writer_backward_kernel_config.compile_args = {
+    std::vector<uint32_t> sender_writer_backward_compile_args = {
         ring_index,                                        // my_chip_id
         reserved_packet_header_backward_CB_index,          // reserved_packet_header_cb_id
         num_packet_headers_storable,                       // num_packet_headers_storable
         static_cast<uint32_t>(output_tensor_buffer_type),  // output_buffer_type
         sender_backward_cb_index,                          // cb_forward_id
         num_tiles_to_write_per_packet,                     // num_tiles_to_write_per_packet
-        op_config.get_page_size(),                         // tensor0_page_size
+        page_size,                                         // tensor0_page_size
         num_targets_forward,                               // num_targets_forward_direction
         num_targets_backward,                              // num_targets_backward_direction
         dynamic_alternate,                                 // alternate
@@ -281,13 +305,15 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         static_cast<uint32_t>(topology),                   // topology
         0,                                                 // direction
     };
+    if (output_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(output_tensor, sender_writer_backward_compile_args);
+    }
     auto worker_sender_writer_backward_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/"
-        "interleaved_writer.cpp",
+        "minimal_default_writer.cpp",
         sender_backward_core_ranges,
-        sender_writer_backward_kernel_config);
-
+        tt::tt_metal::WriterDataMovementConfig(sender_writer_backward_compile_args, writer_compute_defines));
     // Kernel Runtime Args
     for (uint32_t link = 0; link < num_links; link++) {
         /* All gather fusion */
@@ -334,6 +360,12 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
             input_tile_id_start % input_tensor_Wt,                    // start_pages_read_in_row
             input_tile_id_start / input_tensor_Wt * output_tensor_Wt  // start_row_offset
         };
+        if (input_is_sharded) {
+            shard_builder::extend_sharding_run_time_args(input_tensor, reader_forward_rt_args);
+        }
+        if (output_is_sharded) {
+            shard_builder::extend_sharding_run_time_args(output_tensor, reader_forward_rt_args);
+        }
         if (fuse_op) {
             fused_op_signaler_forward->push_all_gather_fused_op_rt_args(reader_forward_rt_args, 1, 0, 1);
         }
@@ -359,6 +391,12 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
             input_tile_id_start % input_tensor_Wt,                    // start_pages_read_in_row
             input_tile_id_start / input_tensor_Wt * output_tensor_Wt  // start_row_offset
         };
+        if (input_is_sharded) {
+            shard_builder::extend_sharding_run_time_args(input_tensor, reader_backward_rt_args);
+        }
+        if (output_is_sharded) {
+            shard_builder::extend_sharding_run_time_args(output_tensor, reader_backward_rt_args);
+        }
         if (fuse_op) {
             fused_op_signaler_backward->push_all_gather_fused_op_rt_args(reader_backward_rt_args, 1, 0, 0);
         }
@@ -390,6 +428,9 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
             input_tile_id_start % input_tensor_Wt,                    // start_pages_read_in_row
             input_tile_id_start / input_tensor_Wt * output_tensor_Wt  // start_row_offset
         };
+        if (output_is_sharded) {
+            shard_builder::extend_sharding_run_time_args(output_tensor, writer_forward_rt_args);
+        }
         writer_forward_rt_args.push_back(false);
         writer_forward_rt_args.push_back(backward_device.has_value());
         if (backward_device.has_value()) {
@@ -428,6 +469,9 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
             input_tile_id_start % input_tensor_Wt,                    // start_pages_read_in_row
             input_tile_id_start / input_tensor_Wt * output_tensor_Wt  // start_row_offset
         };
+        if (output_is_sharded) {
+            shard_builder::extend_sharding_run_time_args(output_tensor, writer_backward_rt_args);
+        }
         writer_backward_rt_args.push_back(forward_device.has_value());
         if (forward_device.has_value()) {
             const auto sender_fabric_node_id =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -6,6 +6,7 @@
 #include <tt-metalium/buffer_types.hpp>
 #include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
+#include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 #include <cstdint>
 #include <utility>
 
@@ -50,18 +51,68 @@ void kernel_main() {
     uint32_t start_pages_read_in_row = get_arg_val<uint32_t>(arg_idx++);
     uint32_t start_row_offset = get_arg_val<uint32_t>(arg_idx++);
 
+    constexpr uint32_t ct_idx = 11;
+
+#ifdef INPUT_IS_SHARDED
+    constexpr uint32_t ct_offset = 7;
+
+    using input_tensor_shard_info = ShardedInfo<
+        get_compile_time_arg_val(ct_idx),       // Memory layout
+        get_compile_time_arg_val(ct_idx + 1),   // The number of sharding cores
+        get_compile_time_arg_val(ct_idx + 2),   // The page size we offset each write to
+        get_compile_time_arg_val(ct_idx + 3),   // The number of pages in each sharding row not including padding pages
+        get_compile_time_arg_val(ct_idx + 4),   // This defines times when contiguous pages can't be calculated
+        get_compile_time_arg_val(ct_idx + 5),   // pages_per_shard_x
+        get_compile_time_arg_val(ct_idx + 6)>;  // pages_per_shard_y
+
+    const auto [input_mapping_table, input_rt_increment] =
+        experimental::shard_addr_gen_utils::get_shard_map<input_tensor_shard_info>(get_arg_addr(arg_idx));
+    experimental::ShardedAddrGen<input_tensor_shard_info> input_tensor_addrgen = {
+        .bank_base_address = input_tensor_address, .shard_array = input_mapping_table};
+
+    arg_idx += input_rt_increment;
+#else
+    constexpr uint32_t ct_offset = 0;
+
+    constexpr bool input_tensor_is_dram = input_buffer_type == tt::tt_metal::BufferType::DRAM;
+    const InterleavedAddrGenFast<input_tensor_is_dram> input_tensor_addrgen = {
+        .bank_base_address = input_tensor_address,
+        .page_size = input_tensor_page_size,
+        .data_format = get_dataformat(cb_output_id)};
+#endif
+
+#ifdef OUTPUT_IS_SHARDED
+    using output_tensor_shard_info = ShardedInfo<
+        get_compile_time_arg_val(ct_idx + ct_offset),       // Memory layout
+        get_compile_time_arg_val(ct_idx + ct_offset + 1),   // The number of sharding cores
+        get_compile_time_arg_val(ct_idx + ct_offset + 2),   // The page size we offset each write to
+        get_compile_time_arg_val(ct_idx + ct_offset + 3),   // The number of pages in each sharding row not including
+                                                            // padding pages
+        get_compile_time_arg_val(ct_idx + ct_offset + 4),   // This defines times when contiguous pages can't be
+                                                            // calculated
+        get_compile_time_arg_val(ct_idx + ct_offset + 5),   // pages_per_shard_x
+        get_compile_time_arg_val(ct_idx + ct_offset + 6)>;  // pages_per_shard_y
+
+    const auto [output_mapping_table, output_rt_increment] =
+        experimental::shard_addr_gen_utils::get_shard_map<output_tensor_shard_info>(get_arg_addr(arg_idx));
+    experimental::ShardedAddrGen<output_tensor_shard_info> output_tensor_addrgen = {
+        .bank_base_address = output_tensor_address, .shard_array = output_mapping_table};
+
+    arg_idx += output_rt_increment;
+#else
+    constexpr bool output_tensor_is_dram = output_buffer_type == tt::tt_metal::BufferType::DRAM;
+    const InterleavedAddrGenFast<output_tensor_is_dram> output_tensor_addrgen = {
+        .bank_base_address = output_tensor_address,
+        .page_size = input_tensor_page_size,
+        .data_format = get_dataformat(cb_output_id)};
+#endif
+
     OpSignaler op_signaler;
     if constexpr (fuse_op) {
         op_signaler = OpSignaler(arg_idx);
     }
 
     // Push out our local slice
-    constexpr bool input_tensor_is_dram = input_buffer_type == tt::tt_metal::BufferType::DRAM;
-    auto input_tensor_addrgen = InterleavedAddrGenFast<input_tensor_is_dram>{
-        .bank_base_address = input_tensor_address,
-        .page_size = input_tensor_page_size,
-        .data_format = get_dataformat(cb_output_id)};
-
     uint32_t tiles_read = input_tile_id_start;
     uint32_t tiles_to_read = input_tile_id_end;
     uint32_t output_tile_id_start = 0;
@@ -74,7 +125,8 @@ void kernel_main() {
             size_t l1_write_addr = get_write_ptr(cb_output_id);
             for (uint32_t j = 0; j < num_tiles_to_read; ++j) {
                 uint32_t tile_id = output_tile_id_start + tiles_read;
-                noc_async_read_tile(tile_id, input_tensor_addrgen, l1_write_addr);
+                uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
+                noc_async_read(noc_read_addr, l1_write_addr, input_tensor_page_size);
 
                 l1_write_addr += input_tensor_page_size;
                 tiles_read++;
@@ -87,11 +139,7 @@ void kernel_main() {
         tiles_to_read = input_tile_id_end;
         output_tile_id_start += input_tensor_Wt * input_tensor_Ht;
     }
-    constexpr bool output_tensor_is_dram = output_buffer_type == tt::tt_metal::BufferType::DRAM;
-    auto output_tensor_addrgen = InterleavedAddrGenFast<output_tensor_is_dram>{
-        .bank_base_address = output_tensor_address,
-        .page_size = input_tensor_page_size,
-        .data_format = get_dataformat(cb_output_id)};
+
     uint32_t slices_received = 0;
     uint32_t slices_expected = 0;
     uint32_t writes_expected = 0;
@@ -171,7 +219,8 @@ void kernel_main() {
                     size_t l1_write_addr = get_write_ptr(cb_output_id);
                     for (uint32_t j = 0; j < num_tiles_to_read; ++j) {
                         uint32_t tile_id = output_tile_id_start + row_offset + pages_read_in_row;
-                        noc_async_read_tile(tile_id, output_tensor_addrgen, l1_write_addr);
+                        uint64_t noc_read_addr = get_noc_addr(tile_id, output_tensor_addrgen);
+                        noc_async_read(noc_read_addr, l1_write_addr, input_tensor_page_size);
 
                         l1_write_addr += input_tensor_page_size;
                         tiles_read++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/multi_core/all_gather_matmul_async_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/multi_core/all_gather_matmul_async_op_multi_core.cpp
@@ -144,7 +144,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_matmul_async_multi_core
 
     // All Gather
     tt::tt_metal::operation::ProgramWithCallbacks program_with_callbacks =
-        ttnn::all_gather_async_minimal_interleaved_helper(
+        ttnn::all_gather_async_minimal_default_helper(
             matmul_program_with_callbacks->program,
             input_tensor,
             target_device,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/multi_core/all_gather_matmul_async_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/multi_core/all_gather_matmul_async_op_multi_core.cpp
@@ -107,6 +107,24 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_matmul_async_multi_core
                     matmul_fused_op_signaler);
                 matmul_override_runtime_arguments_callback =
                     matmul_program_with_callbacks->override_runtime_arguments_callback;
+            } else if (std::is_same_v<
+                           ProgramConfigType,
+                           operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                matmul_program_with_callbacks = operations::matmul::matmul_multi_core_reuse_mcast_1d_optimized_helper(
+                    program,
+                    all_gather_output_tensor,
+                    {weight_tensor},
+                    bias,
+                    {matmul_output_tensor},
+                    bcast_batch,
+                    compute_kernel_config,
+                    config,
+                    untilize_out,
+                    matmul_fused_op_signaler,
+                    std::nullopt,
+                    std::nullopt);
+                matmul_override_runtime_arguments_callback =
+                    matmul_program_with_callbacks->override_runtime_arguments_callback;
             } else {
                 TT_THROW("Unsupported MatmulProgramConfig type. Needs to be 1D or 2D Multicast.");
             }
@@ -169,7 +187,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_matmul_async_multi_core
                     program,
                     {input_tensors[0]}, /* input tensor */
                     optional_input_tensors,
-                    {output_tensors[1]} /* all gather output tensor */
+                    {output_tensors[0]} /* all gather output tensor */
                 );
             }
         };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/reduce_scatter_minimal_async_writer.cpp
@@ -8,6 +8,7 @@
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
+#include "cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "minimal_ccl_common.hpp"
 #include <cstdint>
@@ -58,6 +59,63 @@ void kernel_main() {
     int32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
     uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
 
+    constexpr uint32_t ct_idx = 15;
+
+#ifdef INTERMEDIATE_IS_SHARDED
+    constexpr uint32_t ct_offset = 7;
+
+    using intermediate_tensor_shard_info = ShardedInfo<
+        get_compile_time_arg_val(ct_idx),       // Memory layout
+        get_compile_time_arg_val(ct_idx + 1),   // The number of sharding cores
+        get_compile_time_arg_val(ct_idx + 2),   // The page size we offset each write to
+        get_compile_time_arg_val(ct_idx + 3),   // The number of pages in each sharding row not including padding pages
+        get_compile_time_arg_val(ct_idx + 4),   // This defines times when contiguous pages can't be calculated
+        get_compile_time_arg_val(ct_idx + 5),   // pages_per_shard_x
+        get_compile_time_arg_val(ct_idx + 6)>;  // pages_per_shard_y
+
+    const auto [intermediate_mapping_table, intermediate_rt_increment] =
+        experimental::shard_addr_gen_utils::get_shard_map<intermediate_tensor_shard_info>(get_arg_addr(arg_idx));
+    experimental::ShardedAddrGen<intermediate_tensor_shard_info> intermediate_addrgen = {
+        .bank_base_address = intermediate_address, .shard_array = intermediate_mapping_table};
+
+    arg_idx += intermediate_rt_increment;
+
+#else
+    constexpr uint32_t ct_offset = 0;
+
+    constexpr bool intermediate_is_dram = intermediate_type == tt::tt_metal::BufferType::DRAM;
+    auto intermediate_addrgen = InterleavedAddrGenFast<intermediate_is_dram>{
+        .bank_base_address = intermediate_address,
+        .page_size = intermediate_page_size,
+        .data_format = get_dataformat(cb_compute_output_id)};
+#endif
+
+#ifdef OUTPUT_IS_SHARDED
+    using output_tensor_shard_info = ShardedInfo<
+        get_compile_time_arg_val(ct_idx + ct_offset),       // Memory layout
+        get_compile_time_arg_val(ct_idx + ct_offset + 1),   // The number of sharding cores
+        get_compile_time_arg_val(ct_idx + ct_offset + 2),   // The page size we offset each write to
+        get_compile_time_arg_val(ct_idx + ct_offset + 3),   // The number of pages in each sharding row not including
+                                                            // padding pages
+        get_compile_time_arg_val(ct_idx + ct_offset + 4),   // This defines times when contiguous pages can't be
+                                                            // calculated
+        get_compile_time_arg_val(ct_idx + ct_offset + 5),   // pages_per_shard_x
+        get_compile_time_arg_val(ct_idx + ct_offset + 6)>;  // pages_per_shard_y
+
+    const auto [output_mapping_table, output_rt_increment] =
+        experimental::shard_addr_gen_utils::get_shard_map<output_tensor_shard_info>(get_arg_addr(arg_idx));
+    experimental::ShardedAddrGen<output_tensor_shard_info> output_addrgen = {
+        .bank_base_address = output_address, .shard_array = output_mapping_table};
+
+    arg_idx += output_rt_increment;
+#else
+    constexpr bool output_is_dram = output_type == tt::tt_metal::BufferType::DRAM;
+    auto output_addrgen = InterleavedAddrGenFast<output_is_dram>{
+        .bank_base_address = output_address,
+        .page_size = intermediate_page_size,
+        .data_format = get_dataformat(cb_compute_output_id)};
+#endif
+
     size_t arg_for_fab = arg_idx;
     auto fabric_connection = FabricConnectionManager::build_from_args(arg_for_fab);
 
@@ -75,18 +133,6 @@ void kernel_main() {
 
     volatile PACKET_HEADER_TYPE* pkt_hdr_seminc =
         reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
-
-    // interleaved addrgen
-    constexpr bool intermediate_is_dram = intermediate_type == tt::tt_metal::BufferType::DRAM;
-    auto intermediate_addrgen = InterleavedAddrGenFast<intermediate_is_dram>{
-        .bank_base_address = intermediate_address,
-        .page_size = intermediate_page_size,
-        .data_format = get_dataformat(cb_compute_output_id)};
-    constexpr bool output_is_dram = output_type == tt::tt_metal::BufferType::DRAM;
-    auto output_addrgen = InterleavedAddrGenFast<output_is_dram>{
-        .bank_base_address = output_address,
-        .page_size = intermediate_page_size,
-        .data_format = get_dataformat(cb_compute_output_id)};
 
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.open();
@@ -261,7 +307,8 @@ void kernel_main() {
                     size_t l1_read_addr = get_read_ptr(cb_output_id);
                     for (uint32_t j = 0; j < tiles_to_read_in_current_direction; ++j) {
                         uint32_t tile_id = tile_id_start + tiles_read;
-                        noc_async_write_tile(tile_id, output_addrgen, l1_read_addr);
+                        uint64_t local_noc_addr = get_noc_addr(tile_id, output_addrgen);
+                        noc_async_write(l1_read_addr, local_noc_addr, intermediate_page_size);
                         l1_read_addr += intermediate_page_size;
                         tiles_read++;
                     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -28,8 +28,11 @@ void ReduceScatterMinimalAsync::validate_with_output_tensors(
         "Worker cores used by links are parallelizaed over rows");
 
     TT_FATAL(
-        input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-        "Unsupported memory layout {}.",
+        input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED ||
+            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
+            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
+        "Unsupported input tensor memory layout {}.",
         input_tensor.memory_config().memory_layout());
 
     if (output_tensors.size() > 0 and output_tensors[0].has_value()) {
@@ -69,10 +72,10 @@ void ReduceScatterMinimalAsync::validate_with_output_tensors(
         for (size_t i = 0; i < input_shape.size(); ++i) {
             if (i == this->dim) {
                 TT_FATAL(
-                    output_shape[i] <= input_shape[i] * this->ring_size,
+                    output_shape[i] == input_shape[i] / this->ring_size,
                     "Error, Output tensor shape at dimension {} should be {} but has {}",
                     i,
-                    input_shape[i] * this->ring_size,
+                    input_shape[i] / this->ring_size,
                     output_shape[i]);
             } else {
                 TT_FATAL(
@@ -84,11 +87,18 @@ void ReduceScatterMinimalAsync::validate_with_output_tensors(
             }
         }
 
-        // check memory layout
+        // Don't support output DRAM block sharding
+        if (output_tensor.value().memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+            TT_FATAL(
+                output_tensor.value().memory_config().buffer_type() == BufferType::L1,
+                "We don't support output DRAM block sharding");
+        }
+    }
+
+    // Don't support input DRAM block sharding
+    if (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
         TT_FATAL(
-            output_tensor.value().memory_config().memory_layout() == input_tensor.memory_config().memory_layout(),
-            "Error, Output tensor memory layout should be same as input tensor memory layout but has {}",
-            output_tensor.value().memory_config().memory_layout());
+            input_tensor.memory_config().buffer_type() == BufferType::L1, "We don't support input DRAM block sharding");
     }
 
     // Each direction has a ready semaphore and there's a global sync semaphore, per link.


### PR DESCRIPTION
### Ticket
#21726 

### Problem description
Need to get rid of all legacy usage in Falcon 40b and Mixtral on T3K and use Fabric instead, this PR specifically creates all the persistent buffers necessary for those CCLs on model compilation rather than during runtime. Creating intermediate/output tensors during runtime creates race conditions within CCL ops, thus the need to preallocate PBs.

### What's changed
Extracted shapes and mem_configs of PBs going into Fabric ccls and create them on compilation.

(This should be merged after the commits authored by Grayson are merged)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes