### PR TITLE
Added `huggingface-cli` Weights Clarification to `tt-transformers` and `llama3_subdevices` ReadMe

### DIFF
--- a/models/demos/llama3_subdevices/README.md
+++ b/models/demos/llama3_subdevices/README.md
@@ -55,7 +55,7 @@ If providing a different output directory, please copy the `params.json` and the
 >```
 >huggingface-cli download meta-llama/Meta-Llama-3-70B-Instruct --include "original/*" --local-dir Meta-Llama-3-70B-Instruct
 >```
-> will be in the same format as a direct download from Meta (i.e. as `consolidated.xx.pth` files). Hence, you will still need to repack your weights as before. This is contrary to if you downloaded your weights directly from `huggingface`, as those weights will be downloaded as sharded `.safetensors` files.
+> will be in the same format as a direct download from Meta (i.e. as `consolidated.xx.pth` files). Hence, you will still need to repack your weights and export `LLAMA_DIR` as before. This is contrary to if you downloaded your weights directly from `huggingface`, as those weights will be downloaded as sharded `.safetensors` files.
 
 ## Setting the Environment Variables
 

--- a/models/demos/llama3_subdevices/README.md
+++ b/models/demos/llama3_subdevices/README.md
@@ -49,6 +49,14 @@ python models/tt_transformers/scripts/repack_weights_70b.py <path_to_checkpoint_
 
 If providing a different output directory, please copy the `params.json` and the `tokenizer.model` files to the new directory.
 
+**⚠️ Warning**
+>
+> Weights downloaded from the `huggingface-cli` via
+>```
+>huggingface-cli download meta-llama/Meta-Llama-3-70B-Instruct --include "original/*" --local-dir Meta-Llama-3-70B-Instruct
+>```
+> will be in the same format as a direct download from Meta (i.e. as `consolidated.xx.pth` files). Hence, you will still need to repack your weights as before. This is contrary to if you downloaded your weights directly from `huggingface`, as those weights will be downloaded as sharded `.safetensors` files.
+
 ## Setting the Environment Variables
 
 ```

--- a/models/tt_transformers/README.md
+++ b/models/tt_transformers/README.md
@@ -70,6 +70,14 @@ python models/tt_transformers/scripts/repack_weights_70b.py <path_to_checkpoint_
 
 If providing a different output directory, please copy the `params.json` and the `tokenizer.model` files to the new directory.
 
+**⚠️ Warning**
+>
+> For Llama3 models, weights downloaded from the `huggingface-cli` via
+>```
+>huggingface-cli download meta-llama/Meta-Llama-3-70B-Instruct --include "original/*" --local-dir Meta-Llama-3-70B-Instruct
+>```
+> will be in the same format as a direct download from Meta (i.e. as `consolidated.xx.pth` files). Hence, you will still need to repack your weights and export `LLAMA_DIR` as before. This is contrary to if you downloaded your weights directly from `huggingface`, as those weights will be downloaded as sharded `.safetensors` files.
+
 #### Option 2: download weights from HuggingFace
 
 If you wish to download the weights from [HuggingFace](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-70B) ensure your model directory has the following structure:


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The ReadMe for `tt-transformers` and the `llama3_subdevices` package currently contains no directions for weights downloaded using the `huggingface-cli`. This may cause confusion as weights downloaded this way are formatted in the same way as Meta Llama weights (hence requiring setting `LLAMA_DIR` and repacking) and not as HF weights (which require setting `HF_MODEL`).

### What's changed
A warning box is added to the ReadMes of `tt-transformers` and the `llama3_subdevices` package to notify users of this.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes