### PR TITLE
Reland shift left of ttnn tensor tests

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -52,7 +52,6 @@ jobs:
           {name: ttnn cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn},
           {name: ttnn ccl cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn_ccl},
           {name: ttnn ccl ops cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn_ccl_ops},
-          {name: ttnn tensor cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn_tensor},
         ]
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     container:

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -87,7 +87,6 @@ target_link_libraries(
     PRIVATE
         TTNN::Test::Smoke
         TTNN::Test::Basic
-        TTNN::Test::Basic::Tensor
         TTNN::Test::Slow
 )
 

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -87,6 +87,7 @@ target_link_libraries(
     PRIVATE
         TTNN::Test::Smoke
         TTNN::Test::Basic
+        TTNN::Test::Basic::Tensor
         TTNN::Test::Slow
 )
 
@@ -157,9 +158,10 @@ setup_ttnn_test_target(unit_tests_ttnn_accessor)
 
 # unit_tests_ttnn_tensor
 
-add_executable(unit_tests_ttnn_tensor)
+add_library(unit_tests_ttnn_tensor_lib OBJECT)
+add_library(TTNN::Test::Basic::Tensor ALIAS unit_tests_ttnn_tensor_lib)
 target_sources(
-    unit_tests_ttnn_tensor
+    unit_tests_ttnn_tensor_lib
     PRIVATE
         tensor/common_tensor_test_utils.cpp
         tensor/test_create_tensor.cpp
@@ -176,8 +178,11 @@ target_sources(
         tensor/test_xtensor_adapter.cpp
         tensor/test_xtensor_conversion.cpp
 )
-setup_ttnn_test_target(unit_tests_ttnn_tensor)
-target_link_libraries(unit_tests_ttnn_tensor PRIVATE xtensor)
+setup_ttnn_test_target(unit_tests_ttnn_tensor_lib)
+target_link_libraries(unit_tests_ttnn_tensor_lib PRIVATE xtensor)
+
+add_executable(unit_tests_ttnn_tensor)
+target_link_libraries(unit_tests_ttnn_tensor PRIVATE TTNN::Test::Basic::Tensor)
 
 # test_ccl_multi_cq_multi_device
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
@@ -214,7 +214,7 @@ TEST(PartitionTest, DimensionOutofRange) {
 TEST(PartitionTest, EmptyInput) {
     std::vector<xt::xarray<int>> input;
     EXPECT_NO_THROW(concat(input, 0));
-    EXPECT_TRUE(xt::allclose(concat(input, 0).expr(), xt::xarray<int>{}));
+    EXPECT_TRUE(concat(input, 0).data().empty());
 }
 
 TEST(PartitionTest, ChunkDoesNotAccessData) {

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -53,7 +53,7 @@ set_source_files_properties(
 )
 
 # TODO(afuller): this should be self-describing modules.
-#   For now just cherry-pick all the files I discovered empirally by trying to run a test.
+#   For now just cherry-pick all the files I discovered empirically by trying to run a test.
 add_library(jitapi INTERFACE)
 # These headers are for the device, not host; will require cross compiling to verify.
 set_target_properties(
@@ -63,6 +63,7 @@ set_target_properties(
             FALSE
 )
 
+file(GLOB_RECURSE COMPUTE_KERNEL_API include/*)
 target_sources(
     jitapi
     INTERFACE
@@ -109,36 +110,7 @@ target_sources(
             impl/dispatch/kernels/cq_helpers.hpp
             impl/dispatch/kernels/packet_queue.hpp
             impl/dispatch/kernels/packet_queue_ctrl.hpp
-            include/compute_kernel_api.h
-            include/compute_kernel_api/bcast.h
-            include/compute_kernel_api/blank.h
-            include/compute_kernel_api/cb_api.h
-            include/compute_kernel_api/common.h
-            include/compute_kernel_api/common_globals.h
-            include/compute_kernel_api/compute_kernel_hw_startup.h
-            include/compute_kernel_api/eltwise_binary.h
-            include/compute_kernel_api/eltwise_unary/comp.h
-            include/compute_kernel_api/eltwise_unary/eltwise_unary.h
-            include/compute_kernel_api/eltwise_unary/exp.h
-            include/compute_kernel_api/eltwise_unary/negative.h
-            include/compute_kernel_api/eltwise_unary/recip.h
-            include/compute_kernel_api/eltwise_unary/relu.h
-            include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
-            include/compute_kernel_api/eltwise_unary/sqrt.h
-            include/compute_kernel_api/mask.h
-            include/compute_kernel_api/matmul.h
-            include/compute_kernel_api/pack.h
-            include/compute_kernel_api/pack_untilize.h
-            include/compute_kernel_api/reconfig_data_format.h
-            include/compute_kernel_api/reduce.h
-            include/compute_kernel_api/reg_api.h
-            include/compute_kernel_api/softmax.h
-            include/compute_kernel_api/tile_move_copy.h
-            include/compute_kernel_api/tilize.h
-            include/compute_kernel_api/transpose_wh.h
-            include/compute_kernel_api/untilize.h
-            include/compute_kernel_api/eltwise_binary.h
-            include/compute_kernel_api/tile_move_copy.h
+            ${COMPUTE_KERNEL_API}
             soc_descriptors/blackhole_140_arch.yaml
             soc_descriptors/wormhole_b0_80_arch.yaml
             third_party/tt_llk/tt_llk_blackhole/common/inc/ckernel.h

--- a/ttnn/test/CMakeLists.txt
+++ b/ttnn/test/CMakeLists.txt
@@ -11,6 +11,11 @@ install(TARGETS tt-nn-validation-smoke RUNTIME COMPONENT ttnn-validation)
 # Basic
 add_executable(tt-nn-validation-basic)
 
-target_link_libraries(tt-nn-validation-basic PRIVATE TTNN::Test::Basic)
+target_link_libraries(
+    tt-nn-validation-basic
+    PRIVATE
+        TTNN::Test::Basic
+        TTNN::Test::Basic::Tensor
+)
 
 install(TARGETS tt-nn-validation-basic RUNTIME COMPONENT ttnn-validation)


### PR DESCRIPTION
### Ticket
NA

### Problem description
Previously in https://github.com/tenstorrent/tt-metal/pull/24620, I shifted these `ttnn tensor unit tests` left, but I made the mistake of trying to do too much.

What I mean by that, is in the same PR, I tried to clean up the C++ test cases to allow them to be built in a `Unity` build.
My changes were good enough to get that working in clang, but problems came up in gcc builds.

### What's changed
Repeat the same changes, but this time, DO NOT touch C++ except where required, and DO NOT enable Unity build.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16288759338) CI passes
- [x] [Merge Gate](https://github.com/tenstorrent/tt-metal/actions/runs/16289901972) CI passes
- [x] New/Existing tests provide coverage for changes