### PR TITLE
add fallback distro build ID for rolling release

### DIFF
--- a/build_metal.sh
+++ b/build_metal.sh
@@ -3,9 +3,18 @@
 set -eo pipefail
 
 FLAVOR=`grep '^ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
-VERSION=`grep '^VERSION_ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
-MAJOR=${VERSION%.*}
 ARCH=`uname -m`
+
+# VERSION_ID is optional in os-release. Use BUILD_ID as fallback
+RAW_BUILD_ID=`grep '^VERSION_ID=' /etc/os-release`
+RAW_VERSION=`grep '^BUILD_ID=' /etc/os-release`
+if [[ -z "$RAW_VERSION" ]]; then
+    VERSION=`echo "$RAW_BUILD_ID" | awk -F= '{print $2}' | tr -d '"'`
+elif [[ -z "$RAW_BUILD_ID" ]]; then
+    VERSION=`echo "$RAW_VERSION" | awk -F= '{print $2}' | tr -d '"'`
+else
+    VERSION="unknown-version"
+fi
 
 # Function to display help
 show_help() {

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -5,15 +5,13 @@ set -eo pipefail
 FLAVOR=`grep '^ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
 ARCH=`uname -m`
 
-# VERSION_ID is optional in os-release. Use BUILD_ID as fallback
-RAW_BUILD_ID=`grep '^VERSION_ID=' /etc/os-release`
-RAW_VERSION=`grep '^BUILD_ID=' /etc/os-release`
-if [[ -z "$RAW_VERSION" ]]; then
-    VERSION=`echo "$RAW_BUILD_ID" | awk -F= '{print $2}' | tr -d '"'`
-elif [[ -z "$RAW_BUILD_ID" ]]; then
-    VERSION=`echo "$RAW_VERSION" | awk -F= '{print $2}' | tr -d '"'`
-else
-    VERSION="unknown-version"
+# VERSION_ID and BUILD_ID are standard within /etc/os-release but both options
+source /etc/os-release
+VERSION="unknown-version"
+if [[ -v "$VERSION_ID" ]]; then
+    VERSION="${VERSION_ID}"
+elif [[ -v "$BUILD_ID" ]]; then
+    VERSION="${BUILD_ID}"
 fi
 
 # Function to display help

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 FLAVOR=`grep '^ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
 ARCH=`uname -m`
 
-# VERSION_ID and BUILD_ID are standard within /etc/os-release but both options
+# VERSION_ID and BUILD_ID are standard within /etc/os-release but both optional
 source /etc/os-release
 VERSION="unknown-version"
 if [[ -v "$VERSION_ID" ]]; then


### PR DESCRIPTION
### Ticket
#25068

### Problem description
`build_metal.sh` fails silently on Arch Linux due to missing os-release information (that is option by spec).

### What's changed
Added fallback path for release information.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes