### PR TITLE
 #21550: Add trace2CQ support for yolov5x

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -276,6 +276,15 @@ jobs:
         if: ${{ !cancelled() && matrix.test-info.civ2-compatible && !matrix.test-info.job-set1 }}
         timeout-minutes: ${{ matrix.test-info.timeout }}
 
+      - name: yolov5x tests
+        uses: tenstorrent/tt-metal/.github/actions/device-perf-test@main
+        with:
+          model_name: "yolov5x"
+          commands: |
+            pytest models/experimental/yolov5x/tests/perf -m models_device_performance_bare_metal
+        if: ${{ !cancelled() && matrix.test-info.civ2-compatible && !matrix.test-info.job-set1 }}
+        timeout-minutes: ${{ matrix.test-info.timeout }}
+
       - name: Merge test reports
         id: generate-device-perf-report
         timeout-minutes: ${{ matrix.test-info.timeout }}

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -71,6 +71,7 @@ jobs:
               - models/demos/yolov8x/tests/perf/
               # e2e performant test is present in .../vit/demo folder only
               - models/demos/wormhole/vit/demo/
+              - models/experimental/yolov5x/tests/perf/
 
     name: "${{ matrix.model-group.name }} ${{ matrix.test-info.name }}"
     defaults:

--- a/models/experimental/yolov5x/README.md
+++ b/models/experimental/yolov5x/README.md
@@ -1,29 +1,38 @@
-# Yolov5x - Model
+# Yolov5x
 
-### Platforms:
+## Platforms:
 
 Wormhole N150, N300
 
-To obtain the perf reports through profiler, please build with following command:
-```
-./build_metal.sh -p
-```
 
-### Introduction
-
+## Introduction
 **YOLOv5x** is the largest variant in the YOLOv5 series, delivering top-tier accuracy and performance for advanced object detection tasks. It features a deeper and wider architecture, making it ideal for high-precision applications where accuracy is prioritized over model size or inference speed.
 
 
-### Details
+## Prerequisites
+- Cloned [tt-metal repository](https://github.com/tenstorrent/tt-metal) for source code
+- Installed: [TT-Metalium™ / TT-NN™](https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md)
+  - To obtain the perf reports through profiler, please build with: `./build_metal.sh -p`
 
-- The entry point to the yolov11 is located at:`models/experimental/yolov5x/tt/yolov5x.py`
-- Batch Size :1
-- Supported Input Resolution - (640,640) (Height,Width)
-
-### How to Run:
-
-Use the following command to run the model :
+## How to Run:
+Use the following command to run the model:
 
 ```
 pytest --disable-warnings models/experimental/yolov5x/tests/pcc/test_ttnn_yolov5x.py::test_yolov5x
 ```
+
+## Performant Model with Trace+2CQ
+- end-2-end perf is 46 FPS
+
+Use the following command to run the performant Model with Trace+2CQs:
+
+```
+pytest --disable-warnings models/experimental/yolov5x/tests/test_e2e_performant.py
+```
+
+
+## Details
+
+- The entry point to the yolov11 is located at:`models/experimental/yolov5x/tt/yolov5x.py`
+- Batch Size :1
+- Supported Input Resolution - (640,640) (Height,Width)

--- a/models/experimental/yolov5x/common.py
+++ b/models/experimental/yolov5x/common.py
@@ -8,6 +8,8 @@ import torch
 from ultralytics import YOLO
 from models.experimental.yolov5x.reference.yolov5x import YOLOv5
 
+YOLOV5X_L1_SMALL_SIZE = 24576
+
 
 def load_torch_model(model_location_generator=None):
     if model_location_generator == None or "TT_GH_CI_INFRA" not in os.environ:

--- a/models/experimental/yolov5x/runner/performant_runner.py
+++ b/models/experimental/yolov5x/runner/performant_runner.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.experimental.yolov5x.runner.performant_runner_infra import YOLOv5xPerformanceRunnerInfra
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+class YOLOv5xPerformantRunner:
+    def __init__(
+        self,
+        device,
+        device_batch_size=1,
+        act_dtype=ttnn.bfloat16,
+        weight_dtype=ttnn.bfloat16,
+        model_location_generator=None,
+        resolution=(640, 640),
+        torch_input_tensor=None,
+    ):
+        self.device = device
+        self.resolution = resolution
+        self.torch_input_tensor = torch_input_tensor
+        self.runner_infra = YOLOv5xPerformanceRunnerInfra(
+            device,
+            device_batch_size,
+            act_dtype,
+            weight_dtype,
+            model_location_generator,
+            resolution=resolution,
+            torch_input_tensor=self.torch_input_tensor,
+        )
+
+        (
+            self.tt_inputs_host,
+            sharded_mem_config_DRAM,
+            self.input_mem_config,
+        ) = self.runner_infra.setup_dram_sharded_input(device)
+        self.tt_image_res = self.tt_inputs_host.to(device, sharded_mem_config_DRAM)
+
+    def _capture_yolov5x_trace_2cqs(self):
+        # Initialize the op event so we can write
+        self.op_event = ttnn.record_event(self.device, 0)
+
+        # First run configures convs JIT
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.runner_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        spec = self.runner_infra.input_tensor.spec
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.run()
+        self.runner_infra.validate()
+        self.runner_infra.dealloc_output()
+
+        # Optimized run
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.runner_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.run()
+        self.runner_infra.validate()
+
+        # Capture
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.runner_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        self.op_event = ttnn.record_event(self.device, 0)
+        self.runner_infra.dealloc_output()
+        trace_input_addr = self.runner_infra.input_tensor.buffer_address()
+        self.tid = ttnn.begin_trace_capture(self.device, cq_id=0)
+        self.runner_infra.run()
+        self.input_tensor = ttnn.allocate_tensor_on_device(spec, self.device)
+        ttnn.end_trace_capture(self.device, self.tid, cq_id=0)
+        assert trace_input_addr == self.input_tensor.buffer_address()
+
+    def _execute_yolov5x_trace_2cqs_inference(self, tt_inputs_host=None):
+        tt_inputs_host = self.tt_inputs_host if tt_inputs_host is None else tt_inputs_host
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        if self.input_tensor.is_sharded():
+            self.input_tensor = ttnn.reshard(self.tt_image_res, self.input_mem_config, self.input_tensor)
+        self.op_event = ttnn.record_event(self.device, 0)
+        ttnn.execute_trace(self.device, self.tid, cq_id=0, blocking=False)
+        ttnn.synchronize_device(self.device)
+        return self.runner_infra.output_tensor
+
+    def _validate(self, input_tensor, result_output_tensor):
+        torch_output_tensor = self.runner_infra.torch_output_tensor
+        assert_with_pcc(torch_output_tensor, result_output_tensor, 0.99)
+
+    def run(self, torch_input_tensor=None, check_pcc=False):
+        tt_inputs_host, _ = self.runner_infra._setup_l1_sharded_input(self.device, torch_input_tensor)
+        output = self._execute_yolov5x_trace_2cqs_inference(tt_inputs_host)
+        if check_pcc:
+            torch_input_tensor = torch_input_tensor.reshape(n, h, w, c)
+            torch_input_tensor = torch_input_tensor.permute(0, 3, 1, 2)
+            self._validate(torch_input_tensor, output)
+
+        return output
+
+    def release(self):
+        ttnn.release_trace(self.device, self.tid)

--- a/models/experimental/yolov5x/runner/performant_runner_infra.py
+++ b/models/experimental/yolov5x/runner/performant_runner_infra.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+from loguru import logger
+import ttnn
+from models.experimental.yolov5x.tt.model_preprocessing import (
+    create_yolov5x_model_parameters,
+)
+from models.experimental.yolov5x.tt.yolov5x import Yolov5x
+from models.utility_functions import divup, is_wormhole_b0
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.experimental.yolov5x.common import load_torch_model
+
+
+class YOLOv5xPerformanceRunnerInfra:
+    def __init__(
+        self,
+        device,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        model_location_generator=None,
+        resolution=(640, 640),
+        torch_input_tensor=None,
+    ):
+        torch.manual_seed(0)
+        self.resolution = resolution
+        self.pcc_passed = False
+        self.pcc_message = "Did you forget to call validate()?"
+        self.device = device
+        self.batch_size = batch_size
+        self.act_dtype = act_dtype
+        self.weight_dtype = weight_dtype
+        self.model_location_generator = model_location_generator
+        self.torch_input_tensor = torch_input_tensor
+
+        self.torch_model = load_torch_model(model_location_generator)
+        self.torch_model = self.torch_model.model
+
+        self.torch_input_tensor = (
+            torch.randn((1, 3, 640, 640), dtype=torch.float32)
+            if self.torch_input_tensor is None
+            else self.torch_input_tensor
+        )
+
+        self.parameters = create_yolov5x_model_parameters(self.torch_model, self.torch_input_tensor, self.device)
+
+        self.ttnn_yolov5x_model = Yolov5x(device=self.device, parameters=self.parameters, conv_pt=self.parameters)
+
+        self.torch_output_tensor = self.torch_model(self.torch_input_tensor)
+
+    def _setup_l1_sharded_input(self, device, torch_input_tensor=None, min_channels=16):
+        if is_wormhole_b0():
+            core_grid = ttnn.CoreGrid(y=8, x=8)
+        else:
+            exit("Unsupported device")
+
+        num_devices = device.get_num_devices()
+        torch_input_tensor = self.torch_input_tensor if torch_input_tensor is None else torch_input_tensor
+
+        n, c, h, w = torch_input_tensor.shape
+        if c == 3:
+            c = min_channels
+        input_mem_config = ttnn.create_sharded_memory_config(
+            [n, c, h, w],
+            ttnn.CoreGrid(x=8, y=8),
+            ttnn.ShardStrategy.HEIGHT,
+        )
+        tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+        return tt_inputs_host, input_mem_config
+
+    def setup_dram_sharded_input(self, device, torch_input_tensor=None, mesh_mapper=None, mesh_composer=None):
+        tt_inputs_host, input_mem_config = self._setup_l1_sharded_input(device)
+        dram_grid_size = device.dram_grid_size()
+        dram_shard_spec = ttnn.ShardSpec(
+            ttnn.CoreRangeSet(
+                {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
+            ),
+            [
+                divup(tt_inputs_host.volume() // tt_inputs_host.shape[-1], dram_grid_size.x * dram_grid_size.y),
+                tt_inputs_host.shape[-1],
+            ],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        sharded_mem_config_DRAM = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, dram_shard_spec
+        )
+
+        return tt_inputs_host, sharded_mem_config_DRAM, input_mem_config
+
+    def run(self):
+        self.output_tensor = self.ttnn_yolov5x_model(self.input_tensor)
+
+    def validate(self, output_tensor=None, torch_output_tensor=None):
+        ttnn_output_tensor = self.output_tensor if output_tensor is None else output_tensor
+        torch_output_tensor = self.torch_output_tensor if torch_output_tensor is None else torch_output_tensor
+        output_tensor = ttnn.to_torch(ttnn_output_tensor)
+        self.pcc_passed, self.pcc_message = assert_with_pcc(self.torch_output_tensor[0], output_tensor, pcc=0.99)
+
+        logger.info(
+            f"YoloV5x - batch_size={self.batch_size}, act_dtype={self.act_dtype}, weight_dtype={self.weight_dtype}, PCC={self.pcc_message}"
+        )
+
+    def dealloc_output(self):
+        ttnn.deallocate(self.output_tensor)

--- a/models/experimental/yolov5x/tests/pcc/test_ttnn_yolov5x.py
+++ b/models/experimental/yolov5x/tests/pcc/test_ttnn_yolov5x.py
@@ -10,10 +10,10 @@ from models.experimental.yolov5x.tt.model_preprocessing import (
     create_yolov5x_input_tensors,
     create_yolov5x_model_parameters,
 )
-from models.experimental.yolov5x.common import load_torch_model
+from models.experimental.yolov5x.common import load_torch_model, YOLOV5X_L1_SMALL_SIZE
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV5X_L1_SMALL_SIZE}], indirect=True)
 def test_yolov5x(device, reset_seeds, model_location_generator):
     torch_input, ttnn_input = create_yolov5x_input_tensors(device)
     n, c, h, w = torch_input.shape

--- a/models/experimental/yolov5x/tests/pcc/test_ttnn_yolov5x_bottleneck.py
+++ b/models/experimental/yolov5x/tests/pcc/test_ttnn_yolov5x_bottleneck.py
@@ -10,7 +10,7 @@ from models.experimental.yolov5x.tt.model_preprocessing import (
     create_yolov5x_input_tensors,
     create_yolov5x_model_parameters,
 )
-from models.experimental.yolov5x.common import load_torch_model
+from models.experimental.yolov5x.common import load_torch_model, YOLOV5X_L1_SMALL_SIZE
 
 
 @pytest.mark.parametrize(
@@ -33,7 +33,7 @@ from models.experimental.yolov5x.common import load_torch_model
         ),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV5X_L1_SMALL_SIZE}], indirect=True)
 def test_yolov5x_Bottleneck(
     device,
     reset_seeds,

--- a/models/experimental/yolov5x/tests/pcc/test_ttnn_yolov5x_c3.py
+++ b/models/experimental/yolov5x/tests/pcc/test_ttnn_yolov5x_c3.py
@@ -10,7 +10,7 @@ from models.experimental.yolov5x.tt.model_preprocessing import (
     create_yolov5x_input_tensors,
     create_yolov5x_model_parameters,
 )
-from models.experimental.yolov5x.common import load_torch_model
+from models.experimental.yolov5x.common import load_torch_model, YOLOV5X_L1_SMALL_SIZE
 
 
 @pytest.mark.parametrize(
@@ -36,7 +36,7 @@ from models.experimental.yolov5x.common import load_torch_model
         ),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV5X_L1_SMALL_SIZE}], indirect=True)
 def test_yolov5x_C3(
     device,
     reset_seeds,

--- a/models/experimental/yolov5x/tests/pcc/test_ttnn_yolov5x_detect.py
+++ b/models/experimental/yolov5x/tests/pcc/test_ttnn_yolov5x_detect.py
@@ -10,7 +10,7 @@ from models.experimental.yolov5x.tt.model_preprocessing import (
     create_yolov5x_input_tensors,
     create_yolov5x_model_parameters_detect,
 )
-from models.experimental.yolov5x.common import load_torch_model
+from models.experimental.yolov5x.common import load_torch_model, YOLOV5X_L1_SMALL_SIZE
 
 
 @pytest.mark.parametrize(
@@ -19,7 +19,7 @@ from models.experimental.yolov5x.common import load_torch_model
         ([1, 320, 80, 80], [1, 640, 40, 40], [1, 1280, 20, 20]),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 83000}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV5X_L1_SMALL_SIZE}], indirect=True)
 def test_yolov5x_Detect(
     device,
     reset_seeds,

--- a/models/experimental/yolov5x/tests/pcc/test_ttnn_yolov5x_sppf.py
+++ b/models/experimental/yolov5x/tests/pcc/test_ttnn_yolov5x_sppf.py
@@ -10,10 +10,10 @@ from models.experimental.yolov5x.tt.model_preprocessing import (
     create_yolov5x_input_tensors,
     create_yolov5x_model_parameters,
 )
-from models.experimental.yolov5x.common import load_torch_model
+from models.experimental.yolov5x.common import load_torch_model, YOLOV5X_L1_SMALL_SIZE
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV5X_L1_SMALL_SIZE}], indirect=True)
 def test_yolov5x_SPPF(device, reset_seeds, model_location_generator):
     fwd_input_shape = [1, 1280, 20, 20]
     torch_input, ttnn_input = create_yolov5x_input_tensors(

--- a/models/experimental/yolov5x/tests/perf/test_e2e_performant.py
+++ b/models/experimental/yolov5x/tests/perf/test_e2e_performant.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+import pytest
+from loguru import logger
+import ttnn
+from models.experimental.yolov5x.runner.performant_runner import YOLOv5xPerformantRunner
+from models.utility_functions import run_for_wormhole_b0
+from models.experimental.yolov5x.common import YOLOV5X_L1_SMALL_SIZE
+
+
+@pytest.mark.parametrize(
+    "batch_size, act_dtype, weight_dtype",
+    ((1, ttnn.bfloat8_b, ttnn.bfloat8_b),),
+)
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (640, 640),
+    ],
+)
+@pytest.mark.models_performance_bare_metal
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": YOLOV5X_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
+    indirect=True,
+)
+def test_e2e_performant(
+    device,
+    batch_size,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    resolution,
+):
+    performant_runner = YOLOv5xPerformantRunner(
+        device,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        resolution=resolution,
+        model_location_generator=model_location_generator,
+    )
+    performant_runner._capture_yolov5x_trace_2cqs()
+    inference_times = []
+    for _ in range(10):
+        t0 = time.time()
+        _ = performant_runner.run()
+        t1 = time.time()
+        inference_times.append(t1 - t0)
+
+    performant_runner.release()
+
+    inference_time_avg = round(sum(inference_times) / len(inference_times), 6)
+    logger.info(
+        f"ttnn_yolov5x_batch_size: {batch_size}, resolution: {resolution}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size/inference_time_avg)}"
+    )

--- a/models/experimental/yolov5x/tests/perf/test_perf.py
+++ b/models/experimental/yolov5x/tests/perf/test_perf.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from loguru import logger
+from models.utility_functions import run_for_wormhole_b0
+from models.perf.device_perf_utils import run_device_perf, check_device_perf, prep_device_perf_report
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "batch_size, expected_perf",
+    [
+        [1, 55],
+    ],
+)
+@pytest.mark.models_device_performance_bare_metal
+def test_perf_yolov5x(batch_size, expected_perf):
+    subdir = "ttnn_yolov5x"
+    num_iterations = 1
+    margin = 0.03
+
+    command = f"pytest models/experimental/yolov5x/tests/pcc/test_ttnn_yolov5x.py"
+    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
+
+    inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
+    expected_perf_cols = {inference_time_key: expected_perf}
+
+    post_processed_results = run_device_perf(command, subdir, num_iterations, cols, batch_size)
+    expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols, assert_on_fail=True)
+
+    logger.info(f"{expected_results}")
+
+    prep_device_perf_report(
+        model_name=f"ttnn_yolov5x{batch_size}",
+        batch_size=batch_size,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments="",
+    )


### PR DESCRIPTION
### Ticket
#21550 

### Problem description

- Add test perf with trace and 2 CQs for the Yolov5x model.

### What's changed

- Added Yolov5x with trace and 2CQs.

E2E FPS: 46

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16651639613) CI In Progress
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/16646547350) CI Passed
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/16653062736) CI Passed for yolov5x