### PR TITLE
[skip ci] Demote some info messages to lower severity level

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -136,7 +136,7 @@ void MetalContext::initialize(
             clear_dram_state(device_id);
         }
         int ai_clk = cluster_->get_device_aiclk(device_id);
-        log_info(tt::LogMetal, "AI CLK for device {} is:   {} MHz", device_id, ai_clk);
+        log_debug(tt::LogMetal, "AI CLK for device {} is:   {} MHz", device_id, ai_clk);
         generate_device_bank_to_noc_tables(device_id);
 
         // Create build env for this device, and build FW if it's not built already

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -340,7 +340,7 @@ void DevicePool::initialize_fabric_and_dispatch_fw() const {
     }
     this->initialize_active_devices();
     this->wait_for_fabric_router_sync();
-    log_info(tt::LogMetal, "Devices initialized");
+    log_trace(tt::LogMetal, "Fabric and Dispatch Firmware initialized");
 }
 
 void DevicePool::initialize_host(IDevice* dev) const {
@@ -490,7 +490,7 @@ void DevicePool::initialize_active_devices() const {
         auto tunnels_from_mmio =
             tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
         dev->init_command_queue_device();
-        log_info(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
+        log_debug(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
         if (not this->skip_remote_devices) {
             for (uint32_t t = 0; t < tunnels_from_mmio.size(); t++) {
                 // Need to create devices from farthest to the closest.


### PR DESCRIPTION
### Ticket
NA

### Problem description
People complain that tt-metal logs are useless when running models, because they are so verbose.

### What's changed
Remove some log messages that are more about debug / trace vs USER NEED TO KNOW INFO.

### Checklist
- PR Gate && Merge Gate are good enough.