### PR TITLE
#24928: Unify pcc calculation functions

### DIFF
--- a/ttnn/tt_lib/_internal/comparison_funcs.py
+++ b/ttnn/tt_lib/_internal/comparison_funcs.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import numpy as np
-from loguru import logger
 
 
 def get_atol_rtol_pcc(golden, calculated):
@@ -22,72 +20,9 @@ def get_atol_rtol_pcc(golden, calculated):
 
     # Calculate PCC
     def get_pcc(golden, calculated):
-        # Both tensors are nan
-        if torch.all(torch.isnan(golden)) and torch.all(torch.isnan(calculated)):
-            logger.warning("Both tensors are 'nan'")
-            return 1.0
+        import ttnn
 
-        # One tensor is all nan, the other is not
-        if torch.all(torch.isnan(golden)) or torch.all(torch.isnan(calculated)):
-            logger.error("One tensor is all nan, the other is not.")
-            return 0.0
-
-        # One tensor is all zero, the other is not
-        if torch.any(golden.bool()) != torch.any(calculated.bool()):
-            logger.warning("One tensor is all zero")
-            return 0.0
-
-        # if torch.any(torch.isinf(golden)) or torch.any(torch.isinf(calculated)):
-        #    raise RuntimeError(f"Tensor overflow to infinity: \n{golden}\n{calculated}")
-
-        # if torch.any(torch.isneginf(golden)) or torch.any(torch.isneginf(calculated)):
-        #    raise RuntimeError(f"Tensor overflow to negative infinity: \n{golden}\n{calculated}")
-
-        else:
-            # For now, mask all infs and nans so that we check the rest... TODO
-            golden = golden.clone()
-            golden[
-                torch.logical_or(
-                    torch.isnan(golden),
-                    torch.logical_or(torch.isinf(golden), torch.isneginf(golden)),
-                )
-            ] = 0
-            calculated = calculated.clone()
-            calculated[
-                torch.logical_or(
-                    torch.isnan(calculated),
-                    torch.logical_or(torch.isinf(calculated), torch.isneginf(calculated)),
-                )
-            ] = 0
-
-            if torch.equal(golden, calculated):
-                return 1.0
-
-            if golden.dtype == torch.bfloat16:
-                golden = golden.type(torch.float32)
-                calculated = calculated.type(torch.float32)
-
-            # Single element case
-            if golden.numel() == 1:
-                return float(torch.equal(golden, calculated))
-
-            # If both tensors are contant
-            if torch.max(golden) == torch.min(golden) and torch.max(calculated) == torch.min(calculated):
-                return torch.isclose(torch.max(golden), torch.max(calculated)).item()
-
-            cal_pcc = np.ma.corrcoef(
-                np.ma.masked_invalid(torch.squeeze(golden).detach().numpy()).flatten(),
-                np.ma.masked_invalid(torch.squeeze(calculated).detach().numpy()).flatten(),
-            )
-            # Remove correlation coefficient with self (typically always 1.0)
-            mask = np.ones(cal_pcc.shape, dtype=bool)
-            np.fill_diagonal(mask, 0)
-            cal_pcc = np.min(cal_pcc[mask])
-
-            if isinstance(cal_pcc, np.ma.core.MaskedConstant):
-                return 1.0
-
-            return cal_pcc
+        return ttnn.pearson_correlation_coefficient(golden, calculated)
 
     cal_pcc = get_pcc(golden, calculated)
 


### PR DESCRIPTION
Add special handling of constant tensors that was missing in some implementations

### Ticket
https://github.com/tenstorrent/tt-metal/issues/24928

### Problem description
PCC calculation is invalid if one of the tensors is constant. We added special handling in some implementations of pcc check, but this was not propagated to all implementations/copies

### What's changed
Unify to a single pcc calculation function, and add handling for constant tensors to fall back to allclose with a warning.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes