### PR TITLE
[skip ci] Add input label to BH LLMBox workflows

### DIFF
--- a/.github/workflows/blackhole-llmbox-demo-tests.yaml
+++ b/.github/workflows/blackhole-llmbox-demo-tests.yaml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       runner-label:
-          description: 'Optional: BH-LLMBox'
+          description: 'Optional runner label, default: BH-LLMBox'
           required: false
           type: string
           default: 'BH-LLMBox'
   workflow_call:
     inputs:
       runner-label:
-          description: 'Optional: BH-LLMBox'
+          description: 'Optional runner label, default: BH-LLMBox'
           required: false
           type: string
           default: 'BH-LLMBox'

--- a/.github/workflows/blackhole-llmbox-demo-tests.yaml
+++ b/.github/workflows/blackhole-llmbox-demo-tests.yaml
@@ -2,7 +2,19 @@ name: "(Blackhole) LLMBox Demo tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      runner-label:
+          description: 'Optional: BH-LLMBox'
+          required: false
+          type: string
+          default: 'BH-LLMBox'
   workflow_call:
+    inputs:
+      runner-label:
+          description: 'Optional: BH-LLMBox'
+          required: false
+          type: string
+          default: 'BH-LLMBox'
 
 jobs:
   build-artifact:
@@ -18,7 +30,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-llmbox-demo-tests-impl.yaml
     with:
-      runner-label: BH-LLMBox
+      runner-label: ${{ inputs.runner-label || 'BH-LLMBox' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-llmbox-unit-tests.yaml
+++ b/.github/workflows/blackhole-llmbox-unit-tests.yaml
@@ -2,7 +2,19 @@ name: "(Blackhole) LLMBox unit tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      runner-label:
+          description: 'Optional: BH-LLMBox'
+          required: false
+          type: string
+          default: 'BH-LLMBox'
   workflow_call:
+    inputs:
+      runner-label:
+          description: 'Optional: BH-LLMBox'
+          required: false
+          type: string
+          default: 'BH-LLMBox'
 
 jobs:
   build-artifact:
@@ -19,7 +31,7 @@ jobs:
     uses: ./.github/workflows/blackhole-llmbox-unit-tests-impl.yaml
     with:
       arch: blackhole
-      runner-label: BH-LLMBox
+      runner-label: ${{ inputs.runner-label || 'BH-LLMBox' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-llmbox-unit-tests.yaml
+++ b/.github/workflows/blackhole-llmbox-unit-tests.yaml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       runner-label:
-          description: 'Optional: BH-LLMBox'
+          description: 'Optional runner label, default: BH-LLMBox'
           required: false
           type: string
           default: 'BH-LLMBox'
   workflow_call:
     inputs:
       runner-label:
-          description: 'Optional: BH-LLMBox'
+          description: 'Optional runner label, default: BH-LLMBox'
           required: false
           type: string
           default: 'BH-LLMBox'


### PR DESCRIPTION
### Ticket
None

### Problem description
Label is hardcoded to `BH-LLMBox`

### What's changed
Provide a custom runner-label input for testing purposes

### Checklist
- [x] llmbox unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/16298182831