### PR TITLE
Add to_list() method to TT-NN Tensor Python API

### DIFF
--- a/tests/ttnn/unit_tests/tensor/test_tensor_to_list.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_to_list.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype
+
+ALL_TYPES = [dtype for dtype, _ in ttnn.DataType.__entries.values() if dtype != ttnn.DataType.INVALID]
+TEST_SHAPES = [(5, 5), (32, 32), (50, 50), (16, 16, 16), (16, 16, 16, 16), (16, 16, 16, 16, 16)]
+
+
+@pytest.mark.parametrize("shape", TEST_SHAPES)
+@pytest.mark.parametrize("dtype", ALL_TYPES)
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("is_device", [False, True])
+def test_to_list_all_types(device, is_device, shape, dtype, layout):
+    if dtype == ttnn.bfloat4_b or dtype == ttnn.bfloat8_b and layout != ttnn.TILE_LAYOUT:
+        pytest.skip("types `bfloat4_b` and `bfloat8_b` can only be used with tile layout")
+
+    torch.manual_seed(0)
+    torch_tensor = torch.randint(0, 100, shape, dtype=tt_dtype_to_torch_dtype[dtype])
+    torch_list = torch_tensor.tolist()
+
+    ttnn_tensor = ttnn.from_torch(
+        torch_tensor, device=device if is_device == True else None, dtype=dtype, layout=layout
+    )
+    ttnn_list = ttnn_tensor.to_list()
+
+    assert ttnn_list == torch_list

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -697,7 +697,7 @@ void pytensor_module(py::module& m_tensor) {
     pyTensor.def(py::init<ttnn::Tensor&>())
         .def(
             py::init<>([](std::vector<float>&& data,
-                          const std::vector<uint32_t>& shape,
+                          const std::array<uint32_t, 4>& shape,
                           DataType data_type,
                           Layout layout,
                           const std::optional<Tile>& tile,
@@ -747,7 +747,7 @@ void pytensor_module(py::module& m_tensor) {
             )doc")
         .def(
             py::init<>([](std::vector<float>&& data,
-                          const std::vector<uint32_t>& shape,
+                          const std::array<uint32_t, 4>& shape,
                           DataType data_type,
                           Layout layout,
                           std::optional<MeshDevice*> device,
@@ -809,7 +809,7 @@ void pytensor_module(py::module& m_tensor) {
             )doc")
         .def(
             py::init<>([](std::vector<float>&& data,
-                          const std::vector<uint32_t>& shape,
+                          const std::array<uint32_t, 4>& shape,
                           DataType data_type,
                           Layout layout,
                           std::optional<MeshDevice*> device,

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -1631,7 +1631,7 @@ void pytensor_module(py::module& m_tensor) {
             [](Tensor& self) {
                 using namespace tt::tt_metal::tensor_impl;
                 return dispatch(self.dtype(), [&]<typename T>() -> py::list {
-                    auto logical_shape = self.logical_shape();
+                    const auto& logical_shape = self.logical_shape();
                     std::vector<uint32_t> shape{logical_shape.cbegin(), logical_shape.cend()};
 
                     if constexpr (

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -4,7 +4,6 @@
 
 #include "pytensor.hpp"
 
-#include <algorithm>
 #include <array>
 #include <chrono>
 #include <cstddef>
@@ -698,7 +697,7 @@ void pytensor_module(py::module& m_tensor) {
     pyTensor.def(py::init<ttnn::Tensor&>())
         .def(
             py::init<>([](std::vector<float>&& data,
-                          const std::array<uint32_t, 4>& shape,
+                          const std::vector<uint32_t>& shape,
                           DataType data_type,
                           Layout layout,
                           const std::optional<Tile>& tile,
@@ -748,7 +747,7 @@ void pytensor_module(py::module& m_tensor) {
             )doc")
         .def(
             py::init<>([](std::vector<float>&& data,
-                          const std::array<uint32_t, 4>& shape,
+                          const std::vector<uint32_t>& shape,
                           DataType data_type,
                           Layout layout,
                           std::optional<MeshDevice*> device,
@@ -810,7 +809,7 @@ void pytensor_module(py::module& m_tensor) {
             )doc")
         .def(
             py::init<>([](std::vector<float>&& data,
-                          const std::array<uint32_t, 4>& shape,
+                          const std::vector<uint32_t>& shape,
                           DataType data_type,
                           Layout layout,
                           std::optional<MeshDevice*> device,


### PR DESCRIPTION
### Ticket
[Add to_list() method to TT-NN Tensor Python API](https://github.com/tenstorrent/tt-metal/issues/24786)

### Problem description
Currently, when working with TT-NN’s Python API, converting a tensor to a native Python list requires two steps:

`py_list = ttnn_tensor.to_torch().tolist()`

This approach is verbose and depends on PyTorch.
Ideally, we should be able to call ttnn_tensor.to_list() directly to get a list.

`py_list = ttnn_tensor.to_list()`

### What's changed
Implemented a to_list() method on the ttnn.Tensor class.
Added unit tests to validate the new to_list() functionality.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes. [Results](https://github.com/tenstorrent/tt-metal/actions/runs/16305792744)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable). [Results](https://github.com/tenstorrent/tt-metal/actions/runs/16300926318)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes