### PR TITLE
Add locking around MeshCommandQueue

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -526,5 +526,71 @@ TEST_F(MeshBufferTestSuite, MultiShardReadWrite) {
     }
 }
 
+TEST_F(MeshBufferTestSuite, MultiShardReadWriteMultiThread) {
+    constexpr uint32_t NUM_ITERS = 50;
+    uint32_t seed = tt::parse_env("TT_METAL_SEED", 0);
+    uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
+
+    std::vector<std::thread> threads;
+    for (int thread_idx = 0; thread_idx < 2; thread_idx += 1) {
+        threads.push_back(std::thread([&, thread_idx]() {
+            std::uniform_int_distribution<int> gen_num_datums(32, 128);
+            std::mt19937 rng(seed);
+
+            DeviceLocalBufferConfig per_device_buffer_config{
+                .page_size = single_tile_size, .buffer_type = BufferType::DRAM, .bottom_up = true};
+
+            distributed::MeshCoordinateRange coord_range(mesh_device_->shape());
+
+            uint32_t rows = mesh_device_->num_rows();
+            uint32_t cols = mesh_device_->num_cols();
+            uint32_t num_devices = rows * cols;
+
+            for (auto shard_orientation : {ShardOrientation::COL_MAJOR, ShardOrientation::ROW_MAJOR}) {
+                for (int i = 0; i < NUM_ITERS; i++) {
+                    Shape2D global_buffer_shape = {
+                        gen_num_datums(rng) * constants::TILE_HEIGHT * rows,
+                        gen_num_datums(rng) * constants::TILE_WIDTH * cols};
+                    Shape2D shard_shape = {global_buffer_shape.height() / rows, global_buffer_shape.width() / cols};
+                    uint32_t global_buffer_size =
+                        global_buffer_shape.height() * global_buffer_shape.width() * sizeof(uint32_t);
+                    ShardedBufferConfig sharded_config{
+                        .global_size = global_buffer_size,
+                        .global_buffer_shape = global_buffer_shape,
+                        .shard_shape = shard_shape,
+                        .shard_orientation = shard_orientation,
+                    };
+                    auto mesh_buffer = MeshBuffer::create(sharded_config, per_device_buffer_config, mesh_device_.get());
+
+                    std::vector<uint32_t> src_vec =
+                        std::vector<uint32_t>(global_buffer_size / num_devices / sizeof(uint32_t), 0);
+                    std::iota(src_vec.begin(), src_vec.end(), i);
+                    std::unordered_map<distributed::MeshCoordinate, std::vector<uint32_t>> dst_vec = {};
+                    std::vector<MeshCommandQueue::ShardDataTransfer> input_shards = {};
+                    std::vector<MeshCommandQueue::ShardDataTransfer> output_shards = {};
+
+                    for (auto& coord : coord_range) {
+                        input_shards.push_back({coord, src_vec.data()});
+                    }
+                    for (auto& coord : coord_range) {
+                        dst_vec[coord] = std::vector<uint32_t>(global_buffer_size / num_devices / sizeof(uint32_t), 0);
+                        output_shards.push_back({coord, dst_vec[coord].data()});
+                    }
+
+                    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, input_shards, false);
+                    mesh_device_->mesh_command_queue().enqueue_read_shards(output_shards, mesh_buffer, true);
+
+                    for (auto& dst : dst_vec) {
+                        EXPECT_EQ(dst.second, src_vec);
+                    }
+                }
+            }
+        }));
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+}
+
 }  // namespace
 }  // namespace tt::tt_metal::distributed::test

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -23,7 +23,6 @@ TT_ENABLE_UNITY_BUILD(unit_tests_ttnn_smoke)
 target_sources(
     unit_tests_ttnn_smoke
     PRIVATE
-        test_multiprod_queue.cpp
         test_multi_cq_multi_dev.cpp
         test_reflect.cpp
         test_to_and_from_json.cpp
@@ -55,6 +54,7 @@ target_sources(
         test_graph_query_op_runtime.cpp
         test_launch_operation.cpp # TODO: Fix data race (TSan) then shift-left
         test_matmul_benchmark.cpp
+        test_multiprod_queue.cpp
 )
 target_include_directories(unit_tests_ttnn_basic PRIVATE ${PROJECT_SOURCE_DIR}/tests)
 target_link_libraries(

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -54,7 +54,6 @@ target_sources(
         test_graph_query_op_runtime.cpp
         test_launch_operation.cpp # TODO: Fix data race (TSan) then shift-left
         test_matmul_benchmark.cpp
-        test_multiprod_queue.cpp
 )
 target_include_directories(unit_tests_ttnn_basic PRIVATE ${PROJECT_SOURCE_DIR}/tests)
 target_link_libraries(
@@ -72,6 +71,7 @@ target_sources(
     PRIVATE
         test_async_runtime.cpp # TODO: Fix memory leak (LSan) then shift-left
         test_conv2d.cpp # TODO: Fix misaligned memory load (UBSan) then shift-left
+        test_multiprod_queue.cpp
 )
 target_include_directories(unit_tests_ttnn_slow PRIVATE ${PROJECT_SOURCE_DIR}/tests)
 target_link_libraries(

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -23,7 +23,6 @@ TT_ENABLE_UNITY_BUILD(unit_tests_ttnn_smoke)
 target_sources(
     unit_tests_ttnn_smoke
     PRIVATE
-        test_multi_cq_multi_dev.cpp
         test_reflect.cpp
         test_to_and_from_json.cpp
         test_sliding_window_infra.cpp
@@ -71,6 +70,7 @@ target_sources(
     PRIVATE
         test_async_runtime.cpp # TODO: Fix memory leak (LSan) then shift-left
         test_conv2d.cpp # TODO: Fix misaligned memory load (UBSan) then shift-left
+        test_multi_cq_multi_dev.cpp
         test_multiprod_queue.cpp
 )
 target_include_directories(unit_tests_ttnn_slow PRIVATE ${PROJECT_SOURCE_DIR}/tests)

--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -66,8 +66,7 @@ Tensor dispatch_ops_to_device(IDevice* dev, Tensor input_tensor, QueueId cq_id) 
     return output_tensor;
 }
 
-// Disabled: https://github.com/tenstorrent/tt-metal/issues/21666
-TEST_F(MultiCommandQueueT3KFixture, DISABLED_Test2CQMultiDeviceProgramsOnCQ1) {
+TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
     MemoryConfig mem_cfg = MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
 
     ttnn::Shape shape{1, 3, 2048, 2048};
@@ -119,8 +118,7 @@ TEST_F(MultiCommandQueueT3KFixture, DISABLED_Test2CQMultiDeviceProgramsOnCQ1) {
     }
 }
 
-// Disabled: https://github.com/tenstorrent/tt-metal/issues/21666
-TEST_F(MultiCommandQueueT3KFixture, DISABLED_Test2CQMultiDeviceProgramsOnCQ0) {
+TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
     MemoryConfig mem_cfg = MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
 
     ttnn::Shape shape{1, 3, 2048, 2048};
@@ -173,8 +171,7 @@ TEST_F(MultiCommandQueueT3KFixture, DISABLED_Test2CQMultiDeviceProgramsOnCQ0) {
     }
 }
 
-// Disabled: https://github.com/tenstorrent/tt-metal/issues/21666
-TEST_F(MultiCommandQueueT3KFixture, DISABLED_Test2CQMultiDeviceWithCQ1Only) {
+TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceWithCQ1Only) {
     MemoryConfig mem_cfg = MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
 
     ttnn::Shape shape{1, 3, 2048, 2048};

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -39,12 +39,11 @@ using ::tt::tt_metal::is_device_tensor;
 
 using MultiProducerCommandQueueTest = ttnn::MultiCommandQueueSingleDeviceFixture;
 
-// #21556: Disabled until we have clarity about user space multi-threading support
-TEST_F(MultiProducerCommandQueueTest, DISABLED_Stress) {
+TEST_F(MultiProducerCommandQueueTest, Stress) {
     // Spawn 2 application level threads intefacing with the same device through the async engine.
     // This leads to shared access of the work_executor and host side worker queue.
     // Test thread safety.
-    IDevice* device = this->device_;
+    auto device = this->device_;
 
     const ttnn::Shape tensor_shape{1, 1, 1024, 1024};
     const MemoryConfig mem_cfg = MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
@@ -84,8 +83,7 @@ TEST_F(MultiProducerCommandQueueTest, DISABLED_Stress) {
     t1.join();
 }
 
-// #21556: Disabled until we have clarity about user space multi-threading support
-TEST_F(MultiProducerCommandQueueTest, DISABLED_EventSync) {
+TEST_F(MultiProducerCommandQueueTest, EventSync) {
     // Verify that the event_synchronize API stalls the calling thread until
     // the device records the event being polled.
     // Thread 0 = writer thread. Thread 1 = reader thread.

--- a/tt_metal/api/tt-metalium/allocator.hpp
+++ b/tt_metal/api/tt-metalium/allocator.hpp
@@ -39,9 +39,8 @@ public:
     void deallocate_buffer(Buffer* buffer);
     void deallocate_buffers();
 
-    std::unique_lock<std::mutex> lock() { return std::unique_lock<std::mutex>(mutex_); }
-    // lock must be held while using the returned reference
-    const std::unordered_set<Buffer*>& get_allocated_buffers() const;
+    std::unordered_set<Buffer*> get_allocated_buffers() const;
+    size_t get_num_allocated_buffers() const;
 
     uint32_t get_num_banks(const BufferType& buffer_type) const;
     DeviceAddr get_bank_size(const BufferType& buffer_type) const;

--- a/tt_metal/api/tt-metalium/allocator.hpp
+++ b/tt_metal/api/tt-metalium/allocator.hpp
@@ -27,6 +27,7 @@ class Buffer;
 // Fwd declares
 enum class BufferType;
 
+// THREAD SAFETY: Allocator is thread safe.
 class Allocator {
 public:
     Allocator(const AllocatorConfig& alloc_config);
@@ -38,6 +39,8 @@ public:
     void deallocate_buffer(Buffer* buffer);
     void deallocate_buffers();
 
+    std::unique_lock<std::mutex> lock() { return std::unique_lock<std::mutex>(mutex_); }
+    // lock must be held while using the returned reference
     const std::unordered_set<Buffer*>& get_allocated_buffers() const;
 
     uint32_t get_num_banks(const BufferType& buffer_type) const;
@@ -84,6 +87,8 @@ protected:
 private:
     void verify_safe_allocation() const;
 
+    mutable std::mutex mutex_;
+
     // Set to true if allocating a buffer is unsafe. This happens when a live trace on device can corrupt
     // memory allocated by the user (memory used by trace is not tracked in the allocator once the trace is captured).
     bool allocations_unsafe_ = false;
@@ -98,7 +103,7 @@ private:
     std::unordered_map<BufferType, std::unordered_map<CoreCoord, std::vector<uint32_t>>> logical_core_to_bank_ids_;
     std::unordered_set<Buffer*> allocated_buffers_;
 
-    AllocatorConfig config_;
+    const AllocatorConfig config_;
 };
 
 }  // namespace tt_metal

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -56,6 +56,7 @@ struct MeshCoreDataReadDescriptor;
 using MeshCompletionReaderVariant =
     std::variant<MeshBufferReadDescriptor, MeshReadEventDescriptor, MeshCoreDataReadDescriptor>;
 
+// THREAD SAFETY: All methods are thread safe.
 class MeshCommandQueue {
     // Main interface to dispatch data and workloads to a MeshDevice
     // Currently only supports dispatching workloads and relies on the

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -134,6 +134,8 @@ private:
 
     std::shared_ptr<MeshTraceBuffer>& create_mesh_trace(const MeshTraceId& trace_id);
 
+    std::lock_guard<std::mutex> lock_api() { return std::lock_guard<std::mutex>(api_mutex_); }
+
 public:
     MeshDevice(
         std::shared_ptr<ScopedDevices> scoped_devices,
@@ -283,8 +285,6 @@ public:
     bool is_local(const MeshCoordinate& coord) const;
 
     const MeshShape& shape() const;
-
-    std::unique_lock<std::mutex> lock_api() { return std::unique_lock<std::mutex>(api_mutex_); }
 
     // Reshapes the logical mesh and re-maps the physical devices to the new logical coordinates.
     // Reshaping Rules:

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -103,6 +103,11 @@ private:
 
         const std::vector<MaybeRemote<IDevice*>>& root_devices() const;
     };
+
+    // THREAD SAFETY: Enqueueing work on the device should be thread safe. Operations that modify state should be
+    // protected by api_mutex_. Operations that reconfigure global state (e.g. setting subdevices or enabling tracing)
+    // on the device may not be thread safe.
+    std::mutex api_mutex_;
     std::shared_ptr<ScopedDevices> scoped_devices_;
     int mesh_id_;
     std::unique_ptr<MeshDeviceView> view_;
@@ -278,6 +283,8 @@ public:
     bool is_local(const MeshCoordinate& coord) const;
 
     const MeshShape& shape() const;
+
+    std::unique_lock<std::mutex> lock_api() { return std::unique_lock<std::mutex>(api_mutex_); }
 
     // Reshapes the logical mesh and re-maps the physical devices to the new logical coordinates.
     // Reshaping Rules:

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -72,8 +72,9 @@ FDMeshCommandQueue::FDMeshCommandQueue(
     uint32_t id,
     std::shared_ptr<ThreadPool>& dispatch_thread_pool,
     std::shared_ptr<ThreadPool>& reader_thread_pool,
-    std::shared_ptr<CQSharedState>& cq_shared_state) :
-    MeshCommandQueueBase(mesh_device, id, dispatch_thread_pool),
+    std::shared_ptr<CQSharedState>& cq_shared_state,
+    std::function<std::lock_guard<std::mutex>()> lock_api_function) :
+    MeshCommandQueueBase(mesh_device, id, dispatch_thread_pool, lock_api_function),
     reader_thread_pool_(reader_thread_pool),
     cq_shared_state_(cq_shared_state),
     dispatch_core_type_(MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type()),
@@ -183,7 +184,7 @@ void FDMeshCommandQueue::clear_expected_num_workers_completed() {
 }
 
 void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     in_use_ = true;
     uint64_t command_hash = *mesh_device_->get_active_sub_device_manager_id();
     std::unordered_set<SubDeviceId> sub_device_ids = mesh_workload.impl().determine_sub_device_ids(mesh_device_);
@@ -381,7 +382,7 @@ void FDMeshCommandQueue::enqueue_write_shard_to_core(
     uint32_t size_bytes,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Writes are not supported during trace capture.");
 
@@ -411,7 +412,7 @@ void FDMeshCommandQueue::enqueue_read_shard_from_core(
     uint32_t size_bytes,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Reads are not supported during trace capture.");
 
@@ -452,7 +453,7 @@ void FDMeshCommandQueue::finish_locked(tt::stl::Span<const SubDeviceId> sub_devi
 }
 
 void FDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     this->finish_locked(sub_device_ids);
 }
 
@@ -599,7 +600,7 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_helper(
 
 MeshEvent FDMeshCommandQueue::enqueue_record_event(
     tt::stl::Span<const SubDeviceId> sub_device_ids, const std::optional<MeshCoordinateRange>& device_range) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
 
     MeshEvent event = this->enqueue_record_event_helper(sub_device_ids, /*notify_host=*/false, device_range);
@@ -626,12 +627,12 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_to_host_locked(
 
 MeshEvent FDMeshCommandQueue::enqueue_record_event_to_host(
     tt::stl::Span<const SubDeviceId> sub_device_ids, const std::optional<MeshCoordinateRange>& device_range) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     return this->enqueue_record_event_to_host_locked(sub_device_ids, device_range);
 }
 
 void FDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent& sync_event) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Event Synchronization is not supported during trace capture.");
     for (const auto& coord : sync_event.device_range()) {
@@ -900,7 +901,7 @@ void FDMeshCommandQueue::capture_go_signal_trace_on_unused_subgrids(
 }
 
 void FDMeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blocking) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     in_use_ = true;
     auto trace_inst = mesh_device_->get_mesh_trace(trace_id);
     auto descriptor = trace_inst->desc;
@@ -943,7 +944,7 @@ void FDMeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blockin
 }
 
 void FDMeshCommandQueue::record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     trace_dispatch::reset_host_dispatch_state_for_trace(
         mesh_device_->num_sub_devices(),
         cq_shared_state_->worker_launch_message_buffer_state,

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -183,6 +183,7 @@ void FDMeshCommandQueue::clear_expected_num_workers_completed() {
 }
 
 void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) {
+    auto lock = mesh_device_->lock_api();
     in_use_ = true;
     uint64_t command_hash = *mesh_device_->get_active_sub_device_manager_id();
     std::unordered_set<SubDeviceId> sub_device_ids = mesh_workload.impl().determine_sub_device_ids(mesh_device_);
@@ -370,7 +371,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     mesh_workload.set_last_used_command_queue_for_testing(this);
 
     if (blocking) {
-        this->finish({sub_device_id});
+        this->finish_locked({sub_device_id});
     }
 }
 
@@ -380,6 +381,7 @@ void FDMeshCommandQueue::enqueue_write_shard_to_core(
     uint32_t size_bytes,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    auto lock = mesh_device_->lock_api();
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Writes are not supported during trace capture.");
 
@@ -399,7 +401,7 @@ void FDMeshCommandQueue::enqueue_write_shard_to_core(
         sub_device_ids);
 
     if (blocking) {
-        this->finish(sub_device_ids);
+        this->finish_locked(sub_device_ids);
     }
 }
 
@@ -409,6 +411,7 @@ void FDMeshCommandQueue::enqueue_read_shard_from_core(
     uint32_t size_bytes,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    auto lock = mesh_device_->lock_api();
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Reads are not supported during trace capture.");
 
@@ -437,8 +440,8 @@ void FDMeshCommandQueue::enqueue_read_shard_from_core(
         ReadCoreDataDescriptor(dst, size_bytes), address.device_coord, blocking, sub_device_ids);
 }
 
-void FDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    auto event = this->enqueue_record_event_to_host(sub_device_ids);
+void FDMeshCommandQueue::finish_locked(tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    auto event = this->enqueue_record_event_to_host_locked(sub_device_ids);
 
     std::unique_lock<std::mutex> lock(reads_processed_cv_mutex_);
     reads_processed_cv_.wait(lock, [this] { return num_outstanding_reads_.load() == 0; });
@@ -446,6 +449,11 @@ void FDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids)
     for (auto& sub_device_id : buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids)) {
         sub_device_cq_owner[*sub_device_id].finished(this->id_);
     }
+}
+
+void FDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    auto lock = mesh_device_->lock_api();
+    this->finish_locked(sub_device_ids);
 }
 
 void FDMeshCommandQueue::write_shard_to_device(
@@ -537,7 +545,7 @@ void FDMeshCommandQueue::submit_memcpy_request(
     this->increment_num_entries_in_completion_queue();
 
     if (blocking) {
-        this->finish();
+        this->finish_locked();
     }
 }
 
@@ -551,7 +559,7 @@ void FDMeshCommandQueue::submit_core_data_memcpy_request(
     this->increment_num_entries_in_completion_queue();
 
     if (blocking) {
-        this->finish(sub_device_ids);
+        this->finish_locked(sub_device_ids);
     }
 }
 
@@ -591,6 +599,7 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_helper(
 
 MeshEvent FDMeshCommandQueue::enqueue_record_event(
     tt::stl::Span<const SubDeviceId> sub_device_ids, const std::optional<MeshCoordinateRange>& device_range) {
+    auto lock = mesh_device_->lock_api();
     auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
 
     MeshEvent event = this->enqueue_record_event_helper(sub_device_ids, /*notify_host=*/false, device_range);
@@ -601,7 +610,7 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event(
     return event;
 }
 
-MeshEvent FDMeshCommandQueue::enqueue_record_event_to_host(
+MeshEvent FDMeshCommandQueue::enqueue_record_event_to_host_locked(
     tt::stl::Span<const SubDeviceId> sub_device_ids, const std::optional<MeshCoordinateRange>& device_range) {
     auto event = this->enqueue_record_event_helper(sub_device_ids, /*notify_host=*/true, device_range);
     completion_queue_reads_.push(std::make_shared<MeshCompletionReaderVariant>(
@@ -615,7 +624,14 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_to_host(
     return event;
 }
 
+MeshEvent FDMeshCommandQueue::enqueue_record_event_to_host(
+    tt::stl::Span<const SubDeviceId> sub_device_ids, const std::optional<MeshCoordinateRange>& device_range) {
+    auto lock = mesh_device_->lock_api();
+    return this->enqueue_record_event_to_host_locked(sub_device_ids, device_range);
+}
+
 void FDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent& sync_event) {
+    auto lock = mesh_device_->lock_api();
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Event Synchronization is not supported during trace capture.");
     for (const auto& coord : sync_event.device_range()) {
@@ -884,6 +900,7 @@ void FDMeshCommandQueue::capture_go_signal_trace_on_unused_subgrids(
 }
 
 void FDMeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blocking) {
+    auto lock = mesh_device_->lock_api();
     in_use_ = true;
     auto trace_inst = mesh_device_->get_mesh_trace(trace_id);
     auto descriptor = trace_inst->desc;
@@ -921,11 +938,12 @@ void FDMeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blockin
         expected_num_workers_completed_);
 
     if (blocking) {
-        this->finish();
+        this->finish_locked();
     }
 }
 
 void FDMeshCommandQueue::record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) {
+    auto lock = mesh_device_->lock_api();
     trace_dispatch::reset_host_dispatch_state_for_trace(
         mesh_device_->num_sub_devices(),
         cq_shared_state_->worker_launch_message_buffer_state,

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -183,8 +183,8 @@ protected:
         std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) override;
-    void finish_locked(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
-    MeshEvent enqueue_record_event_to_host_locked(
+    void finish_nolock(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
+    MeshEvent enqueue_record_event_to_host_nolock(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},
         const std::optional<MeshCoordinateRange>& device_range = std::nullopt);
 

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -194,7 +194,8 @@ public:
         uint32_t id,
         std::shared_ptr<ThreadPool>& dispatch_thread_pool,
         std::shared_ptr<ThreadPool>& reader_thread_pool,
-        std::shared_ptr<CQSharedState>& cq_shared_state);
+        std::shared_ptr<CQSharedState>& cq_shared_state,
+        std::function<std::lock_guard<std::mutex>()> lock_api_function);
 
     ~FDMeshCommandQueue() override;
 

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -183,6 +183,10 @@ protected:
         std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) override;
+    void finish_locked(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
+    MeshEvent enqueue_record_event_to_host_locked(
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {},
+        const std::optional<MeshCoordinateRange>& device_range = std::nullopt);
 
 public:
     FDMeshCommandQueue(

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -167,7 +167,7 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
     const MeshCoordinateRange& device_range,
     bool blocking,
     std::optional<BufferRegion> region) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     if (buffer.global_layout() == MeshBufferLayout::REPLICATED) {
         // Multi-Threaded writes supported for Replicated buffers.
         // Currently not supported when doing TT-Mesh Native sharding, since we
@@ -197,7 +197,7 @@ void MeshCommandQueueBase::enqueue_write_mesh_buffer(
 
 void MeshCommandQueueBase::enqueue_read_mesh_buffer(
     void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     TT_FATAL(
         buffer->global_layout() == MeshBufferLayout::SHARDED, "Can only read a Sharded MeshBuffer from a MeshDevice.");
     TT_FATAL(
@@ -233,13 +233,13 @@ void MeshCommandQueueBase::enqueue_write_shards(
     const std::shared_ptr<MeshBuffer>& mesh_buffer,
     const std::vector<ShardDataTransfer>& shard_data_transfers,
     bool blocking) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     this->enqueue_write_shards_locked(mesh_buffer, shard_data_transfers, blocking);
 }
 
 void MeshCommandQueueBase::enqueue_write(
     const std::shared_ptr<MeshBuffer>& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     // Iterate over global coordinates; skip host-remote coordinates, as per `host_buffer` configuration.
     std::vector<ShardDataTransfer> shard_data_transfers;
     for (const auto& host_buffer_coord : host_buffer.shard_coords()) {
@@ -277,7 +277,7 @@ void MeshCommandQueueBase::enqueue_read_shards(
     const std::vector<ShardDataTransfer>& shard_data_transfers,
     const std::shared_ptr<MeshBuffer>& mesh_buffer,
     bool blocking) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     this->enqueue_read_shards_locked(shard_data_transfers, mesh_buffer, blocking);
 }
 
@@ -286,7 +286,7 @@ void MeshCommandQueueBase::enqueue_read(
     DistributedHostBuffer& host_buffer,
     const std::optional<std::unordered_set<MeshCoordinate>>& shards,
     bool blocking) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     std::vector<ShardDataTransfer> shard_data_transfers;
     for (const auto& coord : MeshCoordinateRange(buffer->device()->shape())) {
         if (shards.has_value() && !shards->contains(coord)) {

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -185,7 +185,7 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
     }
 
     if (blocking) {
-        this->finish_locked();
+        this->finish_nolock();
     }
 }
 
@@ -205,7 +205,7 @@ void MeshCommandQueueBase::enqueue_read_mesh_buffer(
     this->read_sharded_buffer(*buffer, host_data);
 }
 
-void MeshCommandQueueBase::enqueue_write_shards_locked(
+void MeshCommandQueueBase::enqueue_write_shards_nolock(
     const std::shared_ptr<MeshBuffer>& buffer,
     const std::vector<ShardDataTransfer>& shard_data_transfers,
     bool blocking) {
@@ -225,7 +225,7 @@ void MeshCommandQueueBase::enqueue_write_shards_locked(
     dispatch_thread_pool_->wait();
 
     if (blocking) {
-        this->finish_locked();
+        this->finish_nolock();
     }
 }
 
@@ -234,7 +234,7 @@ void MeshCommandQueueBase::enqueue_write_shards(
     const std::vector<ShardDataTransfer>& shard_data_transfers,
     bool blocking) {
     auto lock = lock_api_function_();
-    this->enqueue_write_shards_locked(mesh_buffer, shard_data_transfers, blocking);
+    this->enqueue_write_shards_nolock(mesh_buffer, shard_data_transfers, blocking);
 }
 
 void MeshCommandQueueBase::enqueue_write(
@@ -252,10 +252,10 @@ void MeshCommandQueueBase::enqueue_write(
         }
     }
 
-    this->enqueue_write_shards_locked(mesh_buffer, shard_data_transfers, blocking);
+    this->enqueue_write_shards_nolock(mesh_buffer, shard_data_transfers, blocking);
 }
 
-void MeshCommandQueueBase::enqueue_read_shards_locked(
+void MeshCommandQueueBase::enqueue_read_shards_nolock(
     const std::vector<ShardDataTransfer>& shard_data_transfers,
     const std::shared_ptr<MeshBuffer>& buffer,
     bool blocking) {
@@ -278,7 +278,7 @@ void MeshCommandQueueBase::enqueue_read_shards(
     const std::shared_ptr<MeshBuffer>& mesh_buffer,
     bool blocking) {
     auto lock = lock_api_function_();
-    this->enqueue_read_shards_locked(shard_data_transfers, mesh_buffer, blocking);
+    this->enqueue_read_shards_nolock(shard_data_transfers, mesh_buffer, blocking);
 }
 
 void MeshCommandQueueBase::enqueue_read(
@@ -302,7 +302,7 @@ void MeshCommandQueueBase::enqueue_read(
         }
     }
 
-    this->enqueue_read_shards_locked(shard_data_transfers, buffer, blocking);
+    this->enqueue_read_shards_nolock(shard_data_transfers, buffer, blocking);
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -30,11 +30,21 @@ protected:
         std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
     virtual void submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) = 0;
+    virtual void finish_locked(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
 
 private:
     // Helper functions for read and write entire Sharded-MeshBuffers
     void write_sharded_buffer(const MeshBuffer& buffer, const void* src);
     void read_sharded_buffer(MeshBuffer& buffer, void* dst);
+
+    void enqueue_read_shards_locked(
+        const std::vector<ShardDataTransfer>& shard_data_transfers,
+        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        bool blocking);
+    void enqueue_write_shards_locked(
+        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        const std::vector<ShardDataTransfer>& shard_data_transfers,
+        bool blocking);
 
 public:
     MeshCommandQueueBase(MeshDevice* mesh_device, uint32_t id, std::shared_ptr<ThreadPool> dispatch_thread_pool) :

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -34,18 +34,21 @@ protected:
         std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
     virtual void submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) = 0;
-    virtual void finish_locked(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
+    // Must be called with lock_api_function_() held.
+    virtual void finish_nolock(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
 
 private:
     // Helper functions for read and write entire Sharded-MeshBuffers
     void write_sharded_buffer(const MeshBuffer& buffer, const void* src);
     void read_sharded_buffer(MeshBuffer& buffer, void* dst);
 
-    void enqueue_read_shards_locked(
+    // Must be called with lock_api_function_() held.
+    void enqueue_read_shards_nolock(
         const std::vector<ShardDataTransfer>& shard_data_transfers,
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         bool blocking);
-    void enqueue_write_shards_locked(
+    // Must be called with lock_api_function_() held.
+    void enqueue_write_shards_nolock(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const std::vector<ShardDataTransfer>& shard_data_transfers,
         bool blocking);

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -859,11 +859,17 @@ bool MeshDevice::initialize(
     if (this->using_fast_dispatch()) {
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
             mesh_command_queues_.push_back(std::make_unique<FDMeshCommandQueue>(
-                this, cq_id, dispatch_thread_pool_, reader_thread_pool_, cq_shared_state));
+                this,
+                cq_id,
+                dispatch_thread_pool_,
+                reader_thread_pool_,
+                cq_shared_state,
+                std::bind(&MeshDevice::lock_api, this)));
         }
     } else {
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
-            mesh_command_queues_.push_back(std::make_unique<SDMeshCommandQueue>(this, cq_id));
+            mesh_command_queues_.push_back(
+                std::make_unique<SDMeshCommandQueue>(this, cq_id, std::bind(&MeshDevice::lock_api, this)));
         }
     }
     Inspector::mesh_device_initialized(this);

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -591,12 +591,15 @@ size_t MeshDevice::num_program_cache_entries() { return program_cache_->num_entr
 
 SubDeviceManagerId MeshDevice::create_sub_device_manager(
     tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
+    auto lock = lock_api();
     return sub_device_manager_tracker_->create_sub_device_manager(sub_devices, local_l1_size);
 }
 void MeshDevice::remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
+    auto lock = lock_api();
     sub_device_manager_tracker_->remove_sub_device_manager(sub_device_manager_id);
 }
 void MeshDevice::load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
+    auto lock = lock_api();
     sub_device_manager_tracker_->load_sub_device_manager(sub_device_manager_id);
 }
 void MeshDevice::clear_loaded_sub_device_manager() { sub_device_manager_tracker_->clear_loaded_sub_device_manager(); }

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -10,8 +10,9 @@
 
 namespace tt::tt_metal::distributed {
 
-SDMeshCommandQueue::SDMeshCommandQueue(MeshDevice* mesh_device, uint32_t id) :
-    MeshCommandQueueBase(mesh_device, id, create_passthrough_thread_pool()) {}
+SDMeshCommandQueue::SDMeshCommandQueue(
+    MeshDevice* mesh_device, uint32_t id, std::function<std::lock_guard<std::mutex>()> lock_api_function) :
+    MeshCommandQueueBase(mesh_device, id, create_passthrough_thread_pool(), lock_api_function) {}
 
 void SDMeshCommandQueue::write_shard_to_device(
     const MeshBuffer& buffer,
@@ -50,7 +51,7 @@ WorkerConfigBufferMgr& SDMeshCommandQueue::get_config_buffer_mgr(uint32_t index)
 }
 
 void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) {
-    auto lock = mesh_device_->lock_api();
+    auto lock = lock_api_function_();
     if (!blocking) {
         log_warning(
             tt::LogMetal, "Using Slow Dispatch for {}. This leads to blocking workload exection.", __FUNCTION__);

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -50,6 +50,7 @@ WorkerConfigBufferMgr& SDMeshCommandQueue::get_config_buffer_mgr(uint32_t index)
 }
 
 void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) {
+    auto lock = mesh_device_->lock_api();
     if (!blocking) {
         log_warning(
             tt::LogMetal, "Using Slow Dispatch for {}. This leads to blocking workload exection.", __FUNCTION__);
@@ -76,6 +77,7 @@ MeshEvent SDMeshCommandQueue::enqueue_record_event_to_host(
 
 void SDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent&) {}
 void SDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId>) {}
+void SDMeshCommandQueue::finish_locked(tt::stl::Span<const SubDeviceId>) {}
 
 void SDMeshCommandQueue::reset_worker_state(bool, uint32_t, const vector_aligned<uint32_t>&) {}
 

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -78,7 +78,7 @@ MeshEvent SDMeshCommandQueue::enqueue_record_event_to_host(
 
 void SDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent&) {}
 void SDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId>) {}
-void SDMeshCommandQueue::finish_locked(tt::stl::Span<const SubDeviceId>) {}
+void SDMeshCommandQueue::finish_nolock(tt::stl::Span<const SubDeviceId>) {}
 
 void SDMeshCommandQueue::reset_worker_state(bool, uint32_t, const vector_aligned<uint32_t>&) {}
 

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -24,6 +24,7 @@ protected:
         std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) override;
+    void finish_locked(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
 
 public:
     SDMeshCommandQueue(MeshDevice* mesh_device, uint32_t id);

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -24,7 +24,7 @@ protected:
         std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) override;
-    void finish_locked(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
+    void finish_nolock(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
 
 public:
     SDMeshCommandQueue(

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -27,7 +27,8 @@ protected:
     void finish_locked(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
 
 public:
-    SDMeshCommandQueue(MeshDevice* mesh_device, uint32_t id);
+    SDMeshCommandQueue(
+        MeshDevice* mesh_device, uint32_t id, std::function<std::lock_guard<std::mutex>()> lock_api_function);
     ~SDMeshCommandQueue() override = default;
 
     WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) override;

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -163,7 +163,15 @@ void Allocator::deallocate_buffers() {
     trace_buffer_manager_->deallocate_all();
 }
 
-const std::unordered_set<Buffer*>& Allocator::get_allocated_buffers() const { return allocated_buffers_; }
+std::unordered_set<Buffer*> Allocator::get_allocated_buffers() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return allocated_buffers_;
+}
+
+size_t Allocator::get_num_allocated_buffers() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return allocated_buffers_.size();
+}
 
 uint32_t Allocator::get_num_banks(const BufferType& buffer_type) const {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -81,9 +81,7 @@ SubDeviceManager::~SubDeviceManager() {
             allocator->clear();
             // Deallocate all buffers
             // This is done to set buffer object status to Deallocated
-            // Don't lock the allocator here, since no other thread should be accessing it while we're deallocating, and
-            // DeallocateBuffer will need to lock it.
-            const auto& allocated_buffers = allocator->get_allocated_buffers();
+            const auto allocated_buffers = allocator->get_allocated_buffers();
             for (auto buf = allocated_buffers.begin(); buf != allocated_buffers.end();) {
                 tt::tt_metal::DeallocateBuffer(*(*(buf++)));
             }
@@ -153,7 +151,7 @@ std::shared_ptr<TraceBuffer> SubDeviceManager::get_trace(uint32_t tid) {
 
 bool SubDeviceManager::has_allocations() const {
     for (const auto& allocator : sub_device_allocators_) {
-        if (allocator && allocator->get_allocated_buffers().size() > 0) {
+        if (allocator && allocator->get_num_allocated_buffers() > 0) {
             return true;
         }
     }

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -81,6 +81,8 @@ SubDeviceManager::~SubDeviceManager() {
             allocator->clear();
             // Deallocate all buffers
             // This is done to set buffer object status to Deallocated
+            // Don't lock the allocator here, since no other thread should be accessing it while we're deallocating, and
+            // DeallocateBuffer will need to lock it.
             const auto& allocated_buffers = allocator->get_allocated_buffers();
             for (auto buf = allocated_buffers.begin(); buf != allocated_buffers.end();) {
                 tt::tt_metal::DeallocateBuffer(*(*(buf++)));

--- a/ttnn/core/reports.cpp
+++ b/ttnn/core/reports.cpp
@@ -49,11 +49,7 @@ DeviceInfo get_device_info(tt::tt_metal::distributed::MeshDevice* device) {
 std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed::MeshDevice*>& devices) {
     std::vector<BufferInfo> buffer_infos;
     for (auto device : devices) {
-        std::unordered_set<tt::tt_metal::Buffer*> allocated_buffers;
-        {
-            auto lock = device->allocator()->lock();
-            allocated_buffers = device->allocator()->get_allocated_buffers();
-        }
+        const auto allocated_buffers = device->allocator()->get_allocated_buffers();
         for (const auto& buffer : allocated_buffers) {
             auto device_id = device->id();
             auto address = buffer->address();
@@ -105,11 +101,7 @@ std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed:
 std::vector<BufferPageInfo> get_buffer_pages(const std::vector<tt::tt_metal::distributed::MeshDevice*>& devices) {
     std::vector<BufferPageInfo> buffer_page_infos;
     for (auto device : devices) {
-        std::unordered_set<tt::tt_metal::Buffer*> allocated_buffers;
-        {
-            auto lock = device->allocator()->lock();
-            allocated_buffers = device->allocator()->get_allocated_buffers();
-        }
+        const auto allocated_buffers = device->allocator()->get_allocated_buffers();
         for (const auto& buffer : allocated_buffers) {
             if (not buffer->is_l1()) {
                 continue;

--- a/ttnn/core/reports.cpp
+++ b/ttnn/core/reports.cpp
@@ -49,7 +49,12 @@ DeviceInfo get_device_info(tt::tt_metal::distributed::MeshDevice* device) {
 std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed::MeshDevice*>& devices) {
     std::vector<BufferInfo> buffer_infos;
     for (auto device : devices) {
-        for (const auto& buffer : device->allocator()->get_allocated_buffers()) {
+        std::unordered_set<tt::tt_metal::Buffer*> allocated_buffers;
+        {
+            auto lock = device->allocator()->lock();
+            allocated_buffers = device->allocator()->get_allocated_buffers();
+        }
+        for (const auto& buffer : allocated_buffers) {
             auto device_id = device->id();
             auto address = buffer->address();
 
@@ -100,7 +105,12 @@ std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed:
 std::vector<BufferPageInfo> get_buffer_pages(const std::vector<tt::tt_metal::distributed::MeshDevice*>& devices) {
     std::vector<BufferPageInfo> buffer_page_infos;
     for (auto device : devices) {
-        for (const auto& buffer : device->allocator()->get_allocated_buffers()) {
+        std::unordered_set<tt::tt_metal::Buffer*> allocated_buffers;
+        {
+            auto lock = device->allocator()->lock();
+            allocated_buffers = device->allocator()->get_allocated_buffers();
+        }
+        for (const auto& buffer : allocated_buffers) {
             if (not buffer->is_l1()) {
                 continue;
             }


### PR DESCRIPTION
### Ticket
#20802
#21666
#21556

### Problem description
Moreh wants to be able to enqueue commands onto a single CQ from multiple threads.

### What's changed
Add a lock in MeshDevice that will be taken by MeshCommandQueue implementations when enqueueing commands. This lock is used for both CQs (and some MeshDevice state), since there is some state that's shared between command queues, and to reduce implementation complexity. We can split it into fine-grained locks later if we discover performance problems.

The lock is used at all times, even if the client code has no need for thread-safety. If uncontended it should be fast, and having it enabled all the time ensures that all codepaths are tested to avoid deadlocks.

Allocator also has lock that it uses to guard its data, since it's exposed from the MeshDevice and used by several other objects.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes