### PR TITLE
Added Dynamic Tiled Implementation For Llama Vision Model

### DIFF
--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -419,8 +419,8 @@ def test_multimodal_demo_text(
         tt_device_name = model_args[0].device_name
         base_model_name = model_args[0].base_model_name
         target_prefill_tok_s = {
-            "N300_Llama-3.2-11B": 13.2,
-            "T3K_Llama-3.2-11B": 13.2,
+            "N300_Llama-3.2-11B": 23.5,
+            "T3K_Llama-3.2-11B": 23.5,
             "T3K_Llama-3.2-90B": 3,
         }[f"{tt_device_name}_{base_model_name}"]
 

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -420,7 +420,7 @@ def test_multimodal_demo_text(
         base_model_name = model_args[0].base_model_name
         target_prefill_tok_s = {
             "N300_Llama-3.2-11B": 23.5,
-            "T3K_Llama-3.2-11B": 23.5,
+            "T3K_Llama-3.2-11B": 21.5,
             "T3K_Llama-3.2-90B": 3,
         }[f"{tt_device_name}_{base_model_name}"]
 

--- a/models/tt_transformers/tt/multimodal/llama_cross_attention_transformer_vision.py
+++ b/models/tt_transformers/tt/multimodal/llama_cross_attention_transformer_vision.py
@@ -83,8 +83,8 @@ class TtLlamaCrossAttentionTransformerVision(LightweightModule):
         self.vision_projection_bias = as_interleaved_tensor("vision_projection", "bias", ttnn.bfloat16, dim=-1)
         self.vision_projection_bias = ttnn.reshape(self.vision_projection_bias, [1, -1])
 
-    def forward(self, images, ar):
-        vision_tokens = self.vision_encoder(images, ar)
+    def forward(self, images, ar, max_actual_num_chunks):
+        vision_tokens = self.vision_encoder(images, ar, max_actual_num_chunks)
 
         seq_len = vision_tokens.shape[-2]
 

--- a/models/tt_transformers/tt/multimodal/llama_cross_attention_transformer_vision.py
+++ b/models/tt_transformers/tt/multimodal/llama_cross_attention_transformer_vision.py
@@ -83,7 +83,9 @@ class TtLlamaCrossAttentionTransformerVision(LightweightModule):
         self.vision_projection_bias = as_interleaved_tensor("vision_projection", "bias", ttnn.bfloat16, dim=-1)
         self.vision_projection_bias = ttnn.reshape(self.vision_projection_bias, [1, -1])
 
-    def forward(self, images, ar, max_actual_num_chunks):
+    def forward(self, images, ar, max_actual_num_chunks=None):
+        if max_actual_num_chunks is None:
+            max_actual_num_chunks = images.shape[2]
         vision_tokens = self.vision_encoder(images, ar, max_actual_num_chunks)
 
         seq_len = vision_tokens.shape[-2]

--- a/models/tt_transformers/tt/multimodal/llama_image_block.py
+++ b/models/tt_transformers/tt/multimodal/llama_image_block.py
@@ -87,7 +87,7 @@ class TtLlamaImageTransformerBlock(LightweightModule):
 
     def forward(self, x_11SH, mask=None):
         seq_len = x_11SH.shape[-2]
-        assert seq_len % 128 == 0 and seq_len > 0, "Seqlen must be divisible by 128"
+        assert seq_len % 32 == 0 and seq_len > 0, "Seqlen must be divisible by 32"
 
         attn_out = self.attn(self.ln_1(x_11SH), mask=mask)
         if self.gated:
@@ -98,4 +98,7 @@ class TtLlamaImageTransformerBlock(LightweightModule):
         if self.gated:
             mlp_out = ttnn.mul(mlp_out, ttnn.tanh(self.gate_ffn))
         out = ttnn.add(res, mlp_out)
+        ttnn.deallocate(mlp_out)
+        ttnn.deallocate(attn_out)
+        ttnn.deallocate(res)
         return out

--- a/models/tt_transformers/tt/multimodal/llama_image_transformer.py
+++ b/models/tt_transformers/tt/multimodal/llama_image_transformer.py
@@ -46,7 +46,7 @@ class TtLlamaImageTransformer(LightweightModule):
         Outer code will have to be aware and handle this correctly.
         """
         seq_len = x.shape[-2]
-        assert seq_len % 128 == 0 and seq_len > 0, "Seqlen must be divisible by 128"
+        assert seq_len % 32 == 0 and seq_len > 0, "Seqlen must be divisible by 32"
 
         out = []
         for idx, r in enumerate(self.resblocks):

--- a/models/tt_transformers/tt/multimodal/llama_tile_position_embedding.py
+++ b/models/tt_transformers/tt/multimodal/llama_tile_position_embedding.py
@@ -123,6 +123,6 @@ class TtLlamaTilePositionEmbedding(LightweightModule):
         )
 
         # Concatenate with input tensor
-        x = x + out_pos_embed[:, :, : x.shape[2], :]
+        x = x + out_pos_embed[:, : x.shape[1], : x.shape[2], :]
 
         return x

--- a/models/tt_transformers/tt/multimodal/llama_vision_encoder.py
+++ b/models/tt_transformers/tt/multimodal/llama_vision_encoder.py
@@ -178,7 +178,10 @@ class TtLlamaVisionEncoder(LightweightModule):
             gated=True,
         )
 
-    def forward(self, images, ar, max_actual_num_chunks):
+    def forward(self, images, ar, max_actual_num_chunks=None):
+        if max_actual_num_chunks is None:
+            max_actual_num_chunks = images.shape[2]
+
         assert isinstance(
             images, torch.Tensor
         ), "VisionEncoder input must be a torch tensor because of unfold in self.conv1"


### PR DESCRIPTION
### Ticket
#25111

### Problem description
In the current implementation of the vision model, the inputs passed to the encoder are always of resolution 1120x1120 (max resolution) with the rest of the image being 0 padded. This is done to enable the graph compile for prefill stage. A downside of this is that it increases the prefill time to around 1300ms for all images.

### What's changed
As part of llama's image preprocessing each image is divided into chunks of 560x560. Before inputs are passed to the encoder we only use the slice that contains the desired number of chunks. We compile three different traces for vision prefill for 1, 2 and 4 chunks respectively. This reduces prefill time for smaller images drastically.

## Results

TTFT for 512x512 image in tt-inference-server has reduced from 1400ms to 500ms and prefill tok/s in `simple_vision_demo.py` increased from 13 tok/s to 24tok/s