### PR TITLE
[skip ci] Reduce load on llmbox in CIv2

### DIFF
--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -12,6 +12,10 @@ on:
       wheel-artifact-name:
         required: true
         type: string
+      extra-tag:
+        required: false
+        type: string
+        default: "in-service"
 
 jobs:
   t3000-unit-tests:
@@ -19,11 +23,14 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k fabric tests", arch: wormhole_b0, cmd: run_t3000_ttfabric_tests, timeout: 10, owner_id: UJ45FEC7M}, # Allan Liu
+          { name: "t3k fabric tests", arch: wormhole_b0, cmd: run_t3000_ttfabric_tests, timeout: 10, label: pipeline-functional, owner_id: UJ45FEC7M}, # Allan Liu
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:
-      - tt-beta-ubuntu-2204-N300-llmbox-large-stable
+      - arch-wormhole_b0
+      - config-t3000
+      - ${{ matrix.test-group.label}}
+      - ${{ inputs.extra-tag }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
CIv2 isn't keeping up with demand for llmboxes.  This is very negatively impacting Merge Gate.

### What's changed
Revert #24187