### PR TITLE
Added check for repacked/chunked vs sharded weights

### DIFF
--- a/models/demos/llama3_subdevices/tt/load_checkpoints.py
+++ b/models/demos/llama3_subdevices/tt/load_checkpoints.py
@@ -121,8 +121,9 @@ def map_hf_to_meta_keys(loaded_weights):
 def load_meta_state_dict(ckpt_dir, n_layers=None, start_layer_idx=0):
     checkpoints = sorted(Path(ckpt_dir).glob("*.pth"))
     assert len(checkpoints) > 0, f"no checkpoint files found in {ckpt_dir}"
-    is_chunked = "layers_" in str(checkpoints[0])
+    is_chunked = any(ckpt.stem.startswith("layers_") for ckpt in checkpoints)
     if is_chunked:
+        checkpoints = [ckpt_name for ckpt_name in checkpoints if ckpt_name.stem.startswith("layers_")]
         checkpoint = load_chunked_checkpoints(checkpoints, n_layers, start_layer_idx)
     else:
         checkpoint = load_sharded_checkpoints(checkpoints, n_layers)
@@ -132,7 +133,6 @@ def load_meta_state_dict(ckpt_dir, n_layers=None, start_layer_idx=0):
 
 def load_chunked_checkpoints(checkpoints, n_layers, start_layer_idx):
     checkpoint = {}
-
     (f"Loading {len(checkpoints)} checkpoint files")
     for ckpt in tqdm(checkpoints):
         if n_layers:

--- a/models/tt_transformers/tt/load_checkpoints.py
+++ b/models/tt_transformers/tt/load_checkpoints.py
@@ -151,8 +151,9 @@ def map_hf_to_meta_keys(loaded_weights):
 def load_meta_state_dict(ckpt_dir, n_layers=None, start_layer_idx=0):
     checkpoints = sorted(Path(ckpt_dir).glob("*.pth"))
     assert len(checkpoints) > 0, f"no checkpoint files found in {ckpt_dir}"
-    is_chunked = "layers_" in str(checkpoints[0])
+    is_chunked = any(ckpt.stem.startswith("layers_") for ckpt in checkpoints)
     if is_chunked:
+        checkpoints = [ckpt_name for ckpt_name in checkpoints if ckpt_name.stem.startswith("layers_")]
         checkpoint = load_chunked_checkpoints(checkpoints, n_layers, start_layer_idx)
     else:
         checkpoint = load_sharded_checkpoints(checkpoints, n_layers)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25125

### Problem description
The error was occurring because when weights are repacked into the same directory as original weights, current weight loading would iterate through all pth files in the directory, the same weight would appear twice hence all weights are concat twice. 

### What's changed
- Removed dead code inside model_config.py
- Added a check to see if there exists repacked weights (`layers_`) if so we will proceed with sharded checkpoints and filter out the rest of the checkpoints in the directory, if it doesnt exist we load using chunked checkpoints 

### Checklist
- This only affects model loading so TG demo was run (CI Run [here](https://github.com/tenstorrent/tt-metal/actions/runs/16307700075))
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes