### PR TITLE
Add Experts with distributed exec

### DIFF
--- a/models/demos/deepseek_v3/reference/modeling_deepseek.py
+++ b/models/demos/deepseek_v3/reference/modeling_deepseek.py
@@ -407,31 +407,6 @@ class MoEGate(nn.Module):
         return topk_idx, topk_weight
 
 
-class DeepseekV3MoE_Experts(nn.Module):
-    """
-    A mixed expert module containing shared experts.
-    """
-
-    def __init__(self, config):
-        super().__init__()
-        self.config = config
-
-        self.experts = nn.ModuleList(
-            [
-                DeepseekV3MLP(config, intermediate_size=config.moe_intermediate_size)
-                for i in range(config.n_routed_experts)
-            ]
-        )
-
-    def forward(self, hidden_states):
-        outputs = []
-        for expert in self.experts:
-            outputs.append(expert(hidden_states))
-
-        # returns a tensor of shape (topK_experts, batch_size, seq_len, hidden_size)
-        return torch.cat(outputs, dim=0)
-
-
 class DeepseekV3MoE(nn.Module):
     """
     A mixed expert module containing shared experts.

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -18,15 +18,15 @@ from models.utility_functions import comp_pcc
 @pytest.fixture
 def reference_model(hf_config):
     """Get the actual DeepSeek MLP model using local implementation."""
+    hf_config.n_routed_experts = 64  # Set number of experts for testing
     return DeepseekV3MoE_Experts(hf_config)
 
 
 @pytest.mark.parametrize(
     "mode,seq_len",
     [
-        ("decode", 32),
-        # ("prefill", 512),
-        # ("prefill", 2048),  # Test chunking
+        ("decode", 128),
+        ("prefill", 2048),
     ],
 )
 def test_forward_pass(
@@ -38,6 +38,7 @@ def test_forward_pass(
     galaxy_or_t3k_mesh,
 ):
     """Test forward pass against reference model."""
+    torch.manual_seed(0)
     batch_size = 1
 
     # Get state dict from actual model - pass directly to convert_weights
@@ -45,7 +46,6 @@ def test_forward_pass(
 
     # Setup: Convert weights and get weight_config
     weight_config = TTExpert.convert_weights_moe(hf_config_single_layer, hf_state_dict, temp_dir, galaxy_or_t3k_mesh)
-    breakpoint()
     # Generate appropriate config
     if mode == "prefill":
         model_config = TTExpert.prefill_model_config(hf_config_single_layer, galaxy_or_t3k_mesh)
@@ -66,7 +66,7 @@ def test_forward_pass(
 
     # Convert input to TTNN
     tt_input = ttnn.from_torch(
-        torch_input,
+        torch_input.repeat(1, run_config["num_experts_per_device"], 1, 1),  # repeating activations for each expert
         device=galaxy_or_t3k_mesh,
         mesh_mapper=ttnn.ReplicateTensorToMesh(galaxy_or_t3k_mesh),
         dtype=ttnn.bfloat16,
@@ -90,13 +90,20 @@ def test_forward_pass(
         actual_output_memory_config == expected_output_memory_config
     ), f"Output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
 
+    # output shape per device  = [1, experts_per_device, seq_len, hidden_size]
+    # There are 32 groups of unique experts output in case TG
+    # We first concate rows and then columns to get the final output
     # Convert output back to torch
     tt_output_torch = ttnn.to_torch(
         tt_output,
         mesh_composer=ttnn.ConcatMesh2dToTensor(
-            galaxy_or_t3k_mesh, dims=(-2, -1), mesh_shape=tuple(galaxy_or_t3k_mesh.shape)
+            galaxy_or_t3k_mesh, dims=(0, 1), mesh_shape=tuple(galaxy_or_t3k_mesh.shape)
         ),
     )
+    # (4, experts_per_device*8, seq_len, hidden_size)
+    tt_output_torch = tt_output_torch.reshape(batch_size, -1, seq_len, hf_config_single_layer.hidden_size)
+    # (1, experts_per_device*8*4, seq_len, hidden_size)
+    tt_output_torch = tt_output_torch[0].unsqueeze(1)
 
     # Compare outputs
     pcc_required = 0.98  # Slightly lower due to bfloat conversions

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -26,7 +26,8 @@ def reference_model(hf_config):
     "mode,seq_len",
     [
         ("decode", 128),
-        ("prefill", 2048),
+        ("prefill", 256),
+        # ("prefill", 2048),
     ],
 )
 def test_forward_pass(
@@ -91,7 +92,7 @@ def test_forward_pass(
     ), f"Output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
 
     # output shape per device  = [1, experts_per_device, seq_len, hidden_size]
-    # There are 32 groups of unique experts output in case TG
+    # There are 32 groups of unique experts output in case of TG
     # We first concate rows and then columns to get the final output
     # Convert output back to torch
     tt_output_torch = ttnn.to_torch(
@@ -100,9 +101,9 @@ def test_forward_pass(
             galaxy_or_t3k_mesh, dims=(0, 1), mesh_shape=tuple(galaxy_or_t3k_mesh.shape)
         ),
     )
-    # (4, experts_per_device*8, seq_len, hidden_size)
+    # example shape (4, experts_per_device*8, seq_len, hidden_size) for TG
     tt_output_torch = tt_output_torch.reshape(batch_size, -1, seq_len, hf_config_single_layer.hidden_size)
-    # (1, experts_per_device*8*4, seq_len, hidden_size)
+    # example shape (1, experts_per_device*8*4, seq_len, hidden_size) for TG
     tt_output_torch = tt_output_torch[0].unsqueeze(1)
 
     # Compare outputs

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MoE_Experts
+
+# Import from local reference files instead of HuggingFace
+from models.demos.deepseek_v3.tt.expert import Expert as TTExpert
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.utility_functions import comp_pcc
+
+
+@pytest.fixture
+def reference_model(hf_config):
+    """Get the actual DeepSeek MLP model using local implementation."""
+    return DeepseekV3MoE_Experts(hf_config)
+
+
+@pytest.mark.parametrize(
+    "mode,seq_len",
+    [
+        ("decode", 32),
+        # ("prefill", 512),
+        # ("prefill", 2048),  # Test chunking
+    ],
+)
+def test_forward_pass(
+    mode,
+    seq_len,
+    reference_model,
+    hf_config_single_layer,
+    temp_dir,
+    galaxy_or_t3k_mesh,
+):
+    """Test forward pass against reference model."""
+    batch_size = 1
+
+    # Get state dict from actual model - pass directly to convert_weights
+    hf_state_dict = reference_model.state_dict()
+
+    # Setup: Convert weights and get weight_config
+    weight_config = TTExpert.convert_weights_moe(hf_config_single_layer, hf_state_dict, temp_dir, galaxy_or_t3k_mesh)
+
+    # Generate appropriate config
+    if mode == "prefill":
+        model_config = TTExpert.prefill_model_config(hf_config_single_layer, galaxy_or_t3k_mesh)
+    else:
+        model_config = TTExpert.decode_model_config(hf_config_single_layer, galaxy_or_t3k_mesh)
+
+    # Create a new model state
+    model_state = TTExpert.create_state(hf_config_single_layer, mesh_device=galaxy_or_t3k_mesh)
+
+    # Create RunConfig using both weight_config and model_config
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    # Create input tensor
+    torch_input = torch.randn(batch_size, 1, seq_len, hf_config_single_layer.hidden_size)
+
+    # Reference forward pass
+    reference_output = reference_model(torch_input)
+
+    # Convert input to TTNN
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=galaxy_or_t3k_mesh,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(galaxy_or_t3k_mesh),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    # TTNN forward pass
+    if mode == "prefill":
+        tt_input = ttnn.to_memory_config(tt_input, run_config["input_memory_config"])
+        tt_output = TTExpert.forward_prefill(tt_input, run_config)
+        expected_output_memory_config = run_config["output_memory_config"]
+    else:
+        tt_input = ttnn.to_memory_config(tt_input, run_config["input_memory_config"])
+        tt_output = TTExpert.forward_decode(tt_input, run_config)
+        expected_output_memory_config = run_config["output_memory_config"]
+
+    # Verify output memory config matches expected
+    actual_output_memory_config = tt_output.memory_config()
+    assert (
+        actual_output_memory_config == expected_output_memory_config
+    ), f"Output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
+
+    # Convert output back to torch
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(
+            galaxy_or_t3k_mesh, dims=(-2, -1), mesh_shape=tuple(galaxy_or_t3k_mesh.shape)
+        ),
+    )
+
+    # Compare outputs
+    pcc_required = 0.98  # Slightly lower due to bfloat conversions
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)
+
+    logger.info(f"Mode: {mode}, Seq len: {seq_len}")
+    logger.info(f"PCC: {pcc_message}")
+
+    assert passing, f"TTExpert output does not meet PCC requirement {pcc_required}: {pcc_message}"
+
+    # Cleanup
+    ttnn.deallocate(tt_output)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -45,7 +45,7 @@ def test_forward_pass(
 
     # Setup: Convert weights and get weight_config
     weight_config = TTExpert.convert_weights_moe(hf_config_single_layer, hf_state_dict, temp_dir, galaxy_or_t3k_mesh)
-
+    breakpoint()
     # Generate appropriate config
     if mode == "prefill":
         model_config = TTExpert.prefill_model_config(hf_config_single_layer, galaxy_or_t3k_mesh)

--- a/models/demos/deepseek_v3/tt/expert.py
+++ b/models/demos/deepseek_v3/tt/expert.py
@@ -2,9 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from pathlib import Path
+from typing import final
+
+import torch
 from transformers.configuration_utils import PretrainedConfig
 
+import ttnn
 from models.demos.deepseek_v3.tt.mlp_1d import MLP1D
+from models.demos.deepseek_v3.utils.config_helpers import dram_sharded_weight_config, save_and_get_path
+from models.demos.deepseek_v3.utils.run_config import WeightConfig
 
 
 class Expert(MLP1D):  # The only difference with the regular Dequantized MLP is the intermediate layer size
@@ -15,3 +22,102 @@ class Expert(MLP1D):  # The only difference with the regular Dequantized MLP is 
         dim = hf_config.hidden_size
         hidden_dim = hf_config.moe_intermediate_size
         return dim, hidden_dim
+
+    @classmethod
+    def convert_weights_moe(
+        cls,
+        hf_config: PretrainedConfig,
+        state_dict: dict[str, torch.Tensor],
+        output_path: Path,
+        mesh_device: ttnn.Device,
+    ) -> WeightConfig:
+        # assert cls.is_device_supported(mesh_device)
+
+        # breakpoint()  # Debugging point to inspect the state_dict structure
+        num_experts_per_device = hf_config.n_routed_experts // mesh_device.get_num_devices()
+        num_groups = hf_config.n_routed_experts // num_experts_per_device
+
+        w1_per_device_state_dict_group = []
+        w2_per_device_state_dict_group = []
+        w3_per_device_state_dict_group = []
+
+        # Group experts by device
+        for device_idx in range(mesh_device.get_num_devices()):
+            w1_sub_group = []
+            w2_sub_group = []
+            w3_sub_group = []
+
+            # Add experts for this device
+            start_expert = device_idx * num_experts_per_device
+            end_expert = start_expert + num_experts_per_device
+
+            for expert_idx in range(start_expert, end_expert):
+                w1_sub_group.append(state_dict[f"experts.{expert_idx}.gate_proj.weight"])
+                w2_sub_group.append(state_dict[f"experts.{expert_idx}.down_proj.weight"])
+                w3_sub_group.append(state_dict[f"experts.{expert_idx}.up_proj.weight"])
+
+            w1_per_device_state_dict_group.append(torch.stack(w1_sub_group, dim=0).permute(0, 2, 1))
+            w2_per_device_state_dict_group.append(torch.stack(w2_sub_group, dim=0).permute(0, 2, 1))
+            w3_per_device_state_dict_group.append(torch.stack(w3_sub_group, dim=0).permute(0, 2, 1))
+
+        # Convert weights for each expert group
+        return {
+            "w1_experts": {
+                "input_tensor_b": save_and_get_path(
+                    output_path / f"w1_experts.input_tensor_b",
+                    cls._convert_weight_moe(hf_config, w1_per_device_state_dict_group, mesh_device, is_w2=False),
+                )
+            },
+            "w2_experts": {
+                "input_tensor_b": save_and_get_path(
+                    output_path / f"w2_experts.input_tensor_b",
+                    cls._convert_weight_moe(hf_config, w2_per_device_state_dict_group, mesh_device, is_w2=True),
+                )
+            },
+            "w3_experts": {
+                "input_tensor_b": save_and_get_path(
+                    output_path / f"w3_experts.input_tensor_b",
+                    cls._convert_weight_moe(hf_config, w3_per_device_state_dict_group, mesh_device, is_w2=False),
+                )
+            },
+        }
+
+    @final
+    @classmethod
+    def _convert_weight_moe(
+        cls,
+        hf_config: PretrainedConfig,
+        wx_per_device_state_dict_group: list[torch.Tensor],
+        mesh_device: ttnn.Device,
+        is_w2: bool,
+    ) -> ttnn.Tensor:
+        """
+        Convert a normal (non-quantized) weight tensor to a format suitable for TTNN.
+
+        Args:
+            weight_tensor: The weight tensor.
+            mesh_device: The mesh device to use for the conversion.
+
+        Returns:
+            The converted TTNN tensor.
+        """
+        dim, hidden_dim = cls._get_model_dims_from_cfg(hf_config)
+
+        per_device_in_features, per_device_out_features = dim, hidden_dim
+        if is_w2:
+            per_device_in_features, per_device_out_features = hidden_dim, dim
+
+        multi_dev_host_weights = ttnn.from_host_shards(
+            [ttnn.from_torch(e, dtype=ttnn.bfloat4_b, layout=ttnn.TILE_LAYOUT) for e in wx_per_device_state_dict_group],
+            mesh_device.shape,
+        )
+
+        multi_dev_weights = ttnn.to_device(
+            multi_dev_host_weights,
+            mesh_device,
+            memory_config=dram_sharded_weight_config(
+                per_device_in_features * 8, per_device_out_features, mesh_device.dram_grid_size()
+            ),
+        )
+
+        return multi_dev_weights

--- a/models/demos/deepseek_v3/tt/expert.py
+++ b/models/demos/deepseek_v3/tt/expert.py
@@ -14,12 +14,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, Li
 from models.demos.deepseek_v3.utils.config_helpers import (
     COMPUTE_KERNEL_CONFIG_LOFI,
     COMPUTE_KERNEL_CONFIG_SDPA,
-    MAX_BATCH_SIZE,
-    SEQ_LEN_CHUNK_SIZE,
-    dram_sharded_weight_config,
     even_int_div,
-    get_activation_sharding_core_counts_for_dram_matmul,
-    get_dram_sharded_matmul_config,
     save_and_get_path,
 )
 from models.demos.deepseek_v3.utils.run_config import (
@@ -82,19 +77,37 @@ class Expert(MLP1D):  # The only difference with the regular Dequantized MLP is 
             "w1_experts": {
                 "input_tensor_b": save_and_get_path(
                     output_path / f"w1_experts.input_tensor_b",
-                    cls._convert_weight_moe(hf_config, w1_per_device_state_dict_group, mesh_device, is_w2=False),
+                    cls._convert_weight_moe(
+                        hf_config,
+                        w1_per_device_state_dict_group,
+                        mesh_device,
+                        is_w2=False,
+                        num_experts_per_device=num_experts_per_device,
+                    ),
                 )
             },
             "w2_experts": {
                 "input_tensor_b": save_and_get_path(
                     output_path / f"w2_experts.input_tensor_b",
-                    cls._convert_weight_moe(hf_config, w2_per_device_state_dict_group, mesh_device, is_w2=True),
+                    cls._convert_weight_moe(
+                        hf_config,
+                        w2_per_device_state_dict_group,
+                        mesh_device,
+                        is_w2=True,
+                        num_experts_per_device=num_experts_per_device,
+                    ),
                 )
             },
             "w3_experts": {
                 "input_tensor_b": save_and_get_path(
                     output_path / f"w3_experts.input_tensor_b",
-                    cls._convert_weight_moe(hf_config, w3_per_device_state_dict_group, mesh_device, is_w2=False),
+                    cls._convert_weight_moe(
+                        hf_config,
+                        w3_per_device_state_dict_group,
+                        mesh_device,
+                        is_w2=False,
+                        num_experts_per_device=num_experts_per_device,
+                    ),
                 )
             },
         }
@@ -107,6 +120,7 @@ class Expert(MLP1D):  # The only difference with the regular Dequantized MLP is 
         wx_per_device_state_dict_group: list[torch.Tensor],
         mesh_device: ttnn.Device,
         is_w2: bool,
+        num_experts_per_device: int,
     ) -> ttnn.Tensor:
         """
         Convert a normal (non-quantized) weight tensor to a format suitable for TTNN.
@@ -125,16 +139,17 @@ class Expert(MLP1D):  # The only difference with the regular Dequantized MLP is 
             per_device_in_features, per_device_out_features = hidden_dim, dim
 
         multi_dev_host_weights = ttnn.from_host_shards(
-            [ttnn.from_torch(e, dtype=ttnn.bfloat4_b, layout=ttnn.TILE_LAYOUT) for e in wx_per_device_state_dict_group],
+            [
+                ttnn.from_torch(e.unsqueeze(0), dtype=ttnn.bfloat4_b, layout=ttnn.TILE_LAYOUT)
+                for e in wx_per_device_state_dict_group
+            ],
             mesh_device.shape,
         )
 
         multi_dev_weights = ttnn.to_device(
             multi_dev_host_weights,
             mesh_device,
-            memory_config=dram_sharded_weight_config(
-                per_device_in_features * 8, per_device_out_features, mesh_device.dram_grid_size()
-            ),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
         return multi_dev_weights
@@ -152,54 +167,6 @@ class Expert(MLP1D):  # The only difference with the regular Dequantized MLP is 
             True if the device is supported, False otherwise.
         """
         return tuple(mesh_device.shape)[0] >= 1
-
-    @classmethod
-    def prefill_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> ModelPrefillConfig:
-        """Generate prefill configuration for this module.
-
-        Args:
-            hf_config: HuggingFace model configuration object
-            mesh_device: TTNN mesh device the model will be placed later on
-
-        Returns:
-            ModelPrefillConfig containing operator configurations for prefill mode
-        """
-        matmul_core_grid_size = ttnn.CoreCoord(  # Matmul expects the core grid size in (y, x) format
-            mesh_device.core_grid.x,
-            mesh_device.core_grid.y,
-        )  # NOTE: we might modify this later during optimization stage
-
-        num_experts_per_device = hf_config.n_routed_experts // mesh_device.get_num_devices()
-
-        num_devices = 1  # Weights are not TP'd
-
-        # Extract dimensions from HF config
-        dim, hidden_dim = cls._get_model_dims_from_cfg(hf_config)
-
-        # Compute the program config for the linear layers
-        linear_op_config = LinearConfig(
-            input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
-        )
-
-        # Construct the config
-        return {
-            "max_rows": SEQ_LEN_CHUNK_SIZE,  # NOTE: should be 512 for blackhole (in case of future bring-up)
-            "linear_pc_gen": cls.MLPProgramConfigData(
-                dim=dim, hidden_dim=hidden_dim, num_devices=num_devices, core_grid_size=matmul_core_grid_size
-            ),
-            "w1_experts": linear_op_config,
-            "w2_experts": linear_op_config,
-            "w3_experts": linear_op_config,
-            "mul_experts": MulConfig(
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
-            ),
-            "input_memory_config": ttnn.DRAM_MEMORY_CONFIG,  # RMSNorm must provide this shard spec as its output
-            "output_memory_config": ttnn.DRAM_MEMORY_CONFIG,
-            "num_experts_per_device": num_experts_per_device,
-        }
 
     @classmethod
     def decode_model_config(
@@ -225,31 +192,7 @@ class Expert(MLP1D):  # The only difference with the regular Dequantized MLP is 
         # Extract dimensions from HF config
         dim, hidden_dim = cls._get_model_dims_from_cfg(hf_config)
 
-        num_experts_per_device = hf_config.n_routed_experts // mesh_device.get_num_devices()
-
-        # Calculate device metrics
-        num_devices = 1  # Weights are not TP'd
-        max_num_cores = mesh_device.core_grid.x * mesh_device.core_grid.y
-        input_num_cores = input_num_cores or max(
-            get_activation_sharding_core_counts_for_dram_matmul(dim, max_num_cores)
-        )
-        inner_num_cores = max(
-            get_activation_sharding_core_counts_for_dram_matmul(even_int_div(hidden_dim, num_devices), max_num_cores)
-        )
-        output_num_cores = output_num_cores or max(
-            get_activation_sharding_core_counts_for_dram_matmul(even_int_div(dim, num_devices), max_num_cores)
-        )
-        assert (
-            input_num_cores <= max_num_cores
-        ), "input_num_cores must be less than or equal to the maximum number of cores"
-        assert (
-            output_num_cores <= max_num_cores
-        ), "output_num_cores must be less than or equal to the maximum number of cores"
-        assert dim % input_num_cores == 0, "input_num_cores must divide the input tensor width evenly"
-        assert (
-            even_int_div(dim, num_devices) % output_num_cores == 0
-        ), "output_num_cores must divide the output tensor width evenly"
-
+        num_experts_per_device = even_int_div(hf_config.n_routed_experts, mesh_device.get_num_devices())
         # Calculate input and output memory configurations
         input_memory_config = ttnn.L1_MEMORY_CONFIG
         output_memory_config = ttnn.L1_MEMORY_CONFIG
@@ -258,34 +201,21 @@ class Expert(MLP1D):  # The only difference with the regular Dequantized MLP is 
         return {
             "w1_experts": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-                memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-                program_config=get_dram_sharded_matmul_config(
-                    MAX_BATCH_SIZE, dim, even_int_div(hidden_dim, num_devices), input_num_cores, inner_num_cores
-                ),
+                memory_config=ttnn.L1_MEMORY_CONFIG,
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
             ),
             "w2_experts": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-                memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-                program_config=get_dram_sharded_matmul_config(
-                    MAX_BATCH_SIZE,
-                    even_int_div(hidden_dim, num_devices),
-                    dim,
-                    inner_num_cores,
-                    output_num_cores,
-                ),
+                memory_config=ttnn.L1_MEMORY_CONFIG,
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_SDPA,
             ),
             "w3_experts": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-                memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-                program_config=get_dram_sharded_matmul_config(
-                    MAX_BATCH_SIZE, dim, even_int_div(hidden_dim, num_devices), input_num_cores, inner_num_cores
-                ),
+                memory_config=ttnn.L1_MEMORY_CONFIG,
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
             ),
             "mul_experts": MulConfig(
-                memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
                 input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
             ),
             "input_memory_config": input_memory_config,  # For asserting the input to the MLP
@@ -294,58 +224,55 @@ class Expert(MLP1D):  # The only difference with the regular Dequantized MLP is 
         }
 
     @classmethod
-    def forward_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig) -> ttnn.Tensor:
-        # Repeat the activations for each expert as we don't support activation broadcasting inside the matmul
-        x = ttnn.repeat(x, ttnn.Shape((1, cfg["num_experts_per_device"], 1, 1)))
-        _, experts_per_device, seq_len, _ = x.shape
+    def prefill_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> ModelPrefillConfig:
+        """Generate prefill configuration for this module.
 
-        if seq_len > cfg["max_rows"]:  # For large sequence lengths, process the input in chunks
-            x = ttnn.reshape(x, [1, even_int_div(seq_len, cfg["max_rows"]) * experts_per_device, cfg["max_rows"], -1])
-            seq_len = cfg["max_rows"]
+        Args:
+            hf_config: HuggingFace model configuration object
+            mesh_device: TTNN mesh device the model will be placed later on
 
-        # Gate and up projections with dynamic program configs
-        w1_out = ttnn.linear(
-            x, program_config=cls._get_prefill_pc(seq_len=seq_len, is_w2=False, **cfg["linear_pc_gen"]), **cfg["w1"]
-        )
-        w3_out = ttnn.linear(
-            x, program_config=cls._get_prefill_pc(seq_len=seq_len, is_w2=False, **cfg["linear_pc_gen"]), **cfg["w3"]
-        )
-        ttnn.deallocate(x)
+        Returns:
+            ModelPrefillConfig containing operator configurations for prefill mode
+        """
+        # Extract dimensions from HF config
+        dim, hidden_dim = cls._get_model_dims_from_cfg(hf_config)
 
-        # add reduce-scatter here to gather intermediates
+        num_experts_per_device = even_int_div(hf_config.n_routed_experts, mesh_device.get_num_devices())
+        # Calculate input and output memory configurations
+        input_memory_config = ttnn.DRAM_MEMORY_CONFIG
+        output_memory_config = ttnn.DRAM_MEMORY_CONFIG
 
-        # Apply activation and multiply
-        activated = ttnn.mul(w1_out, w3_out, **cfg["mul"])
-        ttnn.deallocate(w1_out)
-        ttnn.deallocate(w3_out)
-
-        # Down projection with dynamic program configs, no need to reshard as we are using dram activations
-        output = ttnn.linear(
-            activated,
-            program_config=cls._get_prefill_pc(seq_len=seq_len, is_w2=True, **cfg["linear_pc_gen"]),
-            **cfg["w2"],
-        )
-        ttnn.deallocate(activated)
-
-        # Reduce-scatter across devices to sum partial results
-        output = ttnn.reduce_scatter(output, **cfg["reduce_scatter"])
-
-        # De-chunk the output if the input was chunked
-        _, num_chunks, _, output_dim = output.shape
-        if num_chunks > 1:
-            output = ttnn.reshape(output, [1, 1, -1, output_dim])
-
-        assert output.memory_config() == cfg["output_memory_config"]
-        return output
+        # Construct the config
+        return {
+            "w1_experts": LinearConfig(
+                input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            ),
+            "w2_experts": LinearConfig(
+                input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_SDPA,
+            ),
+            "w3_experts": LinearConfig(
+                input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            ),
+            "mul_experts": MulConfig(
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
+            ),
+            "input_memory_config": input_memory_config,  # For asserting the input to the MLP
+            "output_memory_config": output_memory_config,  # For asserting the output of the MLP
+            "num_experts_per_device": num_experts_per_device,
+        }
 
     @classmethod
     def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig) -> ttnn.Tensor:
         assert x.memory_config() == cfg["input_memory_config"]
-        breakpoint()
 
-        # Repeat the activations for each expert as we don't support activation broadcasting inside the matmul
-        x = ttnn.repeat(x, ttnn.Shape((1, cfg["num_experts_per_device"], 1, 1)))
-
+        # activations are repeated for each expert as we don't support activation broadcasting inside the matmul
         _, experts_per_device, batch_size, _ = x.shape
 
         # Gate and up projections
@@ -354,6 +281,8 @@ class Expert(MLP1D):  # The only difference with the regular Dequantized MLP is 
 
         # Apply activation and multiply
         activated = ttnn.mul(w1_out, w3_out, **cfg["mul_experts"])
+        ttnn.deallocate(w1_out)
+        ttnn.deallocate(w3_out)
 
         # Down projection
         output = ttnn.linear(activated, **cfg["w2_experts"])
@@ -361,3 +290,7 @@ class Expert(MLP1D):  # The only difference with the regular Dequantized MLP is 
 
         assert output.memory_config() == cfg["output_memory_config"]
         return output
+
+    @classmethod
+    def forward_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig) -> ttnn.Tensor:
+        return cls.forward_decode(x, cfg)


### PR DESCRIPTION
### Ticket
None

### Problem description
Change expert.py to execute deepseek experts on TT hardware. This code creates `n_routed_experts//num_of_devices` groups and executes each group on a device.

### What's changed
Change expert.py
Add test_moe_experts.py to test the 'Expert' module

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes