### PR TITLE
#25009: Add DP Support for Yolov11n

### DIFF
--- a/models/demos/yolov11/README.md
+++ b/models/demos/yolov11/README.md
@@ -4,31 +4,32 @@
 
 Wormhole N150, N300
 
-**Note:** On N300, make sure to use `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` with the pytest.
+### Note:
 
-Or, make sure to set the following environment variable in the terminal:
-```
-export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
-```
+- On N300, Make sure to use `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` with the pytest.
 
-To obtain the perf reports through profiler, please build with following command:
-```
-./build_metal.sh -p
-```
+- Or, make sure to set the following environment variable in the terminal:
+  ```
+  export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+  ```
+- To obtain the perf reports through profiler, please build with following command:
+  ```
+  ./build_metal.sh -p
+  ```
 
-### Introduction
+## Introduction
 
 **YOLOv11n** is the smallest variant in the YOLOV11 series, it offers improvements in accuracy, speed, and efficiency for real-time object detection. It features enhanced architecture and optimized training methods, suitable for various computer vision tasks.
 
 
 ### Details
 
-- The entry point to the yolov11 is located at:`models/demos/yolov11/tt/ttnn_yolov11.py`
-- Batch Size :1
-- Supported Input Resolution - (640,640) (Height,Width)
-- Dataset used for evaluation - **coco-2017**
+- The entry point to the `yolov11` is located at : `models/demos/yolov11/tt/ttnn_yolov11.py`
+- Batch Size : `1` (Single Device), `2` (Multi Device).
+- Supported Input Resolution : `(640, 640)` - (Height, Width).
+- Dataset used for evaluation : **COCO-2017**
 
-### How to Run:
+## How to Run:
 
 Use the following command to run the model :
 
@@ -36,21 +37,77 @@ Use the following command to run the model :
 pytest --disable-warnings models/demos/yolov11/tests/pcc/test_ttnn_yolov11.py::test_yolov11
 ```
 
-### Performant Model with Trace+2CQ
-- end-2-end perf is 190 FPS
+#
+## Model performant running with Trace+2CQ
 
-Use the following command to run the performant Model with Trace+2CQs:
+### Single Device (BS=1):
+- For `640x640`, end-2-end perf is `145` FPS :
 
 ```
-pytest --disable-warnings models/demos/yolov11/tests/perf/test_e2e_performant.py
+pytest --disable-warnings models/demos/yolov11/tests/perf/test_e2e_performant.py::test_e2e_performant
 ```
 ### Performant Demo with Trace+2CQ
 
-Use the following command to run the performant Demo with Trace+2CQs:
+### Multi Device (DP=2, N300):
 
-```
-pytest --disable-warnings models/demos/yolov11/demo/demo.py::test_demo
-```
+- For `640x640`, end-2-end perf is `275` FPS :
+
+  ```
+  pytest --disable-warnings models/demos/yolov11/tests/test_e2e_performant.py::test_e2e_performant_dp
+  ```
+
+### Demo with Trace+2CQ
+
+#### Note: Output images will be saved in the `models/demos/yolov11/demo/runs` folder.
+
+### Single Device (BS=1):
+
+#### Custom Images:
+
+- Use the following command to run demo for `640x640` resolution :
+
+    ```bash
+    pytest --disable-warnings models/demos/yolov11/demo/demo.py::test_demo
+    ```
+
+- To use a different image(s) for demo, replace your image(s) in the image path `models/demos/yolov11/demo/images` and run :
+
+    ```bash
+    pytest --disable-warnings models/demos/yolov11/demo/demo.py::test_demo
+    ```
+
+#### COCO-2017 dataset:
+
+- Use the following command to run demo for `640x640` resolution :
+
+  ```
+  pytest --disable-warnings models/demos/yolov11/demo/demo.py::test_demo_dataset
+  ```
+
+### Multi Device (DP=2, N300):
+
+#### Custom Images:
+
+- Use the following command to run demo for `640x640` resolution :
+
+  ```bash
+  pytest --disable-warnings models/demos/yolov11/demo/demo.py::test_demo_dp
+  ```
+
+- To use a different image(s) for demo, replace your image(s) in the image path `models/demos/yolov8x/demo/images` and run :
+
+  ```
+  pytest --disable-warnings models/demos/yolov11/demo/demo.py::test_demo_dp
+  ```
+
+#### Coco-2017 dataset:
+
+- Use the following command to run demo for `640x640` resolution :
+
+  ```
+  pytest --disable-warnings models/demos/yolov11/demo/demo.py::test_demo_dataset_dp
+  ```
+
 
 ### Performant evaluation with Trace+2CQ
 Use the following command to run the performant evaluation with Trace+2CQs:

--- a/models/demos/yolov11/common.py
+++ b/models/demos/yolov11/common.py
@@ -9,6 +9,8 @@ from ultralytics import YOLO
 
 from models.demos.yolov11.reference import yolov11
 
+YOLOV11_L1_SMALL_SIZE = 24576
+
 
 def load_torch_model(model_location_generator=None):
     torch_model = yolov11.YoloV11()

--- a/models/demos/yolov11/demo/demo.py
+++ b/models/demos/yolov11/demo/demo.py
@@ -2,88 +2,277 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
-import time
 
+import fiftyone
 import pytest
 import torch
 from loguru import logger
 
 import ttnn
-from models.demos.yolov11.common import load_torch_model
-from models.demos.yolov11.demo.demo_utils import load_coco_class_names
+from models.demos.yolov11.common import YOLOV11_L1_SMALL_SIZE, load_torch_model
+from models.demos.yolov11.demo.demo_utils import LoadImages, load_coco_class_names
 from models.demos.yolov11.reference import yolov11
 from models.demos.yolov11.runner.performant_runner import YOLOv11PerformantRunner
-from models.demos.yolov11.tt.model_preprocessing import create_yolov11_input_tensors, create_yolov11_model_parameters
+from models.demos.yolov11.tt.common import get_mesh_mappers
 from models.experimental.yolo_eval.evaluate import save_yolo_predictions_by_model
-from models.experimental.yolo_eval.utils import LoadImages, postprocess, preprocess
+from models.experimental.yolo_eval.utils import postprocess, preprocess
 from models.utility_functions import disable_persistent_kernel_cache
 
 
-@pytest.mark.parametrize(
-    "source, model_type,resolution",
-    [
-        ("models/demos/yolov11/demo/images/cycle_girl.jpg", "torch_model", [3, 640, 640]),
-        ("models/demos/yolov11/demo/images/cycle_girl.jpg", "tt_model", [3, 640, 640]),
-        # ("models/demos/yolov11/demo/images/dog.jpg","torch_model",[3, 640, 640]),  # Uncomment this to run for different image
-        # ("models/demos/yolov11/demo/images/dog.jpg", "tt_model", [3, 640, 640]),
-    ],
-)
-@pytest.mark.parametrize(
-    "use_pretrained_weight",
-    [
-        True,
-        #  False
-    ],
-    ids=[
-        "pretrained_weight_true",
-        # "pretrained_weight_false",
-    ],
-)
-@pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 24576, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
-)
-def test_demo(device, source, model_type, resolution, use_pretrained_weight, model_location_generator):
+def init_model_and_runner(
+    device, model_type, use_weights_from_ultralytics, batch_size_per_device, model_location_generator
+):
     disable_persistent_kernel_cache()
-    model = yolov11.YoloV11()
-    model.eval()
 
-    if use_pretrained_weight:
-        model = load_torch_model(model_location_generator)
-    if model_type == "torch_model":
-        logger.info("Inferencing using Torch Model")
+    num_devices = device.get_num_devices()
+    batch_size = batch_size_per_device * num_devices
+
+    logger.info(f"Running with batch_size={batch_size} across {num_devices} devices")
+
+    inputs_mesh_mapper, weights_mesh_mapper, outputs_mesh_composer = get_mesh_mappers(device)
+
+    if use_weights_from_ultralytics:
+        torch_model = load_torch_model(model_location_generator)
+        model = torch_model.eval()
     else:
-        torch_input, ttnn_input = create_yolov11_input_tensors(
+        model = yolov11.YoloV11()
+
+    performant_runner = None
+    if model_type == "tt_model":
+        performant_runner = YOLOv11PerformantRunner(
             device,
-            input_channels=resolution[0],
-            input_height=resolution[1],
-            input_width=resolution[2],
-            is_sub_module=False,
+            batch_size_per_device,
+            model_location_generator=model_location_generator,
+            inputs_mesh_mapper=inputs_mesh_mapper,
+            weights_mesh_mapper=weights_mesh_mapper,
+            outputs_mesh_composer=outputs_mesh_composer,
         )
-        parameters = create_yolov11_model_parameters(model, torch_input, device=device)
-        logger.info("Inferencing using ttnn Model")
+
+    return model, performant_runner, outputs_mesh_composer, batch_size
+
+
+def process_images(dataset, res, batch_size):
+    torch_images, orig_images, paths_images = [], [], []
+
+    for paths, im0s, _ in dataset:
+        assert len(im0s) == batch_size, f"Expected batch of size {batch_size}, but got {len(im0s)}"
+
+        paths_images.extend(paths)
+        orig_images.extend(im0s)
+
+        for idx, img in enumerate(im0s):
+            if img is None:
+                raise ValueError(f"Could not read image: {paths[idx]}")
+            tensor = preprocess([img], res=res)
+            torch_images.append(tensor)
+
+        if len(torch_images) >= batch_size:
+            break
+
+    torch_input_tensor = torch.cat(torch_images, dim=0)
+    return torch_input_tensor, orig_images, paths_images
+
+
+def run_inference_and_save(
+    model, runner, model_type, outputs_mesh_composer, im_tensor, orig_images, paths_images, save_dir, names
+):
+    if model_type == "torch_model":
+        preds = model(im_tensor)
+    else:
+        preds = runner.run(im_tensor)
+        preds = ttnn.to_torch(preds, dtype=torch.float32, mesh_composer=outputs_mesh_composer)
+
+    results = postprocess(preds, im_tensor, orig_images, paths_images, names)
+
+    for result, image_path in zip(results, paths_images):
+        save_yolo_predictions_by_model(result, save_dir, image_path, model_type)
+
+
+def run_yolov11n_demo(
+    device, model_type, use_weights_from_ultralytics, res, input_loc, batch_size_per_device, model_location_generator
+):
+    model, runner, mesh_composer, batch_size = init_model_and_runner(
+        device, model_type, use_weights_from_ultralytics, batch_size_per_device, model_location_generator
+    )
+
+    dataset = LoadImages(path=os.path.abspath(input_loc), batch=batch_size)
+    im_tensor, orig_images, paths_images = process_images(dataset, res, batch_size)
+    names = load_coco_class_names()
+    save_dir = "models/demos/yolov11/demo/runs"
+
+    run_inference_and_save(
+        model, runner, model_type, mesh_composer, im_tensor, orig_images, paths_images, save_dir, names
+    )
+
+    if runner:
+        runner.release()
+    logger.info("Inference done")
+
+
+def run_yolov11n_demo_dataset(
+    device, model_type, use_weights_from_ultralytics, res, batch_size_per_device, model_location_generator
+):
+    model, runner, mesh_composer, batch_size = init_model_and_runner(
+        device, model_type, use_weights_from_ultralytics, batch_size_per_device, model_location_generator
+    )
+
+    dataset = fiftyone.zoo.load_zoo_dataset("coco-2017", split="validation", max_samples=batch_size)
+    filepaths = [sample["filepath"] for sample in dataset]
+    image_loader = LoadImages(filepaths, batch=batch_size)
+    im_tensor, orig_images, paths_images = process_images(image_loader, res, batch_size)
+
+    with open(os.path.expanduser("~") + "/fiftyone/coco-2017/info.json") as f:
+        names = json.load(f)["classes"]
 
     save_dir = "models/demos/yolov11/demo/runs"
-    dataset = LoadImages(path=source)
-    model_save_dir = os.path.join(save_dir, model_type)
-    os.makedirs(model_save_dir, exist_ok=True)
-    ttnn_module = None
-    for batch in dataset:
-        paths, im0s, s = batch
-        im = preprocess(im0s, (resolution[1], resolution[2]))
-        if model_type == "torch_model":
-            t0 = time.time()
-            preds = model(im)
-            t1 = time.time()
-        else:
-            if ttnn_module is None:
-                performant_runner = YOLOv11PerformantRunner(
-                    device, act_dtype=ttnn.bfloat8_b, weight_dtype=ttnn.bfloat8_b, torch_input_tensor=im
-                )
-                performant_runner._capture_yolov11_trace_2cqs()
-            t0 = time.time()
-            preds = performant_runner.run(im)
-            t1 = time.time()
-            preds = ttnn.to_torch(preds, dtype=torch.float32)
-        results = postprocess(preds, im, im0s, batch, load_coco_class_names())[0]
-        save_yolo_predictions_by_model(results, save_dir, source, model_type)
+    run_inference_and_save(
+        model, runner, model_type, mesh_composer, im_tensor, orig_images, paths_images, save_dir, names
+    )
+
+    if runner:
+        runner.release()
+    logger.info("Inference done")
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": YOLOV11_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "model_type",
+    (
+        # "torch_model", # Uncomment to run the demo with torch model
+        "tt_model",
+    ),
+)
+@pytest.mark.parametrize(
+    "use_weights_from_ultralytics",
+    [True],
+)
+@pytest.mark.parametrize("res", [(640, 640)])
+@pytest.mark.parametrize(
+    "input_loc, batch_size_per_device ",
+    [
+        (
+            "models/demos/yolov11/demo/images",
+            1,
+        ),
+    ],
+)
+def test_demo(
+    device, model_type, use_weights_from_ultralytics, res, input_loc, batch_size_per_device, model_location_generator
+):
+    run_yolov11n_demo(
+        device,
+        model_type,
+        use_weights_from_ultralytics,
+        res,
+        input_loc,
+        batch_size_per_device,
+        model_location_generator,
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": YOLOV11_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "model_type",
+    (
+        # "torch_model", # Uncomment to run the demo with torch model
+        "tt_model",
+    ),
+)
+@pytest.mark.parametrize(
+    "use_weights_from_ultralytics",
+    [True],
+)
+@pytest.mark.parametrize("res", [(640, 640)])
+@pytest.mark.parametrize(
+    "input_loc, batch_size_per_device ",
+    [
+        (
+            "models/demos/yolov11/demo/images",
+            1,
+        ),
+    ],
+)
+def test_demo_dp(
+    mesh_device,
+    model_type,
+    use_weights_from_ultralytics,
+    res,
+    input_loc,
+    batch_size_per_device,
+    model_location_generator,
+):
+    run_yolov11n_demo(
+        mesh_device,
+        model_type,
+        use_weights_from_ultralytics,
+        res,
+        input_loc,
+        batch_size_per_device,
+        model_location_generator,
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": YOLOV11_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "model_type",
+    (
+        # "torch_model", # Uncomment to run the demo with torch model
+        "tt_model",
+    ),
+)
+@pytest.mark.parametrize(
+    "use_weights_from_ultralytics",
+    [True],
+)
+@pytest.mark.parametrize("res", [(640, 640)])
+def test_demo_dataset(device, model_type, use_weights_from_ultralytics, res, model_location_generator):
+    run_yolov11n_demo_dataset(
+        device,
+        model_type,
+        use_weights_from_ultralytics,
+        res,
+        batch_size_per_device=1,
+        model_location_generator=model_location_generator,
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": YOLOV11_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "model_type",
+    (
+        # "torch_model", # Uncomment to run the demo with torch model
+        "tt_model",
+    ),
+)
+@pytest.mark.parametrize(
+    "use_weights_from_ultralytics",
+    [True],
+)
+@pytest.mark.parametrize("res", [(640, 640)])
+def test_demo_dataset_dp(mesh_device, model_type, use_weights_from_ultralytics, res, model_location_generator):
+    run_yolov11n_demo_dataset(
+        mesh_device,
+        model_type,
+        use_weights_from_ultralytics,
+        res,
+        batch_size_per_device=1,
+        model_location_generator=model_location_generator,
+    )

--- a/models/demos/yolov11/demo/demo_utils.py
+++ b/models/demos/yolov11/demo/demo_utils.py
@@ -2,9 +2,90 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import os
+from pathlib import Path
 
+import cv2
+import numpy as np
 import requests
+from loguru import logger
+
+
+def imread(filename: str, flags: int = cv2.IMREAD_COLOR):
+    return cv2.imdecode(np.fromfile(filename, np.uint8), flags)
+
+
+IMG_FORMATS = {"bmp", "dng", "jpeg", "jpg", "mpo", "png", "tif", "tiff", "webp", "pfm", "heic"}
+
+
+class LoadImages:
+    def __init__(self, path, batch=1, vid_stride=1):
+        files = []
+        for p in sorted(path) if isinstance(path, (list, tuple)) else [path]:
+            a = str(Path(p).absolute())
+            if os.path.isdir(a):
+                for f in os.listdir(a):
+                    if f.lower().endswith((".jpg", ".jpeg", ".png", ".bmp")):
+                        files.append(os.path.join(a, f))
+            elif os.path.isfile(a):
+                files.append(a)
+            else:
+                raise FileNotFoundError(f"{p} does not exist or is not a valid file/directory")
+
+        images = []
+        for f in files:
+            suffix = f.split(".")[-1].lower()
+            if suffix in IMG_FORMATS:
+                images.append(f)
+        ni = len(images)
+
+        self.files = images
+        self.nf = ni
+        self.ni = ni
+        self.mode = "image"
+        self.vid_stride = vid_stride
+        self.bs = batch
+        if self.nf == 0:
+            raise FileNotFoundError(f"No images or videos found in {p}")
+
+    def __iter__(self):
+        self.count = 0
+        return self
+
+    def __next__(self):
+        paths, imgs, info = [], [], []
+        while len(imgs) < self.bs:
+            if self.count >= self.nf:
+                if imgs:
+                    return paths, imgs, info
+                else:
+                    raise StopIteration
+
+            path = self.files[self.count]
+            im0 = imread(path)
+            if im0 is None:
+                logger.warning(f"WARNING ⚠️ Image Read Error {path}")
+            else:
+                paths.append(path)
+                imgs.append(im0)
+                info.append(f"image {self.count + 1}/{self.nf} {path}: ")
+            self.count += 1
+            if self.count >= self.ni:
+                break
+
+        return paths, imgs, info
+
+    def _new_video(self, path):
+        self.frame = 0
+        self.cap = cv2.VideoCapture(path)
+        self.fps = int(self.cap.get(cv2.CAP_PROP_FPS))
+        if not self.cap.isOpened():
+            raise FileNotFoundError(f"Failed to open video {path}")
+        self.frames = int(self.cap.get(cv2.CAP_PROP_FRAME_COUNT) / self.vid_stride)
+
+    def __len__(self):
+        return math.ceil(self.nf / self.bs)
 
 
 def load_coco_class_names():

--- a/models/demos/yolov11/reference/yolov11.py
+++ b/models/demos/yolov11/reference/yolov11.py
@@ -281,15 +281,15 @@ class C3k2(nn.Module):
         if self.is_bk_enabled:
             x = self.cv1(x)
             y = list(x.chunk(2, 1))
-            y.extend(self.m[0](y[-1]))
-            y[-1] = y[-1].unsqueeze(0)
+            m_out = self.m[0](y[-1])
+            y.append(m_out)
             x = torch.cat(y, 1)
             x = self.cv2(x)
         else:
             x = self.cv1(x)
             y = list(x.chunk(2, 1))
-            y.extend(self.m[0](y[-1]))
-            y[-1] = y[-1].unsqueeze(0)
+            m_out = self.m[0](y[-1])
+            y.append(m_out)
             x = torch.cat(y, 1)
             x = self.cv2(x)
         return x

--- a/models/demos/yolov11/runner/performant_runner.py
+++ b/models/demos/yolov11/runner/performant_runner.py
@@ -17,10 +17,18 @@ class YOLOv11PerformantRunner:
         model_location_generator=None,
         resolution=(640, 640),
         torch_input_tensor=None,
+        inputs_mesh_mapper=None,
+        weights_mesh_mapper=None,
+        outputs_mesh_composer=None,
     ):
         self.device = device
         self.resolution = resolution
         self.torch_input_tensor = torch_input_tensor
+
+        self.mesh_mapper = inputs_mesh_mapper
+        self.weights_mesh_mapper = weights_mesh_mapper
+        self.mesh_composer = outputs_mesh_composer
+
         self.runner_infra = YOLOv11PerformanceRunnerInfra(
             device,
             device_batch_size,
@@ -29,6 +37,9 @@ class YOLOv11PerformantRunner:
             model_location_generator,
             resolution=resolution,
             torch_input_tensor=self.torch_input_tensor,
+            inputs_mesh_mapper=self.mesh_mapper,
+            weights_mesh_mapper=self.weights_mesh_mapper,
+            outputs_mesh_composer=self.mesh_composer,
         )
 
         (
@@ -37,12 +48,10 @@ class YOLOv11PerformantRunner:
             self.input_mem_config,
         ) = self.runner_infra.setup_dram_sharded_input(device)
         self.tt_image_res = self.tt_inputs_host.to(device, sharded_mem_config_DRAM)
+        self._capture_yolov11_trace_2cqs()
 
     def _capture_yolov11_trace_2cqs(self):
-        # Initialize the op event so we can write
         self.op_event = ttnn.record_event(self.device, 0)
-
-        # First run configures convs JIT
         ttnn.wait_for_event(1, self.op_event)
         ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
         self.write_event = ttnn.record_event(self.device, 1)
@@ -53,7 +62,6 @@ class YOLOv11PerformantRunner:
         self.runner_infra.run()
         self.runner_infra.validate()
         self.runner_infra.dealloc_output()
-
         # Optimized run
         ttnn.wait_for_event(1, self.op_event)
         ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
@@ -63,7 +71,6 @@ class YOLOv11PerformantRunner:
         self.op_event = ttnn.record_event(self.device, 0)
         self.runner_infra.run()
         self.runner_infra.validate()
-
         # Capture
         ttnn.wait_for_event(1, self.op_event)
         ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
@@ -85,8 +92,7 @@ class YOLOv11PerformantRunner:
         ttnn.copy_host_to_device_tensor(tt_inputs_host, self.tt_image_res, 1)
         self.write_event = ttnn.record_event(self.device, 1)
         ttnn.wait_for_event(0, self.write_event)
-        if self.input_tensor.is_sharded():
-            self.input_tensor = ttnn.reshard(self.tt_image_res, self.input_mem_config, self.input_tensor)
+        self.input_tensor = ttnn.reshard(self.tt_image_res, self.input_mem_config, self.input_tensor)
         self.op_event = ttnn.record_event(self.device, 0)
         ttnn.execute_trace(self.device, self.tid, cq_id=0, blocking=False)
         return self.runner_infra.output_tensor
@@ -99,8 +105,6 @@ class YOLOv11PerformantRunner:
         tt_inputs_host, _ = self.runner_infra._setup_l1_sharded_input(self.device, torch_input_tensor)
         output = self._execute_yolov11_trace_2cqs_inference(tt_inputs_host)
         if check_pcc:
-            torch_input_tensor = torch_input_tensor.reshape(n, h, w, c)
-            torch_input_tensor = torch_input_tensor.permute(0, 3, 1, 2)
             self._validate(torch_input_tensor, output)
 
         return output

--- a/models/demos/yolov11/runner/performant_runner_infra.py
+++ b/models/demos/yolov11/runner/performant_runner_infra.py
@@ -24,12 +24,21 @@ class YOLOv11PerformanceRunnerInfra:
         model_location_generator=None,
         resolution=(640, 640),
         torch_input_tensor=None,
+        inputs_mesh_mapper=None,
+        weights_mesh_mapper=None,
+        outputs_mesh_composer=None,
     ):
         torch.manual_seed(0)
         self.resolution = resolution
         self.pcc_passed = False
         self.pcc_message = "Did you forget to call validate()?"
+
         self.device = device
+        self.num_devices = self.device.get_num_devices()
+        self.mesh_mapper = inputs_mesh_mapper
+        self.weights_mesh_mapper = weights_mesh_mapper
+        self.mesh_composer = outputs_mesh_composer
+
         self.batch_size = batch_size
         self.act_dtype = act_dtype
         self.weight_dtype = weight_dtype
@@ -39,35 +48,43 @@ class YOLOv11PerformanceRunnerInfra:
         self.torch_model = load_torch_model(model_location_generator)
 
         self.torch_input_tensor = (
-            torch.randn((1, 3, 640, 640), dtype=torch.float32)
+            torch.randn((batch_size * self.num_devices, 3, 640, 640), dtype=torch.float32)
             if self.torch_input_tensor is None
             else self.torch_input_tensor
         )
-
-        self.parameters = create_yolov11_model_parameters(self.torch_model, self.torch_input_tensor, device=self.device)
+        self.torch_input_params = torch.randn((batch_size, 3, 640, 640), dtype=torch.float32)
+        self.parameters = create_yolov11_model_parameters(self.torch_model, self.torch_input_params, device=self.device)
 
         self.ttnn_yolov11_model = ttnn_yolov11.TtnnYoloV11(self.device, self.parameters)
 
         self.torch_output_tensor = self.torch_model(self.torch_input_tensor)
 
-    def _setup_l1_sharded_input(self, device, torch_input_tensor=None, min_channels=8):
+    def _setup_l1_sharded_input(self, device, torch_input_tensor=None, min_channels=16):
         if is_wormhole_b0():
             core_grid = ttnn.CoreGrid(y=8, x=8)
         else:
             exit("Unsupported device")
 
-        num_devices = device.get_num_devices()
         torch_input_tensor = self.torch_input_tensor if torch_input_tensor is None else torch_input_tensor
 
         n, c, h, w = torch_input_tensor.shape
-        if c == 3:
+        if c < min_channels:
             c = min_channels
+        elif c % min_channels != 0:
+            c = ((c // min_channels) + 1) * min_channels
+
+        n = n // self.num_devices if n // self.num_devices != 0 else n
         input_mem_config = ttnn.create_sharded_memory_config(
             [n, c, h, w],
             ttnn.CoreGrid(x=8, y=8),
             ttnn.ShardStrategy.HEIGHT,
         )
-        tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+        assert torch_input_tensor.ndim == 4, "Expected input tensor to have shape (BS, C, H, W)"
+
+        input_tensor = [torch_input_tensor[i].unsqueeze(0) for i in range(torch_input_tensor.shape[0])]
+        tt_inputs_host = ttnn.from_host_shards(
+            [ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT) for t in input_tensor], device.shape
+        )
         return tt_inputs_host, input_mem_config
 
     def setup_dram_sharded_input(self, device, torch_input_tensor=None, mesh_mapper=None, mesh_composer=None):
@@ -78,7 +95,7 @@ class YOLOv11PerformanceRunnerInfra:
                 {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
             ),
             [
-                divup(tt_inputs_host.volume() // tt_inputs_host.shape[-1], dram_grid_size.x * dram_grid_size.y),
+                divup(tt_inputs_host.volume() // tt_inputs_host.shape[-1], (dram_grid_size.x * dram_grid_size.y)),
                 tt_inputs_host.shape[-1],
             ],
             ttnn.ShardOrientation.ROW_MAJOR,
@@ -95,7 +112,7 @@ class YOLOv11PerformanceRunnerInfra:
     def validate(self, output_tensor=None, torch_output_tensor=None):
         ttnn_output_tensor = self.output_tensor if output_tensor is None else output_tensor
         torch_output_tensor = self.torch_output_tensor if torch_output_tensor is None else torch_output_tensor
-        output_tensor = ttnn.to_torch(ttnn_output_tensor)
+        output_tensor = ttnn.to_torch(ttnn_output_tensor, mesh_composer=self.mesh_composer)
         self.pcc_passed, self.pcc_message = assert_with_pcc(self.torch_output_tensor, output_tensor, pcc=0.99)
 
         logger.info(

--- a/models/demos/yolov11/tests/pcc/test_ttnn_yolov11.py
+++ b/models/demos/yolov11/tests/pcc/test_ttnn_yolov11.py
@@ -5,7 +5,7 @@
 import pytest
 
 import ttnn
-from models.demos.yolov11.common import load_torch_model
+from models.demos.yolov11.common import YOLOV11_L1_SMALL_SIZE, load_torch_model
 from models.demos.yolov11.reference import yolov11
 from models.demos.yolov11.tt import ttnn_yolov11
 from models.demos.yolov11.tt.model_preprocessing import create_yolov11_input_tensors, create_yolov11_model_parameters
@@ -25,7 +25,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         # False
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV11_L1_SMALL_SIZE}], indirect=True)
 def test_yolov11(device, reset_seeds, resolution, use_pretrained_weights, model_location_generator, min_channels=8):
     torch_model = yolov11.YoloV11()
     torch_model.eval()

--- a/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_attention.py
+++ b/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_attention.py
@@ -5,6 +5,7 @@
 import pytest
 
 import ttnn
+from models.demos.yolov11.common import YOLOV11_L1_SMALL_SIZE
 from models.demos.yolov11.reference.yolov11 import Attention as torch_attention
 from models.demos.yolov11.tt.model_preprocessing import create_yolov11_input_tensors, create_yolov11_model_parameters
 from models.demos.yolov11.tt.ttnn_yolov11_attention import TtnnAttention as ttnn_attention
@@ -17,7 +18,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ([128, 128, 128], [256, 128, 128], [1, 1, 3], [1, 1, 1], [0, 0, 1], [1, 1, 1], [1, 1, 128], [1, 128, 7, 7]),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV11_L1_SMALL_SIZE}], indirect=True)
 def test_yolo_v11_attention(
     device,
     reset_seeds,

--- a/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_botttleneck.py
+++ b/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_botttleneck.py
@@ -6,6 +6,7 @@
 import pytest
 
 import ttnn
+from models.demos.yolov11.common import YOLOV11_L1_SMALL_SIZE
 from models.demos.yolov11.reference.yolov11 import Bottleneck as torch_bottleneck
 from models.demos.yolov11.tt.model_preprocessing import create_yolov11_input_tensors, create_yolov11_model_parameters
 from models.demos.yolov11.tt.ttnn_yolov11_bottleneck import TtnnBottleneck as ttnn_bottleneck
@@ -25,7 +26,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ([64, 64], [64, 64], [3, 3], [1, 1], [1, 1], [1, 1], [1, 1], [1, 64, 7, 7]),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV11_L1_SMALL_SIZE}], indirect=True)
 def test_yolo_v11_bottleneck(
     device,
     reset_seeds,

--- a/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_c2psa.py
+++ b/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_c2psa.py
@@ -5,6 +5,7 @@
 import pytest
 
 import ttnn
+from models.demos.yolov11.common import YOLOV11_L1_SMALL_SIZE
 from models.demos.yolov11.reference.yolov11 import C2PSA as torch_c2psa_block
 from models.demos.yolov11.tt.model_preprocessing import create_yolov11_input_tensors, create_yolov11_model_parameters
 from models.demos.yolov11.tt.ttnn_yolov11_c2psa import TtnnC2PSA as ttnn_c2psa_block
@@ -26,7 +27,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV11_L1_SMALL_SIZE}], indirect=True)
 def test_yolo_v11_c2psa_block(
     device,
     reset_seeds,

--- a/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_c3k.py
+++ b/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_c3k.py
@@ -5,6 +5,7 @@
 import pytest
 
 import ttnn
+from models.demos.yolov11.common import YOLOV11_L1_SMALL_SIZE
 from models.demos.yolov11.reference.yolov11 import C3k as torch_c3k
 from models.demos.yolov11.tt.model_preprocessing import create_yolov11_input_tensors, create_yolov11_model_parameters
 from models.demos.yolov11.tt.ttnn_yolov11_c3k import TtnnC3K as ttnn_c3k
@@ -56,7 +57,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV11_L1_SMALL_SIZE}], indirect=True)
 def test_yolo_v11_c3k(
     device,
     reset_seeds,

--- a/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_c3k2.py
+++ b/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_c3k2.py
@@ -5,6 +5,7 @@
 import pytest
 
 import ttnn
+from models.demos.yolov11.common import YOLOV11_L1_SMALL_SIZE
 from models.demos.yolov11.reference.yolov11 import C3k2 as torch_c3k2
 from models.demos.yolov11.tt.model_preprocessing import create_yolov11_input_tensors, create_yolov11_model_parameters
 from models.demos.yolov11.tt.ttnn_yolov11_c3k2 import TtnnC3k2 as ttnn_c3k2
@@ -104,7 +105,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV11_L1_SMALL_SIZE}], indirect=True)
 def test_yolo_v11_c3k2(
     device,
     reset_seeds,

--- a/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_detect.py
+++ b/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_detect.py
@@ -5,6 +5,7 @@
 import pytest
 
 import ttnn
+from models.demos.yolov11.common import YOLOV11_L1_SMALL_SIZE
 from models.demos.yolov11.reference.yolov11 import Detect as torch_detect
 from models.demos.yolov11.tt.model_preprocessing import (
     create_yolov11_input_tensors,
@@ -29,7 +30,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV11_L1_SMALL_SIZE}], indirect=True)
 def test_yolo_v11_detect(
     device,
     reset_seeds,

--- a/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_psa.py
+++ b/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_psa.py
@@ -5,6 +5,7 @@
 import pytest
 
 import ttnn
+from models.demos.yolov11.common import YOLOV11_L1_SMALL_SIZE
 from models.demos.yolov11.reference.yolov11 import PSABlock as torch_psa_block
 from models.demos.yolov11.tt.model_preprocessing import create_yolov11_input_tensors, create_yolov11_model_parameters
 from models.demos.yolov11.tt.ttnn_yolov11_psa import TtnnPSABlock as ttnn_psa_block
@@ -26,7 +27,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV11_L1_SMALL_SIZE}], indirect=True)
 def test_yolo_v11_psa_block(
     device,
     reset_seeds,

--- a/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_sppf.py
+++ b/models/demos/yolov11/tests/pcc/test_ttnn_yolov11_sppf.py
@@ -5,6 +5,7 @@
 import pytest
 
 import ttnn
+from models.demos.yolov11.common import YOLOV11_L1_SMALL_SIZE
 from models.demos.yolov11.reference.yolov11 import SPPF as torch_sppf
 from models.demos.yolov11.tt.model_preprocessing import create_yolov11_input_tensors, create_yolov11_model_parameters
 from models.demos.yolov11.tt.ttnn_yolov11_sppf import TtnnSPPF as ttnn_sppf
@@ -17,7 +18,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ([256, 512], [128, 256], [1, 1], [1, 1], [0, 0], [1, 1], [1, 1], [1, 256, 20, 20]),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": YOLOV11_L1_SMALL_SIZE}], indirect=True)
 def test_yolo_v11_sppf(
     device,
     reset_seeds,

--- a/models/demos/yolov11/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov11/tests/perf/test_e2e_performant.py
@@ -5,15 +5,59 @@
 import time
 
 import pytest
+import torch
 from loguru import logger
 
 import ttnn
+from models.demos.yolov11.common import YOLOV11_L1_SMALL_SIZE
 from models.demos.yolov11.runner.performant_runner import YOLOv11PerformantRunner
+from models.demos.yolov11.tt.common import get_mesh_mappers
 from models.utility_functions import run_for_wormhole_b0
 
 
+def run_yolov11_inference(
+    device,
+    batch_size_per_device,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    resolution,
+):
+    inputs_mesh_mapper, weights_mesh_mapper, outputs_mesh_composer = get_mesh_mappers(device)
+
+    num_devices = device.get_num_devices()
+    batch_size = batch_size_per_device * num_devices
+
+    performant_runner = YOLOv11PerformantRunner(
+        device,
+        batch_size_per_device,
+        act_dtype,
+        weight_dtype,
+        resolution=resolution,
+        model_location_generator=model_location_generator,
+        inputs_mesh_mapper=inputs_mesh_mapper,
+        weights_mesh_mapper=weights_mesh_mapper,
+        outputs_mesh_composer=outputs_mesh_composer,
+    )
+
+    input_shape = (batch_size, 3, *resolution)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+
+    t0 = time.time()
+    for _ in range(10):
+        _ = performant_runner.run(torch_input_tensor=torch_input_tensor)
+    ttnn.synchronize_device(device)
+    t1 = time.time()
+
+    performant_runner.release()
+    inference_time_avg = round((t1 - t0) / 10, 6)
+    logger.info(
+        f"Model: ttnn_yolov11 - batch_size: {batch_size}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size / inference_time_avg)}"
+    )
+
+
 @pytest.mark.parametrize(
-    "batch_size, act_dtype, weight_dtype",
+    "batch_size_per_device, act_dtype, weight_dtype",
     ((1, ttnn.bfloat8_b, ttnn.bfloat8_b),),
 )
 @pytest.mark.parametrize(
@@ -25,35 +69,60 @@ from models.utility_functions import run_for_wormhole_b0
 @pytest.mark.models_performance_bare_metal
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 24576, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
+    "device_params",
+    [{"l1_small_size": YOLOV11_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
+    indirect=True,
 )
 def test_e2e_performant(
     device,
-    batch_size,
+    batch_size_per_device,
     act_dtype,
     weight_dtype,
     model_location_generator,
     resolution,
+    reset_seeds,
 ):
-    performant_runner = YOLOv11PerformantRunner(
+    run_yolov11_inference(
         device,
-        batch_size,
+        batch_size_per_device,
         act_dtype,
         weight_dtype,
         resolution=resolution,
         model_location_generator=model_location_generator,
     )
-    performant_runner._capture_yolov11_trace_2cqs()
-    inference_times = []
-    for _ in range(10):
-        t0 = time.time()
-        _ = performant_runner.run()
-        t1 = time.time()
-        inference_times.append(t1 - t0)
 
-    performant_runner.release()
 
-    inference_time_avg = round(sum(inference_times) / len(inference_times), 6)
-    logger.info(
-        f"ttnn_yolov11_batch_size: {batch_size}, resolution: {resolution}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size/inference_time_avg)}"
+@pytest.mark.parametrize(
+    "batch_size_per_device, act_dtype, weight_dtype",
+    ((1, ttnn.bfloat8_b, ttnn.bfloat8_b),),
+)
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (640, 640),
+    ],
+)
+@pytest.mark.models_performance_bare_metal
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": YOLOV11_L1_SMALL_SIZE, "trace_region_size": 23887872, "num_command_queues": 2}],
+    indirect=True,
+)
+def test_e2e_performant_dp(
+    mesh_device,
+    batch_size_per_device,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    resolution,
+    reset_seeds,
+):
+    run_yolov11_inference(
+        mesh_device,
+        batch_size_per_device,
+        act_dtype,
+        weight_dtype,
+        model_location_generator,
+        resolution,
     )

--- a/models/demos/yolov11/tt/common.py
+++ b/models/demos/yolov11/tt/common.py
@@ -228,3 +228,27 @@ class TtnnConv:
 def deallocate_tensors(*tensors):
     for t in tensors:
         ttnn.deallocate(t)
+
+
+def get_mesh_mappers(device):
+    if device.get_num_devices() > 1:
+        inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
+        weights_mesh_mapper = ttnn.ReplicateTensorToMesh(device)
+        output_mesh_composer = ttnn.ConcatMeshToTensor(device, dim=0)
+    else:
+        inputs_mesh_mapper = None
+        weights_mesh_mapper = None
+        output_mesh_composer = None
+    return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer
+
+
+def get_mesh_mappers(device):
+    if device.get_num_devices() > 1:
+        inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
+        weights_mesh_mapper = ttnn.ReplicateTensorToMesh(device)
+        output_mesh_composer = ttnn.ConcatMeshToTensor(device, dim=0)
+    else:
+        inputs_mesh_mapper = None
+        weights_mesh_mapper = None
+        output_mesh_composer = None
+    return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer

--- a/models/demos/yolov11/tt/model_preprocessing.py
+++ b/models/demos/yolov11/tt/model_preprocessing.py
@@ -8,27 +8,51 @@ from ttnn.model_preprocessing import fold_batch_norm2d_into_conv2d, infer_ttnn_m
 
 import ttnn
 from models.demos.yolov11.reference.yolov11 import Conv, YoloV11
+from models.demos.yolov11.tt.common import get_mesh_mappers
 
 
 def create_yolov11_input_tensors(
     device, batch=1, input_channels=3, input_height=640, input_width=640, is_sub_module=True
 ):
-    torch_input_tensor = torch.randn(batch, input_channels, input_height, input_width)
+    num_devices = device.get_num_devices()
+    inputs_mesh_mapper, _, _ = get_mesh_mappers(device)
+    torch_input_tensor = torch.randn(batch * device.get_num_devices(), input_channels, input_height, input_width)
     if is_sub_module:
         ttnn_input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))
-        ttnn_input_tensor = ttnn_input_tensor.reshape(
-            1,
-            1,
-            ttnn_input_tensor.shape[0] * ttnn_input_tensor.shape[1] * ttnn_input_tensor.shape[2],
-            ttnn_input_tensor.shape[3],
+        ttnn_input_tensor = torch.reshape(
+            ttnn_input_tensor,
+            (
+                1,
+                1,
+                ttnn_input_tensor.shape[0] * ttnn_input_tensor.shape[1] * ttnn_input_tensor.shape[2],
+                ttnn_input_tensor.shape[-1],
+            ),
         )
-        ttnn_input_tensor = ttnn.from_torch(ttnn_input_tensor, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b)
+        ttnn_input_tensor = ttnn.from_torch(
+            ttnn_input_tensor, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b, mesh_mapper=inputs_mesh_mapper
+        )
     else:
-        ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16)
+        n, c, h, w = torch_input_tensor.shape
+        if c == 3:
+            c = 16
+        n = n // num_devices if n // num_devices != 0 else n
+        input_mem_config = ttnn.create_sharded_memory_config(
+            [n, c, h, w],
+            ttnn.CoreGrid(x=8, y=8),
+            ttnn.ShardStrategy.HEIGHT,
+        )
+        ttnn_input_tensor = ttnn.from_torch(
+            torch_input_tensor,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=input_mem_config,
+            mesh_mapper=inputs_mesh_mapper,
+        )
     return torch_input_tensor, ttnn_input_tensor
 
 
-def make_anchors(device, feats, strides, grid_cell_offset=0.5):
+def make_anchors(device, feats, strides, grid_cell_offset=0.5, mesh_mapper=None):
     anchor_points, stride_tensor = [], []
     assert feats is not None
     for i, stride in enumerate(strides):
@@ -43,33 +67,35 @@ def make_anchors(device, feats, strides, grid_cell_offset=0.5):
     b = torch.cat(stride_tensor).transpose(0, 1)
 
     return (
-        ttnn.from_torch(a, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device),
-        ttnn.from_torch(b, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device),
+        ttnn.from_torch(a, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, mesh_mapper=mesh_mapper),
+        ttnn.from_torch(b, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, mesh_mapper=mesh_mapper),
     )
 
 
-def custom_preprocessor(model, name):
+def custom_preprocessor(model, name, mesh_mapper=None):
     parameters = {}
     if isinstance(model, nn.Conv2d):
-        parameters["weight"] = ttnn.from_torch(model.weight, dtype=ttnn.float32)
+        parameters["weight"] = ttnn.from_torch(model.weight, dtype=ttnn.float32, mesh_mapper=mesh_mapper)
         if model.bias is not None:
             bias = model.bias.reshape((1, 1, 1, -1))
-            parameters["bias"] = ttnn.from_torch(bias, dtype=ttnn.float32)
+            parameters["bias"] = ttnn.from_torch(bias, dtype=ttnn.float32, mesh_mapper=mesh_mapper)
 
     if isinstance(model, Conv):
         weight, bias = fold_batch_norm2d_into_conv2d(model.conv, model.bn)
         parameters["conv"] = {}
-        parameters["conv"]["weight"] = ttnn.from_torch(weight, dtype=ttnn.float32)
+        parameters["conv"]["weight"] = ttnn.from_torch(weight, dtype=ttnn.float32, mesh_mapper=mesh_mapper)
         bias = bias.reshape((1, 1, 1, -1))
-        parameters["conv"]["bias"] = ttnn.from_torch(bias, dtype=ttnn.float32)
+        parameters["conv"]["bias"] = ttnn.from_torch(bias, dtype=ttnn.float32, mesh_mapper=mesh_mapper)
 
     return parameters
 
 
 def create_yolov11_model_parameters(model: YoloV11, input_tensor: torch.Tensor, device):
+    _, weights_mesh_mapper, _ = get_mesh_mappers(device)
+
     parameters = preprocess_model_parameters(
         initialize_model=lambda: model,
-        custom_preprocessor=custom_preprocessor,
+        custom_preprocessor=create_custom_mesh_preprocessor(weights_mesh_mapper),
         device=device,
     )
     parameters.conv_args = {}
@@ -84,7 +110,7 @@ def create_yolov11_model_parameters(model: YoloV11, input_tensor: torch.Tensor, 
     ]
     strides = [8.0, 16.0, 32.0]
 
-    anchors, strides = make_anchors(device, feats, strides)
+    anchors, strides = make_anchors(device, feats, strides, mesh_mapper=weights_mesh_mapper)
 
     if "model" in parameters:
         parameters.model[23]["anchors"] = anchors
@@ -96,9 +122,11 @@ def create_yolov11_model_parameters(model: YoloV11, input_tensor: torch.Tensor, 
 def create_yolov11_model_parameters_detect(
     model: YoloV11, input_tensor_1: torch.Tensor, input_tensor_2, input_tensor_3, device
 ):
+    _, weights_mesh_mapper, _ = get_mesh_mappers(device)
+
     parameters = preprocess_model_parameters(
         initialize_model=lambda: model,
-        custom_preprocessor=custom_preprocessor,
+        custom_preprocessor=create_custom_mesh_preprocessor(weights_mesh_mapper),
         device=device,
     )
     parameters.conv_args = {}
@@ -109,7 +137,7 @@ def create_yolov11_model_parameters_detect(
     feats = [28, 14, 7]
     strides = [8.0, 16.0, 32.0]
 
-    anchors, strides = make_anchors(device, feats, strides)
+    anchors, strides = make_anchors(device, feats, strides, mesh_mapper=weights_mesh_mapper)
 
     parameters["anchors"] = anchors
     parameters["strides"] = strides
@@ -117,3 +145,10 @@ def create_yolov11_model_parameters_detect(
     parameters["model"] = model
 
     return parameters
+
+
+def create_custom_mesh_preprocessor(mesh_mapper=None):
+    def custom_mesh_preprocessor(model, name, ttnn_module_args, convert_to_ttnn):
+        return custom_preprocessor(model, name, mesh_mapper)
+
+    return custom_mesh_preprocessor

--- a/models/demos/yolov11/web_demo/server/fast_api_yolov11.py
+++ b/models/demos/yolov11/web_demo/server/fast_api_yolov11.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI, File, UploadFile
 from PIL import Image
 
 import ttnn
+from models.demos.yolov11.common import YOLOV11_L1_SMALL_SIZE
 from models.demos.yolov11.runner.performant_runner import YOLOv11PerformantRunner
 from models.experimental.yolo_common.yolo_web_demo.yolo_evaluation_utils import postprocess
 
@@ -53,7 +54,7 @@ async def startup():
         device = ttnn.CreateDevice(
             device_id,
             dispatch_core_config=get_dispatch_core_config(),
-            l1_small_size=24576,
+            l1_small_size=YOLOV11_L1_SMALL_SIZE,
             trace_region_size=6434816,
             num_command_queues=2,
         )
@@ -61,7 +62,9 @@ async def startup():
         model = YOLOv11PerformantRunner(device)
     else:
         device_id = 0
-        device = ttnn.CreateDevice(device_id, l1_small_size=24576, trace_region_size=3211264, num_command_queues=2)
+        device = ttnn.CreateDevice(
+            device_id, l1_small_size=YOLOV11_L1_SMALL_SIZE, trace_region_size=3211264, num_command_queues=2
+        )
         device.enable_program_cache()
         model = YOLOv11PerformantRunner(device)
     model._capture_yolov11_trace_2cqs()


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25009)

### Problem description
Add DataParallel support for Yolov11n model.

### What's changed
Added data parallel support for Yolov11n model to :
- Demo and
- e2e performant.
  - For 640x640 resolution,
    - Single Device : 145 FPS
    - Multi Device (N300) : 275 FPS

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/16674469613) Passed
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/16674489746) Yolov11 passed
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI disabled currently
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/16674498468) Yolov11 passed
- [x] [Single-card Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/16674503676) Yolov11 passed