### PR TITLE
L2 nightly N300 tests skip

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3066,6 +3066,18 @@ def test_conv2d_model_fruit(
     input_dtype,
     input_layout,
 ):
+
+    if (
+        device.core_grid.y < 8
+        and is_wormhole_b0()
+        and batch == 1
+        and input_channels == 64
+        and output_channels == 128
+        and input_height == 1024
+        and input_width == 128
+    ):
+        pytest.skip("Needs 8x8 grid for wormhole_b0")
+
     config_override = {}
     config_override["act_block_h"] = act_block_h_override
     config_override["act_block_w_div"] = act_block_w_div

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3186,6 +3186,10 @@ def test_conv2d_sdxl(
     w_db,
 ):
 
+    # Skip all on N300
+    if device.core_grid.y != 8 and is_wormhole_b0():
+        pytest.skip("Needs 8x8 grid for wormhole_b0")
+
     config_override = {}
     config_override["act_block_h"] = act_block_h_override
     config_override["act_block_w_div"] = act_block_w_div
@@ -3311,6 +3315,9 @@ def test_conv2d_vae_sdxl(
     act_block_h_override
 ):
 
+    # Skip all on N300
+    if device.core_grid.y != 8 and is_wormhole_b0():
+        pytest.skip("Needs 8x8 grid for wormhole_b0")
     # Skip specific test case for Blackhole devices
     if is_blackhole() and (batch, input_channels, output_channels, input_height, input_width, weights_dtype) == (1, 4, 4, 128, 128, ttnn.bfloat8_b):
         pytest.skip("Skipping this test case for Blackhole devices due to PCC issue, tracked in ISSUE-24463")
@@ -3451,6 +3458,9 @@ def test_conv_sharded_non_tile(device):
     shard_width = 32
     input_shape = (batch, input_channels, input_height, input_width)
     weights_shape = (output_channels, input_channels, filter, filter)
+
+    if device.core_grid.y != 8 and is_wormhole_b0():
+        pytest.skip("Needs 8x8 grid for wormhole_b0")
 
     torch.manual_seed(0)
     torch_input = torch.randn(input_shape, dtype=torch.bfloat16)

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -2866,8 +2866,8 @@ def test_split_reader_regression(
     shard_layout,
     config_override,
 ):
-    # if device.core_grid.y != 8 and is_wormhole_b0():
-    #     pytest.skip("Needs 8x8 grid for wormhole_b0")
+    if device.core_grid.y != 8 and is_wormhole_b0():
+        pytest.skip("Needs 8x8 grid for wormhole_b0")
 
     run_conv(
         device,

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -2866,6 +2866,9 @@ def test_split_reader_regression(
     shard_layout,
     config_override,
 ):
+    # if device.core_grid.y != 8 and is_wormhole_b0():
+    #     pytest.skip("Needs 8x8 grid for wormhole_b0")
+
     run_conv(
         device,
         torch_tensor_map,

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_max_pool2d_sweeps.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_max_pool2d_sweeps.py
@@ -4,6 +4,7 @@
 
 from tests.sweep_framework.sweep_utils.max_pool2d_common import run_max_pool2d
 from tests.sweep_framework.sweeps.max_pool2d.short.max_pool2d_short_sweep import parameters as parameters_ttnn_pytorch
+from models.utility_functions import is_wormhole_b0
 
 from models.utility_functions import skip_for_grayskull
 
@@ -31,6 +32,18 @@ def test_ttnn_pytorch_sweep(device, dtype, input_spec):
         dilation_w,
         ceil_mode,
     ) = input_spec
+
+    if (
+        is_wormhole_b0()
+        and device.core_grid.y < 8
+        and in_n == 1
+        and in_c == 64
+        and in_h == 360
+        and in_w == 640
+        and dtype == ttnn.bfloat16
+    ):
+        pytest.skip("OOM (N300)")
+
     run_max_pool2d(
         in_n,
         in_c,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24943
https://github.com/tenstorrent/tt-metal/issues/24944

### Problem description
Some tests fail on N300, skip them to have the pipeline green again

### What's changed
- skipped sdxl tests in conv2d nightly when grid isn't 8x8
- skipped one conv fruit test case
- skipped one OOM conv sweep test case
- skipped test_split_reader_regression
- skipped test_conv_sharded_non_tile

### Checklist
- [x] [Nightly tt-metal L2 tests (N300)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/16296628903)